### PR TITLE
GDN fwd_h/fwd_o ascendc performance optim

### DIFF
--- a/fla/ops/ascendc/common/kernel_utils/block/block_mmad_pingpong_tla_preloadA_l1B.hpp
+++ b/fla/ops/ascendc/common/kernel_utils/block/block_mmad_pingpong_tla_preloadA_l1B.hpp
@@ -1,0 +1,532 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CATLASS_GEMM_BLOCK_BLOCK_MMAD_PINGPONG_TLA_PRELOADA_L1B_HPP
+#define CATLASS_GEMM_BLOCK_BLOCK_MMAD_PINGPONG_TLA_PRELOADA_L1B_HPP
+
+
+#include "catlass/catlass.hpp"
+#include "catlass/arch/resource.hpp"
+#include "catlass/coord.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/gemm/dispatch_policy.hpp"
+#include "catlass/gemm/helper.hpp"
+#include "catlass/gemm/tile/tile_copy.hpp"
+#include "catlass/gemm/tile/tile_mmad.hpp"
+#include "tla/layout.hpp"
+#include "tla/tensor.hpp"
+
+namespace Catlass::Gemm {
+
+template <class ArchTag_, bool ENABLE_UNIT_FLAG_ = false, uint32_t L0C_STAGES_ = 1,
+    uint32_t L1A_STAGES_ = 2, uint32_t L1B_STAGES_ = 2, uint32_t L0A_STAGES_ = 2,
+    uint32_t L0B_STAGES_ = 2>
+struct MmadPingpongTlaPreloadAL1B : public MmadBase<ArchTag_, false> {
+    static constexpr uint32_t L1A_STAGES = L1A_STAGES_;
+    static constexpr uint32_t L1B_STAGES = L1B_STAGES_;
+    static constexpr uint32_t L0A_STAGES = L0A_STAGES_;
+    static constexpr uint32_t L0B_STAGES = L0B_STAGES_;
+    static constexpr uint32_t L0C_STAGES = L0C_STAGES_;
+    static constexpr bool ENABLE_UNIT_FLAG = ENABLE_UNIT_FLAG_;
+};
+
+}  // namespace Catlass::Gemm
+
+namespace Catlass::Gemm::Block {
+
+template <
+    class ArchTag_,
+    bool ENABLE_UNIT_FLAG_,
+    uint32_t L0C_STAGES_,
+    uint32_t L1A_STAGES_,
+    uint32_t L1B_STAGES_,
+    uint32_t L0A_STAGES_,
+    uint32_t L0B_STAGES_,
+    class L1TileShape_,
+    class L0TileShape_,
+    class ElementA_,
+    class ElementB_,
+    class ElementC_,
+    class ElementBias_,
+    class TileCopy_,
+    class TileMmad_
+>
+struct BlockMmadTla <
+    MmadPingpongTlaPreloadAL1B<ArchTag_, ENABLE_UNIT_FLAG_, L0C_STAGES_, L1A_STAGES_, 
+        L1B_STAGES_, L0A_STAGES_, L0B_STAGES_>,
+    L1TileShape_,
+    L0TileShape_,
+    ElementA_,
+    ElementB_,
+    ElementC_,
+    ElementBias_,
+    TileCopy_,
+    TileMmad_
+> {
+public:
+    // Type Aliases
+    using DispatchPolicy = MmadPingpongTlaPreloadAL1B<ArchTag_, ENABLE_UNIT_FLAG_, L0C_STAGES_, 
+        L1A_STAGES_, L1B_STAGES_, L0A_STAGES_, L0B_STAGES_>;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+    using TileCopy = TileCopy_;
+    using L1TileShape = L1TileShape_;
+    using L0TileShape = L0TileShape_;
+    using ElementA = ElementA_;
+    using LayoutA = typename TileCopy::LayoutA;
+    using ElementB = ElementB_;
+    using LayoutB = typename TileCopy::LayoutB;
+    using ElementC = ElementC_;
+    using LayoutC = typename TileCopy::LayoutC;
+
+    using TileMmad = TileMmad_;
+
+    using CopyL1ToL0A = typename TileCopy::CopyL1ToL0A;
+    using CopyL1ToL0B = typename TileCopy::CopyL1ToL0B;
+    using CopyL1ToBT = typename TileCopy::CopyL1ToBT;
+
+    using ElementAccumulator = typename TileCopy::ElementAccumulator;
+
+    using LayoutTagL1A = typename TileCopy::LayoutTagL1A;
+    using LayoutTagL1B = typename TileCopy::LayoutTagL1B;
+    using LayoutTagL0A = typename TileCopy::LayoutTagL0A;
+    using LayoutTagL0B = typename TileCopy::LayoutTagL0B;
+
+    using L1AAlignHelper = typename TileCopy_::L1AAlignHelper;
+    using L1BAlignHelper = typename TileCopy_::L1BAlignHelper;
+
+    static_assert(tla::is_tuple<L1TileShape>::value && tla::is_static<L1TileShape>::value,
+        "L1TileShape must be tla::tuple and static!");
+    static_assert(tla::is_tuple<L0TileShape>::value && tla::is_static<L0TileShape>::value,
+        "L0TileShape must be tla::tuple and static!");
+
+    static constexpr bool ENABLE_UNIT_FLAG = DispatchPolicy::ENABLE_UNIT_FLAG;
+    static constexpr uint32_t L1A_STAGES = DispatchPolicy::L1A_STAGES;
+    static constexpr uint32_t L1B_STAGES = DispatchPolicy::L1B_STAGES;
+    static constexpr uint32_t L0A_STAGES = DispatchPolicy::L0A_STAGES;
+    static constexpr uint32_t L0B_STAGES = DispatchPolicy::L0B_STAGES;
+    static constexpr uint32_t L0C_STAGES = DispatchPolicy::L0C_STAGES;
+    static constexpr uint32_t L1_TILE_M = tla::get<0>(L1TileShape{});
+    static constexpr uint32_t L1_TILE_N = tla::get<1>(L1TileShape{});
+    static constexpr uint32_t L1_TILE_K = tla::get<2>(L1TileShape{});
+    static constexpr uint32_t L0_TILE_M = tla::get<0>(L0TileShape{});
+    static constexpr uint32_t L0_TILE_N = tla::get<1>(L0TileShape{});
+    static constexpr uint32_t L0_TILE_K = tla::get<2>(L0TileShape{});
+
+    // L1 tile size
+    static constexpr uint32_t L1A_TILE_SIZE = L1_TILE_M * L1_TILE_K * sizeof(ElementA);
+    static constexpr uint32_t L1B_TILE_SIZE = L1_TILE_N * L1_TILE_K * sizeof(ElementB);
+    // L0 tile size
+    static constexpr uint32_t L0A_TILE_SIZE = L0_TILE_M * L0_TILE_K * sizeof(ElementA);
+    static constexpr uint32_t L0B_TILE_SIZE = L0_TILE_K * L0_TILE_N * sizeof(ElementB);
+    static constexpr uint32_t L0C_TILE_SIZE = L1_TILE_M * L1_TILE_N * sizeof(ElementAccumulator);
+
+    // Check L0C_STAGES
+    static_assert(!(ENABLE_UNIT_FLAG && L0C_STAGES != 1), "L0C_STAGES must be 1 when UnitFlag is true!");
+
+    // Check LayoutC
+    static_assert(tla::detail::isRowMajor<LayoutC>::value ||
+                    ((std::is_same_v<ElementC, half> || std::is_same_v<ElementC, bfloat16_t> ||
+                        std::is_same_v<ElementC, float>) && tla::detail::iszN<ElementC, LayoutC>::value),
+        "LayoutC only supports zN in half or bfloat16 or float, RowMajor in all dtype yet!");
+
+    // Check L1TileShape
+    static_assert(L1A_TILE_SIZE * L1A_STAGES + L1B_TILE_SIZE * L1B_STAGES <= ArchTag::L1_SIZE,
+        "L1TileShape exceeding the L1 space!");
+
+    // Check L0TileShape
+    static_assert(L0A_TILE_SIZE * L0A_STAGES <= ArchTag::L0A_SIZE, "L0TileShape exceeding the L0A space!");
+    static_assert(L0B_TILE_SIZE * L0B_STAGES <= ArchTag::L0B_SIZE, "L0TileShape exceeding the L0B space!");
+    static_assert(L0C_TILE_SIZE * L0C_STAGES <= ArchTag::L0C_SIZE, "L0TileShape exceeding the L0C space!");
+
+    static constexpr uint32_t _32B = 32*8; // in bits
+    static_assert(L1_TILE_M == L0_TILE_M && L1_TILE_N == L0_TILE_N,
+        "The situation where the basic blocks of L1 and L0 differ on the m and n axes is not supported yet");
+    static_assert(L0_TILE_K <= L1_TILE_K, "L0TileShape::K cannot exceed L1TileShape::K");
+#if (defined (CATLASS_ARCH) && CATLASS_ARCH == 2201)
+    static_assert(L1_TILE_M * SizeOfBits<ElementA>::value % _32B == 0, "L1TileShape::M must be 32B aligned.");
+    static_assert(L1_TILE_K * SizeOfBits<ElementA>::value % _32B == 0, "L1TileShape::K must be 32B aligned.");
+    static_assert(L1_TILE_K * SizeOfBits<ElementB>::value % _32B == 0, "L1TileShape::K must be 32B aligned.");
+    static_assert(L1_TILE_N * SizeOfBits<ElementB>::value % _32B == 0, "L1TileShape::N must be 32B aligned.");
+    static_assert(L0_TILE_K * SizeOfBits<ElementB>::value % _32B == 0, "L0TileShape::K must be 32B aligned.");
+#endif
+
+    static constexpr auto L1A_LAYOUT =
+        tla::MakeLayout<ElementA, LayoutTagL1A>(tla::Int<L1_TILE_M>{}, tla::Int<L1_TILE_K>{});
+    static constexpr auto L1B_LAYOUT =
+        tla::MakeLayout<ElementB, LayoutTagL1B>(tla::Int<L1_TILE_K>{}, tla::Int<L1_TILE_N>{});
+    static constexpr auto L1BIAS_LAYOUT = tla::MakeLayout(tla::Int<L1_TILE_N>{});
+    static constexpr auto L0BIAS_LAYOUT = tla::MakeLayout(tla::Int<L0_TILE_N>{});
+
+    // When enabling L1 resident mode, restore the pointer and coordinates that record the last state
+    // to the initial state. if two blockmmad instances need to be consecutively invoked at the kernel layer,
+    // RestoreStatus() must be inserted between them.
+    CATLASS_DEVICE
+    void RestoreStatus()
+    {
+        for (int i = 0; i < L1A_STAGES; ++i) {
+            lastAddrA[i] = nullptr;
+            lastCoordA[i] = MatrixCoord{0U, 0U};
+        }
+        for (int i = 0; i < L1B_STAGES; ++i) {
+            lastAddrB[i] = nullptr;
+            lastCoordB[i] = MatrixCoord{0U, 0U};
+        }
+    }
+
+    /// Construct
+    CATLASS_DEVICE
+    BlockMmadTla(Arch::Resource<ArchTag> &resource, uint32_t l1BufAddrStart = 0)
+    {
+        if ASCEND_IS_AIC {
+            uint32_t l1AOffset = l1BufAddrStart;
+            uint32_t l1BOffset = l1BufAddrStart + L1A_TILE_SIZE * L1A_STAGES;
+            // Init buffers
+            for (uint32_t i = 0; i < L1A_STAGES; i++) {
+                // Assign L1/L0A/L0B space for each stages
+                l1ATensorList[i] = resource.l1Buf.template GetBufferByByte<ElementA>(l1AOffset + L1A_TILE_SIZE * i);
+                // Assign event ID for each stages
+                l1AEventList[i] = i;
+            }
+            for (uint32_t i = 0; i < L1B_STAGES; i++) {
+                // Assign L1/L0A/L0B space for each stages
+                l1BTensorList[i] = resource.l1Buf.template GetBufferByByte<ElementB>(l1BOffset + L1B_TILE_SIZE * i);
+                // Assign event ID for each stages
+                l1BEventList[i] = i + L1A_STAGES;
+            }
+            for (uint32_t i = 0; i < L0A_STAGES; i++) {
+                // Assign L1/L0A/L0B space for each stages
+                l0ATensorList[i] = resource.l0ABuf.template GetBufferByByte<ElementA>(L0A_TILE_SIZE * i);
+                // Assign event ID for each stages
+                l0AEventList[i] = i;
+            }
+            for (uint32_t i = 0; i < L0B_STAGES; i++) {
+                // Assign L1/L0A/L0B space for each stages
+                l0BTensorList[i] = resource.l0BBuf.template GetBufferByByte<ElementB>(L0B_TILE_SIZE * i);
+                // Assign event ID for each stages
+                l0BEventList[i] = i + L0A_STAGES;
+            }
+            if constexpr(!ENABLE_UNIT_FLAG) {
+                for (uint32_t i = 0; i < L0C_STAGES; i++) {
+                    l0CTensorList[i] = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(L0C_TILE_SIZE * i);
+                    l0CEventList[i] = i;
+                }
+            } else {
+                l0CTensorList[0] = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(0);
+            }
+        }
+    }
+
+    /// Destructor
+    CATLASS_DEVICE
+    ~BlockMmadTla() {}
+
+    CATLASS_DEVICE
+    void preSetFlags() {
+
+        if ASCEND_IS_AIC {
+            if constexpr (ENABLE_UNIT_FLAG && tla::detail::isRowMajor<LayoutC>::value) {
+                AscendC::SetMMLayoutTransform(true);
+            }
+            for (uint32_t i = 0; i < L1A_STAGES; i++) {
+                AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEventList[i]);
+            }
+            for (uint32_t i = 0; i < L1B_STAGES; i++) {
+                AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList[i]);
+            }
+            for (uint32_t i = 0; i < L0A_STAGES; i++) {
+                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0AEventList[i]);
+            }
+            for (uint32_t i = 0; i < L0B_STAGES; i++) {
+                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0BEventList[i]);
+            }
+            if constexpr(!ENABLE_UNIT_FLAG) {
+                for (uint32_t i = 0; i < L0C_STAGES; i++) {
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(l0CEventList[i]);
+                }
+            }
+        }
+    }
+
+    CATLASS_DEVICE
+    void finalWaitFlags() {
+        if ASCEND_IS_AIC {
+            if constexpr (ENABLE_UNIT_FLAG && tla::detail::isRowMajor<LayoutC>::value) {
+                AscendC::SetMMLayoutTransform(false);
+            }
+            for (uint32_t i = 0; i < L1A_STAGES; i++) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEventList[i]);
+            }
+            for (uint32_t i = 0; i < L1B_STAGES; i++) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList[i]);
+            }
+            for (uint32_t i = 0; i < L0A_STAGES; i++) {
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0AEventList[i]);
+            }
+            for (uint32_t i = 0; i < L0B_STAGES; i++) {
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0BEventList[i]);
+            }
+            if constexpr(!ENABLE_UNIT_FLAG) {
+                for (uint32_t i = 0; i < L0C_STAGES; i++) {
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(l0CEventList[i]);
+                }
+            }
+        }
+    }
+
+    /// Perform a block-scoped matrix multiply-accumulate
+    template <class TensorA, class TensorB, class TensorC, class TensorBias = EmptyClass>
+    CATLASS_DEVICE void operator()(TensorA &tensorA, TensorB &tensorB, TensorC &tensorC, GemmCoord const &actualShape)
+    {
+        using CopyGmToL1A = typename TileCopy_::template CopyGmToL1A<TensorA>;
+        // using CopyGmToL1B = typename TileCopy_::template CopyGmToL1B<TensorB>;
+        CopyGmToL1A copyGmToL1A;
+        // CopyGmToL1B copyGmToL1B;
+#if (defined (CATLASS_ARCH) && CATLASS_ARCH == 2201)
+        using CopyL0CToGm = typename TileCopy_::template CopyL0CToGm<TensorC>;
+        CopyL0CToGm copyL0CToDst;
+#endif        
+#if (defined (CATLASS_ARCH) && CATLASS_ARCH == 3510)
+        using CopyL0CToDst = typename TileCopy_::template CopyL0CToDst<TensorC>;
+        CopyL0CToDst copyL0CToDst;
+#endif        
+
+        uint32_t mBlockActual = actualShape.m();
+        uint32_t kBlockActual = actualShape.k();
+        uint32_t nBlockActual = actualShape.n();
+
+        uint32_t mL1Actual = mBlockActual;
+        if constexpr (std::is_same_v<ArchTag, Arch::AtlasA2>) {
+            // Avoid using the gemv mode in mmad
+            if (mL1Actual == 1) {
+                mL1Actual = 16;
+            }
+        }
+        uint32_t nL1Actual = nBlockActual;
+
+        auto layoutInL0C = tla::MakeLayoutL0C(mL1Actual, nL1Actual);
+        auto tensorL0C = tla::MakeTensor(l0CTensorList[l0CListId], layoutInL0C, Arch::PositionL0C{});
+        auto tensorL0Bias = tla::MakeTensor(l0BiasTensor, L0BIAS_LAYOUT, Arch::PositionBias{});
+
+        uint32_t kL1Actual = min(kBlockActual, L1_TILE_K);
+        // load first matrix A tile from GM to L1
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEventList[l1AListId]);
+        auto tensorL1A = tla::MakeTensor(l1ATensorList[l1AListId], L1A_LAYOUT, Arch::PositionL1{});
+        auto tensorTileA = GetTileA(tensorA, 0, 0, mBlockActual, kL1Actual);
+        copyGmToL1A(tensorL1A, tensorTileA);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1AEventList[l1AListId]);
+
+        // load first matrix B tile from GM to L1
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList[l1BListId]);
+        // auto tensorL1B = tla::MakeTensor(l1BTensorList[l1BListId], L1B_LAYOUT, Arch::PositionL1{});
+        // auto tensorTileB = GetTile(tensorB, tla::MakeCoord(0, 0), tla::MakeShape(kL1Actual, nBlockActual));
+        // copyGmToL1B(tensorL1B, tensorTileB);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1BEventList[l1BListId]);
+
+        if constexpr (!ENABLE_UNIT_FLAG) {
+            AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(l0CEventList[l0CListId]);
+        }
+
+        uint32_t mL0Loop = CeilDiv<L0_TILE_M>(mL1Actual);
+        uint32_t nL0Loop = CeilDiv<L0_TILE_N>(nL1Actual);
+
+        // main loop
+        uint32_t kL1Loop = CeilDiv<L1_TILE_K>(kBlockActual);
+        for (uint32_t kL1Idx = 0; kL1Idx < kL1Loop; kL1Idx++) {
+            uint32_t l1AListIdNext = (l1AListId + 1 < L1A_STAGES) ? (l1AListId + 1) : 0;
+            uint32_t l1BListIdNext = (l1BListId + 1 < L1B_STAGES) ? (l1BListId + 1) : 0;
+            uint32_t kL1ActualNext{0};
+            // preload next tile from GM to L1
+            if (kL1Idx < kL1Loop - 1) {
+                uint32_t kL1IdxNext = kL1Idx + 1;
+                kL1ActualNext = (kL1IdxNext < kL1Loop - 1) ? L1_TILE_K : (kBlockActual - kL1IdxNext * L1_TILE_K);
+
+                // Get L1 tensor for next stage
+                auto l1ATensor = l1ATensorList[l1AListIdNext];
+                auto l1BTensor = l1BTensorList[l1BListIdNext];
+                auto tensorL1A = tla::MakeTensor(l1ATensor, L1A_LAYOUT, Arch::PositionL1{});
+                auto tensorL1B = tla::MakeTensor(l1BTensor, L1B_LAYOUT, Arch::PositionL1{});
+                // Get GM tile for next stage
+                auto tensorTileA = GetTileA(tensorA, 0, kL1IdxNext * L1_TILE_K, mBlockActual, kL1ActualNext);
+                auto tensorTileB = GetTile(tensorB, tla::MakeCoord(kL1IdxNext * L1_TILE_K, 0),
+                    tla::MakeShape(kL1ActualNext, nBlockActual));
+
+                // load next matrix A tile from GM to L1
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEventList[l1AListIdNext]);
+                copyGmToL1A(tensorL1A, tensorTileA);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1AEventList[l1AListIdNext]);
+
+                // load next matrix B tile from GM to L1
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList[l1BListIdNext]);
+                // copyGmToL1B(tensorL1B, tensorTileB);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1BEventList[l1BListIdNext]);
+            }
+
+            // Get L1 tensor for current stage
+            auto l1ATensor = l1ATensorList[l1AListId];
+            // auto l1BTensor = l1BTensorList[l1BListId];
+            tensorL1A = tla::MakeTensor(l1ATensor, L1A_LAYOUT, Arch::PositionL1{});
+            // tensorL1B = tla::MakeTensor(l1BTensor, L1B_LAYOUT, Arch::PositionL1{});
+            // Get the loop nums on L0
+            uint32_t kL0Loop = CeilDiv<L0_TILE_K>(kL1Actual);
+
+            for (int mL0Idx = 0; mL0Idx < mL0Loop; mL0Idx++) {
+                uint32_t mL0Actual = (mL0Idx < mL0Loop - 1) ? L0_TILE_M : (mL1Actual - mL0Idx * L0_TILE_M);
+
+                for (int kL0Idx = 0; kL0Idx < kL0Loop; kL0Idx++) {
+                    uint32_t kL0Actual = (kL0Idx < kL0Loop - 1) ? L0_TILE_K : (kL1Actual - kL0Idx * L0_TILE_K);
+
+                    // Locate the current tile on L0A
+                    auto l0ATile = l0ATensorList[l0AListId];
+                    auto layoutAInL0 = tla::MakeLayout<ElementA, LayoutTagL0A>(mL0Actual, kL0Actual);
+                    auto tensorL0A = tla::MakeTensor(l0ATile, layoutAInL0, Arch::PositionL0A{});
+                    // Locate the current tile of matrix A on L1
+                    auto tensorTileL1A = GetTileA(tensorL1A, mL0Idx * L0_TILE_M, kL0Idx * L0_TILE_K, mL0Actual, kL0Actual);
+
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0AEventList[l0AListId]);
+                    if ((mL0Idx == 0) && (kL0Idx == 0)) {
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(l1AEventList[l1AListId]);
+                    }
+
+                    // Load current tile from L1 to L0A
+                    copyL1ToL0A(tensorL0A, tensorTileL1A);
+
+                    if ((mL0Idx == mL0Loop - 1) && (kL0Idx == kL0Loop - 1)) {
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEventList[l1AListId]);
+                    }
+
+                    bool initC = ((kL1Idx == 0) && (kL0Idx == 0));
+                    for (int nL0Idx = 0; nL0Idx < nL0Loop; nL0Idx++) {
+                        uint32_t nL0Actual = (nL0Idx < nL0Loop - 1) ? L0_TILE_N : (nL1Actual - nL0Idx * L0_TILE_N);
+
+                        // Locate the current tile on L0B
+                        auto l0BTile = l0BTensorList[l0BListId];
+                        auto layoutBInL0 = tla::MakeLayout<ElementB, LayoutTagL0B>(kL0Actual, nL0Actual);
+                        auto tensorL0B = tla::MakeTensor(l0BTile, layoutBInL0, Arch::PositionL0B{});
+                        // Locate the current tile of matrix B on L1
+                        // auto tensorTileL1B = GetTile(tensorL1B,
+                        //                              tla::MakeCoord(kL0Idx * L0_TILE_K, nL0Idx * L0_TILE_N),
+                        //                              tla::MakeShape(kL0Actual, nL0Actual));
+                        auto tensorTileL1B = GetTile(tensorB,
+                                                    tla::MakeCoord(kL0Idx * L0_TILE_K, nL0Idx * L0_TILE_N),
+                                                    tla::MakeShape(kL0Actual, nL0Actual));
+
+                        // Wait for mmad finished
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0BEventList[l0BListId]);
+                        // If the current tile is the first one on the k&n axis, wait for loading matrix B from GM to L1
+                        if ((mL0Idx == 0) && (kL0Idx == 0) && (nL0Idx == 0)) {
+                            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(l1BEventList[l1BListId]);
+                        }
+
+                        // Load current tile from L1 to L0B
+                        copyL1ToL0B(tensorL0B, tensorTileL1B);
+
+                        // If the current tile is the last one on the k&n axis, notify to load matrix B from GM to L1
+                        if ((mL0Idx == mL0Loop - 1) && (kL0Idx == kL0Loop - 1) && (nL0Idx == nL0Loop - 1)) {
+                            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList[l1BListId]);
+                        }
+
+                        // Notify to do mmad
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(l0CEventList[l0CListId]);
+
+                        // Locate the current tile on L0C
+                        auto tensorTileL0C = GetTile(tensorL0C,
+                                                    tla::MakeCoord(mL0Idx * L0_TILE_M, nL0Idx * L0_TILE_N),
+                                                    tla::MakeShape(mL0Actual, nL0Actual));
+
+                        // Compute the matrix multiplication on L0A and L0B and write the result to the accumulator
+                        // Wait for loading L0B
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(l0CEventList[l0CListId]);
+
+                        // If the unit flag is enabled, the unit flag is set according to the calculation progress
+                        uint8_t unitFlag = 0b00;
+                        if constexpr (ENABLE_UNIT_FLAG) {
+                            if ((kL1Idx == kL1Loop - 1) && (mL0Idx == mL0Loop - 1) &&
+                                (kL0Idx == kL0Loop - 1) && (nL0Idx == nL0Loop - 1)) {
+                                unitFlag = 0b11;
+                            } else {
+                                unitFlag = 0b10;
+                            }
+                        }
+
+                        tileMmad(tensorTileL0C, tensorL0A, tensorL0B,
+                                mL0Actual, nL0Actual, kL0Actual, initC, unitFlag);
+
+                        // Notify to move the next L0B tile
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0BEventList[l0BListId]);
+                        l0BListId = (l0BListId + 1 < L0B_STAGES) ? (l0BListId + 1) : 0;
+                    }
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0AEventList[l0AListId]);
+                    l0AListId = (l0AListId + 1 < L0A_STAGES) ? (l0AListId + 1) : 0;
+                }
+            }
+            l1AListId = l1AListIdNext;
+            l1BListId = l1BListIdNext;
+            kL1Actual = kL1ActualNext;
+        }
+
+        // copy block out
+        if constexpr (!ENABLE_UNIT_FLAG) {
+            AscendC::SetFlag<AscendC::HardEvent::M_FIX>(l0CEventList[l0CListId]);
+            AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(l0CEventList[l0CListId]);
+            copyL0CToDst(tensorC, tensorL0C);
+            AscendC::SetFlag<AscendC::HardEvent::FIX_M>(l0CEventList[l0CListId]);
+            l0CListId = (l0CListId + 1 < L0C_STAGES) ? (l0CListId + 1) : 0;
+        } else {
+            copyL0CToDst(tensorC, tensorL0C, 0b11);
+        }
+    }
+
+protected:
+    template<class TensorA>
+    CATLASS_DEVICE auto GetTileA(TensorA &tensorA, uint32_t mIndex, uint32_t kIndex, uint32_t mSize, uint32_t kSize)
+    {
+        if constexpr(tla::detail::isVector<LayoutA>::value) {
+            return GetTile(tensorA, tla::MakeCoord(kIndex), tla::MakeShape(kSize));
+        } else {
+            return GetTile(tensorA, tla::MakeCoord(mIndex, kIndex), tla::MakeShape(mSize, kSize));
+        }
+    }
+
+    // Multi-stage tensors list
+    AscendC::LocalTensor<ElementA> l1ATensorList[L1A_STAGES];
+    AscendC::LocalTensor<ElementB> l1BTensorList[L1B_STAGES];
+    AscendC::LocalTensor<ElementA> l0ATensorList[L0A_STAGES];
+    AscendC::LocalTensor<ElementB> l0BTensorList[L0B_STAGES];
+    AscendC::LocalTensor<ElementAccumulator> l0CTensorList[L0C_STAGES];
+    AscendC::LocalTensor<uint8_t> l1BiasTensor;
+    AscendC::LocalTensor<ElementAccumulator> l0BiasTensor;
+
+    // Multi-stage event id list
+    int32_t l1AEventList[L1A_STAGES];
+    int32_t l1BEventList[L1B_STAGES];
+    int32_t l0AEventList[L0A_STAGES];
+    int32_t l0BEventList[L0B_STAGES];
+    int32_t l0CEventList[L0C_STAGES];
+
+    __gm__ typename AscendC::GlobalTensor<ElementA>::PrimType* lastAddrA[L1A_STAGES];
+    __gm__ typename AscendC::GlobalTensor<ElementB>::PrimType* lastAddrB[L1B_STAGES];
+    MatrixCoord lastCoordA[L1A_STAGES];
+    MatrixCoord lastCoordB[L1B_STAGES];
+    
+    // The id of current stage
+    uint32_t l1AListId{0};
+    uint32_t l1BListId{0};
+    uint32_t l0AListId{0};
+    uint32_t l0BListId{0};
+    uint32_t l0CListId{0};
+
+    TileMmad tileMmad;
+    CopyL1ToL0A copyL1ToL0A;
+    CopyL1ToL0B copyL1ToL0B;
+    CopyL1ToBT copyL1ToBT;
+};
+
+} // namespace Catlass::Gemm::Block
+
+#endif // CATLASS_GEMM_BLOCK_BLOCK_MMAD_PINGPONG_TLA_PRELOADA_L1B_HPP

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/gemm/kernel/gdn_fwd_o_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/gemm/kernel/gdn_fwd_o_kernel.hpp
@@ -255,14 +255,11 @@ public:
             auto vnewLayout = tla::MakeLayout<ElementVNEW, LayoutVNEW>(shapeBatch * vNumHead * seqlen, vHeadDim);
 
             bool needRun = false;
