### PR TITLE
优化 prepare_wy_repr_bwd_full 算子性能

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/prepare_wy_repr_bwd_full_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/prepare_wy_repr_bwd_full_tiling.cpp
@@ -102,177 +102,81 @@ public:
         }
         return ge::GRAPH_SUCCESS;
     }
-    ge::graphStatus SetKBeteVecRow(uint64_t ubSize, ge::DataType kType, ge::DataType betaType)
+    uint64_t AlignUp(uint64_t value, uint64_t align)
     {
-        uint64_t rowNum = chunkSize / 2;
-        uint64_t sizeofKType = SIZE_FP32;
-        uint64_t sizeofBetaType = SIZE_FP32;
-        if (kType != ge::DataType::DT_FLOAT) {
-            sizeofKType = SIZE_HALF;
-        }
-        if (betaType != ge::DataType::DT_FLOAT) {
-            sizeofBetaType = SIZE_HALF;
-        }
-        while (rowNum >= 8) {
-            uint64_t useUbSize = 0;
-            useUbSize += 2 * rowNum * K * sizeofKType;
-            useUbSize += 2 * rowNum * sizeofBetaType;
-            useUbSize += 2 * rowNum * K * sizeofKType;
-            useUbSize += rowNum * K * sizeof(float);
-            useUbSize += rowNum * sizeof(float);
-            useUbSize += rowNum * ONE_BLOCK_32;
-            
-            if (useUbSize <= ubSize) {
-                break;
-            }
-            rowNum = rowNum / 2;
-            
-        }
-        tiling_.set_kBeteVecRow(rowNum);
-        return ge::GRAPH_SUCCESS;
+        return (value + align - 1) / align * align;
     }