-            bool isFirstC3 = true;
 
             while (cubeBlockScheduler.isRunning) {
                 cubeBlockScheduler.InitTask();
 
                 if (cubeBlockScheduler.isRunning && coreIdx < coreNum) {
-
-                    Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done);
 
                     GDNFwdOOffsets& cube1Offsets = cubeBlockScheduler.GetCube1Offsets();
                     int64_t cube1OffsetQ = cube1Offsets.qkOffset; 
@@ -285,8 +282,7 @@ public:
                 // AscendC::PipeBarrier<PIPE_ALL>();
 
                 if (needRun && coreIdx < coreNum) {
-                    if(!cubeBlockScheduler.isRunning) Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done);
-                    Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done);
+                    Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done);
                     GDNFwdOOffsets& cube2Offsets = cubeBlockScheduler.GetCube23Offsets();
                     int64_t cube2OffsetQ = cube2Offsets.qkOffset;
                     int64_t cube2OffsetH = cube2Offsets.hOffset;
@@ -301,12 +297,13 @@ public:
                     blockMmadQH.preSetFlags();
                     blockMmadQH(tensorBlockQ, tensorBlockH, tensorBlockHWork, cube2Shape);
                     blockMmadQH.finalWaitFlags();
-                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube2Done);
                 }
+
+                AscendC::PipeBarrier<PIPE_MTE2>();
+                AscendC::PipeBarrier<PIPE_FIX>();
 
                 if (needRun && coreIdx < coreNum) {
                     GDNFwdOOffsets& cube3Offsets = cubeBlockScheduler.GetCube23Offsets();
-                    if(isFirstC3) Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done);
                     int64_t cube3OffsetAttnMask = cube3Offsets.attnWorkOffset; 
                     int64_t cube3OffsetV = cube3Offsets.ovOffset; 
                     int64_t cube3OffsetVWork = cube3Offsets.hvWorkOffset; 
@@ -322,14 +319,9 @@ public:
                     blockMmadAttenVNEW(tensorBlockAttnMask, tensorBlockV, tensorBlockVWork, cube3Shape);
                     blockMmadAttenVNEW.finalWaitFlags();
                     Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube3Done);
-                    isFirstC3 = false;
                 }
                 needRun = true;
                 // AscendC::PipeBarrier<PIPE_ALL>();
-            }
-            if (coreIdx < coreNum) {
-                Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done);
-
             }
         }
 
@@ -348,12 +340,6 @@ public:
 
             bool needRun = false;
             uint32_t pingpongFlag = 0;
-
-            if (coreIdx < coreNum * subBlockNum) {
-                Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec1Done);
-                Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec1Done);
-                Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done);
-            }
 
             while (vecBlockScheduler.isRunning) {
                 vecBlockScheduler.InitTask();
@@ -376,7 +362,6 @@ public:
                 // AscendC::PipeBarrier<PIPE_ALL>();
 
                 if (needRun && coreIdx < coreNum * subBlockNum) {
-                    Arch::CrossCoreWaitFlag(vecBlockScheduler.cube2Done);
                     Arch::CrossCoreWaitFlag(vecBlockScheduler.cube3Done);
                     GDNFwdOOffsets& vec2Offsets = vecBlockScheduler.GetVec2Offsets();
                     int64_t vec2OffsetO = vec2Offsets.ovOffset;
@@ -389,11 +374,7 @@ public:
                         gmG[vec2OffsetG], gmVWorkspace[vec2OffsetVWork], gmHWorkspace[vec2OffsetHWork], 
                         scale, vec2Offsets.blockTokens, kHeadDim, vHeadDim, pingpongFlag, vec2Offsets.batchIdx, vec2Offsets.headIdx, vec2Offsets.chunkIdx
                     );
-                    Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done);
                 }
-                
-                // AscendC::PipeBarrier<PIPE_ALL>();
-
                 needRun = true;
             }
         }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
@@ -92,7 +92,9 @@ public:
         uint32_t kHeadDim,
         uint32_t vHeadDim,
         Arch::CrossCoreFlag cube2Done,
+        bool isInitialState,
         bool isFinalState,
+        bool storeFinalState,
         bool isPing
     )
     {
@@ -119,13 +121,20 @@ public:
         AscendC::LocalTensor<HElementOutput> hUbTensor = isPing ? hUbTensor_ping : hUbTensor_pong;
         AscendC::LocalTensor<float> glastUbTensor = isPing ? glastUbTensor_ping : glastUbTensor_pong;
 
-        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
+        if (storeFinalState && isInitialState && std::is_same<FinalStateElement, float>::value) {
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
+        } else {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
+        }
         AscendC::DataCopy(hUbTensor, hInputThisSubBlock, mActualThisSubBlock * nActual);
         AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
         AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
 
         AscendC::Cast(calcUbTensor, hUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nActual);
         AscendC::PipeBarrier<PIPE_V>();
+        if (storeFinalState && isFinalState && std::is_same<FinalStateElement, float>::value) {
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
+        }
         
         GElementInput gLastVal = gInputThisSubBlock.GetValue(chunkSize-1);
         float gLastFloat = 0.0f;
@@ -154,12 +163,32 @@ public:
         AscendC::Add<float>(hUpdateUbTensor, calcUbTensor, hUpdateUbTensor, mActualThisSubBlock * nActual);
         AscendC::PipeBarrier<PIPE_V>();
 
-        AscendC::Cast(hUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
-        AscendC::DataCopy(hOutputThisSubBlock, hUbTensor, mActualThisSubBlock * nActual);
-        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
+        if constexpr(std::is_same<FinalStateElement, float>::value) {
+            if (storeFinalState && isFinalState) {
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::DataCopy(finalStateThisSubBlock, hUpdateUbTensor, mActualThisSubBlock * nActual);
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0 + pingpongFlag);
+            } else {
+                AscendC::Cast(hUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
+                AscendC::DataCopy(hOutputThisSubBlock, hUbTensor, mActualThisSubBlock * nActual);
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
+            }
+        } else {
+            AscendC::Cast(hUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
+            if (isFinalState) {
+                AscendC::DataCopy(finalStateThisSubBlock, hUbTensor, mActualThisSubBlock * nActual);
+            } else {
+                AscendC::DataCopy(hOutputThisSubBlock, hUbTensor, mActualThisSubBlock * nActual);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
+        }
         
     }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
@@ -92,7 +92,8 @@ public:
         uint32_t kHeadDim,
         uint32_t vHeadDim,
         Arch::CrossCoreFlag cube2Done,
-        bool isFinalState
+        bool isFinalState,
+        bool isPing
     )
     {
         uint32_t mActual = kHeadDim;
@@ -150,27 +151,20 @@ public:
 
         Arch::CrossCoreWaitFlag(cube2Done);
 
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
-        AscendC::DataCopy(hUpdateUbTensor, hUpdateInputThisSubBlock, mActualThisSubBlock * nActual);
-        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
         AscendC::Add<float>(hUpdateUbTensor, calcUbTensor, hUpdateUbTensor, mActualThisSubBlock * nActual);
         AscendC::PipeBarrier<PIPE_V>();
 
         AscendC::Cast(hUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
         AscendC::PipeBarrier<PIPE_V>();
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
         AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
         AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
         AscendC::DataCopy(hOutputThisSubBlock, hUbTensor, mActualThisSubBlock * nActual);
         AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
         
-        isPing = !isPing;
     }
 
 private:
     uint32_t pongBaseEvent = 4;
-    bool isPing = true;
 
     AscendC::LocalTensor<float> calcUbTensor;
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDH_UPDATE_HPP
+#define CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDH_UPDATE_HPP
+#include "catlass/catlass.hpp"
+#include "catlass/arch/resource.hpp"
+#include "../gdn_fwd_h_epilogue_policies.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/matrix_coord.hpp"
+#include "catlass/epilogue/tile/tile_copy.hpp"
+
+namespace Catlass::Epilogue::Block {
+
+template <
+    class HOutputType_,
+    class GInputType_,
+    class HInputType_,
+    class HUpdateInputType_,
+    class FinalStateType_
+>
+class BlockEpilogue <
+    EpilogueAtlasGDNFwdHUpdate,
+    HOutputType_,
+    GInputType_,
+    HInputType_,
+    HUpdateInputType_,
+    FinalStateType_
+> {
+public:
+    // Type aliases
+    using DispatchPolicy = EpilogueAtlasGDNFwdHUpdate;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+
+    using HElementOutput = typename HOutputType_::Element;
+    using GElementInput = typename GInputType_::Element;
+    using HElementInput = typename HInputType_::Element;
+    using HUpdateElementInput = typename HUpdateInputType_::Element;
+    using FinalStateElement = typename FinalStateType_::Element;
+
+    CATLASS_DEVICE
+    BlockEpilogue(Arch::Resource<ArchTag> &resource)
+    {
+
+        constexpr uint32_t CALC_BUF_OFFSET = 0;
+        constexpr uint32_t PING_BUF_0_OFFSET = 32 * 1024;
+        constexpr uint32_t PING_BUF_1_OFFSET = 48 * 1024;
+        constexpr uint32_t PING_BUF_2_OFFSET = 64 * 1024;
+        constexpr uint32_t PING_BUF_3_OFFSET = 80 * 1024;
+        constexpr uint32_t PONG_BUF_0_OFFSET = 96 * 1024;
+        constexpr uint32_t PONG_BUF_1_OFFSET = 112 * 1024;
+        constexpr uint32_t PONG_BUF_2_OFFSET = 128 * 1024;
+        constexpr uint32_t PONG_BUF_3_OFFSET = 144 * 1024;
+        constexpr uint32_t PING_G_BUF_OFFSET = 160 * 1024;
+        constexpr uint32_t PONG_G_BUF_OFFSET = 161 * 1024;
+        constexpr uint32_t PING_G_SUB_BUF_OFFSET = 162 * 1024;
+        constexpr uint32_t PONG_G_SUB_BUF_OFFSET = 163 * 1024;
+        constexpr uint32_t PING_G_INPUT_BUF_OFFSET = 164 * 1024;
+        constexpr uint32_t PONG_G_INPUT_BUF_OFFSET = 165 * 1024;
+        constexpr uint32_t SHARE_BUF_OFFSET = 166 * 1024;
+
+
+        calcUbTensor = resource.ubBuf.template GetBufferByByte<float>(CALC_BUF_OFFSET);
+
+        hUpdateUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_BUF_0_OFFSET);
+        hUbTensor_ping = resource.ubBuf.template GetBufferByByte<HElementOutput>(PING_BUF_3_OFFSET);
+        glastUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_G_INPUT_BUF_OFFSET);
+
+        hUpdateUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_BUF_0_OFFSET);
+        hUbTensor_pong = resource.ubBuf.template GetBufferByByte<HElementOutput>(PONG_BUF_3_OFFSET);
+        glastUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_G_INPUT_BUF_OFFSET);
+
+    }
+
+    CATLASS_DEVICE
+    ~BlockEpilogue() {}
+
+    CATLASS_DEVICE
+    void operator()(
+        AscendC::GlobalTensor<HElementOutput> hOutput,
+        AscendC::GlobalTensor<FinalStateElement> finalState,
+        AscendC::GlobalTensor<GElementInput> gInput,
+        AscendC::GlobalTensor<HElementInput> hInput,
+        AscendC::GlobalTensor<float> hUpdateInput,
+        uint32_t chunkSize,
+        uint32_t kHeadDim,
+        uint32_t vHeadDim,
+        Arch::CrossCoreFlag cube2Done,
+        bool isFinalState
+    )
+    {
+        uint32_t mActual = kHeadDim;
+        uint32_t nActual = vHeadDim;
+        uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
+        uint32_t subBlockNum = AscendC::GetSubBlockNum();
+        uint32_t mActualPerSubBlock = CeilDiv(mActual, subBlockNum);
+        uint32_t mActualThisSubBlock = (subBlockIdx == 0) ? mActualPerSubBlock : (mActual - mActualPerSubBlock);
+        uint32_t mOffset = subBlockIdx * mActualPerSubBlock;
+        uint32_t nOffset = 0;
+        int64_t offsetH = mOffset * nActual + nOffset;
+
+        AscendC::ResetMask();
+
+        AscendC::GlobalTensor<HElementOutput> hOutputThisSubBlock = hOutput[offsetH];
+        AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
+        AscendC::GlobalTensor<HElementInput> hInputThisSubBlock = hInput[offsetH];
+        AscendC::GlobalTensor<float> hUpdateInputThisSubBlock = hUpdateInput[offsetH];
+        AscendC::GlobalTensor<FinalStateElement> finalStateThisSubBlock = finalState[offsetH];
+
+        uint32_t pingpongFlag = isPing ? 0 : pongBaseEvent;
+        AscendC::LocalTensor<float> hUpdateUbTensor = isPing ? hUpdateUbTensor_ping : hUpdateUbTensor_pong;
+        AscendC::LocalTensor<HElementOutput> hUbTensor = isPing ? hUbTensor_ping : hUbTensor_pong;
+        AscendC::LocalTensor<float> glastUbTensor = isPing ? glastUbTensor_ping : glastUbTensor_pong;
+
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
+        AscendC::DataCopy(hUbTensor, hInputThisSubBlock, mActualThisSubBlock * nActual);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+
+        AscendC::Cast(calcUbTensor, hUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nActual);
+        AscendC::PipeBarrier<PIPE_V>();
+        
+        GElementInput gLastVal = gInputThisSubBlock.GetValue(chunkSize-1);
+        float gLastFloat = 0.0f;
+        if constexpr(std::is_same<GElementInput, float>::value) {
+            gLastFloat = gLastVal;
+        } else if constexpr(std::is_same<GElementInput, half>::value) {
+            gLastFloat = (float)gLastVal;
+        } else if constexpr(std::is_same<GElementInput, bfloat16_t>::value) {
+            gLastFloat = AscendC::ToFloat(gLastVal);
+        }
+        glastUbTensor.SetValue(0, gLastFloat);
+
+        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+        AscendC::Exp(glastUbTensor, glastUbTensor, 1);
+        AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+        float muls = glastUbTensor.GetValue(0);
+        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+        AscendC::Muls(calcUbTensor, calcUbTensor, muls, mActualThisSubBlock * nActual);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        Arch::CrossCoreWaitFlag(cube2Done);
+
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+        AscendC::DataCopy(hUpdateUbTensor, hUpdateInputThisSubBlock, mActualThisSubBlock * nActual);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+        AscendC::Add<float>(hUpdateUbTensor, calcUbTensor, hUpdateUbTensor, mActualThisSubBlock * nActual);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        AscendC::Cast(hUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
+        AscendC::DataCopy(hOutputThisSubBlock, hUbTensor, mActualThisSubBlock * nActual);
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
+        
+        isPing = !isPing;
+    }
+
+private:
+    uint32_t pongBaseEvent = 4;
+    bool isPing = true;
+
+    AscendC::LocalTensor<float> calcUbTensor;
+
+    AscendC::LocalTensor<float> hUpdateUbTensor_ping;
+    AscendC::LocalTensor<HElementOutput> hUbTensor_ping;
+    AscendC::LocalTensor<float> glastUbTensor_ping;
+
+    AscendC::LocalTensor<float> hUpdateUbTensor_pong;
+    AscendC::LocalTensor<HElementOutput> hUbTensor_pong;
+    AscendC::LocalTensor<float> glastUbTensor_pong;
+
+};
+}
+
+#endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
@@ -25,7 +25,8 @@ template <
     class GInputType_,
     class UInputType_,
     class WSInputType_,
-    class VUpdateType_
+    class VUpdateType_,
+    class FinalStateType_
 >
 class BlockEpilogue <
     EpilogueAtlasGDNFwdHVnew,
@@ -33,7 +34,8 @@ class BlockEpilogue <
     GInputType_,
     UInputType_,
     WSInputType_,
-    VUpdateType_
+    VUpdateType_,
+    FinalStateType_
 > {
 public:
     // Type aliases
@@ -46,6 +48,7 @@ public:
     using WSElementInput = typename WSInputType_::Element;
     using VElementUpdate = typename VUpdateType_::Element;
     using VLayoutUpdate = typename VUpdateType_::Layout;
+    using FinalStateElement = typename FinalStateType_::Element;
 
     CATLASS_DEVICE
     BlockEpilogue(Arch::Resource<ArchTag> &resource)
@@ -109,6 +112,8 @@ public:
         Arch::CrossCoreFlag cube1Done,
         Arch::CrossCoreFlag vec1Done,
         bool isInitialState,
+        bool isFinalState,
+        bool storeFinalState,
         bool isPing
     )
     {
@@ -208,6 +213,9 @@ public:
 
         Arch::CrossCoreWaitFlag(cube1Done);
 
+        if (storeFinalState && isInitialState && std::is_same<FinalStateElement, float>::value) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0 + pingpongFlag);
+        }
         AscendC::Sub<float>(wsUbTensor, calcUbTensor, wsUbTensor, mActualThisSubBlock * nvActual);
         AscendC::PipeBarrier<PIPE_V>();
         
@@ -230,11 +238,12 @@ public:
         AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
         
         uint32_t ubToL1Loops = nvActual / SIZE_16_NUM_PER_C0;
+        uint32_t mActualPadded = (mActual + NZ_BLOCK_SIZE - 1) / NZ_BLOCK_SIZE * NZ_BLOCK_SIZE;
         AscendC::DataCopyParams intriParams;
         intriParams.blockCount = ubToL1Loops;
         intriParams.blockLen = mActualThisSubBlock;
         intriParams.srcGap = 0;
-        intriParams.dstGap = mActual - mActualThisSubBlock;
+        intriParams.dstGap = mActualPadded - mActualThisSubBlock;
         uint32_t l1Addr = mOffset * SIZE_16_NUM_PER_C0;
         AscendC::DataCopy(l1VUpdate[l1Addr], vNewDecayUbTensor, intriParams);
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
@@ -24,14 +24,16 @@ template <
     class VOutputType_,
     class GInputType_,
     class UInputType_,
-    class WSInputType_
+    class WSInputType_,
+    class VUpdateType_
 >
 class BlockEpilogue <
     EpilogueAtlasGDNFwdHVnew,
     VOutputType_,
     GInputType_,
     UInputType_,
-    WSInputType_
+    WSInputType_,
+    VUpdateType_
 > {
 public:
     // Type aliases
@@ -42,6 +44,8 @@ public:
     using GElementInput = typename GInputType_::Element;
     using UElementInput = typename UInputType_::Element;
     using WSElementInput = typename WSInputType_::Element;
+    using VElementUpdate = typename VUpdateType_::Element;
+    using VLayoutUpdate = typename VUpdateType_::Layout;
 
     CATLASS_DEVICE
     BlockEpilogue(Arch::Resource<ArchTag> &resource)
@@ -95,6 +99,7 @@ public:
     void operator()(
         AscendC::GlobalTensor<VElementOutput> vnewOutput,
         AscendC::GlobalTensor<VElementOutput> vnewdecayOutput,
+        AscendC::LocalTensor<VElementUpdate> l1VUpdate,
         AscendC::GlobalTensor<GElementInput> gInput,
         AscendC::GlobalTensor<UElementInput> uInput,
         AscendC::GlobalTensor<float> wsInput,
@@ -103,7 +108,8 @@ public:
         uint32_t vHeadDim,
         Arch::CrossCoreFlag cube1Done,
         Arch::CrossCoreFlag vec1Done,
-        bool isInitialState 
+        bool isInitialState,
+        bool isPing
     )
     {
         uint32_t mActual = chunkSize;
@@ -202,11 +208,6 @@ public:
 
         Arch::CrossCoreWaitFlag(cube1Done);
 
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
-        AscendC::DataCopy(wsUbTensor, wsInputThisSubBlock, mActualThisSubBlock * nvActual);
-        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
-        
         AscendC::Sub<float>(wsUbTensor, calcUbTensor, wsUbTensor, mActualThisSubBlock * nvActual);
         AscendC::PipeBarrier<PIPE_V>();
         
@@ -217,12 +218,26 @@ public:
         AscendC::Mul(calcUbTensor[gbrcEffStart*nvActual], wsUbTensor, calcUbTensor[gbrcEffStart*nvActual], mActualThisSubBlock * nvActual);
         AscendC::PipeBarrier<PIPE_V>();
         
-        AscendC::Cast(vNewDecayUbTensor, calcUbTensor[gbrcEffStart*nvActual], AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nvActual);
-        AscendC::PipeBarrier<PIPE_V>();
+        uint32_t nvLoops = vHeadDim / FLOAT_NUM_PER_REPEAT;
+        for (uint32_t nLoop = 0; nLoop < nvLoops; nLoop++) {
+            uint32_t castSrcOffset = gbrcEffStart * nvActual + nLoop * FLOAT_NUM_PER_REPEAT;
+            uint32_t castDstOffset = nLoop * mActualThisSubBlock * FLOAT_NUM_PER_REPEAT;
+            AscendC::Cast(vNewDecayUbTensor[castDstOffset], calcUbTensor[castSrcOffset], AscendC::RoundMode::CAST_RINT, FLOAT_NUM_PER_REPEAT, mActualThisSubBlock, {(uint16_t)mActualThisSubBlock, 1, 1, (uint8_t)(nvLoops * 8)});
+        }
         
+        AscendC::PipeBarrier<PIPE_V>();
         AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
         AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
-        AscendC::DataCopy(vnewdecayOutputThisSubBlock, vNewDecayUbTensor, mActualThisSubBlock * nvActual);
+        
+        uint32_t ubToL1Loops = nvActual / SIZE_16_NUM_PER_C0;
+        AscendC::DataCopyParams intriParams;
+        intriParams.blockCount = ubToL1Loops;
+        intriParams.blockLen = mActualThisSubBlock;
+        intriParams.srcGap = 0;
+        intriParams.dstGap = mActual - mActualThisSubBlock;
+        uint32_t l1Addr = mOffset * SIZE_16_NUM_PER_C0;
+        AscendC::DataCopy(l1VUpdate[l1Addr], vNewDecayUbTensor, intriParams);
+
         Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vec1Done);
 
         AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1 + pingpongFlag);
@@ -230,17 +245,14 @@ public:
         AscendC::Cast(vNewOutputUbTensor, wsUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nvActual);
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
         AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
         AscendC::DataCopy(vnewOutputThisSubBlock, vNewOutputUbTensor, mActualThisSubBlock * nvActual);
         AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
 
-        isPing = !isPing;
     }
 
 private:
     uint32_t pongBaseEvent = 4;
-    bool isPing = true;
 
     AscendC::LocalTensor<float> calcUbTensor;
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
@@ -1,0 +1,270 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDH_VNEW_HPP
+#define CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDH_VNEW_HPP
+#include "catlass/catlass.hpp"
+#include "catlass/arch/resource.hpp"
+#include "../gdn_fwd_h_epilogue_policies.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/matrix_coord.hpp"
+#include "catlass/epilogue/tile/tile_copy.hpp"
+
+
+
+namespace Catlass::Epilogue::Block {
+
+template <
+    class VOutputType_,
+    class GInputType_,
+    class UInputType_,
+    class WSInputType_
+>
+class BlockEpilogue <
+    EpilogueAtlasGDNFwdHVnew,
+    VOutputType_,
+    GInputType_,
+    UInputType_,
+    WSInputType_
+> {
+public:
+    // Type aliases
+    using DispatchPolicy = EpilogueAtlasGDNFwdHVnew;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+
+    using VElementOutput = typename VOutputType_::Element;
+    using GElementInput = typename GInputType_::Element;
+    using UElementInput = typename UInputType_::Element;
+    using WSElementInput = typename WSInputType_::Element;
+
+    CATLASS_DEVICE
+    BlockEpilogue(Arch::Resource<ArchTag> &resource)
+    {
+
+        constexpr uint32_t CALC_BUF_OFFSET = 0;
+        constexpr uint32_t PING_BUF_0_OFFSET = 32 * 1024;
+        constexpr uint32_t PING_BUF_1_OFFSET = 48 * 1024;
+        constexpr uint32_t PING_BUF_2_OFFSET = 64 * 1024;
+        constexpr uint32_t PING_BUF_3_OFFSET = 80 * 1024;
+        constexpr uint32_t PONG_BUF_0_OFFSET = 96 * 1024;
+        constexpr uint32_t PONG_BUF_1_OFFSET = 112 * 1024;
+        constexpr uint32_t PONG_BUF_2_OFFSET = 128 * 1024;
+        constexpr uint32_t PONG_BUF_3_OFFSET = 144 * 1024;
+        constexpr uint32_t PING_G_BUF_OFFSET = 160 * 1024;
+        constexpr uint32_t PONG_G_BUF_OFFSET = 161 * 1024;
+        constexpr uint32_t PING_G_SUB_BUF_OFFSET = 162 * 1024;
+        constexpr uint32_t PONG_G_SUB_BUF_OFFSET = 163 * 1024;
+        constexpr uint32_t PING_G_INPUT_BUF_OFFSET = 164 * 1024;
+        constexpr uint32_t PONG_G_INPUT_BUF_OFFSET = 165 * 1024;
+        constexpr uint32_t SHARE_BUF_OFFSET = 166 * 1024;
+
+        calcUbTensor = resource.ubBuf.template GetBufferByByte<float>(CALC_BUF_OFFSET);
+
+        uUbTensor_ping = resource.ubBuf.template GetBufferByByte<UElementInput>(PING_BUF_2_OFFSET);
+        wsUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_BUF_0_OFFSET);
+        gUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_G_BUF_OFFSET);
+        gLastUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_G_SUB_BUF_OFFSET);
+        gInputUbTensor_ping = resource.ubBuf.template GetBufferByByte<GElementInput>(PING_G_SUB_BUF_OFFSET);
+        gBrcbUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_BUF_0_OFFSET);
+        vNewOutputUbTensor_ping = resource.ubBuf.template GetBufferByByte<VElementOutput>(PING_BUF_2_OFFSET);
+        vNewDecayUbTensor_ping = resource.ubBuf.template GetBufferByByte<VElementOutput>(PING_BUF_2_OFFSET);
+
+        uUbTensor_pong = resource.ubBuf.template GetBufferByByte<UElementInput>(PONG_BUF_2_OFFSET);
+        wsUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_BUF_0_OFFSET);
+        gUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_G_BUF_OFFSET);
+        gLastUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_G_SUB_BUF_OFFSET);
+        gInputUbTensor_pong = resource.ubBuf.template GetBufferByByte<GElementInput>(PONG_G_SUB_BUF_OFFSET);
+        gBrcbUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PING_BUF_0_OFFSET);
+        vNewOutputUbTensor_pong = resource.ubBuf.template GetBufferByByte<VElementOutput>(PONG_BUF_2_OFFSET);
+        vNewDecayUbTensor_pong = resource.ubBuf.template GetBufferByByte<VElementOutput>(PONG_BUF_2_OFFSET);
+
+        shareBuffer_ = resource.ubBuf.template GetBufferByByte<uint8_t>(SHARE_BUF_OFFSET);
+
+    }
+
+    CATLASS_DEVICE
+    ~BlockEpilogue() {}
+
+    CATLASS_DEVICE
+    void operator()(
+        AscendC::GlobalTensor<VElementOutput> vnewOutput,
+        AscendC::GlobalTensor<VElementOutput> vnewdecayOutput,
+        AscendC::GlobalTensor<GElementInput> gInput,
+        AscendC::GlobalTensor<UElementInput> uInput,
+        AscendC::GlobalTensor<float> wsInput,
+        uint32_t chunkSize,
+        uint32_t kHeadDim,
+        uint32_t vHeadDim,
+        Arch::CrossCoreFlag cube1Done,
+        Arch::CrossCoreFlag vec1Done,
+        bool isInitialState 
+    )
+    {
+        uint32_t mActual = chunkSize;
+        uint32_t nkActual = kHeadDim;
+        uint32_t nvActual = vHeadDim;
+
+        uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
+        uint32_t subBlockNum = AscendC::GetSubBlockNum();
+        uint32_t mActualPerSubBlock = CeilDiv(mActual, subBlockNum);
+        uint32_t mActualThisSubBlock = (subBlockIdx == 0) ? mActualPerSubBlock : (mActual - mActualPerSubBlock);
+        uint32_t mOffset = subBlockIdx * mActualPerSubBlock;
+        uint32_t nOffset = 0;
+        // 当前场景内部一定连续
+        // k [B, H, T, D]
+        // g [B, H, T]
+        // 在外部offset的基础上进一步offset
+        // 当前asset kdim == vHeadDim
+        int64_t offsetK = mOffset * nvActual + nOffset;
+        int64_t offsetD = 0; // 因为要用最后一个数减去之前所有，所以全部读入
+
+        uint32_t gbrcStart, gbrcRealStart, gbrcReptime, gbrcEffStart, gbrcEffEnd;
+        if(subBlockIdx==0)
+        {
+            gbrcStart = 0;
+            gbrcRealStart = 0;
+            gbrcReptime = (mActualThisSubBlock + 8 - 1) / 8;
+
+        }
+        else
+        {
+            gbrcStart = mActualPerSubBlock;
+            gbrcRealStart = gbrcStart & ~15;
+            gbrcReptime = (mActual - gbrcRealStart + 8 - 1) / 8;
+        }
+        gbrcEffStart = gbrcStart-gbrcRealStart;
+        gbrcEffEnd = gbrcEffStart + mActualThisSubBlock;
+        uint32_t dstShape_[2] = {gbrcReptime*8, nvActual};
+        uint32_t srcShape_[2] = {gbrcReptime*8, 1};
+
+        AscendC::ResetMask();
+
+        AscendC::GlobalTensor<VElementOutput> vnewOutputThisSubBlock = vnewOutput[offsetK];
+        AscendC::GlobalTensor<VElementOutput> vnewdecayOutputThisSubBlock = vnewdecayOutput[offsetK];
+        AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
+        AscendC::GlobalTensor<UElementInput> uInputThisSubBlock = uInput[offsetK];
+        AscendC::GlobalTensor<float> wsInputThisSubBlock = wsInput[offsetK];
+
+        uint32_t pingpongFlag = isPing ? 0 : pongBaseEvent;
+        AscendC::LocalTensor<UElementInput> uUbTensor = isPing ? uUbTensor_ping : uUbTensor_pong;
+        AscendC::LocalTensor<float> wsUbTensor = isPing ? wsUbTensor_ping : wsUbTensor_pong;
+        AscendC::LocalTensor<float> gUbTensor = isPing ? gUbTensor_ping : gUbTensor_pong;
+        AscendC::LocalTensor<float> gLastUbTensor = isPing ? gLastUbTensor_ping : gLastUbTensor_pong;
+        AscendC::LocalTensor<GElementInput> gInputUbTensor = isPing ? gInputUbTensor_ping : gInputUbTensor_pong;
+        AscendC::LocalTensor<float> gBrcbUbTensor = isPing ? gBrcbUbTensor_ping : gBrcbUbTensor_pong;
+        AscendC::LocalTensor<VElementOutput> vNewOutputUbTensor = isPing ? vNewOutputUbTensor_ping : vNewOutputUbTensor_pong;
+        AscendC::LocalTensor<VElementOutput> vNewDecayUbTensor = isPing ? vNewDecayUbTensor_ping : vNewDecayUbTensor_pong;
+
+    
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag); // wait v_c2
+        AscendC::DataCopy(uUbTensor, uInputThisSubBlock, mActualThisSubBlock * nvActual); // mte2 u
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag); // set u
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag); // wait u
+        AscendC::Cast(calcUbTensor, uUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nvActual); // cast u
+
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag); // wait last g
+        if constexpr(std::is_same<GElementInput, float>::value) {
+            AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(float)), 0, 0};
+            AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
+            AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams); // copy g
+        } else {
+            AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(half)), 0, 0};
+            AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
+            AscendC::DataCopyPad(gInputUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3 + pingpongFlag);
+        if constexpr(!std::is_same<GElementInput, float>::value) {
+            AscendC::Cast(gUbTensor, gInputUbTensor, AscendC::RoundMode::CAST_NONE, mActual);
+        }
+
+        AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+        float inputVal = gUbTensor.GetValue(mActual-1);
+        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Duplicate<float>(gLastUbTensor, inputVal, mActual);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        AscendC::Sub<float>(gUbTensor, gLastUbTensor, gUbTensor, mActual);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        AscendC::Exp(gUbTensor, gUbTensor, mActual);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        Arch::CrossCoreWaitFlag(cube1Done);
+
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+        AscendC::DataCopy(wsUbTensor, wsInputThisSubBlock, mActualThisSubBlock * nvActual);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+        
+        AscendC::Sub<float>(wsUbTensor, calcUbTensor, wsUbTensor, mActualThisSubBlock * nvActual);
+        AscendC::PipeBarrier<PIPE_V>();
+        
+        AscendC::Broadcast<float, 2, 1>(calcUbTensor, gUbTensor[gbrcRealStart], dstShape_, srcShape_, shareBuffer_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
+
+        AscendC::Mul(calcUbTensor[gbrcEffStart*nvActual], wsUbTensor, calcUbTensor[gbrcEffStart*nvActual], mActualThisSubBlock * nvActual);
+        AscendC::PipeBarrier<PIPE_V>();
+        
+        AscendC::Cast(vNewDecayUbTensor, calcUbTensor[gbrcEffStart*nvActual], AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nvActual);
+        AscendC::PipeBarrier<PIPE_V>();
+        
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
+        AscendC::DataCopy(vnewdecayOutputThisSubBlock, vNewDecayUbTensor, mActualThisSubBlock * nvActual);
+        Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vec1Done);
+
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1 + pingpongFlag);
+        AscendC::Cast(vNewOutputUbTensor, wsUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nvActual);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
+        AscendC::DataCopy(vnewOutputThisSubBlock, vNewOutputUbTensor, mActualThisSubBlock * nvActual);
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
+
+        isPing = !isPing;
+    }
+
+private:
+    uint32_t pongBaseEvent = 4;
+    bool isPing = true;
+
+    AscendC::LocalTensor<float> calcUbTensor;
+
+    AscendC::LocalTensor<UElementInput> uUbTensor_ping;
+    AscendC::LocalTensor<float> wsUbTensor_ping;
+    AscendC::LocalTensor<float> gUbTensor_ping;
+    AscendC::LocalTensor<float> gLastUbTensor_ping;
+    AscendC::LocalTensor<GElementInput> gInputUbTensor_ping;
+    AscendC::LocalTensor<float> gBrcbUbTensor_ping;
+    AscendC::LocalTensor<VElementOutput> vNewOutputUbTensor_ping;
+    AscendC::LocalTensor<VElementOutput> vNewDecayUbTensor_ping;
+
+    AscendC::LocalTensor<UElementInput> uUbTensor_pong;
+    AscendC::LocalTensor<float> wsUbTensor_pong;
+    AscendC::LocalTensor<float> gUbTensor_pong;
+    AscendC::LocalTensor<float> gLastUbTensor_pong;
+    AscendC::LocalTensor<GElementInput> gInputUbTensor_pong;
+    AscendC::LocalTensor<float> gBrcbUbTensor_pong;
+    AscendC::LocalTensor<VElementOutput> vNewOutputUbTensor_pong;
+    AscendC::LocalTensor<VElementOutput> vNewDecayUbTensor_pong;
+
+    AscendC::LocalTensor<uint8_t> shareBuffer_;
+
+};
+}
+
+#endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/gdn_fwd_h_epilogue_policies.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/gdn_fwd_h_epilogue_policies.hpp
@@ -15,11 +15,11 @@
 namespace Catlass::Epilogue {
 
 struct EpilogueAtlasGDNFwdHVnew {
-    using ArchTag = Arch::AtlasA2;
+    using ArchTag = Arch::Ascend950;
 };
 
 struct EpilogueAtlasGDNFwdHUpdate {
-    using ArchTag = Arch::AtlasA2;
+    using ArchTag = Arch::Ascend950;
 };
 
 }  // namespace Catlass::Epilogue

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/block/block_scheduler_gdn_fwd_h.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/block/block_scheduler_gdn_fwd_h.hpp
@@ -20,6 +20,7 @@ constexpr uint32_t BYTES_PER_C0 = 32;
 constexpr uint32_t BYTE_SIZE_PER_REPEAT = 256;
 constexpr uint32_t SIZE_16_NUM_PER_C0 = BYTES_PER_C0 / BYTE_SIZE_16_BIT;
 constexpr uint32_t FLOAT_NUM_PER_REPEAT = BYTE_SIZE_PER_REPEAT / sizeof(float);