-    ge::graphStatus SetDkbVecRow(uint64_t ubSize, ge::DataType kType, ge::DataType betaType)
-    {
-        uint64_t rowNum = chunkSize / 2;
-        uint64_t sizeofKType = SIZE_FP32;
-        uint64_t sizeofBetaType = SIZE_FP32;
-        if (kType != ge::DataType::DT_FLOAT) {
-            sizeofKType = SIZE_HALF;
-        }
-        if (betaType != ge::DataType::DT_FLOAT) {
-            sizeofBetaType = SIZE_HALF;
-        }
-        while (rowNum >= 8) {
-            uint64_t useUbSize = 0;
-            useUbSize += 2 * rowNum * K * sizeofKType;
-            useUbSize += 2 * rowNum * sizeofBetaType;
-            useUbSize += 2 * rowNum * K * sizeofKType;
-            useUbSize += 2 * rowNum * K * sizeofKType;
-            useUbSize += 2 * rowNum * K * sizeofKType;
-            useUbSize += 2 * rowNum * sizeofBetaType;
-            useUbSize += rowNum * K * sizeof(float);
-            useUbSize += rowNum * K * sizeof(float);
-            useUbSize += rowNum * K * sizeof(float);
-            useUbSize += rowNum * sizeof(float);
-            useUbSize += rowNum * ONE_BLOCK_32;
-            useUbSize += rowNum * ONE_BLOCK_32;
-            
-            if (useUbSize <= ubSize) {
-                break;
-            }
-            rowNum = rowNum / 2;
-        }
-        tiling_.set_dkbVecRow(rowNum);
-        return ge::GRAPH_SUCCESS;
-    }
-    ge::graphStatus SetDkbgVecRow(uint64_t ubSize, ge::DataType kType, ge::DataType betaType)
-    {
-        uint64_t rowNum = chunkSize / 2;
-        uint64_t sizeofKType = SIZE_FP32;
-        uint64_t sizeofBetaType = SIZE_FP32;
-        if (kType != ge::DataType::DT_FLOAT) {
-            sizeofKType = SIZE_HALF;
-        }
-        if (betaType != ge::DataType::DT_FLOAT) {
-            sizeofBetaType = SIZE_HALF;
-        }
-        while (rowNum >= 8) {
-            uint64_t useUbSize = 0;
-            useUbSize += 2 * rowNum * K * sizeofKType;
-            useUbSize += 2 * rowNum * sizeofBetaType;
-            useUbSize += 2 * rowNum * sizeofBetaType;
-            useUbSize += 2 * rowNum * K * sizeofKType;
-            useUbSize += 2 * rowNum * K * sizeofKType;
-            useUbSize += 2 * rowNum * sizeofBetaType;
-            useUbSize += 2 * rowNum * K * sizeofKType;
-            useUbSize += 2 * rowNum * sizeofBetaType;
-            useUbSize += 2 * rowNum * sizeofBetaType;
-            useUbSize += rowNum * K * sizeof(float);
-            useUbSize += rowNum * sizeof(float);
-            useUbSize += rowNum * ONE_BLOCK_32;
-            useUbSize += rowNum * sizeof(float);
-            useUbSize += rowNum * ONE_BLOCK_32;
-            useUbSize += rowNum * K * sizeof(float);
-            useUbSize += rowNum * K * sizeof(float);
-            useUbSize += rowNum * sizeof(float);
-            useUbSize += rowNum * sizeof(float);
-            useUbSize += rowNum * sizeof(float);
-            
-            if (useUbSize <= ubSize) {
-                break;
-            }
-            rowNum = rowNum / 2;
-        }
-        tiling_.set_dkbgVecRow(rowNum);
-        return ge::GRAPH_SUCCESS;
-    }
-    ge::graphStatus SetDvbVecRow(uint64_t ubSize, ge::DataType kType, ge::DataType betaType)
-    {
-        uint64_t rowNum = chunkSize / 2;
-        uint64_t sizeofKType = SIZE_FP32;
-        uint64_t sizeofBetaType = SIZE_FP32;
-        if (kType != ge::DataType::DT_FLOAT) {
-            sizeofKType = SIZE_HALF;
-        }
-        if (betaType != ge::DataType::DT_FLOAT) {
-            sizeofBetaType = SIZE_HALF;
-        }
-        while (rowNum >= 8) {
-            uint64_t useUbSize = 0;
-            useUbSize += 2 * rowNum * V * sizeofKType;
-            useUbSize += 2 * rowNum * sizeofBetaType;
-            useUbSize += 2 * rowNum * sizeofBetaType;
-            useUbSize += 2 * rowNum * V * sizeofKType;
-            useUbSize += 2 * rowNum * V * sizeofKType;
-            useUbSize += 2 * rowNum * sizeofBetaType;
 
-            useUbSize += rowNum * V * sizeof(float);
-            useUbSize += rowNum * V * sizeof(float);
-            useUbSize += rowNum * sizeof(float);
-            useUbSize += rowNum * ONE_BLOCK_32;
-            useUbSize += rowNum * sizeof(float);
-            useUbSize += rowNum * sizeof(float);
-            useUbSize += rowNum * ONE_BLOCK_32;
-            
-            if (useUbSize <= ubSize) {
-                break;
-            }
-            rowNum = rowNum / 2;
-        }
-        tiling_.set_dvbVecRow(rowNum);
-        return ge::GRAPH_SUCCESS;
+    uint64_t GetTypeSize(ge::DataType dtype)
+    {
+        return dtype == ge::DataType::DT_FLOAT ? SIZE_FP32 : SIZE_HALF;
     }
-    ge::graphStatus SetKKTVecRow(uint64_t ubSize, ge::DataType kType, ge::DataType betaType)
+
+    uint64_t GetFusedUseUbSize(uint64_t rowNum, uint64_t ubK, uint64_t ubV, uint64_t sizeofKType)
+    {
+        constexpr uint64_t SAFETY_MARGIN = 16 * 1024;
+        uint64_t persistentBytes = 0;
+        persistentBytes += AlignUp(chunkSize * SIZE_FP32, ONE_BLOCK_32); // beta fp32
+        persistentBytes += AlignUp(chunkSize * SIZE_FP32, ONE_BLOCK_32); // exp(g) fp32
+        persistentBytes += AlignUp(chunkSize * SIZE_FP32, ONE_BLOCK_32); // dbeta accumulator
+        persistentBytes += AlignUp(chunkSize * SIZE_FP32, ONE_BLOCK_32); // dg accumulator
+
+        uint64_t queueBytes = 0;
+        queueBytes += 2 * AlignUp(rowNum * ubK * sizeofKType, ONE_BLOCK_32);
+        queueBytes += 2 * AlignUp(rowNum * ubV * sizeofKType, ONE_BLOCK_32);
+
+        uint64_t group1TempBytes = 0;
+        group1TempBytes += AlignUp(5 * rowNum * K * SIZE_FP32, ONE_BLOCK_32);
+        group1TempBytes += AlignUp(rowNum * ONE_BLOCK_32, ONE_BLOCK_32); // beta brcb
+        group1TempBytes += AlignUp(rowNum * ONE_BLOCK_32, ONE_BLOCK_32); // exp(g) brcb
+        group1TempBytes += AlignUp(rowNum * ONE_BLOCK_32, ONE_BLOCK_32); // reduce scratch
+
+        uint64_t group2VTempBytes = 0;
+        group2VTempBytes += AlignUp(2 * rowNum * V * SIZE_FP32, ONE_BLOCK_32);
+        group2VTempBytes += AlignUp(rowNum * ONE_BLOCK_32, ONE_BLOCK_32);
+
+        uint64_t group2KktTempBytes = 0;
+        group2KktTempBytes += AlignUp(chunkSize * chunkSize * SIZE_FP32, ONE_BLOCK_32);
+        group2KktTempBytes += AlignUp(2 * rowNum * chunkSize * SIZE_FP32, ONE_BLOCK_32);
+        group2KktTempBytes += AlignUp(chunkSize * ONE_BLOCK_32, ONE_BLOCK_32);
+
+        uint64_t maxTempBytes = group1TempBytes > group2VTempBytes ? group1TempBytes : group2VTempBytes;
+        maxTempBytes = maxTempBytes > group2KktTempBytes ? maxTempBytes : group2KktTempBytes;
+        return persistentBytes + queueBytes + maxTempBytes + SAFETY_MARGIN;
+    }
+
+    uint64_t GetFusedRowNum(uint64_t ubSize, ge::DataType kType)
     {
         uint64_t rowNum = chunkSize / 2;
-        uint64_t sizeofKType = SIZE_FP32;
-        uint64_t sizeofBetaType = SIZE_FP32;
-        if (kType != ge::DataType::DT_FLOAT) {
-            sizeofKType = SIZE_HALF;
-        }
-        if (betaType != ge::DataType::DT_FLOAT) {
-            sizeofBetaType = SIZE_HALF;
-        }
+        uint64_t sizeofKType = GetTypeSize(kType);
+        uint64_t ubK = K > chunkSize ? K : chunkSize;
+        uint64_t ubV = V > chunkSize ? V : chunkSize;
         while (rowNum >= 8) {
-            uint64_t useUbSize = 0;
-            useUbSize += 2 * chunkSize * sizeofBetaType;
-            useUbSize += 2 * chunkSize * sizeofBetaType;
-            useUbSize += 2 * rowNum * chunkSize * sizeofKType;
-            useUbSize += 2 * rowNum * chunkSize * sizeofKType;
-            useUbSize += 2 * chunkSize * sizeofBetaType;
-
-            useUbSize += rowNum * chunkSize * sizeof(float);
-            useUbSize += rowNum * chunkSize * sizeof(float);
-            useUbSize += chunkSize * sizeof(float);
-            useUbSize += chunkSize * chunkSize * sizeof(float);
-            useUbSize += chunkSize * ONE_BLOCK_32;
-            
+            uint64_t useUbSize = GetFusedUseUbSize(rowNum, ubK, ubV, sizeofKType);
             if (useUbSize <= ubSize) {
                 break;
             }
             rowNum = rowNum / 2;
         }
-        tiling_.set_kktVecRow(rowNum);
+        return rowNum;
+    }
+
+    ge::graphStatus SetFusedTiling(uint64_t ubSize, ge::DataType kType, uint64_t usedCoreNum)
+    {
+        uint64_t fusedRowNum = GetFusedRowNum(ubSize, kType);
+        tiling_.set_fusedKVecRow(fusedRowNum);
+        tiling_.set_fusedVVecRow(fusedRowNum);
+        tiling_.set_fusedKktVecRow(fusedRowNum);
+        tiling_.set_workspaceBufferCount(2);
+        tiling_.set_usedCoreNum(usedCoreNum);
+
+        uint64_t sizeofKType = GetTypeSize(kType);
+        uint64_t maxKV = K > V ? K : V;
+        uint64_t slotSize = 0;
+        slotSize += 3 * AlignUp(chunkSize * K * sizeofKType, ONE_BLOCK_32);
+        slotSize += AlignUp(chunkSize * maxKV * sizeofKType, ONE_BLOCK_32);
+        slotSize += AlignUp(chunkSize * chunkSize * sizeofKType, ONE_BLOCK_32);
+        tiling_.set_workspaceSlotSize(slotSize);
         return ge::GRAPH_SUCCESS;
     }
     ge::graphStatus CommonTiling()
@@ -382,19 +286,9 @@ public:
         auto kDesc = context_->GetDynamicInputDesc(INPUT_K_IDX, 0);
         OP_CHECK_NULL_WITH_CONTEXT(context_, kDesc); // check xDesc is not null
         auto kDType = kDesc->GetDataType();
-        auto betaDesc = context_->GetDynamicInputDesc(INPUT_BETA_IDX, 0);
-        OP_CHECK_NULL_WITH_CONTEXT(context_, betaDesc); // check xDesc is not null
-        auto betaDType = betaDesc->GetDataType();
-
-        OP_CHECK_IF(SetKBeteVecRow(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS,
-                    OP_LOGE(context_->GetNodeName(), "SetKBeteVecRow Failed."), return ge::GRAPH_FAILED);
-        OP_CHECK_IF(SetDkbVecRow(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS, OP_LOGE(context_->GetNodeName(), "SetDkbVecRow Failed."),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(SetDkbgVecRow(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS, OP_LOGE(context_->GetNodeName(), "SetDkbgVecRow Failed."),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(SetDvbVecRow(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS, OP_LOGE(context_->GetNodeName(), "SetDvbVecRow Failed."),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(SetKKTVecRow(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS, OP_LOGE(context_->GetNodeName(), "SetKKTVecRow Failed."),
+        OP_CHECK_IF(SetFusedTiling(ubSize, kDType, platform_ascendc::PlatformAscendC(context_->GetPlatformInfo()).GetCoreNumAic()) !=
+                        ge::GRAPH_SUCCESS,
+                    OP_LOGE(context_->GetNodeName(), "SetFusedTiling Failed."),
                     return ge::GRAPH_FAILED);
         return ge::GRAPH_SUCCESS;
     }
@@ -489,6 +383,9 @@ static void PrepareWyReprBwdFullTilingDataPrint(gert::TilingContext *context, Pr
     OP_LOGD(nodeName, "=== K: %ld", tiling.get_K());
     OP_LOGD(nodeName, "=== V: %ld", tiling.get_V());
     OP_LOGD(nodeName, "=== chunkSize: %ld", tiling.get_chunkSize());
+    OP_LOGD(nodeName, "=== fusedKVecRow: %ld", tiling.get_fusedKVecRow());
+    OP_LOGD(nodeName, "=== workspaceSlotSize: %ld", tiling.get_workspaceSlotSize());
+    OP_LOGD(nodeName, "=== workspaceBufferCount: %ld", tiling.get_workspaceBufferCount());
     OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Print PrepareWyReprBwdFull tiling data end <<<<<<<<<<<<<<<<");
 }
 
@@ -538,7 +435,8 @@ ge::graphStatus Tiling4PrepareWyReprBwdFull(gert::TilingContext *context)
     context->SetBlockDim(ascendcPlatform.GetCoreNumAic());
 
     uint32_t sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
-    uint32_t userWorkspaceSize = 2 * tiling.get_B() * tiling.get_HV() * tiling.get_T() * tiling.get_V();
+    uint64_t userWorkspaceSize =
+        tiling.get_usedCoreNum() * tiling.get_workspaceBufferCount() * tiling.get_workspaceSlotSize();
     size_t *currentWorkspace = context->GetWorkspaceSizes(1);
     currentWorkspace[0] = userWorkspaceSize + sysWorkspaceSize;
     context->SetScheduleMode(1); // set as batchmod for template using SyncAll

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/prepare_wy_repr_bwd_full_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/prepare_wy_repr_bwd_full_tiling.h
@@ -76,11 +76,12 @@ TILING_DATA_FIELD_DEF(int64_t, K);
 TILING_DATA_FIELD_DEF(int64_t, V);
 TILING_DATA_FIELD_DEF(int64_t, chunkNum);
 TILING_DATA_FIELD_DEF(int64_t, chunkSize);
-TILING_DATA_FIELD_DEF(int64_t, kBeteVecRow); // kBeta计算流程时vector单次处理的行数
-TILING_DATA_FIELD_DEF(int64_t, dkbVecRow);   // dk计算流程时vector单次处理的行数
-TILING_DATA_FIELD_DEF(int64_t, dkbgVecRow);  // dkbg计算流程时vector单次处理的行数
-TILING_DATA_FIELD_DEF(int64_t, dvbVecRow);   // dvb计算流程时vector单次处理的行数
-TILING_DATA_FIELD_DEF(int64_t, kktVecRow);   // kkt计算流程时vector单次处理的行数
+TILING_DATA_FIELD_DEF(int64_t, fusedKVecRow);   // fused K-path vector tile rows
+TILING_DATA_FIELD_DEF(int64_t, fusedVVecRow);   // fused V-path vector tile rows
+TILING_DATA_FIELD_DEF(int64_t, fusedKktVecRow); // fused KKT-path vector tile rows
+TILING_DATA_FIELD_DEF(int64_t, workspaceSlotSize);
+TILING_DATA_FIELD_DEF(int64_t, workspaceBufferCount);
+TILING_DATA_FIELD_DEF(int64_t, usedCoreNum);
 TILING_DATA_FIELD_DEF(int64_t, isVariable);
 END_TILING_DATA_DEF;
 REGISTER_TILING_DATA_CLASS(PrepareWyReprBwdFull, PrepareWyReprBwdFullTilingData)

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full.cpp
@@ -50,10 +50,8 @@ __global__ __aicore__ void prepare_wy_repr_bwd_full(GM_ADDR k, GM_ADDR v, GM_ADD
             PrepareWyReprBwdFullProcess<DTYPE_K, DTYPE_BETA> prepareWyReprBwdFullProcess(
                 k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg, workspace);
 #else
-            PrepareWyReprBwdFullProcess<DTYPE_K, DTYPE_BETA, GemmCubeTileShape<_128, _128, _256>,
-                                        GemmCubeTileShape<_128, _128, _128>>
-                prepareWyReprBwdFullProcess(k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg,
-                                            workspace);
+            PrepareWyReprBwdFullProcess<DTYPE_K, DTYPE_BETA> prepareWyReprBwdFullProcess(
+                k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg, workspace);
 #endif
             prepareWyReprBwdFullProcess.Init(tilingData);
             prepareWyReprBwdFullProcess.Process();
@@ -72,10 +70,8 @@ __global__ __aicore__ void prepare_wy_repr_bwd_full(GM_ADDR k, GM_ADDR v, GM_ADD
             PrepareWyReprBwdFullProcess<DTYPE_K, DTYPE_BETA> prepareWyReprBwdFullProcess(
                 k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg, workspace);
 #else
-            PrepareWyReprBwdFullProcess<DTYPE_K, DTYPE_BETA, GemmCubeTileShape<_128, _256, _256>,
-                                        GemmCubeTileShape<_128, _256, _64>>
-                prepareWyReprBwdFullProcess(k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg,
-                                            workspace);
+            PrepareWyReprBwdFullProcess<DTYPE_K, DTYPE_BETA> prepareWyReprBwdFullProcess(
+                k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg, workspace);
 #endif
             prepareWyReprBwdFullProcess.Init(tilingData);
             prepareWyReprBwdFullProcess.Process();

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full_cube.h
@@ -14,15 +14,20 @@
 
 #ifndef PREPARE_WY_REPR_BWD_FULL_CUBE_H
 #define PREPARE_WY_REPR_BWD_FULL_CUBE_H
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#define CATLASS_ARCH 3510
+#else
 #define CATLASS_ARCH 2201
+#endif
 #include "prepare_wy_repr_bwd_full_common.h"
 #include "catlass/arch/arch.hpp"
 #include "catlass/catlass.hpp"
-#include "catlass/gemm/block/block_mmad.hpp"
 #include "catlass/gemm/block/block_swizzle.hpp"
 #include "catlass/gemm/device/device_gemm.hpp"
 #include "catlass/gemm/dispatch_policy.hpp"
 #include "catlass/gemm/gemm_type.hpp"
+#include "catlass/gemm/tile/tile_copy.hpp"
+#include "catlass/gemm/tile/tile_mmad.hpp"
 #include "catlass/layout/layout.hpp"
 #include "catlass/status.hpp"
 #include "tla/layout.hpp"
@@ -34,48 +39,137 @@ using namespace tla;
 namespace Catlass::Gemm::Kernel {
 
 // Template for Matmul kernel. Compute C = A * B
-template <class BlockMmadBdk_, class BlockMmadBdkb_, class BlockMmadBdkbg_, class BlockMmadBdvb_, class BlockMmadBkkT_>
+template <class ArchTag_, class L1TileShape_, class L0TileShape_, class L1TileShapeDvb_, class L0TileShapeDvb_,
+          class TileCopyDk_, class TileCopyDkb_, class TileCopyDkbg_, class TileCopyDvb_, class TileCopyKKT_>
 class PrepareWyReprBwdFullTla {
 public:
-    using BlockMmadBdk = BlockMmadBdk_;
-    using BlockMmadBdkb = BlockMmadBdkb_;
-    using BlockMmadBdkbg = BlockMmadBdkbg_;
-    using BlockMmadBkkT = BlockMmadBkkT_;
-    using BlockMmadBdvb = BlockMmadBdvb_;
-    using ArchTag = typename BlockMmadBdkb::ArchTag;
-    using BdkL1TileShape = typename BlockMmadBdk::L1TileShape;
-    using BdkbL1TileShape = typename BlockMmadBdkb::L1TileShape;
-    using ElementDA = typename BlockMmadBdk::ElementA;
-    using LayoutDA = typename BlockMmadBdk::LayoutA;
-    using ElementKbeta = typename BlockMmadBdk::ElementB;
-    using LayoutKbeta = typename BlockMmadBdk::LayoutB;
-    using ElementDk = typename BlockMmadBdk::ElementC;
-    using LayoutDk = typename BlockMmadBdk::LayoutC;
+    using ArchTag = ArchTag_;
+    using L1TileShape = L1TileShape_;
+    using L0TileShape = L0TileShape_;
+    using L1TileShapeDvb = L1TileShapeDvb_;
+    using L0TileShapeDvb = L0TileShapeDvb_;
+    using TileCopyDk = TileCopyDk_;
+    using TileCopyDkb = TileCopyDkb_;
+    using TileCopyDkbg = TileCopyDkbg_;
+    using TileCopyDvb = TileCopyDvb_;
+    using TileCopyKKT = TileCopyKKT_;
 
-    using ElementDAT = typename BlockMmadBdkb::ElementA;
-    using LayoutDAT = typename BlockMmadBdkb::LayoutA;
-    using ElementK = typename BlockMmadBdkb::ElementB;
-    using LayoutK = typename BlockMmadBdkb::LayoutB;
-    using ElementDkb = typename BlockMmadBdkb::ElementC;
-    using LayoutDkb = typename BlockMmadBdkb::LayoutC;
+    using ElementDA = typename TileCopyDk::ElementA;
+    using LayoutDA = typename TileCopyDk::LayoutA;
+    using ElementKbeta = typename TileCopyDk::ElementB;
+    using LayoutKbeta = typename TileCopyDk::LayoutB;
+    using ElementDk = ElementDA;
+    using LayoutDk = typename TileCopyDk::LayoutC;
 
-    using ElementAT = typename BlockMmadBdkbg::ElementA;
-    using LayoutAT = typename BlockMmadBdkbg::LayoutA;
-    using ElementDw = typename BlockMmadBdkbg::ElementB;
-    using LayoutDw = typename BlockMmadBdkbg::LayoutB;
-    using ElementDkbg = typename BlockMmadBdkbg::ElementC;
-    using LayoutDkbg = typename BlockMmadBdkbg::LayoutC;
+    using ElementDAT = typename TileCopyDkb::ElementA;
+    using LayoutDAT = typename TileCopyDkb::LayoutA;
+    using ElementK = typename TileCopyDkb::ElementB;
+    using LayoutK = typename TileCopyDkb::LayoutB;
+    using ElementDkb = ElementK;
+    using LayoutDkb = typename TileCopyDkb::LayoutC;
 
-    using ElementDu = typename BlockMmadBdvb::ElementB;
-    using LayoutDu = typename BlockMmadBdvb::LayoutB;
-    using ElementDvb = typename BlockMmadBdvb::ElementC;
-    using LayoutDvb = typename BlockMmadBdvb::LayoutC;
+    using ElementAT = typename TileCopyDkbg::ElementA;
+    using LayoutAT = typename TileCopyDkbg::LayoutA;
+    using ElementDw = typename TileCopyDkbg::ElementB;
+    using LayoutDw = typename TileCopyDkbg::LayoutB;
+    using ElementDkbg = ElementDw;
+    using LayoutDkbg = typename TileCopyDkbg::LayoutC;
 
-    using ElementKT = typename BlockMmadBkkT::ElementB;
-    using LayoutKT = typename BlockMmadBkkT::LayoutB;
-    using ElementKKT = typename BlockMmadBkkT::ElementC;
-    using LayoutKKT = typename BlockMmadBkkT::LayoutC;
-    Arch::CrossCoreFlagWithReverse<> flagAicFinishStore{SYNC_FLAG_2, SYNC_FLAG_3};
+    using ElementDu = typename TileCopyDvb::ElementB;
+    using LayoutDu = typename TileCopyDvb::LayoutB;
+    using ElementDvb = ElementDu;
+    using LayoutDvb = typename TileCopyDvb::LayoutC;
+
+    using ElementKT = typename TileCopyKKT::ElementB;
+    using LayoutKT = typename TileCopyKKT::LayoutB;
+    using ElementKKT = ElementK;
+    using LayoutKKT = typename TileCopyKKT::LayoutC;
+    using ElementAccumulator = typename TileCopyDk::ElementAccumulator;
+
+    using CopyL1ToL0A_DK = typename TileCopyDk::CopyL1ToL0A;
+    using CopyL1ToL0B_DK = typename TileCopyDk::CopyL1ToL0B;
+    using CopyL1ToL0A_Dkb = typename TileCopyDkb::CopyL1ToL0A;
+    using CopyL1ToL0B_Dkb = typename TileCopyDkb::CopyL1ToL0B;
+    using CopyL1ToL0A_Dkbg = typename TileCopyDkbg::CopyL1ToL0A;
+    using CopyL1ToL0B_Dkbg = typename TileCopyDkbg::CopyL1ToL0B;
+    using CopyL1ToL0A_Dvb = typename TileCopyDvb::CopyL1ToL0A;
+    using CopyL1ToL0B_Dvb = typename TileCopyDvb::CopyL1ToL0B;
+    using CopyL1ToL0A_KKT = typename TileCopyKKT::CopyL1ToL0A;
+    using CopyL1ToL0B_KKT = typename TileCopyKKT::CopyL1ToL0B;
+
+    using LayoutTagL1A_DK = typename TileCopyDk::LayoutTagL1A;
+    using LayoutTagL1B_DK = typename TileCopyDk::LayoutTagL1B;
+    using LayoutTagL0A_DK = typename TileCopyDk::LayoutTagL0A;
+    using LayoutTagL0B_DK = typename TileCopyDk::LayoutTagL0B;
+    using LayoutTagL1A_Dkb = typename TileCopyDkb::LayoutTagL1A;
+    using LayoutTagL1B_Dkb = typename TileCopyDkb::LayoutTagL1B;
+    using LayoutTagL0A_Dkb = typename TileCopyDkb::LayoutTagL0A;
+    using LayoutTagL0B_Dkb = typename TileCopyDkb::LayoutTagL0B;
+    using LayoutTagL1A_Dkbg = typename TileCopyDkbg::LayoutTagL1A;
+    using LayoutTagL1B_Dkbg = typename TileCopyDkbg::LayoutTagL1B;
+    using LayoutTagL0A_Dkbg = typename TileCopyDkbg::LayoutTagL0A;
+    using LayoutTagL0B_Dkbg = typename TileCopyDkbg::LayoutTagL0B;
+    using LayoutTagL1A_Dvb = typename TileCopyDvb::LayoutTagL1A;
+    using LayoutTagL1B_Dvb = typename TileCopyDvb::LayoutTagL1B;
+    using LayoutTagL0A_Dvb = typename TileCopyDvb::LayoutTagL0A;
+    using LayoutTagL0B_Dvb = typename TileCopyDvb::LayoutTagL0B;
+    using LayoutTagL1A_KKT = typename TileCopyKKT::LayoutTagL1A;
+    using LayoutTagL1B_KKT = typename TileCopyKKT::LayoutTagL1B;
+    using LayoutTagL0A_KKT = typename TileCopyKKT::LayoutTagL0A;
+    using LayoutTagL0B_KKT = typename TileCopyKKT::LayoutTagL0B;
+
+    static constexpr uint32_t TILE_M = tla::get<0>(L0TileShape{});
+    static constexpr uint32_t TILE_N = tla::get<1>(L0TileShape{});
+    static constexpr uint32_t TILE_K = tla::get<2>(L0TileShape{});
+    static constexpr uint32_t TILE_M_DVB = tla::get<0>(L0TileShapeDvb{});
+    static constexpr uint32_t TILE_N_DVB = tla::get<1>(L0TileShapeDvb{});
+    static constexpr uint32_t TILE_K_DVB = tla::get<2>(L0TileShapeDvb{});
+    static constexpr auto L1A_LAYOUT_DK =
+        tla::MakeLayout<ElementDA, LayoutTagL1A_DK>(tla::Int<TILE_M>{}, tla::Int<TILE_K>{});
+    static constexpr auto L1B_LAYOUT_DK =
+        tla::MakeLayout<ElementKbeta, LayoutTagL1B_DK>(tla::Int<TILE_K>{}, tla::Int<TILE_N>{});
+    static constexpr auto L1A_LAYOUT_Dkb =
+        tla::MakeLayout<ElementDAT, LayoutTagL1A_Dkb>(tla::Int<TILE_M>{}, tla::Int<TILE_K>{});
+    static constexpr auto L1B_LAYOUT_Dkb =
+        tla::MakeLayout<ElementK, LayoutTagL1B_Dkb>(tla::Int<TILE_K>{}, tla::Int<TILE_N>{});
+    static constexpr auto L1A_LAYOUT_Dkbg =
+        tla::MakeLayout<ElementAT, LayoutTagL1A_Dkbg>(tla::Int<TILE_M>{}, tla::Int<TILE_K>{});
+    static constexpr auto L1B_LAYOUT_Dkbg =
+        tla::MakeLayout<ElementDw, LayoutTagL1B_Dkbg>(tla::Int<TILE_K>{}, tla::Int<TILE_N>{});
+    static constexpr auto L1A_LAYOUT_Dvb =
+        tla::MakeLayout<ElementAT, LayoutTagL1A_Dvb>(tla::Int<TILE_M_DVB>{}, tla::Int<TILE_K_DVB>{});
+    static constexpr auto L1B_LAYOUT_Dvb =
+        tla::MakeLayout<ElementDu, LayoutTagL1B_Dvb>(tla::Int<TILE_K_DVB>{}, tla::Int<TILE_N_DVB>{});
+    static constexpr auto L1A_LAYOUT_KKT =
+        tla::MakeLayout<ElementK, LayoutTagL1A_KKT>(tla::Int<TILE_M>{}, tla::Int<TILE_K>{});
+    static constexpr auto L1B_LAYOUT_KKT =
+        tla::MakeLayout<ElementKT, LayoutTagL1B_KKT>(tla::Int<TILE_K>{}, tla::Int<TILE_N>{});
+
+    static constexpr uint32_t L1A_TILE_SIZE_DK = TILE_M * TILE_K * sizeof(ElementDA);
+    static constexpr uint32_t L1B_TILE_SIZE_DK = TILE_K * TILE_N * sizeof(ElementKbeta);
+    static constexpr uint32_t L1A_TILE_SIZE_Dkb = TILE_M * TILE_K * sizeof(ElementDAT);
+    static constexpr uint32_t L1B_TILE_SIZE_Dkb = TILE_K * TILE_N * sizeof(ElementK);
+    static constexpr uint32_t L1A_TILE_SIZE_Dkbg = TILE_M * TILE_K * sizeof(ElementAT);
+    static constexpr uint32_t L1B_TILE_SIZE_Dkbg = TILE_K * TILE_N * sizeof(ElementDw);
+    static constexpr uint32_t L1A_TILE_SIZE_Dvb = TILE_M_DVB * TILE_K_DVB * sizeof(ElementAT);
+    static constexpr uint32_t L1B_TILE_SIZE_Dvb = TILE_K_DVB * TILE_N_DVB * sizeof(ElementDu);
+    static constexpr uint32_t L1A_TILE_SIZE_KKT = TILE_M * TILE_K * sizeof(ElementK);
+    static constexpr uint32_t L1B_TILE_SIZE_KKT = TILE_K * TILE_N * sizeof(ElementKT);
+
+    using TileMmadDK = Tile::TileMmadTla<ArchTag, ElementDA, LayoutTagL1A_DK>;
+    using TileMmadDkb = Tile::TileMmadTla<ArchTag, ElementDAT, LayoutTagL1A_Dkb>;
+    using TileMmadDkbg = Tile::TileMmadTla<ArchTag, ElementAT, LayoutTagL1A_Dkbg>;
+    using TileMmadDvb = Tile::TileMmadTla<ArchTag, ElementAT, LayoutTagL1A_Dvb>;
+    using TileMmadKKT = Tile::TileMmadTla<ArchTag, ElementK, LayoutTagL1A_KKT>;
+
+    // AIC -> AIV has five ready events in one (chunk, head):
+    //   1. Dkb  = dA^T @ K
+    //   2. Dkbg = A^T @ dw
+    //   3. DK   = dA @ Kbeta
+    //   4. Dvb  = A^T @ du
+    //   5. KKT  = K @ K^T
+    // AIV -> AIC has one event: Kbeta = K * beta[:, None] is ready.
+    Arch::CrossCoreFlagWithReverse<5> flagAicFinishStore{SYNC_FLAG_2, SYNC_FLAG_3};
     Arch::CrossCoreFlagWithReverse<> flagAivFinishStore{SYNC_FLAG_4, SYNC_FLAG_5};
     /// Parameters structure
     struct Params {
@@ -97,7 +191,7 @@ public:
         GM_ADDR ptrDw;
         LayoutDw layoutDw;
         GM_ADDR ptrDkbg;
-        LayoutDw layoutDkbg;
+        LayoutDkbg layoutDkbg;
         GM_ADDR ptrDu;
         LayoutDu layoutDu;
         GM_ADDR ptrDvb;
@@ -111,12 +205,18 @@ public:
         uint64_t chunkNum;
         uint64_t B = 1;
         uint64_t T = 32768;
-        uint64_t HK = 32;
         uint64_t HV = 32;
+        uint64_t HK = 32;
         uint64_t K = 128;
         uint64_t V = 128;
         uint64_t chunkSize = 64;
         uint64_t stage = 2;
+        uint64_t fusedKVecRow = 0;
+        uint64_t fusedVVecRow = 0;
+        uint64_t fusedKktVecRow = 0;
+        uint64_t workspaceSlotSize = 0;
+        uint64_t workspaceBufferCount = 1;
+        uint64_t usedCoreNum = 0;
 
         // Methods
         CATLASS_DEVICE
@@ -126,19 +226,24 @@ public:
 
         CATLASS_DEVICE
         Params(GM_ADDR ptrptrKbeta_, LayoutKbeta layoutKbeta_, GM_ADDR ptrDA_, LayoutDA layoutDA_, GM_ADDR ptrDk_,
-               LayoutKbeta layoutDk_, GM_ADDR ptrDAT_, LayoutDAT layoutDAT_, GM_ADDR ptrK_, LayoutK layoutK_,
+               LayoutDk layoutDk_, GM_ADDR ptrDAT_, LayoutDAT layoutDAT_, GM_ADDR ptrK_, LayoutK layoutK_,
                GM_ADDR ptrDkb_, LayoutDkb layoutDkb_, GM_ADDR ptrAT_, LayoutAT layoutAT_, GM_ADDR ptrDw_,
-               LayoutDw layoutDw_, GM_ADDR ptrDkbg_, LayoutDkbg layoutDkbg_, GM_ADDR ptrDu_, LayoutDkbg layoutDu_,
-               GM_ADDR ptrDvb_, LayoutDkbg layoutDvb_, GM_ADDR ptrKT_, LayoutKT layoutKT_, GM_ADDR ptrKKT_,
+               LayoutDw layoutDw_, GM_ADDR ptrDkbg_, LayoutDkbg layoutDkbg_, GM_ADDR ptrDu_, LayoutDu layoutDu_,
+               GM_ADDR ptrDvb_, LayoutDvb layoutDvb_, GM_ADDR ptrKT_, LayoutKT layoutKT_, GM_ADDR ptrKKT_,
                LayoutKKT layoutKKT_, GM_ADDR ptrCuSeqLens_, GM_ADDR ptrChunkIndices_, uint64_t chunkNum_, uint64_t B_,
-               uint64_t T_, uint64_t HK_, uint64_t HV_, uint64_t K_, uint64_t V_, uint64_t BT_, uint64_t stage_)
+               uint64_t T_, uint64_t HV_, uint64_t HK_, uint64_t K_, uint64_t V_, uint64_t BT_, uint64_t stage_,
+               uint64_t fusedKVecRow_, uint64_t fusedVVecRow_, uint64_t fusedKktVecRow_,
+               uint64_t workspaceSlotSize_, uint64_t workspaceBufferCount_, uint64_t usedCoreNum_)
             : ptrKbeta(ptrptrKbeta_), layoutKbeta(layoutKbeta_), ptrDA(ptrDA_), layoutDA(layoutDA_), ptrDk(ptrDk_),
               layoutDk(layoutDk_), ptrDAT(ptrDAT_), layoutDAT(layoutDAT_), ptrK(ptrK_), layoutK(layoutK_),
               ptrDkb(ptrDkb_), layoutDkb(layoutDkb_), ptrAT(ptrAT_), layoutAT(layoutAT_), ptrDw(ptrDw_),
               layoutDw(layoutDw_), ptrDkbg(ptrDkbg_), layoutDkbg(layoutDkbg_), ptrDu(ptrDu_), layoutDu(layoutDu_),
-              ptrDvb(ptrDvb_), layoutDvb(layoutDvb_), ptrKT(ptrKT_), layoutKT(layoutKT_), ptrKKT(ptrKKT_),
-              layoutKKT(layoutKKT_), ptrCuSeqLens(ptrCuSeqLens_), ptrChunkIndices(ptrChunkIndices_),
-              chunkNum(chunkNum_), B(B_), T(T_), HK(HK_), HV(HV_), K(K_), V(V_), chunkSize(BT_), stage(stage_)
+               ptrDvb(ptrDvb_), layoutDvb(layoutDvb_), ptrKT(ptrKT_), layoutKT(layoutKT_), ptrKKT(ptrKKT_),
+               layoutKKT(layoutKKT_), ptrCuSeqLens(ptrCuSeqLens_), ptrChunkIndices(ptrChunkIndices_),
+               chunkNum(chunkNum_), B(B_), T(T_), HV(HV_), HK(HK_), K(K_), V(V_), chunkSize(BT_), stage(stage_),
+               fusedKVecRow(fusedKVecRow_), fusedVVecRow(fusedVVecRow_), fusedKktVecRow(fusedKktVecRow_),
+               workspaceSlotSize(workspaceSlotSize_), workspaceBufferCount(workspaceBufferCount_),
+              usedCoreNum(usedCoreNum_)
         {
         }
     };
@@ -161,190 +266,517 @@ public:
         uint32_t coreLoops = params.chunkNum;
         uint32_t bos = 0;
         uint32_t eos = 0;
-        { //处理第一部分cube DA @ Kbeta     V->C
-            BlockMmadBdk blockMmadBdk(resource);
-            AscendC::GlobalTensor<ElementDA> gmDA;
-            AscendC::GlobalTensor<ElementKbeta> gmKbeta;
-            AscendC::GlobalTensor<ElementDk> gmDk;
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
-                               params.chunkSize, loopIdx, bos, eos);
-                uint32_t curChunkSize = eos - bos;
-                GemmCoord blockCoord{0, 0, 0};
-                GemmCoord actualBlockShape{curChunkSize, static_cast<uint32_t>(params.K), curChunkSize};
-                for (int h = 0; h < params.HV; h++) {
-                    // Represent the full gm
-                    gmDA.SetGlobalBuffer((__gm__ ElementDA *)params.ptrDA + (h * params.T + bos) * params.chunkSize);
-                    gmKbeta.SetGlobalBuffer((__gm__ ElementKbeta *)params.ptrKbeta + (h * params.T + bos) * params.K);
-                    gmDk.SetGlobalBuffer((__gm__ ElementDk *)params.ptrDk + (h * params.T + bos) * params.K);
 
-                    // Represent the full tensors
-                    auto tensorDA = tla::MakeTensor(gmDA, params.layoutDA, Arch::PositionGM{});
-                    auto tensorKbeta = tla::MakeTensor(gmKbeta, params.layoutKbeta, Arch::PositionGM{});
-                    auto tensorDk = tla::MakeTensor(gmDk, params.layoutDk, Arch::PositionGM{});
+        // These byte sizes define the same workspace slot layout as tiling.cpp
+        // and vector.h.  Every AIC core owns workspaceBufferCount slots; the
+        // slots are ping-ponged by taskIdx so AIC can start the next task while
+        // AIV still consumes the previous task's intermediates.
+        uint64_t kBytes = ((params.chunkSize * params.K * sizeof(ElementK) + ONE_BLOCK_32 - 1) / ONE_BLOCK_32) * ONE_BLOCK_32;
+        uint64_t vBytes = ((params.chunkSize * params.V * sizeof(ElementK) + ONE_BLOCK_32 - 1) / ONE_BLOCK_32) * ONE_BLOCK_32;
+        uint64_t maxKVBytes = kBytes > vBytes ? kBytes : vBytes;
+        uint64_t kktBytes = ((params.chunkSize * params.chunkSize * sizeof(ElementK) + ONE_BLOCK_32 - 1) / ONE_BLOCK_32) * ONE_BLOCK_32;
+        (void)kktBytes;
 
-                    Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_FIX>(flagAivFinishStore);
-                    // Make tiled views
-                    auto tensorBlockDA = GetTile(tensorDA, tla::MakeCoord(0, 0),
-                                                 tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockKbeta = GetTile(tensorKbeta, tla::MakeCoord(0, 0),
-                                                    tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDk = GetTile(tensorDk, tla::MakeCoord(0, 0),
-                                                 tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    // Compute block-scoped matrix multiply-add
-                    blockMmadBdk(tensorBlockDA, tensorBlockKbeta, tensorBlockDk, actualBlockShape);
-                }
+        AscendC::GlobalTensor<ElementDA> gmDA;
+        AscendC::GlobalTensor<ElementDAT> gmDAT;
+        AscendC::GlobalTensor<ElementAT> gmAT;
+        AscendC::GlobalTensor<ElementK> gmK;
+        AscendC::GlobalTensor<ElementKT> gmKT;
+        AscendC::GlobalTensor<ElementKbeta> gmKbeta;
+        AscendC::GlobalTensor<ElementDw> gmDw;
+        AscendC::GlobalTensor<ElementDu> gmDu;
+        AscendC::GlobalTensor<ElementDk> gmDK;
+        AscendC::GlobalTensor<ElementDkb> gmDkb;
+        AscendC::GlobalTensor<ElementDkbg> gmDkbg;
+        AscendC::GlobalTensor<ElementDvb> gmDvb;
+        AscendC::GlobalTensor<ElementKKT> gmKKT;
+        uint64_t l1Offset = 0;
+        auto l1ADkb = resource.l1Buf.template GetBufferByByte<ElementDAT>(l1Offset);
+        l1Offset += L1A_TILE_SIZE_Dkb;
+        auto l1BDkb = resource.l1Buf.template GetBufferByByte<ElementK>(l1Offset);
+        l1Offset += L1B_TILE_SIZE_Dkb;
+        auto l1ADkbg = resource.l1Buf.template GetBufferByByte<ElementAT>(l1Offset);
+        l1Offset += L1A_TILE_SIZE_Dkbg;
+        auto l1BDkbg = resource.l1Buf.template GetBufferByByte<ElementDw>(l1Offset);
+        l1Offset += L1B_TILE_SIZE_Dkbg;
+        auto l1ADK = resource.l1Buf.template GetBufferByByte<ElementDA>(l1Offset);
+        l1Offset += L1A_TILE_SIZE_DK;
+        auto l1BDK = resource.l1Buf.template GetBufferByByte<ElementKbeta>(l1Offset);
+        l1Offset += L1B_TILE_SIZE_DK;
+        auto l1ADvb = resource.l1Buf.template GetBufferByByte<ElementAT>(l1Offset);
+        l1Offset += L1A_TILE_SIZE_Dvb;
+        auto l1BDvb = resource.l1Buf.template GetBufferByByte<ElementDu>(l1Offset);
+        l1Offset += L1B_TILE_SIZE_Dvb;
+        auto l1AKKT = resource.l1Buf.template GetBufferByByte<ElementK>(l1Offset);
+        l1Offset += L1A_TILE_SIZE_KKT;
+        auto l1BKKT = resource.l1Buf.template GetBufferByByte<ElementKT>(l1Offset);
+
+        auto l0ADkb = resource.l0ABuf.template GetBufferByByte<ElementDAT>(0);
+        auto l0BDkb = resource.l0BBuf.template GetBufferByByte<ElementK>(0);
+        auto l0ADkbg = resource.l0ABuf.template GetBufferByByte<ElementAT>(0);
+        auto l0BDkbg = resource.l0BBuf.template GetBufferByByte<ElementDw>(0);
+        auto l0ADK = resource.l0ABuf.template GetBufferByByte<ElementDA>(0);
+        auto l0BDK = resource.l0BBuf.template GetBufferByByte<ElementKbeta>(0);
+        auto l0ADvb = resource.l0ABuf.template GetBufferByByte<ElementAT>(0);
+        auto l0BDvb = resource.l0BBuf.template GetBufferByByte<ElementDu>(0);
+        auto l0AKKT = resource.l0ABuf.template GetBufferByByte<ElementK>(0);
+        auto l0BKKT = resource.l0BBuf.template GetBufferByByte<ElementKT>(0);
+        auto l0CBuf = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(0);
+
+        CopyL1ToL0A_Dkb copyL1ToL0A_Dkb;
+        CopyL1ToL0B_Dkb copyL1ToL0B_Dkb;
+        CopyL1ToL0A_Dkbg copyL1ToL0A_Dkbg;
+        CopyL1ToL0B_Dkbg copyL1ToL0B_Dkbg;
+        CopyL1ToL0A_DK copyL1ToL0A_DK;
+        CopyL1ToL0B_DK copyL1ToL0B_DK;
+        CopyL1ToL0A_Dvb copyL1ToL0A_Dvb;
+        CopyL1ToL0B_Dvb copyL1ToL0B_Dvb;
+        CopyL1ToL0A_KKT copyL1ToL0A_KKT;
+        CopyL1ToL0B_KKT copyL1ToL0B_KKT;
+        TileMmadDkb tileMmadDkb;
+        TileMmadDkbg tileMmadDkbg;
+        TileMmadDK tileMmadDK;
+        TileMmadDvb tileMmadDvb;
+        TileMmadKKT tileMmadKKT;
+        constexpr int32_t EVENT_L1A = 0;
+        constexpr int32_t EVENT_L1B = 1;
+        constexpr int32_t EVENT_L0A = 0;
+        constexpr int32_t EVENT_L0B = 1;
+        constexpr int32_t EVENT_L0C = 0;
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1A);
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1B);
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0A);
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0B);
+        AscendC::SetFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
+
+        // Outer loop slices chunks across AIC cores.  Inner loop traverses all
+        // heads for the current chunk, so all AIC/AIV stages are completed for
+        // one (chunk, head) before moving to the next head.
+        uint64_t taskIdx = 0;
+        for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
+            GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
+                           params.chunkSize, loopIdx, bos, eos);
+            uint32_t curChunkSize = eos - bos;
+            GemmCoord shapeK{curChunkSize, static_cast<uint32_t>(params.K), curChunkSize};
+            GemmCoord shapeV{curChunkSize, static_cast<uint32_t>(params.V), curChunkSize};
+            GemmCoord shapeKKT{curChunkSize, curChunkSize, static_cast<uint32_t>(params.K)};
+            // GQA: value heads are grouped onto key heads, so k/dk use HK layout
+            // while A/dA/dw/du/beta/g/dv/dbeta/dg keep HV layout.
+            uint64_t keyBos = bos;
+            if (params.ptrCuSeqLens == nullptr && params.HV != params.HK) {
+                uint64_t batchIdx = bos / (params.HV * params.T);
+                uint64_t timeBos = bos - batchIdx * params.HV * params.T;
+                keyBos = batchIdx * params.HK * params.T + timeBos;
             }
-        }
-        AscendC::SyncAll<false>();
-        { //处理第二部分 DAT@K -> DKB
-            BlockMmadBdkb blockMmadBdkb(resource);
-            AscendC::GlobalTensor<ElementDAT> gmDAT;
-            AscendC::GlobalTensor<ElementK> gmK;
-            AscendC::GlobalTensor<ElementDkb> gmDkb;
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
-                               params.chunkSize, loopIdx, bos, eos);
-                uint32_t curChunkSize = eos - bos;
-                GemmCoord blockCoord{0, 0, 0};
-                GemmCoord actualBlockShape{curChunkSize, static_cast<uint32_t>(params.K), curChunkSize};
-                for (int h = 0; h < params.HV; h++) {
-                    // Represent the full gm
-                    gmDAT.SetGlobalBuffer((__gm__ ElementDAT *)params.ptrDAT + (h * params.T + bos) * params.chunkSize);
-                    gmK.SetGlobalBuffer((__gm__ ElementK *)params.ptrK + (h * params.T + bos) * params.K);
-                    gmDkb.SetGlobalBuffer((__gm__ ElementDkb *)params.ptrDkb + (h * params.T + bos) * params.K);
+            uint64_t headRatio = params.HV / params.HK;
 
-                    // Represent the full tensors
-                    auto tensorDAT = tla::MakeTensor(gmDAT, params.layoutDAT, Arch::PositionGM{});
-                    auto tensorK = tla::MakeTensor(gmK, params.layoutK, Arch::PositionGM{});
-                    auto tensorDkb = tla::MakeTensor(gmDkb, params.layoutDkb, Arch::PositionGM{});
+            for (int h = 0; h < params.HV; h++) {
+                uint64_t kh = h / headRatio;
+                uint64_t valueBase = h * params.T + bos;
+                uint64_t keyBase = kh * params.T + keyBos;
+                // Per-task workspace layout:
+                //   slotDK        : DK   = dA @ Kbeta
+                //   slotDkb       : Dkb  = dA^T @ K
+                //   slotDkbg      : Dkbg = A^T @ dw
+                //   slotKbetaDvb  : first Kbeta, later reused as Dvb = A^T @ du
+                //   slotKKT       : KKT  = K @ K^T
+                uint64_t workspaceBufferIdx = taskIdx % params.workspaceBufferCount;
+                uint64_t slotBaseBytes =
+                    (coreIdx * params.workspaceBufferCount + workspaceBufferIdx) * params.workspaceSlotSize;
+                uint64_t slotDK = slotBaseBytes / sizeof(ElementK);
+                uint64_t slotDkb = (slotBaseBytes + kBytes) / sizeof(ElementK);
+                uint64_t slotDkbg = (slotBaseBytes + 2 * kBytes) / sizeof(ElementK);
+                uint64_t slotKbetaDvb = (slotBaseBytes + 3 * kBytes) / sizeof(ElementK);
+                uint64_t slotKKT = (slotBaseBytes + 3 * kBytes + maxKVBytes) / sizeof(ElementK);
+                ++taskIdx;
 
-                    // Make tiled views
-                    auto tensorBlockDAT = GetTile(tensorDAT, tla::MakeCoord(0, 0),
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0),
-                                                tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDkb = GetTile(tensorDkb, tla::MakeCoord(0, 0),
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    // Compute block-scoped matrix multiply-add
-                    blockMmadBdkb(tensorBlockDAT, tensorBlockK, tensorBlockDkb, actualBlockShape);
+                gmDK.SetGlobalBuffer((__gm__ ElementDk *)params.ptrKbeta + slotDK);
+                gmDkb.SetGlobalBuffer((__gm__ ElementDkb *)params.ptrKbeta + slotDkb);
+                gmDkbg.SetGlobalBuffer((__gm__ ElementDkbg *)params.ptrKbeta + slotDkbg);
+                gmKbeta.SetGlobalBuffer((__gm__ ElementKbeta *)params.ptrKbeta + slotKbetaDvb);
+                gmDvb.SetGlobalBuffer((__gm__ ElementDvb *)params.ptrKbeta + slotKbetaDvb);
+                gmKKT.SetGlobalBuffer((__gm__ ElementKKT *)params.ptrKbeta + slotKKT);
+
+                gmDA.SetGlobalBuffer((__gm__ ElementDA *)params.ptrDA + valueBase * params.chunkSize);
+                gmDAT.SetGlobalBuffer((__gm__ ElementDAT *)params.ptrDAT + valueBase * params.chunkSize);
+                gmAT.SetGlobalBuffer((__gm__ ElementAT *)params.ptrAT + valueBase * params.chunkSize);
+                gmK.SetGlobalBuffer((__gm__ ElementK *)params.ptrK + keyBase * params.K);
+                gmKT.SetGlobalBuffer((__gm__ ElementKT *)params.ptrKT + keyBase * params.K);
+                gmDw.SetGlobalBuffer((__gm__ ElementDw *)params.ptrDw + valueBase * params.K);
+                gmDu.SetGlobalBuffer((__gm__ ElementDu *)params.ptrDu + valueBase * params.V);
+
+                auto tensorDA = tla::MakeTensor(gmDA, params.layoutDA, Arch::PositionGM{});
+                auto tensorDAT = tla::MakeTensor(gmDAT, params.layoutDAT, Arch::PositionGM{});
+                auto tensorAT = tla::MakeTensor(gmAT, params.layoutAT, Arch::PositionGM{});
+                auto tensorK = tla::MakeTensor(gmK, params.layoutK, Arch::PositionGM{});
+                auto tensorKT = tla::MakeTensor(gmKT, params.layoutKT, Arch::PositionGM{});
+                auto tensorKbeta = tla::MakeTensor(gmKbeta, params.layoutKbeta, Arch::PositionGM{});
+                auto tensorDw = tla::MakeTensor(gmDw, params.layoutDw, Arch::PositionGM{});
+                auto tensorDu = tla::MakeTensor(gmDu, params.layoutDu, Arch::PositionGM{});
+                auto tensorDK = tla::MakeTensor(gmDK, params.layoutDk, Arch::PositionGM{});
+                auto tensorDkb = tla::MakeTensor(gmDkb, params.layoutDkb, Arch::PositionGM{});
+                auto tensorDkbg = tla::MakeTensor(gmDkbg, params.layoutDkbg, Arch::PositionGM{});
+                auto tensorDvb = tla::MakeTensor(gmDvb, params.layoutDvb, Arch::PositionGM{});
+                auto tensorKKT = tla::MakeTensor(gmKKT, params.layoutKKT, Arch::PositionGM{});
+
+                // Stage C1 prepares the first two independent GEMMs:
+                //   Dkb  = dA^T @ K
+                //   Dkbg = A^T @ dw
+                // They do not depend on Kbeta, so AIC can compute them while
+                // AIV is generating Kbeta.
+                auto tensorBlockDAT = GetTile(tensorDAT, tla::MakeCoord(0, 0),
+                                               tla::MakeShape(shapeK.m(), shapeK.k()));
+                auto tensorBlockKForDkb = GetTile(tensorK, tla::MakeCoord(0, 0),
+                                                  tla::MakeShape(shapeK.k(), shapeK.n()));
+                auto tensorBlockDkb = GetTile(tensorDkb, tla::MakeCoord(0, 0),
+                                               tla::MakeShape(shapeK.m(), shapeK.n()));
+                auto tensorBlockATForDkbg = GetTile(tensorAT, tla::MakeCoord(0, 0),
+                                                   tla::MakeShape(shapeK.m(), shapeK.k()));
+                auto tensorBlockDw = GetTile(tensorDw, tla::MakeCoord(0, 0),
+                                             tla::MakeShape(shapeK.k(), shapeK.n()));
+                auto tensorBlockDkbg = GetTile(tensorDkbg, tla::MakeCoord(0, 0),
+                                               tla::MakeShape(shapeK.m(), shapeK.n()));
+                auto tensorBlockDA = GetTile(tensorDA, tla::MakeCoord(0, 0),
+                                             tla::MakeShape(shapeK.m(), shapeK.k()));
+                auto tensorBlockKbeta = GetTile(tensorKbeta, tla::MakeCoord(0, 0),
+                                                 tla::MakeShape(shapeK.k(), shapeK.n()));
+                auto tensorBlockDK = GetTile(tensorDK, tla::MakeCoord(0, 0),
+                                               tla::MakeShape(shapeK.m(), shapeK.n()));
+                using CopyGmToL1A_Dkb = typename TileCopyDkb::template CopyGmToL1A<decltype(tensorBlockDAT)>;
+                using CopyGmToL1B_Dkb = typename TileCopyDkb::template CopyGmToL1B<decltype(tensorBlockKForDkb)>;
+                using CopyGmToL1A_DK = typename TileCopyDk::template CopyGmToL1A<decltype(tensorBlockDA)>;
+#if (defined(CATLASS_ARCH) && CATLASS_ARCH == 3510)
+                using CopyL0CToGm_Dkb = typename TileCopyDkb::template CopyL0CToDst<decltype(tensorBlockDkb)>;
+#else
+                using CopyL0CToGm_Dkb = typename TileCopyDkb::template CopyL0CToGm<decltype(tensorBlockDkb)>;
+#endif
+                using CopyGmToL1A_Dkbg = typename TileCopyDkbg::template CopyGmToL1A<decltype(tensorBlockATForDkbg)>;
+                using CopyGmToL1B_Dkbg = typename TileCopyDkbg::template CopyGmToL1B<decltype(tensorBlockDw)>;
+#if (defined(CATLASS_ARCH) && CATLASS_ARCH == 3510)
+                using CopyL0CToGm_Dkbg = typename TileCopyDkbg::template CopyL0CToDst<decltype(tensorBlockDkbg)>;
+#else
+                using CopyL0CToGm_Dkbg = typename TileCopyDkbg::template CopyL0CToGm<decltype(tensorBlockDkbg)>;
+#endif
+                CopyGmToL1A_Dkb copyGmToL1A_Dkb;
+                CopyGmToL1B_Dkb copyGmToL1B_Dkb;
+                CopyL0CToGm_Dkb copyL0CToGm_Dkb;
+                CopyGmToL1A_DK copyGmToL1A_DK;
+                CopyGmToL1A_Dkbg copyGmToL1A_Dkbg;
+                CopyGmToL1B_Dkbg copyGmToL1B_Dkbg;
+                CopyL0CToGm_Dkbg copyL0CToGm_Dkbg;
+                auto tensorL1A_Dkb = tla::MakeTensor(l1ADkb, L1A_LAYOUT_Dkb, Arch::PositionL1{});
+                auto tensorL1B_Dkb = tla::MakeTensor(l1BDkb, L1B_LAYOUT_Dkb, Arch::PositionL1{});
+                auto tensorL1A_Dkbg = tla::MakeTensor(l1ADkbg, L1A_LAYOUT_Dkbg, Arch::PositionL1{});
+                auto tensorL1B_Dkbg = tla::MakeTensor(l1BDkbg, L1B_LAYOUT_Dkbg, Arch::PositionL1{});
+
+                // Dkb dataflow:
+                //   GM(dA^T, K) -> L1 -> L0A/L0B -> MMAD -> L0C -> GM(slotDkb)
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1A);
+                copyGmToL1A_Dkb(tensorL1A_Dkb, tensorBlockDAT);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1A);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1B);
+                copyGmToL1B_Dkb(tensorL1B_Dkb, tensorBlockKForDkb);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1B);
+                uint32_t mActualDkb = shapeK.m();
+                if constexpr (std::is_same_v<ArchTag, Arch::AtlasA2>) {
+                    if (mActualDkb == 1) {
+                        mActualDkb = 16;
+                    }
+                }
+                auto layoutL0A_Dkb = tla::MakeLayout<ElementDAT, LayoutTagL0A_Dkb>(mActualDkb, shapeK.k());
+                auto tensorL0A_Dkb = tla::MakeTensor(l0ADkb, layoutL0A_Dkb, Arch::PositionL0A{});
+                auto tensorTileL1A_Dkb = GetTile(tensorL1A_Dkb, tla::MakeCoord(0, 0),
+                                                 tla::MakeShape(mActualDkb, shapeK.k()));
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1A);
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0A);
+                copyL1ToL0A_Dkb(tensorL0A_Dkb, tensorTileL1A_Dkb);
+                AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1A);
+                auto layoutL0B_Dkb = tla::MakeLayout<ElementK, LayoutTagL0B_Dkb>(shapeK.k(), shapeK.n());
+                auto tensorL0B_Dkb = tla::MakeTensor(l0BDkb, layoutL0B_Dkb, Arch::PositionL0B{});
+                auto tensorTileL1B_Dkb = GetTile(tensorL1B_Dkb, tla::MakeCoord(0, 0),
+                                                 tla::MakeShape(shapeK.k(), shapeK.n()));
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1B);
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0B);
+                copyL1ToL0B_Dkb(tensorL0B_Dkb, tensorTileL1B_Dkb);
+                AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1B);
+                AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(EVENT_L0C);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1A);
+                copyGmToL1A_Dkbg(tensorL1A_Dkbg, tensorBlockATForDkbg);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1A);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1B);
+                copyGmToL1B_Dkbg(tensorL1B_Dkbg, tensorBlockDw);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1B);
+                auto layoutL0C_Dkb = tla::MakeLayoutL0C(mActualDkb, shapeK.n());
+                auto tensorL0C_Dkb = tla::MakeTensor(l0CBuf, layoutL0C_Dkb, Arch::PositionL0C{});
+                auto tensorTileL0C_Dkb = GetTile(tensorL0C_Dkb, tla::MakeCoord(0, 0),
+                                                 tla::MakeShape(mActualDkb, shapeK.n()));
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(EVENT_L0C);
+                AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
+                tileMmadDkb(tensorTileL0C_Dkb, tensorL0A_Dkb, tensorL0B_Dkb, true, 0b11);
+                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0A);
+                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0B);
+                AscendC::SetFlag<AscendC::HardEvent::M_FIX>(EVENT_L0C);
+
+                {
+                    // While Dkb is in MMAD/copyout, load A^T and dw for Dkbg.
+                    // Dkbg dataflow:
+                    //   GM(A^T, dw) -> L1 -> L0A/L0B -> MMAD -> L0C -> GM(slotDkbg)
+                    uint32_t mActual = shapeK.m();
+                    if constexpr (std::is_same_v<ArchTag, Arch::AtlasA2>) {
+                        if (mActual == 1) {
+                            mActual = 16;
+                        }
+                    }
+                    auto layoutL0A = tla::MakeLayout<ElementAT, LayoutTagL0A_Dkbg>(mActual, shapeK.k());
+                    auto tensorL0A = tla::MakeTensor(l0ADkbg, layoutL0A, Arch::PositionL0A{});
+                    auto tensorTileL1A = GetTile(tensorL1A_Dkbg, tla::MakeCoord(0, 0), tla::MakeShape(mActual, shapeK.k()));
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1A);
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0A);
+                    copyL1ToL0A_Dkbg(tensorL0A, tensorTileL1A);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1A);
+                    auto layoutL0B = tla::MakeLayout<ElementDw, LayoutTagL0B_Dkbg>(shapeK.k(), shapeK.n());
+                    auto tensorL0B = tla::MakeTensor(l0BDkbg, layoutL0B, Arch::PositionL0B{});
+                    auto tensorTileL1B = GetTile(tensorL1B_Dkbg, tla::MakeCoord(0, 0), tla::MakeShape(shapeK.k(), shapeK.n()));
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1B);
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0B);
+                    copyL1ToL0B_Dkbg(tensorL0B, tensorTileL1B);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1B);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(EVENT_L0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(EVENT_L0C);
+                    copyL0CToGm_Dkb(tensorBlockDkb, tensorL0C_Dkb, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
+                    // Ready event #1: AIV can start Dkb-related dbeta and
+                    // keep Dkb*beta in UB while AIC computes Dkbg.
+                    Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
+                    auto layoutL0C = tla::MakeLayoutL0C(mActual, shapeK.n());
+                    auto tensorL0C = tla::MakeTensor(l0CBuf, layoutL0C, Arch::PositionL0C{});
+                    auto tensorTileL0C = GetTile(tensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(mActual, shapeK.n()));
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(EVENT_L0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
+                    tileMmadDkbg(tensorTileL0C, tensorL0A, tensorL0B, true, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0A);
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0B);
+                    AscendC::SetFlag<AscendC::HardEvent::M_FIX>(EVENT_L0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(EVENT_L0C);
+                    copyL0CToGm_Dkbg(tensorBlockDkbg, tensorL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
+                    // Ready event #2: AIV can now consume Dkbg and finish the
+                    // Dkbg-related dk/dbeta/dg partials.
                     Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
                 }
-            }
-        }
-        AscendC::SyncAll<false>();
-        { //处理第三部分 AT@dw -> DKBG
-            BlockMmadBdkbg blockMmadBdkbg(resource);
-            AscendC::GlobalTensor<ElementAT> gmAT;
-            AscendC::GlobalTensor<ElementK> gmDw;
-            AscendC::GlobalTensor<ElementDkbg> gmDkbg;
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
-                               params.chunkSize, loopIdx, bos, eos);
-                uint32_t curChunkSize = eos - bos;
-                GemmCoord blockCoord{0, 0, 0};
-                GemmCoord actualBlockShape{curChunkSize, static_cast<uint32_t>(params.K), curChunkSize};
-                for (int h = 0; h < params.HV; h++) {
-                    // Represent the full gm
-                    gmAT.SetGlobalBuffer((__gm__ ElementAT *)params.ptrAT + (h * params.T + bos) * params.chunkSize);
-                    gmDw.SetGlobalBuffer((__gm__ ElementDw *)params.ptrDw + (h * params.T + bos) * params.K);
-                    gmDkbg.SetGlobalBuffer((__gm__ ElementDkbg *)params.ptrDkbg + (h * params.T + bos) * params.K);
 
-                    // Represent the full tensors
-                    auto tensorAT = tla::MakeTensor(gmAT, params.layoutAT, Arch::PositionGM{});
-                    auto tensorDw = tla::MakeTensor(gmDw, params.layoutDw, Arch::PositionGM{});
-                    auto tensorDkbg = tla::MakeTensor(gmDkbg, params.layoutDkbg, Arch::PositionGM{});
+                // Wait for AIV to produce Kbeta = K * beta[:, None] into
+                // slotKbetaDvb.  DK depends on this vector-side result.
+                Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_FIX>(flagAivFinishStore);
 
-                    // Make tiled views
-                    auto tensorBlockAT = GetTile(tensorAT, tla::MakeCoord(0, 0),
-                                                 tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockDw = GetTile(tensorDw, tla::MakeCoord(0, 0),
-                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDkbg = GetTile(tensorDkbg, tla::MakeCoord(0, 0),
-                                                   tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    // Compute block-scoped matrix multiply-add
-                    blockMmadBdkbg(tensorBlockAT, tensorBlockDw, tensorBlockDkbg, actualBlockShape);
-                    Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
+                auto tensorBlockATForDvb = GetTile(tensorAT, tla::MakeCoord(0, 0),
+                                                   tla::MakeShape(shapeV.m(), shapeV.k()));
+                auto tensorBlockDu = GetTile(tensorDu, tla::MakeCoord(0, 0),
+                                              tla::MakeShape(shapeV.k(), shapeV.n()));
+                auto tensorBlockDvb = GetTile(tensorDvb, tla::MakeCoord(0, 0),
+                                              tla::MakeShape(shapeV.m(), shapeV.n()));
+                using CopyGmToL1A_Dvb = typename TileCopyDvb::template CopyGmToL1A<decltype(tensorBlockATForDvb)>;
+                using CopyGmToL1B_Dvb = typename TileCopyDvb::template CopyGmToL1B<decltype(tensorBlockDu)>;
+#if (defined(CATLASS_ARCH) && CATLASS_ARCH == 3510)
+                using CopyL0CToGm_Dvb = typename TileCopyDvb::template CopyL0CToDst<decltype(tensorBlockDvb)>;
+#else
+                using CopyL0CToGm_Dvb = typename TileCopyDvb::template CopyL0CToGm<decltype(tensorBlockDvb)>;
+#endif
+                CopyGmToL1A_Dvb copyGmToL1A_Dvb;
+                CopyGmToL1B_Dvb copyGmToL1B_Dvb;
+                CopyL0CToGm_Dvb copyL0CToGm_Dvb;
+                auto tensorL1A_Dvb = tla::MakeTensor(l1ADvb, L1A_LAYOUT_Dvb, Arch::PositionL1{});
+                auto tensorL1B_Dvb = tla::MakeTensor(l1BDvb, L1B_LAYOUT_Dvb, Arch::PositionL1{});
+                {
+                    // Stage C2a:
+                    //   DK = dA @ Kbeta
+                    // Dataflow: GM(dA, Kbeta workspace) -> L1 -> L0 -> MMAD
+                    // -> GM(slotDK).  This is the first dk term.
+                    using CopyGmToL1B_DK = typename TileCopyDk::template CopyGmToL1B<decltype(tensorBlockKbeta)>;
+#if (defined(CATLASS_ARCH) && CATLASS_ARCH == 3510)
+                    using CopyL0CToGm_DK = typename TileCopyDk::template CopyL0CToDst<decltype(tensorBlockDK)>;
+#else
+                    using CopyL0CToGm_DK = typename TileCopyDk::template CopyL0CToGm<decltype(tensorBlockDK)>;
+#endif
+                    CopyGmToL1B_DK copyGmToL1B_DK;
+                    CopyL0CToGm_DK copyL0CToGm_DK;
+                    auto tensorL1A_DK = tla::MakeTensor(l1ADK, L1A_LAYOUT_DK, Arch::PositionL1{});
+                    auto tensorL1B = tla::MakeTensor(l1BDK, L1B_LAYOUT_DK, Arch::PositionL1{});
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1A);
+                    copyGmToL1A_DK(tensorL1A_DK, tensorBlockDA);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1A);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1B);
+                    copyGmToL1B_DK(tensorL1B, tensorBlockKbeta);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1B);
+                    uint32_t mActual = shapeK.m();
+                    if constexpr (std::is_same_v<ArchTag, Arch::AtlasA2>) {
+                        if (mActual == 1) {
+                            mActual = 16;
+                        }
+                    }
+                    auto layoutL0A = tla::MakeLayout<ElementDA, LayoutTagL0A_DK>(mActual, shapeK.k());
+                    auto tensorL0A = tla::MakeTensor(l0ADK, layoutL0A, Arch::PositionL0A{});
+                    auto tensorTileL1A = GetTile(tensorL1A_DK, tla::MakeCoord(0, 0), tla::MakeShape(mActual, shapeK.k()));
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1A);
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0A);
+                    copyL1ToL0A_DK(tensorL0A, tensorTileL1A);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1A);
+                    auto layoutL0B = tla::MakeLayout<ElementKbeta, LayoutTagL0B_DK>(shapeK.k(), shapeK.n());
+                    auto tensorL0B = tla::MakeTensor(l0BDK, layoutL0B, Arch::PositionL0B{});
+                    auto tensorTileL1B = GetTile(tensorL1B, tla::MakeCoord(0, 0), tla::MakeShape(shapeK.k(), shapeK.n()));
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1B);
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0B);
+                    copyL1ToL0B_DK(tensorL0B, tensorTileL1B);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1B);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(EVENT_L0C);
+                    auto layoutL0C = tla::MakeLayoutL0C(mActual, shapeK.n());
+                    auto tensorL0C = tla::MakeTensor(l0CBuf, layoutL0C, Arch::PositionL0C{});
+                    auto tensorTileL0C = GetTile(tensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(mActual, shapeK.n()));
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(EVENT_L0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
+                    tileMmadDK(tensorTileL0C, tensorL0A, tensorL0B, true, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0A);
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0B);
+                    AscendC::SetFlag<AscendC::HardEvent::M_FIX>(EVENT_L0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(EVENT_L0C);
+                    copyL0CToGm_DK(tensorBlockDK, tensorL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
                 }
-            }
-        }
-        AscendC::SyncAll<false>();
-        { //处理第四部分 AT@du -> dvb
-            BlockMmadBdvb blockMmadBdvb(resource);
-            AscendC::GlobalTensor<ElementAT> gmAT;
-            AscendC::GlobalTensor<ElementK> gmDu;
-            AscendC::GlobalTensor<ElementDvb> gmDvb;
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
-                               params.chunkSize, loopIdx, bos, eos);
-                uint32_t curChunkSize = eos - bos;
-                GemmCoord blockCoord{0, 0, 0};
-                GemmCoord actualBlockShape{curChunkSize, static_cast<uint32_t>(params.V), curChunkSize};
-                for (int h = 0; h < params.HV; h++) {
-                    // Represent the full gm
-                    gmAT.SetGlobalBuffer((__gm__ ElementAT *)params.ptrAT + (h * params.T + bos) * params.chunkSize);
-                    gmDu.SetGlobalBuffer((__gm__ ElementDu *)params.ptrDu + (h * params.T + bos) * params.V);
-                    gmDvb.SetGlobalBuffer((__gm__ ElementDvb *)params.ptrDvb + (h * params.T + bos) * params.V);
 
-                    // Represent the full tensors
-                    auto tensorAT = tla::MakeTensor(gmAT, params.layoutAT, Arch::PositionGM{});
-                    auto tensorDu = tla::MakeTensor(gmDu, params.layoutDu, Arch::PositionGM{});
-                    auto tensorDvb = tla::MakeTensor(gmDvb, params.layoutDvb, Arch::PositionGM{});
+                // Ready event #3: DK is available; AIV can finish dk writeback.
+                Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
 
-                    // Make tiled views
-                    auto tensorBlockAT = GetTile(tensorAT, tla::MakeCoord(0, 0),
-                                                 tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockDu = GetTile(tensorDu, tla::MakeCoord(0, 0),
-                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDvb = GetTile(tensorDvb, tla::MakeCoord(0, 0),
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    // Compute block-scoped matrix multiply-add
-                    blockMmadBdvb(tensorBlockAT, tensorBlockDu, tensorBlockDvb, actualBlockShape);
-                    Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
+                auto tensorBlockKForKKT = GetTile(tensorK, tla::MakeCoord(0, 0),
+                                                 tla::MakeShape(shapeKKT.m(), shapeKKT.k()));
+                auto tensorBlockKT = GetTile(tensorKT, tla::MakeCoord(0, 0),
+                                             tla::MakeShape(shapeKKT.k(), shapeKKT.n()));
+                auto tensorBlockKKT = GetTile(tensorKKT, tla::MakeCoord(0, 0),
+                                             tla::MakeShape(shapeKKT.m(), shapeKKT.n()));
+                using CopyGmToL1A_KKT = typename TileCopyKKT::template CopyGmToL1A<decltype(tensorBlockKForKKT)>;
+                using CopyGmToL1B_KKT = typename TileCopyKKT::template CopyGmToL1B<decltype(tensorBlockKT)>;
+#if (defined(CATLASS_ARCH) && CATLASS_ARCH == 3510)
+                using CopyL0CToGm_KKT = typename TileCopyKKT::template CopyL0CToDst<decltype(tensorBlockKKT)>;
+#else
+                using CopyL0CToGm_KKT = typename TileCopyKKT::template CopyL0CToGm<decltype(tensorBlockKKT)>;
+#endif
+                CopyGmToL1A_KKT copyGmToL1A_KKT;
+                CopyGmToL1B_KKT copyGmToL1B_KKT;
+                CopyL0CToGm_KKT copyL0CToGm_KKT;
+                auto tensorL1A_KKT = tla::MakeTensor(l1AKKT, L1A_LAYOUT_KKT, Arch::PositionL1{});
+                auto tensorL1B_KKT = tla::MakeTensor(l1BKKT, L1B_LAYOUT_KKT, Arch::PositionL1{});
+                uint32_t mActualDvb = shapeV.m();
+                if constexpr (std::is_same_v<ArchTag, Arch::AtlasA2>) {
+                    if (mActualDvb == 1) {
+                        mActualDvb = 16;
+                    }
                 }
-            }
-        }
-        AscendC::SyncAll<false>();
-        { //处理第五部分 K@KT -> kkT
-            BlockMmadBkkT blockMmadkkT(resource);
-            AscendC::GlobalTensor<ElementK> gmK;
-            AscendC::GlobalTensor<ElementKT> gmKT;
-            AscendC::GlobalTensor<ElementKKT> gmKKT;
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
-                               params.chunkSize, loopIdx, bos, eos);
-                uint32_t curChunkSize = eos - bos;
-                GemmCoord blockCoord{0, 0, 0};
-                GemmCoord actualBlockShape{curChunkSize, curChunkSize, static_cast<uint32_t>(params.K)};
-                for (int h = 0; h < params.HV; h++) {
-                    // Represent the full gm
-                    gmK.SetGlobalBuffer((__gm__ ElementK *)params.ptrK + (h * params.T + bos) * params.K);
-                    gmKT.SetGlobalBuffer((__gm__ ElementKT *)params.ptrKT + (h * params.T + bos) * params.K);
-                    gmKKT.SetGlobalBuffer((__gm__ ElementKKT *)params.ptrKKT + (h * params.T + bos) * params.chunkSize);
-
-                    // Represent the full tensors
-                    auto tensorK = tla::MakeTensor(gmK, params.layoutK, Arch::PositionGM{});
-                    auto tensorKT = tla::MakeTensor(gmKT, params.layoutKT, Arch::PositionGM{});
-                    auto tensorKKT = tla::MakeTensor(gmKKT, params.layoutKKT, Arch::PositionGM{});
-
-                    // Make tiled views
-                    auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0),
-                                                tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockKT = GetTile(tensorKT, tla::MakeCoord(0, 0),
-                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockKKT = GetTile(tensorKKT, tla::MakeCoord(0, 0),
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    // Compute block-scoped matrix multiply-add
-                    blockMmadkkT(tensorBlockK, tensorBlockKT, tensorBlockKKT, actualBlockShape);
-                    Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
+                auto layoutL0C_Dvb = tla::MakeLayoutL0C(mActualDvb, shapeV.n());
+                auto tensorL0C_Dvb = tla::MakeTensor(l0CBuf, layoutL0C_Dvb, Arch::PositionL0C{});
+                {
+                    // Stage C2b starts Dvb and preloads KKT operands while Dvb
+                    // MMAD is running:
+                    //   Dvb = A^T @ du
+                    // AIV later computes dv = Dvb * beta[:, None] and
+                    // dbeta += reduce(Dvb * V).
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1A);
+                    copyGmToL1A_Dvb(tensorL1A_Dvb, tensorBlockATForDvb);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1A);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1B);
+                    copyGmToL1B_Dvb(tensorL1B_Dvb, tensorBlockDu);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1B);
+                    auto layoutL0A = tla::MakeLayout<ElementAT, LayoutTagL0A_Dvb>(mActualDvb, shapeV.k());
+                    auto tensorL0A = tla::MakeTensor(l0ADvb, layoutL0A, Arch::PositionL0A{});
+                    auto tensorTileL1A = GetTile(tensorL1A_Dvb, tla::MakeCoord(0, 0), tla::MakeShape(mActualDvb, shapeV.k()));
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1A);
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0A);
+                    copyL1ToL0A_Dvb(tensorL0A, tensorTileL1A);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1A);
+                    auto layoutL0B = tla::MakeLayout<ElementDu, LayoutTagL0B_Dvb>(shapeV.k(), shapeV.n());
+                    auto tensorL0B = tla::MakeTensor(l0BDvb, layoutL0B, Arch::PositionL0B{});
+                    auto tensorTileL1B = GetTile(tensorL1B_Dvb, tla::MakeCoord(0, 0), tla::MakeShape(shapeV.k(), shapeV.n()));
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1B);
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0B);
+                    copyL1ToL0B_Dvb(tensorL0B, tensorTileL1B);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1B);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(EVENT_L0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1A);
+                    copyGmToL1A_KKT(tensorL1A_KKT, tensorBlockKForKKT);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1A);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1B);
+                    copyGmToL1B_KKT(tensorL1B_KKT, tensorBlockKT);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1B);
+                    auto tensorTileL0C = GetTile(tensorL0C_Dvb, tla::MakeCoord(0, 0), tla::MakeShape(mActualDvb, shapeV.n()));
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(EVENT_L0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
+                    tileMmadDvb(tensorTileL0C, tensorL0A, tensorL0B, true, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0A);
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0B);
+                    AscendC::SetFlag<AscendC::HardEvent::M_FIX>(EVENT_L0C);
                 }