+constexpr uint32_t NZ_BLOCK_SIZE = 16;
 
 template <typename T>
 CATLASS_DEVICE T AlignUp(T a, T b) {
@@ -95,6 +96,7 @@ struct BlockSchedulerGdnFwdH {
     uint32_t tokenBatch;
     bool useInitialState;
     bool storeFinalState;
+    uint32_t numSeqWorkspaceOffset;
     uint32_t numChunksWorkspaceOffset;
 
     uint32_t taskIdx;
@@ -117,6 +119,7 @@ struct BlockSchedulerGdnFwdH {
     bool isRunning;
 
     AscendC::GlobalTensor<int64_t> gmSeqlen;
+    AscendC::GlobalTensor<int64_t> gmNumSeq;
     AscendC::GlobalTensor<int64_t> gmNumChunks;
 
     Arch::CrossCoreFlag cube1Done{0};
@@ -143,10 +146,36 @@ struct BlockSchedulerGdnFwdH {
         tokenBatch = gdnFwdHTilingData->tokenBatch;
         useInitialState = gdnFwdHTilingData->useInitialState;
         storeFinalState = gdnFwdHTilingData->storeFinalState;
+        numSeqWorkspaceOffset = gdnFwdHTilingData->numSeqWorkspaceOffset;
         numChunksWorkspaceOffset = gdnFwdHTilingData->numChunksWorkspaceOffset;
 
         gmSeqlen.SetGlobalBuffer((__gm__ int64_t *)cu_seqlens);
+        gmNumSeq.SetGlobalBuffer((__gm__ int64_t *)(user + numSeqWorkspaceOffset));
         gmNumChunks.SetGlobalBuffer((__gm__ int64_t *)(user + numChunksWorkspaceOffset));
+
+        if (isVariedLen) {
+            gmNumChunks.SetValue(0, 0);
+            uint32_t actualBatch = 0;
+            int64_t prevSeq = 0, currSeq;
+            for (uint32_t b = 1; b <= tokenBatch; b++) {
+                currSeq = gmSeqlen.GetValue(b);
+                int64_t batchSeqLen = currSeq - prevSeq;
+                if (batchSeqLen > 0) {
+                    actualBatch++;
+                    gmNumSeq.SetValue(actualBatch, currSeq);
+                    int64_t batchChunk = (batchSeqLen + chunkSize - 1) / chunkSize;
+                    gmNumChunks.SetValue(actualBatch, gmNumChunks.GetValue(actualBatch - 1) + batchChunk);
+                }
+                prevSeq = currSeq;
+            }
+            tokenBatch = actualBatch;
+            batch = actualBatch;
+            totalChunks = gmNumChunks.GetValue(tokenBatch);
+            totalTokens = gmNumSeq.GetValue(tokenBatch);
+        } else {
+            totalChunks = (seqlen + chunkSize - 1) / chunkSize;
+            totalTokens = seqlen;
+        }
 
         cubeCoreIdx = coreIdx;
         cubeCoreNum = coreNum;
@@ -172,19 +201,6 @@ struct BlockSchedulerGdnFwdH {
         taskIdx = curLoopTaskBegin + PING_PONG_STAGES; // 第一次创建task时重新初始化taskIdx
         isRunning = curLoopTaskBegin < taskNum;
 
-        if (isVariedLen) {
-            gmNumChunks.SetValue(0, 0); //
-            for (uint32_t b = 1; b <= tokenBatch; b++) {
-                int64_t batchChunk = (gmSeqlen.GetValue(b) - gmSeqlen.GetValue(b - 1) + chunkSize - 1) / chunkSize;
-                gmNumChunks.SetValue(b, gmNumChunks.GetValue(b - 1) + batchChunk);
-            }
-            totalChunks = gmNumChunks.GetValue(tokenBatch);
-            totalTokens = gmSeqlen.GetValue(tokenBatch);
-        } else {
-            totalChunks = (seqlen + chunkSize - 1) / chunkSize;
-            totalTokens = seqlen;
-        }
-
     }
 
 
@@ -198,8 +214,8 @@ struct BlockSchedulerGdnFwdH {
         newStream.tokenBatchIdx = isVariedLen ? newStream.batchIdx : 0;
         newStream.chunkOffset = isVariedLen ? gmNumChunks.GetValue(newStream.tokenBatchIdx) : 0;
         newStream.batchChunks = isVariedLen ? (gmNumChunks.GetValue(newStream.tokenBatchIdx + 1) - newStream.chunkOffset) : totalChunks;
-        newStream.tokenOffset = isVariedLen ? gmSeqlen.GetValue(newStream.tokenBatchIdx) : 0;
-        newStream.batchTokens = isVariedLen ? (gmSeqlen.GetValue(newStream.tokenBatchIdx + 1) - newStream.tokenOffset) : totalTokens;
+        newStream.tokenOffset = isVariedLen ? gmNumSeq.GetValue(newStream.tokenBatchIdx) : 0;
+        newStream.batchTokens = isVariedLen ? (gmNumSeq.GetValue(newStream.tokenBatchIdx + 1) - newStream.tokenOffset) : totalTokens;
         newStream.chunkIdx = 0;
     }
      

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/block/block_scheduler_gdn_fwd_h.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/block/block_scheduler_gdn_fwd_h.hpp
@@ -15,6 +15,11 @@ using namespace Catlass;
 
 // constexpr uint32_t PING_PONG_STAGES = 1;
 constexpr uint32_t PING_PONG_STAGES = 2;
+constexpr uint32_t BYTE_SIZE_16_BIT = 2;
+constexpr uint32_t BYTES_PER_C0 = 32;
+constexpr uint32_t BYTE_SIZE_PER_REPEAT = 256;
+constexpr uint32_t SIZE_16_NUM_PER_C0 = BYTES_PER_C0 / BYTE_SIZE_16_BIT;
+constexpr uint32_t FLOAT_NUM_PER_REPEAT = BYTE_SIZE_PER_REPEAT / sizeof(float);
 
 template <typename T>
 CATLASS_DEVICE T AlignUp(T a, T b) {

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/block/block_scheduler_gdn_fwd_h.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/block/block_scheduler_gdn_fwd_h.hpp
@@ -1,0 +1,324 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "catlass/gemm_coord.hpp"
+using namespace Catlass;
+
+#ifndef CATLASS_GEMM_SCHEDULER_GDN_FWD_H_HPP
+#define CATLASS_GEMM_SCHEDULER_GDN_FWD_H_HPP
+
+// constexpr uint32_t PING_PONG_STAGES = 1;
+constexpr uint32_t PING_PONG_STAGES = 2;
+
+template <typename T>
+CATLASS_DEVICE T AlignUp(T a, T b) {
+    return (b == 0) ? 0 : (a + b - 1) / b * b;
+}
+
+template <typename T>
+CATLASS_DEVICE T Min(T a, T b) {
+    return (a > b) ? b : a;
+}
+
+template <typename T>
+CATLASS_DEVICE T Max(T a, T b) {
+    return (a > b) ? a : b;
+}
+
+namespace Catlass::Gemm::Block {
+
+struct GDNFwdHOffsets {
+    uint32_t hSrcOffset;
+    uint32_t hDstOffset;
+    uint32_t uvOffset;
+    uint32_t wkOffset;
+    uint32_t wOffset;
+    uint32_t gOffset;
+    uint32_t hWorkOffset;
+    uint32_t vWorkOffset;
+    uint32_t initialStateOffset;
+    uint32_t finalStateOffset;
+    bool isInitialState;
+    bool isFinalState;
+    uint32_t blockTokens;
+    // for debug
+    uint32_t batchIdx;
+    uint32_t headIdx;
+    uint32_t chunkIdx;
+
+};
+
+struct GDNFwdHStream {
+    uint32_t vIdx;
+    uint32_t batchIdx;
+    uint32_t chunkIdx{0};
+    uint32_t vHeadIdx;
+    uint32_t kHeadIdx;
+    uint32_t shapeBatchIdx;
+    uint32_t tokenBatchIdx;
+     
+    uint32_t chunkOffset;
+    uint32_t tokenOffset;
+    uint32_t batchChunks{0};
+    uint32_t batchTokens;
+     
+    GDNFwdHOffsets offset;
+};
+     
+struct GDNFwdHRunningQ {
+    GDNFwdHStream streams[PING_PONG_STAGES];
+    uint32_t head{0};
+};
+
+struct BlockSchedulerGdnFwdH {
+    uint32_t batch;
+    uint32_t seqlen;
+    uint32_t kNumHead;
+    uint32_t vNumHead;
+    uint32_t kHeadDim;
+    uint32_t vHeadDim;
+    uint32_t chunkSize;
+    uint32_t vBlockSize{128};
+    uint32_t isVariedLen;
+    uint32_t shapeBatch;
+    uint32_t tokenBatch;
+    bool useInitialState;
+    bool storeFinalState;
+    uint32_t numChunksWorkspaceOffset;
+
+    uint32_t taskIdx;
+    uint32_t taskLoops;
+    uint32_t cubeCoreIdx;
+    uint32_t cubeCoreNum;
+    uint32_t vLoops;
+    uint32_t taskNum;
+    uint32_t headGroups;
+    uint32_t totalChunks;
+    uint32_t totalTokens;
+    bool hasDummyHead;
+
+    GDNFwdHRunningQ runningQ;
+    uint32_t curLoopIdx;
+    uint32_t curLoopTaskBegin;
+    uint32_t curLoopTaskCnt;
+    uint32_t lastLoopTaskCnt;
+
+    bool isRunning;
+
+    AscendC::GlobalTensor<int64_t> gmSeqlen;
+    AscendC::GlobalTensor<int64_t> gmNumChunks;
+
+    Arch::CrossCoreFlag cube1Done{0};
+    Arch::CrossCoreFlag vec1Done{1};
+    Arch::CrossCoreFlag cube2Done{2};
+    Arch::CrossCoreFlag vec2Done[PING_PONG_STAGES] = {3, 4};
+
+    CATLASS_DEVICE
+    BlockSchedulerGdnFwdH() {}
+
+    CATLASS_DEVICE
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR tiling, GM_ADDR user, uint32_t coreIdx, uint32_t coreNum) {
+        __gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict>(tiling);
+
+        batch = gdnFwdHTilingData->batch;
+        seqlen = gdnFwdHTilingData->seqlen;
+        kNumHead = gdnFwdHTilingData->kNumHead;
+        vNumHead = gdnFwdHTilingData->vNumHead;
+        kHeadDim = gdnFwdHTilingData->kHeadDim;
+        vHeadDim = gdnFwdHTilingData->vHeadDim;
+        chunkSize = gdnFwdHTilingData->chunkSize;
+        isVariedLen = gdnFwdHTilingData->isVariedLen;
+        shapeBatch = gdnFwdHTilingData->shapeBatch;
+        tokenBatch = gdnFwdHTilingData->tokenBatch;
+        useInitialState = gdnFwdHTilingData->useInitialState;
+        storeFinalState = gdnFwdHTilingData->storeFinalState;
+        numChunksWorkspaceOffset = gdnFwdHTilingData->numChunksWorkspaceOffset;
+
+        gmSeqlen.SetGlobalBuffer((__gm__ int64_t *)cu_seqlens);
+        gmNumChunks.SetGlobalBuffer((__gm__ int64_t *)(user + numChunksWorkspaceOffset));
+
+        cubeCoreIdx = coreIdx;
+        cubeCoreNum = coreNum;
+        vLoops = vHeadDim / vBlockSize;
+        taskNum = vLoops * batch * vNumHead;
+        headGroups = vNumHead / kNumHead;
+        hasDummyHead = (taskNum % (PING_PONG_STAGES * cubeCoreNum) <= cubeCoreNum) && (taskNum % (PING_PONG_STAGES * cubeCoreNum) > 0);
+        taskLoops = (taskNum + cubeCoreNum * PING_PONG_STAGES - 1) / (cubeCoreNum * PING_PONG_STAGES);
+        uint32_t maxTaskCntPerLoop = taskNum > cubeCoreNum ? PING_PONG_STAGES : 1;
+        curLoopTaskBegin = cubeCoreIdx * maxTaskCntPerLoop;
+        uint32_t lastLoopTaskBegin = curLoopTaskBegin + (taskLoops - 1) * maxTaskCntPerLoop * cubeCoreNum;
+        if (lastLoopTaskBegin >= taskNum) {
+            lastLoopTaskCnt = 0;
+        } else {
+            uint32_t maxTaskCntLastLoop = hasDummyHead ? 1 : PING_PONG_STAGES;
+            lastLoopTaskCnt = taskNum - lastLoopTaskBegin;
+            if (lastLoopTaskCnt >= maxTaskCntLastLoop) {
+                lastLoopTaskCnt = maxTaskCntLastLoop;
+            }
+        }
+        curLoopTaskCnt = taskLoops > 1 ? PING_PONG_STAGES : lastLoopTaskCnt;
+        curLoopIdx = -1; // -1: 第一次创建task时会将curLoopIdx加1
+        taskIdx = curLoopTaskBegin + PING_PONG_STAGES; // 第一次创建task时重新初始化taskIdx
+        isRunning = curLoopTaskBegin < taskNum;
+
+        if (isVariedLen) {
+            gmNumChunks.SetValue(0, 0); //
+            for (uint32_t b = 1; b <= tokenBatch; b++) {
+                int64_t batchChunk = (gmSeqlen.GetValue(b) - gmSeqlen.GetValue(b - 1) + chunkSize - 1) / chunkSize;
+                gmNumChunks.SetValue(b, gmNumChunks.GetValue(b - 1) + batchChunk);
+            }
+            totalChunks = gmNumChunks.GetValue(tokenBatch);
+            totalTokens = gmSeqlen.GetValue(tokenBatch);
+        } else {
+            totalChunks = (seqlen + chunkSize - 1) / chunkSize;
+            totalTokens = seqlen;
+        }
+
+    }
+
+
+    CATLASS_DEVICE
+    void InitNewStream(GDNFwdHStream& newStream) {
+        newStream.vIdx = taskIdx / (batch * vNumHead);
+        newStream.batchIdx = (taskIdx - newStream.vIdx * batch * vNumHead) / vNumHead;
+        newStream.vHeadIdx = taskIdx % vNumHead;
+        newStream.kHeadIdx = newStream.vHeadIdx / headGroups;
+        newStream.shapeBatchIdx = isVariedLen ? 0 : newStream.batchIdx;
+        newStream.tokenBatchIdx = isVariedLen ? newStream.batchIdx : 0;
+        newStream.chunkOffset = isVariedLen ? gmNumChunks.GetValue(newStream.tokenBatchIdx) : 0;
+        newStream.batchChunks = isVariedLen ? (gmNumChunks.GetValue(newStream.tokenBatchIdx + 1) - newStream.chunkOffset) : totalChunks;
+        newStream.tokenOffset = isVariedLen ? gmSeqlen.GetValue(newStream.tokenBatchIdx) : 0;
+        newStream.batchTokens = isVariedLen ? (gmSeqlen.GetValue(newStream.tokenBatchIdx + 1) - newStream.tokenOffset) : totalTokens;
+        newStream.chunkIdx = 0;
+    }
+     
+    CATLASS_DEVICE
+    void UpdateTask(uint32_t streamId) {
+        auto& stream = runningQ.streams[streamId];
+        auto& offset = stream.offset;
+     
+        offset.isInitialState = stream.chunkIdx == 0; 
+        offset.isFinalState = stream.chunkIdx == (stream.batchChunks - 1); 
+        offset.initialStateOffset = (stream.batchIdx * vNumHead + stream.vHeadIdx) * kHeadDim * vHeadDim; 
+        offset.finalStateOffset = (stream.batchIdx * vNumHead + stream.vHeadIdx) * kHeadDim * vHeadDim; 
+        offset.hSrcOffset = (stream.shapeBatchIdx * vNumHead * totalChunks + stream.vHeadIdx * totalChunks + stream.chunkOffset + stream.chunkIdx) * kHeadDim * vHeadDim;
+        offset.hDstOffset = offset.hSrcOffset + kHeadDim * vHeadDim;
+        offset.uvOffset = (stream.shapeBatchIdx * vNumHead * totalTokens + stream.vHeadIdx * totalTokens + stream.tokenOffset + stream.chunkIdx * chunkSize) * vHeadDim;
+        offset.wkOffset = (stream.shapeBatchIdx * kNumHead * totalTokens + stream.kHeadIdx * totalTokens + stream.tokenOffset + stream.chunkIdx * chunkSize) * kHeadDim;
+        offset.wOffset = (stream.shapeBatchIdx * vNumHead * totalTokens + stream.vHeadIdx * totalTokens + stream.tokenOffset + stream.chunkIdx * chunkSize) * kHeadDim;
+        offset.gOffset = stream.shapeBatchIdx * vNumHead * totalTokens + stream.vHeadIdx * totalTokens + stream.tokenOffset + stream.chunkIdx * chunkSize;
+        offset.hWorkOffset = (cubeCoreIdx * PING_PONG_STAGES + streamId) * kHeadDim * vHeadDim;
+        offset.vWorkOffset = (cubeCoreIdx * PING_PONG_STAGES + streamId) * chunkSize * vHeadDim;
+        offset.blockTokens = offset.isFinalState ? (stream.batchTokens - stream.chunkIdx * chunkSize) : chunkSize;
+        offset.batchIdx = stream.batchIdx; 
+        offset.headIdx = stream.vHeadIdx; 
+        offset.chunkIdx = stream.chunkIdx;
+    }
+     
+    CATLASS_DEVICE
+    void InitTasks() {
+        //auto oldHead = runningQ.head;
+        auto streamId = runningQ.head;
+        for (uint32_t i = 0; i < PING_PONG_STAGES; ++i) {
+            //auto streamId = (oldHead + i) % PING_PONG_STAGES;
+            auto& stream = runningQ.streams[streamId];
+            stream.chunkIdx += 1;
+            if (StreamIsDone(stream)) {
+                // 当前stream已完成，用一个新stream替换它
+                taskIdx += 1;
+                if (taskIdx >= (curLoopTaskBegin + curLoopTaskCnt)) {
+                    curLoopIdx += 1;
+                    // curLoopTaskBegin = curLoopIdx * PING_PONG_STAGES * cubeCoreNum + PING_PONG_STAGES * cubeCoreIdx;
+                    // if (curLoopIdx + 1 >= taskLoops) {
+                    //     curLoopTaskCnt = lastLoopTaskCnt;
+                    // }
+                    if (curLoopIdx + 1 < taskLoops) {
+                        curLoopTaskBegin = curLoopIdx * PING_PONG_STAGES * cubeCoreNum + PING_PONG_STAGES * cubeCoreIdx;
+                    } else {
+                        curLoopTaskBegin = curLoopIdx * PING_PONG_STAGES * cubeCoreNum + (hasDummyHead ? 1 : PING_PONG_STAGES) * cubeCoreIdx;
+                        curLoopTaskCnt = lastLoopTaskCnt;
+                    }
+                    taskIdx = curLoopTaskBegin;
+                }
+     
+                //runningQ.head = (streamId + 1) % PING_PONG_STAGES;
+                stream.batchChunks = 0;
+                if (taskIdx < taskNum) {
+                    InitNewStream(stream);
+                    UpdateTask(streamId);
+                } 
+
+                if (streamId == runningQ.head) {
+                    runningQ.head = (runningQ.head + 1) % PING_PONG_STAGES;
+                    if (taskIdx >= taskNum) {
+                        // 没有新stream了，将head推进到下一个未完成的stream上
+                        for (uint32_t j = 0; j < PING_PONG_STAGES && StreamIsDone(runningQ.streams[runningQ.head]); ++j) {
+                            runningQ.head = (runningQ.head + 1) % PING_PONG_STAGES;
+                        }
+                        isRunning = ! StreamIsDone(runningQ.streams[runningQ.head]);
+                    }
+                    streamId = runningQ.head;
+                }
+                else {
+                    streamId = (streamId + 1) % PING_PONG_STAGES;
+                }
+
+            } else {
+                UpdateTask(streamId);
+                streamId = (streamId + 1) % PING_PONG_STAGES;
+            }
+        }
+    }
+    
+    CATLASS_DEVICE
+    const GDNFwdHStream& GetStream(uint32_t i) const {
+        return runningQ.streams[(runningQ.head + i) % PING_PONG_STAGES];
+    }
+
+    CATLASS_DEVICE
+    const GDNFwdHOffsets& GetCurTaskOffsets(const GDNFwdHStream& stream) const {
+        return stream.offset;
+    }
+
+    CATLASS_DEVICE
+    bool StreamIsDone(const GDNFwdHStream& stream) const {
+        return stream.chunkIdx >= stream.batchChunks;
+    }
+
+    CATLASS_DEVICE
+    bool NeedProcessStage2(const GDNFwdHStream& stream) {
+        return storeFinalState || !stream.offset.isFinalState;
+    }
+};
+
+struct BlockSchedulerGdnFwdHCube : public BlockSchedulerGdnFwdH {
+    CATLASS_DEVICE
+    BlockSchedulerGdnFwdHCube() {}
+
+    CATLASS_DEVICE
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR tiling, GM_ADDR user) {
+        BlockSchedulerGdnFwdH::Init(cu_seqlens, chunk_indices, tiling, user, AscendC::GetBlockIdx(), AscendC::GetBlockNum());
+    }
+
+};
+
+struct BlockSchedulerGdnFwdHVec : public BlockSchedulerGdnFwdH {
+    CATLASS_DEVICE
+    BlockSchedulerGdnFwdHVec() {}
+
+    CATLASS_DEVICE
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR tiling, GM_ADDR user) {
+        BlockSchedulerGdnFwdH::Init(cu_seqlens, chunk_indices, tiling, user, AscendC::GetBlockIdx() / AscendC::GetSubBlockNum(), AscendC::GetBlockNum());
+    }
+
+};
+
+}  // namespace Catlass::Gemm::Block
+
+#endif  // CATLASS_GEMM_SCHEDULER_GDN_FWD_H_HPP

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -96,7 +96,7 @@ public:
 
     // vec 1
     using DispatchPolicyGDNFwdHVnew = Epilogue::EpilogueAtlasGDNFwdHVnew;
-    using EpilogueGDNFwdHVnew = Epilogue::Block::BlockEpilogue<DispatchPolicyGDNFwdHVnew, VType, GType, UType, VworkType, VUpdateType>;
+    using EpilogueGDNFwdHVnew = Epilogue::Block::BlockEpilogue<DispatchPolicyGDNFwdHVnew, VType, GType, UType, VworkType, VUpdateType, FinalStateType>;
 
     // vec 2
     using DispatchPolicyGDNFwdHUpdate = Epilogue::EpilogueAtlasGDNFwdHUpdate;
@@ -164,9 +164,6 @@ public:
 
     AscendC::LocalTensor<ElementV> l1VUpdatePing;
     AscendC::LocalTensor<ElementV> l1VUpdatePong;
-
-    bool stage1Ping {true};
-    bool stage2Ping {true};
 
     CubeScheduler cubeBlockScheduler;
     VecScheduler vecBlockScheduler;
@@ -267,7 +264,7 @@ public:
                         int64_t cube1OffsetVwork = cube1Offsets.vWorkOffset;
                         auto tensorW = tla::MakeTensor(gmW[cube1OffsetW], wLayout, Catlass::Arch::PositionGM{});
                         auto tensorH = tla::MakeTensor(gmH[cube1OffsetH], hLayout, Catlass::Arch::PositionGM{});
-                        AscendC::LocalTensor<ElementVWork> ubVWork = stage1Ping ? ubVWorkPing : ubVWorkPong;
+                        AscendC::LocalTensor<ElementVWork> ubVWork = (i == 0) ? ubVWorkPing : ubVWorkPong;
                         auto tensorV = tla::MakeTensor(ubVWork, vLayout, Catlass::Arch::PositionUB{});
                         GemmCoord cube1Shape {cube1Offsets.blockTokens, vHeadDim, kHeadDim};
                         auto tensorBlockW = GetTile(tensorW, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.k()));
@@ -276,7 +273,6 @@ public:
                         blockMmadWH.preSetFlags();
                         blockMmadWH(tensorBlockW, tensorBlockH, tensorV, cube1Shape);
                         blockMmadWH.finalWaitFlags();
-                        stage1Ping = !stage1Ping;
                         Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done);
                     }
                 } else {
@@ -296,9 +292,9 @@ public:
                             int64_t cube2OffsetH = cube2Offsets.hWorkOffset;
                             auto tensorK = tla::MakeTensor(gmK[cube2OffsetK], kLayout, Catlass::Arch::PositionGM{});
                             auto vUpdateLayout = tla::MakeLayout<ElementVUpdate, LayoutVUpdate>(cube2Offsets.blockTokens, vHeadDim);
-                            AscendC::LocalTensor<ElementHWork> ubHUpdate = stage2Ping ? ubHUpdatePing : ubHUpdatePong;
+                            AscendC::LocalTensor<ElementHWork> ubHUpdate = (i == 0) ? ubHUpdatePing : ubHUpdatePong;
                             auto tensorHwork = tla::MakeTensor(ubHUpdate, hworkLayout, Catlass::Arch::PositionUB{});
-                            AscendC::LocalTensor<ElementV> l1VUpdate = stage2Ping ? l1VUpdatePing : l1VUpdatePong;
+                            AscendC::LocalTensor<ElementV> l1VUpdate = (i == 0) ? l1VUpdatePing : l1VUpdatePong;
                             auto tensorVwork = tla::MakeTensor(l1VUpdate, vUpdateLayout, Catlass::Arch::PositionL1{});
                             GemmCoord cube2Shape{kHeadDim, vHeadDim, cube2Offsets.blockTokens};
                             auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.k()));
@@ -306,7 +302,6 @@ public:
                             blockMmadKV.preSetFlags();
                             blockMmadKV(tensorBlockK, tensorVwork, tensorHwork, cube2Shape);
                             blockMmadKV.finalWaitFlags();
-                            stage2Ping = !stage2Ping;
                         }
                         Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube2Done);
                     }
@@ -390,10 +385,17 @@ public:
 
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0); // preset v
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pongBaseEvent);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0); // preset v
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0 + pongBaseEvent);
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1); // preset u
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pongBaseEvent);
-            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2); // preset h
-            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pongBaseEvent);
+            if (storeFinalState && std::is_same<ElementFinalState, float>::value) {
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2); // preset h
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pongBaseEvent);
+            } else {
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2); // preset h
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pongBaseEvent);
+            }
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3); // preset g
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pongBaseEvent);
 
@@ -413,14 +415,14 @@ public:
                             continue;
                         }
                         const GDNFwdHOffsets& vec1Offsets = vecBlockScheduler.GetCurTaskOffsets(stream);
-                        AscendC::LocalTensor<ElementV> l1VUpdate = stage1Ping ? l1VUpdatePing : l1VUpdatePong;
+                        AscendC::LocalTensor<ElementV> l1VUpdate = (i == 0) ? l1VUpdatePing : l1VUpdatePong;
                         epilogueGDNFwdHVnew(
                             gmV[vec1Offsets.uvOffset], gmVUpdateWorkspace[vec1Offsets.vWorkOffset], l1VUpdate,
                             gmG[vec1Offsets.gOffset], gmU[vec1Offsets.uvOffset], gmVWorkspace[vec1Offsets.vWorkOffset], 
                             vec1Offsets.blockTokens, kHeadDim, vHeadDim, 
-                            vecBlockScheduler.cube1Done, vecBlockScheduler.vec1Done, vec1Offsets.isInitialState, stage1Ping
+                            vecBlockScheduler.cube1Done, vecBlockScheduler.vec1Done,
+                            vec1Offsets.isInitialState, vec1Offsets.isFinalState, storeFinalState, (i == 0)
                         );
-                        stage1Ping = !stage1Ping;
                     }
                 } else {
                     /* V2: h[i+1] += h_work if i < num_chunks - 1 else None */
@@ -439,9 +441,8 @@ public:
                                 gmH[vec2Offsets.hSrcOffset],
                                 gmHWorkspace[vec2Offsets.hWorkOffset],
                                 vec2Offsets.blockTokens, kHeadDim, vHeadDim, vecBlockScheduler.cube2Done,
-                                (vec2Offsets.isFinalState && storeFinalState), stage2Ping
+                                vec2Offsets.isInitialState, vec2Offsets.isFinalState, storeFinalState, (i == 0)
                             );
-                            stage2Ping = !stage2Ping;
                         } else {
                             Arch::CrossCoreWaitFlag(vecBlockScheduler.cube2Done);
                         }
@@ -453,10 +454,17 @@ public:
 
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0); // preset v
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pongBaseEvent);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0); // preset v
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0 + pongBaseEvent);
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1); // preset u
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pongBaseEvent);
-            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2); // preset h
-            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pongBaseEvent);
+            if (storeFinalState && std::is_same<ElementFinalState, float>::value) {
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2); // preset h
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pongBaseEvent);
+            } else {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2); // preset h
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pongBaseEvent);
+            }
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3); // preset g
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pongBaseEvent);
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -14,13 +14,14 @@
 #include "catlass/arch/resource.hpp"
 #include "catlass/catlass.hpp"
 #include "catlass/debug.hpp"
+#include "../block/block_scheduler_gdn_fwd_h.hpp"
 #include "catlass/epilogue/block/block_epilogue.hpp"
 #include "../../epilogue/block/block_epilogue_gdn_fwdh_update.hpp"
 #include "../../epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp"
 #include "catlass/gemm/block/block_mmad.hpp"
 #include "kernel_utils/block/block_mmad_pingpong_tla_multi.hpp"
+#include "kernel_utils/block/block_mmad_pingpong_tla_preloadA_l1B.hpp"
 #include "catlass/gemm/block/block_swizzle.hpp"
-#include "../block/block_scheduler_gdn_fwd_h.hpp"
 #include "catlass/gemm/dispatch_policy.hpp"
 #include "catlass/gemm/gemm_type.hpp"
 #include "catlass/layout/layout.hpp"
@@ -68,7 +69,8 @@ public:
     using CubeScheduler = typename Catlass::Gemm::Block::BlockSchedulerGdnFwdHCube;
     using VecScheduler = typename Catlass::Gemm::Block::BlockSchedulerGdnFwdHVec;
 
-    using DispatchPolicyTla = Gemm::MmadPingpongTlaMulti<ArchTag, true, false>;
+    using DispatchPolicyTlaMulti = Gemm::MmadPingpongTlaMulti<ArchTag, true, false>;
+    using DispatchPolicyTlaPreloadAL1B = Gemm::MmadPingpongTlaPreloadAL1B<ArchTag, true>;
     using L1TileShapeTla = Shape<_128, _128, _128>;
     using L0TileShapeTla = L1TileShapeTla;
 
@@ -81,18 +83,20 @@ public:
     using GType = Gemm::GemmType<G_TYPE, layout::RowMajor>;
     using UType = Gemm::GemmType<INPUT_TYPE, layout::RowMajor>;
     using FinalStateType = Gemm::GemmType<STATE_TYPE, layout::RowMajor>;
+    using VUpdateType = Gemm::GemmType<INPUT_TYPE, layout::zN>;
 
     // cube 1
-    using TileCopyWH = Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor>;
-    using BlockMmadWH = Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeTla, L0TileShapeTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyWH>;
+    using TileCopyWH = Catlass::Gemm::Tile::PackedTileCopyTlaToUB<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor, void, Catlass::Gemm::Tile::CopyL0CToUBMode::SPLIT_M>;
+    using BlockMmadWH = Gemm::Block::BlockMmadTla<DispatchPolicyTlaMulti, L1TileShapeTla, L0TileShapeTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyWH>;
 
     // cube 2
-    using TileCopyKV = Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, INPUT_TYPE, layout::ColumnMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor>;
-    using BlockMmadKV = Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeTla, L0TileShapeTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyKV>;
+    using TileCopyKV = Catlass::Gemm::Tile::PackedTileCopyTlaToUB<ArchTag, INPUT_TYPE, layout::ColumnMajor, INPUT_TYPE, layout::zN, WORKSPACE_TYPE, layout::RowMajor, void, Catlass::Gemm::Tile::CopyL0CToUBMode::SPLIT_M>;
+    using TileMmadKV = Gemm::Tile::TileMmadTla<ArchTag, INPUT_TYPE, typename TileCopyKV::LayoutTagL1A>;
+    using BlockMmadKV = Gemm::Block::BlockMmadTla<DispatchPolicyTlaPreloadAL1B, L1TileShapeTla, L0TileShapeTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyKV, TileMmadKV>;
 
     // vec 1
     using DispatchPolicyGDNFwdHVnew = Epilogue::EpilogueAtlasGDNFwdHVnew;
-    using EpilogueGDNFwdHVnew = Epilogue::Block::BlockEpilogue<DispatchPolicyGDNFwdHVnew, VType, GType, UType, VworkType>;
+    using EpilogueGDNFwdHVnew = Epilogue::Block::BlockEpilogue<DispatchPolicyGDNFwdHVnew, VType, GType, UType, VworkType, VUpdateType>;
 
     // vec 2
     using DispatchPolicyGDNFwdHUpdate = Epilogue::EpilogueAtlasGDNFwdHUpdate;
@@ -106,6 +110,7 @@ public:
     using ElementG = G_TYPE;
     using ElementH = INPUT_TYPE;
     using ElementV = INPUT_TYPE;
+    using ElementVUpdate = INPUT_TYPE;
     using ElementVWork = WORKSPACE_TYPE;
     using ElementHWork = WORKSPACE_TYPE;
     using ElementInitialState = STATE_TYPE;
@@ -115,6 +120,7 @@ public:
     using LayoutH = Catlass::layout::RowMajor;
     using LayoutV = Catlass::layout::RowMajor;
     using LayoutK = Catlass::layout::ColumnMajor;
+    using LayoutVUpdate = typename VUpdateType::Layout;
 
     
     uint32_t batch;
@@ -150,6 +156,17 @@ public:
     AscendC::GlobalTensor<int64_t> gmSeqlen;
     AscendC::GlobalTensor<int64_t> gmNumSeq;
     AscendC::GlobalTensor<int64_t> gmNumChunks;
+
+    AscendC::LocalTensor<ElementHWork> ubHUpdatePing;
+    AscendC::LocalTensor<ElementHWork> ubHUpdatePong;
+    AscendC::LocalTensor<ElementVWork> ubVWorkPing;
+    AscendC::LocalTensor<ElementVWork> ubVWorkPong;
+
+    AscendC::LocalTensor<ElementV> l1VUpdatePing;
+    AscendC::LocalTensor<ElementV> l1VUpdatePong;
+
+    bool stage1Ping {true};
+    bool stage2Ping {true};
 
     CubeScheduler cubeBlockScheduler;
     VecScheduler vecBlockScheduler;
@@ -198,6 +215,14 @@ public:
         gmNumSeq.SetGlobalBuffer((__gm__ int64_t *)(user + numSeqWorkspaceOffset));
         gmNumChunks.SetGlobalBuffer((__gm__ int64_t *)(user + numChunksWorkspaceOffset));
 
+        ubHUpdatePing = resource.ubBuf.template GetBufferByByte<ElementHWork>(32 * 1024);
+        ubHUpdatePong = resource.ubBuf.template GetBufferByByte<ElementHWork>(96 * 1024);
+        ubVWorkPing = resource.ubBuf.template GetBufferByByte<ElementVWork>(32 * 1024);
+        ubVWorkPong = resource.ubBuf.template GetBufferByByte<ElementVWork>(96 * 1024);
+
+        l1VUpdatePing = resource.l1Buf.template GetBufferByByte<ElementV>(0);
+        l1VUpdatePong = resource.l1Buf.template GetBufferByByte<ElementV>(chunkSize * vHeadDim * sizeof(ElementV));
+
         if ASCEND_IS_AIC {
             cubeBlockScheduler.Init(cu_seqlens, chunk_indices, tiling, user);
         }
@@ -213,16 +238,15 @@ public:
             uint32_t coreIdx = AscendC::GetBlockIdx();
             uint32_t coreNum = AscendC::GetBlockNum();
 
-            BlockMmadWH blockMmadWH(resource);
-            BlockMmadKV blockMmadKV(resource);
+            BlockMmadWH blockMmadWH(resource, chunkSize * vHeadDim * sizeof(ElementV) * PING_PONG_STAGES);
+            BlockMmadKV blockMmadKV(resource, chunkSize * vHeadDim * sizeof(ElementV) * PING_PONG_STAGES);
 
             auto wLayout = tla::MakeLayout<ElementW, LayoutW>(shapeBatch * kNumHead * cubeBlockScheduler.totalTokens, kHeadDim);
             auto hLayout = tla::MakeLayout<ElementH, LayoutH>(shapeBatch * vNumHead * cubeBlockScheduler.totalChunks * kHeadDim, vHeadDim);
-            auto vLayout = tla::MakeLayout<ElementVWork, LayoutV>(coreNum * chunkSize * PING_PONG_STAGES, vHeadDim);
             
             auto kLayout = tla::MakeLayout<ElementK, LayoutK>(kHeadDim, shapeBatch * kNumHead * cubeBlockScheduler.totalTokens);
-            auto vworkLayout = tla::MakeLayout<ElementV, LayoutV>(coreNum * chunkSize * PING_PONG_STAGES, vHeadDim);
-            auto hworkLayout = tla::MakeLayout<ElementHWork, LayoutH>(coreNum * kHeadDim * PING_PONG_STAGES, vHeadDim);
+            auto hworkLayout = tla::MakeLayout<ElementHWork, LayoutH>(kHeadDim, vHeadDim);
+
             AscendC::SyncAll<false>();    
             uint32_t currStage = 0; // 0: C1, 1: C2
             while (cubeBlockScheduler.isRunning) {
@@ -237,19 +261,22 @@ public:
 
                         const GDNFwdHOffsets& cube1Offsets = cubeBlockScheduler.GetCurTaskOffsets(stream);
                         Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[i]);
+                        auto vLayout = tla::MakeLayout<ElementVWork, LayoutV>(cube1Offsets.blockTokens, vHeadDim);
                         int64_t cube1OffsetW = cube1Offsets.wOffset;
                         int64_t cube1OffsetH = cube1Offsets.hSrcOffset;
                         int64_t cube1OffsetVwork = cube1Offsets.vWorkOffset;
                         auto tensorW = tla::MakeTensor(gmW[cube1OffsetW], wLayout, Catlass::Arch::PositionGM{});
                         auto tensorH = tla::MakeTensor(gmH[cube1OffsetH], hLayout, Catlass::Arch::PositionGM{});
-                        auto tensorV = tla::MakeTensor(gmVWorkspace[cube1OffsetVwork], vLayout, Catlass::Arch::PositionGM{});
+                        AscendC::LocalTensor<ElementVWork> ubVWork = stage1Ping ? ubVWorkPing : ubVWorkPong;
+                        auto tensorV = tla::MakeTensor(ubVWork, vLayout, Catlass::Arch::PositionUB{});
                         GemmCoord cube1Shape {cube1Offsets.blockTokens, vHeadDim, kHeadDim};
                         auto tensorBlockW = GetTile(tensorW, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.k()));
                         auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.k(), cube1Shape.n()));
-                        auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.n()));
+
                         blockMmadWH.preSetFlags();
-                        blockMmadWH(tensorBlockW, tensorBlockH, tensorBlockV, cube1Shape);
+                        blockMmadWH(tensorBlockW, tensorBlockH, tensorV, cube1Shape);
                         blockMmadWH.finalWaitFlags();
+                        stage1Ping = !stage1Ping;
                         Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done);
                     }
                 } else {
@@ -268,15 +295,18 @@ public:
                             int64_t cube2OffsetVwork = cube2Offsets.vWorkOffset;
                             int64_t cube2OffsetH = cube2Offsets.hWorkOffset;
                             auto tensorK = tla::MakeTensor(gmK[cube2OffsetK], kLayout, Catlass::Arch::PositionGM{});
-                            auto tensorVwork = tla::MakeTensor(gmVUpdateWorkspace[cube2OffsetVwork], vworkLayout, Catlass::Arch::PositionGM{});
-                            auto tensorHwork = tla::MakeTensor(gmHWorkspace[cube2OffsetH], hworkLayout, Catlass::Arch::PositionGM{});
+                            auto vUpdateLayout = tla::MakeLayout<ElementVUpdate, LayoutVUpdate>(cube2Offsets.blockTokens, vHeadDim);
+                            AscendC::LocalTensor<ElementHWork> ubHUpdate = stage2Ping ? ubHUpdatePing : ubHUpdatePong;
+                            auto tensorHwork = tla::MakeTensor(ubHUpdate, hworkLayout, Catlass::Arch::PositionUB{});
+                            AscendC::LocalTensor<ElementV> l1VUpdate = stage2Ping ? l1VUpdatePing : l1VUpdatePong;
+                            auto tensorVwork = tla::MakeTensor(l1VUpdate, vUpdateLayout, Catlass::Arch::PositionL1{});
                             GemmCoord cube2Shape{kHeadDim, vHeadDim, cube2Offsets.blockTokens};
                             auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.k()));
-                            auto tensorBlockVwork = GetTile(tensorVwork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.k(), cube2Shape.n()));
-                            auto tensorBlockHwork = GetTile(tensorHwork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.n()));
+
                             blockMmadKV.preSetFlags();
-                            blockMmadKV(tensorBlockK, tensorBlockVwork, tensorBlockHwork, cube2Shape);
+                            blockMmadKV(tensorBlockK, tensorVwork, tensorHwork, cube2Shape);
                             blockMmadKV.finalWaitFlags();
+                            stage2Ping = !stage2Ping;
                         }
                         Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube2Done);
                     }
@@ -383,12 +413,14 @@ public:
                             continue;
                         }
                         const GDNFwdHOffsets& vec1Offsets = vecBlockScheduler.GetCurTaskOffsets(stream);
+                        AscendC::LocalTensor<ElementV> l1VUpdate = stage1Ping ? l1VUpdatePing : l1VUpdatePong;
                         epilogueGDNFwdHVnew(
-                            gmV[vec1Offsets.uvOffset], gmVUpdateWorkspace[vec1Offsets.vWorkOffset], 
+                            gmV[vec1Offsets.uvOffset], gmVUpdateWorkspace[vec1Offsets.vWorkOffset], l1VUpdate,
                             gmG[vec1Offsets.gOffset], gmU[vec1Offsets.uvOffset], gmVWorkspace[vec1Offsets.vWorkOffset], 
                             vec1Offsets.blockTokens, kHeadDim, vHeadDim, 
-                            vecBlockScheduler.cube1Done, vecBlockScheduler.vec1Done, vec1Offsets.isInitialState
+                            vecBlockScheduler.cube1Done, vecBlockScheduler.vec1Done, vec1Offsets.isInitialState, stage1Ping
                         );
+                        stage1Ping = !stage1Ping;
                     }
                 } else {
                     /* V2: h[i+1] += h_work if i < num_chunks - 1 else None */
@@ -407,8 +439,9 @@ public:
                                 gmH[vec2Offsets.hSrcOffset],
                                 gmHWorkspace[vec2Offsets.hWorkOffset],
                                 vec2Offsets.blockTokens, kHeadDim, vHeadDim, vecBlockScheduler.cube2Done,
-                                (vec2Offsets.isFinalState && storeFinalState)
+                                (vec2Offsets.isFinalState && storeFinalState), stage2Ping
                             );
+                            stage2Ping = !stage2Ping;
                         } else {
                             Arch::CrossCoreWaitFlag(vecBlockScheduler.cube2Done);
                         }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -7,7 +7,7 @@
  * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#define CATLASS_ARCH 2201
+#define CATLASS_ARCH 3510
 
 #include "catlass/arch/arch.hpp"
 #include "catlass/arch/cross_core_sync.hpp"
@@ -29,6 +29,24 @@
 #include "tla/layout.hpp"
 #include "tla/tensor.hpp"
 
+using _0 = tla::Int<0>;
+using _1 = tla::Int<1>;
+using _2 = tla::Int<2>;
+using _4 = tla::Int<4>;
+using _8 = tla::Int<8>;
+using _16 = tla::Int<16>;
+using _32 = tla::Int<32>;
+using _64 = tla::Int<64>;
+using _128 = tla::Int<128>;
+using _256 = tla::Int<256>;
+using _512 = tla::Int<512>;
+using _1024 = tla::Int<1024>;
+using _2048 = tla::Int<2048>;
+using _4096 = tla::Int<4096>;
+using _8192 = tla::Int<8192>;
+using _16384 = tla::Int<16384>;
+using _32768 = tla::Int<32768>;
+using _65536 = tla::Int<65536>;
 
 
 #include "kernel_operator.h"
@@ -46,7 +64,7 @@ template<
 class GDNFwdHKernel {
 public:
     
-    using ArchTag = Arch::AtlasA2;
+    using ArchTag = Arch::Ascend950;
     using CubeScheduler = typename Catlass::Gemm::Block::BlockSchedulerGdnFwdHCube;
     using VecScheduler = typename Catlass::Gemm::Block::BlockSchedulerGdnFwdHVec;
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h.cpp
@@ -12,8 +12,12 @@
  * \brief
  */
 
-// #include "chunk_gated_delta_rule_fwd_h.h"
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#include "arch35/gemm/kernel/gdn_fwd_h_kernel.hpp"
+#else
 #include "gemm/kernel/gdn_fwd_h_kernel.hpp"
+#endif
+
 #include "lib/matmul_intf.h"
 
 using namespace Catlass;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
@@ -50,20 +50,31 @@ public:
 
         constexpr uint32_t CALC_BUF_OFFSET = 0;
         constexpr uint32_t PING_BUF_0_OFFSET = 32 * 1024;
-        constexpr uint32_t PING_BUF_1_OFFSET = 64 * 1024;
-        constexpr uint32_t PING_BUF_2_OFFSET = 80 * 1024;
+        constexpr uint32_t PING_BUF_1_OFFSET = 48 * 1024;
+        constexpr uint32_t PING_BUF_2_OFFSET = 64 * 1024;
+        constexpr uint32_t PING_BUF_3_OFFSET = 80 * 1024;
+        constexpr uint32_t PONG_BUF_0_OFFSET = 96 * 1024;
+        constexpr uint32_t PONG_BUF_1_OFFSET = 112 * 1024;
+        constexpr uint32_t PONG_BUF_2_OFFSET = 128 * 1024;
+        constexpr uint32_t PONG_BUF_3_OFFSET = 144 * 1024;
         constexpr uint32_t PING_G_BUF_OFFSET = 160 * 1024;
+        constexpr uint32_t PONG_G_BUF_OFFSET = 161 * 1024;
+        constexpr uint32_t PING_G_SUB_BUF_OFFSET = 162 * 1024;
+        constexpr uint32_t PONG_G_SUB_BUF_OFFSET = 163 * 1024;
+        constexpr uint32_t PING_G_INPUT_BUF_OFFSET = 164 * 1024;
+        constexpr uint32_t PONG_G_INPUT_BUF_OFFSET = 165 * 1024;
+        constexpr uint32_t SHARE_BUF_OFFSET = 166 * 1024;
 
 
         calcUbTensor = resource.ubBuf.template GetBufferByByte<float>(CALC_BUF_OFFSET);
 
-        hUpdateUbTensor = resource.ubBuf.template GetBufferByByte<float>(PING_BUF_1_OFFSET);
-        hUbTensor = resource.ubBuf.template GetBufferByByte<HElementInput>(PING_BUF_0_OFFSET);
+        hUpdateUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_BUF_0_OFFSET);
+        hUbTensor_ping = resource.ubBuf.template GetBufferByByte<HElementOutput>(PING_BUF_3_OFFSET);
+        glastUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_G_INPUT_BUF_OFFSET);
 
-        hOutputUbTensor = resource.ubBuf.template GetBufferByByte<HElementOutput>(PING_BUF_1_OFFSET);
-        finalOutputUbTensor = resource.ubBuf.template GetBufferByByte<FinalStateElement>(PING_BUF_1_OFFSET);
-
-        glastUbTensor = resource.ubBuf.template GetBufferByByte<float>(PING_G_BUF_OFFSET);
+        hUpdateUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_BUF_0_OFFSET);
+        hUbTensor_pong = resource.ubBuf.template GetBufferByByte<HElementOutput>(PONG_BUF_3_OFFSET);
+        glastUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_G_INPUT_BUF_OFFSET);
 
     }
 
@@ -102,11 +113,16 @@ public:
         AscendC::GlobalTensor<float> hUpdateInputThisSubBlock = hUpdateInput[offsetH];
         AscendC::GlobalTensor<FinalStateElement> finalStateThisSubBlock = finalState[offsetH];
 
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+        uint32_t pingpongFlag = isPing ? 0 : pongBaseEvent;
+        AscendC::LocalTensor<float> hUpdateUbTensor = isPing ? hUpdateUbTensor_ping : hUpdateUbTensor_pong;
+        AscendC::LocalTensor<HElementOutput> hUbTensor = isPing ? hUbTensor_ping : hUbTensor_pong;
+        AscendC::LocalTensor<float> glastUbTensor = isPing ? glastUbTensor_ping : glastUbTensor_pong;
+
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
         AscendC::DataCopy(hUbTensor, hInputThisSubBlock, mActualThisSubBlock * nActual);
-        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+
         AscendC::Cast(calcUbTensor, hUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nActual);
         AscendC::PipeBarrier<PIPE_V>();
         
@@ -121,58 +137,50 @@ public:
         }
         glastUbTensor.SetValue(0, gLastFloat);
 
-        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
-        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
+        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
         AscendC::Exp(glastUbTensor, glastUbTensor, 1);
-        AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID0);
-        AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID0);
+        AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
         float muls = glastUbTensor.GetValue(0);
-        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
-        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
+        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
         AscendC::Muls(calcUbTensor, calcUbTensor, muls, mActualThisSubBlock * nActual);
+        AscendC::PipeBarrier<PIPE_V>();
 
         Arch::CrossCoreWaitFlag(cube2Done);
 
-        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
         AscendC::DataCopy(hUpdateUbTensor, hUpdateInputThisSubBlock, mActualThisSubBlock * nActual);
-        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
         AscendC::Add<float>(hUpdateUbTensor, calcUbTensor, hUpdateUbTensor, mActualThisSubBlock * nActual);
+        AscendC::PipeBarrier<PIPE_V>();
 