+
+                {
+                    // Stage C2c:
+                    //   KKT = K @ K^T
+                    // Dvb is copied out first, then KKT is computed into the
+                    // dedicated KKT slot for AIV's dg row/column reductions.
+                    uint32_t mActual = shapeKKT.m();
+                    if constexpr (std::is_same_v<ArchTag, Arch::AtlasA2>) {
+                        if (mActual == 1) {
+                            mActual = 16;
+                        }
+                    }
+                    auto layoutL0A = tla::MakeLayout<ElementK, LayoutTagL0A_KKT>(mActual, shapeKKT.k());
+                    auto tensorL0A = tla::MakeTensor(l0AKKT, layoutL0A, Arch::PositionL0A{});
+                    auto tensorTileL1A = GetTile(tensorL1A_KKT, tla::MakeCoord(0, 0), tla::MakeShape(mActual, shapeKKT.k()));
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1A);
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0A);
+                    copyL1ToL0A_KKT(tensorL0A, tensorTileL1A);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1A);
+                    auto layoutL0B = tla::MakeLayout<ElementKT, LayoutTagL0B_KKT>(shapeKKT.k(), shapeKKT.n());
+                    auto tensorL0B = tla::MakeTensor(l0BKKT, layoutL0B, Arch::PositionL0B{});
+                    auto tensorTileL1B = GetTile(tensorL1B_KKT, tla::MakeCoord(0, 0), tla::MakeShape(shapeKKT.k(), shapeKKT.n()));
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_L1B);
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0B);
+                    copyL1ToL0B_KKT(tensorL0B, tensorTileL1B);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1B);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(EVENT_L0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(EVENT_L0C);
+                    copyL0CToGm_Dvb(tensorBlockDvb, tensorL0C_Dvb, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
+                    // Ready event #4: Dvb is available.
+                    Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
+                    auto layoutL0C = tla::MakeLayoutL0C(mActual, shapeKKT.n());
+                    auto tensorL0C = tla::MakeTensor(l0CBuf, layoutL0C, Arch::PositionL0C{});
+                    auto tensorTileL0C = GetTile(tensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(mActual, shapeKKT.n()));
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(EVENT_L0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
+                    tileMmadKKT(tensorTileL0C, tensorL0A, tensorL0B, true, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0A);
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0B);
+                    AscendC::SetFlag<AscendC::HardEvent::M_FIX>(EVENT_L0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(EVENT_L0C);
+                    copyL0CToGm_KKT(tensorBlockKKT, tensorL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
+                }
+
+                // Ready event #5: KKT is available; AIV can finish dg.
+                Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
             }
         }
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1A);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1B);
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0A);
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0B);
+        AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
     }
 };
 } // namespace Catlass::Gemm::Kernel
 
-template <typename kType, typename betaType, typename L1TileShape, typename L0TileShape>
+template <typename kType, typename betaType>
 class PrepareWyReprBwdFullProcess {
 public:
     /** @brief constructor */
@@ -358,6 +790,9 @@ public:
     __aicore__ inline void Init(const PrepareWyReprBwdFullTilingData &tiling);
 
 private:
+    template <class L1TileShape, class L0TileShape, class L1TileShapeDvb, class L0TileShapeDvb>
+    __aicore__ inline void ProcessImpl();
+
     uint64_t B = 0;
     uint64_t T = 0;
     uint64_t HV = 0;
@@ -366,6 +801,12 @@ private:
     uint64_t V = 0;
     uint64_t chunkSize = 0;
     uint64_t chunkNum;
+    uint64_t fusedKVecRow = 0;
+    uint64_t fusedVVecRow = 0;
+    uint64_t fusedKktVecRow = 0;
+    uint64_t workspaceSlotSize = 0;
+    uint64_t workspaceBufferCount = 1;
+    uint64_t usedCoreNum = 0;
     GM_ADDR k;
     GM_ADDR v;
     GM_ADDR beta;
@@ -383,17 +824,16 @@ private:
     GM_ADDR workspace;
 };
 
-template <typename kType, typename betaType, typename L1TileShape, typename L0TileShape>
-__aicore__ inline PrepareWyReprBwdFullProcess<kType, betaType, L1TileShape, L0TileShape>::PrepareWyReprBwdFullProcess(
+template <typename kType, typename betaType>
+__aicore__ inline PrepareWyReprBwdFullProcess<kType, betaType>::PrepareWyReprBwdFullProcess(
     GM_ADDR k_, GM_ADDR v_, GM_ADDR beta_, GM_ADDR A_, GM_ADDR dA_, GM_ADDR dw_, GM_ADDR du_, GM_ADDR g_,
     GM_ADDR cu_seqlens_, GM_ADDR chunk_indices_, GM_ADDR dk_, GM_ADDR dv_, GM_ADDR dbeta_, GM_ADDR dg_,
     GM_ADDR workspace_)
     : k(k_), v(v_), beta(beta_), A(A_), dA(dA_), dw(dw_), du(du_), g(g_), cu_seqlens(cu_seqlens_),
       chunk_indices(chunk_indices_), dk(dk_), dv(dv_), dbeta(dbeta_), dg(dg_), workspace(workspace_){};
 
-template <typename kType, typename betaType, typename L1TileShape, typename L0TileShape>
-__aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType, L1TileShape, L0TileShape>::Init(
-    const PrepareWyReprBwdFullTilingData &tiling)
+template <typename kType, typename betaType>
+__aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType>::Init(const PrepareWyReprBwdFullTilingData &tiling)
 {
     B = tiling.B;
     T = tiling.T;
@@ -403,13 +843,34 @@ __aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType, L1TileShape,
     V = tiling.V;
     chunkSize = tiling.chunkSize;
     chunkNum = tiling.chunkNum;
+    fusedKVecRow = tiling.fusedKVecRow;
+    fusedVVecRow = tiling.fusedVVecRow;
+    fusedKktVecRow = tiling.fusedKktVecRow;
+    workspaceSlotSize = tiling.workspaceSlotSize;
+    workspaceBufferCount = tiling.workspaceBufferCount;
+    usedCoreNum = tiling.usedCoreNum;
     return;
 }
 
-template <typename kType, typename betaType, typename L1TileShape, typename L0TileShape>
-__aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType, L1TileShape, L0TileShape>::Process()
+template <typename kType, typename betaType>
+__aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType>::Process()
 {
-    //输入
+    if (V == 256) {
+        ProcessImpl<Shape<_128, _128, _256>, Shape<_128, _128, _128>, Shape<_128, _256, _256>,
+                    Shape<_128, _256, _128>>();
+    } else {
+        ProcessImpl<Shape<_128, _128, _256>, Shape<_128, _128, _128>, Shape<_128, _128, _256>,
+                    Shape<_128, _128, _128>>();
+    }
+}
+
+template <typename kType, typename betaType>
+template <class L1TileShape, class L0TileShape, class L1TileShapeDvb, class L0TileShapeDvb>
+__aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType>::ProcessImpl()
+{
+    // GM tensor layouts used by tile_mmad.  A and dA have both row-major and
+    // column-major views because different GEMMs need A^T/dA^T without
+    // materializing a transpose in this kernel.
     using LayoutTagA = layout::RowMajor;
     using LayoutTagAT = layout::ColumnMajor;
     using LayoutTagDW = layout::RowMajor;
@@ -423,7 +884,11 @@ __aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType, L1TileShape,
     using LayoutTagDvb = layout::RowMajor;
 
 
-    //输入
+    // Input logical matrices for one (chunk, head):
+    //   A/dA : chunkSize x chunkSize
+    //   K/V  : chunkSize x K/V
+    //   dw/du: chunkSize x K/V
+    // ColumnMajor tags reinterpret A/dA/K as transposed operands for MMAD.
     LayoutTagA tagA = LayoutTagA::MakeLayout<kType>(chunkSize, chunkSize);
     LayoutTagAT tagAT = LayoutTagAT::MakeLayout<kType>(chunkSize, chunkSize);
     LayoutTagDW tagDW = LayoutTagDW::MakeLayout<kType>(chunkSize, K);
@@ -434,7 +899,13 @@ __aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType, L1TileShape,
     LayoutTagKT tagKT = LayoutTagKT::MakeLayout<kType>(K, chunkSize);
     LayoutTagDu tagDu = LayoutTagDu::MakeLayout<kType>(chunkSize, V);
 
-    //中间结果
+    // Workspace intermediate layouts.  These matrices are scoped to the
+    // ping-pong slot for the current (chunk, head):
+    //   Kbeta = K * beta[:, None]
+    //   Dkb   = dA^T @ K
+    //   Dkbg  = A^T @ dw
+    //   Dvb   = A^T @ du
+    //   KKT   = K @ K^T
     using LayoutTagKbeta = layout::RowMajor;
     LayoutTagKbeta tagKbeta = LayoutTagKbeta::MakeLayout<kType>(chunkSize, K);
 
@@ -450,38 +921,36 @@ __aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType, L1TileShape,
     using LayoutTagKKT = layout::RowMajor;
     LayoutTagKKT tagKKT = LayoutTagKKT::MakeLayout<kType>(chunkSize, chunkSize);
 
-    //输出
+    // Output dk is written directly to GM after AIV adds all dk terms.
     using LayoutTagDk = layout::RowMajor;
     LayoutTagDk tagDk = LayoutTagDk::MakeLayout<kType>(chunkSize, K);
-
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    using ArchTag = Arch::Ascend950;
+#else
     using ArchTag = Arch::AtlasA2;
+#endif
     using DispatchPolicy = Gemm::MmadPingpong<ArchTag, true>;
 
-    //计算dk第一部分, dA @ Kbeta
+    // Tile copy policies bind each MMAD's operand/result layouts:
+    //   TileCopyDk   : DK   = dA @ Kbeta
+    //   TileCopyDkb  : Dkb  = dA^T @ K
+    //   TileCopyDkbg : Dkbg = A^T @ dw
+    //   TileCopyDvb  : Dvb  = A^T @ du
+    //   TileCopyKKT  : KKT  = K @ K^T
     using TileCopyDk =
         Gemm::Tile::PackedTileCopyTla<ArchTag, kType, LayoutTagDA, kType, LayoutTagKbeta, kType, LayoutTagDk>;
-    using BlockMmadDk =
-        Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, kType, kType, kType, void, TileCopyDk>;
 
     using TileCopyDkb =
         Gemm::Tile::PackedTileCopyTla<ArchTag, kType, LayoutTagDAT, kType, LayoutTagK, kType, LayoutTagDkb>;
-    using BlockMmadDkb =
-        Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, kType, kType, kType, void, TileCopyDkb>;
 
     using TileCopyDkbg =
         Gemm::Tile::PackedTileCopyTla<ArchTag, kType, LayoutTagAT, kType, LayoutTagDW, kType, LayoutTagDkbg>;
-    using BlockMmadDkbg =
-        Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, kType, kType, kType, void, TileCopyDkbg>;
 
     using TileCopyDvb =
         Gemm::Tile::PackedTileCopyTla<ArchTag, kType, LayoutTagAT, kType, LayoutTagDu, kType, LayoutTagDvb>;
-    using BlockMmadDvb =
-        Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, kType, kType, kType, void, TileCopyDvb>;
 
     using TileCopyKKT =
         Gemm::Tile::PackedTileCopyTla<ArchTag, kType, LayoutTagK, kType, LayoutTagKT, kType, LayoutTagKKT>;
-    using BlockMmadKKT =
-        Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, kType, kType, kType, void, TileCopyKKT>;
 
     auto layoutKbeta = MakeLayoutFromTag(tagKbeta);
     auto layoutDA = MakeLayoutFromTag(tagDA);
@@ -498,15 +967,20 @@ __aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType, L1TileShape,
     auto layoutKKT = MakeLayoutFromTag(tagKKT);
     // kernel level
     using MatmulKernel =
-        Gemm::Kernel::PrepareWyReprBwdFullTla<BlockMmadDk, BlockMmadDkb, BlockMmadDkbg, BlockMmadDvb, BlockMmadKKT>;
+        Gemm::Kernel::PrepareWyReprBwdFullTla<ArchTag, L1TileShape, L0TileShape, L1TileShapeDvb, L0TileShapeDvb,
+                                              TileCopyDk, TileCopyDkb, TileCopyDkbg, TileCopyDvb, TileCopyKKT>;
 
     MatmulKernel kernel;
 
+    // params.ptrKbeta is the workspace base.  The kernel computes per-core
+    // slot offsets internally and aliases the same workspace base as Kbeta,
+    // Dkb, Dkbg, Dvb and KKT according to the slot layout.
     typename MatmulKernel::Params param{
         workspace, layoutKbeta, dA, layoutDA, dk,        layoutDK,  dA,         layoutDAT,     k,        layoutK,
         workspace, layoutDkb,   A,  layoutAT, dw,        layoutDw,  workspace,  layoutDkbg,    du,       layoutDu,
         workspace, layoutDvb,   k,  layoutKT, workspace, layoutKKT, cu_seqlens, chunk_indices, chunkNum, B,
-        T,         HK,           HV,         K,  V,        chunkSize, 4};
+        T,         HV,          HK, K,        V,          chunkSize, 4, fusedKVecRow, fusedVVecRow, fusedKktVecRow,
+        workspaceSlotSize, workspaceBufferCount, usedCoreNum};
     kernel(param);
 }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full_vector.h