-        if (isFinalState) {
-            if constexpr(!std::is_same<FinalStateElement, float>::value) {
-                AscendC::PipeBarrier<PIPE_V>();
-                AscendC::Cast(finalOutputUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
-                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
-                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
-                AscendC::DataCopy(finalStateThisSubBlock, finalOutputUbTensor, mActualThisSubBlock * nActual);
-            } else {
-                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
-                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
-                AscendC::DataCopy(finalStateThisSubBlock, hUpdateUbTensor, mActualThisSubBlock * nActual);
-            }
-        } else {
-            AscendC::PipeBarrier<PIPE_V>();
-            AscendC::Cast(hOutputUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
-            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
-            AscendC::DataCopy(hOutputThisSubBlock, hOutputUbTensor, mActualThisSubBlock * nActual);
-        }
+        AscendC::Cast(hUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
+        AscendC::DataCopy(hOutputThisSubBlock, hUbTensor, mActualThisSubBlock * nActual);
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
+        
+        isPing = !isPing;
     }
 
 private:
+    uint32_t pongBaseEvent = 4;
+    bool isPing = true;
+
     AscendC::LocalTensor<float> calcUbTensor;
 
-    AscendC::LocalTensor<HElementInput> hUbTensor;
-    AscendC::LocalTensor<float> hUpdateUbTensor;
+    AscendC::LocalTensor<float> hUpdateUbTensor_ping;
+    AscendC::LocalTensor<HElementOutput> hUbTensor_ping;
+    AscendC::LocalTensor<float> glastUbTensor_ping;
 
-    AscendC::LocalTensor<HElementOutput> hOutputUbTensor;
-    AscendC::LocalTensor<FinalStateElement> finalOutputUbTensor;
-
-    AscendC::LocalTensor<float> glastUbTensor;
+    AscendC::LocalTensor<float> hUpdateUbTensor_pong;
+    AscendC::LocalTensor<HElementOutput> hUbTensor_pong;
+    AscendC::LocalTensor<float> glastUbTensor_pong;
 
 };
 }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
@@ -92,7 +92,10 @@ public:
         uint32_t kHeadDim,
         uint32_t vHeadDim,
         Arch::CrossCoreFlag cube2Done,
-        bool isFinalState
+        bool isInitialState,
+        bool isFinalState,
+        bool storeFinalState,
+        bool isPing
     )
     {
         uint32_t mActual = kHeadDim;
@@ -118,13 +121,20 @@ public:
         AscendC::LocalTensor<HElementOutput> hUbTensor = isPing ? hUbTensor_ping : hUbTensor_pong;
         AscendC::LocalTensor<float> glastUbTensor = isPing ? glastUbTensor_ping : glastUbTensor_pong;
 
-        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
+        if (storeFinalState && isInitialState && std::is_same<FinalStateElement, float>::value) {
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
+        } else {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
+        }
         AscendC::DataCopy(hUbTensor, hInputThisSubBlock, mActualThisSubBlock * nActual);
         AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
         AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
 
         AscendC::Cast(calcUbTensor, hUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nActual);
         AscendC::PipeBarrier<PIPE_V>();
+        if (storeFinalState && isFinalState && std::is_same<FinalStateElement, float>::value) {
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
+        }
         
         GElementInput gLastVal = gInputThisSubBlock.GetValue(chunkSize-1);
         float gLastFloat = 0.0f;
@@ -157,20 +167,39 @@ public:
         AscendC::Add<float>(hUpdateUbTensor, calcUbTensor, hUpdateUbTensor, mActualThisSubBlock * nActual);
         AscendC::PipeBarrier<PIPE_V>();
 
-        AscendC::Cast(hUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
-        AscendC::DataCopy(hOutputThisSubBlock, hUbTensor, mActualThisSubBlock * nActual);
-        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
+        if constexpr(std::is_same<FinalStateElement, float>::value) {
+            if (storeFinalState && isFinalState) {
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::DataCopy(finalStateThisSubBlock, hUpdateUbTensor, mActualThisSubBlock * nActual);
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
+            } else {
+                AscendC::Cast(hUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
+                AscendC::DataCopy(hOutputThisSubBlock, hUbTensor, mActualThisSubBlock * nActual);
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
+            }
+        } else {
+            AscendC::Cast(hUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
+            if (isFinalState) {
+                AscendC::DataCopy(finalStateThisSubBlock, hUbTensor, mActualThisSubBlock * nActual);
+            } else {
+                AscendC::DataCopy(hOutputThisSubBlock, hUbTensor, mActualThisSubBlock * nActual);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
+        }
         
-        isPing = !isPing;
     }
 
 private:
     uint32_t pongBaseEvent = 4;
-    bool isPing = true;
 
     AscendC::LocalTensor<float> calcUbTensor;
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
@@ -24,14 +24,16 @@ template <
     class VOutputType_,
     class GInputType_,
     class UInputType_,
-    class WSInputType_
+    class WSInputType_,
+    class FinalStateType_
 >
 class BlockEpilogue <
     EpilogueAtlasGDNFwdHVnew,
     VOutputType_,
     GInputType_,
     UInputType_,
-    WSInputType_
+    WSInputType_,
+    FinalStateType_
 > {
 public:
     // Type aliases
@@ -42,6 +44,7 @@ public:
     using GElementInput = typename GInputType_::Element;
     using UElementInput = typename UInputType_::Element;
     using WSElementInput = typename WSInputType_::Element;
+    using FinalStateElement = typename FinalStateType_::Element;
 
     CATLASS_DEVICE
     BlockEpilogue(Arch::Resource<ArchTag> &resource)
@@ -103,7 +106,10 @@ public:
         uint32_t vHeadDim,
         Arch::CrossCoreFlag cube1Done,
         Arch::CrossCoreFlag vec1Done,
-        bool isInitialState 
+        bool isInitialState,
+        bool isFinalState,
+        bool storeFinalState,
+        bool isPing
     )
     {
         uint32_t mActual = chunkSize;
@@ -202,7 +208,11 @@ public:
 
         Arch::CrossCoreWaitFlag(cube1Done);
 
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+        if (storeFinalState && isInitialState && std::is_same<FinalStateElement, float>::value) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
+        } else {
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+        }
         AscendC::DataCopy(wsUbTensor, wsInputThisSubBlock, mActualThisSubBlock * nvActual);
         AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
         AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
@@ -235,12 +245,10 @@ public:
         AscendC::DataCopy(vnewOutputThisSubBlock, vNewOutputUbTensor, mActualThisSubBlock * nvActual);
         AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
 
-        isPing = !isPing;
     }
 
 private:
     uint32_t pongBaseEvent = 4;
-    bool isPing = true;
 
     AscendC::LocalTensor<float> calcUbTensor;
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
@@ -49,9 +49,13 @@ public:
 
         constexpr uint32_t CALC_BUF_OFFSET = 0;
         constexpr uint32_t PING_BUF_0_OFFSET = 32 * 1024;
-        constexpr uint32_t PING_BUF_1_OFFSET = 64 * 1024;
+        constexpr uint32_t PING_BUF_1_OFFSET = 48 * 1024;
+        constexpr uint32_t PING_BUF_2_OFFSET = 64 * 1024;
+        constexpr uint32_t PING_BUF_3_OFFSET = 80 * 1024;
         constexpr uint32_t PONG_BUF_0_OFFSET = 96 * 1024;
-        constexpr uint32_t PONG_BUF_1_OFFSET = 128 * 1024;
+        constexpr uint32_t PONG_BUF_1_OFFSET = 112 * 1024;
+        constexpr uint32_t PONG_BUF_2_OFFSET = 128 * 1024;
+        constexpr uint32_t PONG_BUF_3_OFFSET = 144 * 1024;
         constexpr uint32_t PING_G_BUF_OFFSET = 160 * 1024;
         constexpr uint32_t PONG_G_BUF_OFFSET = 161 * 1024;
         constexpr uint32_t PING_G_SUB_BUF_OFFSET = 162 * 1024;
@@ -62,23 +66,23 @@ public:
 
         calcUbTensor = resource.ubBuf.template GetBufferByByte<float>(CALC_BUF_OFFSET);
 
-        uUbTensor_ping = resource.ubBuf.template GetBufferByByte<UElementInput>(PING_BUF_1_OFFSET);
-        uUbFloatTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_BUF_0_OFFSET);
-        wsUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_BUF_1_OFFSET);
+        uUbTensor_ping = resource.ubBuf.template GetBufferByByte<UElementInput>(PING_BUF_2_OFFSET);
+        wsUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_BUF_0_OFFSET);
         gUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_G_BUF_OFFSET);
         gLastUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_G_SUB_BUF_OFFSET);
-        gInputUbTensor_ping = resource.ubBuf.template GetBufferByByte<GElementInput>(PING_G_INPUT_BUF_OFFSET);
-        vNewOutputUbTensor_ping = resource.ubBuf.template GetBufferByByte<VElementOutput>(PING_BUF_1_OFFSET);
-        vNewDecayUbTensor_ping = resource.ubBuf.template GetBufferByByte<VElementOutput>(PING_BUF_0_OFFSET);
+        gInputUbTensor_ping = resource.ubBuf.template GetBufferByByte<GElementInput>(PING_G_SUB_BUF_OFFSET);
+        gBrcbUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_BUF_0_OFFSET);
+        vNewOutputUbTensor_ping = resource.ubBuf.template GetBufferByByte<VElementOutput>(PING_BUF_2_OFFSET);
+        vNewDecayUbTensor_ping = resource.ubBuf.template GetBufferByByte<VElementOutput>(PING_BUF_2_OFFSET);
 
-        uUbTensor_pong = resource.ubBuf.template GetBufferByByte<UElementInput>(PONG_BUF_1_OFFSET);
-        uUbFloatTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_BUF_0_OFFSET);
-        wsUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_BUF_1_OFFSET);
+        uUbTensor_pong = resource.ubBuf.template GetBufferByByte<UElementInput>(PONG_BUF_2_OFFSET);
+        wsUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_BUF_0_OFFSET);
         gUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_G_BUF_OFFSET);
         gLastUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_G_SUB_BUF_OFFSET);
-        gInputUbTensor_pong = resource.ubBuf.template GetBufferByByte<GElementInput>(PONG_G_INPUT_BUF_OFFSET);
-        vNewOutputUbTensor_pong = resource.ubBuf.template GetBufferByByte<VElementOutput>(PONG_BUF_1_OFFSET);
-        vNewDecayUbTensor_pong = resource.ubBuf.template GetBufferByByte<VElementOutput>(PONG_BUF_0_OFFSET);
+        gInputUbTensor_pong = resource.ubBuf.template GetBufferByByte<GElementInput>(PONG_G_SUB_BUF_OFFSET);
+        gBrcbUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PING_BUF_0_OFFSET);
+        vNewOutputUbTensor_pong = resource.ubBuf.template GetBufferByByte<VElementOutput>(PONG_BUF_2_OFFSET);
+        vNewDecayUbTensor_pong = resource.ubBuf.template GetBufferByByte<VElementOutput>(PONG_BUF_2_OFFSET);
 
         shareBuffer_ = resource.ubBuf.template GetBufferByByte<uint8_t>(SHARE_BUF_OFFSET);
 
@@ -97,9 +101,9 @@ public:
         uint32_t chunkSize,
         uint32_t kHeadDim,
         uint32_t vHeadDim,
-        Arch::CrossCoreFlag cube1Done
-        // const LayoutOutput &layoutOutput,
-        // const LayoutInput &LayoutInput    
+        Arch::CrossCoreFlag cube1Done,
+        Arch::CrossCoreFlag vec1Done,
+        bool isInitialState 
     )
     {
         uint32_t mActual = chunkSize;
@@ -136,6 +140,8 @@ public:
         }
         gbrcEffStart = gbrcStart-gbrcRealStart;
         gbrcEffEnd = gbrcEffStart + mActualThisSubBlock;
+        uint32_t dstShape_[2] = {gbrcReptime*8, nvActual};
+        uint32_t srcShape_[2] = {gbrcReptime*8, 1};
 
         AscendC::ResetMask();
 
@@ -145,40 +151,44 @@ public:
         AscendC::GlobalTensor<UElementInput> uInputThisSubBlock = uInput[offsetK];
         AscendC::GlobalTensor<float> wsInputThisSubBlock = wsInput[offsetK];
 
-        pingpongFlag = isFirst ? 0 : 4;
-        AscendC::LocalTensor<UElementInput> uUbTensor = isFirst ? uUbTensor_ping : uUbTensor_pong;
-        AscendC::LocalTensor<float> uUbFloatTensor = isFirst ? uUbFloatTensor_ping : uUbFloatTensor_pong;
-        AscendC::LocalTensor<float> wsUbTensor = isFirst ? wsUbTensor_ping : wsUbTensor_pong;
-        AscendC::LocalTensor<float> gUbTensor = isFirst ? gUbTensor_ping : gUbTensor_pong;
-        AscendC::LocalTensor<float> gLastUbTensor = isFirst ? gLastUbTensor_ping : gLastUbTensor_pong;
-        AscendC::LocalTensor<GElementInput> gInputUbTensor = isFirst ? gInputUbTensor_ping : gInputUbTensor_pong;
-        AscendC::LocalTensor<VElementOutput> vNewOutputUbTensor = isFirst ? vNewOutputUbTensor_ping : vNewOutputUbTensor_pong;
-        AscendC::LocalTensor<VElementOutput> vNewDecayUbTensor = isFirst ? vNewDecayUbTensor_ping : vNewDecayUbTensor_pong;
+        uint32_t pingpongFlag = isPing ? 0 : pongBaseEvent;
+        AscendC::LocalTensor<UElementInput> uUbTensor = isPing ? uUbTensor_ping : uUbTensor_pong;
+        AscendC::LocalTensor<float> wsUbTensor = isPing ? wsUbTensor_ping : wsUbTensor_pong;
+        AscendC::LocalTensor<float> gUbTensor = isPing ? gUbTensor_ping : gUbTensor_pong;
+        AscendC::LocalTensor<float> gLastUbTensor = isPing ? gLastUbTensor_ping : gLastUbTensor_pong;
+        AscendC::LocalTensor<GElementInput> gInputUbTensor = isPing ? gInputUbTensor_ping : gInputUbTensor_pong;
+        AscendC::LocalTensor<float> gBrcbUbTensor = isPing ? gBrcbUbTensor_ping : gBrcbUbTensor_pong;
+        AscendC::LocalTensor<VElementOutput> vNewOutputUbTensor = isPing ? vNewOutputUbTensor_ping : vNewOutputUbTensor_pong;
+        AscendC::LocalTensor<VElementOutput> vNewDecayUbTensor = isPing ? vNewDecayUbTensor_ping : vNewDecayUbTensor_pong;
 
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
+    
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag); // wait v_c2
+        AscendC::DataCopy(uUbTensor, uInputThisSubBlock, mActualThisSubBlock * nvActual); // mte2 u
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag); // set u
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag); // wait u
+        AscendC::Cast(calcUbTensor, uUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nvActual); // cast u
 
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag); // wait last g
         if constexpr(std::is_same<GElementInput, float>::value) {
             AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(float)), 0, 0};
             AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
-            AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams);
+            AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams); // copy g
         } else {
             AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(half)), 0, 0};
             AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
             AscendC::DataCopyPad(gInputUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams);
         }
-        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3 + pingpongFlag);
         if constexpr(!std::is_same<GElementInput, float>::value) {
             AscendC::Cast(gUbTensor, gInputUbTensor, AscendC::RoundMode::CAST_NONE, mActual);
         }
 
-        AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID2 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID2 + pingpongFlag);
+        AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
         float inputVal = gUbTensor.GetValue(mActual-1);
-        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID2 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID2 + pingpongFlag);
+        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
 
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::Duplicate<float>(gLastUbTensor, inputVal, mActual);
@@ -190,73 +200,65 @@ public:
         AscendC::Exp(gUbTensor, gUbTensor, mActual);
         AscendC::PipeBarrier<PIPE_V>();
 
-        uint32_t dstShape_[2] = {gbrcReptime*8, nvActual};
-        uint32_t srcShape_[2] = {gbrcReptime*8, 1};
-        AscendC::Broadcast<float, 2, 1>(calcUbTensor, gUbTensor[gbrcRealStart], dstShape_, srcShape_, shareBuffer_);
-        AscendC::PipeBarrier<PIPE_V>();
-
         Arch::CrossCoreWaitFlag(cube1Done);
 
         AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
-        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
-        
-        AscendC::DataCopy(uUbTensor, uInputThisSubBlock, mActualThisSubBlock * nvActual);
+        AscendC::DataCopy(wsUbTensor, wsInputThisSubBlock, mActualThisSubBlock * nvActual);
         AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
         AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
-        AscendC::Cast(uUbFloatTensor, uUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nvActual);
-        AscendC::PipeBarrier<PIPE_V>();
-
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
-        AscendC::DataCopy(wsUbTensor, wsInputThisSubBlock, mActualThisSubBlock * nvActual);
-        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
         
-        AscendC::Sub<float>(uUbFloatTensor, uUbFloatTensor, wsUbTensor, mActualThisSubBlock * nvActual);
+        AscendC::Sub<float>(wsUbTensor, calcUbTensor, wsUbTensor, mActualThisSubBlock * nvActual);
         AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Cast(vNewOutputUbTensor, uUbFloatTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nvActual);
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-        AscendC::DataCopy(vnewOutputThisSubBlock, vNewOutputUbTensor, mActualThisSubBlock * nvActual);
+        
+        AscendC::Broadcast<float, 2, 1>(calcUbTensor, gUbTensor[gbrcRealStart], dstShape_, srcShape_, shareBuffer_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
 
+        AscendC::Mul(calcUbTensor[gbrcEffStart*nvActual], wsUbTensor, calcUbTensor[gbrcEffStart*nvActual], mActualThisSubBlock * nvActual);
         AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Mul(calcUbTensor[gbrcEffStart*nvActual], uUbFloatTensor, calcUbTensor[gbrcEffStart*nvActual], mActualThisSubBlock * nvActual);
-        AscendC::PipeBarrier<PIPE_V>();
+        
         AscendC::Cast(vNewDecayUbTensor, calcUbTensor[gbrcEffStart*nvActual], AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nvActual);
+        AscendC::PipeBarrier<PIPE_V>();
         
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
         AscendC::DataCopy(vnewdecayOutputThisSubBlock, vNewDecayUbTensor, mActualThisSubBlock * nvActual);
+        Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vec1Done);
 
-        if (isFirst) {
-            AscendC::PipeBarrier<PIPE_ALL>();
-        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1 + pingpongFlag);
+        AscendC::Cast(vNewOutputUbTensor, wsUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nvActual);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
+        AscendC::DataCopy(vnewOutputThisSubBlock, vNewOutputUbTensor, mActualThisSubBlock * nvActual);
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
 
-        isFirst = false;
+        isPing = !isPing;
     }
 
 private:
-    uint32_t pingpongFlag = 0;
-    bool isFirst = true;
+    uint32_t pongBaseEvent = 4;
+    bool isPing = true;
 
     AscendC::LocalTensor<float> calcUbTensor;
 
     AscendC::LocalTensor<UElementInput> uUbTensor_ping;
-    AscendC::LocalTensor<float> uUbFloatTensor_ping;
     AscendC::LocalTensor<float> wsUbTensor_ping;
     AscendC::LocalTensor<float> gUbTensor_ping;
     AscendC::LocalTensor<float> gLastUbTensor_ping;
     AscendC::LocalTensor<GElementInput> gInputUbTensor_ping;
+    AscendC::LocalTensor<float> gBrcbUbTensor_ping;
     AscendC::LocalTensor<VElementOutput> vNewOutputUbTensor_ping;
     AscendC::LocalTensor<VElementOutput> vNewDecayUbTensor_ping;
 
     AscendC::LocalTensor<UElementInput> uUbTensor_pong;
-    AscendC::LocalTensor<float> uUbFloatTensor_pong;
     AscendC::LocalTensor<float> wsUbTensor_pong;
     AscendC::LocalTensor<float> gUbTensor_pong;
     AscendC::LocalTensor<float> gLastUbTensor_pong;
     AscendC::LocalTensor<GElementInput> gInputUbTensor_pong;