@@ -29,11 +29,7 @@ public:
                                                         GM_ADDR dbeta_, GM_ADDR dg_, GM_ADDR workspace_);
 
     __aicore__ inline void Process();
-    __aicore__ inline void ProcessKBeta();
-    __aicore__ inline void ProcessDkb();
-    __aicore__ inline void ProcessDkbg();
-    __aicore__ inline void ProcessDvb();
-    __aicore__ inline void ProcessKKT();
+    __aicore__ inline void ProcessFused();
     __aicore__ inline void Init(const PrepareWyReprBwdFullTilingData &tiling, AscendC::TPipe *pipe_);
 
 private:
@@ -45,11 +41,12 @@ private:
     uint64_t V = 0;
     uint64_t chunkSize = 0;
     uint64_t chunkNum = 0;
-    uint64_t kBeteVecRow = 0;
-    uint64_t dkbVecRow = 0;
-    uint64_t dkbgVecRow = 0;
-    uint64_t dvbVecRow = 0;
-    uint64_t kktVecRow = 0;
+    uint64_t fusedKVecRow = 0;
+    uint64_t fusedVVecRow = 0;
+    uint64_t fusedKktVecRow = 0;
+    uint64_t workspaceSlotSize = 0;
+    uint64_t workspaceBufferCount = 1;
+    uint64_t usedCoreNum = 0;
 
     GM_ADDR k;
     GM_ADDR v;
@@ -81,45 +78,14 @@ private:
     GlobalTensor<betaType> dgTensor;
     GlobalTensor<kType> dATensor;
     GlobalTensor<kType> workSpaceTensor;
-    Arch::CrossCoreFlagWithReverse<> flagAicFinishStore{SYNC_FLAG_2, SYNC_FLAG_3};
+    Arch::CrossCoreFlagWithReverse<5> flagAicFinishStore{SYNC_FLAG_2, SYNC_FLAG_3};
     Arch::CrossCoreFlagWithReverse<> flagAivFinishStore{SYNC_FLAG_4, SYNC_FLAG_5};
 
-    TQue<AscendC::TPosition::VECIN, 1> kInQue;
-    TQue<AscendC::TPosition::VECIN, 1> vInQue;
-    TQue<AscendC::TPosition::VECIN, 1> betaInQue;
-    TQue<AscendC::TPosition::VECIN, 1> gInQue;
-    TQue<AscendC::TPosition::VECIN, 1> dkInQue;
-    TQue<AscendC::TPosition::VECIN, 1> daInQue;
-    TQue<AscendC::TPosition::VECIN, 1> dgInQue;
-    TQue<AscendC::TPosition::VECIN, 1> dbetaInQue;
-    TQue<AscendC::TPosition::VECIN, 1> dkbInQue;
-    TQue<AscendC::TPosition::VECIN, 1> dkbgInQue;
-    TQue<AscendC::TPosition::VECIN, 1> dvbInQue;
-    TQue<AscendC::TPosition::VECIN, 1> kktInQue;
+    TQue<AscendC::TPosition::VECIN, 1> oneInQue;
+    TQue<AscendC::TPosition::VECOUT, 1> oneOutQue;
 
-    TQue<AscendC::TPosition::VECOUT, 1> kBetaOutQue;
-    TQue<AscendC::TPosition::VECOUT, 1> dkOutQue;
-    TQue<AscendC::TPosition::VECOUT, 1> dBetaOutQue;
-    TQue<AscendC::TPosition::VECOUT, 1> dgOutQue;
-    TQue<AscendC::TPosition::VECOUT, 1> dvOutQue;
-
-    TBuf<AscendC::TPosition::VECCALC> kFp32Buf;
-    TBuf<AscendC::TPosition::VECCALC> vFp32Buf;
-    TBuf<AscendC::TPosition::VECCALC> dkFp32Buf;
-    TBuf<AscendC::TPosition::VECCALC> dkbFp32Buf;
-    TBuf<AscendC::TPosition::VECCALC> dkbgFp32Buf;
-    TBuf<AscendC::TPosition::VECCALC> dvbFp32Buf;
-    TBuf<AscendC::TPosition::VECCALC> daFp32Buf;
-    TBuf<AscendC::TPosition::VECCALC> kktFp32Buf;
-    TBuf<AscendC::TPosition::VECCALC> daaFp32Buf;
-    TBuf<AscendC::TPosition::VECCALC> betaFp32Buf;
-    TBuf<AscendC::TPosition::VECCALC> betaFp32BrcbBuf;
-    TBuf<AscendC::TPosition::VECCALC> gFp32Buf;
-    TBuf<AscendC::TPosition::VECCALC> gFp32BrcbBuf;
-    TBuf<AscendC::TPosition::VECCALC> reduceSumTmpBuf;
-    TBuf<AscendC::TPosition::VECCALC> dbetaFp32Buf;
-    TBuf<AscendC::TPosition::VECCALC> dbetaAddFp32Buf;
-    TBuf<AscendC::TPosition::VECCALC> dgFp32Buf;
+    TBuf<AscendC::TPosition::VECCALC> persistentArena;
+    TBuf<AscendC::TPosition::VECCALC> tempArena;
 };
 
 template <typename kType, typename betaType>
@@ -154,11 +120,12 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Init(
     V = tiling.V;
     chunkSize = tiling.chunkSize;
     chunkNum = tiling.chunkNum;
-    kBeteVecRow = tiling.kBeteVecRow;
-    dkbVecRow = tiling.dkbVecRow;
-    dkbgVecRow = tiling.dkbgVecRow;
-    dvbVecRow = tiling.dvbVecRow;
-    kktVecRow = tiling.kktVecRow;
+    fusedKVecRow = tiling.fusedKVecRow;
+    fusedVVecRow = tiling.fusedVVecRow;
+    fusedKktVecRow = tiling.fusedKktVecRow;
+    workspaceSlotSize = tiling.workspaceSlotSize;
+    workspaceBufferCount = tiling.workspaceBufferCount;
+    usedCoreNum = tiling.usedCoreNum;
 
     return;
 }
@@ -166,768 +133,574 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Init(
 template <typename kType, typename betaType>
 __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Process()
 {
-    //计算K * Beta[:None]
-    ProcessKBeta();
-    pipe->Reset();
-    AscendC::SyncAll<false>();
-    ProcessDkb();
-    pipe->Reset();
-    AscendC::SyncAll<false>();
-    ProcessDkbg();
-    pipe->Reset();
-    AscendC::SyncAll<false>();
-    ProcessDvb();
-    pipe->Reset();
-    AscendC::SyncAll<false>();
-    ProcessKKT();
+    ProcessFused();
     return;
 }
 
 template <typename kType, typename betaType>
-__aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessKKT()
+__aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessFused()
 {
     uint32_t coreLoops = chunkNum;
     uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
     uint32_t coreNumAic = GetBlockNum();
-    uint32_t rowNum = kktVecRow;
-    uint32_t rowOffset = 0;
+    uint32_t subBlockIdx = GetSubBlockIdx();
+    uint32_t subBlockNum = GetSubBlockNum();
     uint32_t vecTaskIdx = 0;
     uint32_t bos = 0;
     uint32_t eos = 0;
-    uint32_t curRowNum = rowNum;
+    uint32_t rowK = fusedKVecRow;
+    uint32_t rowV = fusedVVecRow;
+    uint32_t rowKkt = fusedKktVecRow;
+    uint32_t rowOwned = rowK < rowV ? rowK : rowV;
+    uint64_t maxDim = K > V ? K : V;
+    maxDim = maxDim > chunkSize ? maxDim : chunkSize;
+    uint64_t maxRow = rowK > rowV ? rowK : rowV;
+    maxRow = maxRow > rowKkt ? maxRow : rowKkt;
+    uint64_t align = ONE_BLOCK_32;
 
-    // init
-    pipe->InitBuffer(betaInQue, 2, chunkSize * sizeof(betaType));
-    pipe->InitBuffer(dgInQue, 2, chunkSize * sizeof(betaType));
-    pipe->InitBuffer(daInQue, 2, rowNum * chunkSize * sizeof(kType));
-    pipe->InitBuffer(kktInQue, 2, rowNum * chunkSize * sizeof(kType));
+    // Workspace slot offsets must match tiling.cpp.  kBytes/vBytes are
+    // rounded to 32B because AIC and AIV exchange all intermediate matrices
+    // through GM workspace and both sides use aligned GM copies.
+    uint64_t kBytes = ((chunkSize * K * sizeof(kType) + align - 1) / align) * align;
+    uint64_t vBytes = ((chunkSize * V * sizeof(kType) + align - 1) / align) * align;
+    uint64_t maxKVBytes = kBytes > vBytes ? kBytes : vBytes;
 
-    pipe->InitBuffer(dgOutQue, 2, chunkSize * sizeof(betaType));
+    // One input queue and one output queue are intentionally reused by all
+    // logical tensors.  The size is the largest tile that can be copied by
+    // this vector kernel: K/V tiles or a beta/g chunk vector.
+    uint64_t queueBytes = maxRow * maxDim * sizeof(kType);
+    uint64_t betaChunkBytes = chunkSize * sizeof(betaType);
+    queueBytes = queueBytes > betaChunkBytes ? queueBytes : betaChunkBytes;
+    pipe->InitBuffer(oneInQue, 1, queueBytes);
+    pipe->InitBuffer(oneOutQue, 1, queueBytes);
 
-    pipe->InitBuffer(kktFp32Buf, rowNum * chunkSize * sizeof(float32_t));
-    pipe->InitBuffer(daFp32Buf, rowNum * chunkSize * sizeof(float32_t));
-    pipe->InitBuffer(betaFp32Buf, chunkSize * sizeof(float32_t));
-    // daaFp32Buf，dg保存全量当前chunk数据，用于reducesum及累加
-    pipe->InitBuffer(daaFp32Buf, chunkSize * chunkSize * sizeof(float32_t));
-    pipe->InitBuffer(reduceSumTmpBuf, chunkSize * ONE_BLOCK_32);
+    // persistentArena stores values with chunk lifetime:
+    //   beta fp32       : beta cast/copy to FP32
+    //   exp(g) fp32     : g cast/copy to FP32, then Exp in place
+    //   dbeta accumulator: dbeta partial sum across all formula terms
+    //   dg accumulator   : dg partial sum across all formula terms
+    // tempArena is reused by the current stage only.
+    uint64_t persistentStride = ((chunkSize * sizeof(float32_t) + align - 1) / align) * align / sizeof(float32_t);
+    uint64_t persistentBytes = 4 * persistentStride * sizeof(float32_t);
+    uint64_t group1Bytes = 5 * rowK * K * sizeof(float32_t) + 3 * rowK * ONE_BLOCK_32;
+    uint64_t group2VBytes = 2 * rowV * V * sizeof(float32_t) + 2 * rowV * ONE_BLOCK_32;
+    uint64_t group2KktBytes = chunkSize * chunkSize * sizeof(float32_t) +
+                              2 * rowKkt * chunkSize * sizeof(float32_t) + chunkSize * ONE_BLOCK_32;
+    uint64_t tempBytes = group1Bytes > group2VBytes ? group1Bytes : group2VBytes;
+    tempBytes = tempBytes > group2KktBytes ? tempBytes : group2KktBytes;
+    pipe->InitBuffer(persistentArena, persistentBytes);
+    pipe->InitBuffer(tempArena, tempBytes + ONE_BLOCK_32);
 
-    auto tensorKKTFp32 = kktFp32Buf.Get<float32_t>();
-    auto tensorDaFp32 = daFp32Buf.Get<float32_t>();
-    auto tensorBetaFP32 = betaFp32Buf.Get<float32_t>();
-    auto tensorDaaFP32 = daaFp32Buf.Get<float32_t>();
+    auto persistent = persistentArena.Get<float32_t>();
+    auto temp = tempArena.Get<float32_t>();
+    auto tensorBetaFP32 = persistent[0];
+    auto tensorGExpFP32 = persistent[persistentStride];
+    auto tensorDbetaAccFP32 = persistent[2 * persistentStride];
+    auto tensorDgAccFP32 = persistent[3 * persistentStride];
 
-    auto tensorReduceSum = reduceSumTmpBuf.Get<float32_t>();
-    //复用空间
-    auto tensorDgFP32 = kktFp32Buf.Get<float32_t>();
-    auto tensorDgFP32Add = betaFp32Buf.Get<float32_t>();
-    auto tensorSum1DaaFP32 = daFp32Buf.Get<float32_t>();
-
-    
+    // Outer loop distributes chunks across AIC/AIV core groups; inner loop
+    // iterates heads for the same chunk.  For each (chunk, head), AIV performs
+    // all vector work and consumes AIC results before moving to the next head.
     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
         GetChunkOffset(cu_seqlens, chunk_indices, B, HV, T, chunkSize, loopIdx, bos, eos);
         uint32_t curChunkSize = eos - bos;
-        uint32_t wholeReduceSumCnt = CeilDiv(curChunkSize, FP32_PER_REPEAT_64);
-        for (int h = 0; h < HV; h++) {
+        uint32_t wholeReduceKCnt = CeilDiv(K, FP32_PER_REPEAT_64);
+        uint32_t wholeReduceVCnt = CeilDiv(V, FP32_PER_REPEAT_64);
+        uint32_t wholeReduceChunkCnt = CeilDiv(curChunkSize, FP32_PER_REPEAT_64);
+        // GQA uses kh = h / (HV / HK) for k/dk, while the rest of the tensors
+        // are still indexed by value head h.
+        uint64_t keyBos = bos;
+        if (cu_seqlens == nullptr && HV != HK) {
+            uint64_t batchIdx = bos / (HV * T);
+            uint64_t timeBos = bos - batchIdx * HV * T;
+            keyBos = batchIdx * HK * T + timeBos;
+        }
+        uint64_t headRatio = HV / HK;
+        for (uint32_t h = 0; h < HV; h++) {
+            // Ping-pong slot selected by logical task order.  AIC and AIV use
+            // the same formula, so both sides agree on which slot stores DK,
+            // Dkb, Dkbg, Kbeta/Dvb and KKT for this (chunk, head).
+            uint64_t workspaceBufferIdx = vecTaskIdx % workspaceBufferCount;
+            uint64_t slotBaseBytes = (coreIdx * workspaceBufferCount + workspaceBufferIdx) * workspaceSlotSize;
+            uint64_t slotDK = slotBaseBytes / sizeof(kType);
+            uint64_t slotDkb = (slotBaseBytes + kBytes) / sizeof(kType);
+            uint64_t slotDkbg = (slotBaseBytes + 2 * kBytes) / sizeof(kType);
+            uint64_t slotKbetaDvb = (slotBaseBytes + 3 * kBytes) / sizeof(kType);
+            uint64_t slotKKT = (slotBaseBytes + 3 * kBytes + maxKVBytes) / sizeof(kType);
             ++vecTaskIdx;
-            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
-                continue;
-            }
-            {// copyin
-                auto tensorBeta = betaInQue.AllocTensor<betaType>();
-                auto tensorDg = dgInQue.AllocTensor<betaType>();
-                DataCopyPad(tensorBeta, betaTensor[h * T + bos], {1, curChunkSize * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
-                DataCopyPad(tensorDg, dgTensor[h * T + bos], {1, curChunkSize * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
-                betaInQue.EnQue(tensorBeta);
-                dgInQue.EnQue(tensorDg);
-            }
-            {//compute
-                auto tensorBeta =betaInQue.DeQue<betaType>();
+
+            uint64_t kh = h / headRatio;
+            uint64_t valueBase = h * T + bos;
+            uint64_t keyBase = kh * T + keyBos;
+            bool isFirstValueHeadInGroup = (h % headRatio) == 0;
+            uint64_t betaOffset = valueBase;
+            uint64_t kBaseOffset = keyBase * K;
+            uint64_t vBaseOffset = valueBase * V;
+            uint64_t daBaseOffset = valueBase * chunkSize;
+
+            {
+                // Load beta[chunk] from GM to UB and normalize it to FP32.
+                // beta is reused by Kbeta = K * beta, dk, dv, dbeta and dg.
+                auto tensorIn = oneInQue.AllocTensor<betaType>();
+                DataCopyPad(tensorIn, betaTensor[betaOffset],
+                            {1, curChunkSize * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},
+                            {false, 0, 0, 0});
+                oneInQue.EnQue(tensorIn);
+                auto tensorBeta = oneInQue.DeQue<betaType>();
                 if constexpr (std::is_same<betaType, float32_t>()) {
-                    DataCopy(tensorBetaFP32, tensorBeta, chunkSize);
+                    // Use Adds(x, 0) instead of UB->UB DataCopy so varlen tail
+                    // chunks with non-32B element counts are still legal.
+                    Adds(tensorBetaFP32, tensorBeta, 0.0f, curChunkSize);
                 } else {
                     Cast(tensorBetaFP32, tensorBeta, RoundMode::CAST_NONE, curChunkSize);
                 }
-                betaInQue.FreeTensor(tensorBeta);
+                oneInQue.FreeTensor(tensorBeta);
             }
-            Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
-            //分批次处理计算daa
-            for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
-                auto dAOffset = (h * T + bos + rowOffset) * chunkSize;
-                auto betaOffset = h * T + bos + rowOffset;
-                curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
-                // copyin
-                {
-                    auto tensordaIn = daInQue.AllocTensor<kType>();
-                    auto tensorKKTin = kktInQue.AllocTensor<kType>();
-
-                    DataCopy(tensordaIn, dATensor[dAOffset], chunkSize * curRowNum);
-                    DataCopy(tensorKKTin, workSpaceTensor[dAOffset], chunkSize * curRowNum);
-
-                    daInQue.EnQue(tensordaIn);
-                    kktInQue.EnQue(tensorKKTin);
+            {
+                // Load g[chunk], cast/copy to FP32, then compute exp(g) in UB.
+                // exp(g) participates in Dkbg-related dbeta/dg/dk terms.
+                auto tensorIn = oneInQue.AllocTensor<betaType>();
+                DataCopyPad(tensorIn, gTensor[betaOffset],
+                            {1, curChunkSize * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},
+                            {false, 0, 0, 0});
+                oneInQue.EnQue(tensorIn);
+                auto tensorG = oneInQue.DeQue<betaType>();
+                if constexpr (std::is_same<betaType, float32_t>()) {
+                    // Same non-aligned varlen tail consideration as beta.
+                    Adds(tensorGExpFP32, tensorG, 0.0f, curChunkSize);
+                } else {
+                    Cast(tensorGExpFP32, tensorG, RoundMode::CAST_NONE, curChunkSize);
                 }
-                // compute
-                {
-                    auto tensordaIn = daInQue.DeQue<kType>();
-                    auto tensorKKTin = kktInQue.DeQue<kType>();
-                    // cast FP32
-                    Cast(tensorKKTFp32, tensorKKTin, RoundMode::CAST_NONE, chunkSize * curRowNum);
-                    Cast(tensorDaFp32, tensordaIn, RoundMode::CAST_NONE, chunkSize * curRowNum);
+                oneInQue.FreeTensor(tensorG);
+            }
+            PipeBarrier<PIPE_V>();
+            Exp(tensorGExpFP32, tensorGExpFP32, curChunkSize);
+            // Accumulators are initialized once for the whole (chunk, head)
+            // and updated by later row tiles.
+            Duplicate(tensorDbetaAccFP32, 0.0f, curChunkSize);
+            Duplicate(tensorDgAccFP32, 0.0f, curChunkSize);
+            PipeBarrier<PIPE_V>();
+
+            // Stage V0: generate Kbeta = K * beta[:, None].
+            // Each AIV sub-block owns interleaved row tiles:
+            //   subBlock 0: rows [0, rowOwned), [2*rowOwned, 3*rowOwned), ...
+            //   subBlock 1: rows [rowOwned, 2*rowOwned), ...
+            // beta is Brcb-broadcast from [row] scalars to row-wise 8-lane
+            // blocks so one vector Mul can apply beta to K columns.
+            for (uint32_t rowOffset = subBlockIdx * rowOwned; rowOffset < curChunkSize;
+                 rowOffset += rowOwned * subBlockNum) {
+                uint32_t curRowNum = rowOffset + rowOwned > curChunkSize ? curChunkSize - rowOffset : rowOwned;
+                auto tensorKFp32 = temp;
+                auto tensorBetaBrcbFP32 = temp[rowK * K];
+                auto tensorIn = oneInQue.AllocTensor<kType>();
+                DataCopy(tensorIn, kTensor[kBaseOffset + rowOffset * K], K * curRowNum);
+                oneInQue.EnQue(tensorIn);
+                auto tensorKIn = oneInQue.DeQue<kType>();
+                Cast(tensorKFp32, tensorKIn, RoundMode::CAST_NONE, K * curRowNum);
+                oneInQue.FreeTensor(tensorKIn);
+                PipeBarrier<PIPE_V>();
+                // Broadcast beta[rowOffset:rowOffset+curRowNum] to FP32
+                // blocks; it is used as beta[:, None] in K * beta.
+                Brcb(tensorBetaBrcbFP32, tensorBetaFP32[rowOffset], static_cast<uint8_t>(CeilDiv(curRowNum, 8)), {1, 8});
+                PipeBarrier<PIPE_V>();
+                uint64_t perchannelResOffset = 0;
+                uint8_t repeatStride = K * sizeof(float32_t) / ONE_BLOCK_32;
+                while (perchannelResOffset < K) {
+                    Mul(tensorKFp32[perchannelResOffset], tensorKFp32[perchannelResOffset], tensorBetaBrcbFP32,
+                        FP32_PER_REPEAT_64, curRowNum, {1, 1, 0, repeatStride, repeatStride, 1});
+                    perchannelResOffset += FP32_PER_REPEAT_64;
+                }
+                PipeBarrier<PIPE_V>();
+                auto tensorOut = oneOutQue.AllocTensor<kType>();
+                Cast(tensorOut, tensorKFp32, RoundMode::CAST_RINT, K * curRowNum);
+                oneOutQue.EnQue(tensorOut);
+                auto tensorKbeta = oneOutQue.DeQue<kType>();
+                DataCopy(workSpaceTensor[slotKbetaDvb + rowOffset * K], tensorKbeta, K * curRowNum);
+                oneOutQue.FreeTensor(tensorKbeta);
+            }
+
+            // Tell AIC that Kbeta is ready in workspace; AIC can now compute
+            // DK = dA @ Kbeta.  Then wait for AIC's first ready event:
+            // Dkb = dA^T @ K.
+            Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(flagAivFinishStore);
+            Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
+
+            bool waitedDkbgReady = false;
+            bool waitedDKReady = false;
+
+            // Stage V1: consume Dkb/Dkbg/DK in row tiles and produce dk plus
+            // dbeta/dg partials:
+            //   dbeta += reduce(Dkb * K)
+            //   Dkb    = Dkb * beta[:, None]
+            //   Dkbg   = (A^T @ dw) * exp(g)[:, None]
+            //   dbeta += reduce(Dkbg * K)
+            //   dg    += reduce(Dkbg * K) * beta
+            //   Dkbg   = Dkbg * beta[:, None]
+            //   dk     = DK + Dkb + Dkbg
+            for (uint32_t rowOffset = subBlockIdx * rowOwned; rowOffset < curChunkSize;
+                 rowOffset += rowOwned * subBlockNum) {
+                uint32_t curRowNum = rowOffset + rowOwned > curChunkSize ? curChunkSize - rowOffset : rowOwned;
+                uint64_t rowElem = rowK * K;
+                auto tensorDkbFp32 = temp;
+                auto tensorDkbgFp32 = temp[rowElem];
+                auto tensorKFp32 = temp[2 * rowElem];
+                auto tensorProductFp32 = temp[3 * rowElem];
+                auto tensorDKFp32 = temp[4 * rowElem];
+                auto tensorBetaBrcbFP32 = temp[5 * rowElem];
+                auto tensorGbrcbFP32 = tensorBetaBrcbFP32[rowK * FP32_PER_BLOCK_8];
+                auto tensorReduceSum = tensorGbrcbFP32[rowK * FP32_PER_BLOCK_8];
+
+                auto tensorIn = oneInQue.AllocTensor<kType>();
+                DataCopy(tensorIn, workSpaceTensor[slotDkb + rowOffset * K], K * curRowNum);
+                oneInQue.EnQue(tensorIn);
+                auto tensorDkbIn = oneInQue.DeQue<kType>();
+                Cast(tensorDkbFp32, tensorDkbIn, RoundMode::CAST_NONE, K * curRowNum);
+                oneInQue.FreeTensor(tensorDkbIn);
+
+                tensorIn = oneInQue.AllocTensor<kType>();
+                DataCopy(tensorIn, kTensor[kBaseOffset + rowOffset * K], K * curRowNum);
+                oneInQue.EnQue(tensorIn);
+                auto tensorKIn = oneInQue.DeQue<kType>();
+                Cast(tensorKFp32, tensorKIn, RoundMode::CAST_NONE, K * curRowNum);
+                oneInQue.FreeTensor(tensorKIn);
+                PipeBarrier<PIPE_V>();
+
+                Brcb(tensorBetaBrcbFP32, tensorBetaFP32[rowOffset], static_cast<uint8_t>(CeilDiv(curRowNum, 8)), {1, 8});
+                Brcb(tensorGbrcbFP32, tensorGExpFP32[rowOffset], static_cast<uint8_t>(CeilDiv(curRowNum, 8)), {1, 8});
+                PipeBarrier<PIPE_V>();
+
+                uint64_t perchannelResOffset = 0;
+                uint8_t repeatStride = K * sizeof(float32_t) / ONE_BLOCK_32;
+                // tensorProductFp32 = Dkb * K, then row-reduce over K to
+                // obtain the Dkb contribution to dbeta.
+                Mul(tensorProductFp32, tensorDkbFp32, tensorKFp32, K * curRowNum);
+                PipeBarrier<PIPE_V>();
+                for (uint32_t row = 0; row < curRowNum; row++) {
+                    WholeReduceSum(tensorReduceSum[row * FP32_PER_BLOCK_8], tensorProductFp32[row * K],
+                                   FP32_PER_REPEAT_64, wholeReduceKCnt, 1, 1, 8);
+                }
+                PipeBarrier<PIPE_V>();
+                WholeReduceSum(tensorProductFp32, tensorReduceSum, wholeReduceKCnt, curRowNum, 1, 1, 1);
+                PipeBarrier<PIPE_V>();
+                Add(tensorDbetaAccFP32[rowOffset], tensorDbetaAccFP32[rowOffset], tensorProductFp32, curRowNum);
+
+                perchannelResOffset = 0;
+                while (perchannelResOffset < K) {
+                    // Dkb becomes the second dk term:
+                    //   (dA^T @ K) * beta[:, None]
+                    Mul(tensorDkbFp32[perchannelResOffset], tensorDkbFp32[perchannelResOffset], tensorBetaBrcbFP32,
+                        FP32_PER_REPEAT_64, curRowNum, {1, 1, 0, repeatStride, repeatStride, 1});
+                    perchannelResOffset += FP32_PER_REPEAT_64;
+                }
+                PipeBarrier<PIPE_V>();
+
+                if (!waitedDkbgReady) {
+                    // Second AIC ready event: Dkbg = A^T @ dw is available.
+                    Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
+                    waitedDkbgReady = true;
+                }
+                tensorIn = oneInQue.AllocTensor<kType>();
+                DataCopy(tensorIn, workSpaceTensor[slotDkbg + rowOffset * K], K * curRowNum);
+                oneInQue.EnQue(tensorIn);
+                auto tensorDkbgIn = oneInQue.DeQue<kType>();
+                Cast(tensorDkbgFp32, tensorDkbgIn, RoundMode::CAST_NONE, K * curRowNum);
+                oneInQue.FreeTensor(tensorDkbgIn);
+                PipeBarrier<PIPE_V>();
+
+                perchannelResOffset = 0;
+                while (perchannelResOffset < K) {
+                    // Apply exp(g) first:
+                    //   Dkbg = (A^T @ dw) * exp(g)[:, None]
+                    Mul(tensorDkbgFp32[perchannelResOffset], tensorDkbgFp32[perchannelResOffset], tensorGbrcbFP32,
+                        FP32_PER_REPEAT_64, curRowNum, {1, 1, 0, repeatStride, repeatStride, 1});
+                    perchannelResOffset += FP32_PER_REPEAT_64;
+                }
+                PipeBarrier<PIPE_V>();
+
+                // tensorProductFp32 = Dkbg * K.  Row reduce gives:
+                //   dbeta2 = reduce((A^T@dw) * exp(g) * K)
+                // The same row-reduced value times beta is the Dkbg
+                // contribution to dg.
+                Mul(tensorProductFp32, tensorDkbgFp32, tensorKFp32, K * curRowNum);
+                PipeBarrier<PIPE_V>();
+                for (uint32_t row = 0; row < curRowNum; row++) {
+                    WholeReduceSum(tensorReduceSum[row * FP32_PER_BLOCK_8], tensorProductFp32[row * K],
+                                   FP32_PER_REPEAT_64, wholeReduceKCnt, 1, 1, 8);
+                }
+                PipeBarrier<PIPE_V>();
+                WholeReduceSum(tensorKFp32, tensorReduceSum, wholeReduceKCnt, curRowNum, 1, 1, 1);
+                PipeBarrier<PIPE_V>();
+                Add(tensorDbetaAccFP32[rowOffset], tensorDbetaAccFP32[rowOffset], tensorKFp32, curRowNum);
+                Mul(tensorKFp32, tensorKFp32, tensorBetaFP32[rowOffset], curRowNum);
+                PipeBarrier<PIPE_V>();
+                Add(tensorDgAccFP32[rowOffset], tensorDgAccFP32[rowOffset], tensorKFp32, curRowNum);
+
+                perchannelResOffset = 0;
+                while (perchannelResOffset < K) {
+                    // Apply beta to form the third dk term:
+                    //   (A^T @ dw) * exp(g)[:, None] * beta[:, None]
+                    Mul(tensorDkbgFp32[perchannelResOffset], tensorDkbgFp32[perchannelResOffset], tensorBetaBrcbFP32,
+                        FP32_PER_REPEAT_64, curRowNum, {1, 1, 0, repeatStride, repeatStride, 1});
+                    perchannelResOffset += FP32_PER_REPEAT_64;
+                }
+                PipeBarrier<PIPE_V>();
+                Add(tensorDkbFp32, tensorDkbFp32, tensorDkbgFp32, K * curRowNum);
+                PipeBarrier<PIPE_V>();
+                if (!waitedDKReady) {
+                    // Third AIC ready event: DK = dA @ Kbeta is available.
+                    Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
+                    waitedDKReady = true;
+                }
+
+                tensorIn = oneInQue.AllocTensor<kType>();
+                DataCopy(tensorIn, workSpaceTensor[slotDK + rowOffset * K], K * curRowNum);
+                oneInQue.EnQue(tensorIn);
+                auto tensorDKIn = oneInQue.DeQue<kType>();
+                Cast(tensorDKFp32, tensorDKIn, RoundMode::CAST_NONE, K * curRowNum);
+                oneInQue.FreeTensor(tensorDKIn);
+                PipeBarrier<PIPE_V>();
+
+                // Final dk row tile:
+                //   dk = DK + Dkb*beta + Dkbg*exp(g)*beta
+                Add(tensorDKFp32, tensorDKFp32, tensorDkbFp32, K * curRowNum);
+                PipeBarrier<PIPE_V>();
+                // Multiple value heads in one GQA group contribute to the same
+                // dk[kh]; the first head writes, later heads accumulate.
+                if (!isFirstValueHeadInGroup) {
+                    tensorIn = oneInQue.AllocTensor<kType>();
+                    DataCopy(tensorIn, dkTensor[kBaseOffset + rowOffset * K], K * curRowNum);
+                    oneInQue.EnQue(tensorIn);
+                    auto tensorDkPrevIn = oneInQue.DeQue<kType>();
+                    Cast(tensorProductFp32, tensorDkPrevIn, RoundMode::CAST_NONE, K * curRowNum);
+                    oneInQue.FreeTensor(tensorDkPrevIn);
                     PipeBarrier<PIPE_V>();
-                    // KKT * beta -> KKT
+                    Add(tensorDKFp32, tensorDKFp32, tensorProductFp32, K * curRowNum);
+                    PipeBarrier<PIPE_V>();
+                }
+                auto tensorOut = oneOutQue.AllocTensor<kType>();
+                Cast(tensorOut, tensorDKFp32, RoundMode::CAST_RINT, K * curRowNum);
+                oneOutQue.EnQue(tensorOut);
+                auto tensorDkOut = oneOutQue.DeQue<kType>();
+                DataCopy(dkTensor[kBaseOffset + rowOffset * K], tensorDkOut, K * curRowNum);
+                oneOutQue.FreeTensor(tensorDkOut);
+            }
+            if (!waitedDkbgReady) {
+                Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
+            }
+            if (!waitedDKReady) {
+                Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
+            }
+
+            // Fourth AIC ready event: Dvb = A^T @ du is available.
+            Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
+
+            // Stage V2: consume Dvb and V to compute:
+            //   dbeta += reduce(Dvb * V)
+            //   dv     = Dvb * beta[:, None]
+            for (uint32_t rowOffset = subBlockIdx * rowOwned; rowOffset < curChunkSize;
+                 rowOffset += rowOwned * subBlockNum) {
+                uint32_t curRowNum = rowOffset + rowOwned > curChunkSize ? curChunkSize - rowOffset : rowOwned;
+                uint64_t rowElem = rowV * V;
+                auto tensorDvbFp32 = temp;
+                auto tensorVFp32 = temp[rowElem];
+                auto tensorBetaBrcbFP32 = temp[2 * rowElem];
+                auto tensorReduceSum = tensorBetaBrcbFP32[rowV * FP32_PER_BLOCK_8];
+
+                auto tensorIn = oneInQue.AllocTensor<kType>();
+                DataCopy(tensorIn, workSpaceTensor[slotKbetaDvb + rowOffset * V], V * curRowNum);
+                oneInQue.EnQue(tensorIn);
+                auto tensorDvbIn = oneInQue.DeQue<kType>();
+                Cast(tensorDvbFp32, tensorDvbIn, RoundMode::CAST_NONE, V * curRowNum);
+                oneInQue.FreeTensor(tensorDvbIn);
+
+                tensorIn = oneInQue.AllocTensor<kType>();
+                DataCopy(tensorIn, vTensor[vBaseOffset + rowOffset * V], V * curRowNum);
+                oneInQue.EnQue(tensorIn);
+                auto tensorVIn = oneInQue.DeQue<kType>();
+                Cast(tensorVFp32, tensorVIn, RoundMode::CAST_NONE, V * curRowNum);
+                oneInQue.FreeTensor(tensorVIn);
+                PipeBarrier<PIPE_V>();
+
+                // Broadcast beta for dv = Dvb * beta[:, None].
+                Brcb(tensorBetaBrcbFP32, tensorBetaFP32[rowOffset], static_cast<uint8_t>(CeilDiv(curRowNum, 8)), {1, 8});
+                // Reuse tensorVFp32 as product Dvb * V before reducing over V.
+                Mul(tensorVFp32, tensorVFp32, tensorDvbFp32, V * curRowNum);
+                PipeBarrier<PIPE_V>();
+                for (uint32_t row = 0; row < curRowNum; row++) {
+                    WholeReduceSum(tensorReduceSum[row * FP32_PER_BLOCK_8], tensorVFp32[row * V],
+                                   FP32_PER_REPEAT_64, wholeReduceVCnt, 1, 1, 8);
+                }
+                PipeBarrier<PIPE_V>();
+                WholeReduceSum(tensorVFp32, tensorReduceSum, wholeReduceVCnt, curRowNum, 1, 1, 1);
+                PipeBarrier<PIPE_V>();
+                Add(tensorDbetaAccFP32[rowOffset], tensorDbetaAccFP32[rowOffset], tensorVFp32, curRowNum);
+
+                uint64_t perchannelResOffset = 0;
+                uint8_t repeatStride = V * sizeof(float32_t) / ONE_BLOCK_32;
+                while (perchannelResOffset < V) {
+                    // Form dv row tile: (A^T @ du) * beta[:, None].
+                    Mul(tensorDvbFp32[perchannelResOffset], tensorDvbFp32[perchannelResOffset], tensorBetaBrcbFP32,
+                        FP32_PER_REPEAT_64, curRowNum, {1, 1, 0, repeatStride, repeatStride, 1});
+                    perchannelResOffset += FP32_PER_REPEAT_64;
+                }
+                PipeBarrier<PIPE_V>();
+                auto tensorOut = oneOutQue.AllocTensor<kType>();
+                Cast(tensorOut, tensorDvbFp32, RoundMode::CAST_RINT, V * curRowNum);
+                oneOutQue.EnQue(tensorOut);
+                auto tensorDvOut = oneOutQue.DeQue<kType>();
+                DataCopy(dvTensor[vBaseOffset + rowOffset * V], tensorDvOut, V * curRowNum);
+                oneOutQue.FreeTensor(tensorDvOut);
+            }
+
+            // Fifth AIC ready event: KKT = K @ K^T is available.
+            Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
+
+            {
+                uint64_t kktOffset = 0;
+                uint64_t daOffset = chunkSize * chunkSize;
+                uint64_t rowSumOffset = daOffset + rowKkt * chunkSize;
+                uint64_t reduceOffset = rowSumOffset + rowKkt;
+                auto tensorKKTFp32 = temp[kktOffset];
+                auto tensorDaFp32 = temp[daOffset];
+                auto tensorRowSumFP32 = temp[rowSumOffset];
+                auto tensorReduceSum = temp[reduceOffset];
+
+                // Stage V3: compute the KKT/dA contribution to dg.
+                // For every KKT row block:
+                //   1) load dA rows and KKT rows
+                //   2) multiply KKT columns by beta[col]
+                //   3) DAA[row, col] = dA^T[row, col] * KKT[row, col] * beta[col]
+                // After all rows are materialized, add:
+                //   dg += col_reduce(DAA) - row_reduce(DAA)
+                for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowKkt) {
+                    uint32_t curRowNum = rowOffset + rowKkt > curChunkSize ? curChunkSize - rowOffset : rowKkt;
+                    auto tensorIn = oneInQue.AllocTensor<kType>();
+                    DataCopy(tensorIn, dATensor[daBaseOffset + rowOffset * chunkSize], chunkSize * curRowNum);
+                    oneInQue.EnQue(tensorIn);
+                    auto tensorDaIn = oneInQue.DeQue<kType>();
+                    Cast(tensorDaFp32, tensorDaIn, RoundMode::CAST_NONE, chunkSize * curRowNum);
+                    oneInQue.FreeTensor(tensorDaIn);
+
+                    tensorIn = oneInQue.AllocTensor<kType>();
+                    DataCopy(tensorIn, workSpaceTensor[slotKKT + rowOffset * chunkSize], chunkSize * curRowNum);
+                    oneInQue.EnQue(tensorIn);
+                    auto tensorKKTIn = oneInQue.DeQue<kType>();
+                    Cast(tensorKKTFp32[rowOffset * chunkSize], tensorKKTIn, RoundMode::CAST_NONE,
+                         chunkSize * curRowNum);
+                    oneInQue.FreeTensor(tensorKKTIn);
+                    PipeBarrier<PIPE_V>();
+
                     uint64_t perchannelResOffset = 0;
                     uint8_t repeatStride = chunkSize * sizeof(float32_t) / ONE_BLOCK_32;
                     while (perchannelResOffset < curChunkSize) {
-                        Mul(tensorKKTFp32[perchannelResOffset], tensorKKTFp32[perchannelResOffset], tensorBetaFP32[perchannelResOffset],
-                            FP32_PER_REPEAT_64, curRowNum, {1, 1, 1, repeatStride, repeatStride, 0});
+                        // Broadcast beta along KKT columns:
+                        //   KKT[:, col] *= beta[col]
+                        Mul(tensorKKTFp32[rowOffset * chunkSize + perchannelResOffset],
+                            tensorKKTFp32[rowOffset * chunkSize + perchannelResOffset],
+                            tensorBetaFP32[perchannelResOffset], FP32_PER_REPEAT_64, curRowNum,
+                            {1, 1, 1, repeatStride, repeatStride, 0});
                         perchannelResOffset += FP32_PER_REPEAT_64;
                     }
                     PipeBarrier<PIPE_V>();
-                    // da * KKT(KKT * beta) -> da_A
-                    Mul(tensorDaaFP32[rowOffset * chunkSize], tensorDaFp32, tensorKKTFp32, chunkSize * curRowNum);
+                    Mul(tensorKKTFp32[rowOffset * chunkSize], tensorDaFp32, tensorKKTFp32[rowOffset * chunkSize],
+                        chunkSize * curRowNum);
                     PipeBarrier<PIPE_V>();
+                    uint32_t remainCnt = curChunkSize % FP32_PER_REPEAT_64;
+                    if (remainCnt > 0) {
+                        uint32_t duplicateOffset = wholeReduceChunkCnt * FP32_PER_REPEAT_64 - FP32_PER_REPEAT_64;
+                        uint64_t mask[1] = {0xffffffffffffffff};
+                        mask[0] <<= remainCnt;
+                        for (uint32_t row = 0; row < curRowNum; row++) {
+                            // Zero padded columns beyond curChunkSize so the
+                            // later WholeReduceSum over 64-wide repeats does
+                            // not include stale values in the varlen tail.
+                            Duplicate(tensorKKTFp32[(rowOffset + row) * chunkSize + duplicateOffset], 0.0f, mask, 1,
+                                      1, 8);
+                        }
+                        PipeBarrier<PIPE_V>();
+                    }
+                }
 
-                    daInQue.FreeTensor(tensordaIn);
-                    kktInQue.FreeTensor(tensorKKTin);
+                // row_reduce(DAA): only reduce rows owned by this AIV sub-block.
+                // Each sub-block writes disjoint dg rows later, so reducing all
+                // rows here duplicated work without changing the final output.
+                for (uint32_t rowOffset = subBlockIdx * rowOwned; rowOffset < curChunkSize;
+                     rowOffset += rowOwned * subBlockNum) {
+                    uint32_t curRowNum = rowOffset + rowOwned > curChunkSize ? curChunkSize - rowOffset : rowOwned;
+                    for (uint32_t row = 0; row < curRowNum; row++) {
+                        WholeReduceSum(tensorReduceSum[(rowOffset + row) * FP32_PER_BLOCK_8],
+                                       tensorKKTFp32[(rowOffset + row) * chunkSize], FP32_PER_REPEAT_64,
+                                       wholeReduceChunkCnt, 1, 1, 8);
+                    }
+                }
+                PipeBarrier<PIPE_V>();
+                for (uint32_t rowOffset = subBlockIdx * rowOwned; rowOffset < curChunkSize;
+                     rowOffset += rowOwned * subBlockNum) {
+                    uint32_t curRowNum = rowOffset + rowOwned > curChunkSize ? curChunkSize - rowOffset : rowOwned;
+                    WholeReduceSum(tensorRowSumFP32, tensorReduceSum[rowOffset * FP32_PER_BLOCK_8],
+                                   wholeReduceChunkCnt, curRowNum, 1, 1, 1);
+                    PipeBarrier<PIPE_V>();
+                    Muls(tensorRowSumFP32, tensorRowSumFP32, -1.0f, curRowNum);
+                    PipeBarrier<PIPE_V>();
+                    Add(tensorDgAccFP32[rowOffset], tensorDgAccFP32[rowOffset], tensorRowSumFP32, curRowNum);
+                    PipeBarrier<PIPE_V>();
+                }
+
+                // col_reduce(DAA): tree-add rows until the first row contains
+                // the sum for every column; add it to dg.
+                uint32_t remainRow = curChunkSize;
+                while (remainRow > 1) {
+                    uint32_t calcCnt = (remainRow / 2) * chunkSize;
+                    remainRow = CeilDiv(remainRow, 2);
+                    uint32_t offset = remainRow * chunkSize;
+                    Add(tensorKKTFp32, tensorKKTFp32, tensorKKTFp32[offset], calcCnt);
+                    PipeBarrier<PIPE_V>();
+                }
+                for (uint32_t rowOffset = subBlockIdx * rowOwned; rowOffset < curChunkSize;
+                     rowOffset += rowOwned * subBlockNum) {
+                    uint32_t curRowNum = rowOffset + rowOwned > curChunkSize ? curChunkSize - rowOffset : rowOwned;
+                    Add(tensorDgAccFP32[rowOffset], tensorDgAccFP32[rowOffset], tensorKKTFp32[rowOffset], curRowNum);
+                    PipeBarrier<PIPE_V>();
                 }
             }
-            //最后处理daa的sum相减
-            {
-                uint32_t remainCnt = curChunkSize % FP32_PER_REPEAT_64;
-                if(remainCnt > 0) {
-                    uint32_t DuplicateOffset = wholeReduceSumCnt * FP32_PER_REPEAT_64 - FP32_PER_REPEAT_64;
-                    uint64_t mask[1] = {0xffffffffffffffff};
-                    mask[0] <<= remainCnt;
-                    for (uint32_t row = 0; row < curChunkSize; row++) {
-                        Duplicate(tensorDaaFP32[row * chunkSize + DuplicateOffset], 0.0f, mask, 1, 1, 8);
-                    }
-                    PipeBarrier<PIPE_V>();
-                }
-                // reducesum
-                for (uint32_t row = 0; row < curChunkSize; row++) {
-                    WholeReduceSum(tensorReduceSum[row * FP32_PER_BLOCK_8], tensorDaaFP32[row * chunkSize],
-                                   FP32_PER_REPEAT_64, wholeReduceSumCnt, 1, 1, 8);
-                }
-                PipeBarrier<PIPE_V>();
-                WholeReduceSum(tensorSum1DaaFP32, tensorReduceSum, wholeReduceSumCnt, curChunkSize, 1, 1, 1);
-                uint32_t remain_row = curChunkSize;
-                uint32_t CalcCnt = 0;
-                uint32_t Offset = 0;
-                while (remain_row > 1) {
-                    CalcCnt = (remain_row / 2) * chunkSize;
-                    remain_row = CeilDiv(remain_row, 2);
-                    Offset = remain_row * chunkSize;
-                    Add(tensorDaaFP32, tensorDaaFP32, tensorDaaFP32[Offset], CalcCnt);
-                    PipeBarrier<PIPE_V>();
-                }
-                PipeBarrier<PIPE_V>();
-                Sub(tensorDgFP32Add, tensorDaaFP32, tensorSum1DaaFP32, curChunkSize);
-                // DataCopy(tensorDgFP32Add, tensorDaaFP32, chunkSize);
-                auto tensorDg = dgInQue.DeQue<betaType>();
-                auto tensorOutDg = dgOutQue.AllocTensor<betaType>();
-                if constexpr (!std::is_same<betaType, float32_t>()) {
-                    Cast(tensorDgFP32, tensorDg, RoundMode::CAST_NONE, curChunkSize);
+
+            for (uint32_t rowOffset = subBlockIdx * rowOwned; rowOffset < curChunkSize;
+                 rowOffset += rowOwned * subBlockNum) {
+                uint32_t curRowNum = rowOffset + rowOwned > curChunkSize ? curChunkSize - rowOffset : rowOwned;
+                auto tensorOut = oneOutQue.AllocTensor<betaType>();
+                if constexpr (std::is_same<betaType, float32_t>()) {
+                    // float32 varlen tails can be non-32B aligned; Adds(x, 0)
+                    // is used as a safe UB copy before DataCopyPad to GM.
+                    Adds(tensorOut, tensorDbetaAccFP32[rowOffset], 0.0f, curRowNum);
                 } else {
-                    DataCopy(tensorDgFP32, tensorDg, chunkSize);
+                    Cast(tensorOut, tensorDbetaAccFP32[rowOffset], RoundMode::CAST_RINT, curRowNum);
                 }
-                dgInQue.FreeTensor(tensorDg);
-                PipeBarrier<PIPE_V>();
-                Add(tensorDgFP32Add, tensorDgFP32Add, tensorDgFP32, curChunkSize);
-                PipeBarrier<PIPE_V>();
-
-                if constexpr (!std::is_same<betaType, float32_t>()) {
-                    Cast(tensorOutDg, tensorDgFP32Add, RoundMode::CAST_RINT, curChunkSize);
+                oneOutQue.EnQue(tensorOut);
+                auto tensorDbetaOut = oneOutQue.DeQue<betaType>();
+                DataCopyPad(dbetaTensor[betaOffset + rowOffset], tensorDbetaOut,
+                            {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0});
+                oneOutQue.FreeTensor(tensorDbetaOut);
+            }
+            for (uint32_t rowOffset = subBlockIdx * rowOwned; rowOffset < curChunkSize;
+                 rowOffset += rowOwned * subBlockNum) {
+                uint32_t curRowNum = rowOffset + rowOwned > curChunkSize ? curChunkSize - rowOffset : rowOwned;
+                auto tensorOut = oneOutQue.AllocTensor<betaType>();
+                if constexpr (std::is_same<betaType, float32_t>()) {
+                    // Same safe UB copy as dbeta for betaType=float32.
+                    Adds(tensorOut, tensorDgAccFP32[rowOffset], 0.0f, curRowNum);
                 } else {
-                    DataCopy(tensorOutDg, tensorDgFP32Add, chunkSize);
+                    Cast(tensorOut, tensorDgAccFP32[rowOffset], RoundMode::CAST_RINT, curRowNum);
                 }
-                dgOutQue.EnQue(tensorOutDg);
-            }
-            {//copyout
-                auto tensorOutDg = dgOutQue.DeQue<betaType>();
-                DataCopyPad(dgTensor[h * T + bos], tensorOutDg, {1, curChunkSize * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0});
-                dgOutQue.FreeTensor(tensorOutDg);
-            }
-        }
-    }
-    return;
-}
-
-
-template <typename kType, typename betaType>
-__aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDvb()
-{
-    uint32_t coreLoops = chunkNum;
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNumAic = GetBlockNum();
-    uint32_t rowNum = dvbVecRow;
-    uint32_t rowOffset = 0;
-    uint32_t vecTaskIdx = 0;
-    uint32_t wholeReduceSumCnt = CeilDiv(V, FP32_PER_REPEAT_64);
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    uint32_t curRowNum = rowNum;
-
-    // init
-    pipe->InitBuffer(vInQue, 2, rowNum * V * sizeof(kType));
-    pipe->InitBuffer(betaInQue, 2, rowNum * sizeof(betaType));
-    pipe->InitBuffer(dbetaInQue, 2, rowNum * sizeof(betaType));
-    pipe->InitBuffer(dvbInQue, 2, rowNum * V * sizeof(kType));
-    pipe->InitBuffer(dvOutQue, 2, rowNum * V * sizeof(kType));
-    pipe->InitBuffer(dBetaOutQue, 2, rowNum * sizeof(betaType));
-
-    pipe->InitBuffer(dvbFp32Buf, rowNum * V * sizeof(float32_t));
-    pipe->InitBuffer(vFp32Buf, rowNum * V * sizeof(float32_t));
-    pipe->InitBuffer(betaFp32Buf, rowNum * sizeof(float32_t));
-    pipe->InitBuffer(betaFp32BrcbBuf, rowNum * ONE_BLOCK_32);
-    pipe->InitBuffer(dbetaFp32Buf, rowNum * sizeof(float32_t));
-    pipe->InitBuffer(dbetaAddFp32Buf, rowNum * sizeof(float32_t));
-    pipe->InitBuffer(reduceSumTmpBuf, rowNum * ONE_BLOCK_32);
-
-    auto tensorDvbFp32 = dvbFp32Buf.Get<float32_t>();
-    auto tensorVFp32 = vFp32Buf.Get<float32_t>();
-    auto tensorBetaFP32 = betaFp32Buf.Get<float32_t>();
-    auto tensorBetaBrcbFP32 = betaFp32BrcbBuf.Get<float32_t>();
-    auto tensorDbetaFP32 = dbetaFp32Buf.Get<float32_t>();
-    auto tensorDbetaAddFP32 = dbetaAddFp32Buf.Get<float32_t>();
-    auto tensorReduceSum = reduceSumTmpBuf.Get<float32_t>();
-
-    
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
-        GetChunkOffset(cu_seqlens, chunk_indices, B, HV, T, chunkSize, loopIdx, bos, eos);
-        uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < HV; h++) {
-            Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
-            for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
-                ++vecTaskIdx;
-                if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                    continue;
-                }
-                curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
-                auto vOffset = (h * T + bos + rowOffset) * V;
-                auto betaOffset = h * T + bos + rowOffset;
-                // copyin
-                {
-                    auto tensorDvbin = dvbInQue.AllocTensor<kType>();
-                    auto tensorVin = vInQue.AllocTensor<kType>();
-                    auto tensorBetain = betaInQue.AllocTensor<betaType>();
-                    auto tensordDbetaIn = dbetaInQue.AllocTensor<betaType>();
-
-                    DataCopy(tensorDvbin, workSpaceTensor[vOffset], V * curRowNum);
-                    DataCopy(tensorVin, vTensor[vOffset], V * curRowNum);
-                    DataCopyPad(tensorBetain, betaTensor[betaOffset], {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
-                    DataCopyPad(tensordDbetaIn, dbetaTensor[betaOffset], {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
-
-                    dvbInQue.EnQue(tensorDvbin);
-                    vInQue.EnQue(tensorVin);
-                    betaInQue.EnQue(tensorBetain);
-                    dbetaInQue.EnQue(tensordDbetaIn);
-                }
-                // compute
-                {
-                    auto tensorDvbin = dvbInQue.DeQue<kType>();
-                    auto tensorVin = vInQue.DeQue<kType>();
-                    auto tensorBetain = betaInQue.DeQue<betaType>();
-                    auto tensorDbetain = dbetaInQue.DeQue<betaType>();
-
-                    auto tensorDvOut = dvOutQue.AllocTensor<kType>();
-                    auto tensorDbetaOut = dBetaOutQue.AllocTensor<betaType>();
-                    // cast FP32
-                    if constexpr (!std::is_same<betaType, float32_t>()) {
-                        Cast(tensorBetaFP32, tensorBetain, RoundMode::CAST_NONE, curRowNum);
-                        Cast(tensorDbetaFP32, tensorDbetain, RoundMode::CAST_NONE, curRowNum);
-                    } else {
-                        DataCopy(tensorBetaFP32, tensorBetain, rowNum);
-                        DataCopy(tensorDbetaFP32, tensorDbetain, rowNum);
-                    }
-                    Cast(tensorDvbFp32, tensorDvbin, RoundMode::CAST_NONE, V * curRowNum);
-
-                    Cast(tensorVFp32, tensorVin, RoundMode::CAST_NONE, V * curRowNum);
-                    PipeBarrier<PIPE_V>();
-                    // brcb(beta)  dvb * v -> v
-                    Brcb(tensorBetaBrcbFP32, tensorBetaFP32, static_cast<uint8_t>(CeilDiv(curRowNum, 8)), {1, 8});
-                    Mul(tensorVFp32, tensorVFp32, tensorDvbFp32, V * curRowNum);
-                    PipeBarrier<PIPE_V>();
-                    // dvb * beta -> dvb
-                    uint64_t perchannelResOffset = 0;
-                    uint8_t repeatStride = V * sizeof(float32_t) / ONE_BLOCK_32;
-                    while (perchannelResOffset < V) {
-                        Mul(tensorDvbFp32[perchannelResOffset], tensorDvbFp32[perchannelResOffset], tensorBetaBrcbFP32,
-                            FP32_PER_REPEAT_64, curRowNum, {1, 1, 0, repeatStride, repeatStride, 1});
-                        perchannelResOffset += FP32_PER_REPEAT_64;
-                    }
-                    PipeBarrier<PIPE_V>();
-                    // reducesum
-                    for (uint32_t row = 0; row < curRowNum; row++) {
-                        WholeReduceSum(tensorReduceSum[row * FP32_PER_BLOCK_8], tensorVFp32[row * V],
-                                       FP32_PER_REPEAT_64, wholeReduceSumCnt, 1, 1, 8);
-                    }
-                    PipeBarrier<PIPE_V>();
-                    WholeReduceSum(tensorDbetaAddFP32, tensorReduceSum, wholeReduceSumCnt, curRowNum, 1, 1, 1);
-                    PipeBarrier<PIPE_V>();
-                    // 累加处理原始dbeta
-                    Add(tensorDbetaAddFP32, tensorDbetaAddFP32, tensorDbetaFP32, curRowNum);
-                    PipeBarrier<PIPE_V>();
-                    // cast
-                    Cast(tensorDvOut, tensorDvbFp32, RoundMode::CAST_RINT, V * curRowNum);
-                    if constexpr (!std::is_same<betaType, float32_t>()) {
-                        Cast(tensorDbetaOut, tensorDbetaAddFP32, RoundMode::CAST_RINT, curRowNum);
-                    } else {
-                        DataCopy(tensorDbetaOut, tensorDbetaAddFP32, rowNum);
-                    }
-                    dvbInQue.FreeTensor(tensorDvbin);
-                    vInQue.FreeTensor(tensorVin);
-                    betaInQue.FreeTensor(tensorBetain);
-                    dbetaInQue.FreeTensor(tensorDbetain);
-
-                    dvOutQue.EnQue(tensorDvOut);
-                    dBetaOutQue.EnQue(tensorDbetaOut);
-                }
-                // copyout
-                {
-                    auto tensorDvOut = dvOutQue.DeQue<kType>();
-                    auto tensorDbetaOut = dBetaOutQue.DeQue<betaType>();
-                    DataCopy(dvTensor[vOffset], tensorDvOut, V * curRowNum);
-                    DataCopyPad(dbetaTensor[betaOffset], tensorDbetaOut, {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0});
-                    dvOutQue.FreeTensor(tensorDvOut);
-                    dBetaOutQue.FreeTensor(tensorDbetaOut);
-                }
-            }
-        }
-    }
-    return;
-}
-
-template <typename kType, typename betaType>
-__aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDkbg()
-{
-
-    uint32_t coreLoops = chunkNum;
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNumAic = GetBlockNum();
-    uint32_t rowNum = dkbgVecRow;
-    uint32_t rowOffset = 0;
-    uint32_t vecTaskIdx = 0;
-    uint32_t wholeReduceSumCnt = CeilDiv(K, FP32_PER_REPEAT_64);
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    uint32_t curRowNum = rowNum;
-
-    // init
-    pipe->InitBuffer(kInQue, 2, rowNum * K * sizeof(kType));
-    pipe->InitBuffer(betaInQue, 2, rowNum * sizeof(betaType));
-    pipe->InitBuffer(gInQue, 2, rowNum * sizeof(betaType));
-    pipe->InitBuffer(dkInQue, 2, rowNum * K * sizeof(kType));
-    pipe->InitBuffer(dkbgInQue, 2, rowNum * K * sizeof(kType));
-    pipe->InitBuffer(dbetaInQue, 2, rowNum * sizeof(betaType));
-    pipe->InitBuffer(dkOutQue, 2, rowNum * K * sizeof(kType));
-    pipe->InitBuffer(dgOutQue, 2, rowNum * sizeof(betaType));
-    pipe->InitBuffer(dBetaOutQue, 2, rowNum * sizeof(betaType));
-
-    pipe->InitBuffer(kFp32Buf, rowNum * K * sizeof(float32_t));
-    pipe->InitBuffer(betaFp32Buf, rowNum * sizeof(float32_t));
-    pipe->InitBuffer(betaFp32BrcbBuf, rowNum * ONE_BLOCK_32);
-    pipe->InitBuffer(gFp32Buf, rowNum * sizeof(float32_t));
-    pipe->InitBuffer(gFp32BrcbBuf, rowNum * ONE_BLOCK_32);
-    pipe->InitBuffer(dkFp32Buf, rowNum * K * sizeof(float32_t));
-    pipe->InitBuffer(dkbgFp32Buf, rowNum * K * sizeof(float32_t));
-    pipe->InitBuffer(dbetaFp32Buf, rowNum * sizeof(float32_t));
-    pipe->InitBuffer(dbetaAddFp32Buf, rowNum * sizeof(float32_t));
-    pipe->InitBuffer(dgFp32Buf, rowNum * sizeof(float32_t));
-
-    auto tensorDkbgFp32 = dkbgFp32Buf.Get<float32_t>();
-    auto tensorDkFp32 = dkFp32Buf.Get<float32_t>();
-    auto tensorKFp32 = kFp32Buf.Get<float32_t>();
-    auto tensorBetaFP32 = betaFp32Buf.Get<float32_t>();
-    auto tensorBetaBrcbFP32 = betaFp32BrcbBuf.Get<float32_t>();
-    auto tensorGFP32 = gFp32Buf.Get<float32_t>();
-    auto tensorDbetaFP32 = dbetaFp32Buf.Get<float32_t>();
-    auto tensorGbrcbFP32 = gFp32BrcbBuf.Get<float32_t>();
-    auto tensorDbetaAddFP32 = dbetaAddFp32Buf.Get<float32_t>();
-    auto tensorDgFp32 = dgFp32Buf.Get<float32_t>();
-    
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
-        GetChunkOffset(cu_seqlens, chunk_indices, B, HV, T, chunkSize, loopIdx, bos, eos);
-        uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < HV; h++) {
-            Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
-            for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
-                ++vecTaskIdx;
-                if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                    continue;
-                }
-                curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
-                auto kOffset = (h * T + bos + rowOffset) * K;
-                auto betaOffset = h * T + bos + rowOffset;
-                // copyin
-                {
-                    auto tensorDkbgin = dkbgInQue.AllocTensor<kType>();
-                    auto tensorKin = kInQue.AllocTensor<kType>();
-                    auto tensorBetain = betaInQue.AllocTensor<betaType>();
-                    auto tensorGin = gInQue.AllocTensor<betaType>();
-                    auto tensorDkin = dkInQue.AllocTensor<kType>();
-                    auto tensordDbetaIn = dbetaInQue.AllocTensor<betaType>();
-
-                    DataCopy(tensorDkbgin, workSpaceTensor[kOffset], K * curRowNum);
-                    DataCopy(tensorKin, kTensor[kOffset], K * curRowNum);
-                    DataCopyPad(tensorBetain, betaTensor[betaOffset], {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
-                    DataCopyPad(tensorGin, gTensor[betaOffset], {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
-                    DataCopy(tensorDkin, dkTensor[kOffset], K * curRowNum);
-                    DataCopyPad(tensordDbetaIn, dbetaTensor[betaOffset], {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
-
-                    dkbgInQue.EnQue(tensorDkbgin);
-                    kInQue.EnQue(tensorKin);
-                    betaInQue.EnQue(tensorBetain);
-                    gInQue.EnQue(tensorGin);
-                    dkInQue.EnQue(tensorDkin);
-                    dbetaInQue.EnQue(tensordDbetaIn);
-                }
-                // compute
-                {
-                    auto tensorDkbgin = dkbgInQue.DeQue<kType>();
-                    auto tensorKin = kInQue.DeQue<kType>();
-                    auto tensorBetain = betaInQue.DeQue<betaType>();
-                    auto tensorGin = gInQue.DeQue<betaType>();
-                    auto tensorDkin = dkInQue.DeQue<kType>();
-                    auto tensorDbetain = dbetaInQue.DeQue<betaType>();
-
-                    auto tensorDkOut = dkOutQue.AllocTensor<kType>();
-                    auto tensorDbetaOut = dBetaOutQue.AllocTensor<betaType>();
-                    auto tensorDgOut = dgOutQue.AllocTensor<betaType>();
-                    // cast FP32
-                    if constexpr (!std::is_same<betaType, float32_t>()) {
-                        Cast(tensorBetaFP32, tensorBetain, RoundMode::CAST_NONE, curRowNum);
-                        Cast(tensorGFP32, tensorGin, RoundMode::CAST_NONE, curRowNum);
-                        Cast(tensorDbetaFP32, tensorDbetain, RoundMode::CAST_NONE, curRowNum);
-                    } else {
-                        DataCopy(tensorBetaFP32, tensorBetain, rowNum);
-                        DataCopy(tensorGFP32, tensorGin, rowNum);
-                        DataCopy(tensorDbetaFP32, tensorDbetain, rowNum);
-                    }
-                    Cast(tensorKFp32, tensorKin, RoundMode::CAST_NONE, K * curRowNum);
-                    Cast(tensorDkbgFp32, tensorDkbgin, RoundMode::CAST_NONE, K * curRowNum);
-
-                    PipeBarrier<PIPE_V>();
-                    // exp(g) ->g
-                    Exp(tensorGFP32, tensorGFP32, curRowNum);
-                    PipeBarrier<PIPE_V>();
-                    // brcb(gexp)  brcb(beta)
-                    Brcb(tensorGbrcbFP32, tensorGFP32, static_cast<uint8_t>(CeilDiv(curRowNum, 8)), {1, 8});
-                    Brcb(tensorBetaBrcbFP32, tensorBetaFP32, static_cast<uint8_t>(CeilDiv(curRowNum, 8)), {1, 8});
-                    PipeBarrier<PIPE_V>();
-                    // dkbg * gexp -> dkbg
-                    uint64_t perchannelResOffset = 0;
-                    uint8_t repeatStride = K * sizeof(float32_t) / ONE_BLOCK_32;
-                    while (perchannelResOffset < K) {
-                        Mul(tensorDkbgFp32[perchannelResOffset], tensorDkbgFp32[perchannelResOffset], tensorGbrcbFP32,
-                            FP32_PER_REPEAT_64, curRowNum, {1, 1, 0, repeatStride, repeatStride, 1});
-                        perchannelResOffset += FP32_PER_REPEAT_64;
-                    }
-                    PipeBarrier<PIPE_V>();
-                    // dkbg(dkbg * gexp) * k ->k
-
-                    Mul(tensorKFp32, tensorKFp32, tensorDkbgFp32, K * curRowNum);
-                    PipeBarrier<PIPE_V>();
-                    perchannelResOffset = 0;
-                    while (perchannelResOffset < K) {
-                        Mul(tensorDkFp32[perchannelResOffset], tensorKFp32[perchannelResOffset], tensorBetaBrcbFP32,
-                            FP32_PER_REPEAT_64, curRowNum, {1, 1, 0, repeatStride, repeatStride, 1});
-                        perchannelResOffset += FP32_PER_REPEAT_64;
-                    }
-
-                    // reducesum 
-                    for (uint32_t row = 0; row < curRowNum; row++) {
-                        WholeReduceSum(tensorKFp32[row * FP32_PER_BLOCK_8], tensorKFp32[row * K], FP32_PER_REPEAT_64,
-                                       wholeReduceSumCnt, 1, 1, 8);
-                        WholeReduceSum(tensorDkFp32[row * FP32_PER_BLOCK_8], tensorDkFp32[row * K], FP32_PER_REPEAT_64,
-                                       wholeReduceSumCnt, 1, 1, 8);
-                    }
-                    PipeBarrier<PIPE_V>();
-                    WholeReduceSum(tensorDbetaAddFP32, tensorKFp32, wholeReduceSumCnt, curRowNum, 1, 1, 1);
-                    WholeReduceSum(tensorDgFp32, tensorDkFp32, wholeReduceSumCnt, curRowNum, 1, 1, 1);
-                    PipeBarrier<PIPE_V>();
-                    // cast dg
-                    Cast(tensorDgOut, tensorDgFp32, RoundMode::CAST_RINT, curRowNum);
-                    // 累加第二部分产生的处理原始dbeta
-                    Add(tensorDbetaAddFP32, tensorDbetaAddFP32, tensorDbetaFP32, curRowNum);
-                    // 计算当前dk公式为 dkbg(dkbg * gexp) * beta -> dkbg
-                    perchannelResOffset = 0;
-                    while (perchannelResOffset < K) {
-                        Mul(tensorDkbgFp32[perchannelResOffset], tensorDkbgFp32[perchannelResOffset],
-                            tensorBetaBrcbFP32, FP32_PER_REPEAT_64, curRowNum, {1, 1, 0, repeatStride, repeatStride, 1});
-                        perchannelResOffset += FP32_PER_REPEAT_64;
-                    }
-                    Cast(tensorDkFp32, tensorDkin, RoundMode::CAST_NONE, K * curRowNum);
-                    PipeBarrier<PIPE_V>();
-                    // 累加第二部分产生的处理原始dk
-                    Add(tensorDkFp32, tensorDkFp32, tensorDkbgFp32, K * curRowNum);
-                    PipeBarrier<PIPE_V>();
-                    // cast
-                    Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, K * curRowNum);
-                    if constexpr (!std::is_same<betaType, float32_t>()) {
-                        Cast(tensorDbetaOut, tensorDbetaAddFP32, RoundMode::CAST_RINT, curRowNum);
-                    } else {
-                        DataCopy(tensorDbetaOut, tensorDbetaAddFP32, rowNum);
-                    }
-
-                    dkbgInQue.FreeTensor(tensorDkbgin);
-                    kInQue.FreeTensor(tensorKin);
-                    betaInQue.FreeTensor(tensorBetain);
-                    gInQue.FreeTensor(tensorGin);
-                    dkInQue.FreeTensor(tensorDkin);
-                    dbetaInQue.FreeTensor(tensorDbetain);
-
-                    dkOutQue.EnQue(tensorDkOut);
-                    dBetaOutQue.EnQue(tensorDbetaOut);
-                    dgOutQue.EnQue(tensorDgOut);
-                }
-                // copyout
-                {
-                    auto tensorDkOut = dkOutQue.DeQue<kType>();
-                    auto tensorDbetaOut = dBetaOutQue.DeQue<betaType>();
-                    auto tensorDgOut = dgOutQue.DeQue<betaType>();
-                    DataCopy(dkTensor[kOffset], tensorDkOut, K * curRowNum);
-                    DataCopyPad(dbetaTensor[betaOffset], tensorDbetaOut, {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0});
-                    DataCopyPad(dgTensor[betaOffset], tensorDgOut, {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0});
-                    dkOutQue.FreeTensor(tensorDkOut);
-                    dBetaOutQue.FreeTensor(tensorDbetaOut);
-                    dgOutQue.FreeTensor(tensorDgOut);
-                }
-            }
-        }
-    }
-    return;
-}
-
-template <typename kType, typename betaType>
-__aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDkb()
-{
-    uint32_t coreLoops = chunkNum;
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNumAic = GetBlockNum();
-    uint32_t rowNum = dkbVecRow;
-    uint32_t rowOffset = 0;
-    uint32_t vecTaskIdx = 0;
-    uint32_t wholeReduceSumCnt = CeilDiv(K, FP32_PER_REPEAT_64);
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    uint32_t curRowNum = rowNum;
-
-    // init
-    pipe->InitBuffer(kInQue, 2, rowNum * K * sizeof(kType));
-    pipe->InitBuffer(betaInQue, 2, rowNum * sizeof(betaType));
-    pipe->InitBuffer(dkInQue, 2, rowNum * K * sizeof(kType));
-    pipe->InitBuffer(dkbInQue, 2, rowNum * K * sizeof(kType));
-    pipe->InitBuffer(dkOutQue, 2, rowNum * K * sizeof(kType));
-    pipe->InitBuffer(dBetaOutQue, 2, rowNum * sizeof(betaType));
-    pipe->InitBuffer(dkbFp32Buf, rowNum * K * sizeof(float32_t));
-    pipe->InitBuffer(dkFp32Buf, rowNum * K * sizeof(float32_t));
-    pipe->InitBuffer(kFp32Buf, rowNum * K * sizeof(float32_t));
-    pipe->InitBuffer(betaFp32Buf, rowNum * sizeof(float32_t));
-    pipe->InitBuffer(betaFp32BrcbBuf, rowNum * ONE_BLOCK_32);
-    pipe->InitBuffer(reduceSumTmpBuf, rowNum * ONE_BLOCK_32);
-
-    auto tensorDkbFp32 = dkbFp32Buf.Get<float32_t>();
-    auto tensorDkFp32 = dkFp32Buf.Get<float32_t>();
-    auto tensorKFp32 = kFp32Buf.Get<float32_t>();
-    auto tensorBetaFP32 = betaFp32Buf.Get<float32_t>();
-    auto tensorBetaBrcbFP32 = betaFp32BrcbBuf.Get<float32_t>();
-    auto tensorReduceSum = reduceSumTmpBuf.Get<float32_t>();
-
-    
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
-        GetChunkOffset(cu_seqlens, chunk_indices, B, HV, T, chunkSize, loopIdx, bos, eos);
-        uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < HV; h++) {
-            Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
-            for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
-                ++vecTaskIdx;
-                if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                    continue;
-                }
-                curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
-                auto kOffset = (h * T + bos + rowOffset) * K;
-                auto betaOffset = h * T + bos + rowOffset;
-                // copyin
-                {
-                    auto tensorDkbin = dkbInQue.AllocTensor<kType>();
-                    auto tensorKin = kInQue.AllocTensor<kType>();
-                    auto tensorBetain = betaInQue.AllocTensor<betaType>();
-                    auto tensorDkin = dkInQue.AllocTensor<kType>();
-
-                    DataCopy(tensorDkbin, workSpaceTensor[kOffset], K * curRowNum);
-                    DataCopy(tensorKin, kTensor[kOffset], K * curRowNum);
-                    DataCopyPad(tensorBetain, betaTensor[betaOffset], {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
-                    DataCopy(tensorDkin, dkTensor[kOffset], K * curRowNum);
-
-                    dkbInQue.EnQue(tensorDkbin);
-                    kInQue.EnQue(tensorKin);
-                    betaInQue.EnQue(tensorBetain);
-                    dkInQue.EnQue(tensorDkin);
-                }
-                // compute
-                {
-                    auto tensorDkbin = dkbInQue.DeQue<kType>();
-                    auto tensorKin = kInQue.DeQue<kType>();
-                    auto tensorBetain = betaInQue.DeQue<betaType>();
-                    auto tensorDkin = dkInQue.DeQue<kType>();
-
-                    auto tensorDkOut = dkOutQue.AllocTensor<kType>();
-                    auto tensorDbetaOut = dBetaOutQue.AllocTensor<betaType>();
-                    // cast FP32
-                    if constexpr (!std::is_same<betaType, float32_t>()) {
-                        Cast(tensorBetaFP32, tensorBetain, RoundMode::CAST_NONE, curRowNum);
-                    } else {
-                        DataCopy(tensorBetaFP32, tensorBetain, rowNum);
-                    }
-                    Cast(tensorKFp32, tensorKin, RoundMode::CAST_NONE, K * curRowNum);
-                    Cast(tensorDkbFp32, tensorDkbin, RoundMode::CAST_NONE, K * curRowNum);
-                    Cast(tensorDkFp32, tensorDkin, RoundMode::CAST_NONE, K * curRowNum);
-                    PipeBarrier<PIPE_V>();
-                    // brcb
-                    Brcb(tensorBetaBrcbFP32, tensorBetaFP32, static_cast<uint8_t>(CeilDiv(curRowNum, 8)), {1, 8});
-                    PipeBarrier<PIPE_V>();
-                    // mul
-                    Mul(tensorKFp32, tensorKFp32, tensorDkbFp32, K * curRowNum);
-                    PipeBarrier<PIPE_V>();
-                    uint64_t perchannelResOffset = 0;
-                    uint8_t repeatStride = K * sizeof(float32_t) / ONE_BLOCK_32;
-                    while (perchannelResOffset < K) {
-                        Mul(tensorDkbFp32[perchannelResOffset], tensorDkbFp32[perchannelResOffset], tensorBetaBrcbFP32,
-                            FP32_PER_REPEAT_64, curRowNum, {1, 1, 0, repeatStride, repeatStride, 1});
-                        perchannelResOffset += FP32_PER_REPEAT_64;
-                    }
-                    // reducesum
-                    for (uint32_t row = 0; row < curRowNum; row++) {
-                        WholeReduceSum(tensorReduceSum[row * FP32_PER_BLOCK_8], tensorKFp32[row * K],
-                                       FP32_PER_REPEAT_64, wholeReduceSumCnt, 1, 1, 8);
-                    }
-                    PipeBarrier<PIPE_V>();
-                    WholeReduceSum(tensorBetaFP32, tensorReduceSum, wholeReduceSumCnt, curRowNum, 1, 1, 1);
-                    // ADD
-                    PipeBarrier<PIPE_V>();
-                    Add(tensorDkFp32, tensorDkFp32, tensorDkbFp32, K * curRowNum);
-                    PipeBarrier<PIPE_V>();
-                    // cast
-                    Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, K * curRowNum);
-                    if constexpr (!std::is_same<betaType, float32_t>()) {
-                        Cast(tensorDbetaOut, tensorBetaFP32, RoundMode::CAST_RINT, curRowNum);
-                    } else {
-                        DataCopy(tensorDbetaOut, tensorBetaFP32, rowNum);
-                    }
-
-                    dkbInQue.FreeTensor(tensorDkbin);
-                    kInQue.FreeTensor(tensorKin);
-                    betaInQue.FreeTensor(tensorBetain);
-                    dkInQue.FreeTensor(tensorDkin);
-                    dkOutQue.EnQue(tensorDkOut);
-                    dBetaOutQue.EnQue(tensorDbetaOut);
-                }
-                // copyout
-                {
-                    auto tensorDkOut = dkOutQue.DeQue<kType>();
-                    auto tensorDbetaOut = dBetaOutQue.DeQue<betaType>();
-                    DataCopy(dkTensor[kOffset], tensorDkOut, K * curRowNum);
-                    DataCopyPad(dbetaTensor[betaOffset], tensorDbetaOut, {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0});
-                    dkOutQue.FreeTensor(tensorDkOut);
-                    dBetaOutQue.FreeTensor(tensorDbetaOut);
-                }
+                oneOutQue.EnQue(tensorOut);
+                auto tensorDgOut = oneOutQue.DeQue<betaType>();
+                DataCopyPad(dgTensor[betaOffset + rowOffset], tensorDgOut,
+                            {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0});
+                oneOutQue.FreeTensor(tensorDgOut);
             }
 
         }
     }
     return;
 }
-
-template <typename kType, typename betaType>
-__aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessKBeta()
-{
-    uint32_t coreLoops = chunkNum;
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNumAic = GetBlockNum();
-    uint32_t rowNum = kBeteVecRow;
-    uint32_t rowOffset = 0;
-    uint32_t vecTaskIdx = 0;
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    uint32_t curRowNum = rowNum;
-
-    // init
-    pipe->InitBuffer(kInQue, 2, rowNum * K * sizeof(kType));
-    pipe->InitBuffer(betaInQue, 2, rowNum * sizeof(betaType));
-    pipe->InitBuffer(kBetaOutQue, 2, rowNum * K * sizeof(kType));
-    pipe->InitBuffer(kFp32Buf, rowNum * K * sizeof(float32_t));
-    pipe->InitBuffer(betaFp32Buf, rowNum * sizeof(float32_t));
-    pipe->InitBuffer(betaFp32BrcbBuf, rowNum * ONE_BLOCK_32);
-
-    auto tensorKFp32 = kFp32Buf.Get<float32_t>();
-    auto tensorBetaFP32 = betaFp32Buf.Get<float32_t>();
-    auto tensorBetaBrcbFP32 = betaFp32BrcbBuf.Get<float32_t>();
-    
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
-        GetChunkOffset(cu_seqlens, chunk_indices, B, HV, T, chunkSize, loopIdx, bos, eos);
-        uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < HV; h++) {
-            for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
-                ++vecTaskIdx;
-                if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                    continue;
-                }
-                curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
-                auto kOffset = (h * T + bos + rowOffset) * K;
-                auto betaOffset = h * T + bos + rowOffset;
-                // copyin
-                {
-                    auto tensorKin = kInQue.AllocTensor<kType>();
-                    DataCopy(tensorKin, kTensor[kOffset], K * curRowNum);
-                    auto tensorBetain = betaInQue.AllocTensor<betaType>();
-                    DataCopyPad(tensorBetain, betaTensor[betaOffset], {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
-
-                    kInQue.EnQue(tensorKin);
-                    betaInQue.EnQue(tensorBetain);
-                }
-                // compute
-                {
-                    auto tensorKin = kInQue.DeQue<kType>();
-                    auto tensorBetain = betaInQue.DeQue<betaType>();
-                    auto tensorOut = kBetaOutQue.AllocTensor<kType>();
-                    // cast FP32
-                    if constexpr (!std::is_same<betaType, float32_t>()) {
-                        Cast(tensorBetaFP32, tensorBetain, RoundMode::CAST_NONE, curRowNum);
-                    } else {
-                        DataCopy(tensorBetaFP32, tensorBetain, rowNum);
-                    }
-                    Cast(tensorKFp32, tensorKin, RoundMode::CAST_NONE, K * curRowNum);
-                    PipeBarrier<PIPE_V>();
-                    // brcb
-                    Brcb(tensorBetaBrcbFP32, tensorBetaFP32, static_cast<uint8_t>(CeilDiv(curRowNum, 8)), {1, 8});
-                    PipeBarrier<PIPE_V>();
-                    // mul
-                    uint64_t perchannelResOffset = 0;
-                    uint8_t repeatStride = K * sizeof(float32_t) / ONE_BLOCK_32;
-                    while (perchannelResOffset < K) {
-                        Mul(tensorKFp32[perchannelResOffset], tensorKFp32[perchannelResOffset], tensorBetaBrcbFP32,
-                            FP32_PER_REPEAT_64, curRowNum, {1, 1, 0, repeatStride, repeatStride, 1});
-                        perchannelResOffset += FP32_PER_REPEAT_64;
-                    }
-                    PipeBarrier<PIPE_V>();
-                    Cast(tensorOut, tensorKFp32, RoundMode::CAST_RINT, K * curRowNum);
-                    kInQue.FreeTensor(tensorKin);
-                    betaInQue.FreeTensor(tensorBetain);
-                    kBetaOutQue.EnQue(tensorOut);
-                }
-                // copyout
-                {
-                    auto tensorOut = kBetaOutQue.DeQue<kType>();
-                    DataCopy(workSpaceTensor[kOffset], tensorOut, K * curRowNum);
-                    kBetaOutQue.FreeTensor(tensorOut);
-                }
-            }
-            Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(flagAivFinishStore);
-        }
-    }
-    return;
-}
-
 
 #endif // PREPARE_WY_REPR_BWD_FULL_VECTOR_H


### PR DESCRIPTION
# Pull Request 模板

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [x] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人:
- 修改范围:
  - [x] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:

## 版本与产品编译矩阵

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

## 验证方法

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

工程 UT:

```sh
bash build.sh -u --ops=<op_name> --soc=<soc>
```

按模块精确验证:

```sh
bash build.sh --ophost_test --ops=<op_name> --soc=<soc>
bash build.sh --opapi_test --ops=<op_name> --soc=<soc>
bash build.sh --opkernel_test --ops=<op_name> --soc=<soc>
```

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

如本 PR 修改了 aclnn example 或新增了算子 example，同时执行:

```sh
bash build.sh --run_example <op_name> eager cust --vendor_name=fla_npu --soc=<soc>
```

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

## 修改算子测试

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `bash build.sh -u --ops=<op_name> --soc=ascend910b` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `bash build.sh -u --ops=<op_name> --soc=ascend910_93` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `bash build.sh -u --ops=<op_name> --soc=ascend950` | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

## 整体 Example ST 验证

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python examples/flash_gated_delta_rule.py` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python examples/flash_gated_delta_rule.py` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python examples/flash_gated_delta_rule.py` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [x] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