+    AscendC::LocalTensor<float> gBrcbUbTensor_pong;
     AscendC::LocalTensor<VElementOutput> vNewOutputUbTensor_pong;
     AscendC::LocalTensor<VElementOutput> vNewDecayUbTensor_pong;
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
@@ -47,12 +47,33 @@ struct GDNFwdHOffsets {
     bool isInitialState;
     bool isFinalState;
     uint32_t blockTokens;
-    bool isDummyHead;
     // for debug
     uint32_t batchIdx;
     uint32_t headIdx;
     uint32_t chunkIdx;
 
+};
+
+struct GDNFwdHStream {
+    uint32_t vIdx;
+    uint32_t batchIdx;
+    uint32_t chunkIdx{0};
+    uint32_t vHeadIdx;
+    uint32_t kHeadIdx;
+    uint32_t shapeBatchIdx;
+    uint32_t tokenBatchIdx;
+     
+    uint32_t chunkOffset;
+    uint32_t tokenOffset;
+    uint32_t batchChunks{0};
+    uint32_t batchTokens;
+     
+    GDNFwdHOffsets offset;
+};
+     
+struct GDNFwdHRunningQ {
+    GDNFwdHStream streams[PING_PONG_STAGES];
+    uint32_t head{0};
 };
 
 struct BlockSchedulerGdnFwdH {
@@ -69,7 +90,6 @@ struct BlockSchedulerGdnFwdH {
     uint32_t tokenBatch;
     bool useInitialState;
     bool storeFinalState;
-    uint32_t numSeqWorkspaceOffset;
     uint32_t numChunksWorkspaceOffset;
 
     uint32_t taskIdx;
@@ -81,40 +101,23 @@ struct BlockSchedulerGdnFwdH {
     uint32_t headGroups;
     uint32_t totalChunks;
     uint32_t totalTokens;
-    uint32_t headInnerLoop;
-
-    uint32_t iterId {0};
     bool hasDummyHead;
-    bool isRunning;
-    bool processNewTask {true};
-    bool firstLoop {true};
-    bool lastLoop {false};
-    GDNFwdHOffsets offsets[PING_PONG_STAGES];
-    int32_t currStage{PING_PONG_STAGES - 1};
 
-    uint32_t vIdx;
-    uint32_t batchIdx;
-    uint32_t baseHeadIdx;
-    uint32_t chunkIdx;
-    uint32_t headInnerIdx;
-    uint32_t vHeadIdx;
-    uint32_t kHeadIdx;
-    uint32_t shapeBatchIdx;
-    uint32_t tokenBatchIdx;
-    
-    uint32_t chunkOffset;
-    uint32_t tokenOffset;
-    uint32_t batchChunks;
-    uint32_t batchTokens;
+    GDNFwdHRunningQ runningQ;
+    uint32_t curLoopIdx;
+    uint32_t curLoopTaskBegin;
+    uint32_t curLoopTaskCnt;
+    uint32_t lastLoopTaskCnt;
+
+    bool isRunning;
 
     AscendC::GlobalTensor<int64_t> gmSeqlen;
-    AscendC::GlobalTensor<int64_t> gmNumSeq;
     AscendC::GlobalTensor<int64_t> gmNumChunks;
 
     Arch::CrossCoreFlag cube1Done{0};
     Arch::CrossCoreFlag vec1Done{1};
     Arch::CrossCoreFlag cube2Done{2};
-    Arch::CrossCoreFlag vec2Done{3};
+    Arch::CrossCoreFlag vec2Done[PING_PONG_STAGES] = {3, 4};
 
     CATLASS_DEVICE
     BlockSchedulerGdnFwdH() {}
@@ -135,37 +138,10 @@ struct BlockSchedulerGdnFwdH {
         tokenBatch = gdnFwdHTilingData->tokenBatch;
         useInitialState = gdnFwdHTilingData->useInitialState;
         storeFinalState = gdnFwdHTilingData->storeFinalState;
-        numSeqWorkspaceOffset = gdnFwdHTilingData->numSeqWorkspaceOffset;
         numChunksWorkspaceOffset = gdnFwdHTilingData->numChunksWorkspaceOffset;
 
         gmSeqlen.SetGlobalBuffer((__gm__ int64_t *)cu_seqlens);
-        gmNumSeq.SetGlobalBuffer((__gm__ int64_t *)(user + numSeqWorkspaceOffset));
         gmNumChunks.SetGlobalBuffer((__gm__ int64_t *)(user + numChunksWorkspaceOffset));
-
-        if (isVariedLen) {
-            gmNumChunks.SetValue(0, 0);
-            gmNumSeq.SetValue(0, 0);
-            uint32_t actualBatch = 0;
-            int64_t prevSeq = 0, currSeq;
-            for (uint32_t b = 1; b <= tokenBatch; b++) {
-                currSeq = gmSeqlen.GetValue(b);
-                int64_t batchSeqLen = currSeq - prevSeq;
-                if (batchSeqLen > 0) {
-                    actualBatch++;
-                    gmNumSeq.SetValue(actualBatch, currSeq);
-                    int64_t batchChunk = (batchSeqLen + chunkSize - 1) / chunkSize;
-                    gmNumChunks.SetValue(actualBatch, gmNumChunks.GetValue(actualBatch - 1) + batchChunk);
-                }
-                prevSeq = currSeq;
-            }
-            tokenBatch = actualBatch;
-            batch = actualBatch;
-            totalChunks = gmNumChunks.GetValue(tokenBatch);
-            totalTokens = gmNumSeq.GetValue(tokenBatch);
-        } else {
-            totalChunks = (seqlen + chunkSize - 1) / chunkSize;
-            totalTokens = seqlen;
-        }
 
         cubeCoreIdx = coreIdx;
         cubeCoreNum = coreNum;
@@ -174,86 +150,150 @@ struct BlockSchedulerGdnFwdH {
         headGroups = vNumHead / kNumHead;
         hasDummyHead = (taskNum % (PING_PONG_STAGES * cubeCoreNum) <= cubeCoreNum) && (taskNum % (PING_PONG_STAGES * cubeCoreNum) > 0);
         taskLoops = (taskNum + cubeCoreNum * PING_PONG_STAGES - 1) / (cubeCoreNum * PING_PONG_STAGES);
-        headInnerLoop = taskNum > cubeCoreNum ? PING_PONG_STAGES : 1;
-        taskIdx = cubeCoreIdx * headInnerLoop;
-        isRunning = taskIdx < taskNum;
-
-    }
-
-    CATLASS_DEVICE
-    void InitTask() {
-        iterId++;
-        currStage = (currStage + 1) % PING_PONG_STAGES;
-        if (processNewTask) {
-            if (taskIdx >= taskNum) {
-                lastLoop = true;
-                isRunning = false;
-                return;
-            }
-            vIdx = taskIdx / (batch * vNumHead);
-            batchIdx = (taskIdx - vIdx * batch * vNumHead) / vNumHead;
-            baseHeadIdx = taskIdx % vNumHead;
-            shapeBatchIdx = isVariedLen ? 0 : batchIdx;
-            tokenBatchIdx = isVariedLen ? batchIdx : 0;
-            chunkOffset = isVariedLen ? gmNumChunks.GetValue(tokenBatchIdx) : 0;
-            batchChunks = isVariedLen ? (gmNumChunks.GetValue(tokenBatchIdx + 1) - chunkOffset) : totalChunks;
-            tokenOffset = isVariedLen ? gmNumSeq.GetValue(tokenBatchIdx) : 0;
-            batchTokens = isVariedLen ? (gmNumSeq.GetValue(tokenBatchIdx + 1) - tokenOffset) : totalTokens;
-            chunkIdx = 0;
-            headInnerIdx = 0;
+        uint32_t maxTaskCntPerLoop = taskNum > cubeCoreNum ? PING_PONG_STAGES : 1;
+        curLoopTaskBegin = cubeCoreIdx * maxTaskCntPerLoop;
+        uint32_t lastLoopTaskBegin = curLoopTaskBegin + (taskLoops - 1) * maxTaskCntPerLoop * cubeCoreNum;
+        if (lastLoopTaskBegin >= taskNum) {
+            lastLoopTaskCnt = 0;
         } else {
-            chunkIdx = headInnerIdx == PING_PONG_STAGES - 1 ? chunkIdx + 1 : chunkIdx;
-            headInnerIdx = (headInnerIdx + 1) % PING_PONG_STAGES;
+            uint32_t maxTaskCntLastLoop = hasDummyHead ? 1 : PING_PONG_STAGES;
+            lastLoopTaskCnt = taskNum - lastLoopTaskBegin;
+            if (lastLoopTaskCnt >= maxTaskCntLastLoop) {
+                lastLoopTaskCnt = maxTaskCntLastLoop;
+            }
         }
-        
-        vHeadIdx = baseHeadIdx + headInnerIdx;
-        kHeadIdx = vHeadIdx / headGroups;
-        offsets[currStage].isInitialState = chunkIdx == 0; 
-        offsets[currStage].isFinalState = chunkIdx == (batchChunks - 1);
-        offsets[currStage].initialStateOffset = (batchIdx * vNumHead + vHeadIdx) * kHeadDim * vHeadDim; 
-        offsets[currStage].finalStateOffset = (batchIdx * vNumHead + vHeadIdx) * kHeadDim * vHeadDim;  
-        offsets[currStage].hSrcOffset = (shapeBatchIdx * vNumHead * totalChunks + vHeadIdx * totalChunks + chunkOffset + chunkIdx) * kHeadDim * vHeadDim;
-        offsets[currStage].hDstOffset = offsets[currStage].hSrcOffset + kHeadDim * vHeadDim;
-        offsets[currStage].uvOffset = (shapeBatchIdx * vNumHead * totalTokens + vHeadIdx * totalTokens + tokenOffset + chunkIdx * chunkSize) * vHeadDim;
-        offsets[currStage].wkOffset = (shapeBatchIdx * kNumHead * totalTokens + kHeadIdx * totalTokens + tokenOffset + chunkIdx * chunkSize) * kHeadDim;
-        offsets[currStage].wOffset = (shapeBatchIdx * vNumHead * totalTokens + vHeadIdx * totalTokens + tokenOffset + chunkIdx * chunkSize) * kHeadDim;
-        offsets[currStage].gOffset = shapeBatchIdx * vNumHead * totalTokens + vHeadIdx * totalTokens + tokenOffset + chunkIdx * chunkSize;
-        offsets[currStage].hWorkOffset = (cubeCoreIdx * PING_PONG_STAGES + currStage) * kHeadDim * vHeadDim;
-        offsets[currStage].vWorkOffset = (cubeCoreIdx * PING_PONG_STAGES + currStage) * chunkSize * vHeadDim;
-        offsets[currStage].blockTokens = offsets[currStage].isFinalState ? (batchTokens - chunkIdx * chunkSize) : chunkSize;
-        offsets[currStage].isDummyHead = headInnerLoop < PING_PONG_STAGES && headInnerIdx >= headInnerLoop; 
-        offsets[currStage].batchIdx = batchIdx; 
-        offsets[currStage].headIdx = vHeadIdx; 
-        offsets[currStage].chunkIdx = chunkIdx; 
+        curLoopTaskCnt = taskLoops > 1 ? PING_PONG_STAGES : lastLoopTaskCnt;
+        curLoopIdx = -1; // -1: 第一次创建task时会将curLoopIdx加1
+        taskIdx = curLoopTaskBegin + PING_PONG_STAGES; // 第一次创建task时重新初始化taskIdx
+        isRunning = curLoopTaskBegin < taskNum;
 
-        processNewTask = chunkIdx == batchChunks - 1 && headInnerIdx == PING_PONG_STAGES - 1;
-        if (processNewTask) {
-            uint32_t currLoopIdx = taskIdx / (PING_PONG_STAGES * cubeCoreNum);
-            headInnerLoop = ((currLoopIdx + 2 == taskLoops) && hasDummyHead) ? 1 : PING_PONG_STAGES;
-            taskIdx = (currLoopIdx + 1) * PING_PONG_STAGES * cubeCoreNum + headInnerLoop * cubeCoreIdx;
+        if (isVariedLen) {
+            gmNumChunks.SetValue(0, 0); //
+            for (uint32_t b = 1; b <= tokenBatch; b++) {
+                int64_t batchChunk = (gmSeqlen.GetValue(b) - gmSeqlen.GetValue(b - 1) + chunkSize - 1) / chunkSize;
+                gmNumChunks.SetValue(b, gmNumChunks.GetValue(b - 1) + batchChunk);
+            }
+            totalChunks = gmNumChunks.GetValue(tokenBatch);
+            totalTokens = gmSeqlen.GetValue(tokenBatch);
+        } else {
+            totalChunks = (seqlen + chunkSize - 1) / chunkSize;
+            totalTokens = seqlen;
         }
+
     }
 
+
     CATLASS_DEVICE
-    GDNFwdHOffsets& GetStage1Offsets() {
-        return offsets[currStage];
+    void InitNewStream(GDNFwdHStream& newStream) {
+        newStream.vIdx = taskIdx / (batch * vNumHead);
+        newStream.batchIdx = (taskIdx - newStream.vIdx * batch * vNumHead) / vNumHead;
+        newStream.vHeadIdx = taskIdx % vNumHead;
+        newStream.kHeadIdx = newStream.vHeadIdx / headGroups;
+        newStream.shapeBatchIdx = isVariedLen ? 0 : newStream.batchIdx;
+        newStream.tokenBatchIdx = isVariedLen ? newStream.batchIdx : 0;
+        newStream.chunkOffset = isVariedLen ? gmNumChunks.GetValue(newStream.tokenBatchIdx) : 0;
+        newStream.batchChunks = isVariedLen ? (gmNumChunks.GetValue(newStream.tokenBatchIdx + 1) - newStream.chunkOffset) : totalChunks;
+        newStream.tokenOffset = isVariedLen ? gmSeqlen.GetValue(newStream.tokenBatchIdx) : 0;
+        newStream.batchTokens = isVariedLen ? (gmSeqlen.GetValue(newStream.tokenBatchIdx + 1) - newStream.tokenOffset) : totalTokens;
+        newStream.chunkIdx = 0;
+    }
+     
+    CATLASS_DEVICE
+    void UpdateTask(uint32_t streamId) {
+        auto& stream = runningQ.streams[streamId];
+        auto& offset = stream.offset;
+     
+        offset.isInitialState = stream.chunkIdx == 0; 
+        offset.isFinalState = stream.chunkIdx == (stream.batchChunks - 1); 
+        offset.initialStateOffset = (stream.batchIdx * vNumHead + stream.vHeadIdx) * kHeadDim * vHeadDim; 
+        offset.finalStateOffset = (stream.batchIdx * vNumHead + stream.vHeadIdx) * kHeadDim * vHeadDim; 
+        offset.hSrcOffset = (stream.shapeBatchIdx * vNumHead * totalChunks + stream.vHeadIdx * totalChunks + stream.chunkOffset + stream.chunkIdx) * kHeadDim * vHeadDim;
+        offset.hDstOffset = offset.hSrcOffset + kHeadDim * vHeadDim;
+        offset.uvOffset = (stream.shapeBatchIdx * vNumHead * totalTokens + stream.vHeadIdx * totalTokens + stream.tokenOffset + stream.chunkIdx * chunkSize) * vHeadDim;
+        offset.wkOffset = (stream.shapeBatchIdx * kNumHead * totalTokens + stream.kHeadIdx * totalTokens + stream.tokenOffset + stream.chunkIdx * chunkSize) * kHeadDim;
+        offset.wOffset = (stream.shapeBatchIdx * vNumHead * totalTokens + stream.vHeadIdx * totalTokens + stream.tokenOffset + stream.chunkIdx * chunkSize) * kHeadDim;
+        offset.gOffset = stream.shapeBatchIdx * vNumHead * totalTokens + stream.vHeadIdx * totalTokens + stream.tokenOffset + stream.chunkIdx * chunkSize;
+        offset.hWorkOffset = (cubeCoreIdx * PING_PONG_STAGES + streamId) * kHeadDim * vHeadDim;
+        offset.vWorkOffset = (cubeCoreIdx * PING_PONG_STAGES + streamId) * chunkSize * vHeadDim;
+        offset.blockTokens = offset.isFinalState ? (stream.batchTokens - stream.chunkIdx * chunkSize) : chunkSize;
+        offset.batchIdx = stream.batchIdx; 
+        offset.headIdx = stream.vHeadIdx; 
+        offset.chunkIdx = stream.chunkIdx;
+    }
+     
+    CATLASS_DEVICE
+    void InitTasks() {
+        //auto oldHead = runningQ.head;
+        auto streamId = runningQ.head;
+        for (uint32_t i = 0; i < PING_PONG_STAGES; ++i) {
+            //auto streamId = (oldHead + i) % PING_PONG_STAGES;
+            auto& stream = runningQ.streams[streamId];
+            stream.chunkIdx += 1;
+            if (StreamIsDone(stream)) {
+                // 当前stream已完成，用一个新stream替换它
+                taskIdx += 1;
+                if (taskIdx >= (curLoopTaskBegin + curLoopTaskCnt)) {
+                    curLoopIdx += 1;
+                    // curLoopTaskBegin = curLoopIdx * PING_PONG_STAGES * cubeCoreNum + PING_PONG_STAGES * cubeCoreIdx;
+                    // if (curLoopIdx + 1 >= taskLoops) {
+                    //     curLoopTaskCnt = lastLoopTaskCnt;
+                    // }
+                    if (curLoopIdx + 1 < taskLoops) {
+                        curLoopTaskBegin = curLoopIdx * PING_PONG_STAGES * cubeCoreNum + PING_PONG_STAGES * cubeCoreIdx;
+                    } else {
+                        curLoopTaskBegin = curLoopIdx * PING_PONG_STAGES * cubeCoreNum + (hasDummyHead ? 1 : PING_PONG_STAGES) * cubeCoreIdx;
+                        curLoopTaskCnt = lastLoopTaskCnt;
+                    }
+                    taskIdx = curLoopTaskBegin;
+                }
+     
+                //runningQ.head = (streamId + 1) % PING_PONG_STAGES;
+                stream.batchChunks = 0;
+                if (taskIdx < taskNum) {
+                    InitNewStream(stream);
+                    UpdateTask(streamId);
+                } 
+
+                if (streamId == runningQ.head) {
+                    runningQ.head = (runningQ.head + 1) % PING_PONG_STAGES;
+                    if (taskIdx >= taskNum) {
+                        // 没有新stream了，将head推进到下一个未完成的stream上
+                        for (uint32_t j = 0; j < PING_PONG_STAGES && StreamIsDone(runningQ.streams[runningQ.head]); ++j) {
+                            runningQ.head = (runningQ.head + 1) % PING_PONG_STAGES;
+                        }
+                        isRunning = ! StreamIsDone(runningQ.streams[runningQ.head]);
+                    }
+                    streamId = runningQ.head;
+                }
+                else {
+                    streamId = (streamId + 1) % PING_PONG_STAGES;
+                }
+
+            } else {
+                UpdateTask(streamId);
+                streamId = (streamId + 1) % PING_PONG_STAGES;
+            }
+        }
     }
     
     CATLASS_DEVICE
-    bool NeedProcessStage1() {
-        GDNFwdHOffsets& stage1Offsets = GetStage1Offsets();
-        return !(lastLoop || stage1Offsets.isDummyHead);
+    const GDNFwdHStream& GetStream(uint32_t i) const {
+        return runningQ.streams[(runningQ.head + i) % PING_PONG_STAGES];
     }
 
     CATLASS_DEVICE
-    GDNFwdHOffsets& GetStage2Offsets() {
-        return offsets[(currStage - 1) % PING_PONG_STAGES];
+    const GDNFwdHOffsets& GetCurTaskOffsets(const GDNFwdHStream& stream) const {
+        return stream.offset;
     }
 
     CATLASS_DEVICE
-    bool NeedProcessStage2() {
-        GDNFwdHOffsets& stage2Offsets = GetStage2Offsets();
-        return !(iterId == 1 || (!storeFinalState && stage2Offsets.isFinalState) || stage2Offsets.isDummyHead);
+    bool StreamIsDone(const GDNFwdHStream& stream) const {
+        return stream.chunkIdx >= stream.batchChunks;
+    }
+
+    CATLASS_DEVICE
+    bool NeedProcessStage2(const GDNFwdHStream& stream) {
+        return storeFinalState || !stream.offset.isFinalState;
     }
 };
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
@@ -15,6 +15,12 @@ using namespace Catlass;
 
 // constexpr uint32_t PING_PONG_STAGES = 1;
 constexpr uint32_t PING_PONG_STAGES = 2;
+constexpr uint32_t BYTE_SIZE_16_BIT = 2;
+constexpr uint32_t BYTES_PER_C0 = 32;
+constexpr uint32_t BYTE_SIZE_PER_REPEAT = 256;
+constexpr uint32_t SIZE_16_NUM_PER_C0 = BYTES_PER_C0 / BYTE_SIZE_16_BIT;
+constexpr uint32_t FLOAT_NUM_PER_REPEAT = BYTE_SIZE_PER_REPEAT / sizeof(float);
+constexpr uint32_t NZ_BLOCK_SIZE = 16;
 
 template <typename T>
 CATLASS_DEVICE T AlignUp(T a, T b) {
@@ -90,6 +96,7 @@ struct BlockSchedulerGdnFwdH {
     uint32_t tokenBatch;
     bool useInitialState;
     bool storeFinalState;
+    uint32_t numSeqWorkspaceOffset;
     uint32_t numChunksWorkspaceOffset;
 
     uint32_t taskIdx;
@@ -112,6 +119,7 @@ struct BlockSchedulerGdnFwdH {
     bool isRunning;
 
     AscendC::GlobalTensor<int64_t> gmSeqlen;
+    AscendC::GlobalTensor<int64_t> gmNumSeq;
     AscendC::GlobalTensor<int64_t> gmNumChunks;
 
     Arch::CrossCoreFlag cube1Done{0};
@@ -138,10 +146,36 @@ struct BlockSchedulerGdnFwdH {
         tokenBatch = gdnFwdHTilingData->tokenBatch;
         useInitialState = gdnFwdHTilingData->useInitialState;
         storeFinalState = gdnFwdHTilingData->storeFinalState;
+        numSeqWorkspaceOffset = gdnFwdHTilingData->numSeqWorkspaceOffset;
         numChunksWorkspaceOffset = gdnFwdHTilingData->numChunksWorkspaceOffset;
 
         gmSeqlen.SetGlobalBuffer((__gm__ int64_t *)cu_seqlens);
+        gmNumSeq.SetGlobalBuffer((__gm__ int64_t *)(user + numSeqWorkspaceOffset));
         gmNumChunks.SetGlobalBuffer((__gm__ int64_t *)(user + numChunksWorkspaceOffset));
+
+        if (isVariedLen) {
+            gmNumChunks.SetValue(0, 0);
+            uint32_t actualBatch = 0;
+            int64_t prevSeq = 0, currSeq;
+            for (uint32_t b = 1; b <= tokenBatch; b++) {
+                currSeq = gmSeqlen.GetValue(b);
+                int64_t batchSeqLen = currSeq - prevSeq;
+                if (batchSeqLen > 0) {
+                    actualBatch++;
+                    gmNumSeq.SetValue(actualBatch, currSeq);
+                    int64_t batchChunk = (batchSeqLen + chunkSize - 1) / chunkSize;
+                    gmNumChunks.SetValue(actualBatch, gmNumChunks.GetValue(actualBatch - 1) + batchChunk);
+                }
+                prevSeq = currSeq;
+            }
+            tokenBatch = actualBatch;
+            batch = actualBatch;
+            totalChunks = gmNumChunks.GetValue(tokenBatch);
+            totalTokens = gmNumSeq.GetValue(tokenBatch);
+        } else {
+            totalChunks = (seqlen + chunkSize - 1) / chunkSize;
+            totalTokens = seqlen;
+        }
 
         cubeCoreIdx = coreIdx;
         cubeCoreNum = coreNum;
@@ -167,19 +201,6 @@ struct BlockSchedulerGdnFwdH {
         taskIdx = curLoopTaskBegin + PING_PONG_STAGES; // 第一次创建task时重新初始化taskIdx
         isRunning = curLoopTaskBegin < taskNum;
 
-        if (isVariedLen) {
-            gmNumChunks.SetValue(0, 0); //
-            for (uint32_t b = 1; b <= tokenBatch; b++) {
-                int64_t batchChunk = (gmSeqlen.GetValue(b) - gmSeqlen.GetValue(b - 1) + chunkSize - 1) / chunkSize;
-                gmNumChunks.SetValue(b, gmNumChunks.GetValue(b - 1) + batchChunk);
-            }
-            totalChunks = gmNumChunks.GetValue(tokenBatch);
-            totalTokens = gmSeqlen.GetValue(tokenBatch);
-        } else {
-            totalChunks = (seqlen + chunkSize - 1) / chunkSize;
-            totalTokens = seqlen;
-        }
-
     }
 
 
@@ -193,8 +214,8 @@ struct BlockSchedulerGdnFwdH {
         newStream.tokenBatchIdx = isVariedLen ? newStream.batchIdx : 0;
         newStream.chunkOffset = isVariedLen ? gmNumChunks.GetValue(newStream.tokenBatchIdx) : 0;
         newStream.batchChunks = isVariedLen ? (gmNumChunks.GetValue(newStream.tokenBatchIdx + 1) - newStream.chunkOffset) : totalChunks;
-        newStream.tokenOffset = isVariedLen ? gmSeqlen.GetValue(newStream.tokenBatchIdx) : 0;
-        newStream.batchTokens = isVariedLen ? (gmSeqlen.GetValue(newStream.tokenBatchIdx + 1) - newStream.tokenOffset) : totalTokens;
+        newStream.tokenOffset = isVariedLen ? gmNumSeq.GetValue(newStream.tokenBatchIdx) : 0;
+        newStream.batchTokens = isVariedLen ? (gmNumSeq.GetValue(newStream.tokenBatchIdx + 1) - newStream.tokenOffset) : totalTokens;
         newStream.chunkIdx = 0;
     }
      

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -74,7 +74,7 @@ public:
 
     // vec 1
     using DispatchPolicyGDNFwdHVnew = Epilogue::EpilogueAtlasGDNFwdHVnew;
-    using EpilogueGDNFwdHVnew = Epilogue::Block::BlockEpilogue<DispatchPolicyGDNFwdHVnew, VType, GType, UType, VworkType>;
+    using EpilogueGDNFwdHVnew = Epilogue::Block::BlockEpilogue<DispatchPolicyGDNFwdHVnew, VType, GType, UType, VworkType, FinalStateType>;
 
     // vec 2
     using DispatchPolicyGDNFwdHUpdate = Epilogue::EpilogueAtlasGDNFwdHUpdate;
@@ -340,12 +340,19 @@ public:
             EpilogueGDNFwdHUpdate epilogueGDNFwdHUpdate(resource);
             uint32_t pongBaseEvent = 4;
 
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0); // preset v
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pongBaseEvent);
+            if (storeFinalState && std::is_same<ElementFinalState, float>::value) {
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0); // preset v
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pongBaseEvent);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2); // preset h
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pongBaseEvent);
+            } else {
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0); // preset v
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pongBaseEvent);
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2); // preset h
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pongBaseEvent);
+            }
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1); // preset u
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pongBaseEvent);
-            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2); // preset h
-            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pongBaseEvent);
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3); // preset g
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pongBaseEvent);
 
@@ -369,7 +376,8 @@ public:
                             gmV[vec1Offsets.uvOffset], gmVUpdateWorkspace[vec1Offsets.vWorkOffset], 
                             gmG[vec1Offsets.gOffset], gmU[vec1Offsets.uvOffset], gmVWorkspace[vec1Offsets.vWorkOffset], 
                             vec1Offsets.blockTokens, kHeadDim, vHeadDim, 
-                            vecBlockScheduler.cube1Done, vecBlockScheduler.vec1Done, vec1Offsets.isInitialState
+                            vecBlockScheduler.cube1Done, vecBlockScheduler.vec1Done,
+                            vec1Offsets.isInitialState, vec1Offsets.isFinalState, storeFinalState, (i == 0)
                         );
                     }
                 } else {
@@ -389,7 +397,7 @@ public:
                                 gmH[vec2Offsets.hSrcOffset],
                                 gmHWorkspace[vec2Offsets.hWorkOffset],
                                 vec2Offsets.blockTokens, kHeadDim, vHeadDim, vecBlockScheduler.cube2Done,
-                                (vec2Offsets.isFinalState && storeFinalState)
+                                vec2Offsets.isInitialState, vec2Offsets.isFinalState, storeFinalState, (i == 0)
                             );
                         } else {
                             Arch::CrossCoreWaitFlag(vecBlockScheduler.cube2Done);
@@ -400,12 +408,19 @@ public:
                 currStage ^= 0x01;
             }
 
-            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0); // preset v
-            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pongBaseEvent);
+            if (storeFinalState && std::is_same<ElementFinalState, float>::value) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0); // preset v
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pongBaseEvent);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2); // preset h
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pongBaseEvent);
+            } else {
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0); // preset v
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pongBaseEvent);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2); // preset h
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pongBaseEvent);
+            }
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1); // preset u
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pongBaseEvent);
-            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2); // preset h
-            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pongBaseEvent);
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3); // preset g
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pongBaseEvent);
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -253,52 +253,68 @@ public:
             auto kLayout = tla::MakeLayout<ElementK, LayoutK>(kHeadDim, shapeBatch * kNumHead * cubeBlockScheduler.totalTokens);
             auto vworkLayout = tla::MakeLayout<ElementV, LayoutV>(coreNum * chunkSize * PING_PONG_STAGES, vHeadDim);
             auto hworkLayout = tla::MakeLayout<ElementHWork, LayoutH>(coreNum * kHeadDim * PING_PONG_STAGES, vHeadDim);
-
+            AscendC::SyncAll<false>();    
+            uint32_t currStage = 0; // 0: C1, 1: C2
             while (cubeBlockScheduler.isRunning) {
-                cubeBlockScheduler.InitTask();
-                // step 1: v_work = w @ h[i]
-                GDNFwdHOffsets& cube1Offsets = cubeBlockScheduler.GetStage1Offsets();
-                Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done);
-                if (cubeBlockScheduler.NeedProcessStage1()) {
-                    int64_t cube1OffsetW = cube1Offsets.wOffset;
-                    int64_t cube1OffsetH = cube1Offsets.hSrcOffset;
-                    int64_t cube1OffsetVwork = cube1Offsets.vWorkOffset;
-                    auto tensorW = tla::MakeTensor(gmW[cube1OffsetW], wLayout, Catlass::Arch::PositionGM{});
-                    auto tensorH = tla::MakeTensor(gmH[cube1OffsetH], hLayout, Catlass::Arch::PositionGM{});
-                    auto tensorV = tla::MakeTensor(gmVWorkspace[cube1OffsetVwork], vLayout, Catlass::Arch::PositionGM{});
-                    GemmCoord cube1Shape {cube1Offsets.blockTokens, vHeadDim, kHeadDim};
-                    auto tensorBlockW = GetTile(tensorW, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.k()));
-                    auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.k(), cube1Shape.n()));
-                    auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.n()));
-                    blockMmadWH.preSetFlags();
-                    blockMmadWH(tensorBlockW, tensorBlockH, tensorBlockV, cube1Shape);
-                    blockMmadWH.finalWaitFlags();
-                }
-                Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done);
+                if (currStage == 0) {
+                    /* C1: v_work = w @ h[i] */                    
+                    cubeBlockScheduler.InitTasks();
+                    for (uint32_t i = 0; i < PING_PONG_STAGES; ++i) {
+                        const auto& stream = cubeBlockScheduler.GetStream(i);
+                        if (cubeBlockScheduler.StreamIsDone(stream)) {
+                            continue;
+                        }
 
-                if (cubeBlockScheduler.iterId > 1) {
-                    Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done);
-                    GDNFwdHOffsets& cube2Offsets = cubeBlockScheduler.GetStage2Offsets();
-                    if (cubeBlockScheduler.NeedProcessStage2()) {
-                        // step 3: h[i+1] = k.T @ v_work
-                        int64_t cube2OffsetK = cube2Offsets.wkOffset;
-                        int64_t cube2OffsetVwork = cube2Offsets.vWorkOffset;
-                        int64_t cube2OffsetH = cube2Offsets.hWorkOffset;
-                        auto tensorK = tla::MakeTensor(gmK[cube2OffsetK], kLayout, Catlass::Arch::PositionGM{});
-                        auto tensorVwork = tla::MakeTensor(gmVUpdateWorkspace[cube2OffsetVwork], vworkLayout, Catlass::Arch::PositionGM{});
-                        auto tensorHwork = tla::MakeTensor(gmHWorkspace[cube2OffsetH], hworkLayout, Catlass::Arch::PositionGM{});
-                        GemmCoord cube2Shape{kHeadDim, vHeadDim, cube2Offsets.blockTokens};
-                        auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.k()));
-                        auto tensorBlockVwork = GetTile(tensorVwork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.k(), cube2Shape.n()));
-                        auto tensorBlockHwork = GetTile(tensorHwork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.n()));
-                        blockMmadKV.preSetFlags();
-                        blockMmadKV(tensorBlockK, tensorBlockVwork, tensorBlockHwork, cube2Shape);
-                        blockMmadKV.finalWaitFlags();
+                        const GDNFwdHOffsets& cube1Offsets = cubeBlockScheduler.GetCurTaskOffsets(stream);
+                        Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[i]);
+                        int64_t cube1OffsetW = cube1Offsets.wOffset;
+                        int64_t cube1OffsetH = cube1Offsets.hSrcOffset;
+                        int64_t cube1OffsetVwork = cube1Offsets.vWorkOffset;
+                        auto tensorW = tla::MakeTensor(gmW[cube1OffsetW], wLayout, Catlass::Arch::PositionGM{});
+                        auto tensorH = tla::MakeTensor(gmH[cube1OffsetH], hLayout, Catlass::Arch::PositionGM{});
+                        auto tensorV = tla::MakeTensor(gmVWorkspace[cube1OffsetVwork], vLayout, Catlass::Arch::PositionGM{});
+                        GemmCoord cube1Shape {cube1Offsets.blockTokens, vHeadDim, kHeadDim};
+                        auto tensorBlockW = GetTile(tensorW, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.k()));
+                        auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.k(), cube1Shape.n()));
+                        auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.n()));
+                        blockMmadWH.preSetFlags();
+                        blockMmadWH(tensorBlockW, tensorBlockH, tensorBlockV, cube1Shape);
+                        blockMmadWH.finalWaitFlags();
+                        Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done);
                     }
-                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube2Done);
+                } else {
+                    /* C2: h[i+1] = k.T @ v_work */
+                    for (uint32_t i = 0; i < PING_PONG_STAGES; ++i) {
+                        const auto& stream = cubeBlockScheduler.GetStream(i);
+                        if (cubeBlockScheduler.StreamIsDone(stream)) {
+                            continue;
+                        }
+                        const GDNFwdHOffsets& cube2Offsets = cubeBlockScheduler.GetCurTaskOffsets(stream);
+                        Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done);
+
+                        if (cubeBlockScheduler.NeedProcessStage2(stream)) {
+                            // step 3: h[i+1] = k.T @ v_work
+                            int64_t cube2OffsetK = cube2Offsets.wkOffset;
+                            int64_t cube2OffsetVwork = cube2Offsets.vWorkOffset;
+                            int64_t cube2OffsetH = cube2Offsets.hWorkOffset;
+                            auto tensorK = tla::MakeTensor(gmK[cube2OffsetK], kLayout, Catlass::Arch::PositionGM{});
+                            auto tensorVwork = tla::MakeTensor(gmVUpdateWorkspace[cube2OffsetVwork], vworkLayout, Catlass::Arch::PositionGM{});
+                            auto tensorHwork = tla::MakeTensor(gmHWorkspace[cube2OffsetH], hworkLayout, Catlass::Arch::PositionGM{});
+                            GemmCoord cube2Shape{kHeadDim, vHeadDim, cube2Offsets.blockTokens};
+                            auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.k()));
+                            auto tensorBlockVwork = GetTile(tensorVwork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.k(), cube2Shape.n()));
+                            auto tensorBlockHwork = GetTile(tensorHwork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.n()));
+                            blockMmadKV.preSetFlags();
+                            blockMmadKV(tensorBlockK, tensorBlockVwork, tensorBlockHwork, cube2Shape);
+                            blockMmadKV.finalWaitFlags();
+                        }
+                        Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube2Done);
+                    }
                 }
+                currStage ^= 0x01;
             }
-            Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done);
+            Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[0]);
+            Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[1]);
 
         }
 
@@ -308,93 +324,138 @@ public:
             uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
             uint32_t subBlockNum = AscendC::GetSubBlockNum();
 
-            EpilogueGDNFwdHVnew epilogueGDNFwdHVnew(resource);
-
             if (useInitialState) {
                 AscendC::LocalTensor<ElementInitialState> stateUbTensorPing = resource.ubBuf.template GetBufferByByte<ElementInitialState>(0);
                 AscendC::LocalTensor<ElementInitialState> stateUbTensorPong = resource.ubBuf.template GetBufferByByte<ElementInitialState>(96 * 1024);
                 AscendC::LocalTensor<ElementH> hUbTensorPing = resource.ubBuf.template GetBufferByByte<ElementH>(64 * 1024);
                 AscendC::LocalTensor<ElementH> hUbTensorPong = resource.ubBuf.template GetBufferByByte<ElementH>(160 * 1024);
                 uint32_t totalChunks = isVariedLen ? vecBlockScheduler.totalChunks : ((seqlen + chunkSize - 1) / chunkSize);
+                uint32_t transferCount = isVariedLen ? (vecBlockScheduler.tokenBatch * vNumHead / coreNum) : (shapeBatch * vNumHead / coreNum);
+                uint32_t remainderFlag = isVariedLen ? (((vecBlockScheduler.tokenBatch * vNumHead) % coreNum) != 0): (((shapeBatch * vNumHead) % coreNum) != 0);
+                uint32_t step = transferCount + remainderFlag;
                 uint32_t stateBlockSize = kHeadDim * vHeadDim;
                 uint32_t pingpongFlag = 1;
+                uint32_t start = coreIdx * step;
+                uint32_t end = start + step;
+                uint32_t maxLimit = isVariedLen ? vecBlockScheduler.tokenBatch * vNumHead : shapeBatch * vNumHead;
+                uint32_t realEnd = min(end, maxLimit);
                 AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
                 AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
-                for (uint32_t shapeBatchIdx = 0; shapeBatchIdx < shapeBatch; shapeBatchIdx++) {
-                    for (uint32_t vHeadIdx = 0; vHeadIdx < vNumHead; vHeadIdx++) {
-                        for (uint32_t tokenBatchIdx = 0; tokenBatchIdx < vecBlockScheduler.tokenBatch; tokenBatchIdx++) {
-                            uint32_t batchIdx = isVariedLen ? tokenBatchIdx : shapeBatchIdx;
-                            uint32_t chunkOffset = isVariedLen ? gmNumChunks.GetValue(tokenBatchIdx) : 0;
-                            uint32_t initialStateOffset = (batchIdx * vNumHead + vHeadIdx) * stateBlockSize;
-                            uint32_t hOffset = (shapeBatchIdx * vNumHead * totalChunks + vHeadIdx * totalChunks + chunkOffset) * stateBlockSize;
-                            AscendC::LocalTensor<ElementInitialState> stateUbTensor = pingpongFlag ? stateUbTensorPing : stateUbTensorPong;
-                            AscendC::LocalTensor<ElementH> hUbTensor = pingpongFlag ? hUbTensorPing : hUbTensorPong;
-                            auto event_id = pingpongFlag ? EVENT_ID1 : EVENT_ID0;
-                            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
-                            if constexpr(!std::is_same<ElementInitialState, ElementH>::value) {
-                                AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateOffset], stateBlockSize);
-                                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(event_id);
-                                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(event_id);
-                                AscendC::Cast(hUbTensor, stateUbTensor, AscendC::RoundMode::CAST_RINT, stateBlockSize);
-                                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(event_id);
-                                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(event_id);
-                                AscendC::DataCopy(gmH[hOffset], hUbTensor, stateBlockSize);
-                            } else {
-                                AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateOffset], stateBlockSize);
-                                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
-                                AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
-                                AscendC::DataCopy(gmH[hOffset], stateUbTensor, stateBlockSize);
-                            }
-                            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
-                            pingpongFlag = 1 - pingpongFlag;
-                        }
-                        
+                for(uint32_t initialStateBlockOffset = start ;initialStateBlockOffset >= start && initialStateBlockOffset < realEnd;initialStateBlockOffset++)
+                {   
+                    uint32_t batchIdx = initialStateBlockOffset / vNumHead;
+                    uint32_t vHeadIdx = initialStateBlockOffset % vNumHead;
+                    uint32_t chunkOffset = isVariedLen ? gmNumChunks.GetValue(batchIdx) : 0; 
+                    uint32_t initialStateOffset = initialStateBlockOffset * stateBlockSize;
+                    uint32_t shapeBatchIdx = isVariedLen ? 0 : batchIdx;
+                    uint32_t hOffset = (shapeBatchIdx * vNumHead * totalChunks + vHeadIdx * totalChunks + chunkOffset) * stateBlockSize;
+                    AscendC::LocalTensor<ElementInitialState> stateUbTensor = pingpongFlag ? stateUbTensorPing : stateUbTensorPong;
+                    AscendC::LocalTensor<ElementH> hUbTensor = pingpongFlag ? hUbTensorPing : hUbTensorPong;
+                    auto event_id = pingpongFlag ? EVENT_ID1 : EVENT_ID0;
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
+                    if constexpr(!std::is_same<ElementInitialState, ElementH>::value) {
+                        AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateOffset], stateBlockSize);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(event_id);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(event_id);
+                        AscendC::Cast(hUbTensor, stateUbTensor, AscendC::RoundMode::CAST_RINT, stateBlockSize);
+                        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(event_id);
+                        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(event_id);
+                        AscendC::DataCopy(gmH[hOffset], hUbTensor, stateBlockSize);
+                    } else {
+                        AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateOffset], stateBlockSize);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
+                        AscendC::DataCopy(gmH[hOffset], stateUbTensor, stateBlockSize);
                     }
+                    AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
+                    pingpongFlag = 1 - pingpongFlag;
+                
                 }
+
+                
+                
                 AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
                 AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
+            
             }
+            
+            AscendC::SyncAll<false>();
 
-            Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done);
-            Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done);
+            Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done[0]);
+            Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done[1]);
+
+            EpilogueGDNFwdHVnew epilogueGDNFwdHVnew(resource);
+            EpilogueGDNFwdHUpdate epilogueGDNFwdHUpdate(resource);
+            uint32_t pongBaseEvent = 4;
+
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0); // preset v
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pongBaseEvent);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1); // preset u
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pongBaseEvent);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2); // preset h
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pongBaseEvent);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3); // preset g
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pongBaseEvent);
+
+            uint32_t currStage = 0; // 0: V1, 1: V2
             while (vecBlockScheduler.isRunning) {
-                vecBlockScheduler.InitTask();
-                // step 2:
-                GDNFwdHOffsets& vec1Offsets = vecBlockScheduler.GetStage1Offsets();
-                // gmV = gmU - gmVWorkspace
-                // g_buf = gmG[-1] - gmG
-                // g_buf = exp(g_buf)
-                // gmVWorkspace = g_buf * gmV
-                if (vecBlockScheduler.NeedProcessStage1()) {
-                    epilogueGDNFwdHVnew(
-                        gmV[vec1Offsets.uvOffset], gmVUpdateWorkspace[vec1Offsets.vWorkOffset], 
-                        gmG[vec1Offsets.gOffset], gmU[vec1Offsets.uvOffset], gmVWorkspace[vec1Offsets.vWorkOffset], 
-                        vec1Offsets.blockTokens, kHeadDim, vHeadDim, vecBlockScheduler.cube1Done
-                    );
-                } else {
-                    Arch::CrossCoreWaitFlag(vecBlockScheduler.cube1Done);
-                }
-                Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec1Done);
-
-                if (vecBlockScheduler.iterId > 1) {
-                    GDNFwdHOffsets& vec2Offsets = vecBlockScheduler.GetStage2Offsets();
-                    if (vecBlockScheduler.NeedProcessStage2()) {
-                        // step 4:  h[i+1] += h_work if i < num_chunks - 1 else None
-                        EpilogueGDNFwdHUpdate epilogueGDNFwdHUpdate(resource);
-                        epilogueGDNFwdHUpdate(
-                            gmH[vec2Offsets.hDstOffset], gmFinalState[vec2Offsets.finalStateOffset],
-                            gmG[vec2Offsets.gOffset],
-                            gmH[vec2Offsets.hSrcOffset],
-                            gmHWorkspace[vec2Offsets.hWorkOffset],
-                            vec2Offsets.blockTokens, kHeadDim, vHeadDim, vecBlockScheduler.cube2Done,
-                            (vec2Offsets.isFinalState && storeFinalState)
+                if (currStage == 0) {
+                    /* V1:
+                     * gmV = gmU - gmVWorkspace
+                     * g_buf = gmG[-1] - gmG
+                     * g_buf = exp(g_buf)
+                     * gmVWorkspace = g_buf * gmV
+                     */
+                    vecBlockScheduler.InitTasks();
+                    for (uint32_t i = 0; i < PING_PONG_STAGES; ++i) {
+                        const auto& stream = vecBlockScheduler.GetStream(i);
+                        if (vecBlockScheduler.StreamIsDone(stream)) {
+                            continue;
+                        }
+                        const GDNFwdHOffsets& vec1Offsets = vecBlockScheduler.GetCurTaskOffsets(stream);
+                        epilogueGDNFwdHVnew(
+                            gmV[vec1Offsets.uvOffset], gmVUpdateWorkspace[vec1Offsets.vWorkOffset], 
+                            gmG[vec1Offsets.gOffset], gmU[vec1Offsets.uvOffset], gmVWorkspace[vec1Offsets.vWorkOffset], 
+                            vec1Offsets.blockTokens, kHeadDim, vHeadDim, 
+                            vecBlockScheduler.cube1Done, vecBlockScheduler.vec1Done, vec1Offsets.isInitialState
                         );
-                    } else {
-                        Arch::CrossCoreWaitFlag(vecBlockScheduler.cube2Done);
                     }
-                    Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done);
+                } else {
+                    /* V2: h[i+1] += h_work if i < num_chunks - 1 else None */
+                    for (uint32_t i = 0; i < PING_PONG_STAGES; ++i) {
+                        const auto& stream = vecBlockScheduler.GetStream(i);
+                        if (vecBlockScheduler.StreamIsDone(stream)) {
+                            continue;
+                        }
+                        const GDNFwdHOffsets& vec2Offsets = vecBlockScheduler.GetCurTaskOffsets(stream);
+
+                        if (vecBlockScheduler.NeedProcessStage2(stream)) {
+                            // step 4:  h[i+1] += h_work if i < num_chunks - 1 else None
+                            epilogueGDNFwdHUpdate(
+                                gmH[vec2Offsets.hDstOffset], gmFinalState[vec2Offsets.finalStateOffset],
+                                gmG[vec2Offsets.gOffset],
+                                gmH[vec2Offsets.hSrcOffset],
+                                gmHWorkspace[vec2Offsets.hWorkOffset],
+                                vec2Offsets.blockTokens, kHeadDim, vHeadDim, vecBlockScheduler.cube2Done,
+                                (vec2Offsets.isFinalState && storeFinalState)
+                            );
+                        } else {
+                            Arch::CrossCoreWaitFlag(vecBlockScheduler.cube2Done);
+                        }
+                        Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done[i]);
+                    }
                 }
+                currStage ^= 0x01;
             }
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0); // preset v
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pongBaseEvent);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1); // preset u
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pongBaseEvent);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2); // preset h
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pongBaseEvent);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3); // preset g
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pongBaseEvent);
 
         }
     }


### PR DESCRIPTION
# Pull Request 模板

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:
GDN fwd_h fwd_o算子A5/通用场景性能优化：
1. (A5)fwd_h L0C->UB通路优化
2. (A5)fwd_h UB->L1通路优化
3. (A2/A3/A5)fwd_h cv流水调度优化
4. (A2/A3/A5)vector流水调度优化
5. (A2/A3/A5)initial_state分核处理


典型场景性能验证如下（不同芯片型号结果可能有一定出入，仅供参考）：
| 场景 | [B,T,H,D] | layout | dType | fwd_h A5 improve | fwd_h A2 improve | fwd_o A5 improve | fwd_o A2 improve | 
| --- | --- | --- | --- | --- | --- | --- | --- | 
| 长序列  | [1,32768,32,128] | BNSD | bf16 | 26.16% | 29.89%| 13.94% | 25.74% |
| TND | [1,32768,32,128] | TND | bf16 | 28.77% | 23.92% | 14.31% | 26.12% |
| 超短序列 | [1,256,32,128] | BNSD | bf16 | 19.76% | 26.89% | 8.57% | 17.77% |
| 中等序列多batch | [64,1024,8,128] | BNSD | fp16 | 34.48% | 26.11% | 13.45% | 25.29% |


## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [x] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
chunk_gated_delta_rule_fwd_h, chunk_fwd_o
- 涉及目录 / 文件:
fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h, fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o
- 责任人 / 提交人:
姜东明
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:

## 版本与产品编译矩阵

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

## 验证方法

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

工程 UT:

```sh
bash build.sh -u --ops=<op_name> --soc=<soc>
```

按模块精确验证:

```sh
bash build.sh --ophost_test --ops=<op_name> --soc=<soc>
bash build.sh --opapi_test --ops=<op_name> --soc=<soc>
bash build.sh --opkernel_test --ops=<op_name> --soc=<soc>
```

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

如本 PR 修改了 aclnn example 或新增了算子 example，同时执行:

```sh
bash build.sh --run_example <op_name> eager cust --vendor_name=fla_npu --soc=<soc>
```

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过  |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过  |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

## 修改算子测试

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `bash build.sh -u --ops=<op_name> --soc=ascend910b` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `bash build.sh -u --ops=<op_name> --soc=ascend910_93` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `bash build.sh -u --ops=<op_name> --soc=ascend950` | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

## 整体 Example ST 验证

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python examples/flash_gated_delta_rule.py` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python examples/flash_gated_delta_rule.py` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python examples/flash_gated_delta_rule.py` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
