### PR TITLE
GitHub cherry zhang e old dqkwg

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
@@ -18,6 +18,7 @@
  #include "tiling_base/tiling_templates_registry.h"
  #include "tiling_base/tiling_type.h"
  #include <cmath>
+ #include <cstdlib>
  
  namespace optiling {
  
@@ -140,44 +141,61 @@
      auto sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
      const int64_t aicNum = ascendcPlatform.GetCoreNumAic();
      
-     // 设置 TilingKey
-     context->SetTilingKey(1);
-     
-     size_t dwSize = B * H * T * K * FP32_SIZE;                     // b_dw workspace, conservatively reserved
-     dwSize = ((dwSize + 31) / 32) * 32;
-     size_t dgLastSize = B * H * numChunks * 8 * FP32_SIZE;         // b_dg_last, one 32B slot per scalar
-     // // 对齐到 32 字节
-     dgLastSize = ((dgLastSize + 31) / 32) * 32;
-     
+     uint64_t tilingKey = 2;
+     const char *implEnv = std::getenv("DQKWG_IMPL");
+     if (implEnv != nullptr && (implEnv[0] == '1' || implEnv[0] == 'o' || implEnv[0] == 'O')) {
+         tilingKey = 1;
+     }
+     context->SetTilingKey(tilingKey);
+
      // size_t mm5Size = B * H * T * BT * FP16_SIZE;                   // mm5 (q @ k^T)
      size_t mm5Size = B * H * T * K * FP16_SIZE;// mm5 (q @ k^T): B * H * T * BT * FP16_SIZE, mm6/mm7 需要复用 mm5 的空间，BT 可能是 64 或 128，这里直接按 128 来计算，保证空间足够
      size_t dsTempSize = B * H * T * BT * FP16_SIZE;                // b_ds_temp
-     // Reuse existing storage so old_dqkwg keeps the same workspace size as main.
-     // mm6/mm7 reuse mm5 after Part3 consumes mm5; mul1 uses dq as scratch before Part4 rewrites dq.
- 
-     
-     // Workspace 偏移计算
+
      size_t offset = 0;
-     
-     size_t wsDwOffset = offset;
-     offset += dwSize;
-     
-     size_t wsDgLastOffset = offset;
- // std::cout << "[tiling] offset: " << offset << ", dgLastSize: "<<dgLastSize<<"\n";
-     offset += dgLastSize;
- 
-     size_t wsMm5Offset = offset;
- // std::cout << "[tiling] offset: " << offset << ", mm5Size: "<<mm5Size<<"\n";
-     offset += mm5Size;
-     
-     size_t wsDsTempOffset = offset;
- // std::cout << "[tiling] offset: " << offset << ", dsTempSize: "<<dsTempSize<<"\n";
-     offset += dsTempSize;
- 
-     size_t wsMm6Offset = wsMm5Offset;
-     size_t wsMm7Offset = wsMm5Offset;
+     size_t wsDwOffset = 0;
+     size_t wsDgLastOffset = 0;
+     size_t wsMm5Offset = 0;
+     size_t wsDsTempOffset = 0;
+     size_t wsMm6Offset = 0;
+     size_t wsMm7Offset = 0;
      size_t wsMul1Offset = 0;
-     
+     size_t dgLastSize = 0;
+
+     if (tilingKey == 1) {
+         // Legacy path: Part 1 writes dw directly to output, so only dg_last/mm5/ds_temp need workspace.
+         dgLastSize = B * H * numChunks * FP32_SIZE;
+         dgLastSize = ((dgLastSize + 31) / 32) * 32;
+
+         wsDgLastOffset = offset;
+         offset += dgLastSize;
+         wsMm5Offset = offset;
+         offset += mm5Size;
+         wsDsTempOffset = offset;
+         offset += dsTempSize;
+         wsMm6Offset = wsMm5Offset;
+         wsMm7Offset = wsMm5Offset;
+         wsMul1Offset = 0;
+     } else {
+         // Current path: Cube stores dw in dtype workspace, Vector finalizes/sign-fixes it.
+         size_t dwSize = B * H * T * K * FP16_SIZE;
+         dwSize = ((dwSize + 31) / 32) * 32;
+         dgLastSize = B * H * numChunks * 8 * FP32_SIZE;         // one 32B slot per scalar
+         dgLastSize = ((dgLastSize + 31) / 32) * 32;
+
+         wsDwOffset = offset;
+         offset += dwSize;
+         wsDgLastOffset = offset;
+         offset += dgLastSize;
+         wsMm5Offset = offset;
+         offset += mm5Size;
+         wsDsTempOffset = offset;
+         offset += dsTempSize;
+         wsMm6Offset = wsMm5Offset;
+         wsMm7Offset = wsMm5Offset;
+         wsMul1Offset = 0;
+     }
+
      size_t totalUserWorkspace = offset;
      // std::cout << "[tiling] totalUserWorkspace: " << totalUserWorkspace << ", sysWorkspaceSize: " << sysWorkspaceSize << "\n";
      
@@ -233,4 +251,4 @@
      .TilingParse<ChunkBwdDqkwgCompileInfo>(TilingParseChunkBwdDqkwg);
  
  }  // namespace optiling
- 
+

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
@@ -150,9 +150,9 @@ ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* contex
     // size_t mm5Size = B * H * T * BT * FP16_SIZE;                   // mm5 (q @ k^T)
     size_t mm5Size = B * H * T * K * FP16_SIZE;// mm5 (q @ k^T): B * H * T * BT * FP16_SIZE, mm6/mm7 需要复用 mm5 的空间，BT 可能是 64 或 128，这里直接按 128 来计算，保证空间足够
     size_t dsTempSize = B * H * T * BT * FP16_SIZE;                // b_ds_temp
-    // size_t mm6Size = B * H * T * K * FP16_SIZE;                   // mm6
-    // size_t mm7Size = B * H * T * K * FP16_SIZE;                   // mm7
-    // size_t mul1Size = B * H * T * BT * FP16_SIZE;                   // mul1
+    size_t mm6Size = B * H * T * K * FP16_SIZE;                   // mm6
+    size_t mm7Size = B * H * T * K * FP16_SIZE;                   // mm7
+    size_t mul1Size = B * H * T * BT * FP16_SIZE;                   // mul1
 
     
     // Workspace 偏移计算
@@ -173,17 +173,17 @@ ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* contex
 // std::cout << "[tiling] offset: " << offset << ", dsTempSize: "<<dsTempSize<<"\n";
     offset += dsTempSize;
 
-//     size_t wsMm6Offset = offset;
-// // std::cout << "[tiling] offset: " << mm6Size << ", mm6Size: "<<mm6Size<<"\n";
-//     offset += mm6Size;
+    size_t wsMm6Offset = offset;
+// std::cout << "[tiling] offset: " << mm6Size << ", mm6Size: "<<mm6Size<<"\n";
+    offset += mm6Size;
 
-//     size_t wsMm7Offset = offset;
-// // std::cout << "[tiling] offset: " << offset << ", mm7Size: "<<mm7Size<<"\n";
-//     offset += mm7Size;
+    size_t wsMm7Offset = offset;
+// std::cout << "[tiling] offset: " << offset << ", mm7Size: "<<mm7Size<<"\n";
+    offset += mm7Size;
 
-//     size_t wsMul1Offset = offset;
-// // std::cout << "[tiling] offset: " << offset << ", mul1Size: "<<mul1Size<<"\n";
-//     offset += mul1Size;
+    size_t wsMul1Offset = offset;
+// std::cout << "[tiling] offset: " << offset << ", mul1Size: "<<mul1Size<<"\n";
+    offset += mul1Size;
     
     size_t totalUserWorkspace = offset;
     // std::cout << "[tiling] totalUserWorkspace: " << totalUserWorkspace << ", sysWorkspaceSize: " << sysWorkspaceSize << "\n";
@@ -214,9 +214,9 @@ ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* contex
     tilingData.set_wsMm5Offset(wsMm5Offset);
     tilingData.set_wsDsTempOffset(wsDsTempOffset);
     tilingData.set_totalWorkspaceSize(totalUserWorkspace);
-    // tilingData.set_wsMm6Offset(wsMm6Offset);
-    // tilingData.set_wsMm7Offset(wsMm7Offset);
-    // tilingData.set_wsMul1Offset(wsMul1Offset);
+    tilingData.set_wsMm6Offset(wsMm6Offset);
+    tilingData.set_wsMm7Offset(wsMm7Offset);
+    tilingData.set_wsMul1Offset(wsMul1Offset);
     
     // 检查是否有 cu_seqlens 输入来判断 IS_VARLEN
     tilingData.set_isVarLen(isVarLen);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
@@ -12,222 +12,225 @@
  * \brief ChunkBwdDqkwg Tiling 实现
  */
 
-#include "chunk_bwd_dqkwg_tiling.h"
-#include <register/op_impl_registry.h>
-#include "tiling_base/data_copy_transpose_tiling.h"
-#include "tiling_base/tiling_templates_registry.h"
-#include "tiling_base/tiling_type.h"
-#include <cmath>
-
-namespace optiling {
-
-constexpr int64_t CONST_B = 1;
-constexpr int64_t CONST_H = 4;
-constexpr int64_t CONST_T = 2816;
-constexpr int64_t CONST_K = 128;
-constexpr int64_t CONST_V = 128;
-constexpr int64_t CONST_BT = 64;
-
-// 数据类型大小
-constexpr size_t FP16_SIZE = 2;
-constexpr size_t FP32_SIZE = 4;
-
-int64_t CeilDiv(int64_t a, int64_t b)
-{
-    if (unlikely(b == 0)) {
-        return 0;
-    }
-    return (a + b - 1) / b;
-}
-
-ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* context) {
-    const gert::Shape qStorageShape = context->GetRequiredInputShape(0)->GetStorageShape();
-    const gert::Shape kStorageShape = context->GetRequiredInputShape(1)->GetStorageShape();
-    const gert::Shape vStorageShape = context->GetRequiredInputShape(2)->GetStorageShape();
-    const gert::Shape gStorageShape = context->GetRequiredInputShape(3)->GetStorageShape();
-    const gert::Shape hStorageShape = context->GetRequiredInputShape(4)->GetStorageShape();
-    const gert::Shape doxStorageShape = context->GetRequiredInputShape(5)->GetStorageShape();
-    const gert::Shape dhStorageShape = context->GetRequiredInputShape(6)->GetStorageShape();
-    const gert::Shape dvStorageShape = context->GetRequiredInputShape(7)->GetStorageShape();
-
-    int64_t B = vStorageShape.GetDim(0);//CONST_B;
-    int64_t H = vStorageShape.GetDim(1);//CONST_H;
-    int64_t T = vStorageShape.GetDim(2);//CONST_T;
-    int64_t K = kStorageShape.GetDim(3);//CONST_K;
-    int64_t V = vStorageShape.GetDim(3);//CONST_V;
-    int64_t BT = CONST_BT;
-    auto attr = context->GetAttrs();
-    const int ATTR_CHUNK_SIZE_ITEM = 1;
-    const int32_t* chunkSizePtr = attr->GetAttrPointer<int32_t>(ATTR_CHUNK_SIZE_ITEM);
-    if (chunkSizePtr != nullptr) {
-        BT = *chunkSizePtr;
-        // std::cout << "[tiling] BT: " << BT << "\n";
-        if (BT != 64 && BT != 128) {
-            std::cout << "BT should be 64 or 128 ." << std::endl;
-            return ge::GRAPH_FAILED;
-        }
-        
-    }
-
-
-    if (context->GetOptionalInputTensor(10) != nullptr || context->GetOptionalInputTensor(11) != nullptr) {
-        std::cout << "w and g_gamma should be set at nullptr." << std::endl;
-        return ge::GRAPH_FAILED;
-    }
-
-    auto cuSeqlensTensor = context->GetOptionalInputTensor(8);
-    int64_t numChunks = CeilDiv(T, BT);  // = 32
-    int isVarLen = 0;
-    if (cuSeqlensTensor != nullptr) {
-        auto cuChunkIndicesTensor = context->GetOptionalInputTensor(9);
-        const gert::StorageShape *chunkIndicesShape = context->GetOptionalInputShape(9);
-        OP_CHECK_NULL_WITH_CONTEXT(context, chunkIndicesShape);
-        const gert::Shape chunkIndicesStorageShape = chunkIndicesShape->GetStorageShape();
-        numChunks = chunkIndicesStorageShape.GetDim(0);
-        if (numChunks % 2 != 0) {
-            std::cout << "numChunks should be even, but now is " << chunkIndicesStorageShape.GetDim(1) << "!" << std::endl;
-            return ge::GRAPH_FAILED;
-        }
-        numChunks /= 2;
-        isVarLen = 1;
-    }
-    if (isVarLen == 1 && B != 1) {
-        std::cout << "varlen mode only support B = 1, but now B = " << B << "." << std::endl;
-        return ge::GRAPH_FAILED;
-    }
-        // std::cout << "[tiling] isVarLen: " << isVarLen << "\n";
-    {
-        // 检查输入维度是否符合预期
-        if (qStorageShape.GetDim(0) != B || qStorageShape.GetDim(1) != H || qStorageShape.GetDim(2) != T || qStorageShape.GetDim(3) != K ||
-            kStorageShape.GetDim(0) != B || kStorageShape.GetDim(1) != H || kStorageShape.GetDim(2) != T || kStorageShape.GetDim(3) != K ||
-            vStorageShape.GetDim(0) != B || vStorageShape.GetDim(1) != H || vStorageShape.GetDim(2) != T || vStorageShape.GetDim(3) != V ||
-            gStorageShape.GetDim(0) != B || gStorageShape.GetDim(1) != H || gStorageShape.GetDim(2) != T ||
-            hStorageShape.GetDim(0) != B || hStorageShape.GetDim(1) != H || hStorageShape.GetDim(2) != numChunks || hStorageShape.GetDim(3) != K || hStorageShape.GetDim(4) != V ||
-            doxStorageShape.GetDim(0) != B || doxStorageShape.GetDim(1) != H || doxStorageShape.GetDim(2) != T || doxStorageShape.GetDim(3) != V ||
-            dhStorageShape.GetDim(0) != B || dhStorageShape.GetDim(1) != H || dhStorageShape.GetDim(2) != numChunks || dhStorageShape.GetDim(3) != K || dhStorageShape.GetDim(4) != V ||
-            dvStorageShape.GetDim(0) != B || dvStorageShape.GetDim(1) != H || dvStorageShape.GetDim(2) != T || dvStorageShape.GetDim(3) != V) {
-            std::cout << "Input tensor shapes do not match expected dimensions!" << std::endl;
-            return ge::GRAPH_FAILED;
-        }
-        if (K != 128) {
-            std::cout << "K should be 128, but now K = " << K << "." << std::endl;
-            return ge::GRAPH_FAILED;
-        }
-        if (V != 128 && V != 256) {
-            std::cout << "V should be 128 or 256, but now V = " << V << "." << std::endl;
-            return ge::GRAPH_FAILED;
-        }
-
-    }
-    
-    // std::cout << "[tiling] B: " << B << ", H: " << H << ", T: " << T << ", K: " << K << ", V: " << V << ", BT: " << BT << ", numChunks: " << numChunks << std::endl;
-    
-    
-    // 计算 scale = 1.0 / sqrt(K)
-    // float scale = 1.0f / std::sqrt(static_cast<float>(K));
-    const int ATTR_SCALE_ITEM = 0;
-    
-    const float* scalePtr = attr->GetAttrPointer<float>(ATTR_SCALE_ITEM);
-    if (scalePtr == nullptr) {
-        std::cout << "scale should not be nullptr!" << std::endl;
-        return ge::GRAPH_FAILED;
-    }
-    float scale = *scalePtr;
-    // std::cout << "[tiling] scale is " << scale << std::endl;
-    
-    // 获取平台信息
-    auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
-    auto sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
-    const int64_t aicNum = ascendcPlatform.GetCoreNumAic();
-    
-    // 设置 TilingKey
-    context->SetTilingKey(1);
-    
-    size_t dgLastSize = B * H * numChunks * 1 * FP32_SIZE;         // b_dg_last (fp32)
-    // // 对齐到 32 字节
-    dgLastSize = ((dgLastSize + 31) / 32) * 32;
-    
-    // size_t mm5Size = B * H * T * BT * FP16_SIZE;                   // mm5 (q @ k^T)
-    size_t mm5Size = B * H * T * K * FP16_SIZE;// mm5 (q @ k^T): B * H * T * BT * FP16_SIZE, mm6/mm7 需要复用 mm5 的空间，BT 可能是 64 或 128，这里直接按 128 来计算，保证空间足够
-    size_t dsTempSize = B * H * T * BT * FP16_SIZE;                // b_ds_temp
-    // Reuse existing storage so old_dqkwg keeps the same workspace size as main.
-    // mm6/mm7 reuse mm5 after Part3 consumes mm5; mul1 uses dq as scratch before Part4 rewrites dq.
-
-    
-    // Workspace 偏移计算
-    size_t offset = 0;
-    
-    // size_t wsDwOffset = offset;
-    // offset += dwSize;
-    
-    size_t wsDgLastOffset = offset;
-// std::cout << "[tiling] offset: " << offset << ", dgLastSize: "<<dgLastSize<<"\n";
-    offset += dgLastSize;
-
-    size_t wsMm5Offset = offset;
-// std::cout << "[tiling] offset: " << offset << ", mm5Size: "<<mm5Size<<"\n";
-    offset += mm5Size;
-    
-    size_t wsDsTempOffset = offset;
-// std::cout << "[tiling] offset: " << offset << ", dsTempSize: "<<dsTempSize<<"\n";
-    offset += dsTempSize;
-
-    size_t wsMm6Offset = wsMm5Offset;
-    size_t wsMm7Offset = wsMm5Offset;
-    size_t wsMul1Offset = 0;
-    
-    size_t totalUserWorkspace = offset;
-    // std::cout << "[tiling] totalUserWorkspace: " << totalUserWorkspace << ", sysWorkspaceSize: " << sysWorkspaceSize << "\n";
-    
-    // 设置 workspace 大小
-    size_t* workspaces = context->GetWorkspaceSizes(1);
-    workspaces[0] = static_cast<size_t>(sysWorkspaceSize + totalUserWorkspace);
-    
-    // 设置 block 数量
-    context->SetBlockDim(aicNum);
-    context->SetScheduleMode(1); // set as batchmod for template using SyncAll
-    
-    // 填充 TilingData
-    ChunkBwdDqkwgTilingData tilingData;
-    tilingData.set_B(B);
-    tilingData.set_H(H);
-    tilingData.set_T(T);
-    tilingData.set_K(K);
-    tilingData.set_V(V);
-    tilingData.set_BT(BT);
-    tilingData.set_numChunks(numChunks);
-    tilingData.set_scale(scale);
-    tilingData.set_mul0RowNum(V == 256 ? 16 : 32);
-    
-    // tilingData.set_wsDwOffset(wsDwOffset);
-    tilingData.set_wsDgLastOffset(wsDgLastOffset);
-    tilingData.set_dgLastSize(dgLastSize);
-    tilingData.set_wsMm5Offset(wsMm5Offset);
-    tilingData.set_wsDsTempOffset(wsDsTempOffset);
-    tilingData.set_totalWorkspaceSize(totalUserWorkspace);
-    tilingData.set_wsMm6Offset(wsMm6Offset);
-    tilingData.set_wsMm7Offset(wsMm7Offset);
-    tilingData.set_wsMul1Offset(wsMul1Offset);
-    
-    // 检查是否有 cu_seqlens 输入来判断 IS_VARLEN
-    tilingData.set_isVarLen(isVarLen);
-    
-    // 保存 tiling data
-    tilingData.SaveToBuffer(context->GetRawTilingData()->GetData(), 
-                            context->GetRawTilingData()->GetCapacity());
-    context->GetRawTilingData()->SetDataSize(tilingData.GetDataSize());
-    
-    return ge::GRAPH_SUCCESS;
-}
-
-struct ChunkBwdDqkwgCompileInfo {};
-ASCENDC_EXTERN_C ge::graphStatus TilingParseChunkBwdDqkwg(gert::TilingParseContext* context) {
-    (void)context;
-    return ge::GRAPH_SUCCESS;
-}
-
-IMPL_OP_OPTILING(ChunkBwdDqkwg)
-    .Tiling(TilingChunkBwdDqkwg)
-    .TilingParse<ChunkBwdDqkwgCompileInfo>(TilingParseChunkBwdDqkwg);
-
-}  // namespace optiling
+ #include "chunk_bwd_dqkwg_tiling.h"
+ #include <register/op_impl_registry.h>
+ #include "tiling_base/data_copy_transpose_tiling.h"
+ #include "tiling_base/tiling_templates_registry.h"
+ #include "tiling_base/tiling_type.h"
+ #include <cmath>
+ 
+ namespace optiling {
+ 
+ constexpr int64_t CONST_B = 1;
+ constexpr int64_t CONST_H = 4;
+ constexpr int64_t CONST_T = 2816;
+ constexpr int64_t CONST_K = 128;
+ constexpr int64_t CONST_V = 128;
+ constexpr int64_t CONST_BT = 64;
+ 
+ // 数据类型大小
+ constexpr size_t FP16_SIZE = 2;
+ constexpr size_t FP32_SIZE = 4;
+ 
+ int64_t CeilDiv(int64_t a, int64_t b)
+ {
+     if (unlikely(b == 0)) {
+         return 0;
+     }
+     return (a + b - 1) / b;
+ }
+ 
+ ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* context) {
+     const gert::Shape qStorageShape = context->GetRequiredInputShape(0)->GetStorageShape();
+     const gert::Shape kStorageShape = context->GetRequiredInputShape(1)->GetStorageShape();
+     const gert::Shape vStorageShape = context->GetRequiredInputShape(2)->GetStorageShape();
+     const gert::Shape gStorageShape = context->GetRequiredInputShape(3)->GetStorageShape();
+     const gert::Shape hStorageShape = context->GetRequiredInputShape(4)->GetStorageShape();
+     const gert::Shape doxStorageShape = context->GetRequiredInputShape(5)->GetStorageShape();
+     const gert::Shape dhStorageShape = context->GetRequiredInputShape(6)->GetStorageShape();
+     const gert::Shape dvStorageShape = context->GetRequiredInputShape(7)->GetStorageShape();
+ 
+     int64_t B = vStorageShape.GetDim(0);//CONST_B;
+     int64_t H = vStorageShape.GetDim(1);//CONST_H;
+     int64_t T = vStorageShape.GetDim(2);//CONST_T;
+     int64_t K = kStorageShape.GetDim(3);//CONST_K;
+     int64_t V = vStorageShape.GetDim(3);//CONST_V;
+     int64_t BT = CONST_BT;
+     auto attr = context->GetAttrs();
+     const int ATTR_CHUNK_SIZE_ITEM = 1;
+     const int32_t* chunkSizePtr = attr->GetAttrPointer<int32_t>(ATTR_CHUNK_SIZE_ITEM);
+     if (chunkSizePtr != nullptr) {
+         BT = *chunkSizePtr;
+         // std::cout << "[tiling] BT: " << BT << "\n";
+         if (BT != 64 && BT != 128) {
+             std::cout << "BT should be 64 or 128 ." << std::endl;
+             return ge::GRAPH_FAILED;
+         }
+         
+     }
+ 
+ 
+     if (context->GetOptionalInputTensor(10) != nullptr || context->GetOptionalInputTensor(11) != nullptr) {
+         std::cout << "w and g_gamma should be set at nullptr." << std::endl;
+         return ge::GRAPH_FAILED;
+     }
+ 
+     auto cuSeqlensTensor = context->GetOptionalInputTensor(8);
+     int64_t numChunks = CeilDiv(T, BT);  // = 32
+     int isVarLen = 0;
+     if (cuSeqlensTensor != nullptr) {
+         auto cuChunkIndicesTensor = context->GetOptionalInputTensor(9);
+         const gert::StorageShape *chunkIndicesShape = context->GetOptionalInputShape(9);
+         OP_CHECK_NULL_WITH_CONTEXT(context, chunkIndicesShape);
+         const gert::Shape chunkIndicesStorageShape = chunkIndicesShape->GetStorageShape();
+         numChunks = chunkIndicesStorageShape.GetDim(0);
+         if (numChunks % 2 != 0) {
+             std::cout << "numChunks should be even, but now is " << chunkIndicesStorageShape.GetDim(1) << "!" << std::endl;
+             return ge::GRAPH_FAILED;
+         }
+         numChunks /= 2;
+         isVarLen = 1;
+     }
+     if (isVarLen == 1 && B != 1) {
+         std::cout << "varlen mode only support B = 1, but now B = " << B << "." << std::endl;
+         return ge::GRAPH_FAILED;
+     }
+         // std::cout << "[tiling] isVarLen: " << isVarLen << "\n";
+     {
+         // 检查输入维度是否符合预期
+         if (qStorageShape.GetDim(0) != B || qStorageShape.GetDim(1) != H || qStorageShape.GetDim(2) != T || qStorageShape.GetDim(3) != K ||
+             kStorageShape.GetDim(0) != B || kStorageShape.GetDim(1) != H || kStorageShape.GetDim(2) != T || kStorageShape.GetDim(3) != K ||
+             vStorageShape.GetDim(0) != B || vStorageShape.GetDim(1) != H || vStorageShape.GetDim(2) != T || vStorageShape.GetDim(3) != V ||
+             gStorageShape.GetDim(0) != B || gStorageShape.GetDim(1) != H || gStorageShape.GetDim(2) != T ||
+             hStorageShape.GetDim(0) != B || hStorageShape.GetDim(1) != H || hStorageShape.GetDim(2) != numChunks || hStorageShape.GetDim(3) != K || hStorageShape.GetDim(4) != V ||
+             doxStorageShape.GetDim(0) != B || doxStorageShape.GetDim(1) != H || doxStorageShape.GetDim(2) != T || doxStorageShape.GetDim(3) != V ||
+             dhStorageShape.GetDim(0) != B || dhStorageShape.GetDim(1) != H || dhStorageShape.GetDim(2) != numChunks || dhStorageShape.GetDim(3) != K || dhStorageShape.GetDim(4) != V ||
+             dvStorageShape.GetDim(0) != B || dvStorageShape.GetDim(1) != H || dvStorageShape.GetDim(2) != T || dvStorageShape.GetDim(3) != V) {
+             std::cout << "Input tensor shapes do not match expected dimensions!" << std::endl;
+             return ge::GRAPH_FAILED;
+         }
+         if (K != 128) {
+             std::cout << "K should be 128, but now K = " << K << "." << std::endl;
+             return ge::GRAPH_FAILED;
+         }
+         if (V != 128 && V != 256) {
+             std::cout << "V should be 128 or 256, but now V = " << V << "." << std::endl;
+             return ge::GRAPH_FAILED;
+         }
+ 
+     }
+     
+     // std::cout << "[tiling] B: " << B << ", H: " << H << ", T: " << T << ", K: " << K << ", V: " << V << ", BT: " << BT << ", numChunks: " << numChunks << std::endl;
+     
+     
+     // 计算 scale = 1.0 / sqrt(K)
+     // float scale = 1.0f / std::sqrt(static_cast<float>(K));
+     const int ATTR_SCALE_ITEM = 0;
+     
+     const float* scalePtr = attr->GetAttrPointer<float>(ATTR_SCALE_ITEM);
+     if (scalePtr == nullptr) {
+         std::cout << "scale should not be nullptr!" << std::endl;
+         return ge::GRAPH_FAILED;
+     }
+     float scale = *scalePtr;
+     // std::cout << "[tiling] scale is " << scale << std::endl;
+     
+     // 获取平台信息
+     auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
+     auto sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
+     const int64_t aicNum = ascendcPlatform.GetCoreNumAic();
+     
+     // 设置 TilingKey
+     context->SetTilingKey(1);
+     
+     size_t dwSize = B * H * T * K * FP32_SIZE;                     // b_dw workspace, conservatively reserved
+     dwSize = ((dwSize + 31) / 32) * 32;
+     size_t dgLastSize = B * H * numChunks * 8 * FP32_SIZE;         // b_dg_last, one 32B slot per scalar
+     // // 对齐到 32 字节
+     dgLastSize = ((dgLastSize + 31) / 32) * 32;
+     
+     // size_t mm5Size = B * H * T * BT * FP16_SIZE;                   // mm5 (q @ k^T)
+     size_t mm5Size = B * H * T * K * FP16_SIZE;// mm5 (q @ k^T): B * H * T * BT * FP16_SIZE, mm6/mm7 需要复用 mm5 的空间，BT 可能是 64 或 128，这里直接按 128 来计算，保证空间足够
+     size_t dsTempSize = B * H * T * BT * FP16_SIZE;                // b_ds_temp
+     // Reuse existing storage so old_dqkwg keeps the same workspace size as main.
+     // mm6/mm7 reuse mm5 after Part3 consumes mm5; mul1 uses dq as scratch before Part4 rewrites dq.
+ 
+     
+     // Workspace 偏移计算
+     size_t offset = 0;
+     
+     size_t wsDwOffset = offset;
+     offset += dwSize;
+     
+     size_t wsDgLastOffset = offset;
+ // std::cout << "[tiling] offset: " << offset << ", dgLastSize: "<<dgLastSize<<"\n";
+     offset += dgLastSize;
+ 
+     size_t wsMm5Offset = offset;
+ // std::cout << "[tiling] offset: " << offset << ", mm5Size: "<<mm5Size<<"\n";
+     offset += mm5Size;
+     
+     size_t wsDsTempOffset = offset;
+ // std::cout << "[tiling] offset: " << offset << ", dsTempSize: "<<dsTempSize<<"\n";
+     offset += dsTempSize;
+ 
+     size_t wsMm6Offset = wsMm5Offset;
+     size_t wsMm7Offset = wsMm5Offset;
+     size_t wsMul1Offset = 0;
+     
+     size_t totalUserWorkspace = offset;
+     // std::cout << "[tiling] totalUserWorkspace: " << totalUserWorkspace << ", sysWorkspaceSize: " << sysWorkspaceSize << "\n";
+     
+     // 设置 workspace 大小
+     size_t* workspaces = context->GetWorkspaceSizes(1);
+     workspaces[0] = static_cast<size_t>(sysWorkspaceSize + totalUserWorkspace);
+     
+     // 设置 block 数量
+     context->SetBlockDim(aicNum);
+     context->SetScheduleMode(1); // set as batchmod for template using SyncAll
+     
+     // 填充 TilingData
+     ChunkBwdDqkwgTilingData tilingData;
+     tilingData.set_B(B);
+     tilingData.set_H(H);
+     tilingData.set_T(T);
+     tilingData.set_K(K);
+     tilingData.set_V(V);
+     tilingData.set_BT(BT);
+     tilingData.set_numChunks(numChunks);
+     tilingData.set_scale(scale);
+     tilingData.set_mul0RowNum(V == 256 ? 16 : 32);
+     
+     tilingData.set_wsDwOffset(wsDwOffset);
+     tilingData.set_wsDgLastOffset(wsDgLastOffset);
+     tilingData.set_dgLastSize(dgLastSize);
+     tilingData.set_wsMm5Offset(wsMm5Offset);
+     tilingData.set_wsDsTempOffset(wsDsTempOffset);
+     tilingData.set_totalWorkspaceSize(totalUserWorkspace);
+     tilingData.set_wsMm6Offset(wsMm6Offset);
+     tilingData.set_wsMm7Offset(wsMm7Offset);
+     tilingData.set_wsMul1Offset(wsMul1Offset);
+     
+     // 检查是否有 cu_seqlens 输入来判断 IS_VARLEN
+     tilingData.set_isVarLen(isVarLen);
+     
+     // 保存 tiling data
+     tilingData.SaveToBuffer(context->GetRawTilingData()->GetData(), 
+                             context->GetRawTilingData()->GetCapacity());
+     context->GetRawTilingData()->SetDataSize(tilingData.GetDataSize());
+     
+     return ge::GRAPH_SUCCESS;
+ }
+ 
+ struct ChunkBwdDqkwgCompileInfo {};
+ ASCENDC_EXTERN_C ge::graphStatus TilingParseChunkBwdDqkwg(gert::TilingParseContext* context) {
+     (void)context;
+     return ge::GRAPH_SUCCESS;
+ }
+ 
+ IMPL_OP_OPTILING(ChunkBwdDqkwg)
+     .Tiling(TilingChunkBwdDqkwg)
+     .TilingParse<ChunkBwdDqkwgCompileInfo>(TilingParseChunkBwdDqkwg);
+ 
+ }  // namespace optiling
+ 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
@@ -150,9 +150,8 @@ ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* contex
     // size_t mm5Size = B * H * T * BT * FP16_SIZE;                   // mm5 (q @ k^T)
     size_t mm5Size = B * H * T * K * FP16_SIZE;// mm5 (q @ k^T): B * H * T * BT * FP16_SIZE, mm6/mm7 需要复用 mm5 的空间，BT 可能是 64 或 128，这里直接按 128 来计算，保证空间足够
     size_t dsTempSize = B * H * T * BT * FP16_SIZE;                // b_ds_temp
-    size_t mm6Size = B * H * T * K * FP16_SIZE;                   // mm6
-    size_t mm7Size = B * H * T * K * FP16_SIZE;                   // mm7
-    size_t mul1Size = B * H * T * BT * FP16_SIZE;                   // mul1
+    // Reuse existing storage so old_dqkwg keeps the same workspace size as main.
+    // mm6/mm7 reuse mm5 after Part3 consumes mm5; mul1 uses dq as scratch before Part4 rewrites dq.
 
     
     // Workspace 偏移计算
@@ -173,17 +172,9 @@ ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* contex
 // std::cout << "[tiling] offset: " << offset << ", dsTempSize: "<<dsTempSize<<"\n";
     offset += dsTempSize;
 
-    size_t wsMm6Offset = offset;
-// std::cout << "[tiling] offset: " << mm6Size << ", mm6Size: "<<mm6Size<<"\n";
-    offset += mm6Size;
-
-    size_t wsMm7Offset = offset;
-// std::cout << "[tiling] offset: " << offset << ", mm7Size: "<<mm7Size<<"\n";
-    offset += mm7Size;
-
-    size_t wsMul1Offset = offset;
-// std::cout << "[tiling] offset: " << offset << ", mul1Size: "<<mul1Size<<"\n";
-    offset += mul1Size;
+    size_t wsMm6Offset = wsMm5Offset;
+    size_t wsMm7Offset = wsMm5Offset;
+    size_t wsMul1Offset = 0;
     
     size_t totalUserWorkspace = offset;
     // std::cout << "[tiling] totalUserWorkspace: " << totalUserWorkspace << ", sysWorkspaceSize: " << sysWorkspaceSize << "\n";

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.h
@@ -38,14 +38,14 @@ BEGIN_TILING_DATA_DEF(ChunkBwdDqkwgTilingData)
     TILING_DATA_FIELD_DEF(uint32_t, mul0RowNum);
     
     // Workspace 偏移量 (按字节)
-    TILING_DATA_FIELD_DEF(uint64_t, wsDwOffset);         // Part 1: b_dw 偏移
+    // TILING_DATA_FIELD_DEF(uint64_t, wsDwOffset);         // Part 1: b_dw 偏移
     TILING_DATA_FIELD_DEF(uint64_t, wsDgLastOffset);     // Part 1: b_dg_last 偏移
     TILING_DATA_FIELD_DEF(uint64_t, dgLastSize);     // Part 1: b_dg_last 偏移
     TILING_DATA_FIELD_DEF(uint64_t, wsMm5Offset);        // Part 2: mm5 (q @ k^T) 偏移
     TILING_DATA_FIELD_DEF(uint64_t, wsDsTempOffset);     // Part 3: b_ds_temp 偏移
-    // TILING_DATA_FIELD_DEF(uint64_t, wsMm6Offset);        // Part 6: mm6 偏移
-    // TILING_DATA_FIELD_DEF(uint64_t, wsMm7Offset);        // Part 7: mm7 偏移
-    // TILING_DATA_FIELD_DEF(uint64_t, wsMul1Offset);        // Part 2: mul1 偏移
+    TILING_DATA_FIELD_DEF(uint64_t, wsMm6Offset);        // Part 6: mm6 偏移
+    TILING_DATA_FIELD_DEF(uint64_t, wsMm7Offset);        // Part 7: mm7 偏移
+    TILING_DATA_FIELD_DEF(uint64_t, wsMul1Offset);        // Part 2: mul1 偏移
     
     // 其他偏移
     TILING_DATA_FIELD_DEF(uint64_t, totalWorkspaceSize); // 总 workspace 大小

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.h
@@ -12,52 +12,53 @@
  * \brief ChunkBwdDqkwg Tiling 数据结构定义
  */
 
-#ifndef CHUNK_BWD_DQKWG_TILING_H
-#define CHUNK_BWD_DQKWG_TILING_H
-
-#include <exe_graph/runtime/tiling_context.h>
-#include <graph/utils/type_utils.h>
-
-#include "register/tilingdata_base.h"
-#include "tiling/tiling_api.h"
-
-namespace optiling {
-
-BEGIN_TILING_DATA_DEF(ChunkBwdDqkwgTilingData)
-    // 基本形状参数
-    TILING_DATA_FIELD_DEF(uint64_t, B);              // batch size
-    TILING_DATA_FIELD_DEF(uint64_t, H);              // number of heads
-    TILING_DATA_FIELD_DEF(uint64_t, T);              // sequence length
-    TILING_DATA_FIELD_DEF(uint64_t, K);              // key/query dimension
-    TILING_DATA_FIELD_DEF(uint64_t, V);              // value dimension
-    TILING_DATA_FIELD_DEF(uint64_t, BT);             // chunk size (tile size in T dimension)
-    TILING_DATA_FIELD_DEF(uint64_t, numChunks);      // T / BT
-    
-    // scale 参数
-    TILING_DATA_FIELD_DEF(float, scale);             // 1.0 / sqrt(K)
-    TILING_DATA_FIELD_DEF(uint32_t, mul0RowNum);
-    
-    // Workspace 偏移量 (按字节)
-    // TILING_DATA_FIELD_DEF(uint64_t, wsDwOffset);         // Part 1: b_dw 偏移
-    TILING_DATA_FIELD_DEF(uint64_t, wsDgLastOffset);     // Part 1: b_dg_last 偏移
-    TILING_DATA_FIELD_DEF(uint64_t, dgLastSize);     // Part 1: b_dg_last 偏移
-    TILING_DATA_FIELD_DEF(uint64_t, wsMm5Offset);        // Part 2: mm5 (q @ k^T) 偏移
-    TILING_DATA_FIELD_DEF(uint64_t, wsDsTempOffset);     // Part 3: b_ds_temp 偏移
-    TILING_DATA_FIELD_DEF(uint64_t, wsMm6Offset);        // Part 6: mm6 aliases mm5
-    TILING_DATA_FIELD_DEF(uint64_t, wsMm7Offset);        // Part 7: mm7 aliases mm5
-    TILING_DATA_FIELD_DEF(uint64_t, wsMul1Offset);        // Part 2: mul1 uses dq scratch
-    
-    // 其他偏移
-    TILING_DATA_FIELD_DEF(uint64_t, totalWorkspaceSize); // 总 workspace 大小
-    
-    // IS_VARLEN 相关
-    TILING_DATA_FIELD_DEF(uint64_t, isVarLen);           // 是否变长序列
-    
-END_TILING_DATA_DEF;
-
-REGISTER_TILING_DATA_CLASS(ChunkBwdDqkwg, ChunkBwdDqkwgTilingData)
-
-
-}  // namespace optiling
-
-#endif  // CHUNK_BWD_DQKWG_TILING_H
+ #ifndef CHUNK_BWD_DQKWG_TILING_H
+ #define CHUNK_BWD_DQKWG_TILING_H
+ 
+ #include <exe_graph/runtime/tiling_context.h>
+ #include <graph/utils/type_utils.h>
+ 
+ #include "register/tilingdata_base.h"
+ #include "tiling/tiling_api.h"
+ 
+ namespace optiling {
+ 
+ BEGIN_TILING_DATA_DEF(ChunkBwdDqkwgTilingData)
+     // 基本形状参数
+     TILING_DATA_FIELD_DEF(uint64_t, B);              // batch size
+     TILING_DATA_FIELD_DEF(uint64_t, H);              // number of heads
+     TILING_DATA_FIELD_DEF(uint64_t, T);              // sequence length
+     TILING_DATA_FIELD_DEF(uint64_t, K);              // key/query dimension
+     TILING_DATA_FIELD_DEF(uint64_t, V);              // value dimension
+     TILING_DATA_FIELD_DEF(uint64_t, BT);             // chunk size (tile size in T dimension)
+     TILING_DATA_FIELD_DEF(uint64_t, numChunks);      // T / BT
+     
+     // scale 参数
+     TILING_DATA_FIELD_DEF(float, scale);             // 1.0 / sqrt(K)
+     TILING_DATA_FIELD_DEF(uint32_t, mul0RowNum);
+     
+     // Workspace 偏移量 (按字节)
+     TILING_DATA_FIELD_DEF(uint64_t, wsDwOffset);         // Part 1: b_dw 偏移
+     TILING_DATA_FIELD_DEF(uint64_t, wsDgLastOffset);     // Part 1: b_dg_last 偏移
+     TILING_DATA_FIELD_DEF(uint64_t, dgLastSize);     // Part 1: b_dg_last size, padded to 32B slots
+     TILING_DATA_FIELD_DEF(uint64_t, wsMm5Offset);        // Part 2: mm5 (q @ k^T) 偏移
+     TILING_DATA_FIELD_DEF(uint64_t, wsDsTempOffset);     // Part 3: b_ds_temp 偏移
+     TILING_DATA_FIELD_DEF(uint64_t, wsMm6Offset);        // Part 6: mm6 aliases mm5
+     TILING_DATA_FIELD_DEF(uint64_t, wsMm7Offset);        // Part 7: mm7 aliases mm5
+     TILING_DATA_FIELD_DEF(uint64_t, wsMul1Offset);        // Part 2: mul1 uses dq scratch
+     
+     // 其他偏移
+     TILING_DATA_FIELD_DEF(uint64_t, totalWorkspaceSize); // 总 workspace 大小
+     
+     // IS_VARLEN 相关
+     TILING_DATA_FIELD_DEF(uint64_t, isVarLen);           // 是否变长序列
+     
+ END_TILING_DATA_DEF;
+ 
+ REGISTER_TILING_DATA_CLASS(ChunkBwdDqkwg, ChunkBwdDqkwgTilingData)
+ 
+ 
+ }  // namespace optiling
+ 
+ #endif  // CHUNK_BWD_DQKWG_TILING_H
+ 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.h
@@ -43,9 +43,9 @@ BEGIN_TILING_DATA_DEF(ChunkBwdDqkwgTilingData)
     TILING_DATA_FIELD_DEF(uint64_t, dgLastSize);     // Part 1: b_dg_last 偏移
     TILING_DATA_FIELD_DEF(uint64_t, wsMm5Offset);        // Part 2: mm5 (q @ k^T) 偏移
     TILING_DATA_FIELD_DEF(uint64_t, wsDsTempOffset);     // Part 3: b_ds_temp 偏移
-    TILING_DATA_FIELD_DEF(uint64_t, wsMm6Offset);        // Part 6: mm6 偏移
-    TILING_DATA_FIELD_DEF(uint64_t, wsMm7Offset);        // Part 7: mm7 偏移
-    TILING_DATA_FIELD_DEF(uint64_t, wsMul1Offset);        // Part 2: mul1 偏移
+    TILING_DATA_FIELD_DEF(uint64_t, wsMm6Offset);        // Part 6: mm6 aliases mm5
+    TILING_DATA_FIELD_DEF(uint64_t, wsMm7Offset);        // Part 7: mm7 aliases mm5
+    TILING_DATA_FIELD_DEF(uint64_t, wsMul1Offset);        // Part 2: mul1 uses dq scratch
     
     // 其他偏移
     TILING_DATA_FIELD_DEF(uint64_t, totalWorkspaceSize); // 总 workspace 大小

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg.cpp
@@ -11,81 +11,81 @@
  * \file chunk_bwd_dqkwg.cpp
  */
 
-#include "kernel_operator.h"
-#include "chunk_bwd_dqkwg_common.h"
-#include "chunk_bwd_dqkwg_cube.h"
-#include "chunk_bwd_dqkwg_vector.h"
-#include "lib/matmul_intf.h"
-
-using namespace AscendC;
-
-#ifndef DTYPE_Q
-#define DTYPE_Q half
-#endif
-
-#ifndef DTYPE_G
-#define DTYPE_G float
-#endif
-
-
-__global__ __aicore__ void chunk_bwd_dqkwg(
-    GM_ADDR q,              // [B, H, T, K]
-    GM_ADDR k,              // [B, H, T, K]
-    GM_ADDR v,              // [B, H, T, V]
-    GM_ADDR g,              // [B, H, T]
-    GM_ADDR h,              // [B, num_chunks, H, K, V]
-    GM_ADDR do_,            // [B, H, T, V]
-    GM_ADDR dh,             // [B, num_chunks, H, K, V]
-    GM_ADDR dv,             // [B, H, T, V]
-    GM_ADDR cu_seqlens,     // [N+1] (optional)
-    GM_ADDR chunk_indices,  // [num_chunks, 2] (optional)
-    GM_ADDR w,
-    GM_ADDR g_gamma,
-    GM_ADDR dq,             // [B, H, T, K] - output
-    GM_ADDR dk,             // [B, H, T, K] - output
-    GM_ADDR dw,             // [B, H, T, K] - output
-    GM_ADDR dg,             // [B, H, T] - output (fp32)
-    GM_ADDR workspace,      // workspace buffer
-    GM_ADDR tiling          // . data
-)
-{
-
-    // 设置溢出处理
-    AscendCUtils::SetOverflow(1);
-    
-    // 根据 TilingKey 选择执行路径
-    if (TILING_KEY_IS(1)) {
-
-        // 使用 C-V 融合模式
-        KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
-        GET_TILING_DATA(tilingData, tiling);
-        // AIC (Cube) 端执行
-
-        if ASCEND_IS_AIC {
-            ChunkBwdDqkwgCubeProcess<DTYPE_Q, DTYPE_G> cubeProcess(
-                q, k, v, g, h,
-                do_, dh, dv, cu_seqlens, chunk_indices,
-                dq, dk, dw, dg,
-                workspace
-            );
-            cubeProcess.Init(tilingData);
-            cubeProcess.Process();
-        }
-        
-        // AIV (Vector) 端执行
-        if ASCEND_IS_AIV {
-            TPipe tPipe; // 创建 TPipe 用于 Vector 端流水
-            ChunkBwdDqkwgVectorProcess<DTYPE_Q, DTYPE_G> vectorProcess(
-                q, k, v, g, h,
-                do_, dh, dv, cu_seqlens, chunk_indices, nullptr,        //mask = nullptr
-                dq, dk, dw, dg,
-                workspace
-            );
-            vectorProcess.Init(tilingData, &tPipe);
-            vectorProcess.Process();
-        }
-
-    }
-
-    return;
-}
+ #include "kernel_operator.h"
+ #include "chunk_bwd_dqkwg_common.h"
+ #include "chunk_bwd_dqkwg_cube.h"
+ #include "chunk_bwd_dqkwg_vector.h"
+ #include "lib/matmul_intf.h"
+ 
+ using namespace AscendC;
+ 
+ #ifndef DTYPE_Q
+ #define DTYPE_Q half
+ #endif
+ 
+ #ifndef DTYPE_G
+ #define DTYPE_G float
+ #endif
+ 
+ 
+ __global__ __aicore__ void chunk_bwd_dqkwg(
+     GM_ADDR q,              // [B, H, T, K]
+     GM_ADDR k,              // [B, H, T, K]
+     GM_ADDR v,              // [B, H, T, V]
+     GM_ADDR g,              // [B, H, T]
+     GM_ADDR h,              // [B, num_chunks, H, K, V]
+     GM_ADDR do_,            // [B, H, T, V]
+     GM_ADDR dh,             // [B, num_chunks, H, K, V]
+     GM_ADDR dv,             // [B, H, T, V]
+     GM_ADDR cu_seqlens,     // [N+1] (optional)
+     GM_ADDR chunk_indices,  // [num_chunks, 2] (optional)
+     GM_ADDR w,
+     GM_ADDR g_gamma,
+     GM_ADDR dq,             // [B, H, T, K] - output
+     GM_ADDR dk,             // [B, H, T, K] - output
+     GM_ADDR dw,             // [B, H, T, K] - output
+     GM_ADDR dg,             // [B, H, T] - output (fp32)
+     GM_ADDR workspace,      // workspace buffer
+     GM_ADDR tiling          // . data
+ )
+ {
+ 
+     // 设置溢出处理
+     AscendCUtils::SetOverflow(1);
+     
+     // 根据 TilingKey 选择执行路径
+     if (TILING_KEY_IS(1)) {
+ 
+         // 使用 C-V 融合模式
+         KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
+         GET_TILING_DATA(tilingData, tiling);
+         // AIC (Cube) 端执行
+ 
+         if ASCEND_IS_AIC {
+             ChunkBwdDqkwgCubeProcess<DTYPE_Q, DTYPE_G> cubeProcess(
+                 q, k, v, g, h,
+                 do_, dh, dv, cu_seqlens, chunk_indices,
+                 dq, dk, dw, dg,
+                 workspace
+             );
+             cubeProcess.Init(tilingData);
+             cubeProcess.Process();
+         }
+         
+         // AIV (Vector) 端执行
+         if ASCEND_IS_AIV {
+             TPipe tPipe; // 创建 TPipe 用于 Vector 端流水
+             ChunkBwdDqkwgVectorProcess<DTYPE_Q, DTYPE_G> vectorProcess(
+                 q, k, v, g, h,
+                 do_, dh, dv, cu_seqlens, chunk_indices, nullptr,        //mask = nullptr
+                 dq, dk, dw, dg,
+                 workspace
+             );
+             vectorProcess.Init(tilingData, &tPipe);
+             vectorProcess.Process();
+         }
+ 
+     }
+ 
+     return;
+ }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg.cpp
@@ -15,6 +15,8 @@
  #include "chunk_bwd_dqkwg_common.h"
  #include "chunk_bwd_dqkwg_cube.h"
  #include "chunk_bwd_dqkwg_vector.h"
+ #include "chunk_bwd_dqkwg_cube_legacy.h"
+ #include "chunk_bwd_dqkwg_vector_legacy.h"
  #include "lib/matmul_intf.h"
  
  using namespace AscendC;
@@ -53,20 +55,21 @@
      // 设置溢出处理
      AscendCUtils::SetOverflow(1);
      
-     // 根据 TilingKey 选择执行路径
+     GET_TILING_DATA(tilingData, tiling);
+     GM_ADDR userWorkspace = AscendC::GetUserWorkspace(workspace);
+     if (userWorkspace == nullptr) {
+         return;
+     }
+
+     // 根据 TilingKey 选择执行路径: 1 = legacy, 2 = current.
      if (TILING_KEY_IS(1)) {
- 
+
          // 使用 C-V 融合模式
          KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
-         GET_TILING_DATA(tilingData, tiling);
-         GM_ADDR userWorkspace = AscendC::GetUserWorkspace(workspace);
-         if (userWorkspace == nullptr) {
-             return;
-         }
          // AIC (Cube) 端执行
- 
+
          if ASCEND_IS_AIC {
-             ChunkBwdDqkwgCubeProcess<DTYPE_Q, DTYPE_G> cubeProcess(
+             ChunkBwdDqkwgCubeProcessLegacy<DTYPE_Q, DTYPE_G> cubeProcess(
                  q, k, v, g, h,
                  do_, dh, dv, cu_seqlens, chunk_indices,
                  dq, dk, dw, dg,
@@ -79,7 +82,7 @@
          // AIV (Vector) 端执行
          if ASCEND_IS_AIV {
              TPipe tPipe; // 创建 TPipe 用于 Vector 端流水
-             ChunkBwdDqkwgVectorProcess<DTYPE_Q, DTYPE_G> vectorProcess(
+             ChunkBwdDqkwgVectorProcessLegacy<DTYPE_Q, DTYPE_G> vectorProcess(
                  q, k, v, g, h,
                  do_, dh, dv, cu_seqlens, chunk_indices, nullptr,        //mask = nullptr
                  dq, dk, dw, dg,
@@ -88,7 +91,34 @@
              vectorProcess.Init(tilingData, &tPipe);
              vectorProcess.Process();
          }
- 
+
+     } else if (TILING_KEY_IS(2)) {
+
+         KERNEL_TASK_TYPE(2, KERNEL_TYPE_MIX_AIC_1_2);
+
+         if ASCEND_IS_AIC {
+             ChunkBwdDqkwgCubeProcess<DTYPE_Q, DTYPE_G> cubeProcess(
+                 q, k, v, g, h,
+                 do_, dh, dv, cu_seqlens, chunk_indices,
+                 dq, dk, dw, dg,
+                 userWorkspace
+             );
+             cubeProcess.Init(tilingData);
+             cubeProcess.Process();
+         }
+
+         if ASCEND_IS_AIV {
+             TPipe tPipe;
+             ChunkBwdDqkwgVectorProcess<DTYPE_Q, DTYPE_G> vectorProcess(
+                 q, k, v, g, h,
+                 do_, dh, dv, cu_seqlens, chunk_indices, nullptr,
+                 dq, dk, dw, dg,
+                 userWorkspace
+             );
+             vectorProcess.Init(tilingData, &tPipe);
+             vectorProcess.Process();
+         }
+
      }
  
      return;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg.cpp
@@ -59,6 +59,10 @@
          // 使用 C-V 融合模式
          KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
          GET_TILING_DATA(tilingData, tiling);
+         GM_ADDR userWorkspace = AscendC::GetUserWorkspace(workspace);
+         if (userWorkspace == nullptr) {
+             return;
+         }
          // AIC (Cube) 端执行
  
          if ASCEND_IS_AIC {
@@ -66,7 +70,7 @@
                  q, k, v, g, h,
                  do_, dh, dv, cu_seqlens, chunk_indices,
                  dq, dk, dw, dg,
-                 workspace
+                 userWorkspace
              );
              cubeProcess.Init(tilingData);
              cubeProcess.Process();
@@ -79,7 +83,7 @@
                  q, k, v, g, h,
                  do_, dh, dv, cu_seqlens, chunk_indices, nullptr,        //mask = nullptr
                  dq, dk, dw, dg,
-                 workspace
+                 userWorkspace
              );
              vectorProcess.Init(tilingData, &tPipe);
              vectorProcess.Process();

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_common.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_common.h
@@ -12,102 +12,103 @@
  * \brief ChunkBwdDqkwg 通用常量和定义
  */
 
-#ifndef CHUNK_BWD_DQKWG_COMMON_H
-#define CHUNK_BWD_DQKWG_COMMON_H
-
-#include "kernel_operator.h"
-
-constexpr uint64_t CONST_B = 1;
-constexpr uint64_t CONST_H = 4;
-constexpr uint64_t CONST_T = 2816;
-constexpr uint64_t CONST_K = 128;
-constexpr uint64_t CONST_V = 128;
-constexpr uint64_t CONST_BT = 64;
-constexpr uint64_t CONST_NUM_CHUNKS = 44;//CONST_T / CONST_BT;  // 32
-constexpr int32_t CAL_NUM_FLOAT = 64; // API一次能处理256B，能计算64个float元素
-// Part 1: dw 和 dg_last 计算 (C-V 融合)
-constexpr uint64_t SYNC_PART1_AIC_AIV = 10;  // AIC -> AIV
-constexpr uint64_t SYNC_PART1_AIV_AIC = 11;  // AIV -> AIC
-
-// Part 2: mm5 = q @ k^T (纯 Cube)
-constexpr uint64_t SYNC_PART2_AIC_AIV = 20;  // AIC -> AIV
-constexpr uint64_t SYNC_PART2_AIV_AIC = 21;  // AIV -> AIC
-
-// Part 3: ds 计算 (C-V 融合)
-constexpr uint64_t SYNC_PART3_AIC_AIV = 30;  // AIC -> AIV
-constexpr uint64_t SYNC_PART3_AIV_AIC = 31;  // AIV -> AIC
-
-// Part 4: dq 计算 (C-V 融合)
-constexpr uint64_t SYNC_PART4_AIC_AIV = 40;  // AIC -> AIV
-constexpr uint64_t SYNC_PART4_AIV_AIC = 41;  // AIV -> AIC
-
-// Part 5: dk 计算 (C-V 融合)
-constexpr uint64_t SYNC_PART5_AIC_AIV = 50;  // AIC -> AIV
-constexpr uint64_t SYNC_PART5_AIV_AIC = 51;  // AIV -> AIC
-
-// Part 6: dq += ds @ k (C-V 融合)
-constexpr uint64_t SYNC_PART6_AIC_AIV = 60;  // AIC -> AIV
-constexpr uint64_t SYNC_PART6_AIV_AIC = 61;  // AIV -> AIC
-
-// Part 7: dk += ds^T @ q (C-V 融合)
-constexpr uint64_t SYNC_PART7_AIC_AIV = 70;  // AIC -> AIV
-constexpr uint64_t SYNC_PART7_AIV_AIC = 71;  // AIV -> AIC
-
-// 通用同步 Flag (用于简化)
-constexpr uint64_t SYNC_AIV_AIC_FLAG_0 = 3;
-constexpr uint64_t SYNC_AIC_AIV_FLAG_0 = 5;
-
-constexpr uint32_t UB_SIZE = 192 * 1024;  // 192KB
-constexpr uint32_t ONE_BLOCK_32 = 32;
-constexpr uint32_t FP32_PER_REPEAT = 64;
-constexpr uint32_t FP16_PER_BLOCK = 16;  // 32 bytes / 2 bytes per fp16
-
-constexpr uint32_t FP16_SIZE = 2;
-constexpr uint32_t FP32_SIZE = 4;
-constexpr uint32_t BF16_SIZE = 2;
-
-#define CEIL_DIV(x, y) (((x) + (y) - 1) / (y))
-#define ALIGN_UP(x, align) (((x) + (align) - 1) / (align) * (align))
-
-template<typename T>
-struct TypeTraits {
-    using ComputeType = float;  // 默认计算类型为 fp32
-    static constexpr bool needsCast = true;
-};
-
-template<>
-struct TypeTraits<half> {
-    using ComputeType = float;
-    static constexpr bool needsCast = true;
-};
-
-__aicore__ void inline GetChunkOffset(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, uint64_t B, uint64_t H, uint64_t T,
-                                      uint64_t chunkSize, uint32_t loopIdx, uint32_t &bos, uint32_t &eos)
-{
-    if (cu_seqlens == nullptr) {
-        // AscendC::printf("111\n");
-        uint32_t coreLoopsInB = CEIL_DIV(T, chunkSize);
-        uint32_t chunkIdx = loopIdx % coreLoopsInB;
-        uint32_t bIdx = loopIdx / coreLoopsInB;
-        bos = chunkIdx * chunkSize;
-        eos = bos + chunkSize > T ? T : bos + chunkSize;
-        bos += (bIdx * H * T);
-        eos += (bIdx * H * T);
-    } else {
-        AscendC::GlobalTensor<uint64_t> cuSeqlensTensor;
-        AscendC::GlobalTensor<uint64_t> chunkIndicesTensor;
-        cuSeqlensTensor.SetGlobalBuffer((__gm__ uint64_t *)cu_seqlens);
-        chunkIndicesTensor.SetGlobalBuffer((__gm__ uint64_t *)chunk_indices);
-
-        uint32_t seqIdx = chunkIndicesTensor.GetValue(2 * loopIdx);
-        uint32_t chunkIdx = chunkIndicesTensor.GetValue(2 * loopIdx + 1);
-        uint32_t curSeqBegin = cuSeqlensTensor.GetValue(seqIdx);
-        uint32_t curSeqEnd = cuSeqlensTensor.GetValue(seqIdx + 1);
-        bos = curSeqBegin + chunkIdx * chunkSize;
-        eos = bos + chunkSize > curSeqEnd ? curSeqEnd : bos + chunkSize;
-    }
-
-    return;
-}
-
-#endif  // CHUNK_BWD_DQKWG_COMMON_H
+ #ifndef CHUNK_BWD_DQKWG_COMMON_H
+ #define CHUNK_BWD_DQKWG_COMMON_H
+ 
+ #include "kernel_operator.h"
+ 
+ constexpr uint64_t CONST_B = 1;
+ constexpr uint64_t CONST_H = 4;
+ constexpr uint64_t CONST_T = 2816;
+ constexpr uint64_t CONST_K = 128;
+ constexpr uint64_t CONST_V = 128;
+ constexpr uint64_t CONST_BT = 64;
+ constexpr uint64_t CONST_NUM_CHUNKS = 44;//CONST_T / CONST_BT;  // 32
+ constexpr int32_t CAL_NUM_FLOAT = 64; // API一次能处理256B，能计算64个float元素
+ // Part 1: dw 和 dg_last 计算 (C-V 融合)
+ constexpr uint64_t SYNC_PART1_AIC_AIV = 10;  // AIC -> AIV
+ constexpr uint64_t SYNC_PART1_AIV_AIC = 11;  // AIV -> AIC
+ 
+ // Part 2: mm5 = q @ k^T (纯 Cube)
+ constexpr uint64_t SYNC_PART2_AIC_AIV = 20;  // AIC -> AIV
+ constexpr uint64_t SYNC_PART2_AIV_AIC = 21;  // AIV -> AIC
+ 
+ // Part 3: ds 计算 (C-V 融合)
+ constexpr uint64_t SYNC_PART3_AIC_AIV = 30;  // AIC -> AIV
+ constexpr uint64_t SYNC_PART3_AIV_AIC = 31;  // AIV -> AIC
+ 
+ // Part 4: dq 计算 (C-V 融合)
+ constexpr uint64_t SYNC_PART4_AIC_AIV = 40;  // AIC -> AIV
+ constexpr uint64_t SYNC_PART4_AIV_AIC = 41;  // AIV -> AIC
+ 
+ // Part 5: dk 计算 (C-V 融合)
+ constexpr uint64_t SYNC_PART5_AIC_AIV = 50;  // AIC -> AIV
+ constexpr uint64_t SYNC_PART5_AIV_AIC = 51;  // AIV -> AIC
+ 
+ // Part 6: dq += ds @ k (C-V 融合)
+ constexpr uint64_t SYNC_PART6_AIC_AIV = 60;  // AIC -> AIV
+ constexpr uint64_t SYNC_PART6_AIV_AIC = 61;  // AIV -> AIC
+ 
+ // Part 7: dk += ds^T @ q (C-V 融合)
+ constexpr uint64_t SYNC_PART7_AIC_AIV = 70;  // AIC -> AIV
+ constexpr uint64_t SYNC_PART7_AIV_AIC = 71;  // AIV -> AIC
+ 
+ // 通用同步 Flag (用于简化)
+ constexpr uint64_t SYNC_AIV_AIC_FLAG_0 = 3;
+ constexpr uint64_t SYNC_AIC_AIV_FLAG_0 = 5;
+ 
+ constexpr uint32_t UB_SIZE = 192 * 1024;  // 192KB
+ constexpr uint32_t ONE_BLOCK_32 = 32;
+ constexpr uint32_t FP32_PER_REPEAT = 64;
+ constexpr uint32_t FP16_PER_BLOCK = 16;  // 32 bytes / 2 bytes per fp16
+ 
+ constexpr uint32_t FP16_SIZE = 2;
+ constexpr uint32_t FP32_SIZE = 4;
+ constexpr uint32_t BF16_SIZE = 2;
+ 
+ #define CEIL_DIV(x, y) (((x) + (y) - 1) / (y))
+ #define ALIGN_UP(x, align) (((x) + (align) - 1) / (align) * (align))
+ 
+ template<typename T>
+ struct TypeTraits {
+     using ComputeType = float;  // 默认计算类型为 fp32
+     static constexpr bool needsCast = true;
+ };
+ 
+ template<>
+ struct TypeTraits<half> {
+     using ComputeType = float;
+     static constexpr bool needsCast = true;
+ };
+ 
+ __aicore__ void inline GetChunkOffset(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, uint64_t B, uint64_t H, uint64_t T,
+                                       uint64_t chunkSize, uint32_t loopIdx, uint32_t &bos, uint32_t &eos)
+ {
+     if (cu_seqlens == nullptr) {
+         // AscendC::printf("111\n");
+         uint32_t coreLoopsInB = CEIL_DIV(T, chunkSize);
+         uint32_t chunkIdx = loopIdx % coreLoopsInB;
+         uint32_t bIdx = loopIdx / coreLoopsInB;
+         bos = chunkIdx * chunkSize;
+         eos = bos + chunkSize > T ? T : bos + chunkSize;
+         bos += (bIdx * H * T);
+         eos += (bIdx * H * T);
+     } else {
+         AscendC::GlobalTensor<uint64_t> cuSeqlensTensor;
+         AscendC::GlobalTensor<uint64_t> chunkIndicesTensor;
+         cuSeqlensTensor.SetGlobalBuffer((__gm__ uint64_t *)cu_seqlens);
+         chunkIndicesTensor.SetGlobalBuffer((__gm__ uint64_t *)chunk_indices);
+ 
+         uint32_t seqIdx = chunkIndicesTensor.GetValue(2 * loopIdx);
+         uint32_t chunkIdx = chunkIndicesTensor.GetValue(2 * loopIdx + 1);
+         uint32_t curSeqBegin = cuSeqlensTensor.GetValue(seqIdx);
+         uint32_t curSeqEnd = cuSeqlensTensor.GetValue(seqIdx + 1);
+         bos = curSeqBegin + chunkIdx * chunkSize;
+         eos = bos + chunkSize > curSeqEnd ? curSeqEnd : bos + chunkSize;
+     }
+ 
+     return;
+ }
+ 
+ #endif  // CHUNK_BWD_DQKWG_COMMON_H
+ 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
@@ -65,812 +65,812 @@
  using namespace Catlass;
  using namespace AscendC;
  
- namespace Catlass::Gemm::Kernel {
- 
- /**
-  * TileGemmDirect: Single-shot tile-level GEMM replacing BlockMmadTla.
-  * Directly performs GM→L1→L0→Mmad→FixPipe→GM without tiling loops or pingpong buffers.
-  * Optimal when all matrix dimensions fit in a single L0 tile (M≤128, N≤128, K≤128).
-  *
-  * Compared to BlockMmadTla<MmadPingpong>:
-  *  - No multi-stage L1/L0 buffers (1 stage vs 2)
-  *  - No nested tiling loops (kL1×mL0×kL0×nL0 all = 1 for our sizes)
-  *  - Minimal event overhead: 4 Set + 4 Wait per GEMM vs ~20+ in Block
-  *  - Half the L1/L0 memory usage (no pingpong double-buffering)
-  */
- template <class ArchTag_, class ElementC_, class TileCopy_>
- struct TileGemmDirect {
-     using ArchTag = ArchTag_;
-     using TileCopy = TileCopy_;
-     using ElementA = typename TileCopy::ElementA;
-     using ElementB = typename TileCopy::ElementB;
-     using ElementC = ElementC_;
-     using ElementAccumulator = typename TileCopy::ElementAccumulator;
- 
-     using LayoutTagL1A = typename TileCopy::LayoutTagL1A;
-     using LayoutTagL1B = typename TileCopy::LayoutTagL1B;
-     using LayoutTagL0A = typename TileCopy::LayoutTagL0A;
-     using LayoutTagL0B = typename TileCopy::LayoutTagL0B;
-     using CopyL1ToL0A = typename TileCopy::CopyL1ToL0A;
-     using CopyL1ToL0B = typename TileCopy::CopyL1ToL0B;
-     using TileMmadType = Tile::TileMmadTla<ArchTag, ElementA, LayoutTagL1A>;
- 
-     // Single L0 tile dimensions (max supported by AtlasA2 Cube)
-     static constexpr uint32_t TILE_M = 128;
-     static constexpr uint32_t TILE_N = 128;
-     static constexpr uint32_t TILE_K = 128;
- 
-     // Single-stage buffer sizes (no pingpong)
-     static constexpr uint32_t L1A_TILE_SIZE = TILE_M * TILE_K * sizeof(ElementA);
-     static constexpr uint32_t L1B_TILE_SIZE = TILE_K * TILE_N * sizeof(ElementB);
- 
-     // Static L1 layouts for tile-sized buffers
-     static constexpr auto L1A_LAYOUT =
-         tla::MakeLayout<ElementA, LayoutTagL1A>(tla::Int<TILE_M>{}, tla::Int<TILE_K>{});
-     static constexpr auto L1B_LAYOUT =
-         tla::MakeLayout<ElementB, LayoutTagL1B>(tla::Int<TILE_K>{}, tla::Int<TILE_N>{});
- 
-     /// Construct: allocate single-stage buffers, initialize events
-     CATLASS_DEVICE
-     TileGemmDirect(Arch::Resource<ArchTag> &resource)
-     {
-         if ASCEND_IS_AIC {
-             AscendC::SetMMLayoutTransform(true);
- 
-             // Allocate single-stage buffers from resource pools
-             l1ABuf = resource.l1Buf.template GetBufferByByte<ElementA>(0);
-             l1BBuf = resource.l1Buf.template GetBufferByByte<ElementB>(L1A_TILE_SIZE);
-             l0ABuf = resource.l0ABuf.template GetBufferByByte<ElementA>(0);
-             l0BBuf = resource.l0BBuf.template GetBufferByByte<ElementB>(0);
-             l0CBuf = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(0);
- 
-             // Initialize events: buffers are initially free
-             AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(0);  // L1 free for MTE2 write
-             AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(0);     // L0A/L0B free for MTE1 write
-         }
-     }
- 
-     /// Destructor: drain pending events
-     CATLASS_DEVICE
-     ~TileGemmDirect()
-     {
-         if ASCEND_IS_AIC {
-             AscendC::SetMMLayoutTransform(false);
-             AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(0);
-             AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(0);
-         }
-     }
- 
-     /// Perform a single-tile GEMM: C = A @ B
-     template <class TensorA, class TensorB, class TensorC>
-     CATLASS_DEVICE
-     void operator()(TensorA &tensorA, TensorB &tensorB, TensorC &tensorC, GemmCoord const &actualShape)
-     {
-         using CopyGmToL1A = typename TileCopy::template CopyGmToL1A<TensorA>;
-         using CopyGmToL1B = typename TileCopy::template CopyGmToL1B<TensorB>;
- #if (defined(CATLASS_ARCH) && CATLASS_ARCH == 2201)
-         using CopyL0CToGm = typename TileCopy::template CopyL0CToGm<TensorC>;
- #endif
- #if (defined(CATLASS_ARCH) && CATLASS_ARCH == 3510)
-         using CopyL0CToGm = typename TileCopy::template CopyL0CToDst<TensorC>;
- #endif
- 
-         CopyGmToL1A copyGmToL1A;
-         CopyGmToL1B copyGmToL1B;
-         CopyL1ToL0A copyL1ToL0A;
-         CopyL1ToL0B copyL1ToL0B;
-         CopyL0CToGm copyL0CToGm;
-         TileMmadType tileMmad;
- 
-         uint32_t m = actualShape.m();
-         uint32_t k = actualShape.k();
-         uint32_t n = actualShape.n();
- 
-         // Avoid gemv mode on AtlasA2
-         uint32_t mActual = m;
-         if constexpr (std::is_same_v<ArchTag, Arch::AtlasA2>) {
-             if (mActual == 1) mActual = 16;
-         }
- 
-         // Create L1 tensor views (static tile-size layout)
-         auto tensorL1A = tla::MakeTensor(l1ABuf, L1A_LAYOUT, Arch::PositionL1{});
-         auto tensorL1B = tla::MakeTensor(l1BBuf, L1B_LAYOUT, Arch::PositionL1{});
- 
-         // ---- Step 1: GM → L1 (MTE2) ----
-         AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(0);  // Wait L1 free
-         copyGmToL1A(tensorL1A, tensorA);
-         copyGmToL1B(tensorL1B, tensorB);
-         AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(0);   // Signal L1 data ready
- 
-         // ---- Step 2: L1 → L0A/L0B (MTE1) ----
-         AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(0);  // Wait L1 data ready
-         AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(0);     // Wait L0A/L0B free
- 
-         auto layoutL0A = tla::MakeLayout<ElementA, LayoutTagL0A>(mActual, k);
-         auto tensorL0A = tla::MakeTensor(l0ABuf, layoutL0A, Arch::PositionL0A{});
-         auto tensorTileL1A = GetTile(tensorL1A, tla::MakeCoord(0, 0), tla::MakeShape(mActual, k));
-         copyL1ToL0A(tensorL0A, tensorTileL1A);
- 
-         auto layoutL0B = tla::MakeLayout<ElementB, LayoutTagL0B>(k, n);
-         auto tensorL0B = tla::MakeTensor(l0BBuf, layoutL0B, Arch::PositionL0B{});
-         auto tensorTileL1B = GetTile(tensorL1B, tla::MakeCoord(0, 0), tla::MakeShape(k, n));
-         copyL1ToL0B(tensorL0B, tensorTileL1B);
- 
-         AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(0);   // Signal L1 free
-         AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(0);      // Signal L0 data ready
- 
-         // ---- Step 3: Mmad (Cube) ----
-         AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(0);
- 
-         auto layoutL0C = tla::MakeLayoutL0C(mActual, n);
-         auto tensorL0C = tla::MakeTensor(l0CBuf, layoutL0C, Arch::PositionL0C{});
- 
-         tileMmad(tensorL0C, tensorL0A, tensorL0B, mActual, n, k, true, 0b11);
- 
-         AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(0);      // Signal L0A/L0B free
- 
-         // ---- Step 4: L0C → GM (FixPipe, auto-triggered by unitFlag=0b11) ----
-         copyL0CToGm(tensorC, tensorL0C, 0b11);
-     }
- 
- private:
-     AscendC::LocalTensor<ElementA> l1ABuf;
-     AscendC::LocalTensor<ElementB> l1BBuf;
-     AscendC::LocalTensor<ElementA> l0ABuf;
-     AscendC::LocalTensor<ElementB> l0BBuf;
-     AscendC::LocalTensor<ElementAccumulator> l0CBuf;
- };
- 
- /**
-  * ChunkBwdDqkwg Cube Kernel 模板类
-  * 
-  * 模板参数:
-  * - BlockMmadPart1_: Part 1 的矩阵乘法 (dv @ h^T -> dw)
-  * - BlockMmadPart2_: Part 2 的矩阵乘法 (q @ k^T -> mm5)
-  * - BlockMmadPart3_: Part 3 的矩阵乘法 (do @ v^T -> ds)
-  * - BlockMmadPart4_: Part 4 的矩阵乘法 (do @ h^T -> dq)
-  * - BlockMmadPart5_: Part 5 的矩阵乘法 (v @ dh -> dk)
-  * - BlockMmadPart6_: Part 6 的矩阵乘法 (ds @ k -> dq+=)
-  * - BlockMmadPart7_: Part 7 的矩阵乘法 (ds^T @ q -> dk+=)
-  */
- template <
-     class BlockMmadPart1_,  // dv @ h^T -> dw
-     class BlockMmadPart2_,  // q @ k^T -> mm5
-     class BlockMmadPart3_,  // do @ v^T -> ds
-     class BlockMmadPart4_,  // do @ h^T -> dq
-     class BlockMmadPart5_,  // v @ dh -> dk
-     class BlockMmadPart6_,  // ds @ k -> dq
-     class BlockMmadPart7_   // ds^T @ q -> dk
- >
- class ChunkBwdDqkwgTla {
- public:
-     using BlockMmadPart1 = BlockMmadPart1_;
-     using BlockMmadPart2 = BlockMmadPart2_;
-     using BlockMmadPart3 = BlockMmadPart3_;
-     using BlockMmadPart4 = BlockMmadPart4_;
-     using BlockMmadPart5 = BlockMmadPart5_;
-     using BlockMmadPart6 = BlockMmadPart6_;
-     using BlockMmadPart7 = BlockMmadPart7_;
-     
-     using ArchTag = typename BlockMmadPart1::ArchTag;
-     
-     // 数据类型定义 (基于 Part 2: q @ k^T)
-     using ElementA = typename BlockMmadPart2::ElementA;
-     using ElementB = typename BlockMmadPart2::ElementB;
-     using ElementC = typename BlockMmadPart2::ElementC;
-     
-     // Layout 定义
-     using LayoutRowMajor = layout::RowMajor;
-     using LayoutColMajor = layout::ColumnMajor;
-     
-     /// Parameters structure
-     struct Params {
-         // 输入指针
-         GM_ADDR ptrQ;      // [B, H, T, K]
-         GM_ADDR ptrK;      // [B, H, T, K]
-         GM_ADDR ptrV;      // [B, H, T, V]
-         GM_ADDR ptrG;      // [B, H, T]
-         GM_ADDR ptrH;      // [B, num_chunks, H, K, V]
-         GM_ADDR ptrDo;     // [B, H, T, V]
-         GM_ADDR ptrDh;     // [B, num_chunks, H, K, V]
-         GM_ADDR ptrDv;     // [B, H, T, V]
-         //varlen
-         GM_ADDR ptrCuSeqLens;
-         GM_ADDR ptrChunkIndices;
-         
-         // 输出指针
-         GM_ADDR ptrDq;     // [B, H, T, K]
-         GM_ADDR ptrDk;     // [B, H, T, K]
-         GM_ADDR ptrDw;     // [B, H, T, K]
-         GM_ADDR ptrDg;     // [B, H, T]
-         
-         // Workspace 指针
-         GM_ADDR ptrWorkspace;
-         
-         // Workspace 偏移
-         uint64_t wsDwOffset;
-         uint64_t wsDgLastOffset;
-         uint64_t wsMm5Offset;
-         uint64_t wsDsTempOffset;
-         uint64_t wsMm6Offset;
-         uint64_t wsMm7Offset;
-         
-         // 形状参数
-         uint64_t B;// = CONST_B;
-         uint64_t H;// = CONST_H;
-         uint64_t T;// = CONST_T;
-         uint64_t K;// = CONST_K;
-         uint64_t V;// = CONST_V;
-         uint64_t BT;// = CONST_BT;
-         uint64_t numChunks;// = CONST_NUM_CHUNKS;
-         // uint64_t chunkSize = 64;
-         uint64_t isVarLen;
-         
-         // 其他参数
-         float scale;
-         
-         CATLASS_DEVICE
-         Params() {}
-         
-         CATLASS_DEVICE
-         Params(
-             GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
-             GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
-             GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
-             GM_ADDR workspace,
-             uint64_t B, uint64_t H, uint64_t T, uint64_t K, uint64_t V, uint64_t BT, uint64_t numChunks, 
-             uint64_t wsDw, uint64_t wsDgLast, uint64_t wsMm5, uint64_t wsDsTemp, uint64_t wsMm6, uint64_t wsMm7,
-             float s, uint64_t isVarLen
-         ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
-             ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLens(cu_seqlen), ptrChunkIndices(chunk_indices),
-             ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
-             ptrWorkspace(workspace),
-             wsDwOffset(wsDw), wsDgLastOffset(wsDgLast),
-             wsMm5Offset(wsMm5), wsDsTempOffset(wsDsTemp), wsMm6Offset(wsMm6), wsMm7Offset(wsMm7),
-             scale(s), B(B), H(H), T(T), K(K), V(V), BT(BT), numChunks(numChunks), isVarLen(isVarLen) {}
-     };
-     
-     CATLASS_DEVICE
-     ChunkBwdDqkwgTla() {}
-     
-     template <int32_t CORE_TYPE = g_coreType>
-     CATLASS_DEVICE
-     void operator()(Params const &params);
-     
-     /**
-      * AIC (Cube) 执行入口
-      */
-     template <>
-     CATLASS_DEVICE
-     void operator()<AscendC::AIC>(Params const &params) {
-         Arch::Resource<ArchTag> resource;
-         uint32_t coreIdx = AscendC::GetBlockIdx();
-         uint32_t coreNum = AscendC::GetBlockNum();
-         
-         uint32_t coreLoops = params.B * params.numChunks;
-         
-         // Layout 创建
-         auto layoutBTxK = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.K);
-         auto layoutKxBT = LayoutColMajor::MakeLayout<ElementA>(params.K, params.BT);
-         auto layoutBTxV = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.V);
-         auto layoutVxBT = LayoutColMajor::MakeLayout<ElementA>(params.V, params.BT);
-         auto layoutBTxBT = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.BT);
-         auto layoutBTxBT_T = LayoutColMajor::MakeLayout<ElementA>(params.BT, params.BT);
-         auto layoutKxV = LayoutRowMajor::MakeLayout<ElementA>(params.K, params.V);
-         auto layoutVxK = LayoutColMajor::MakeLayout<ElementA>(params.V, params.K);
- 
-         uint32_t bos = 0;
-         uint32_t eos = 0;
- 
-         // ========== Part 1: b_dw = b_dv @ b_h^T ==========
-         {
-             BlockMmadPart1 blockMmadPart1(resource);
-             auto layoutH = LayoutColMajor::MakeLayout<ElementA>(params.K, params.V);
-             // printf("[cube]coreLoops %d, H %d\n",coreLoops,params.H);
-             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
-                                 params.BT, loopIdx, bos, eos);
-                 uint32_t actual_chunk_len = eos-bos;
-                 uint32_t bIdx = loopIdx / params.numChunks;
-                 uint32_t chunkIdx = loopIdx % params.numChunks;
- 
-                 GemmCoord actualBlockShape{
-                     static_cast<uint32_t>(actual_chunk_len),
-                     static_cast<uint32_t>(params.K),
-                     static_cast<uint32_t>(params.V)
-                 };
- 
-                 for (uint32_t h = 0; h < params.H; h++) {
- 
-                     // 设置 GM 地址
-                     // dv: [B, H, T, V] -> offset = ((b * H + h) * T + chunk * BT) * V
-                     // uint64_t dvOffset = ((bIdx * params.H + h) * params.T + bos) * params.V;
-                     uint64_t dvOffset = (h * params.T + bos) * params.V;
- 
-                     // h: [B, H, num_chunks, K, V] -> offset = ((b * numChunks + chunk) * H + h) * K * V
-                     uint64_t hOffset = ((bIdx * params.H + h) * params.numChunks + chunkIdx) * params.K * params.V;
- 
-                     // dw output (workspace): [B, H, T, K]
-                     // uint64_t dwOffset = ((bIdx * params.H + h) * params.T + bos) * params.K;
-                     uint64_t dwOffset = (h * params.T + bos) * params.K;
- 
-                     GlobalTensor<ElementA> gmDv;
-                     gmDv.SetGlobalBuffer((__gm__ ElementA *)params.ptrDv + dvOffset);
-                     // gmDv.SetGlobalBuffer((__gm__ ElementA *)params.ptrDv);
-                     GlobalTensor<ElementA> gmH;
-                     gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
-                     // gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH);
-                     GlobalTensor<ElementC> gmDw;
-                     // gmDw.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDwOffset) + dwOffset);
-                     gmDw.SetGlobalBuffer((__gm__ ElementC *)params.ptrDw + dwOffset);
- 
-                     auto tensorDv = tla::MakeTensor(gmDv, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
-                     auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});  // h^T
-                     auto tensorDw = tla::MakeTensor(gmDw, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                     
-                     AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
- 
-                     auto tensorBlockDv = GetTile(tensorDv, tla::MakeCoord(0, 0), 
-                                                   tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                     auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                     auto tensorBlockDw = GetTile(tensorDw, tla::MakeCoord(0, 0), 
-                                                   tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                     
-                     blockMmadPart1(tensorBlockDv, tensorBlockH, tensorBlockDw, actualBlockShape);
- 
- 
-                     AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
- 
-                 }
-             }
-             // 最终同步(后移)
-             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-         }
- 
-         // ========== Part 2: mm5 = q @ k^T (纯 Cube) ==========
-         {
-             BlockMmadPart2 blockMmadPart2(resource);
-             
-             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
-                                 params.BT, loopIdx, bos, eos);
-                 uint32_t actual_chunk_len = eos-bos;
-                 uint32_t bIdx = loopIdx / params.numChunks;
-                 uint32_t chunkIdx = loopIdx % params.numChunks;
-                 
-                 GemmCoord actualBlockShape{
-                     static_cast<uint32_t>(actual_chunk_len),
-                     static_cast<uint32_t>(actual_chunk_len),
-                     static_cast<uint32_t>(params.K)
-                 };
-                 
-                 for (uint32_t h = 0; h < params.H; h++) {
-                     // q, k: [B, H, T, K]
-                     uint64_t qkOffset = (h * params.T + bos) * params.K;
-                     // mm5: workspace [B, H, T, BT]
-                     uint64_t mm5Offset = (h * params.T + bos) * params.BT;
-                     
-                     GlobalTensor<ElementA> gmQ;
-                     gmQ.SetGlobalBuffer((__gm__ ElementA *)params.ptrQ + qkOffset);
-                     GlobalTensor<ElementA> gmK;
-                     gmK.SetGlobalBuffer((__gm__ ElementA *)params.ptrK + qkOffset);
-                     GlobalTensor<ElementC> gmMm5;
-                     gmMm5.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm5Offset) + mm5Offset);
- 
-                     auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                     auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutKxBT), Arch::PositionGM{});  // k^T
-                     auto tensorMm5 = tla::MakeTensor(gmMm5, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
- 
-                     auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                     auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                     auto tensorBlockMm5 = GetTile(tensorMm5, tla::MakeCoord(0, 0), 
-                                                    tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                     
-                     blockMmadPart2(tensorBlockQ, tensorBlockK, tensorBlockMm5, actualBlockShape);
- 
-                 }
-             }
- 
-         }
- 
-         // ========== Part 3: b_ds = b_do @ b_v^T ==========
-         {
-             // AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-             
-             BlockMmadPart3 blockMmadPart3(resource);
-             
-             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
-                                 params.BT, loopIdx, bos, eos);
-                 uint32_t actual_chunk_len = eos-bos;
-                 uint32_t bIdx = loopIdx / params.numChunks;
-                 uint32_t chunkIdx = loopIdx % params.numChunks;
-                 
-                 GemmCoord actualBlockShape{
-                     static_cast<uint32_t>(actual_chunk_len),
-                     static_cast<uint32_t>(actual_chunk_len),
-                     static_cast<uint32_t>(params.V)
-                 };
-                 
-                 for (uint32_t h = 0; h < params.H; h++) {
-                     // do, v: [B, H, T, V]
-                     // uint64_t dvOffset = ((bIdx * params.H + h) * params.T + bos) * params.V;
-                     uint64_t dvOffset = (h * params.T + bos) * params.V;
-                     // ds_temp: workspace [B, H, T, BT]
-                     // uint64_t dsOffset = ((bIdx * params.H + h) * params.T + bos) * params.BT;
-                     uint64_t dsOffset = (h * params.T + bos) * params.BT;
-                     
-                     GlobalTensor<ElementA> gmDo;
-                     gmDo.SetGlobalBuffer((__gm__ ElementA *)params.ptrDo + dvOffset);
-                     GlobalTensor<ElementA> gmV;
-                     gmV.SetGlobalBuffer((__gm__ ElementA *)params.ptrV + dvOffset);
-                     GlobalTensor<ElementC> gmDs;
-                     gmDs.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
-                     
-                     auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
-                     auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutVxBT), Arch::PositionGM{});  // v^T
-                     auto tensorDs = tla::MakeTensor(gmDs, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
-                     
-                     AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-                     // AscendC::PipeBarrier<PIPE_MTE2>();
-                     auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0), 
-                                                   tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                     auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                     auto tensorBlockDs = GetTile(tensorDs, tla::MakeCoord(0, 0), 
-                                                   tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                     
-                     blockMmadPart3(tensorBlockDo, tensorBlockV, tensorBlockDs, actualBlockShape);
- 
-                     AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
-                 }
-             }
-             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-         }
- 
-         // ========== Fused Part 4+6: b_dq = b_do @ b_h^T, then mm6 = b_ds_temp @ b_k ==========
-         // 每次迭代先计算 dq, 再计算 mm6, Vector 端在 UB 中完成 dq += mm6 避免 GM 往返
-         {
-             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
-                                 params.BT, loopIdx, bos, eos);
-                 uint32_t actual_chunk_len = eos-bos;
-                 uint32_t bIdx = loopIdx / params.numChunks;
-                 uint32_t chunkIdx = loopIdx % params.numChunks;
- 
-                 for (uint32_t h = 0; h < params.H; h++) {
-                     // --- Sub-part 4: dq = do @ h^T ---
-                     {
-                         GemmCoord actualBlockShape{
-                             static_cast<uint32_t>(actual_chunk_len),
-                             static_cast<uint32_t>(params.K),
-                             static_cast<uint32_t>(params.V)
-                         };
-                         uint64_t doOffset = (h * params.T + bos) * params.V;
-                         uint64_t hOffset = ((bIdx * params.H + h) * params.numChunks + chunkIdx) * params.K * params.V;
-                         uint64_t dqOffset = (h * params.T + bos) * params.K;
- 
-                         GlobalTensor<ElementA> gmDo;
-                         gmDo.SetGlobalBuffer((__gm__ ElementA *)params.ptrDo + doOffset);
-                         GlobalTensor<ElementA> gmH;
-                         gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
-                         GlobalTensor<ElementC> gmDq;
-                         gmDq.SetGlobalBuffer((__gm__ ElementC *)params.ptrDq + dqOffset);
- 
-                         auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
-                         auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});
-                         auto tensorDq = tla::MakeTensor(gmDq, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
- 
-                         AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
- 
-                         auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0),
-                                                       tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                         auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0),
-                                                      tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                         auto tensorBlockDq = GetTile(tensorDq, tla::MakeCoord(0, 0),
-                                                       tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
- 
-                         BlockMmadPart4 blockMmadPart4(resource);
-                         blockMmadPart4(tensorBlockDo, tensorBlockH, tensorBlockDq, actualBlockShape);
-                     }
-                     AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
- 
-                     // --- Sub-part 6: mm6 = ds_temp @ k ---
-                     {
-                         GemmCoord actualBlockShape{
-                             static_cast<uint32_t>(actual_chunk_len),
-                             static_cast<uint32_t>(params.K),
-                             static_cast<uint32_t>(actual_chunk_len)
-                         };
-                         uint64_t dsOffset = (h * params.T + bos) * params.BT;
-                         uint64_t kOffset = (h * params.T + bos) * params.K;
- 
-                         GlobalTensor<ElementA> gmDsTemp;
-                         gmDsTemp.SetGlobalBuffer((__gm__ ElementA *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
-                         GlobalTensor<ElementA> gmK;
-                         gmK.SetGlobalBuffer((__gm__ ElementA *)params.ptrK + kOffset);
-                         GlobalTensor<ElementC> gmMm6;
-                         gmMm6.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm6Offset) + kOffset);
- 
-                         auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
-                         auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                         auto tensorMm6 = tla::MakeTensor(gmMm6, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
- 
-                         AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
- 
-                         auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0),
-                                                           tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                         auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0),
-                                                      tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                         auto tensorBlockMm6 = GetTile(tensorMm6, tla::MakeCoord(0, 0),
-                                                        tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
- 
-                         BlockMmadPart6 blockMmadPart6(resource);
-                         blockMmadPart6(tensorBlockDsTemp, tensorBlockK, tensorBlockMm6, actualBlockShape);
-                     }
-                     AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
-                 }
-             }
-             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-         }
- 
-         // ========== Fused Part 5+7: b_dk = b_v @ b_dh, then mm7 = b_ds_temp^T @ b_q ==========
-         {
-             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
-                                 params.BT, loopIdx, bos, eos);
-                 uint32_t actual_chunk_len = eos-bos;
-                 uint32_t bIdx = loopIdx / params.numChunks;
-                 uint32_t chunkIdx = loopIdx % params.numChunks;
- 
-                 for (uint32_t h = 0; h < params.H; h++) {
-                     // --- Sub-part 5: dk = v @ dh ---
-                     {
-                         GemmCoord actualBlockShape{
-                             static_cast<uint32_t>(actual_chunk_len),
-                             static_cast<uint32_t>(params.K),
-                             static_cast<uint32_t>(params.V)
-                         };
-                         uint64_t vOffset = (h * params.T + bos) * params.V;
-                         uint64_t dhOffset = ((bIdx * params.H + h) * params.numChunks + chunkIdx) * params.K * params.V;
-                         uint64_t dkOffset = (h * params.T + bos) * params.K;
- 
-                         GlobalTensor<ElementA> gmV;
-                         gmV.SetGlobalBuffer((__gm__ ElementA *)params.ptrV + vOffset);
-                         GlobalTensor<ElementA> gmDh;
-                         gmDh.SetGlobalBuffer((__gm__ ElementA *)params.ptrDh + dhOffset);
-                         GlobalTensor<ElementC> gmDk;
-                         gmDk.SetGlobalBuffer((__gm__ ElementC *)params.ptrDk + dkOffset);
- 
-                         auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
-                         auto tensorDh = tla::MakeTensor(gmDh, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});
-                         auto tensorDk = tla::MakeTensor(gmDk, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
- 
-                         AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
- 
-                         auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0),
+namespace Catlass::Gemm::Kernel {
+
+    /**
+     * TileGemmDirect: Single-shot tile-level GEMM replacing BlockMmadTla.
+     * Directly performs GM→L1→L0→Mmad→FixPipe→GM without tiling loops or pingpong buffers.
+     * Optimal when all matrix dimensions fit in a single L0 tile (M≤128, N≤128, K≤128).
+     *
+     * Compared to BlockMmadTla<MmadPingpong>:
+     *  - No multi-stage L1/L0 buffers (1 stage vs 2)
+     *  - No nested tiling loops (kL1×mL0×kL0×nL0 all = 1 for our sizes)
+     *  - Minimal event overhead: 4 Set + 4 Wait per GEMM vs ~20+ in Block
+     *  - Half the L1/L0 memory usage (no pingpong double-buffering)
+     */
+    template <class ArchTag_, class ElementC_, class TileCopy_>
+    struct TileGemmDirect {
+        using ArchTag = ArchTag_;
+        using TileCopy = TileCopy_;
+        using ElementA = typename TileCopy::ElementA;
+        using ElementB = typename TileCopy::ElementB;
+        using ElementC = ElementC_;
+        using ElementAccumulator = typename TileCopy::ElementAccumulator;
+    
+        using LayoutTagL1A = typename TileCopy::LayoutTagL1A;
+        using LayoutTagL1B = typename TileCopy::LayoutTagL1B;
+        using LayoutTagL0A = typename TileCopy::LayoutTagL0A;
+        using LayoutTagL0B = typename TileCopy::LayoutTagL0B;
+        using CopyL1ToL0A = typename TileCopy::CopyL1ToL0A;
+        using CopyL1ToL0B = typename TileCopy::CopyL1ToL0B;
+        using TileMmadType = Tile::TileMmadTla<ArchTag, ElementA, LayoutTagL1A>;
+    
+        // Single L0 tile dimensions (max supported by AtlasA2 Cube)
+        static constexpr uint32_t TILE_M = 128;
+        static constexpr uint32_t TILE_N = 128;
+        static constexpr uint32_t TILE_K = 128;
+    
+        // Single-stage buffer sizes (no pingpong)
+        static constexpr uint32_t L1A_TILE_SIZE = TILE_M * TILE_K * sizeof(ElementA);
+        static constexpr uint32_t L1B_TILE_SIZE = TILE_K * TILE_N * sizeof(ElementB);
+    
+        // Static L1 layouts for tile-sized buffers
+        static constexpr auto L1A_LAYOUT =
+            tla::MakeLayout<ElementA, LayoutTagL1A>(tla::Int<TILE_M>{}, tla::Int<TILE_K>{});
+        static constexpr auto L1B_LAYOUT =
+            tla::MakeLayout<ElementB, LayoutTagL1B>(tla::Int<TILE_K>{}, tla::Int<TILE_N>{});
+    
+        /// Construct: allocate single-stage buffers, initialize events
+        CATLASS_DEVICE
+        TileGemmDirect(Arch::Resource<ArchTag> &resource)
+        {
+            if ASCEND_IS_AIC {
+                AscendC::SetMMLayoutTransform(true);
+    
+                // Allocate single-stage buffers from resource pools
+                l1ABuf = resource.l1Buf.template GetBufferByByte<ElementA>(0);
+                l1BBuf = resource.l1Buf.template GetBufferByByte<ElementB>(L1A_TILE_SIZE);
+                l0ABuf = resource.l0ABuf.template GetBufferByByte<ElementA>(0);
+                l0BBuf = resource.l0BBuf.template GetBufferByByte<ElementB>(0);
+                l0CBuf = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(0);
+    
+                // Initialize events: buffers are initially free
+                AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(0);  // L1 free for MTE2 write
+                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(0);     // L0A/L0B free for MTE1 write
+            }
+        }
+    
+        /// Destructor: drain pending events
+        CATLASS_DEVICE
+        ~TileGemmDirect()
+        {
+            if ASCEND_IS_AIC {
+                AscendC::SetMMLayoutTransform(false);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(0);
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(0);
+            }
+        }
+    
+        /// Perform a single-tile GEMM: C = A @ B
+        template <class TensorA, class TensorB, class TensorC>
+        CATLASS_DEVICE
+        void operator()(TensorA &tensorA, TensorB &tensorB, TensorC &tensorC, GemmCoord const &actualShape)
+        {
+            using CopyGmToL1A = typename TileCopy::template CopyGmToL1A<TensorA>;
+            using CopyGmToL1B = typename TileCopy::template CopyGmToL1B<TensorB>;
+    #if (defined(CATLASS_ARCH) && CATLASS_ARCH == 2201)
+            using CopyL0CToGm = typename TileCopy::template CopyL0CToGm<TensorC>;
+    #endif
+    #if (defined(CATLASS_ARCH) && CATLASS_ARCH == 3510)
+            using CopyL0CToGm = typename TileCopy::template CopyL0CToDst<TensorC>;
+    #endif
+    
+            CopyGmToL1A copyGmToL1A;
+            CopyGmToL1B copyGmToL1B;
+            CopyL1ToL0A copyL1ToL0A;
+            CopyL1ToL0B copyL1ToL0B;
+            CopyL0CToGm copyL0CToGm;
+            TileMmadType tileMmad;
+    
+            uint32_t m = actualShape.m();
+            uint32_t k = actualShape.k();
+            uint32_t n = actualShape.n();
+    
+            // Avoid gemv mode on AtlasA2
+            uint32_t mActual = m;
+            if constexpr (std::is_same_v<ArchTag, Arch::AtlasA2>) {
+                if (mActual == 1) mActual = 16;
+            }
+    
+            // Create L1 tensor views (static tile-size layout)
+            auto tensorL1A = tla::MakeTensor(l1ABuf, L1A_LAYOUT, Arch::PositionL1{});
+            auto tensorL1B = tla::MakeTensor(l1BBuf, L1B_LAYOUT, Arch::PositionL1{});
+    
+            // ---- Step 1: GM → L1 (MTE2) ----
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(0);  // Wait L1 free
+            copyGmToL1A(tensorL1A, tensorA);
+            copyGmToL1B(tensorL1B, tensorB);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(0);   // Signal L1 data ready
+    
+            // ---- Step 2: L1 → L0A/L0B (MTE1) ----
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(0);  // Wait L1 data ready
+            AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(0);     // Wait L0A/L0B free
+    
+            auto layoutL0A = tla::MakeLayout<ElementA, LayoutTagL0A>(mActual, k);
+            auto tensorL0A = tla::MakeTensor(l0ABuf, layoutL0A, Arch::PositionL0A{});
+            auto tensorTileL1A = GetTile(tensorL1A, tla::MakeCoord(0, 0), tla::MakeShape(mActual, k));
+            copyL1ToL0A(tensorL0A, tensorTileL1A);
+    
+            auto layoutL0B = tla::MakeLayout<ElementB, LayoutTagL0B>(k, n);
+            auto tensorL0B = tla::MakeTensor(l0BBuf, layoutL0B, Arch::PositionL0B{});
+            auto tensorTileL1B = GetTile(tensorL1B, tla::MakeCoord(0, 0), tla::MakeShape(k, n));
+            copyL1ToL0B(tensorL0B, tensorTileL1B);
+    
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(0);   // Signal L1 free
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(0);      // Signal L0 data ready
+    
+            // ---- Step 3: Mmad (Cube) ----
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(0);
+    
+            auto layoutL0C = tla::MakeLayoutL0C(mActual, n);
+            auto tensorL0C = tla::MakeTensor(l0CBuf, layoutL0C, Arch::PositionL0C{});
+    
+            tileMmad(tensorL0C, tensorL0A, tensorL0B, mActual, n, k, true, 0b11);
+    
+            AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(0);      // Signal L0A/L0B free
+    
+            // ---- Step 4: L0C → GM (FixPipe, auto-triggered by unitFlag=0b11) ----
+            copyL0CToGm(tensorC, tensorL0C, 0b11);
+        }
+    
+    private:
+        AscendC::LocalTensor<ElementA> l1ABuf;
+        AscendC::LocalTensor<ElementB> l1BBuf;
+        AscendC::LocalTensor<ElementA> l0ABuf;
+        AscendC::LocalTensor<ElementB> l0BBuf;
+        AscendC::LocalTensor<ElementAccumulator> l0CBuf;
+    };
+    
+    /**
+     * ChunkBwdDqkwg Cube Kernel 模板类
+     * 
+     * 模板参数:
+     * - BlockMmadPart1_: Part 1 的矩阵乘法 (dv @ h^T -> dw)
+     * - BlockMmadPart2_: Part 2 的矩阵乘法 (q @ k^T -> mm5)
+     * - BlockMmadPart3_: Part 3 的矩阵乘法 (do @ v^T -> ds)
+     * - BlockMmadPart4_: Part 4 的矩阵乘法 (do @ h^T -> dq)
+     * - BlockMmadPart5_: Part 5 的矩阵乘法 (v @ dh -> dk)
+     * - BlockMmadPart6_: Part 6 的矩阵乘法 (ds @ k -> dq+=)
+     * - BlockMmadPart7_: Part 7 的矩阵乘法 (ds^T @ q -> dk+=)
+     */
+    template <
+        class BlockMmadPart1_,  // dv @ h^T -> dw
+        class BlockMmadPart2_,  // q @ k^T -> mm5
+        class BlockMmadPart3_,  // do @ v^T -> ds
+        class BlockMmadPart4_,  // do @ h^T -> dq
+        class BlockMmadPart5_,  // v @ dh -> dk
+        class BlockMmadPart6_,  // ds @ k -> dq
+        class BlockMmadPart7_   // ds^T @ q -> dk
+    >
+    class ChunkBwdDqkwgTla {
+    public:
+        using BlockMmadPart1 = BlockMmadPart1_;
+        using BlockMmadPart2 = BlockMmadPart2_;
+        using BlockMmadPart3 = BlockMmadPart3_;
+        using BlockMmadPart4 = BlockMmadPart4_;
+        using BlockMmadPart5 = BlockMmadPart5_;
+        using BlockMmadPart6 = BlockMmadPart6_;
+        using BlockMmadPart7 = BlockMmadPart7_;
+        
+        using ArchTag = typename BlockMmadPart1::ArchTag;
+        
+        // 数据类型定义 (基于 Part 2: q @ k^T)
+        using ElementA = typename BlockMmadPart2::ElementA;
+        using ElementB = typename BlockMmadPart2::ElementB;
+        using ElementC = typename BlockMmadPart2::ElementC;
+        
+        // Layout 定义
+        using LayoutRowMajor = layout::RowMajor;
+        using LayoutColMajor = layout::ColumnMajor;
+        
+        /// Parameters structure
+        struct Params {
+            // 输入指针
+            GM_ADDR ptrQ;      // [B, H, T, K]
+            GM_ADDR ptrK;      // [B, H, T, K]
+            GM_ADDR ptrV;      // [B, H, T, V]
+            GM_ADDR ptrG;      // [B, H, T]
+            GM_ADDR ptrH;      // [B, num_chunks, H, K, V]
+            GM_ADDR ptrDo;     // [B, H, T, V]
+            GM_ADDR ptrDh;     // [B, num_chunks, H, K, V]
+            GM_ADDR ptrDv;     // [B, H, T, V]
+            //varlen
+            GM_ADDR ptrCuSeqLens;
+            GM_ADDR ptrChunkIndices;
+            
+            // 输出指针
+            GM_ADDR ptrDq;     // [B, H, T, K]
+            GM_ADDR ptrDk;     // [B, H, T, K]
+            GM_ADDR ptrDw;     // [B, H, T, K]
+            GM_ADDR ptrDg;     // [B, H, T]
+            
+            // Workspace 指针
+            GM_ADDR ptrWorkspace;
+            
+            // Workspace 偏移
+            uint64_t wsDwOffset;
+            uint64_t wsDgLastOffset;
+            uint64_t wsMm5Offset;
+            uint64_t wsDsTempOffset;
+            uint64_t wsMm6Offset;
+            uint64_t wsMm7Offset;
+            
+            // 形状参数
+            uint64_t B;// = CONST_B;
+            uint64_t H;// = CONST_H;
+            uint64_t T;// = CONST_T;
+            uint64_t K;// = CONST_K;
+            uint64_t V;// = CONST_V;
+            uint64_t BT;// = CONST_BT;
+            uint64_t numChunks;// = CONST_NUM_CHUNKS;
+            // uint64_t chunkSize = 64;
+            uint64_t isVarLen;
+            
+            // 其他参数
+            float scale;
+            
+            CATLASS_DEVICE
+            Params() {}
+            
+            CATLASS_DEVICE
+            Params(
+                GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
+                GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
+                GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
+                GM_ADDR workspace,
+                uint64_t B, uint64_t H, uint64_t T, uint64_t K, uint64_t V, uint64_t BT, uint64_t numChunks, 
+                uint64_t wsDw, uint64_t wsDgLast, uint64_t wsMm5, uint64_t wsDsTemp, uint64_t wsMm6, uint64_t wsMm7,
+                float s, uint64_t isVarLen
+            ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
+                ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLens(cu_seqlen), ptrChunkIndices(chunk_indices),
+                ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
+                ptrWorkspace(workspace),
+                wsDwOffset(wsDw), wsDgLastOffset(wsDgLast),
+                wsMm5Offset(wsMm5), wsDsTempOffset(wsDsTemp), wsMm6Offset(wsMm6), wsMm7Offset(wsMm7),
+                scale(s), B(B), H(H), T(T), K(K), V(V), BT(BT), numChunks(numChunks), isVarLen(isVarLen) {}
+        };
+        
+        CATLASS_DEVICE
+        ChunkBwdDqkwgTla() {}
+        
+        template <int32_t CORE_TYPE = g_coreType>
+        CATLASS_DEVICE
+        void operator()(Params const &params);
+        
+        /**
+         * AIC (Cube) 执行入口
+         */
+        template <>
+        CATLASS_DEVICE
+        void operator()<AscendC::AIC>(Params const &params) {
+            Arch::Resource<ArchTag> resource;
+            uint32_t coreIdx = AscendC::GetBlockIdx();
+            uint32_t coreNum = AscendC::GetBlockNum();
+            
+            uint32_t coreLoops = params.B * params.numChunks;
+            
+            // Layout 创建
+            auto layoutBTxK = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.K);
+            auto layoutKxBT = LayoutColMajor::MakeLayout<ElementA>(params.K, params.BT);
+            auto layoutBTxV = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.V);
+            auto layoutVxBT = LayoutColMajor::MakeLayout<ElementA>(params.V, params.BT);
+            auto layoutBTxBT = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.BT);
+            auto layoutBTxBT_T = LayoutColMajor::MakeLayout<ElementA>(params.BT, params.BT);
+            auto layoutKxV = LayoutRowMajor::MakeLayout<ElementA>(params.K, params.V);
+            auto layoutVxK = LayoutColMajor::MakeLayout<ElementA>(params.V, params.K);
+    
+            uint32_t bos = 0;
+            uint32_t eos = 0;
+    
+            // ========== Part 1: b_dw = b_dv @ b_h^T ==========
+            {
+                BlockMmadPart1 blockMmadPart1(resource);
+                auto layoutH = LayoutColMajor::MakeLayout<ElementA>(params.K, params.V);
+                // printf("[cube]coreLoops %d, H %d\n",coreLoops,params.H);
+                for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                    GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                    params.BT, loopIdx, bos, eos);
+                    uint32_t actual_chunk_len = eos-bos;
+                    uint32_t bIdx = loopIdx / params.numChunks;
+                    uint32_t chunkIdx = loopIdx % params.numChunks;
+    
+                    GemmCoord actualBlockShape{
+                        static_cast<uint32_t>(actual_chunk_len),
+                        static_cast<uint32_t>(params.K),
+                        static_cast<uint32_t>(params.V)
+                    };
+    
+                    for (uint32_t h = 0; h < params.H; h++) {
+    
+                        // 设置 GM 地址
+                        // dv: [B, H, T, V] -> offset = ((b * H + h) * T + chunk * BT) * V
+                        // uint64_t dvOffset = ((bIdx * params.H + h) * params.T + bos) * params.V;
+                        uint64_t dvOffset = (h * params.T + bos) * params.V;
+    
+                        // h: [B, H, num_chunks, K, V] -> offset = ((b * numChunks + chunk) * H + h) * K * V
+                        uint64_t hOffset = ((bIdx * params.H + h) * params.numChunks + chunkIdx) * params.K * params.V;
+    
+                        // dw output (workspace): [B, H, T, K]
+                        // uint64_t dwOffset = ((bIdx * params.H + h) * params.T + bos) * params.K;
+                        uint64_t dwOffset = (h * params.T + bos) * params.K;
+    
+                        GlobalTensor<ElementA> gmDv;
+                        gmDv.SetGlobalBuffer((__gm__ ElementA *)params.ptrDv + dvOffset);
+                        // gmDv.SetGlobalBuffer((__gm__ ElementA *)params.ptrDv);
+                        GlobalTensor<ElementA> gmH;
+                        gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
+                        // gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH);
+                        GlobalTensor<ElementC> gmDw;
+                        // gmDw.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDwOffset) + dwOffset);
+                        gmDw.SetGlobalBuffer((__gm__ ElementC *)params.ptrDw + dwOffset);
+    
+                        auto tensorDv = tla::MakeTensor(gmDv, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                        auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});  // h^T
+                        auto tensorDw = tla::MakeTensor(gmDw, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                        
+                        AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+    
+                        auto tensorBlockDv = GetTile(tensorDv, tla::MakeCoord(0, 0), 
                                                       tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                         auto tensorBlockDh = GetTile(tensorDh, tla::MakeCoord(0, 0),
-                                                       tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                         auto tensorBlockDk = GetTile(tensorDk, tla::MakeCoord(0, 0),
+                        auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), 
+                                                     tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                        auto tensorBlockDw = GetTile(tensorDw, tla::MakeCoord(0, 0), 
+                                                      tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                        
+                        blockMmadPart1(tensorBlockDv, tensorBlockH, tensorBlockDw, actualBlockShape);
+    
+    
+                        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+    
+                    }
+                }
+                // 最终同步(后移)
+                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            }
+    
+            // ========== Part 2: mm5 = q @ k^T (纯 Cube) ==========
+            {
+                BlockMmadPart2 blockMmadPart2(resource);
+                
+                for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                    GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                    params.BT, loopIdx, bos, eos);
+                    uint32_t actual_chunk_len = eos-bos;
+                    uint32_t bIdx = loopIdx / params.numChunks;
+                    uint32_t chunkIdx = loopIdx % params.numChunks;
+                    
+                    GemmCoord actualBlockShape{
+                        static_cast<uint32_t>(actual_chunk_len),
+                        static_cast<uint32_t>(actual_chunk_len),
+                        static_cast<uint32_t>(params.K)
+                    };
+                    
+                    for (uint32_t h = 0; h < params.H; h++) {
+                        // q, k: [B, H, T, K]
+                        uint64_t qkOffset = (h * params.T + bos) * params.K;
+                        // mm5: workspace [B, H, T, BT]
+                        uint64_t mm5Offset = (h * params.T + bos) * params.BT;
+                        
+                        GlobalTensor<ElementA> gmQ;
+                        gmQ.SetGlobalBuffer((__gm__ ElementA *)params.ptrQ + qkOffset);
+                        GlobalTensor<ElementA> gmK;
+                        gmK.SetGlobalBuffer((__gm__ ElementA *)params.ptrK + qkOffset);
+                        GlobalTensor<ElementC> gmMm5;
+                        gmMm5.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm5Offset) + mm5Offset);
+    
+                        auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                        auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutKxBT), Arch::PositionGM{});  // k^T
+                        auto tensorMm5 = tla::MakeTensor(gmMm5, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
+    
+                        auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0), 
+                                                     tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                        auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), 
+                                                     tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                        auto tensorBlockMm5 = GetTile(tensorMm5, tla::MakeCoord(0, 0), 
                                                        tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
- 
-                         BlockMmadPart5 blockMmadPart5(resource);
-                         blockMmadPart5(tensorBlockV, tensorBlockDh, tensorBlockDk, actualBlockShape);
-                     }
-                     AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
- 
-                     // --- Sub-part 7: mm7 = ds_temp^T @ q ---
-                     {
-                         GemmCoord actualBlockShape{
-                             static_cast<uint32_t>(actual_chunk_len),
-                             static_cast<uint32_t>(params.K),
-                             static_cast<uint32_t>(actual_chunk_len)
-                         };
-                         uint64_t dsOffset = (h * params.T + bos) * params.BT;
-                         uint64_t qOffset = (h * params.T + bos) * params.K;
- 
-                         GlobalTensor<ElementA> gmDsTemp;
-                         gmDsTemp.SetGlobalBuffer((__gm__ ElementA *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
-                         GlobalTensor<ElementA> gmQ;
-                         gmQ.SetGlobalBuffer((__gm__ ElementA *)params.ptrQ + qOffset);
-                         GlobalTensor<ElementC> gmMm7;
-                         gmMm7.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm7Offset) + qOffset);
- 
-                         auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT_T), Arch::PositionGM{});
-                         auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                         auto tensorMm7 = tla::MakeTensor(gmMm7, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
- 
-                         AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
- 
-                         auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0),
-                                                           tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                         auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0),
-                                                      tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                         auto tensorBlockMm7 = GetTile(tensorMm7, tla::MakeCoord(0, 0),
-                                                        tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
- 
-                         BlockMmadPart7 blockMmadPart7(resource);
-                         blockMmadPart7(tensorBlockDsTemp, tensorBlockQ, tensorBlockMm7, actualBlockShape);
-                     }
-                     AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
-                 }
-             }
- 
-             // 最终同步
-             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-         }
- 
-     }
- };
- 
- } // namespace Catlass::Gemm::Kernel
- 
- /**
-  * Cube Process 类 (AIC 端入口)
-  */
- template <typename DataType, typename GType>
- class ChunkBwdDqkwgCubeProcess {
- public:
-     __aicore__ inline ChunkBwdDqkwgCubeProcess(
-         GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
-         GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
-         GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
-         GM_ADDR workspace
-     ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
-         ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLen(cu_seqlen), ptrChunkIndices(chunk_indices),
-         ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
-         ptrWorkspace(workspace) {}
-     
-     __aicore__ inline void Init(const ChunkBwdDqkwgTilingData &tiling);
-     __aicore__ inline void Process();
-     
- private:
-     // 输入输出指针
-     GM_ADDR ptrQ;
-     GM_ADDR ptrK;
-     GM_ADDR ptrV;
-     GM_ADDR ptrG;
-     GM_ADDR ptrH;
-     GM_ADDR ptrDo;
-     GM_ADDR ptrDh;
-     GM_ADDR ptrDv;
-     GM_ADDR ptrCuSeqLen;
-     GM_ADDR ptrChunkIndices;
-     GM_ADDR ptrDq;
-     GM_ADDR ptrDk;
-     GM_ADDR ptrDw;
-     GM_ADDR ptrDg;
-     GM_ADDR ptrWorkspace;
-     
-     // Tiling 参数
-     uint64_t B = CONST_B;
-     uint64_t H = CONST_H;
-     uint64_t T = CONST_T;
-     uint64_t K = CONST_K;
-     uint64_t V = CONST_V;
-     uint64_t BT = CONST_BT;
-     uint64_t numChunks = CONST_NUM_CHUNKS;
-     float scale;
-     uint64_t isVarLen;
-     
-     // Workspace 偏移
-     uint64_t wsDwOffset;
-     uint64_t wsDgLastOffset;
-     uint64_t wsMm5Offset;
-     uint64_t wsDsTempOffset;
-     uint64_t wsMm6Offset;
-     uint64_t wsMm7Offset;
- };
- 
- template <typename DataType, typename GType>
- __aicore__ inline void ChunkBwdDqkwgCubeProcess<DataType, GType>::Init(const ChunkBwdDqkwgTilingData &tiling) {
- 
- /*
-     // 设置 workspace 偏移
-     // wsDwOffset = 0;
-     wsDgLastOffset = 0;//B * H * numChunks * sizeof(float);
-     // wsDgLastOffset = ((wsDgLastOffset + 31) / 32) * 32;
-     wsMm5Offset = wsDgLastOffset + ((B * H * numChunks * sizeof(float) + 31) / 32) * 32;
-     // wsMm5Offset = wsMm5Offset;
-     wsDsTempOffset = wsMm5Offset + B * H * T * BT * sizeof(DataType);
-     wsMm6Offset = wsDsTempOffset + B * H * T * BT * sizeof(DataType);
-     wsMm7Offset = wsMm6Offset + B * H * T * K * sizeof(DataType);
- */
-     // printf("[cube] wsDgLastOffset %d,wsMm5Offset %d,wsDsTempOffset %d, wsMm6Offset %d wsMm7Offset %d\n",wsDgLastOffset,wsMm5Offset,wsDsTempOffset,wsMm6Offset, wsMm7Offset);
- ////////////////////tiling/////
-     scale = tiling.scale;
-     B = tiling.B;
-     H = tiling.H;
-     T = tiling.T;
-     K = tiling.K;
-     V = tiling.V;
-     BT = tiling.BT;
-     numChunks = tiling.numChunks;
-     wsDgLastOffset = tiling.wsDgLastOffset;
-     // wsDgLastOffset = ((wsDgLastOffset + 31) / 32) * 32;
-     wsMm5Offset = tiling.wsMm5Offset;
-     // wsMm5Offset = wsMm5Offset;
-     wsDsTempOffset = tiling.wsDsTempOffset;
-     wsMm6Offset = tiling.wsMm6Offset;
-     wsMm7Offset = tiling.wsMm7Offset;
-     isVarLen = tiling.isVarLen;
- // printf("[cube] DTYPE_G %d, float %d\n",sizeof(DTYPE_G),sizeof(float));
- }
- 
- template <typename DataType, typename GType>
- __aicore__ inline void ChunkBwdDqkwgCubeProcess<DataType, GType>::Process() {
-     using namespace Catlass;
-     using namespace Catlass::Gemm;
-     
-     // Layout 类型定义
-     using LayoutRowMajor = layout::RowMajor;
-     using LayoutColMajor = layout::ColumnMajor;
-     
-     // 架构和策略定义
-     using ArchTag = Arch::AtlasA2;
- 
-     // Part 1: dv @ h^T -> dw  [BT, V] @ [V, K] -> [BT, K]
-     using TileCopyPart1 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
-     using BlockMmadPart1 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart1>;
-     
-     // Part 2: q @ k^T -> mm5  [BT, K] @ [K, BT] -> [BT, BT]
-     using TileCopyPart2 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
-     using BlockMmadPart2 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart2>;
-     
-     // Part 3: do @ v^T -> ds  [BT, V] @ [V, BT] -> [BT, BT]
-     using TileCopyPart3 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
-     using BlockMmadPart3 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart3>;
-     
-     // Part 4: do @ h^T -> dq  [BT, V] @ [V, K] -> [BT, K]
-     using TileCopyPart4 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
-     using BlockMmadPart4 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart4>;
-     
-     // Part 5: v @ dh -> dk  [BT, V] @ [V, K] -> [BT, K]
-     using TileCopyPart5 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
-     using BlockMmadPart5 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart5>;
-     
-     // Part 6: ds @ k -> dq+=  [BT, BT] @ [BT, K] -> [BT, K]
-     using TileCopyPart6 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
-     using BlockMmadPart6 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart6>;
-     
-     // Part 7: ds^T @ q -> dk+=  [BT, BT] @ [BT, K] -> [BT, K]
-     using TileCopyPart7 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutColMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
-     using BlockMmadPart7 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart7>;
-     
-     // Kernel 实例
-     using MatmulKernel = Kernel::ChunkBwdDqkwgTla<
-         BlockMmadPart1, BlockMmadPart2, BlockMmadPart3, BlockMmadPart4,
-         BlockMmadPart5, BlockMmadPart6, BlockMmadPart7
-     >;
-     
-     MatmulKernel kernel;
-     typename MatmulKernel::Params params(
-         ptrQ, ptrK, ptrV, ptrG, ptrH,
-         ptrDo, ptrDh, ptrDv, ptrCuSeqLen, ptrChunkIndices,
-         ptrDq, ptrDk, ptrDw, ptrDg,
-         ptrWorkspace, B, H, T, K, V, BT, numChunks,
-         wsDwOffset, wsDgLastOffset, wsMm5Offset, wsDsTempOffset, wsMm6Offset, wsMm7Offset,
-         scale, isVarLen
-     );
-     
-     kernel(params);
- }
- 
- #endif  // CHUNK_BWD_DQKWG_CUBE_H
- 
+                        
+                        blockMmadPart2(tensorBlockQ, tensorBlockK, tensorBlockMm5, actualBlockShape);
+    
+                    }
+                }
+    
+            }
+    
+            // ========== Part 3: b_ds = b_do @ b_v^T ==========
+            {
+                // AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                
+                BlockMmadPart3 blockMmadPart3(resource);
+                
+                for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                    GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                    params.BT, loopIdx, bos, eos);
+                    uint32_t actual_chunk_len = eos-bos;
+                    uint32_t bIdx = loopIdx / params.numChunks;
+                    uint32_t chunkIdx = loopIdx % params.numChunks;
+                    
+                    GemmCoord actualBlockShape{
+                        static_cast<uint32_t>(actual_chunk_len),
+                        static_cast<uint32_t>(actual_chunk_len),
+                        static_cast<uint32_t>(params.V)
+                    };
+                    
+                    for (uint32_t h = 0; h < params.H; h++) {
+                        // do, v: [B, H, T, V]
+                        // uint64_t dvOffset = ((bIdx * params.H + h) * params.T + bos) * params.V;
+                        uint64_t dvOffset = (h * params.T + bos) * params.V;
+                        // ds_temp: workspace [B, H, T, BT]
+                        // uint64_t dsOffset = ((bIdx * params.H + h) * params.T + bos) * params.BT;
+                        uint64_t dsOffset = (h * params.T + bos) * params.BT;
+                        
+                        GlobalTensor<ElementA> gmDo;
+                        gmDo.SetGlobalBuffer((__gm__ ElementA *)params.ptrDo + dvOffset);
+                        GlobalTensor<ElementA> gmV;
+                        gmV.SetGlobalBuffer((__gm__ ElementA *)params.ptrV + dvOffset);
+                        GlobalTensor<ElementC> gmDs;
+                        gmDs.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
+                        
+                        auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                        auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutVxBT), Arch::PositionGM{});  // v^T
+                        auto tensorDs = tla::MakeTensor(gmDs, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
+                        
+                        AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                        // AscendC::PipeBarrier<PIPE_MTE2>();
+                        auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0), 
+                                                      tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                        auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), 
+                                                     tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                        auto tensorBlockDs = GetTile(tensorDs, tla::MakeCoord(0, 0), 
+                                                      tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                        
+                        blockMmadPart3(tensorBlockDo, tensorBlockV, tensorBlockDs, actualBlockShape);
+    
+                        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+                    }
+                }
+                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            }
+    
+            // ========== Fused Part 4+6: b_dq = b_do @ b_h^T, then mm6 = b_ds_temp @ b_k ==========
+            // 每次迭代先计算 dq, 再计算 mm6, Vector 端在 UB 中完成 dq += mm6 避免 GM 往返
+            {
+                for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                    GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                    params.BT, loopIdx, bos, eos);
+                    uint32_t actual_chunk_len = eos-bos;
+                    uint32_t bIdx = loopIdx / params.numChunks;
+                    uint32_t chunkIdx = loopIdx % params.numChunks;
+    
+                    for (uint32_t h = 0; h < params.H; h++) {
+                        // --- Sub-part 4: dq = do @ h^T ---
+                        {
+                            GemmCoord actualBlockShape{
+                                static_cast<uint32_t>(actual_chunk_len),
+                                static_cast<uint32_t>(params.K),
+                                static_cast<uint32_t>(params.V)
+                            };
+                            uint64_t doOffset = (h * params.T + bos) * params.V;
+                            uint64_t hOffset = ((bIdx * params.H + h) * params.numChunks + chunkIdx) * params.K * params.V;
+                            uint64_t dqOffset = (h * params.T + bos) * params.K;
+    
+                            GlobalTensor<ElementA> gmDo;
+                            gmDo.SetGlobalBuffer((__gm__ ElementA *)params.ptrDo + doOffset);
+                            GlobalTensor<ElementA> gmH;
+                            gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
+                            GlobalTensor<ElementC> gmDq;
+                            gmDq.SetGlobalBuffer((__gm__ ElementC *)params.ptrDq + dqOffset);
+    
+                            auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                            auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});
+                            auto tensorDq = tla::MakeTensor(gmDq, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+    
+                            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+    
+                            auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0),
+                                                          tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                            auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0),
+                                                         tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                            auto tensorBlockDq = GetTile(tensorDq, tla::MakeCoord(0, 0),
+                                                          tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+    
+                            BlockMmadPart4 blockMmadPart4(resource);
+                            blockMmadPart4(tensorBlockDo, tensorBlockH, tensorBlockDq, actualBlockShape);
+                        }
+                        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+    
+                        // --- Sub-part 6: mm6 = ds_temp @ k ---
+                        {
+                            GemmCoord actualBlockShape{
+                                static_cast<uint32_t>(actual_chunk_len),
+                                static_cast<uint32_t>(params.K),
+                                static_cast<uint32_t>(actual_chunk_len)
+                            };
+                            uint64_t dsOffset = (h * params.T + bos) * params.BT;
+                            uint64_t kOffset = (h * params.T + bos) * params.K;
+    
+                            GlobalTensor<ElementA> gmDsTemp;
+                            gmDsTemp.SetGlobalBuffer((__gm__ ElementA *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
+                            GlobalTensor<ElementA> gmK;
+                            gmK.SetGlobalBuffer((__gm__ ElementA *)params.ptrK + kOffset);
+                            GlobalTensor<ElementC> gmMm6;
+                            gmMm6.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm6Offset) + kOffset);
+    
+                            auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
+                            auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                            auto tensorMm6 = tla::MakeTensor(gmMm6, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+    
+                            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+    
+                            auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0),
+                                                              tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                            auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0),
+                                                         tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                            auto tensorBlockMm6 = GetTile(tensorMm6, tla::MakeCoord(0, 0),
+                                                           tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+    
+                            BlockMmadPart6 blockMmadPart6(resource);
+                            blockMmadPart6(tensorBlockDsTemp, tensorBlockK, tensorBlockMm6, actualBlockShape);
+                        }
+                        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+                    }
+                }
+                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            }
+    
+            // ========== Fused Part 5+7: b_dk = b_v @ b_dh, then mm7 = b_ds_temp^T @ b_q ==========
+            {
+                for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                    GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                    params.BT, loopIdx, bos, eos);
+                    uint32_t actual_chunk_len = eos-bos;
+                    uint32_t bIdx = loopIdx / params.numChunks;
+                    uint32_t chunkIdx = loopIdx % params.numChunks;
+    
+                    for (uint32_t h = 0; h < params.H; h++) {
+                        // --- Sub-part 5: dk = v @ dh ---
+                        {
+                            GemmCoord actualBlockShape{
+                                static_cast<uint32_t>(actual_chunk_len),
+                                static_cast<uint32_t>(params.K),
+                                static_cast<uint32_t>(params.V)
+                            };
+                            uint64_t vOffset = (h * params.T + bos) * params.V;
+                            uint64_t dhOffset = ((bIdx * params.H + h) * params.numChunks + chunkIdx) * params.K * params.V;
+                            uint64_t dkOffset = (h * params.T + bos) * params.K;
+    
+                            GlobalTensor<ElementA> gmV;
+                            gmV.SetGlobalBuffer((__gm__ ElementA *)params.ptrV + vOffset);
+                            GlobalTensor<ElementA> gmDh;
+                            gmDh.SetGlobalBuffer((__gm__ ElementA *)params.ptrDh + dhOffset);
+                            GlobalTensor<ElementC> gmDk;
+                            gmDk.SetGlobalBuffer((__gm__ ElementC *)params.ptrDk + dkOffset);
+    
+                            auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                            auto tensorDh = tla::MakeTensor(gmDh, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});
+                            auto tensorDk = tla::MakeTensor(gmDk, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+    
+                            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+    
+                            auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0),
+                                                         tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                            auto tensorBlockDh = GetTile(tensorDh, tla::MakeCoord(0, 0),
+                                                          tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                            auto tensorBlockDk = GetTile(tensorDk, tla::MakeCoord(0, 0),
+                                                          tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+    
+                            BlockMmadPart5 blockMmadPart5(resource);
+                            blockMmadPart5(tensorBlockV, tensorBlockDh, tensorBlockDk, actualBlockShape);
+                        }
+                        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+    
+                        // --- Sub-part 7: mm7 = ds_temp^T @ q ---
+                        {
+                            GemmCoord actualBlockShape{
+                                static_cast<uint32_t>(actual_chunk_len),
+                                static_cast<uint32_t>(params.K),
+                                static_cast<uint32_t>(actual_chunk_len)
+                            };
+                            uint64_t dsOffset = (h * params.T + bos) * params.BT;
+                            uint64_t qOffset = (h * params.T + bos) * params.K;
+    
+                            GlobalTensor<ElementA> gmDsTemp;
+                            gmDsTemp.SetGlobalBuffer((__gm__ ElementA *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
+                            GlobalTensor<ElementA> gmQ;
+                            gmQ.SetGlobalBuffer((__gm__ ElementA *)params.ptrQ + qOffset);
+                            GlobalTensor<ElementC> gmMm7;
+                            gmMm7.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm7Offset) + qOffset);
+    
+                            auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT_T), Arch::PositionGM{});
+                            auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                            auto tensorMm7 = tla::MakeTensor(gmMm7, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+    
+                            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+    
+                            auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0),
+                                                              tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                            auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0),
+                                                         tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                            auto tensorBlockMm7 = GetTile(tensorMm7, tla::MakeCoord(0, 0),
+                                                           tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+    
+                            BlockMmadPart7 blockMmadPart7(resource);
+                            blockMmadPart7(tensorBlockDsTemp, tensorBlockQ, tensorBlockMm7, actualBlockShape);
+                        }
+                        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+                    }
+                }
+    
+                // 最终同步
+                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            }
+    
+        }
+    };
+    
+    } // namespace Catlass::Gemm::Kernel
+    
+    /**
+     * Cube Process 类 (AIC 端入口)
+     */
+    template <typename DataType, typename GType>
+    class ChunkBwdDqkwgCubeProcess {
+    public:
+        __aicore__ inline ChunkBwdDqkwgCubeProcess(
+            GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
+            GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
+            GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
+            GM_ADDR workspace
+        ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
+            ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLen(cu_seqlen), ptrChunkIndices(chunk_indices),
+            ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
+            ptrWorkspace(workspace) {}
+        
+        __aicore__ inline void Init(const ChunkBwdDqkwgTilingData &tiling);
+        __aicore__ inline void Process();
+        
+    private:
+        // 输入输出指针
+        GM_ADDR ptrQ;
+        GM_ADDR ptrK;
+        GM_ADDR ptrV;
+        GM_ADDR ptrG;
+        GM_ADDR ptrH;
+        GM_ADDR ptrDo;
+        GM_ADDR ptrDh;
+        GM_ADDR ptrDv;
+        GM_ADDR ptrCuSeqLen;
+        GM_ADDR ptrChunkIndices;
+        GM_ADDR ptrDq;
+        GM_ADDR ptrDk;
+        GM_ADDR ptrDw;
+        GM_ADDR ptrDg;
+        GM_ADDR ptrWorkspace;
+        
+        // Tiling 参数
+        uint64_t B = CONST_B;
+        uint64_t H = CONST_H;
+        uint64_t T = CONST_T;
+        uint64_t K = CONST_K;
+        uint64_t V = CONST_V;
+        uint64_t BT = CONST_BT;
+        uint64_t numChunks = CONST_NUM_CHUNKS;
+        float scale;
+        uint64_t isVarLen;
+        
+        // Workspace 偏移
+        uint64_t wsDwOffset;
+        uint64_t wsDgLastOffset;
+        uint64_t wsMm5Offset;
+        uint64_t wsDsTempOffset;
+        uint64_t wsMm6Offset;
+        uint64_t wsMm7Offset;
+    };
+    
+    template <typename DataType, typename GType>
+    __aicore__ inline void ChunkBwdDqkwgCubeProcess<DataType, GType>::Init(const ChunkBwdDqkwgTilingData &tiling) {
+    
+    /*
+        // 设置 workspace 偏移
+        // wsDwOffset = 0;
+        wsDgLastOffset = 0;//B * H * numChunks * sizeof(float);
+        // wsDgLastOffset = ((wsDgLastOffset + 31) / 32) * 32;
+        wsMm5Offset = wsDgLastOffset + ((B * H * numChunks * sizeof(float) + 31) / 32) * 32;
+        // wsMm5Offset = wsMm5Offset;
+        wsDsTempOffset = wsMm5Offset + B * H * T * BT * sizeof(DataType);
+        wsMm6Offset = wsDsTempOffset + B * H * T * BT * sizeof(DataType);
+        wsMm7Offset = wsMm6Offset + B * H * T * K * sizeof(DataType);
+    */
+        // printf("[cube] wsDgLastOffset %d,wsMm5Offset %d,wsDsTempOffset %d, wsMm6Offset %d wsMm7Offset %d\n",wsDgLastOffset,wsMm5Offset,wsDsTempOffset,wsMm6Offset, wsMm7Offset);
+    ////////////////////tiling/////
+        scale = tiling.scale;
+        B = tiling.B;
+        H = tiling.H;
+        T = tiling.T;
+        K = tiling.K;
+        V = tiling.V;
+        BT = tiling.BT;
+        numChunks = tiling.numChunks;
+        wsDgLastOffset = tiling.wsDgLastOffset;
+        // wsDgLastOffset = ((wsDgLastOffset + 31) / 32) * 32;
+        wsMm5Offset = tiling.wsMm5Offset;
+        // wsMm5Offset = wsMm5Offset;
+        wsDsTempOffset = tiling.wsDsTempOffset;
+        wsMm6Offset = tiling.wsMm6Offset;
+        wsMm7Offset = tiling.wsMm7Offset;
+        isVarLen = tiling.isVarLen;
+    // printf("[cube] DTYPE_G %d, float %d\n",sizeof(DTYPE_G),sizeof(float));
+    }
+    
+    template <typename DataType, typename GType>
+    __aicore__ inline void ChunkBwdDqkwgCubeProcess<DataType, GType>::Process() {
+        using namespace Catlass;
+        using namespace Catlass::Gemm;
+        
+        // Layout 类型定义
+        using LayoutRowMajor = layout::RowMajor;
+        using LayoutColMajor = layout::ColumnMajor;
+        
+        // 架构和策略定义
+        using ArchTag = Arch::AtlasA2;
+    
+        // Part 1: dv @ h^T -> dw  [BT, V] @ [V, K] -> [BT, K]
+        using TileCopyPart1 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart1 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart1>;
+        
+        // Part 2: q @ k^T -> mm5  [BT, K] @ [K, BT] -> [BT, BT]
+        using TileCopyPart2 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart2 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart2>;
+        
+        // Part 3: do @ v^T -> ds  [BT, V] @ [V, BT] -> [BT, BT]
+        using TileCopyPart3 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart3 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart3>;
+        
+        // Part 4: do @ h^T -> dq  [BT, V] @ [V, K] -> [BT, K]
+        using TileCopyPart4 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart4 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart4>;
+        
+        // Part 5: v @ dh -> dk  [BT, V] @ [V, K] -> [BT, K]
+        using TileCopyPart5 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart5 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart5>;
+        
+        // Part 6: ds @ k -> dq+=  [BT, BT] @ [BT, K] -> [BT, K]
+        using TileCopyPart6 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart6 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart6>;
+        
+        // Part 7: ds^T @ q -> dk+=  [BT, BT] @ [BT, K] -> [BT, K]
+        using TileCopyPart7 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutColMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart7 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart7>;
+        
+        // Kernel 实例
+        using MatmulKernel = Kernel::ChunkBwdDqkwgTla<
+            BlockMmadPart1, BlockMmadPart2, BlockMmadPart3, BlockMmadPart4,
+            BlockMmadPart5, BlockMmadPart6, BlockMmadPart7
+        >;
+        
+        MatmulKernel kernel;
+        typename MatmulKernel::Params params(
+            ptrQ, ptrK, ptrV, ptrG, ptrH,
+            ptrDo, ptrDh, ptrDv, ptrCuSeqLen, ptrChunkIndices,
+            ptrDq, ptrDk, ptrDw, ptrDg,
+            ptrWorkspace, B, H, T, K, V, BT, numChunks,
+            wsDwOffset, wsDgLastOffset, wsMm5Offset, wsDsTempOffset, wsMm6Offset, wsMm7Offset,
+            scale, isVarLen
+        );
+        
+        kernel(params);
+    }
+    
+    #endif  // CHUNK_BWD_DQKWG_CUBE_H
+    

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
@@ -401,8 +401,7 @@ namespace Catlass::Gemm::Kernel {
                         gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
                         // gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH);
                         GlobalTensor<ElementC> gmDw;
-                        // gmDw.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDwOffset) + dwOffset);
-                        gmDw.SetGlobalBuffer((__gm__ ElementC *)params.ptrDw + dwOffset);
+                        gmDw.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDwOffset) + dwOffset);
     
                         auto tensorDv = tla::MakeTensor(gmDv, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
                         auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});  // h^T
@@ -414,14 +413,15 @@ namespace Catlass::Gemm::Kernel {
                                                       tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
                         auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), 
                                                      tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                        auto tensorBlockDw = GetTile(tensorDw, tla::MakeCoord(0, 0), 
+                        auto tensorBlockDw = GetTile(tensorDw, tla::MakeCoord(0, 0),
                                                       tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                        
+
                         blockMmadPart1(tensorBlockDv, tensorBlockH, tensorBlockDw, actualBlockShape);
-    
-    
+
+                        AscendC::PipeBarrier<PIPE_FIX>();
+
                         AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
-    
+
                     }
                 }
                 // 最终同步(后移)
@@ -430,7 +430,8 @@ namespace Catlass::Gemm::Kernel {
                 AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
                 AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
             }
-    
+            AscendC::SyncAll<false>();
+
             // ========== Part 2: mm5 = q @ k^T (纯 Cube) ==========
             {
                 BlockMmadPart2 blockMmadPart2(resource);
@@ -478,7 +479,8 @@ namespace Catlass::Gemm::Kernel {
                 }
     
             }
-    
+            AscendC::SyncAll<false>();
+
             // ========== Part 3: b_ds = b_do @ b_v^T ==========
             {
                 // AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
@@ -536,7 +538,8 @@ namespace Catlass::Gemm::Kernel {
                 AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
                 AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
             }
-    
+            AscendC::SyncAll<false>();
+
             // ========== Fused Part 4+6: b_dq = b_do @ b_h^T, then mm6 = b_ds_temp @ b_k ==========
             // 每次迭代先计算 dq, 再计算 mm6, Vector 端在 UB 中完成 dq += mm6 避免 GM 往返
             {
@@ -625,7 +628,8 @@ namespace Catlass::Gemm::Kernel {
                 AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
                 AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
             }
-    
+            AscendC::SyncAll<false>();
+
             // ========== Fused Part 5+7: b_dk = b_v @ b_dh, then mm7 = b_ds_temp^T @ b_q ==========
             {
                 for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
@@ -802,6 +806,7 @@ namespace Catlass::Gemm::Kernel {
         V = tiling.V;
         BT = tiling.BT;
         numChunks = tiling.numChunks;
+        wsDwOffset = tiling.wsDwOffset;
         wsDgLastOffset = tiling.wsDgLastOffset;
         // wsDgLastOffset = ((wsDgLastOffset + 31) / 32) * 32;
         wsMm5Offset = tiling.wsMm5Offset;
@@ -871,6 +876,5 @@ namespace Catlass::Gemm::Kernel {
         
         kernel(params);
     }
-    
+
     #endif  // CHUNK_BWD_DQKWG_CUBE_H
-    

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
@@ -430,7 +430,9 @@ namespace Catlass::Gemm::Kernel {
                 AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
                 AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
             }
-            AscendC::SyncAll<false>();
+            // Part 2 is cube-only and uses no AIV/AIC flags. Keep the four
+            // token drain above; the next flag phase is separated by the
+            // SyncAll after Part 2.
 
             // ========== Part 2: mm5 = q @ k^T (纯 Cube) ==========
             {

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
@@ -11,794 +11,866 @@
  * \file chunk_bwd_dqkwg_cube.h
  */
 
-#ifndef CHUNK_BWD_DQKWG_CUBE_H
-#define CHUNK_BWD_DQKWG_CUBE_H
-
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
-    #define CATLASS_ARCH 3510
-#include "chunk_bwd_dqkwg_common.h"
-#include "catlass/arch/arch.hpp"
-#include "catlass/catlass.hpp"
-#include "catlass/gemm/block/block_mmad.hpp"
-#include "catlass/gemm/block/block_swizzle.hpp"
-#include "catlass/gemm/device/device_gemm.hpp"
-#include "catlass/gemm/dispatch_policy.hpp"
-#include "catlass/gemm/gemm_type.hpp"
-#include "catlass/layout/layout.hpp"
-#include "catlass/status.hpp"
-#include "tla/layout.hpp"
-#include "tla/tensor.hpp"
- using _0 = tla::Int<0>;
- 	 using _1 = tla::Int<1>;
- 	 using _2 = tla::Int<2>;
- 	 using _4 = tla::Int<4>;
- 	 using _8 = tla::Int<8>;
- 	 using _16 = tla::Int<16>;
- 	 using _32 = tla::Int<32>;
- 	 using _64 = tla::Int<64>;
- 	 using _128 = tla::Int<128>;
- 	 using _256 = tla::Int<256>;
- 	 using _512 = tla::Int<512>;
- 	 using _1024 = tla::Int<1024>;
- 	 using _2048 = tla::Int<2048>;
- 	 using _4096 = tla::Int<4096>;
- 	 using _8192 = tla::Int<8192>;
- 	 using _16384 = tla::Int<16384>;
- 	 using _32768 = tla::Int<32768>;
- 	 using _65536 = tla::Int<65536>;
- 	 #else
- 	 #define CATLASS_ARCH 2201
- 	 #include "chunk_bwd_dqkwg_common.h"
- 	 #include "catlass/arch/arch.hpp"
- 	 #include "catlass/catlass.hpp"
- 	 #include "catlass/gemm/block/block_mmad.hpp"
- 	 #include "catlass/gemm/block/block_swizzle.hpp"
- 	 #include "catlass/gemm/device/device_gemm.hpp"
- 	 #include "catlass/gemm/dispatch_policy.hpp"
- 	 #include "catlass/gemm/gemm_type.hpp"
- 	 #include "catlass/layout/layout.hpp"
- 	 #include "catlass/status.hpp"
- 	 #include "tla/layout.hpp"
- 	 #include "tla/tensor.hpp"
- 	 #endif
-using namespace tla;
-using namespace Catlass;
-using namespace AscendC;
-
-namespace Catlass::Gemm::Kernel {
-
-/**
- * ChunkBwdDqkwg Cube Kernel 模板类
- * 
- * 模板参数:
- * - BlockMmadPart1_: Part 1 的矩阵乘法 (dv @ h^T -> dw)
- * - BlockMmadPart2_: Part 2 的矩阵乘法 (q @ k^T -> mm5)
- * - BlockMmadPart3_: Part 3 的矩阵乘法 (do @ v^T -> ds)
- * - BlockMmadPart4_: Part 4 的矩阵乘法 (do @ h^T -> dq)
- * - BlockMmadPart5_: Part 5 的矩阵乘法 (v @ dh -> dk)
- * - BlockMmadPart6_: Part 6 的矩阵乘法 (ds @ k -> dq+=)
- * - BlockMmadPart7_: Part 7 的矩阵乘法 (ds^T @ q -> dk+=)
- */
-template <
-    class BlockMmadPart1_,  // dv @ h^T -> dw
-    class BlockMmadPart2_,  // q @ k^T -> mm5
-    class BlockMmadPart3_,  // do @ v^T -> ds
-    class BlockMmadPart4_,  // do @ h^T -> dq
-    class BlockMmadPart5_,  // v @ dh -> dk
-    class BlockMmadPart6_,  // ds @ k -> dq
-    class BlockMmadPart7_   // ds^T @ q -> dk
->
-class ChunkBwdDqkwgTla {
-public:
-    using BlockMmadPart1 = BlockMmadPart1_;
-    using BlockMmadPart2 = BlockMmadPart2_;
-    using BlockMmadPart3 = BlockMmadPart3_;
-    using BlockMmadPart4 = BlockMmadPart4_;
-    using BlockMmadPart5 = BlockMmadPart5_;
-    using BlockMmadPart6 = BlockMmadPart6_;
-    using BlockMmadPart7 = BlockMmadPart7_;
-    
-    using ArchTag = typename BlockMmadPart1::ArchTag;
-    
-    // 数据类型定义 (基于 Part 2: q @ k^T)
-    using ElementA = typename BlockMmadPart2::ElementA;
-    using ElementB = typename BlockMmadPart2::ElementB;
-    using ElementC = typename BlockMmadPart2::ElementC;
-    
-    // Layout 定义
-    using LayoutRowMajor = layout::RowMajor;
-    using LayoutColMajor = layout::ColumnMajor;
-    
-    /// Parameters structure
-    struct Params {
-        // 输入指针
-        GM_ADDR ptrQ;      // [B, H, T, K]
-        GM_ADDR ptrK;      // [B, H, T, K]
-        GM_ADDR ptrV;      // [B, H, T, V]
-        GM_ADDR ptrG;      // [B, H, T]
-        GM_ADDR ptrH;      // [B, num_chunks, H, K, V]
-        GM_ADDR ptrDo;     // [B, H, T, V]
-        GM_ADDR ptrDh;     // [B, num_chunks, H, K, V]
-        GM_ADDR ptrDv;     // [B, H, T, V]
-        //varlen
-        GM_ADDR ptrCuSeqLens;
-        GM_ADDR ptrChunkIndices;
-        
-        // 输出指针
-        GM_ADDR ptrDq;     // [B, H, T, K]
-        GM_ADDR ptrDk;     // [B, H, T, K]
-        GM_ADDR ptrDw;     // [B, H, T, K]
-        GM_ADDR ptrDg;     // [B, H, T]
-        
-        // Workspace 指针
-        GM_ADDR ptrWorkspace;
-        
-        // Workspace 偏移
-        uint64_t wsDwOffset;
-        uint64_t wsDgLastOffset;
-        uint64_t wsMm5Offset;
-        uint64_t wsDsTempOffset;
-        uint64_t wsMm6Offset;
-        uint64_t wsMm7Offset;
-        
-        // 形状参数
-        uint64_t B;// = CONST_B;
-        uint64_t H;// = CONST_H;
-        uint64_t T;// = CONST_T;
-        uint64_t K;// = CONST_K;
-        uint64_t V;// = CONST_V;
-        uint64_t BT;// = CONST_BT;
-        uint64_t numChunks;// = CONST_NUM_CHUNKS;
-        // uint64_t chunkSize = 64;
-        uint64_t isVarLen;
-        
-        // 其他参数
-        float scale;
-        
-        CATLASS_DEVICE
-        Params() {}
-        
-        CATLASS_DEVICE
-        Params(
-            GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
-            GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
-            GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
-            GM_ADDR workspace,
-            uint64_t B, uint64_t H, uint64_t T, uint64_t K, uint64_t V, uint64_t BT, uint64_t numChunks, 
-            uint64_t wsDw, uint64_t wsDgLast, uint64_t wsMm5, uint64_t wsDsTemp, uint64_t wsMm6, uint64_t wsMm7,
-            float s, uint64_t isVarLen
-        ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
-            ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLens(cu_seqlen), ptrChunkIndices(chunk_indices),
-            ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
-            ptrWorkspace(workspace),
-            wsDwOffset(wsDw), wsDgLastOffset(wsDgLast),
-            wsMm5Offset(wsMm5), wsDsTempOffset(wsDsTemp), wsMm6Offset(wsMm6), wsMm7Offset(wsMm7),
-            scale(s), B(B), H(H), T(T), K(K), V(V), BT(BT), numChunks(numChunks), isVarLen(isVarLen) {}
-    };
-    
-    CATLASS_DEVICE
-    ChunkBwdDqkwgTla() {}
-    
-    template <int32_t CORE_TYPE = g_coreType>
-    CATLASS_DEVICE
-    void operator()(Params const &params);
-    
-    /**
-     * AIC (Cube) 执行入口
-     */
-    template <>
-    CATLASS_DEVICE
-    void operator()<AscendC::AIC>(Params const &params) {
-        Arch::Resource<ArchTag> resource;
-        uint32_t coreIdx = AscendC::GetBlockIdx();
-        uint32_t coreNum = AscendC::GetBlockNum();
-        
-        uint32_t coreLoops = params.B * params.numChunks;
-        
-        // Layout 创建
-        auto layoutBTxK = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.K);
-        auto layoutKxBT = LayoutColMajor::MakeLayout<ElementA>(params.K, params.BT);
-        auto layoutBTxV = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.V);
-        auto layoutVxBT = LayoutColMajor::MakeLayout<ElementA>(params.V, params.BT);
-        auto layoutBTxBT = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.BT);
-        auto layoutBTxBT_T = LayoutColMajor::MakeLayout<ElementA>(params.BT, params.BT);
-        auto layoutKxV = LayoutRowMajor::MakeLayout<ElementA>(params.K, params.V);
-        auto layoutVxK = LayoutColMajor::MakeLayout<ElementA>(params.V, params.K);
-
-        uint32_t bos = 0;
-        uint32_t eos = 0;
-
-        // ========== Part 1: b_dw = b_dv @ b_h^T ==========
-        {
-            BlockMmadPart1 blockMmadPart1(resource);
-            auto layoutH = LayoutColMajor::MakeLayout<ElementA>(params.K, params.V);
-            // printf("[cube]coreLoops %d, H %d\n",coreLoops,params.H);
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
-                                params.BT, loopIdx, bos, eos);
-                uint32_t actual_chunk_len = eos-bos;
-                uint32_t bIdx = loopIdx / params.numChunks;
-                uint32_t chunkIdx = loopIdx % params.numChunks;
-
-                GemmCoord actualBlockShape{
-                    static_cast<uint32_t>(actual_chunk_len),
-                    static_cast<uint32_t>(params.K),
-                    static_cast<uint32_t>(params.V)
-                };
-
-                for (uint32_t h = 0; h < params.H; h++) {
-
-                    // 设置 GM 地址
-                    // dv: [B, H, T, V] -> offset = ((b * H + h) * T + chunk * BT) * V
-                    // uint64_t dvOffset = ((bIdx * params.H + h) * params.T + bos) * params.V;
-                    uint64_t dvOffset = (h * params.T + bos) * params.V;
-
-                    // h: [B, H, num_chunks, K, V] -> offset = ((b * numChunks + chunk) * H + h) * K * V
-                    uint64_t hOffset = ((bIdx * params.H + h) * params.numChunks + chunkIdx) * params.K * params.V;
-
-                    // dw output (workspace): [B, H, T, K]
-                    // uint64_t dwOffset = ((bIdx * params.H + h) * params.T + bos) * params.K;
-                    uint64_t dwOffset = (h * params.T + bos) * params.K;
-
-                    GlobalTensor<ElementA> gmDv;
-                    gmDv.SetGlobalBuffer((__gm__ ElementA *)params.ptrDv + dvOffset);
-                    // gmDv.SetGlobalBuffer((__gm__ ElementA *)params.ptrDv);
-                    GlobalTensor<ElementA> gmH;
-                    gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
-                    // gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH);
-                    GlobalTensor<ElementC> gmDw;
-                    // gmDw.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDwOffset) + dwOffset);
-                    gmDw.SetGlobalBuffer((__gm__ ElementC *)params.ptrDw + dwOffset);
-
-                    auto tensorDv = tla::MakeTensor(gmDv, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
-                    auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});  // h^T
-                    auto tensorDw = tla::MakeTensor(gmDw, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                    
-                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-
-                    auto tensorBlockDv = GetTile(tensorDv, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), 
-                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDw = GetTile(tensorDw, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    
-                    blockMmadPart1(tensorBlockDv, tensorBlockH, tensorBlockDw, actualBlockShape);
-
-
-                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
-
-                }
-            }
-            // 最终同步(后移)
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-        }
-        AscendC::SyncAll<false>();
-
-        // ========== Part 2: mm5 = q @ k^T (纯 Cube) ==========
-        {
-            BlockMmadPart2 blockMmadPart2(resource);
-            
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
-                                params.BT, loopIdx, bos, eos);
-                uint32_t actual_chunk_len = eos-bos;
-                uint32_t bIdx = loopIdx / params.numChunks;
-                uint32_t chunkIdx = loopIdx % params.numChunks;
-                
-                GemmCoord actualBlockShape{
-                    static_cast<uint32_t>(actual_chunk_len),
-                    static_cast<uint32_t>(actual_chunk_len),
-                    static_cast<uint32_t>(params.K)
-                };
-                
-                for (uint32_t h = 0; h < params.H; h++) {
-                    // q, k: [B, H, T, K]
-                    uint64_t qkOffset = (h * params.T + bos) * params.K;
-                    // mm5: workspace [B, H, T, BT]
-                    uint64_t mm5Offset = (h * params.T + bos) * params.BT;
-                    
-                    GlobalTensor<ElementA> gmQ;
-                    gmQ.SetGlobalBuffer((__gm__ ElementA *)params.ptrQ + qkOffset);
-                    GlobalTensor<ElementA> gmK;
-                    gmK.SetGlobalBuffer((__gm__ ElementA *)params.ptrK + qkOffset);
-                    GlobalTensor<ElementC> gmMm5;
-                    gmMm5.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm5Offset) + mm5Offset);
-
-                    auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                    auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutKxBT), Arch::PositionGM{});  // k^T
-                    auto tensorMm5 = tla::MakeTensor(gmMm5, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
-
-                    auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0), 
-                                                 tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), 
-                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockMm5 = GetTile(tensorMm5, tla::MakeCoord(0, 0), 
-                                                   tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    
-                    blockMmadPart2(tensorBlockQ, tensorBlockK, tensorBlockMm5, actualBlockShape);
-
-                }
-            }
-
-        }
-        AscendC::SyncAll<false>();
-
-        // ========== Part 3: b_ds = b_do @ b_v^T ==========
-        {
-            // AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            
-            BlockMmadPart3 blockMmadPart3(resource);
-            
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
-                                params.BT, loopIdx, bos, eos);
-                uint32_t actual_chunk_len = eos-bos;
-                uint32_t bIdx = loopIdx / params.numChunks;
-                uint32_t chunkIdx = loopIdx % params.numChunks;
-                
-                GemmCoord actualBlockShape{
-                    static_cast<uint32_t>(actual_chunk_len),
-                    static_cast<uint32_t>(actual_chunk_len),
-                    static_cast<uint32_t>(params.V)
-                };
-                
-                for (uint32_t h = 0; h < params.H; h++) {
-                    // do, v: [B, H, T, V]
-                    // uint64_t dvOffset = ((bIdx * params.H + h) * params.T + bos) * params.V;
-                    uint64_t dvOffset = (h * params.T + bos) * params.V;
-                    // ds_temp: workspace [B, H, T, BT]
-                    // uint64_t dsOffset = ((bIdx * params.H + h) * params.T + bos) * params.BT;
-                    uint64_t dsOffset = (h * params.T + bos) * params.BT;
-                    
-                    GlobalTensor<ElementA> gmDo;
-                    gmDo.SetGlobalBuffer((__gm__ ElementA *)params.ptrDo + dvOffset);
-                    GlobalTensor<ElementA> gmV;
-                    gmV.SetGlobalBuffer((__gm__ ElementA *)params.ptrV + dvOffset);
-                    GlobalTensor<ElementC> gmDs;
-                    gmDs.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
-                    
-                    auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
-                    auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutVxBT), Arch::PositionGM{});  // v^T
-                    auto tensorDs = tla::MakeTensor(gmDs, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
-                    
-                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-                    // AscendC::PipeBarrier<PIPE_MTE2>();
-                    auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), 
-                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDs = GetTile(tensorDs, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    
-                    blockMmadPart3(tensorBlockDo, tensorBlockV, tensorBlockDs, actualBlockShape);
-
-                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
-                }
-            }
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-        }
-        AscendC::SyncAll<false>();
-
-        // ========== Part 4: b_dq = b_do @ b_h^T ==========
-        {
-            BlockMmadPart4 blockMmadPart4(resource);
-            
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
-                                params.BT, loopIdx, bos, eos);
-                uint32_t actual_chunk_len = eos-bos;
-                uint32_t bIdx = loopIdx / params.numChunks;
-                uint32_t chunkIdx = loopIdx % params.numChunks;
-                
-                GemmCoord actualBlockShape{
-                    static_cast<uint32_t>(actual_chunk_len),
-                    static_cast<uint32_t>(params.K),
-                    static_cast<uint32_t>(params.V)
-                };
-                
-                for (uint32_t h = 0; h < params.H; h++) {
-                    // do: [B, H, T, V]
-                    // uint64_t doOffset = ((bIdx * params.H + h) * params.T + bos) * params.V;
-                    uint64_t doOffset = (h * params.T + bos) * params.V;
-                    // h: [B, H, num_chunks, K, V]   [1, 44, 4, 128, 128]
-                    uint64_t hOffset = ((bIdx * params.H + h) * params.numChunks + chunkIdx) * params.K * params.V;
-                    //bIdx * numChunks * H * K * V + chunkIdx * H * K * V + h * K * V;
-
-                    // dq: [B, H, T, K]
-                    // uint64_t dqOffset = ((bIdx * params.H + h) * params.T + bos) * params.K;
-                    uint64_t dqOffset = (h * params.T + bos) * params.K;
-                    
-                    GlobalTensor<ElementA> gmDo;
-                    gmDo.SetGlobalBuffer((__gm__ ElementA *)params.ptrDo + doOffset);
-                    GlobalTensor<ElementA> gmH;
-                    gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
-                    GlobalTensor<ElementC> gmDq;
-                    gmDq.SetGlobalBuffer((__gm__ ElementC *)params.ptrDq + dqOffset);
-                    
-                    auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
-                    auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});  // h^T: [V, K]
-                    auto tensorDq = tla::MakeTensor(gmDq, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                    
-                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-
-                    auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), 
-                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDq = GetTile(tensorDq, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    
-                    blockMmadPart4(tensorBlockDo, tensorBlockH, tensorBlockDq, actualBlockShape);
-
-                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
-                }
-            }
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-        }
-        AscendC::SyncAll<false>();
-
-        // ========== Part 5: b_dk = b_v @ b_dh ==========
-        {
-            BlockMmadPart5 blockMmadPart5(resource);
-            
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
-                                params.BT, loopIdx, bos, eos);
-                uint32_t actual_chunk_len = eos-bos;
-                uint32_t bIdx = loopIdx / params.numChunks;
-                uint32_t chunkIdx = loopIdx % params.numChunks;
-                
-                GemmCoord actualBlockShape{
-                    static_cast<uint32_t>(actual_chunk_len),
-                    static_cast<uint32_t>(params.K),
-                    static_cast<uint32_t>(params.V)
-                };
-                
-                for (uint32_t h = 0; h < params.H; h++) {
-                    // v: [B, H, T, V]
-                    // uint64_t vOffset = ((bIdx * params.H + h) * params.T + bos) * params.V;
-                    uint64_t vOffset = (h * params.T + bos) * params.V;
-                    // dh: [B, H, num_chunks, K, V]  -> 需要转置访问 [V, K]
-                    // uint64_t dhOffset = ((bIdx * params.numChunks + chunkIdx) * params.H + h) * params.K * params.V;
-                    uint64_t dhOffset = ((bIdx * params.H + h) * params.numChunks + chunkIdx) * params.K * params.V;
-                    // dk: [B, H, T, K]
-                    // uint64_t dkOffset = ((bIdx * params.H + h) * params.T + bos) * params.K;
-                    uint64_t dkOffset = (h * params.T + bos) * params.K;
-                    
-                    GlobalTensor<ElementA> gmV;
-                    gmV.SetGlobalBuffer((__gm__ ElementA *)params.ptrV + vOffset);
-                    GlobalTensor<ElementA> gmDh;
-                    gmDh.SetGlobalBuffer((__gm__ ElementA *)params.ptrDh + dhOffset);
-                    GlobalTensor<ElementC> gmDk;
-                    gmDk.SetGlobalBuffer((__gm__ ElementC *)params.ptrDk + dkOffset);
-                    
-                    auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
-                    auto tensorDh = tla::MakeTensor(gmDh, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});  // dh: [V, K]
-                    auto tensorDk = tla::MakeTensor(gmDk, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                    
-                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-
-                    auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), 
-                                                 tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockDh = GetTile(tensorDh, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDk = GetTile(tensorDk, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    
-                    blockMmadPart5(tensorBlockV, tensorBlockDh, tensorBlockDk, actualBlockShape);
-
-                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
-                }
-            }
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-        }
-        AscendC::SyncAll<false>();
-
-        // ========== Part 6: mm6 = b_ds_temp @ b_k ==========
-        // 结果累加到 dq
-        {
-            BlockMmadPart6 blockMmadPart6(resource);
-            
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
-                                params.BT, loopIdx, bos, eos);
-                uint32_t actual_chunk_len = eos-bos;
-                uint32_t bIdx = loopIdx / params.numChunks;
-                uint32_t chunkIdx = loopIdx % params.numChunks;
-                
-                GemmCoord actualBlockShape{
-                    static_cast<uint32_t>(actual_chunk_len),
-                    static_cast<uint32_t>(params.K),
-                    static_cast<uint32_t>(actual_chunk_len)
-                };
-                
-                for (uint32_t h = 0; h < params.H; h++) {
-                    // ds_temp: workspace [B, H, T, BT]
-                    // uint64_t dsOffset = ((bIdx * params.H + h) * params.T + bos) * params.BT;
-                    uint64_t dsOffset = (h * params.T + bos) * params.BT;
-                    // k: [B, H, T, K]
-                    // uint64_t kOffset = ((bIdx * params.H + h) * params.T + bos) * params.K;
-                    uint64_t kOffset = (h * params.T + bos) * params.K;
-                    // dq: [B, H, T, K] - 累加
-                    uint64_t dqOffset = kOffset;
-                    
-                    GlobalTensor<ElementA> gmDsTemp;
-                    gmDsTemp.SetGlobalBuffer((__gm__ ElementA *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
-                    GlobalTensor<ElementA> gmK;
-                    gmK.SetGlobalBuffer((__gm__ ElementA *)params.ptrK + kOffset);
-                    GlobalTensor<ElementC> gmDq;
-                    gmDq.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm5Offset) + dqOffset);
-
-                    auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
-                    auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                    auto tensorDq = tla::MakeTensor(gmDq, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                    
-                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-                    
-                    auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0), 
-                                                      tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), 
-                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDq = GetTile(tensorDq, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    
-                    blockMmadPart6(tensorBlockDsTemp, tensorBlockK, tensorBlockDq, actualBlockShape);
-// if(h==0&&loopIdx==7){
-//     DumpTensor(gmDsTemp[63*64],__LINE__,64);
-//     DumpTensor(gmK[63*128],__LINE__,64);
-//     DumpTensor(gmDq[63*128],__LINE__,64);
-// }
-                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
-                }
-            }
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-        }
-        AscendC::SyncAll<false>();
-        // ========== Part 7: mm7 = b_ds_temp^T @ b_q ==========
-        // 结果累加到 dk
-        {
-            BlockMmadPart7 blockMmadPart7(resource);
-            
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
-                                params.BT, loopIdx, bos, eos);
-                uint32_t actual_chunk_len = eos-bos;
-                uint32_t bIdx = loopIdx / params.numChunks;
-                uint32_t chunkIdx = loopIdx % params.numChunks;
-                
-                GemmCoord actualBlockShape{
-                    static_cast<uint32_t>(actual_chunk_len),
-                    static_cast<uint32_t>(params.K),
-                    static_cast<uint32_t>(actual_chunk_len)
-                };
-                
-                for (uint32_t h = 0; h < params.H; h++) {
-                    // ds_temp^T: workspace [B, H, T, BT]
-                    // uint64_t dsOffset = ((bIdx * params.H + h) * params.T + bos) * params.BT;
-                    uint64_t dsOffset = (h * params.T + bos) * params.BT;
-                    // q: [B, H, T, K]
-                    // uint64_t qOffset = ((bIdx * params.H + h) * params.T + bos) * params.K;
-                    uint64_t qOffset = (h * params.T + bos) * params.K;
-
-                    // dk: [B, H, T, K] - 累加
-                    uint64_t dkOffset = qOffset;
-                    
-                    GlobalTensor<ElementA> gmDsTemp;
-                    gmDsTemp.SetGlobalBuffer((__gm__ ElementA *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
-                    GlobalTensor<ElementA> gmQ;
-                    gmQ.SetGlobalBuffer((__gm__ ElementA *)params.ptrQ + qOffset);
-                    GlobalTensor<ElementC> gmDk;
-                    gmDk.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm5Offset) + dkOffset);
-                    
-                    auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT_T), Arch::PositionGM{});  // Transposed
-                    auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                    auto tensorDk = tla::MakeTensor(gmDk, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                    
-                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-                    
-                    auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0), 
-                                                      tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0), 
-                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDk = GetTile(tensorDk, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    
-                    blockMmadPart7(tensorBlockDsTemp, tensorBlockQ, tensorBlockDk, actualBlockShape);
-// if(h==0&&loopIdx==0){
-//     DumpTensor(gmDsTemp,__LINE__,64);
-//     DumpTensor(gmQ,__LINE__,64);
-//     DumpTensor(gmDk,__LINE__,64);
-// }
-                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
-                }
-            }
-            
-            // 最终同步
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-        }
-
-    }
-};
-
-} // namespace Catlass::Gemm::Kernel
-
-/**
- * Cube Process 类 (AIC 端入口)
- */
-template <typename DataType, typename GType>
-class ChunkBwdDqkwgCubeProcess {
-public:
-    __aicore__ inline ChunkBwdDqkwgCubeProcess(
-        GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
-        GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
-        GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
-        GM_ADDR workspace
-    ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
-        ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLen(cu_seqlen), ptrChunkIndices(chunk_indices),
-        ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
-        ptrWorkspace(workspace) {}
-    
-    __aicore__ inline void Init(const ChunkBwdDqkwgTilingData &tiling);
-    __aicore__ inline void Process();
-    
-private:
-    // 输入输出指针
-    GM_ADDR ptrQ;
-    GM_ADDR ptrK;
-    GM_ADDR ptrV;
-    GM_ADDR ptrG;
-    GM_ADDR ptrH;
-    GM_ADDR ptrDo;
-    GM_ADDR ptrDh;
-    GM_ADDR ptrDv;
-    GM_ADDR ptrCuSeqLen;
-    GM_ADDR ptrChunkIndices;
-    GM_ADDR ptrDq;
-    GM_ADDR ptrDk;
-    GM_ADDR ptrDw;
-    GM_ADDR ptrDg;
-    GM_ADDR ptrWorkspace;
-    
-    // Tiling 参数
-    uint64_t B = CONST_B;
-    uint64_t H = CONST_H;
-    uint64_t T = CONST_T;
-    uint64_t K = CONST_K;
-    uint64_t V = CONST_V;
-    uint64_t BT = CONST_BT;
-    uint64_t numChunks = CONST_NUM_CHUNKS;
-    float scale;
-    uint64_t isVarLen;
-    
-    // Workspace 偏移
-    uint64_t wsDwOffset;
-    uint64_t wsDgLastOffset;
-    uint64_t wsMm5Offset;
-    uint64_t wsDsTempOffset;
-    uint64_t wsMm6Offset;
-    uint64_t wsMm7Offset;
-};
-
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgCubeProcess<DataType, GType>::Init(const ChunkBwdDqkwgTilingData &tiling) {
-
-/*
-    // 设置 workspace 偏移
-    // wsDwOffset = 0;
-    wsDgLastOffset = 0;//B * H * numChunks * sizeof(float);
-    // wsDgLastOffset = ((wsDgLastOffset + 31) / 32) * 32;
-    wsMm5Offset = wsDgLastOffset + ((B * H * numChunks * sizeof(float) + 31) / 32) * 32;
-    // wsMm5Offset = wsMm5Offset;
-    wsDsTempOffset = wsMm5Offset + B * H * T * BT * sizeof(DataType);
-    wsMm6Offset = wsDsTempOffset + B * H * T * BT * sizeof(DataType);
-    wsMm7Offset = wsMm6Offset + B * H * T * K * sizeof(DataType);
-*/
-    // printf("[cube] wsDgLastOffset %d,wsMm5Offset %d,wsDsTempOffset %d, wsMm6Offset %d wsMm7Offset %d\n",wsDgLastOffset,wsMm5Offset,wsDsTempOffset,wsMm6Offset, wsMm7Offset);
-////////////////////tiling/////
-    scale = tiling.scale;
-    B = tiling.B;
-    H = tiling.H;
-    T = tiling.T;
-    K = tiling.K;
-    V = tiling.V;
-    BT = tiling.BT;
-    numChunks = tiling.numChunks;
-    wsDgLastOffset = tiling.wsDgLastOffset;
-    // wsDgLastOffset = ((wsDgLastOffset + 31) / 32) * 32;
-    wsMm5Offset = tiling.wsMm5Offset;
-    // wsMm5Offset = wsMm5Offset;
-    wsDsTempOffset = tiling.wsDsTempOffset;
-    // wsMm6Offset = tiling.wsMm6Offset;
-    // wsMm7Offset = tiling.wsMm7Offset;
-    isVarLen = tiling.isVarLen;
-// printf("[cube] DTYPE_G %d, float %d\n",sizeof(DTYPE_G),sizeof(float));
-}
-
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgCubeProcess<DataType, GType>::Process() {
-    using namespace Catlass;
-    using namespace Catlass::Gemm;
-    
-    // Layout 类型定义
-    using LayoutRowMajor = layout::RowMajor;
-    using LayoutColMajor = layout::ColumnMajor;
-    
-    // 架构和策略定义
+ #ifndef CHUNK_BWD_DQKWG_CUBE_H
+ #define CHUNK_BWD_DQKWG_CUBE_H
+ 
  #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
- 	     using ArchTag = Arch::Ascend950;
- 	 #else
- 	     using ArchTag = Arch::AtlasA2;
- 	 #endif
- 	     using DispatchPolicy = Gemm::MmadPingpong<ArchTag, true, false>;
-    using DispatchPolicy = Gemm::MmadPingpong<ArchTag, true>;
-    using L1TileShape = tla::Shape<_128, _128, _256>;
-    using L0TileShape = tla::Shape<_128, _128, _128>;
-    // using L1TileShape = tla::Shape<_128, _256, _256>;
-    // using L0TileShape = tla::Shape<_128, _256, _64>;
-    // Part 1: dv @ h^T -> dw  [BT, V] @ [V, K] -> [BT, K]
-    using TileCopyPart1 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
-    using BlockMmadPart1 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart1>;
-    
-    // Part 2: q @ k^T -> mm5  [BT, K] @ [K, BT] -> [BT, BT]
-    using TileCopyPart2 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
-    using BlockMmadPart2 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart2>;
-    
-    // Part 3: do @ v^T -> ds  [BT, V] @ [V, BT] -> [BT, BT]
-    using TileCopyPart3 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
-    using BlockMmadPart3 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart3>;
-    
-    // Part 4: do @ h^T -> dq  [BT, V] @ [V, K] -> [BT, K]
-    using TileCopyPart4 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
-    using BlockMmadPart4 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart4>;
-    
-    // Part 5: v @ dh -> dk  [BT, V] @ [V, K] -> [BT, K]
-    using TileCopyPart5 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
-    using BlockMmadPart5 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart5>;
-    
-    // Part 6: ds @ k -> dq+=  [BT, BT] @ [BT, K] -> [BT, K]
-    using TileCopyPart6 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
-    using BlockMmadPart6 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart6>;
-    
-    // Part 7: ds^T @ q -> dk+=  [BT, BT] @ [BT, K] -> [BT, K]
-    using TileCopyPart7 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutColMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
-    using BlockMmadPart7 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart7>;
-    
-    // Kernel 实例
-    using MatmulKernel = Kernel::ChunkBwdDqkwgTla<
-        BlockMmadPart1, BlockMmadPart2, BlockMmadPart3, BlockMmadPart4,
-        BlockMmadPart5, BlockMmadPart6, BlockMmadPart7
-    >;
-    
-    MatmulKernel kernel;
-    typename MatmulKernel::Params params(
-        ptrQ, ptrK, ptrV, ptrG, ptrH,
-        ptrDo, ptrDh, ptrDv, ptrCuSeqLen, ptrChunkIndices,
-        ptrDq, ptrDk, ptrDw, ptrDg,
-        ptrWorkspace, B, H, T, K, V, BT, numChunks,
-        wsDwOffset, wsDgLastOffset, wsMm5Offset, wsDsTempOffset, wsMm6Offset, wsMm7Offset,
-        scale, isVarLen
-    );
-    
-    kernel(params);
-}
-
-#endif  // CHUNK_BWD_DQKWG_CUBE_H
+     #define CATLASS_ARCH 3510
+ #include "chunk_bwd_dqkwg_common.h"
+ #include "catlass/arch/arch.hpp"
+ #include "catlass/catlass.hpp"
+ #include "catlass/gemm/block/block_mmad.hpp"
+ #include "catlass/gemm/block/block_swizzle.hpp"
+ #include "catlass/gemm/device/device_gemm.hpp"
+ #include "catlass/gemm/dispatch_policy.hpp"
+ #include "catlass/gemm/gemm_type.hpp"
+ #include "catlass/layout/layout.hpp"
+ #include "catlass/status.hpp"
+ #include "tla/layout.hpp"
+ #include "tla/tensor.hpp"
+  using _0 = tla::Int<0>;
+       using _1 = tla::Int<1>;
+       using _2 = tla::Int<2>;
+       using _4 = tla::Int<4>;
+       using _8 = tla::Int<8>;
+       using _16 = tla::Int<16>;
+       using _32 = tla::Int<32>;
+       using _64 = tla::Int<64>;
+       using _128 = tla::Int<128>;
+       using _256 = tla::Int<256>;
+       using _512 = tla::Int<512>;
+       using _1024 = tla::Int<1024>;
+       using _2048 = tla::Int<2048>;
+       using _4096 = tla::Int<4096>;
+       using _8192 = tla::Int<8192>;
+       using _16384 = tla::Int<16384>;
+       using _32768 = tla::Int<32768>;
+       using _65536 = tla::Int<65536>;
+       #else
+       #define CATLASS_ARCH 2201
+       #include "chunk_bwd_dqkwg_common.h"
+       #include "catlass/arch/arch.hpp"
+       #include "catlass/catlass.hpp"
+       #include "catlass/gemm/block/block_mmad.hpp"
+       #include "catlass/gemm/block/block_swizzle.hpp"
+       #include "catlass/gemm/device/device_gemm.hpp"
+       #include "catlass/gemm/dispatch_policy.hpp"
+       #include "catlass/gemm/gemm_type.hpp"
+       #include "catlass/layout/layout.hpp"
+       #include "catlass/status.hpp"
+       #include "tla/layout.hpp"
+       #include "tla/tensor.hpp"
+       #endif
+ using namespace tla;
+ using namespace Catlass;
+ using namespace AscendC;
+ 
+ namespace Catlass::Gemm::Kernel {
+ 
+ /**
+  * TileGemmDirect: Single-shot tile-level GEMM replacing BlockMmadTla.
+  * Directly performs GM→L1→L0→Mmad→FixPipe→GM without tiling loops or pingpong buffers.
+  * Optimal when all matrix dimensions fit in a single L0 tile (M≤128, N≤128, K≤128).
+  *
+  * Compared to BlockMmadTla<MmadPingpong>:
+  *  - No multi-stage L1/L0 buffers (1 stage vs 2)
+  *  - No nested tiling loops (kL1×mL0×kL0×nL0 all = 1 for our sizes)
+  *  - Minimal event overhead: 4 Set + 4 Wait per GEMM vs ~20+ in Block
+  *  - Half the L1/L0 memory usage (no pingpong double-buffering)
+  */
+ template <class ArchTag_, class ElementC_, class TileCopy_>
+ struct TileGemmDirect {
+     using ArchTag = ArchTag_;
+     using TileCopy = TileCopy_;
+     using ElementA = typename TileCopy::ElementA;
+     using ElementB = typename TileCopy::ElementB;
+     using ElementC = ElementC_;
+     using ElementAccumulator = typename TileCopy::ElementAccumulator;
+ 
+     using LayoutTagL1A = typename TileCopy::LayoutTagL1A;
+     using LayoutTagL1B = typename TileCopy::LayoutTagL1B;
+     using LayoutTagL0A = typename TileCopy::LayoutTagL0A;
+     using LayoutTagL0B = typename TileCopy::LayoutTagL0B;
+     using CopyL1ToL0A = typename TileCopy::CopyL1ToL0A;
+     using CopyL1ToL0B = typename TileCopy::CopyL1ToL0B;
+     using TileMmadType = Tile::TileMmadTla<ArchTag, ElementA, LayoutTagL1A>;
+ 
+     // Single L0 tile dimensions (max supported by AtlasA2 Cube)
+     static constexpr uint32_t TILE_M = 128;
+     static constexpr uint32_t TILE_N = 128;
+     static constexpr uint32_t TILE_K = 128;
+ 
+     // Single-stage buffer sizes (no pingpong)
+     static constexpr uint32_t L1A_TILE_SIZE = TILE_M * TILE_K * sizeof(ElementA);
+     static constexpr uint32_t L1B_TILE_SIZE = TILE_K * TILE_N * sizeof(ElementB);
+ 
+     // Static L1 layouts for tile-sized buffers
+     static constexpr auto L1A_LAYOUT =
+         tla::MakeLayout<ElementA, LayoutTagL1A>(tla::Int<TILE_M>{}, tla::Int<TILE_K>{});
+     static constexpr auto L1B_LAYOUT =
+         tla::MakeLayout<ElementB, LayoutTagL1B>(tla::Int<TILE_K>{}, tla::Int<TILE_N>{});
+ 
+     /// Construct: allocate single-stage buffers, initialize events
+     CATLASS_DEVICE
+     TileGemmDirect(Arch::Resource<ArchTag> &resource)
+     {
+         if ASCEND_IS_AIC {
+             AscendC::SetMMLayoutTransform(true);
+ 
+             // Allocate single-stage buffers from resource pools
+             l1ABuf = resource.l1Buf.template GetBufferByByte<ElementA>(0);
+             l1BBuf = resource.l1Buf.template GetBufferByByte<ElementB>(L1A_TILE_SIZE);
+             l0ABuf = resource.l0ABuf.template GetBufferByByte<ElementA>(0);
+             l0BBuf = resource.l0BBuf.template GetBufferByByte<ElementB>(0);
+             l0CBuf = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(0);
+ 
+             // Initialize events: buffers are initially free
+             AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(0);  // L1 free for MTE2 write
+             AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(0);     // L0A/L0B free for MTE1 write
+         }
+     }
+ 
+     /// Destructor: drain pending events
+     CATLASS_DEVICE
+     ~TileGemmDirect()
+     {
+         if ASCEND_IS_AIC {
+             AscendC::SetMMLayoutTransform(false);
+             AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(0);
+             AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(0);
+         }
+     }
+ 
+     /// Perform a single-tile GEMM: C = A @ B
+     template <class TensorA, class TensorB, class TensorC>
+     CATLASS_DEVICE
+     void operator()(TensorA &tensorA, TensorB &tensorB, TensorC &tensorC, GemmCoord const &actualShape)
+     {
+         using CopyGmToL1A = typename TileCopy::template CopyGmToL1A<TensorA>;
+         using CopyGmToL1B = typename TileCopy::template CopyGmToL1B<TensorB>;
+ #if (defined(CATLASS_ARCH) && CATLASS_ARCH == 2201)
+         using CopyL0CToGm = typename TileCopy::template CopyL0CToGm<TensorC>;
+ #endif
+ #if (defined(CATLASS_ARCH) && CATLASS_ARCH == 3510)
+         using CopyL0CToGm = typename TileCopy::template CopyL0CToDst<TensorC>;
+ #endif
+ 
+         CopyGmToL1A copyGmToL1A;
+         CopyGmToL1B copyGmToL1B;
+         CopyL1ToL0A copyL1ToL0A;
+         CopyL1ToL0B copyL1ToL0B;
+         CopyL0CToGm copyL0CToGm;
+         TileMmadType tileMmad;
+ 
+         uint32_t m = actualShape.m();
+         uint32_t k = actualShape.k();
+         uint32_t n = actualShape.n();
+ 
+         // Avoid gemv mode on AtlasA2
+         uint32_t mActual = m;
+         if constexpr (std::is_same_v<ArchTag, Arch::AtlasA2>) {
+             if (mActual == 1) mActual = 16;
+         }
+ 
+         // Create L1 tensor views (static tile-size layout)
+         auto tensorL1A = tla::MakeTensor(l1ABuf, L1A_LAYOUT, Arch::PositionL1{});
+         auto tensorL1B = tla::MakeTensor(l1BBuf, L1B_LAYOUT, Arch::PositionL1{});
+ 
+         // ---- Step 1: GM → L1 (MTE2) ----
+         AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(0);  // Wait L1 free
+         copyGmToL1A(tensorL1A, tensorA);
+         copyGmToL1B(tensorL1B, tensorB);
+         AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(0);   // Signal L1 data ready
+ 
+         // ---- Step 2: L1 → L0A/L0B (MTE1) ----
+         AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(0);  // Wait L1 data ready
+         AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(0);     // Wait L0A/L0B free
+ 
+         auto layoutL0A = tla::MakeLayout<ElementA, LayoutTagL0A>(mActual, k);
+         auto tensorL0A = tla::MakeTensor(l0ABuf, layoutL0A, Arch::PositionL0A{});
+         auto tensorTileL1A = GetTile(tensorL1A, tla::MakeCoord(0, 0), tla::MakeShape(mActual, k));
+         copyL1ToL0A(tensorL0A, tensorTileL1A);
+ 
+         auto layoutL0B = tla::MakeLayout<ElementB, LayoutTagL0B>(k, n);
+         auto tensorL0B = tla::MakeTensor(l0BBuf, layoutL0B, Arch::PositionL0B{});
+         auto tensorTileL1B = GetTile(tensorL1B, tla::MakeCoord(0, 0), tla::MakeShape(k, n));
+         copyL1ToL0B(tensorL0B, tensorTileL1B);
+ 
+         AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(0);   // Signal L1 free
+         AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(0);      // Signal L0 data ready
+ 
+         // ---- Step 3: Mmad (Cube) ----
+         AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(0);
+ 
+         auto layoutL0C = tla::MakeLayoutL0C(mActual, n);
+         auto tensorL0C = tla::MakeTensor(l0CBuf, layoutL0C, Arch::PositionL0C{});
+ 
+         tileMmad(tensorL0C, tensorL0A, tensorL0B, mActual, n, k, true, 0b11);
+ 
+         AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(0);      // Signal L0A/L0B free
+ 
+         // ---- Step 4: L0C → GM (FixPipe, auto-triggered by unitFlag=0b11) ----
+         copyL0CToGm(tensorC, tensorL0C, 0b11);
+     }
+ 
+ private:
+     AscendC::LocalTensor<ElementA> l1ABuf;
+     AscendC::LocalTensor<ElementB> l1BBuf;
+     AscendC::LocalTensor<ElementA> l0ABuf;
+     AscendC::LocalTensor<ElementB> l0BBuf;
+     AscendC::LocalTensor<ElementAccumulator> l0CBuf;
+ };
+ 
+ /**
+  * ChunkBwdDqkwg Cube Kernel 模板类
+  * 
+  * 模板参数:
+  * - BlockMmadPart1_: Part 1 的矩阵乘法 (dv @ h^T -> dw)
+  * - BlockMmadPart2_: Part 2 的矩阵乘法 (q @ k^T -> mm5)
+  * - BlockMmadPart3_: Part 3 的矩阵乘法 (do @ v^T -> ds)
+  * - BlockMmadPart4_: Part 4 的矩阵乘法 (do @ h^T -> dq)
+  * - BlockMmadPart5_: Part 5 的矩阵乘法 (v @ dh -> dk)
+  * - BlockMmadPart6_: Part 6 的矩阵乘法 (ds @ k -> dq+=)
+  * - BlockMmadPart7_: Part 7 的矩阵乘法 (ds^T @ q -> dk+=)
+  */
+ template <
+     class BlockMmadPart1_,  // dv @ h^T -> dw
+     class BlockMmadPart2_,  // q @ k^T -> mm5
+     class BlockMmadPart3_,  // do @ v^T -> ds
+     class BlockMmadPart4_,  // do @ h^T -> dq
+     class BlockMmadPart5_,  // v @ dh -> dk
+     class BlockMmadPart6_,  // ds @ k -> dq
+     class BlockMmadPart7_   // ds^T @ q -> dk
+ >
+ class ChunkBwdDqkwgTla {
+ public:
+     using BlockMmadPart1 = BlockMmadPart1_;
+     using BlockMmadPart2 = BlockMmadPart2_;
+     using BlockMmadPart3 = BlockMmadPart3_;
+     using BlockMmadPart4 = BlockMmadPart4_;
+     using BlockMmadPart5 = BlockMmadPart5_;
+     using BlockMmadPart6 = BlockMmadPart6_;
+     using BlockMmadPart7 = BlockMmadPart7_;
+     
+     using ArchTag = typename BlockMmadPart1::ArchTag;
+     
+     // 数据类型定义 (基于 Part 2: q @ k^T)
+     using ElementA = typename BlockMmadPart2::ElementA;
+     using ElementB = typename BlockMmadPart2::ElementB;
+     using ElementC = typename BlockMmadPart2::ElementC;
+     
+     // Layout 定义
+     using LayoutRowMajor = layout::RowMajor;
+     using LayoutColMajor = layout::ColumnMajor;
+     
+     /// Parameters structure
+     struct Params {
+         // 输入指针
+         GM_ADDR ptrQ;      // [B, H, T, K]
+         GM_ADDR ptrK;      // [B, H, T, K]
+         GM_ADDR ptrV;      // [B, H, T, V]
+         GM_ADDR ptrG;      // [B, H, T]
+         GM_ADDR ptrH;      // [B, num_chunks, H, K, V]
+         GM_ADDR ptrDo;     // [B, H, T, V]
+         GM_ADDR ptrDh;     // [B, num_chunks, H, K, V]
+         GM_ADDR ptrDv;     // [B, H, T, V]
+         //varlen
+         GM_ADDR ptrCuSeqLens;
+         GM_ADDR ptrChunkIndices;
+         
+         // 输出指针
+         GM_ADDR ptrDq;     // [B, H, T, K]
+         GM_ADDR ptrDk;     // [B, H, T, K]
+         GM_ADDR ptrDw;     // [B, H, T, K]
+         GM_ADDR ptrDg;     // [B, H, T]
+         
+         // Workspace 指针
+         GM_ADDR ptrWorkspace;
+         
+         // Workspace 偏移
+         uint64_t wsDwOffset;
+         uint64_t wsDgLastOffset;
+         uint64_t wsMm5Offset;
+         uint64_t wsDsTempOffset;
+         uint64_t wsMm6Offset;
+         uint64_t wsMm7Offset;
+         
+         // 形状参数
+         uint64_t B;// = CONST_B;
+         uint64_t H;// = CONST_H;
+         uint64_t T;// = CONST_T;
+         uint64_t K;// = CONST_K;
+         uint64_t V;// = CONST_V;
+         uint64_t BT;// = CONST_BT;
+         uint64_t numChunks;// = CONST_NUM_CHUNKS;
+         // uint64_t chunkSize = 64;
+         uint64_t isVarLen;
+         
+         // 其他参数
+         float scale;
+         
+         CATLASS_DEVICE
+         Params() {}
+         
+         CATLASS_DEVICE
+         Params(
+             GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
+             GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
+             GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
+             GM_ADDR workspace,
+             uint64_t B, uint64_t H, uint64_t T, uint64_t K, uint64_t V, uint64_t BT, uint64_t numChunks, 
+             uint64_t wsDw, uint64_t wsDgLast, uint64_t wsMm5, uint64_t wsDsTemp, uint64_t wsMm6, uint64_t wsMm7,
+             float s, uint64_t isVarLen
+         ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
+             ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLens(cu_seqlen), ptrChunkIndices(chunk_indices),
+             ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
+             ptrWorkspace(workspace),
+             wsDwOffset(wsDw), wsDgLastOffset(wsDgLast),
+             wsMm5Offset(wsMm5), wsDsTempOffset(wsDsTemp), wsMm6Offset(wsMm6), wsMm7Offset(wsMm7),
+             scale(s), B(B), H(H), T(T), K(K), V(V), BT(BT), numChunks(numChunks), isVarLen(isVarLen) {}
+     };
+     
+     CATLASS_DEVICE
+     ChunkBwdDqkwgTla() {}
+     
+     template <int32_t CORE_TYPE = g_coreType>
+     CATLASS_DEVICE
+     void operator()(Params const &params);
+     
+     /**
+      * AIC (Cube) 执行入口
+      */
+     template <>
+     CATLASS_DEVICE
+     void operator()<AscendC::AIC>(Params const &params) {
+         Arch::Resource<ArchTag> resource;
+         uint32_t coreIdx = AscendC::GetBlockIdx();
+         uint32_t coreNum = AscendC::GetBlockNum();
+         
+         uint32_t coreLoops = params.B * params.numChunks;
+         
+         // Layout 创建
+         auto layoutBTxK = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.K);
+         auto layoutKxBT = LayoutColMajor::MakeLayout<ElementA>(params.K, params.BT);
+         auto layoutBTxV = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.V);
+         auto layoutVxBT = LayoutColMajor::MakeLayout<ElementA>(params.V, params.BT);
+         auto layoutBTxBT = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.BT);
+         auto layoutBTxBT_T = LayoutColMajor::MakeLayout<ElementA>(params.BT, params.BT);
+         auto layoutKxV = LayoutRowMajor::MakeLayout<ElementA>(params.K, params.V);
+         auto layoutVxK = LayoutColMajor::MakeLayout<ElementA>(params.V, params.K);
+ 
+         uint32_t bos = 0;
+         uint32_t eos = 0;
+ 
+         // ========== Part 1: b_dw = b_dv @ b_h^T ==========
+         {
+             BlockMmadPart1 blockMmadPart1(resource);
+             auto layoutH = LayoutColMajor::MakeLayout<ElementA>(params.K, params.V);
+             // printf("[cube]coreLoops %d, H %d\n",coreLoops,params.H);
+             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                 params.BT, loopIdx, bos, eos);
+                 uint32_t actual_chunk_len = eos-bos;
+                 uint32_t bIdx = loopIdx / params.numChunks;
+                 uint32_t chunkIdx = loopIdx % params.numChunks;
+ 
+                 GemmCoord actualBlockShape{
+                     static_cast<uint32_t>(actual_chunk_len),
+                     static_cast<uint32_t>(params.K),
+                     static_cast<uint32_t>(params.V)
+                 };
+ 
+                 for (uint32_t h = 0; h < params.H; h++) {
+ 
+                     // 设置 GM 地址
+                     // dv: [B, H, T, V] -> offset = ((b * H + h) * T + chunk * BT) * V
+                     // uint64_t dvOffset = ((bIdx * params.H + h) * params.T + bos) * params.V;
+                     uint64_t dvOffset = (h * params.T + bos) * params.V;
+ 
+                     // h: [B, H, num_chunks, K, V] -> offset = ((b * numChunks + chunk) * H + h) * K * V
+                     uint64_t hOffset = ((bIdx * params.H + h) * params.numChunks + chunkIdx) * params.K * params.V;
+ 
+                     // dw output (workspace): [B, H, T, K]
+                     // uint64_t dwOffset = ((bIdx * params.H + h) * params.T + bos) * params.K;
+                     uint64_t dwOffset = (h * params.T + bos) * params.K;
+ 
+                     GlobalTensor<ElementA> gmDv;
+                     gmDv.SetGlobalBuffer((__gm__ ElementA *)params.ptrDv + dvOffset);
+                     // gmDv.SetGlobalBuffer((__gm__ ElementA *)params.ptrDv);
+                     GlobalTensor<ElementA> gmH;
+                     gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
+                     // gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH);
+                     GlobalTensor<ElementC> gmDw;
+                     // gmDw.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDwOffset) + dwOffset);
+                     gmDw.SetGlobalBuffer((__gm__ ElementC *)params.ptrDw + dwOffset);
+ 
+                     auto tensorDv = tla::MakeTensor(gmDv, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                     auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});  // h^T
+                     auto tensorDw = tla::MakeTensor(gmDw, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                     
+                     AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+ 
+                     auto tensorBlockDv = GetTile(tensorDv, tla::MakeCoord(0, 0), 
+                                                   tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                     auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), 
+                                                  tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                     auto tensorBlockDw = GetTile(tensorDw, tla::MakeCoord(0, 0), 
+                                                   tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                     
+                     blockMmadPart1(tensorBlockDv, tensorBlockH, tensorBlockDw, actualBlockShape);
+ 
+ 
+                     AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+ 
+                 }
+             }
+             // 最终同步(后移)
+             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+         }
+ 
+         // ========== Part 2: mm5 = q @ k^T (纯 Cube) ==========
+         {
+             BlockMmadPart2 blockMmadPart2(resource);
+             
+             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                 params.BT, loopIdx, bos, eos);
+                 uint32_t actual_chunk_len = eos-bos;
+                 uint32_t bIdx = loopIdx / params.numChunks;
+                 uint32_t chunkIdx = loopIdx % params.numChunks;
+                 
+                 GemmCoord actualBlockShape{
+                     static_cast<uint32_t>(actual_chunk_len),
+                     static_cast<uint32_t>(actual_chunk_len),
+                     static_cast<uint32_t>(params.K)
+                 };
+                 
+                 for (uint32_t h = 0; h < params.H; h++) {
+                     // q, k: [B, H, T, K]
+                     uint64_t qkOffset = (h * params.T + bos) * params.K;
+                     // mm5: workspace [B, H, T, BT]
+                     uint64_t mm5Offset = (h * params.T + bos) * params.BT;
+                     
+                     GlobalTensor<ElementA> gmQ;
+                     gmQ.SetGlobalBuffer((__gm__ ElementA *)params.ptrQ + qkOffset);
+                     GlobalTensor<ElementA> gmK;
+                     gmK.SetGlobalBuffer((__gm__ ElementA *)params.ptrK + qkOffset);
+                     GlobalTensor<ElementC> gmMm5;
+                     gmMm5.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm5Offset) + mm5Offset);
+ 
+                     auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                     auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutKxBT), Arch::PositionGM{});  // k^T
+                     auto tensorMm5 = tla::MakeTensor(gmMm5, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
+ 
+                     auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0), 
+                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                     auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), 
+                                                  tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                     auto tensorBlockMm5 = GetTile(tensorMm5, tla::MakeCoord(0, 0), 
+                                                    tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                     
+                     blockMmadPart2(tensorBlockQ, tensorBlockK, tensorBlockMm5, actualBlockShape);
+ 
+                 }
+             }
+ 
+         }
+ 
+         // ========== Part 3: b_ds = b_do @ b_v^T ==========
+         {
+             // AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+             
+             BlockMmadPart3 blockMmadPart3(resource);
+             
+             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                 params.BT, loopIdx, bos, eos);
+                 uint32_t actual_chunk_len = eos-bos;
+                 uint32_t bIdx = loopIdx / params.numChunks;
+                 uint32_t chunkIdx = loopIdx % params.numChunks;
+                 
+                 GemmCoord actualBlockShape{
+                     static_cast<uint32_t>(actual_chunk_len),
+                     static_cast<uint32_t>(actual_chunk_len),
+                     static_cast<uint32_t>(params.V)
+                 };
+                 
+                 for (uint32_t h = 0; h < params.H; h++) {
+                     // do, v: [B, H, T, V]
+                     // uint64_t dvOffset = ((bIdx * params.H + h) * params.T + bos) * params.V;
+                     uint64_t dvOffset = (h * params.T + bos) * params.V;
+                     // ds_temp: workspace [B, H, T, BT]
+                     // uint64_t dsOffset = ((bIdx * params.H + h) * params.T + bos) * params.BT;
+                     uint64_t dsOffset = (h * params.T + bos) * params.BT;
+                     
+                     GlobalTensor<ElementA> gmDo;
+                     gmDo.SetGlobalBuffer((__gm__ ElementA *)params.ptrDo + dvOffset);
+                     GlobalTensor<ElementA> gmV;
+                     gmV.SetGlobalBuffer((__gm__ ElementA *)params.ptrV + dvOffset);
+                     GlobalTensor<ElementC> gmDs;
+                     gmDs.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
+                     
+                     auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                     auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutVxBT), Arch::PositionGM{});  // v^T
+                     auto tensorDs = tla::MakeTensor(gmDs, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
+                     
+                     AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                     // AscendC::PipeBarrier<PIPE_MTE2>();
+                     auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0), 
+                                                   tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                     auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), 
+                                                  tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                     auto tensorBlockDs = GetTile(tensorDs, tla::MakeCoord(0, 0), 
+                                                   tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                     
+                     blockMmadPart3(tensorBlockDo, tensorBlockV, tensorBlockDs, actualBlockShape);
+ 
+                     AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+                 }
+             }
+             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+         }
+ 
+         // ========== Fused Part 4+6: b_dq = b_do @ b_h^T, then mm6 = b_ds_temp @ b_k ==========
+         // 每次迭代先计算 dq, 再计算 mm6, Vector 端在 UB 中完成 dq += mm6 避免 GM 往返
+         {
+             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                 params.BT, loopIdx, bos, eos);
+                 uint32_t actual_chunk_len = eos-bos;
+                 uint32_t bIdx = loopIdx / params.numChunks;
+                 uint32_t chunkIdx = loopIdx % params.numChunks;
+ 
+                 for (uint32_t h = 0; h < params.H; h++) {
+                     // --- Sub-part 4: dq = do @ h^T ---
+                     {
+                         GemmCoord actualBlockShape{
+                             static_cast<uint32_t>(actual_chunk_len),
+                             static_cast<uint32_t>(params.K),
+                             static_cast<uint32_t>(params.V)
+                         };
+                         uint64_t doOffset = (h * params.T + bos) * params.V;
+                         uint64_t hOffset = ((bIdx * params.H + h) * params.numChunks + chunkIdx) * params.K * params.V;
+                         uint64_t dqOffset = (h * params.T + bos) * params.K;
+ 
+                         GlobalTensor<ElementA> gmDo;
+                         gmDo.SetGlobalBuffer((__gm__ ElementA *)params.ptrDo + doOffset);
+                         GlobalTensor<ElementA> gmH;
+                         gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
+                         GlobalTensor<ElementC> gmDq;
+                         gmDq.SetGlobalBuffer((__gm__ ElementC *)params.ptrDq + dqOffset);
+ 
+                         auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                         auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});
+                         auto tensorDq = tla::MakeTensor(gmDq, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+ 
+                         AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+ 
+                         auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0),
+                                                       tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                         auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0),
+                                                      tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                         auto tensorBlockDq = GetTile(tensorDq, tla::MakeCoord(0, 0),
+                                                       tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+ 
+                         BlockMmadPart4 blockMmadPart4(resource);
+                         blockMmadPart4(tensorBlockDo, tensorBlockH, tensorBlockDq, actualBlockShape);
+                     }
+                     AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+ 
+                     // --- Sub-part 6: mm6 = ds_temp @ k ---
+                     {
+                         GemmCoord actualBlockShape{
+                             static_cast<uint32_t>(actual_chunk_len),
+                             static_cast<uint32_t>(params.K),
+                             static_cast<uint32_t>(actual_chunk_len)
+                         };
+                         uint64_t dsOffset = (h * params.T + bos) * params.BT;
+                         uint64_t kOffset = (h * params.T + bos) * params.K;
+ 
+                         GlobalTensor<ElementA> gmDsTemp;
+                         gmDsTemp.SetGlobalBuffer((__gm__ ElementA *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
+                         GlobalTensor<ElementA> gmK;
+                         gmK.SetGlobalBuffer((__gm__ ElementA *)params.ptrK + kOffset);
+                         GlobalTensor<ElementC> gmMm6;
+                         gmMm6.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm6Offset) + kOffset);
+ 
+                         auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
+                         auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                         auto tensorMm6 = tla::MakeTensor(gmMm6, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+ 
+                         AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+ 
+                         auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0),
+                                                           tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                         auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0),
+                                                      tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                         auto tensorBlockMm6 = GetTile(tensorMm6, tla::MakeCoord(0, 0),
+                                                        tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+ 
+                         BlockMmadPart6 blockMmadPart6(resource);
+                         blockMmadPart6(tensorBlockDsTemp, tensorBlockK, tensorBlockMm6, actualBlockShape);
+                     }
+                     AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+                 }
+             }
+             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+         }
+ 
+         // ========== Fused Part 5+7: b_dk = b_v @ b_dh, then mm7 = b_ds_temp^T @ b_q ==========
+         {
+             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                 params.BT, loopIdx, bos, eos);
+                 uint32_t actual_chunk_len = eos-bos;
+                 uint32_t bIdx = loopIdx / params.numChunks;
+                 uint32_t chunkIdx = loopIdx % params.numChunks;
+ 
+                 for (uint32_t h = 0; h < params.H; h++) {
+                     // --- Sub-part 5: dk = v @ dh ---
+                     {
+                         GemmCoord actualBlockShape{
+                             static_cast<uint32_t>(actual_chunk_len),
+                             static_cast<uint32_t>(params.K),
+                             static_cast<uint32_t>(params.V)
+                         };
+                         uint64_t vOffset = (h * params.T + bos) * params.V;
+                         uint64_t dhOffset = ((bIdx * params.H + h) * params.numChunks + chunkIdx) * params.K * params.V;
+                         uint64_t dkOffset = (h * params.T + bos) * params.K;
+ 
+                         GlobalTensor<ElementA> gmV;
+                         gmV.SetGlobalBuffer((__gm__ ElementA *)params.ptrV + vOffset);
+                         GlobalTensor<ElementA> gmDh;
+                         gmDh.SetGlobalBuffer((__gm__ ElementA *)params.ptrDh + dhOffset);
+                         GlobalTensor<ElementC> gmDk;
+                         gmDk.SetGlobalBuffer((__gm__ ElementC *)params.ptrDk + dkOffset);
+ 
+                         auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                         auto tensorDh = tla::MakeTensor(gmDh, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});
+                         auto tensorDk = tla::MakeTensor(gmDk, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+ 
+                         AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+ 
+                         auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0),
+                                                      tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                         auto tensorBlockDh = GetTile(tensorDh, tla::MakeCoord(0, 0),
+                                                       tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                         auto tensorBlockDk = GetTile(tensorDk, tla::MakeCoord(0, 0),
+                                                       tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+ 
+                         BlockMmadPart5 blockMmadPart5(resource);
+                         blockMmadPart5(tensorBlockV, tensorBlockDh, tensorBlockDk, actualBlockShape);
+                     }
+                     AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+ 
+                     // --- Sub-part 7: mm7 = ds_temp^T @ q ---
+                     {
+                         GemmCoord actualBlockShape{
+                             static_cast<uint32_t>(actual_chunk_len),
+                             static_cast<uint32_t>(params.K),
+                             static_cast<uint32_t>(actual_chunk_len)
+                         };
+                         uint64_t dsOffset = (h * params.T + bos) * params.BT;
+                         uint64_t qOffset = (h * params.T + bos) * params.K;
+ 
+                         GlobalTensor<ElementA> gmDsTemp;
+                         gmDsTemp.SetGlobalBuffer((__gm__ ElementA *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
+                         GlobalTensor<ElementA> gmQ;
+                         gmQ.SetGlobalBuffer((__gm__ ElementA *)params.ptrQ + qOffset);
+                         GlobalTensor<ElementC> gmMm7;
+                         gmMm7.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm7Offset) + qOffset);
+ 
+                         auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT_T), Arch::PositionGM{});
+                         auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                         auto tensorMm7 = tla::MakeTensor(gmMm7, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+ 
+                         AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+ 
+                         auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0),
+                                                           tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                         auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0),
+                                                      tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                         auto tensorBlockMm7 = GetTile(tensorMm7, tla::MakeCoord(0, 0),
+                                                        tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+ 
+                         BlockMmadPart7 blockMmadPart7(resource);
+                         blockMmadPart7(tensorBlockDsTemp, tensorBlockQ, tensorBlockMm7, actualBlockShape);
+                     }
+                     AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+                 }
+             }
+ 
+             // 最终同步
+             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+         }
+ 
+     }
+ };
+ 
+ } // namespace Catlass::Gemm::Kernel
+ 
+ /**
+  * Cube Process 类 (AIC 端入口)
+  */
+ template <typename DataType, typename GType>
+ class ChunkBwdDqkwgCubeProcess {
+ public:
+     __aicore__ inline ChunkBwdDqkwgCubeProcess(
+         GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
+         GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
+         GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
+         GM_ADDR workspace
+     ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
+         ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLen(cu_seqlen), ptrChunkIndices(chunk_indices),
+         ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
+         ptrWorkspace(workspace) {}
+     
+     __aicore__ inline void Init(const ChunkBwdDqkwgTilingData &tiling);
+     __aicore__ inline void Process();
+     
+ private:
+     // 输入输出指针
+     GM_ADDR ptrQ;
+     GM_ADDR ptrK;
+     GM_ADDR ptrV;
+     GM_ADDR ptrG;
+     GM_ADDR ptrH;
+     GM_ADDR ptrDo;
+     GM_ADDR ptrDh;
+     GM_ADDR ptrDv;
+     GM_ADDR ptrCuSeqLen;
+     GM_ADDR ptrChunkIndices;
+     GM_ADDR ptrDq;
+     GM_ADDR ptrDk;
+     GM_ADDR ptrDw;
+     GM_ADDR ptrDg;
+     GM_ADDR ptrWorkspace;
+     
+     // Tiling 参数
+     uint64_t B = CONST_B;
+     uint64_t H = CONST_H;
+     uint64_t T = CONST_T;
+     uint64_t K = CONST_K;
+     uint64_t V = CONST_V;
+     uint64_t BT = CONST_BT;
+     uint64_t numChunks = CONST_NUM_CHUNKS;
+     float scale;
+     uint64_t isVarLen;
+     
+     // Workspace 偏移
+     uint64_t wsDwOffset;
+     uint64_t wsDgLastOffset;
+     uint64_t wsMm5Offset;
+     uint64_t wsDsTempOffset;
+     uint64_t wsMm6Offset;
+     uint64_t wsMm7Offset;
+ };
+ 
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgCubeProcess<DataType, GType>::Init(const ChunkBwdDqkwgTilingData &tiling) {
+ 
+ /*
+     // 设置 workspace 偏移
+     // wsDwOffset = 0;
+     wsDgLastOffset = 0;//B * H * numChunks * sizeof(float);
+     // wsDgLastOffset = ((wsDgLastOffset + 31) / 32) * 32;
+     wsMm5Offset = wsDgLastOffset + ((B * H * numChunks * sizeof(float) + 31) / 32) * 32;
+     // wsMm5Offset = wsMm5Offset;
+     wsDsTempOffset = wsMm5Offset + B * H * T * BT * sizeof(DataType);
+     wsMm6Offset = wsDsTempOffset + B * H * T * BT * sizeof(DataType);
+     wsMm7Offset = wsMm6Offset + B * H * T * K * sizeof(DataType);
+ */
+     // printf("[cube] wsDgLastOffset %d,wsMm5Offset %d,wsDsTempOffset %d, wsMm6Offset %d wsMm7Offset %d\n",wsDgLastOffset,wsMm5Offset,wsDsTempOffset,wsMm6Offset, wsMm7Offset);
+ ////////////////////tiling/////
+     scale = tiling.scale;
+     B = tiling.B;
+     H = tiling.H;
+     T = tiling.T;
+     K = tiling.K;
+     V = tiling.V;
+     BT = tiling.BT;
+     numChunks = tiling.numChunks;
+     wsDgLastOffset = tiling.wsDgLastOffset;
+     // wsDgLastOffset = ((wsDgLastOffset + 31) / 32) * 32;
+     wsMm5Offset = tiling.wsMm5Offset;
+     // wsMm5Offset = wsMm5Offset;
+     wsDsTempOffset = tiling.wsDsTempOffset;
+     wsMm6Offset = tiling.wsMm6Offset;
+     wsMm7Offset = tiling.wsMm7Offset;
+     isVarLen = tiling.isVarLen;
+ // printf("[cube] DTYPE_G %d, float %d\n",sizeof(DTYPE_G),sizeof(float));
+ }
+ 
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgCubeProcess<DataType, GType>::Process() {
+     using namespace Catlass;
+     using namespace Catlass::Gemm;
+     
+     // Layout 类型定义
+     using LayoutRowMajor = layout::RowMajor;
+     using LayoutColMajor = layout::ColumnMajor;
+     
+     // 架构和策略定义
+     using ArchTag = Arch::AtlasA2;
+ 
+     // Part 1: dv @ h^T -> dw  [BT, V] @ [V, K] -> [BT, K]
+     using TileCopyPart1 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+     using BlockMmadPart1 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart1>;
+     
+     // Part 2: q @ k^T -> mm5  [BT, K] @ [K, BT] -> [BT, BT]
+     using TileCopyPart2 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+     using BlockMmadPart2 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart2>;
+     
+     // Part 3: do @ v^T -> ds  [BT, V] @ [V, BT] -> [BT, BT]
+     using TileCopyPart3 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+     using BlockMmadPart3 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart3>;
+     
+     // Part 4: do @ h^T -> dq  [BT, V] @ [V, K] -> [BT, K]
+     using TileCopyPart4 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+     using BlockMmadPart4 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart4>;
+     
+     // Part 5: v @ dh -> dk  [BT, V] @ [V, K] -> [BT, K]
+     using TileCopyPart5 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+     using BlockMmadPart5 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart5>;
+     
+     // Part 6: ds @ k -> dq+=  [BT, BT] @ [BT, K] -> [BT, K]
+     using TileCopyPart6 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
+     using BlockMmadPart6 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart6>;
+     
+     // Part 7: ds^T @ q -> dk+=  [BT, BT] @ [BT, K] -> [BT, K]
+     using TileCopyPart7 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutColMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
+     using BlockMmadPart7 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart7>;
+     
+     // Kernel 实例
+     using MatmulKernel = Kernel::ChunkBwdDqkwgTla<
+         BlockMmadPart1, BlockMmadPart2, BlockMmadPart3, BlockMmadPart4,
+         BlockMmadPart5, BlockMmadPart6, BlockMmadPart7
+     >;
+     
+     MatmulKernel kernel;
+     typename MatmulKernel::Params params(
+         ptrQ, ptrK, ptrV, ptrG, ptrH,
+         ptrDo, ptrDh, ptrDv, ptrCuSeqLen, ptrChunkIndices,
+         ptrDq, ptrDk, ptrDw, ptrDg,
+         ptrWorkspace, B, H, T, K, V, BT, numChunks,
+         wsDwOffset, wsDgLastOffset, wsMm5Offset, wsDsTempOffset, wsMm6Offset, wsMm7Offset,
+         scale, isVarLen
+     );
+     
+     kernel(params);
+ }
+ 
+ #endif  // CHUNK_BWD_DQKWG_CUBE_H
+ 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube_legacy.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube_legacy.h
@@ -1,0 +1,804 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_bwd_dqkwg_cube.h
+ */
+
+#ifndef CHUNK_BWD_DQKWG_CUBE_LEGACY_H
+#define CHUNK_BWD_DQKWG_CUBE_LEGACY_H
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    #define CATLASS_ARCH 3510
+#include "chunk_bwd_dqkwg_common.h"
+#include "catlass/arch/arch.hpp"
+#include "catlass/catlass.hpp"
+#include "catlass/gemm/block/block_mmad.hpp"
+#include "catlass/gemm/block/block_swizzle.hpp"
+#include "catlass/gemm/device/device_gemm.hpp"
+#include "catlass/gemm/dispatch_policy.hpp"
+#include "catlass/gemm/gemm_type.hpp"
+#include "catlass/layout/layout.hpp"
+#include "catlass/status.hpp"
+#include "tla/layout.hpp"
+#include "tla/tensor.hpp"
+ using _0 = tla::Int<0>;
+ 	 using _1 = tla::Int<1>;
+ 	 using _2 = tla::Int<2>;
+ 	 using _4 = tla::Int<4>;
+ 	 using _8 = tla::Int<8>;
+ 	 using _16 = tla::Int<16>;
+ 	 using _32 = tla::Int<32>;
+ 	 using _64 = tla::Int<64>;
+ 	 using _128 = tla::Int<128>;
+ 	 using _256 = tla::Int<256>;
+ 	 using _512 = tla::Int<512>;
+ 	 using _1024 = tla::Int<1024>;
+ 	 using _2048 = tla::Int<2048>;
+ 	 using _4096 = tla::Int<4096>;
+ 	 using _8192 = tla::Int<8192>;
+ 	 using _16384 = tla::Int<16384>;
+ 	 using _32768 = tla::Int<32768>;
+ 	 using _65536 = tla::Int<65536>;
+ 	 #else
+ 	 #define CATLASS_ARCH 2201
+ 	 #include "chunk_bwd_dqkwg_common.h"
+ 	 #include "catlass/arch/arch.hpp"
+ 	 #include "catlass/catlass.hpp"
+ 	 #include "catlass/gemm/block/block_mmad.hpp"
+ 	 #include "catlass/gemm/block/block_swizzle.hpp"
+ 	 #include "catlass/gemm/device/device_gemm.hpp"
+ 	 #include "catlass/gemm/dispatch_policy.hpp"
+ 	 #include "catlass/gemm/gemm_type.hpp"
+ 	 #include "catlass/layout/layout.hpp"
+ 	 #include "catlass/status.hpp"
+ 	 #include "tla/layout.hpp"
+ 	 #include "tla/tensor.hpp"
+ 	 #endif
+using namespace tla;
+using namespace Catlass;
+using namespace AscendC;
+
+namespace Catlass::Gemm::Kernel {
+
+/**
+ * ChunkBwdDqkwg Cube Kernel 模板类
+ * 
+ * 模板参数:
+ * - BlockMmadPart1_: Part 1 的矩阵乘法 (dv @ h^T -> dw)
+ * - BlockMmadPart2_: Part 2 的矩阵乘法 (q @ k^T -> mm5)
+ * - BlockMmadPart3_: Part 3 的矩阵乘法 (do @ v^T -> ds)
+ * - BlockMmadPart4_: Part 4 的矩阵乘法 (do @ h^T -> dq)
+ * - BlockMmadPart5_: Part 5 的矩阵乘法 (v @ dh -> dk)
+ * - BlockMmadPart6_: Part 6 的矩阵乘法 (ds @ k -> dq+=)
+ * - BlockMmadPart7_: Part 7 的矩阵乘法 (ds^T @ q -> dk+=)
+ */
+template <
+    class BlockMmadPart1_,  // dv @ h^T -> dw
+    class BlockMmadPart2_,  // q @ k^T -> mm5
+    class BlockMmadPart3_,  // do @ v^T -> ds
+    class BlockMmadPart4_,  // do @ h^T -> dq
+    class BlockMmadPart5_,  // v @ dh -> dk
+    class BlockMmadPart6_,  // ds @ k -> dq
+    class BlockMmadPart7_   // ds^T @ q -> dk
+>
+class ChunkBwdDqkwgTlaLegacy {
+public:
+    using BlockMmadPart1 = BlockMmadPart1_;
+    using BlockMmadPart2 = BlockMmadPart2_;
+    using BlockMmadPart3 = BlockMmadPart3_;
+    using BlockMmadPart4 = BlockMmadPart4_;
+    using BlockMmadPart5 = BlockMmadPart5_;
+    using BlockMmadPart6 = BlockMmadPart6_;
+    using BlockMmadPart7 = BlockMmadPart7_;
+    
+    using ArchTag = typename BlockMmadPart1::ArchTag;
+    
+    // 数据类型定义 (基于 Part 2: q @ k^T)
+    using ElementA = typename BlockMmadPart2::ElementA;
+    using ElementB = typename BlockMmadPart2::ElementB;
+    using ElementC = typename BlockMmadPart2::ElementC;
+    
+    // Layout 定义
+    using LayoutRowMajor = layout::RowMajor;
+    using LayoutColMajor = layout::ColumnMajor;
+    
+    /// Parameters structure
+    struct Params {
+        // 输入指针
+        GM_ADDR ptrQ;      // [B, H, T, K]
+        GM_ADDR ptrK;      // [B, H, T, K]
+        GM_ADDR ptrV;      // [B, H, T, V]
+        GM_ADDR ptrG;      // [B, H, T]
+        GM_ADDR ptrH;      // [B, num_chunks, H, K, V]
+        GM_ADDR ptrDo;     // [B, H, T, V]
+        GM_ADDR ptrDh;     // [B, num_chunks, H, K, V]
+        GM_ADDR ptrDv;     // [B, H, T, V]
+        //varlen
+        GM_ADDR ptrCuSeqLens;
+        GM_ADDR ptrChunkIndices;
+        
+        // 输出指针
+        GM_ADDR ptrDq;     // [B, H, T, K]
+        GM_ADDR ptrDk;     // [B, H, T, K]
+        GM_ADDR ptrDw;     // [B, H, T, K]
+        GM_ADDR ptrDg;     // [B, H, T]
+        
+        // Workspace 指针
+        GM_ADDR ptrWorkspace;
+        
+        // Workspace 偏移
+        uint64_t wsDwOffset;
+        uint64_t wsDgLastOffset;
+        uint64_t wsMm5Offset;
+        uint64_t wsDsTempOffset;
+        uint64_t wsMm6Offset;
+        uint64_t wsMm7Offset;
+        
+        // 形状参数
+        uint64_t B;// = CONST_B;
+        uint64_t H;// = CONST_H;
+        uint64_t T;// = CONST_T;
+        uint64_t K;// = CONST_K;
+        uint64_t V;// = CONST_V;
+        uint64_t BT;// = CONST_BT;
+        uint64_t numChunks;// = CONST_NUM_CHUNKS;
+        // uint64_t chunkSize = 64;
+        uint64_t isVarLen;
+        
+        // 其他参数
+        float scale;
+        
+        CATLASS_DEVICE
+        Params() {}
+        
+        CATLASS_DEVICE
+        Params(
+            GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
+            GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
+            GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
+            GM_ADDR workspace,
+            uint64_t B, uint64_t H, uint64_t T, uint64_t K, uint64_t V, uint64_t BT, uint64_t numChunks, 
+            uint64_t wsDw, uint64_t wsDgLast, uint64_t wsMm5, uint64_t wsDsTemp, uint64_t wsMm6, uint64_t wsMm7,
+            float s, uint64_t isVarLen
+        ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
+            ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLens(cu_seqlen), ptrChunkIndices(chunk_indices),
+            ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
+            ptrWorkspace(workspace),
+            wsDwOffset(wsDw), wsDgLastOffset(wsDgLast),
+            wsMm5Offset(wsMm5), wsDsTempOffset(wsDsTemp), wsMm6Offset(wsMm6), wsMm7Offset(wsMm7),
+            scale(s), B(B), H(H), T(T), K(K), V(V), BT(BT), numChunks(numChunks), isVarLen(isVarLen) {}
+    };
+    
+    CATLASS_DEVICE
+    ChunkBwdDqkwgTlaLegacy() {}
+    
+    template <int32_t CORE_TYPE = g_coreType>
+    CATLASS_DEVICE
+    void operator()(Params const &params);
+    
+    /**
+     * AIC (Cube) 执行入口
+     */
+    template <>
+    CATLASS_DEVICE
+    void operator()<AscendC::AIC>(Params const &params) {
+        Arch::Resource<ArchTag> resource;
+        uint32_t coreIdx = AscendC::GetBlockIdx();
+        uint32_t coreNum = AscendC::GetBlockNum();
+        
+        uint32_t coreLoops = params.B * params.numChunks;
+        
+        // Layout 创建
+        auto layoutBTxK = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.K);
+        auto layoutKxBT = LayoutColMajor::MakeLayout<ElementA>(params.K, params.BT);
+        auto layoutBTxV = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.V);
+        auto layoutVxBT = LayoutColMajor::MakeLayout<ElementA>(params.V, params.BT);
+        auto layoutBTxBT = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.BT);
+        auto layoutBTxBT_T = LayoutColMajor::MakeLayout<ElementA>(params.BT, params.BT);
+        auto layoutKxV = LayoutRowMajor::MakeLayout<ElementA>(params.K, params.V);
+        auto layoutVxK = LayoutColMajor::MakeLayout<ElementA>(params.V, params.K);
+
+        uint32_t bos = 0;
+        uint32_t eos = 0;
+
+        // ========== Part 1: b_dw = b_dv @ b_h^T ==========
+        {
+            BlockMmadPart1 blockMmadPart1(resource);
+            auto layoutH = LayoutColMajor::MakeLayout<ElementA>(params.K, params.V);
+            // printf("[cube]coreLoops %d, H %d\n",coreLoops,params.H);
+            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                params.BT, loopIdx, bos, eos);
+                uint32_t actual_chunk_len = eos-bos;
+                uint32_t bIdx = loopIdx / params.numChunks;
+                uint32_t chunkIdx = loopIdx % params.numChunks;
+
+                GemmCoord actualBlockShape{
+                    static_cast<uint32_t>(actual_chunk_len),
+                    static_cast<uint32_t>(params.K),
+                    static_cast<uint32_t>(params.V)
+                };
+
+                for (uint32_t h = 0; h < params.H; h++) {
+
+                    // 设置 GM 地址
+                    // dv: [B, H, T, V] -> offset = ((b * H + h) * T + chunk * BT) * V
+                    // uint64_t dvOffset = ((bIdx * params.H + h) * params.T + bos) * params.V;
+                    uint64_t dvOffset = (h * params.T + bos) * params.V;
+
+                    // h: [B, H, num_chunks, K, V] -> offset = ((b * numChunks + chunk) * H + h) * K * V
+                    uint64_t hOffset = ((bIdx * params.H + h) * params.numChunks + chunkIdx) * params.K * params.V;
+
+                    // dw output (workspace): [B, H, T, K]
+                    // uint64_t dwOffset = ((bIdx * params.H + h) * params.T + bos) * params.K;
+                    uint64_t dwOffset = (h * params.T + bos) * params.K;
+
+                    GlobalTensor<ElementA> gmDv;
+                    gmDv.SetGlobalBuffer((__gm__ ElementA *)params.ptrDv + dvOffset);
+                    // gmDv.SetGlobalBuffer((__gm__ ElementA *)params.ptrDv);
+                    GlobalTensor<ElementA> gmH;
+                    gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
+                    // gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH);
+                    GlobalTensor<ElementC> gmDw;
+                    // gmDw.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDwOffset) + dwOffset);
+                    gmDw.SetGlobalBuffer((__gm__ ElementC *)params.ptrDw + dwOffset);
+
+                    auto tensorDv = tla::MakeTensor(gmDv, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                    auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});  // h^T
+                    auto tensorDw = tla::MakeTensor(gmDw, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                    
+                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+
+                    auto tensorBlockDv = GetTile(tensorDv, tla::MakeCoord(0, 0), 
+                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                    auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), 
+                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                    auto tensorBlockDw = GetTile(tensorDw, tla::MakeCoord(0, 0), 
+                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                    
+                    blockMmadPart1(tensorBlockDv, tensorBlockH, tensorBlockDw, actualBlockShape);
+
+
+                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+
+                }
+            }
+            // 最终同步(后移)
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+        }
+        AscendC::SyncAll<false>();
+
+        // ========== Part 2: mm5 = q @ k^T (纯 Cube) ==========
+        {
+            BlockMmadPart2 blockMmadPart2(resource);
+            
+            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                params.BT, loopIdx, bos, eos);
+                uint32_t actual_chunk_len = eos-bos;
+                uint32_t bIdx = loopIdx / params.numChunks;
+                uint32_t chunkIdx = loopIdx % params.numChunks;
+                
+                GemmCoord actualBlockShape{
+                    static_cast<uint32_t>(actual_chunk_len),
+                    static_cast<uint32_t>(actual_chunk_len),
+                    static_cast<uint32_t>(params.K)
+                };
+                
+                for (uint32_t h = 0; h < params.H; h++) {
+                    // q, k: [B, H, T, K]
+                    uint64_t qkOffset = (h * params.T + bos) * params.K;
+                    // mm5: workspace [B, H, T, BT]
+                    uint64_t mm5Offset = (h * params.T + bos) * params.BT;
+                    
+                    GlobalTensor<ElementA> gmQ;
+                    gmQ.SetGlobalBuffer((__gm__ ElementA *)params.ptrQ + qkOffset);
+                    GlobalTensor<ElementA> gmK;
+                    gmK.SetGlobalBuffer((__gm__ ElementA *)params.ptrK + qkOffset);
+                    GlobalTensor<ElementC> gmMm5;
+                    gmMm5.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm5Offset) + mm5Offset);
+
+                    auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                    auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutKxBT), Arch::PositionGM{});  // k^T
+                    auto tensorMm5 = tla::MakeTensor(gmMm5, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
+
+                    auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0), 
+                                                 tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                    auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), 
+                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                    auto tensorBlockMm5 = GetTile(tensorMm5, tla::MakeCoord(0, 0), 
+                                                   tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                    
+                    blockMmadPart2(tensorBlockQ, tensorBlockK, tensorBlockMm5, actualBlockShape);
+
+                }
+            }
+
+        }
+        AscendC::SyncAll<false>();
+
+        // ========== Part 3: b_ds = b_do @ b_v^T ==========
+        {
+            // AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            
+            BlockMmadPart3 blockMmadPart3(resource);
+            
+            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                params.BT, loopIdx, bos, eos);
+                uint32_t actual_chunk_len = eos-bos;
+                uint32_t bIdx = loopIdx / params.numChunks;
+                uint32_t chunkIdx = loopIdx % params.numChunks;
+                
+                GemmCoord actualBlockShape{
+                    static_cast<uint32_t>(actual_chunk_len),
+                    static_cast<uint32_t>(actual_chunk_len),
+                    static_cast<uint32_t>(params.V)
+                };
+                
+                for (uint32_t h = 0; h < params.H; h++) {
+                    // do, v: [B, H, T, V]
+                    // uint64_t dvOffset = ((bIdx * params.H + h) * params.T + bos) * params.V;
+                    uint64_t dvOffset = (h * params.T + bos) * params.V;
+                    // ds_temp: workspace [B, H, T, BT]
+                    // uint64_t dsOffset = ((bIdx * params.H + h) * params.T + bos) * params.BT;
+                    uint64_t dsOffset = (h * params.T + bos) * params.BT;
+                    
+                    GlobalTensor<ElementA> gmDo;
+                    gmDo.SetGlobalBuffer((__gm__ ElementA *)params.ptrDo + dvOffset);
+                    GlobalTensor<ElementA> gmV;
+                    gmV.SetGlobalBuffer((__gm__ ElementA *)params.ptrV + dvOffset);
+                    GlobalTensor<ElementC> gmDs;
+                    gmDs.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
+                    
+                    auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                    auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutVxBT), Arch::PositionGM{});  // v^T
+                    auto tensorDs = tla::MakeTensor(gmDs, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
+                    
+                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                    // AscendC::PipeBarrier<PIPE_MTE2>();
+                    auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0), 
+                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                    auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), 
+                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                    auto tensorBlockDs = GetTile(tensorDs, tla::MakeCoord(0, 0), 
+                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                    
+                    blockMmadPart3(tensorBlockDo, tensorBlockV, tensorBlockDs, actualBlockShape);
+
+                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+                }
+            }
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+        }
+        AscendC::SyncAll<false>();
+
+        // ========== Part 4: b_dq = b_do @ b_h^T ==========
+        {
+            BlockMmadPart4 blockMmadPart4(resource);
+            
+            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                params.BT, loopIdx, bos, eos);
+                uint32_t actual_chunk_len = eos-bos;
+                uint32_t bIdx = loopIdx / params.numChunks;
+                uint32_t chunkIdx = loopIdx % params.numChunks;
+                
+                GemmCoord actualBlockShape{
+                    static_cast<uint32_t>(actual_chunk_len),
+                    static_cast<uint32_t>(params.K),
+                    static_cast<uint32_t>(params.V)
+                };
+                
+                for (uint32_t h = 0; h < params.H; h++) {
+                    // do: [B, H, T, V]
+                    // uint64_t doOffset = ((bIdx * params.H + h) * params.T + bos) * params.V;
+                    uint64_t doOffset = (h * params.T + bos) * params.V;
+                    // h: [B, H, num_chunks, K, V]   [1, 44, 4, 128, 128]
+                    uint64_t hOffset = ((bIdx * params.H + h) * params.numChunks + chunkIdx) * params.K * params.V;
+                    //bIdx * numChunks * H * K * V + chunkIdx * H * K * V + h * K * V;
+
+                    // dq: [B, H, T, K]
+                    // uint64_t dqOffset = ((bIdx * params.H + h) * params.T + bos) * params.K;
+                    uint64_t dqOffset = (h * params.T + bos) * params.K;
+                    
+                    GlobalTensor<ElementA> gmDo;
+                    gmDo.SetGlobalBuffer((__gm__ ElementA *)params.ptrDo + doOffset);
+                    GlobalTensor<ElementA> gmH;
+                    gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
+                    GlobalTensor<ElementC> gmDq;
+                    gmDq.SetGlobalBuffer((__gm__ ElementC *)params.ptrDq + dqOffset);
+                    
+                    auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                    auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});  // h^T: [V, K]
+                    auto tensorDq = tla::MakeTensor(gmDq, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                    
+                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+
+                    auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0), 
+                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                    auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), 
+                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                    auto tensorBlockDq = GetTile(tensorDq, tla::MakeCoord(0, 0), 
+                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                    
+                    blockMmadPart4(tensorBlockDo, tensorBlockH, tensorBlockDq, actualBlockShape);
+
+                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+                }
+            }
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+        }
+        AscendC::SyncAll<false>();
+
+        // ========== Part 5: b_dk = b_v @ b_dh ==========
+        {
+            BlockMmadPart5 blockMmadPart5(resource);
+            
+            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                params.BT, loopIdx, bos, eos);
+                uint32_t actual_chunk_len = eos-bos;
+                uint32_t bIdx = loopIdx / params.numChunks;
+                uint32_t chunkIdx = loopIdx % params.numChunks;
+                
+                GemmCoord actualBlockShape{
+                    static_cast<uint32_t>(actual_chunk_len),
+                    static_cast<uint32_t>(params.K),
+                    static_cast<uint32_t>(params.V)
+                };
+                
+                for (uint32_t h = 0; h < params.H; h++) {
+                    // v: [B, H, T, V]
+                    // uint64_t vOffset = ((bIdx * params.H + h) * params.T + bos) * params.V;
+                    uint64_t vOffset = (h * params.T + bos) * params.V;
+                    // dh: [B, H, num_chunks, K, V]  -> 需要转置访问 [V, K]
+                    // uint64_t dhOffset = ((bIdx * params.numChunks + chunkIdx) * params.H + h) * params.K * params.V;
+                    uint64_t dhOffset = ((bIdx * params.H + h) * params.numChunks + chunkIdx) * params.K * params.V;
+                    // dk: [B, H, T, K]
+                    // uint64_t dkOffset = ((bIdx * params.H + h) * params.T + bos) * params.K;
+                    uint64_t dkOffset = (h * params.T + bos) * params.K;
+                    
+                    GlobalTensor<ElementA> gmV;
+                    gmV.SetGlobalBuffer((__gm__ ElementA *)params.ptrV + vOffset);
+                    GlobalTensor<ElementA> gmDh;
+                    gmDh.SetGlobalBuffer((__gm__ ElementA *)params.ptrDh + dhOffset);
+                    GlobalTensor<ElementC> gmDk;
+                    gmDk.SetGlobalBuffer((__gm__ ElementC *)params.ptrDk + dkOffset);
+                    
+                    auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                    auto tensorDh = tla::MakeTensor(gmDh, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});  // dh: [V, K]
+                    auto tensorDk = tla::MakeTensor(gmDk, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                    
+                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+
+                    auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), 
+                                                 tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                    auto tensorBlockDh = GetTile(tensorDh, tla::MakeCoord(0, 0), 
+                                                  tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                    auto tensorBlockDk = GetTile(tensorDk, tla::MakeCoord(0, 0), 
+                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                    
+                    blockMmadPart5(tensorBlockV, tensorBlockDh, tensorBlockDk, actualBlockShape);
+
+                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+                }
+            }
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+        }
+        AscendC::SyncAll<false>();
+
+        // ========== Part 6: mm6 = b_ds_temp @ b_k ==========
+        // 结果累加到 dq
+        {
+            BlockMmadPart6 blockMmadPart6(resource);
+            
+            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                params.BT, loopIdx, bos, eos);
+                uint32_t actual_chunk_len = eos-bos;
+                uint32_t bIdx = loopIdx / params.numChunks;
+                uint32_t chunkIdx = loopIdx % params.numChunks;
+                
+                GemmCoord actualBlockShape{
+                    static_cast<uint32_t>(actual_chunk_len),
+                    static_cast<uint32_t>(params.K),
+                    static_cast<uint32_t>(actual_chunk_len)
+                };
+                
+                for (uint32_t h = 0; h < params.H; h++) {
+                    // ds_temp: workspace [B, H, T, BT]
+                    // uint64_t dsOffset = ((bIdx * params.H + h) * params.T + bos) * params.BT;
+                    uint64_t dsOffset = (h * params.T + bos) * params.BT;
+                    // k: [B, H, T, K]
+                    // uint64_t kOffset = ((bIdx * params.H + h) * params.T + bos) * params.K;
+                    uint64_t kOffset = (h * params.T + bos) * params.K;
+                    // dq: [B, H, T, K] - 累加
+                    uint64_t dqOffset = kOffset;
+                    
+                    GlobalTensor<ElementA> gmDsTemp;
+                    gmDsTemp.SetGlobalBuffer((__gm__ ElementA *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
+                    GlobalTensor<ElementA> gmK;
+                    gmK.SetGlobalBuffer((__gm__ ElementA *)params.ptrK + kOffset);
+                    GlobalTensor<ElementC> gmDq;
+                    gmDq.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm5Offset) + dqOffset);
+
+                    auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
+                    auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                    auto tensorDq = tla::MakeTensor(gmDq, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                    
+                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                    
+                    auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0), 
+                                                      tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                    auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), 
+                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                    auto tensorBlockDq = GetTile(tensorDq, tla::MakeCoord(0, 0), 
+                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                    
+                    blockMmadPart6(tensorBlockDsTemp, tensorBlockK, tensorBlockDq, actualBlockShape);
+// if(h==0&&loopIdx==7){
+//     DumpTensor(gmDsTemp[63*64],__LINE__,64);
+//     DumpTensor(gmK[63*128],__LINE__,64);
+//     DumpTensor(gmDq[63*128],__LINE__,64);
+// }
+                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+                }
+            }
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+        }
+        AscendC::SyncAll<false>();
+        // ========== Part 7: mm7 = b_ds_temp^T @ b_q ==========
+        // 结果累加到 dk
+        {
+            BlockMmadPart7 blockMmadPart7(resource);
+            
+            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                                params.BT, loopIdx, bos, eos);
+                uint32_t actual_chunk_len = eos-bos;
+                uint32_t bIdx = loopIdx / params.numChunks;
+                uint32_t chunkIdx = loopIdx % params.numChunks;
+                
+                GemmCoord actualBlockShape{
+                    static_cast<uint32_t>(actual_chunk_len),
+                    static_cast<uint32_t>(params.K),
+                    static_cast<uint32_t>(actual_chunk_len)
+                };
+                
+                for (uint32_t h = 0; h < params.H; h++) {
+                    // ds_temp^T: workspace [B, H, T, BT]
+                    // uint64_t dsOffset = ((bIdx * params.H + h) * params.T + bos) * params.BT;
+                    uint64_t dsOffset = (h * params.T + bos) * params.BT;
+                    // q: [B, H, T, K]
+                    // uint64_t qOffset = ((bIdx * params.H + h) * params.T + bos) * params.K;
+                    uint64_t qOffset = (h * params.T + bos) * params.K;
+
+                    // dk: [B, H, T, K] - 累加
+                    uint64_t dkOffset = qOffset;
+                    
+                    GlobalTensor<ElementA> gmDsTemp;
+                    gmDsTemp.SetGlobalBuffer((__gm__ ElementA *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
+                    GlobalTensor<ElementA> gmQ;
+                    gmQ.SetGlobalBuffer((__gm__ ElementA *)params.ptrQ + qOffset);
+                    GlobalTensor<ElementC> gmDk;
+                    gmDk.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm5Offset) + dkOffset);
+                    
+                    auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT_T), Arch::PositionGM{});  // Transposed
+                    auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                    auto tensorDk = tla::MakeTensor(gmDk, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                    
+                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                    
+                    auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0), 
+                                                      tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                    auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0), 
+                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                    auto tensorBlockDk = GetTile(tensorDk, tla::MakeCoord(0, 0), 
+                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                    
+                    blockMmadPart7(tensorBlockDsTemp, tensorBlockQ, tensorBlockDk, actualBlockShape);
+// if(h==0&&loopIdx==0){
+//     DumpTensor(gmDsTemp,__LINE__,64);
+//     DumpTensor(gmQ,__LINE__,64);
+//     DumpTensor(gmDk,__LINE__,64);
+// }
+                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+                }
+            }
+            
+            // 最终同步
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+        }
+
+    }
+};
+
+} // namespace Catlass::Gemm::Kernel
+
+/**
+ * Cube Process 类 (AIC 端入口)
+ */
+template <typename DataType, typename GType>
+class ChunkBwdDqkwgCubeProcessLegacy {
+public:
+    __aicore__ inline ChunkBwdDqkwgCubeProcessLegacy(
+        GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
+        GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
+        GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
+        GM_ADDR workspace
+    ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
+        ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLen(cu_seqlen), ptrChunkIndices(chunk_indices),
+        ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
+        ptrWorkspace(workspace) {}
+    
+    __aicore__ inline void Init(const ChunkBwdDqkwgTilingData &tiling);
+    __aicore__ inline void Process();
+    
+private:
+    // 输入输出指针
+    GM_ADDR ptrQ;
+    GM_ADDR ptrK;
+    GM_ADDR ptrV;
+    GM_ADDR ptrG;
+    GM_ADDR ptrH;
+    GM_ADDR ptrDo;
+    GM_ADDR ptrDh;
+    GM_ADDR ptrDv;
+    GM_ADDR ptrCuSeqLen;
+    GM_ADDR ptrChunkIndices;
+    GM_ADDR ptrDq;
+    GM_ADDR ptrDk;
+    GM_ADDR ptrDw;
+    GM_ADDR ptrDg;
+    GM_ADDR ptrWorkspace;
+    
+    // Tiling 参数
+    uint64_t B = CONST_B;
+    uint64_t H = CONST_H;
+    uint64_t T = CONST_T;
+    uint64_t K = CONST_K;
+    uint64_t V = CONST_V;
+    uint64_t BT = CONST_BT;
+    uint64_t numChunks = CONST_NUM_CHUNKS;
+    float scale;
+    uint64_t isVarLen;
+    
+    // Workspace 偏移
+    uint64_t wsDwOffset;
+    uint64_t wsDgLastOffset;
+    uint64_t wsMm5Offset;
+    uint64_t wsDsTempOffset;
+    uint64_t wsMm6Offset;
+    uint64_t wsMm7Offset;
+};
+
+template <typename DataType, typename GType>
+__aicore__ inline void ChunkBwdDqkwgCubeProcessLegacy<DataType, GType>::Init(const ChunkBwdDqkwgTilingData &tiling) {
+
+/*
+    // 设置 workspace 偏移
+    // wsDwOffset = 0;
+    wsDgLastOffset = 0;//B * H * numChunks * sizeof(float);
+    // wsDgLastOffset = ((wsDgLastOffset + 31) / 32) * 32;
+    wsMm5Offset = wsDgLastOffset + ((B * H * numChunks * sizeof(float) + 31) / 32) * 32;
+    // wsMm5Offset = wsMm5Offset;
+    wsDsTempOffset = wsMm5Offset + B * H * T * BT * sizeof(DataType);
+    wsMm6Offset = wsDsTempOffset + B * H * T * BT * sizeof(DataType);
+    wsMm7Offset = wsMm6Offset + B * H * T * K * sizeof(DataType);
+*/
+    // printf("[cube] wsDgLastOffset %d,wsMm5Offset %d,wsDsTempOffset %d, wsMm6Offset %d wsMm7Offset %d\n",wsDgLastOffset,wsMm5Offset,wsDsTempOffset,wsMm6Offset, wsMm7Offset);
+////////////////////tiling/////
+    scale = tiling.scale;
+    B = tiling.B;
+    H = tiling.H;
+    T = tiling.T;
+    K = tiling.K;
+    V = tiling.V;
+    BT = tiling.BT;
+    numChunks = tiling.numChunks;
+    wsDgLastOffset = tiling.wsDgLastOffset;
+    // wsDgLastOffset = ((wsDgLastOffset + 31) / 32) * 32;
+    wsMm5Offset = tiling.wsMm5Offset;
+    // wsMm5Offset = wsMm5Offset;
+    wsDsTempOffset = tiling.wsDsTempOffset;
+    // wsMm6Offset = tiling.wsMm6Offset;
+    // wsMm7Offset = tiling.wsMm7Offset;
+    isVarLen = tiling.isVarLen;
+// printf("[cube] DTYPE_G %d, float %d\n",sizeof(DTYPE_G),sizeof(float));
+}
+
+template <typename DataType, typename GType>
+__aicore__ inline void ChunkBwdDqkwgCubeProcessLegacy<DataType, GType>::Process() {
+    using namespace Catlass;
+    using namespace Catlass::Gemm;
+    
+    // Layout 类型定义
+    using LayoutRowMajor = layout::RowMajor;
+    using LayoutColMajor = layout::ColumnMajor;
+    
+    // 架构和策略定义
+ #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+ 	     using ArchTag = Arch::Ascend950;
+ 	 #else
+ 	     using ArchTag = Arch::AtlasA2;
+ 	 #endif
+ 	     using DispatchPolicy = Gemm::MmadPingpong<ArchTag, true, false>;
+    using DispatchPolicy = Gemm::MmadPingpong<ArchTag, true>;
+    using L1TileShape = tla::Shape<_128, _128, _256>;
+    using L0TileShape = tla::Shape<_128, _128, _128>;
+    // using L1TileShape = tla::Shape<_128, _256, _256>;
+    // using L0TileShape = tla::Shape<_128, _256, _64>;
+    // Part 1: dv @ h^T -> dw  [BT, V] @ [V, K] -> [BT, K]
+    using TileCopyPart1 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+    using BlockMmadPart1 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart1>;
+    
+    // Part 2: q @ k^T -> mm5  [BT, K] @ [K, BT] -> [BT, BT]
+    using TileCopyPart2 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+    using BlockMmadPart2 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart2>;
+    
+    // Part 3: do @ v^T -> ds  [BT, V] @ [V, BT] -> [BT, BT]
+    using TileCopyPart3 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+    using BlockMmadPart3 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart3>;
+    
+    // Part 4: do @ h^T -> dq  [BT, V] @ [V, K] -> [BT, K]
+    using TileCopyPart4 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+    using BlockMmadPart4 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart4>;
+    
+    // Part 5: v @ dh -> dk  [BT, V] @ [V, K] -> [BT, K]
+    using TileCopyPart5 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+    using BlockMmadPart5 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart5>;
+    
+    // Part 6: ds @ k -> dq+=  [BT, BT] @ [BT, K] -> [BT, K]
+    using TileCopyPart6 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
+    using BlockMmadPart6 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart6>;
+    
+    // Part 7: ds^T @ q -> dk+=  [BT, BT] @ [BT, K] -> [BT, K]
+    using TileCopyPart7 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutColMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
+    using BlockMmadPart7 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart7>;
+    
+    // Kernel 实例
+    using MatmulKernel = Kernel::ChunkBwdDqkwgTlaLegacy<
+        BlockMmadPart1, BlockMmadPart2, BlockMmadPart3, BlockMmadPart4,
+        BlockMmadPart5, BlockMmadPart6, BlockMmadPart7
+    >;
+    
+    MatmulKernel kernel;
+    typename MatmulKernel::Params params(
+        ptrQ, ptrK, ptrV, ptrG, ptrH,
+        ptrDo, ptrDh, ptrDv, ptrCuSeqLen, ptrChunkIndices,
+        ptrDq, ptrDk, ptrDw, ptrDg,
+        ptrWorkspace, B, H, T, K, V, BT, numChunks,
+        wsDwOffset, wsDgLastOffset, wsMm5Offset, wsDsTempOffset, wsMm6Offset, wsMm7Offset,
+        scale, isVarLen
+    );
+    
+    kernel(params);
+}
+
+#endif  // CHUNK_BWD_DQKWG_CUBE_LEGACY_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
@@ -45,6 +45,17 @@
      __aicore__ inline void ApplyLowerTriangularMask(LocalTensor<float> &tensor, uint32_t size);
      __aicore__ inline void ReduceSumX(LocalTensor<float> &src, LocalTensor<float> &dst,
                                        uint32_t rows, uint32_t cols, int axis);
+     __aicore__ inline void CopyGateWithPad(LocalTensor<GType> &dst, GlobalTensor<GType> &src,
+                                            uint64_t offset, uint32_t validLen, uint32_t totalLen);
+     __aicore__ inline void RefineSmallDw(LocalTensor<float> &dw, uint64_t dvOffset,
+                                          uint64_t hOffset, uint32_t rows);
+     __aicore__ inline void RepairDwChunkHeadBlock(LocalTensor<DataType> &dwOut,
+                                                   LocalTensor<DataType> &tmp,
+                                                   LocalTensor<float> &work,
+                                                   LocalTensor<float> &scratch,
+                                                   uint64_t dvOffset,
+                                                   uint64_t hOffset,
+                                                   uint32_t rows);
      
  private:
      // 输入输出指针
@@ -96,6 +107,7 @@
      GlobalTensor<GType> gmG, gmDg;
      GlobalTensor<DataType> gmWorkspace;
      GlobalTensor<float> gmDgLast;
+     GlobalTensor<DataType> gmDwWorkspace;
      GlobalTensor<DataType> gmMm5, gmDsTemp, gmMul1, gmMm6, gmMm7;
      
      // Queues (用于流水)
@@ -148,6 +160,7 @@
      V = tiling.V;
      BT = tiling.BT;
      numChunks = tiling.numChunks;
+     wsDwOffset = tiling.wsDwOffset;
      wsDgLastOffset = tiling.wsDgLastOffset;
      wsMm5Offset = tiling.wsMm5Offset;
      wsDsTempOffset = tiling.wsDsTempOffset;
@@ -179,6 +192,7 @@
      gmDg.SetGlobalBuffer((__gm__ GType *)ptrDg);
  
      gmWorkspace.SetGlobalBuffer((__gm__ DataType *)ptrWorkspace);
+     gmDwWorkspace.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsDwOffset));
      gmDgLast.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t*)ptrWorkspace + wsDgLastOffset));     //中间结果使用float
  
      gmMm5.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm5Offset));
@@ -194,19 +208,121 @@
      // Part 1: dw 和 dg_last 计算
      ProcessPart1();
      pipe->Reset();
+     AscendC::SyncAll<false>();
      // Part 2: 等待 mm5 (q @ k^T) 完成, 计算 mul1
      ProcessPart2();
      pipe->Reset();
+     AscendC::SyncAll<false>();
      // Part 3: ds 处理和 dg 部分计算
      ProcessPart3();
      pipe->Reset();
+     AscendC::SyncAll<false>();
      // Part 4+6 融合: dq 处理 + mm6 累加 (在 UB 中完成, 省去 dq 的 GM 往返)
      ProcessPart4();
      pipe->Reset();
+     AscendC::SyncAll<false>();
      // Part 5+7 融合: dk 处理 + mm7 累加 (在 UB 中完成, 省去 dk 的 GM 往返)
      ProcessPart5();
  }
- 
+
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::CopyGateWithPad(
+     LocalTensor<GType> &dst, GlobalTensor<GType> &src, uint64_t offset, uint32_t validLen, uint32_t totalLen) {
+     Duplicate(dst, static_cast<GType>(0), totalLen);
+     TEventID eventId = GetTPipePtr()->FetchEventID(HardEvent::V_MTE2);
+     SetFlag<HardEvent::V_MTE2>(eventId);
+     WaitFlag<HardEvent::V_MTE2>(eventId);
+     if (validLen == 0) {
+         return;
+     }
+
+     DataCopyExtParams copyParams{1, static_cast<uint32_t>(validLen * sizeof(GType)), 0, 0, 0};
+     constexpr uint32_t elemsPerBlock = UB_BLOCK_SIZE / sizeof(GType);
+     uint8_t rightPadding = static_cast<uint8_t>((elemsPerBlock - (validLen % elemsPerBlock)) % elemsPerBlock);
+     DataCopyPadExtParams<GType> padParams{true, 0, rightPadding, 0};
+     DataCopyPad(dst, src[offset], copyParams, padParams);
+ }
+
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::RefineSmallDw(
+     LocalTensor<float> &dw, uint64_t dvOffset, uint64_t hOffset, uint32_t rows) {
+     if constexpr (std::is_same<DataType, half>::value) {
+         constexpr float refineAbsMin = 3.0e-5f;
+         constexpr float refineAbsMax = 2.0e-4f;
+         uint32_t kLimit = static_cast<uint32_t>(K);
+         uint32_t vLimit = static_cast<uint32_t>(V);
+         for (uint32_t r = 0; r < rows; ++r) {
+             for (uint32_t kIdx = 0; kIdx < kLimit; ++kIdx) {
+                 uint32_t outIdx = r * kLimit + kIdx;
+                 float val = dw.GetValue(outIdx);
+                 float absVal = val >= 0.0f ? val : -val;
+                bool refineSmall = absVal >= refineAbsMin && absVal <= refineAbsMax;
+                bool refineChunkHeadZero = r == 0 && absVal <= refineAbsMax;
+                if (refineSmall || refineChunkHeadZero) {
+                     float sum = 0.0f;
+                     for (uint32_t vIdx = 0; vIdx < vLimit; ++vIdx) {
+                         float dvVal = static_cast<float>(gmDv.GetValue(dvOffset + r * vLimit + vIdx));
+                         float hVal = static_cast<float>(gmH.GetValue(hOffset + kIdx * vLimit + vIdx));
+                         sum += dvVal * hVal;
+                     }
+                     dw.SetValue(outIdx, sum);
+                 }
+             }
+         }
+     }
+ }
+
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::RepairDwChunkHeadBlock(
+     LocalTensor<DataType> &dwOut, LocalTensor<DataType> &tmp, LocalTensor<float> &work,
+     LocalTensor<float> &scratch, uint64_t dvOffset, uint64_t hOffset, uint32_t rows) {
+     if constexpr (std::is_same<DataType, half>::value) {
+         if (rows == 0 || K < FP16_ELEMENTS_PER_BLOCK || V < FP32_PER_REPEAT) {
+             return;
+         }
+
+         constexpr uint32_t repairCols = FP16_ELEMENTS_PER_BLOCK;
+         uint32_t vLimit = static_cast<uint32_t>(V);
+         uint32_t reduceRepeats = vLimit / FP32_PER_REPEAT;
+         if (reduceRepeats == 0) {
+             return;
+         }
+
+         TEventID eventVToMte2 = GetTPipePtr()->FetchEventID(HardEvent::V_MTE2);
+         SetFlag<HardEvent::V_MTE2>(eventVToMte2);
+         WaitFlag<HardEvent::V_MTE2>(eventVToMte2);
+         DataCopy(tmp, gmDv[dvOffset], vLimit);
+         DataCopy(tmp[vLimit], gmH[hOffset], repairCols * vLimit);
+
+         TEventID eventId = GetTPipePtr()->FetchEventID(HardEvent::MTE2_V);
+         SetFlag<HardEvent::MTE2_V>(eventId);
+         WaitFlag<HardEvent::MTE2_V>(eventId);
+
+         Cast(scratch, tmp, RoundMode::CAST_NONE, vLimit);
+         Cast(work, tmp[vLimit], RoundMode::CAST_NONE, repairCols * vLimit);
+         PipeBarrier<PIPE_V>();
+
+         for (uint32_t kIdx = 0; kIdx < repairCols; ++kIdx) {
+             Mul(work[kIdx * vLimit], work[kIdx * vLimit], scratch, vLimit);
+         }
+         PipeBarrier<PIPE_V>();
+
+         for (uint32_t kIdx = 0; kIdx < repairCols; ++kIdx) {
+             WholeReduceSum(scratch[kIdx * FP32_ELEMENTS_PER_BLOCK], work[kIdx * vLimit],
+                            FP32_PER_REPEAT, reduceRepeats, 1, 1, FP32_ELEMENTS_PER_BLOCK);
+         }
+         PipeBarrier<PIPE_V>();
+
+         WholeReduceSum(work, scratch, reduceRepeats, repairCols, 1, 1, 1);
+         PipeBarrier<PIPE_V>();
+
+         Muls(work, work, -1.0f, repairCols);
+         PipeBarrier<PIPE_V>();
+         Cast(dwOut, work, RoundMode::CAST_RINT, repairCols);
+         PipeBarrier<PIPE_V>();
+     }
+ }
+
  // ============== Part 1: dw 和 dg_last 计算 ==============
  template <typename DataType, typename GType>
  __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart1() {
@@ -229,9 +345,14 @@
      uint32_t vecTaskIdx = 0;
  
      uint32_t maxSize = (2 * hDhSize) > dwSize ? (2 * hDhSize) : dwSize;
+     uint32_t inQue1Bytes = 2 * hDhSize * sizeof(DataType);
+     uint32_t dwWorkspaceBytes = dwSize * sizeof(DataType);
+     if (dwWorkspaceBytes > inQue1Bytes) {
+         inQue1Bytes = dwWorkspaceBytes;
+     }
  
      // 初始化 buffers
-     pipe->InitBuffer(inQue1, BUFFER_NUM, maxSize * sizeof(DataType));  // h 和 dh 共用一个输入队列
+     pipe->InitBuffer(inQue1, BUFFER_NUM, inQue1Bytes);  // h/dh and fp32 dw workspace share this queue
      pipe->InitBuffer(outQue1, BUFFER_NUM, sizeof(float) * 8);  // dg_last (对齐到 32 字节)
      pipe->InitBuffer(outQue2, BUFFER_NUM, dwSize * sizeof(DataType));
      pipe->InitBuffer(calcBuf1, maxSize * sizeof(float));
@@ -264,10 +385,11 @@
              // 计算偏移
              // h, dh: [B, H, num_chunks, K, V]
              uint64_t hOffset = ((bIdx * H + h) * numChunks + chunkIdx) * K * V;
+             uint64_t dvOffset = (h * T + bos) * V;
              // dw (workspace): 按 [B, H, T, K] 布局
              uint64_t dwOffset = (h * T + bos) * K;
              // dg_last: [B, H, num_chunks]
-             uint64_t dgLastOffset = (bIdx * H + h) * numChunks + chunkIdx;
+             uint64_t dgLastOffset = ((bIdx * H + h) * numChunks + chunkIdx) * 8;
  
              // ========== 计算 dg_last = sum(h * dh) ==========
              // 等待 Cube 信号 (dw Cube 计算)
@@ -311,18 +433,15 @@
                  }
                  auto tensorDgLastOut = outQue1.AllocTensor<float>();
                  WholeReduceSum(tensorDgLastOut, tensorSumFp32, 64, 1, 1, 1, 8);
+                 PipeBarrier<PIPE_V>();
                  outQue1.EnQue(tensorDgLastOut);
              }
              {
                  auto tensorDgLastOut = outQue1.DeQue<float>();
- 
-                 DataCopyParams dataCopyParams;
-                 dataCopyParams.blockCount = 1;
-                 dataCopyParams.blockLen = 1*sizeof(float);
-                 dataCopyParams.srcStride = 0;
-                 dataCopyParams.dstStride = 0;
-                 DataCopyPad(gmDgLast[dgLastOffset], tensorDgLastOut,dataCopyParams);
- 
+
+                 DataCopy(gmDgLast[dgLastOffset], tensorDgLastOut, 8);
+                 PipeBarrier<PIPE_MTE3>();
+
                  outQue1.FreeTensor(tensorDgLastOut);
              }
  
@@ -335,7 +454,7 @@
              // CopyIn: dw from workspace
              {
                  auto tensorDwIn = inQue1.AllocTensor<DataType>();
-                 DataCopy(tensorDwIn, gmDw[dwOffset], dwSize_sub);
+                 DataCopy(tensorDwIn, gmDwWorkspace[dwOffset], dwSize_sub);
                  inQue1.EnQue(tensorDwIn);
              }
  
@@ -343,13 +462,18 @@
              {
                  auto tensorDwIn = inQue1.DeQue<DataType>();
                  auto tensorDwOut = outQue2.AllocTensor<DataType>();
-                 
-                 // Cast to fp32, 乘以 -1, cast back
+
+                 // Cube stores dtype workspace; refine selected half small values before final negation.
                  Cast(tensorHFp32, tensorDwIn, RoundMode::CAST_NONE, dwSize_sub);
+                 PipeBarrier<PIPE_V>();
+                 RefineSmallDw(tensorHFp32, dvOffset, hOffset, BT_sub);
                  PipeBarrier<PIPE_V>();
                  Muls(tensorHFp32, tensorHFp32, -1.0f, dwSize_sub);
                  PipeBarrier<PIPE_V>();
                  Cast(tensorDwOut, tensorHFp32, RoundMode::CAST_RINT, dwSize_sub);
+                 PipeBarrier<PIPE_V>();
+                 RepairDwChunkHeadBlock(tensorDwOut, tensorDwIn, tensorHFp32, tensorSumFp32,
+                                        dvOffset, hOffset, BT_sub);
                  inQue1.FreeTensor(tensorDwIn);
                  outQue2.EnQue(tensorDwOut);
              }
@@ -358,7 +482,8 @@
              {
                  auto tensorDwOut = outQue2.DeQue<DataType>();
                  DataCopy(gmDw[dwOffset], tensorDwOut, dwSize_sub);
- 
+                 PipeBarrier<PIPE_MTE3>();
+
                  outQue2.FreeTensor(tensorDwOut);
              }
  
@@ -378,7 +503,7 @@
      uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
      uint32_t coreNum = GetBlockNum();
      uint32_t coreLoops = B * numChunks;
-     uint32_t real_BT = BT;
+    uint32_t real_BT = BT;
  
      uint32_t BT_sub = real_BT;
      uint32_t BT_sub_start = 0;
@@ -431,8 +556,9 @@
          GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T, BT, loopIdx, bos, eos);
          bos_orig = bos;
          eos_orig = eos;
-         uint32_t vec_core_0_length = (eos_orig - bos_orig) >= (BT / 2) ? (BT / 2) : (eos_orig - bos_orig);
-         uint32_t vec_core_1_length = (eos_orig - bos_orig) >= (BT / 2) ? (eos_orig - bos_orig - (BT / 2)) : 0;
+         uint32_t actual_chunk_len = eos_orig - bos_orig;
+         uint32_t vec_core_0_length = actual_chunk_len >= (BT / 2) ? (BT / 2) : actual_chunk_len;
+         uint32_t vec_core_1_length = actual_chunk_len >= (BT / 2) ? (actual_chunk_len - (BT / 2)) : 0;
          if (GetSubBlockIdx() == 0) {        // BT: 0..BT_sub_end
              BT_sub_start = 0;
              BT_sub_end = vec_core_0_length;         // [0, vec_core_0_length)
@@ -462,7 +588,7 @@
              // CopyIn: g
              {
                  auto tensorGIn = inQue3.AllocTensor<GType>();
-                 DataCopy(tensorGIn, gmG[gOffset], gSize);
+                 CopyGateWithPad(tensorGIn, gmG, gOffset, actual_chunk_len, gSize);
                  inQue3.EnQue(tensorGIn);
              }
  
@@ -540,7 +666,6 @@
                  inQue3.FreeTensor(tensorGIn);
                  outQue1.EnQue(tensorDsTempOut);
              }
- 
              // CopyOut
              {
                  auto tensorDsTempOut = outQue1.DeQue<float>();
@@ -831,8 +956,8 @@
  
                  DataCopy(tensorDqIn[dqSize_sub], gmDq[qkOffset + dqSize_sub_offset], dqSize_sub);
                  DataCopy(tensorQIn[dqSize_sub], gmQ[qkOffset + dqSize_sub_offset], dqSize_sub);
-                 DataCopy(tensorGIn, gmG[gOffset], gSize);
-                 DataCopy(tensorDgIn, gmDg[gOffset], gSize);
+                 CopyGateWithPad(tensorGIn, gmG, gOffset, actual_chunk_len, gSize);
+                 CopyGateWithPad(tensorDgIn, gmDg, gOffset, actual_chunk_len, gSize);
  
                  inQue1.EnQue(tensorDqIn);
                  inQue2.EnQue(tensorQIn);
@@ -956,18 +1081,20 @@
      uint32_t coreNum = GetBlockNum();
      uint32_t coreLoops = B * numChunks;
      
-     uint32_t dkSize = BT * K;
-     uint32_t gSize = BT;
-     uint32_t real_BT = BT;
+    uint32_t dkSize = BT * K;
+    uint32_t gSize = BT;
+    uint32_t real_BT = BT;
      
      // 初始化 buffers
-     pipe->InitBuffer(inQue1, BUFFER_NUM, dkSize * sizeof(float));
-     pipe->InitBuffer(inQue2, BUFFER_NUM, dkSize * sizeof(float));
+     constexpr int32_t part5BufferNum = 1;
+    uint32_t dkQueueBytes = dkSize * sizeof(float);
+    pipe->InitBuffer(inQue1, part5BufferNum, dkQueueBytes);
+    pipe->InitBuffer(inQue2, part5BufferNum, dkQueueBytes);
      pipe->InitBuffer(inQue3, BUFFER_NUM, gSize * sizeof(GType));
      pipe->InitBuffer(inQue4, BUFFER_NUM, gSize * sizeof(GType));
      // pipe->InitBuffer(inQue5, BUFFER_NUM, 16 * sizeof(float));    // add4中间结果及广播结果
      // pipe->InitBuffer(inQue6, BUFFER_NUM, 16 * sizeof(float));    // part5 gLast中间结果
-     pipe->InitBuffer(outQue1, BUFFER_NUM, dkSize * sizeof(DataType));
+     pipe->InitBuffer(outQue1, part5BufferNum, dkSize * sizeof(DataType));
      pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(GType));
  
      pipe->InitBuffer(calcBuf1, gSize * 8 * sizeof(float));  //gLast
@@ -1009,12 +1136,56 @@
              }
              uint64_t kOffset = (h * T + bos) * K;
              uint64_t gOffset = (h * T + bos);
-             uint64_t dgLastOffset = (bIdx * H + h) * numChunks + chunkIdx;
-             
+             uint64_t hOffset = ((bIdx * H + h) * numChunks + chunkIdx) * K * V;
+
              CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
- 
-             // CopyIn
+
+             // Recompute dg_last locally. The GM handoff from Part1 is not visible reliably
+             // on this fused schedule, while this uses the same reduction as Part1.
              {
+                 const uint32_t hDhSize = mul0RowNum * V;
+                 Duplicate(tensorGLastFp32Tmp[16], 0.0f, 8);
+                 PipeBarrier<PIPE_V>();
+                 for (uint32_t row = 0; row < K; row += mul0RowNum) {
+                     auto tensorHAlloc = inQue1.AllocTensor<DataType>();
+                     auto tensorDhAlloc = inQue2.AllocTensor<DataType>();
+
+                     DataCopy(tensorHAlloc, gmH[hOffset + row * V], hDhSize);
+                     DataCopy(tensorDhAlloc, gmDh[hOffset + row * V], hDhSize);
+                     inQue1.EnQue(tensorHAlloc);
+                     inQue2.EnQue(tensorDhAlloc);
+
+                     auto tensorHIn = inQue1.DeQue<DataType>();
+                     auto tensorDhIn = inQue2.DeQue<DataType>();
+                     auto tensorHFp32 = tensorHIn[hDhSize].template ReinterpretCast<float>();
+                     auto tensorDhFp32 = tensorDhIn[hDhSize].template ReinterpretCast<float>();
+
+                     Cast(tensorHFp32, tensorHIn, RoundMode::CAST_NONE, hDhSize);
+                     Cast(tensorDhFp32, tensorDhIn, RoundMode::CAST_NONE, hDhSize);
+                     PipeBarrier<PIPE_V>();
+                     Mul(tensorHFp32, tensorHFp32, tensorDhFp32, hDhSize);
+                     PipeBarrier<PIPE_V>();
+
+                     uint32_t remainNum = hDhSize;
+                     while (remainNum > 64) {
+                         remainNum = remainNum / 2;
+                         Add(tensorHFp32, tensorHFp32, tensorHFp32[remainNum], remainNum);
+                         PipeBarrier<PIPE_V>();
+                     }
+                     WholeReduceSum(tensorDgLastFp32Tmp[8], tensorHFp32, 64, 1, 1, 1, 8);
+                     PipeBarrier<PIPE_V>();
+                     Brcb(tensorGLastFp32Tmp[24], tensorDgLastFp32Tmp[8], 1, {1, 8});
+                     PipeBarrier<PIPE_V>();
+                     Add(tensorGLastFp32Tmp[16], tensorGLastFp32Tmp[16], tensorGLastFp32Tmp[24], 8);
+                     PipeBarrier<PIPE_V>();
+
+                     inQue1.FreeTensor(tensorHIn);
+                     inQue2.FreeTensor(tensorDhIn);
+                 }
+             }
+
+            // CopyIn
+            {
                  auto tensorDkIn = inQue1.AllocTensor<DataType>();
                  auto tensorKIn = inQue2.AllocTensor<DataType>();
                  auto tensorGIn = inQue3.AllocTensor<GType>();
@@ -1024,9 +1195,8 @@
                  
                  DataCopy(tensorDkIn[dkSize], gmDk[kOffset], dkSize);
                  DataCopy(tensorKIn[dkSize], gmK[kOffset], dkSize);
-                 DataCopy(tensorGIn, gmG[gOffset], gSize);
-                 DataCopy(tensorDgIn, gmDg[gOffset], gSize);
-                 // DataCopy(tensorDgLastIn, gmDgLast[dgLastOffset], 8); // 只需要最后一个位置的 dg 值
+                 CopyGateWithPad(tensorGIn, gmG, gOffset, actual_chunk_len, gSize);
+                 CopyGateWithPad(tensorDgIn, gmDg, gOffset, actual_chunk_len, gSize);
                  // DataCopy(tensorGLastIn, gmG[gOffset + actual_chunk_len - 1], 16); // 只需要最后一个位置的 g 值
  
                  inQue1.EnQue(tensorDkIn);
@@ -1048,12 +1218,11 @@
                  // auto tensorDgLastFp32 = inQue5.DeQue<float>();
                  // auto tensorGLast = inQue6.DeQue<GType>();
                  // auto tensorGLastFp32 = tensorGLast.template ReinterpretCast<float>();
-                 auto tensorDkOut = outQue1.AllocTensor<DataType>();
                  auto tensorDgOut = outQue2.AllocTensor<GType>();
  
                  // Cast
                  Cast(tensorDkFp32, tensorDkIn[dkSize], RoundMode::CAST_NONE, dkSize);
- 
+
                  Cast(tensorKFp32, tensorKIn[dkSize], RoundMode::CAST_NONE, dkSize);
                  PipeBarrier<PIPE_V>();
  
@@ -1093,8 +1262,6 @@
                  AscendC::Mul(tensorDkFp32[CAL_NUM_FLOAT], tensorDkFp32[CAL_NUM_FLOAT], tensorDgFinal, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
                  PipeBarrier<PIPE_V>();
  
-                 Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);      //dk -> fp16 tensorDkFp32
- 
                  Mul(tensorKFp32, tensorKFp32, tensorDkFp32, dkSize);    // mul8 = dk * k
                  PipeBarrier<PIPE_V>();
  
@@ -1125,25 +1292,27 @@
  
                      PipeBarrier<PIPE_V>();
                  }
-                 WholeReduceSum(tensorDkFp32, tensorGFp32, FP32_PER_REPEAT, sum0SumCnt, 1, 1, 8);
+                 WholeReduceSum(tensorDgLastFp32Tmp, tensorGFp32, FP32_PER_REPEAT, sum0SumCnt, 1, 1, 8);
                  // PipeBarrier<PIPE_ALL>();
                  PipeBarrier<PIPE_V>();
-                 WholeReduceSum(tensorDgFinal, tensorDkFp32, sum0SumCnt, 1, 1, 1, 8);
- 
-                 // tensorGLastFp32[0]已经是最后一个位置的 g 值
-                 float dgLast = gmDgLast.GetValue(dgLastOffset); // tensorDgTmp暂存dg值，获取最后一个位置的dgLast
-                 Duplicate(tensorDgLastFp32Tmp, dgLast, 8); // 广播 dgLast
+                 WholeReduceSum(tensorDgFinal, tensorDgLastFp32Tmp, sum0SumCnt, 1, 1, 1, 8);
+                 PipeBarrier<PIPE_V>();
+                 Brcb(tensorDgLastFp32Tmp, tensorDgFinal, 1, {1, 8});
+                 PipeBarrier<PIPE_V>();
+                 DataCopy(tensorDgFinal, tensorDgLastFp32Tmp, 8);
+                 PipeBarrier<PIPE_V>();
                  Exp(tensorGLastFp32Tmp, tensorGLastFp32Tmp, 8);
                  PipeBarrier<PIPE_V>();
-                 Mul(tensorDgLastFp32Tmp, tensorDgLastFp32Tmp, tensorGLastFp32Tmp, 8);
+                 Mul(tensorDgLastFp32Tmp[16], tensorGLastFp32Tmp[16], tensorGLastFp32Tmp, 8);
                  PipeBarrier<PIPE_V>();
-                 Add(tensorDgLastFp32Tmp, tensorDgLastFp32Tmp, tensorDgFinal, 8);  //add4 = tensorDgLastFp32Tmp[0]
+                 Add(tensorDgLastFp32Tmp[16], tensorDgLastFp32Tmp[16], tensorDgFinal, 8);  //add4 = tensorDgLastFp32Tmp[16]
  
  
                  Sub(tensorGFp32, tensorDgTmp, tensorGFp32, BT); //Add.0 最终结果
  
                  PipeBarrier<PIPE_V>();
-                 Brcb(tensorDgFinal, tensorDgLastFp32Tmp, 1, {1, 8}); // [8,8] 只有第一行有效
+                 Brcb(tensorDgFinal, tensorDgLastFp32Tmp[16], 1, {1, 8});
+                 PipeBarrier<PIPE_V>();
                  PipeBarrier<PIPE_V>();
                  uint64_t offset = (real_BT - 1) / 8 * 8; // 每行8个float
                  uint64_t mask[1] = {0};
@@ -1167,74 +1336,57 @@
                  // 读取之前 Part 3/4 计算的 dg, 累加
                  // (简化处理, 实际应该从 GM 读取并累加)
  
-                 inQue1.FreeTensor(tensorDkIn);
                  inQue2.FreeTensor(tensorKIn);
                  inQue3.FreeTensor(tensorGIn);
                  inQue4.FreeTensor(tensorDgIn);
                  // inQue5.FreeTensor(tensorDgLastFp32);
                  // inQue6.FreeTensor(tensorGLast);
-                 outQue1.EnQue(tensorDkOut);
                  outQue2.EnQue(tensorDgOut);
+
+                 {
+                     auto tensorDgOutDeq = outQue2.DeQue<GType>();
+                     DataCopyParams dataCopyParams;
+                     dataCopyParams.blockCount = 1;
+                     dataCopyParams.blockLen = real_BT * sizeof(GType);
+                     dataCopyParams.srcStride = 0;
+                     dataCopyParams.dstStride = 0;
+                     DataCopyPad(gmDg[gOffset], tensorDgOutDeq, dataCopyParams);
+                     outQue2.FreeTensor(tensorDgOutDeq);
+                 }
+
+                 // ---- Phase 2: mm7 accumulation into dk (fused from Part7) ----
+                 CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+                 CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+
+                 {
+                     auto tensorMm7In = inQue2.AllocTensor<DataType>();
+                     DataCopy(tensorMm7In[dkSize], gmMm7[kOffset], dkSize);
+                     inQue2.EnQue(tensorMm7In);
+                 }
+                 {
+                     auto tensorMm7In = inQue2.DeQue<DataType>();
+                     auto tensorMm7Fp32 = tensorMm7In.template ReinterpretCast<float>();
+                     auto tensorDkOut = outQue1.AllocTensor<DataType>();
+
+                     Cast(tensorMm7Fp32, tensorMm7In[dkSize], RoundMode::CAST_NONE, dkSize);
+                     PipeBarrier<PIPE_V>();
+                     Add(tensorDkFp32, tensorDkFp32, tensorMm7Fp32, dkSize);
+                     PipeBarrier<PIPE_V>();
+                     Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);
+
+                     inQue1.FreeTensor(tensorDkIn);
+                     inQue2.FreeTensor(tensorMm7In);
+                     outQue1.EnQue(tensorDkOut);
+                 }
+                 {
+                     auto tensorDkOut = outQue1.DeQue<DataType>();
+                     DataCopy(gmDk[kOffset], tensorDkOut, dkSize);
+                     outQue1.FreeTensor(tensorDkOut);
+                 }
+
+                 CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
              }
-             
-             // CopyOut
-             {
-                 auto tensorDkOut = outQue1.DeQue<DataType>();
-                 auto tensorDgOut = outQue2.DeQue<GType>();
- 
-                 DataCopy(gmDk[kOffset], tensorDkOut, dkSize);
- 
-                 // dg 需要与之前的累加
-                 // 累加到 dg (读取现有值, 加上新值, 写回)
-                 // 简化: 直接累加 (需要在 Part 5 中处理最终值)
-                 // dg 写入最终输出
-                 DataCopyParams dataCopyParams;
-                 dataCopyParams.blockCount = 1;
-                 dataCopyParams.blockLen = real_BT * sizeof(GType);
-                 dataCopyParams.srcStride = 0;
-                 dataCopyParams.dstStride = 0;
-                 DataCopyPad(gmDg[gOffset], tensorDgOut, dataCopyParams);
-                 outQue1.FreeTensor(tensorDkOut);
-                 outQue2.FreeTensor(tensorDgOut);
-             }
- 
-             // ---- Phase 2: mm7 accumulation into dk (fused from Part7) ----
-             CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-             CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
- 
-             {
-                 auto tensorDkIn = inQue1.AllocTensor<DataType>();
-                 auto tensorMm7In = inQue2.AllocTensor<DataType>();
-                 DataCopy(tensorDkIn[dkSize], gmDk[kOffset], dkSize);
-                 DataCopy(tensorMm7In[dkSize], gmMm7[kOffset], dkSize);
-                 inQue1.EnQue(tensorDkIn);
-                 inQue2.EnQue(tensorMm7In);
-             }
-             {
-                 auto tensorDkIn = inQue1.DeQue<DataType>();
-                 auto tensorDkFp32 = tensorDkIn.template ReinterpretCast<float>();
-                 auto tensorMm7In = inQue2.DeQue<DataType>();
-                 auto tensorMm7Fp32 = tensorMm7In.template ReinterpretCast<float>();
-                 auto tensorDkOut = outQue1.AllocTensor<DataType>();
- 
-                 Cast(tensorDkFp32, tensorDkIn[dkSize], RoundMode::CAST_NONE, dkSize);
-                 Cast(tensorMm7Fp32, tensorMm7In[dkSize], RoundMode::CAST_NONE, dkSize);
-                 PipeBarrier<PIPE_V>();
-                 Add(tensorDkFp32, tensorDkFp32, tensorMm7Fp32, dkSize);
-                 PipeBarrier<PIPE_V>();
-                 Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);
- 
-                 inQue1.FreeTensor(tensorDkIn);
-                 inQue2.FreeTensor(tensorMm7In);
-                 outQue1.EnQue(tensorDkOut);
-             }
-             {
-                 auto tensorDkOut = outQue1.DeQue<DataType>();
-                 DataCopy(gmDk[kOffset], tensorDkOut, dkSize);
-                 outQue1.FreeTensor(tensorDkOut);
-             }
- 
-             CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+
          }
      }
  }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
@@ -11,1418 +11,1234 @@
  * \file chunk_bwd_dqkwg_vector.h
  */
 
-#ifndef CHUNK_BWD_DQKWG_VECTOR_H
-#define CHUNK_BWD_DQKWG_VECTOR_H
-
-#include "chunk_bwd_dqkwg_common.h"
-#include "kernel_operator.h"
-
-using namespace AscendC;
-
-template <typename DataType, typename GType>
-class ChunkBwdDqkwgVectorProcess {
-public:
-    __aicore__ inline ChunkBwdDqkwgVectorProcess(
-        GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
-        GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices, GM_ADDR mask_a,
-        GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
-        GM_ADDR workspace
-    );
-    
-    __aicore__ inline void Init(const ChunkBwdDqkwgTilingData &tiling, TPipe *pipe_);
-    __aicore__ inline void Process();
-    
-private:
-    // 7 个 Part 的处理函数
-    __aicore__ inline void ProcessPart1();  // dw = -dv @ h^T, dg_last 计算
-    __aicore__ inline void ProcessPart2();  // 等待 mm5 完成
-    __aicore__ inline void ProcessPart3();  // ds 处理, dg 部分计算
-    __aicore__ inline void ProcessPart4();  // dq 处理, dg 累加
-    __aicore__ inline void ProcessPart5();  // dk 处理, dg 最终计算
-    __aicore__ inline void ProcessPart6();  // dq 累加
-    __aicore__ inline void ProcessPart7();  // dk 累加
-    
-    // 辅助函数
-    __aicore__ inline void ComputeExpScalar(float input, float &output);
-    __aicore__ inline void ApplyLowerTriangularMask(LocalTensor<float> &tensor, uint32_t size);
-    __aicore__ inline void ReduceSumX(LocalTensor<float> &src, LocalTensor<float> &dst,
-                                      uint32_t rows, uint32_t cols, int axis);
-    
-private:
-    // 输入输出指针
-    GM_ADDR ptrQ;
-    GM_ADDR ptrK;
-    GM_ADDR ptrV;
-    GM_ADDR ptrG;
-    GM_ADDR ptrH;
-    GM_ADDR ptrDo;
-    GM_ADDR ptrDh;
-    GM_ADDR ptrDv;
-    GM_ADDR ptrCuSeqLen;
-    GM_ADDR ptrChunkIndices;
-    GM_ADDR ptrMaskA;
-    GM_ADDR ptrDq;
-    GM_ADDR ptrDk;
-    GM_ADDR ptrDw;
-    GM_ADDR ptrDg;
-    GM_ADDR ptrWorkspace;
-    
-    // Tiling 参数
-    uint64_t B;
-    uint64_t H;
-    uint64_t T;
-    uint64_t K;
-    uint64_t V;
-    uint64_t BT;
-    uint64_t numChunks;
-    float scale;
-    int isVarLen;
-    uint32_t mul0RowNum = 0;
-    
-    // Workspace 偏移
-    uint64_t wsDwOffset;
-    uint64_t wsDgLastOffset;
-    uint64_t wsMm5Offset;
-    uint64_t wsDsTempOffset;
-    uint64_t wsMm6Offset;
-    uint64_t wsMm7Offset;
-    uint64_t wsMul1Offset;
-    int BUFFER_NUM = 1;
-    
-    // Pipeline
-    TPipe *pipe = nullptr;
-    
-    // Global Tensors
-    GlobalTensor<DataType> gmQ, gmK, gmV, gmDo, gmH, gmDh, gmDv;
-    GlobalTensor<DataType> gmDq, gmDk, gmDw;
-    GlobalTensor<GType> gmG, gmDg;
-    GlobalTensor<DataType> gmWorkspace;
-    GlobalTensor<float> gmDgLast;
-    GlobalTensor<DataType> gmMm5, gmDsTemp, gmMul1, gmMm6, gmMm7;
-    
-    // Queues (用于流水)
-    TQue<TPosition::VECIN, 2> inQue1;
-    TQue<TPosition::VECIN, 2> inQue2;
-    TQue<TPosition::VECIN, 2> inQue3;
-    TQue<TPosition::VECIN, 2> inQue4;  //用于Add0累加
-    TQue<TPosition::VECIN, 2> inQue5;  //用于Part5 Add4中间结果
-    TQue<TPosition::VECIN, 2> inQue6;  //用于Part5 gLast中间结果
-    TQue<TPosition::VECOUT, 2> outQue1;
-    TQue<TPosition::VECOUT, 2> outQue2;
-
-    
-    // Calc Buffers (UB 空间)
-    TBuf<TPosition::VECCALC> calcBuf1;  // 主计算缓冲区 (fp32)
-    TBuf<TPosition::VECCALC> calcBuf2;  // 辅助计算缓冲区 (fp32)
-    TBuf<TPosition::VECCALC> calcBuf3;  // Exp 缓冲区
-    TBuf<TPosition::VECCALC> calcBuf4;  // 中间结果
-    TBuf<TPosition::VECCALC> gBuf;      // g 值缓冲区
-    TBuf<TPosition::VECCALC> dgBuf;     // dg 值缓冲区
-    
-    // UB 空间常量
-    static constexpr uint32_t UB_BLOCK_SIZE = 32;
-    static constexpr uint32_t FP32_ELEMENTS_PER_BLOCK = 8;
-    static constexpr uint32_t FP16_ELEMENTS_PER_BLOCK = 16;
-};
-
-// ============== 构造函数 ==============
-template <typename DataType, typename GType>
-__aicore__ inline ChunkBwdDqkwgVectorProcess<DataType, GType>::ChunkBwdDqkwgVectorProcess(
-    GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
-    GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices, GM_ADDR mask_a,
-    GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
-    GM_ADDR workspace
-) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
-    ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLen(cu_seqlen), ptrChunkIndices(chunk_indices), ptrMaskA(mask_a),
-    ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
-    ptrWorkspace(workspace) {}
-
-// ============== 初始化 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::Init(const ChunkBwdDqkwgTilingData &tiling, TPipe *pipe_) {
-    pipe = pipe_;
-
-    scale = tiling.scale;
-    B = tiling.B;
-    H = tiling.H;
-    T = tiling.T;
-    K = tiling.K;
-    V = tiling.V;
-    BT = tiling.BT;
-    numChunks = tiling.numChunks;
-    wsDgLastOffset = tiling.wsDgLastOffset;
-    wsMm5Offset = tiling.wsMm5Offset;
-    wsDsTempOffset = tiling.wsDsTempOffset;
-    // wsMm6Offset = tiling.wsMm6Offset;
-    // wsMm7Offset = tiling.wsMm7Offset;
-    // wsMul1Offset = tiling.wsMul1Offset;
-    uint64_t dgLastSize = tiling.dgLastSize;
-    isVarLen = tiling.isVarLen;
-    mul0RowNum = tiling.mul0RowNum;
-
-    if (BT == 64) {
-        BUFFER_NUM = 2;
-    } else {
-        BUFFER_NUM = 1;
-    }
-
-    gmQ.SetGlobalBuffer((__gm__ DataType *)ptrQ);
-    gmK.SetGlobalBuffer((__gm__ DataType *)ptrK);
-    gmV.SetGlobalBuffer((__gm__ DataType *)ptrV);
-    gmG.SetGlobalBuffer((__gm__ GType *)ptrG);
-    gmH.SetGlobalBuffer((__gm__ DataType *)ptrH);
-    gmDo.SetGlobalBuffer((__gm__ DataType *)ptrDo);
-    gmDh.SetGlobalBuffer((__gm__ DataType *)ptrDh);
-    gmDv.SetGlobalBuffer((__gm__ DataType *)ptrDv);
-
-    gmDq.SetGlobalBuffer((__gm__ DataType *)ptrDq);
-    gmDk.SetGlobalBuffer((__gm__ DataType *)ptrDk);
-    gmDw.SetGlobalBuffer((__gm__ DataType *)ptrDw);
-    gmDg.SetGlobalBuffer((__gm__ GType *)ptrDg);
-
-    gmWorkspace.SetGlobalBuffer((__gm__ DataType *)ptrWorkspace);
-    gmDgLast.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t*)ptrWorkspace + wsDgLastOffset));     //中间结果使用float
-
-    gmMm5.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm5Offset));
-    gmDsTemp.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsDsTempOffset));
-    // gmMm6.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm6Offset));
-    // gmMm7.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm7Offset));
-    gmMm6.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm5Offset));
-    gmMm7.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm5Offset));
-    // gmMul1.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMul1Offset));
-    gmMul1.SetGlobalBuffer((__gm__ DataType *)ptrDq);
-}
-
-// ============== 主处理函数 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::Process() {
-    // Part 1: dw 和 dg_last 计算
-    ProcessPart1();
-    pipe->Reset();
-    AscendC::SyncAll<false>();
-    // Part 2: 等待 mm5 (q @ k^T) 完成
-    ProcessPart2();
-    pipe->Reset();
-    AscendC::SyncAll<false>();
-    // Part 3: ds 处理和 dg 部分计算
-    ProcessPart3();
-    pipe->Reset();
-    AscendC::SyncAll<false>();
-    // Part 4: dq 处理
-    ProcessPart4();
-    pipe->Reset();
-    AscendC::SyncAll<false>();
-    // Part 5: dk 处理和 dg 最终计算
-    ProcessPart5();
-    pipe->Reset();
-    AscendC::SyncAll<false>();
-    // Part 6: dq 累加
-    ProcessPart6();
-    pipe->Reset();
-    AscendC::SyncAll<false>();
-    // Part 7: dk 累加
-    ProcessPart7();
-}
-
-// ============== Part 1: dw 和 dg_last 计算 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart1() {
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNum = GetBlockNum();
-    // printf("coreIdx %d, coreNum %d\n", coreIdx, coreNum);
-    uint32_t coreLoops = B * numChunks;
-    
-    // 分配 UB 空间
-    // Part 1 的 Vector 部分主要处理:
-    // 1. h * dh 的逐元素乘法和求和 -> dg_last
-    // 2. dw 的负号处理
-    
-    const uint32_t hDhSize = mul0RowNum * V;  // h 和 dh 的大小
-    const uint32_t dwSize = BT * K;
-    uint32_t BT_sub = BT;
-    uint32_t BT_sub_offset = 0;
-
-    uint32_t dwSize_sub = BT_sub * K;
-    uint32_t vecTaskIdx = 0;
-
-    uint32_t maxSize = (2 * hDhSize) > dwSize ? (2 * hDhSize) : dwSize;
-
-    // 初始化 buffers
-    pipe->InitBuffer(inQue1, BUFFER_NUM, maxSize * sizeof(DataType));  // h 和 dh 共用一个输入队列
-    pipe->InitBuffer(outQue1, BUFFER_NUM, sizeof(float) * 8);  // dg_last (对齐到 32 字节)
-    pipe->InitBuffer(outQue2, BUFFER_NUM, dwSize * sizeof(DataType));
-    pipe->InitBuffer(calcBuf1, maxSize * sizeof(float));
-    pipe->InitBuffer(calcBuf3, hDhSize * sizeof(float));
-    auto tensorHFp32 = calcBuf1.Get<float>();
-    auto tensorDhFp32 = tensorHFp32[hDhSize];
-    auto tensorSumFp32 = calcBuf3.Get<float>();
-
-    // 发送同步信号给 Cube
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-        uint32_t bIdx = loopIdx / numChunks;
-        uint32_t chunkIdx = loopIdx % numChunks;
-        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T, BT, loopIdx, bos, eos);
-        BT_sub = eos-bos;
-        dwSize_sub = BT_sub * K;
-        
-        for (uint32_t h = 0; h < H; h++) {
-            ++vecTaskIdx;
-            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-                continue;
-            }
-            // 计算偏移
-            // h, dh: [B, H, num_chunks, K, V]
-            uint64_t hOffset = ((bIdx * H + h) * numChunks + chunkIdx) * K * V;
-            // dw (workspace): 按 [B, H, T, K] 布局
-            uint64_t dwOffset = (h * T + bos) * K;
-            // dg_last: [B, H, num_chunks]
-            uint64_t dgLastOffset = (bIdx * H + h) * numChunks + chunkIdx;
-
-            // ========== 计算 dg_last = sum(h * dh) ==========
-            // 等待 Cube 信号 (dw Cube 计算)
-            for(uint32_t row = 0; row < K; row += mul0RowNum) {
-                // CopyIn: h 和 dh
-                {
-                    auto tensorHIn = inQue1.AllocTensor<DataType>();
-                    auto tensorDhIn = tensorHIn[hDhSize];
-                    DataCopy(tensorDhIn, gmDh[hOffset + row * V], hDhSize);
-                    DataCopy(tensorHIn, gmH[hOffset + row * V], hDhSize);
-                    inQue1.EnQue(tensorHIn);
-                }
-                // Compute: h * dh -> reduceSum
-                {
-                    auto tensorHIn = inQue1.DeQue<DataType>();
-                    auto tensorDhIn = tensorHIn[hDhSize];
-                    // Cast to fp32 (bf16 不支持直接 Mul)
-                    Cast(tensorHFp32, tensorHIn, RoundMode::CAST_NONE, hDhSize);
-                    Cast(tensorDhFp32, tensorDhIn, RoundMode::CAST_NONE, hDhSize);
-                    PipeBarrier<PIPE_V>();
-
-                    // 逐元素乘法
-                    if(row == 0) {
-                        Mul(tensorSumFp32, tensorHFp32, tensorDhFp32, hDhSize);
-                    } else {
-                        Mul(tensorHFp32, tensorHFp32, tensorDhFp32, hDhSize);
-                        PipeBarrier<PIPE_V>();
-                        Add(tensorSumFp32, tensorSumFp32, tensorHFp32, hDhSize);
-                    }
-
-                    PipeBarrier<PIPE_V>();
-                    inQue1.FreeTensor(tensorHIn);
-                }
-            }
-            {
-                uint32_t remainNum = hDhSize;
-                while(remainNum > 64) {
-                    remainNum = remainNum / 2;
-                    Add(tensorSumFp32, tensorSumFp32, tensorSumFp32[remainNum], remainNum);
-                    PipeBarrier<PIPE_V>();
-                }
-                auto tensorDgLastOut = outQue1.AllocTensor<float>();
-                WholeReduceSum(tensorDgLastOut, tensorSumFp32, 64, 1, 1, 1, 8);
-                outQue1.EnQue(tensorDgLastOut);
-            }
-            {
-                auto tensorDgLastOut = outQue1.DeQue<float>();
-
-                DataCopyParams dataCopyParams;
-                dataCopyParams.blockCount = 1;
-                dataCopyParams.blockLen = 1*sizeof(float);
-                dataCopyParams.srcStride = 0;
-                dataCopyParams.dstStride = 0;
-                DataCopyPad(gmDgLast[dgLastOffset], tensorDgLastOut,dataCopyParams);
-
-                outQue1.FreeTensor(tensorDgLastOut);
-            }
-
-
-
-            // ========== 处理 dw: 取负号 ==========
-            // Cube 计算的是 dv @ h^T, 需要乘以 -1
-            // 从 workspace 读取 dw, 乘以 -1, 写回最终输出
-            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-            // CopyIn: dw from workspace
-            {
-                auto tensorDwIn = inQue1.AllocTensor<DataType>();
-                DataCopy(tensorDwIn, gmDw[dwOffset], dwSize_sub);
-                inQue1.EnQue(tensorDwIn);
-            }
-
-            // Compute: -dw
-            {
-                auto tensorDwIn = inQue1.DeQue<DataType>();
-                auto tensorDwOut = outQue2.AllocTensor<DataType>();
-                
-                // Cast to fp32, 乘以 -1, cast back
-                Cast(tensorHFp32, tensorDwIn, RoundMode::CAST_NONE, dwSize_sub);
-                PipeBarrier<PIPE_V>();
-                Muls(tensorHFp32, tensorHFp32, -1.0f, dwSize_sub);
-                PipeBarrier<PIPE_V>();
-                Cast(tensorDwOut, tensorHFp32, RoundMode::CAST_RINT, dwSize_sub);
-                inQue1.FreeTensor(tensorDwIn);
-                outQue2.EnQue(tensorDwOut);
-            }
-            
-            // CopyOut: dw to final output
-            {
-                auto tensorDwOut = outQue2.DeQue<DataType>();
-                DataCopy(gmDw[dwOffset], tensorDwOut, dwSize_sub);
-
-                outQue2.FreeTensor(tensorDwOut);
-            }
-
-            // 通知 Cube 继续
-            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-        }
-    }
-
-}
-
-// ============== Part 2: 等待 mm5 完成 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart2() {
-    // Part 2 MUL1 + and(m_A)
-    
-    constexpr int32_t BLOCK_SIZE = 32; // API一次能处理256B，能计算64个float元素
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNum = GetBlockNum();
-    uint32_t coreLoops = B * numChunks;
-    uint32_t real_BT = BT;
-
-    uint32_t BT_sub = real_BT;
-    uint32_t BT_sub_start = 0;
-    uint32_t BT_sub_end = BT_sub;
-
-    uint32_t dsSize_sub = BT_sub * BT;
-    uint32_t dsSize_sub_offset = 0;
-    const uint32_t gSize = BT;
-    
-    // 初始化 buffers
-    
-    pipe->InitBuffer(inQue3, 2, gSize * sizeof(float));        // g values
-    pipe->InitBuffer(outQue1, 2, dsSize_sub * sizeof(float) / 2);   // ds_temp output   32K/8K
-
-    pipe->InitBuffer(calcBuf1, BT * 8 * sizeof(float));             // g in fp32
-    pipe->InitBuffer(calcBuf2, BT * sizeof(float));            // g temp [BT,1]
-    pipe->InitBuffer(calcBuf3, BT * sizeof(float));            // g temp [1,BT]
-    pipe->InitBuffer(calcBuf4, BLOCK_SIZE);
-
-    auto tensorBrcbTemp = calcBuf1.Get<float>();
-    auto tensorGFp32Left = calcBuf2.Get<float>();
-    auto tensorGFp32Right = calcBuf3.Get<float>();
-    auto tensorZeroFp32 = calcBuf4.template Get<float>();
-    
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    uint32_t bos_orig = 0;
-    uint32_t eos_orig = 0;
-    // 发送同步信号
-
-    //初始化zero
-    AscendC::Duplicate<float>(tensorZeroFp32, float(0.0), BLOCK_SIZE / sizeof(float));
-    PipeBarrier<PIPE_V>();
-    //搬入m_A
-
-    const uint32_t maskASize = 64*64*sizeof(float);//BT * BT / 8 * sizeof(uint8_t);
-    pipe->InitBuffer(inQue1, 1, maskASize);    // m_A from input
-    auto tensorMaskA = inQue1.AllocTensor<float>();
-
-    Duplicate(tensorMaskA,static_cast<float>(0),64 * 64);
-    PipeBarrier<PIPE_V>();
-    for(int i = 0; i < 64; i++) {
-        Duplicate(tensorMaskA[i * 64], 1.0f, i + 1);
-    }
-    PipeBarrier<PIPE_V>();
-
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T, BT, loopIdx, bos, eos);
-        bos_orig = bos;
-        eos_orig = eos;
-        uint32_t vec_core_0_length = (eos_orig - bos_orig) >= (BT / 2) ? (BT / 2) : (eos_orig - bos_orig);
-        uint32_t vec_core_1_length = (eos_orig - bos_orig) >= (BT / 2) ? (eos_orig - bos_orig - (BT / 2)) : 0;
-        if (GetSubBlockIdx() == 0) {        // BT: 0..BT_sub_end
-            BT_sub_start = 0;
-            BT_sub_end = vec_core_0_length;         // [0, vec_core_0_length)
-            eos = bos + vec_core_0_length;
-        } else {       // BT: BT_sub_end+1..eos
-            BT_sub_start = vec_core_0_length;
-            BT_sub_end = eos_orig - bos_orig;
-            bos = bos + vec_core_0_length;
-        }
-        
-        uint32_t real_BT= eos-bos;
-        uint32_t real_BT_align = ALIGN_UP((eos-bos), 16);
-        dsSize_sub = (eos-bos) * BT;
-        uint32_t bIdx = loopIdx / numChunks;
-        uint32_t chunkIdx = loopIdx % numChunks;
-
-        for (uint32_t h = 0; h < H; h++) {
-            if (real_BT == 0) {       //sub core get 0 token
-                continue;
-            }
-
-            // 偏移计算
-            // g: [B, H, T]
-            uint64_t gOffset = (h * T + bos_orig);
-            // ds, mm5, ds_temp: [B, H, T, BT]
-            uint64_t dsOffset = (h * T + bos) * BT;
-            // CopyIn: g
-            {
-                auto tensorGIn = inQue3.AllocTensor<GType>();
-
-                DataCopyParams dataCopyParams;
-                dataCopyParams.blockCount = 1;
-                dataCopyParams.blockLen = (eos_orig-bos_orig)*sizeof(GType);
-                dataCopyParams.srcStride = 0;
-                dataCopyParams.dstStride = 0;
-                DataCopyPad(tensorGIn, gmG[gOffset],dataCopyParams,{false, 0, 0, 0});
-
-                inQue3.EnQue(tensorGIn);
-            }
-
-            // Compute MUL1
-            {
-                auto tensorGIn = inQue3.DeQue<GType>();
-                auto tensorDsTempOut = outQue1.AllocTensor<float>();
-
-                // g 可能已经是 fp32
-                if constexpr (std::is_same<GType, float>::value) {
-                    DataCopy(tensorGFp32Left, tensorGIn, gSize);
-                } else {
-                    Cast(tensorGFp32Left, tensorGIn, RoundMode::CAST_NONE, gSize);
-                }
-                PipeBarrier<PIPE_V>();
-
-                Muls(tensorGFp32Right, tensorGFp32Left, static_cast<float>(-1), gSize);
-
-                Brcb(tensorBrcbTemp, tensorGFp32Left[BT_sub_start], CEIL_DIV(real_BT, 8), {1, 8}); // Brcb处理数据个数需要8对齐 [BT,8]
-                PipeBarrier<PIPE_V>();
-
-                // copy tensorGFp32Right  chunkLen / 2行
-                if (BT == 64) {
-
-                    AscendC::Add(tensorDsTempOut, tensorGFp32Right, tensorBrcbTemp, CAL_NUM_FLOAT, real_BT,
-                                {1, 1, 0, 8, 0, 1});
-
-                    PipeBarrier<PIPE_V>();
-                    Mins(tensorDsTempOut, tensorDsTempOut, static_cast<float>(0.0), real_BT * BT);
-
-                    PipeBarrier<PIPE_V>();
-                    Exp(tensorDsTempOut, tensorDsTempOut, real_BT * BT);
-                    PipeBarrier<PIPE_V>();
-
-                } else {
-                    AscendC::Copy(tensorDsTempOut, tensorGFp32Right, CAL_NUM_FLOAT, real_BT, {1, 1, 16, 0});
-                    PipeBarrier<PIPE_V>();
-                    AscendC::Copy(tensorDsTempOut[CAL_NUM_FLOAT], tensorGFp32Right[CAL_NUM_FLOAT], CAL_NUM_FLOAT,
-                                real_BT, {1, 1, 16, 0});
-                    PipeBarrier<PIPE_V>();
-                    AscendC::Add(tensorDsTempOut, tensorDsTempOut, tensorBrcbTemp, CAL_NUM_FLOAT, real_BT,
-                                {1, 1, 0, 16, 16, 1});
-                    PipeBarrier<PIPE_V>();
-                    AscendC::Add(tensorDsTempOut[CAL_NUM_FLOAT], tensorDsTempOut[CAL_NUM_FLOAT], tensorBrcbTemp,
-                                CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
-                    PipeBarrier<PIPE_V>();
-                    Mins(tensorDsTempOut, tensorDsTempOut, static_cast<float>(0.0), real_BT * BT);
-                    PipeBarrier<PIPE_V>();
-                    Exp(tensorDsTempOut, tensorDsTempOut, real_BT * BT);
-                }
-
-                PipeBarrier<PIPE_V>();
-
-                if(BT==64) {    //TODO： MASK
-                    Mul(tensorDsTempOut,tensorDsTempOut,tensorMaskA[BT_sub_start*64],32*64);
-                    PipeBarrier<PIPE_V>();
-                } else {
-                    BinaryRepeatParams binaryRepeatParams{1,1,1,16,16,8};
-                    UnaryRepeatParams unaryRepeatParams{1,1,16,8};
-                    PipeBarrier<PIPE_V>();
-                    if (BT_sub_start == 0) {    // vec 0 : 0..64
-                        Mul(tensorDsTempOut,tensorDsTempOut,tensorMaskA,64,64,binaryRepeatParams);
-                        PipeBarrier<PIPE_V>();
-                        Muls(tensorDsTempOut[64],tensorDsTempOut[64],static_cast<float>(0),64,64,unaryRepeatParams);
-                        PipeBarrier<PIPE_V>();
-                    }
-                    else {      // vec 0 : 64..128
-                        Mul(tensorDsTempOut[64],tensorDsTempOut[64],tensorMaskA,64,64,binaryRepeatParams);
-                        PipeBarrier<PIPE_V>();
-                    }
-
-                }
-
-                AscendC::Muls(tensorDsTempOut, tensorDsTempOut, static_cast<float>(scale), real_BT * BT);
-                PipeBarrier<PIPE_V>();
-
-                //Ds是 fp16/bf16
-                Cast(tensorDsTempOut.template ReinterpretCast<DataType>(), tensorDsTempOut, RoundMode::CAST_RINT, real_BT * BT);
-
-                inQue3.FreeTensor(tensorGIn);
-                outQue1.EnQue(tensorDsTempOut);
-            }
-
-            // CopyOut
-            {
-                auto tensorDsTempOut = outQue1.DeQue<float>();
-                DataCopy(gmMul1[dsOffset], tensorDsTempOut.template ReinterpretCast<DataType>(), real_BT * BT);
-
-                outQue1.FreeTensor(tensorDsTempOut);
-            }
-        }
-    }
-    inQue1.FreeTensor<float>(tensorMaskA);
-}
-
-// ============== Part 3: ds 处理和 dg 部分计算 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart3() {
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNum = GetBlockNum();
-    uint32_t coreLoops = B * numChunks;
-    uint32_t real_BT = BT; // TODO：如果BT不对齐
-
-    uint32_t BT_sub = real_BT;
-    uint32_t BT_sub_start = 0;
-    uint32_t BT_sub_end = BT_sub;
-
-
-    uint32_t dsSize_sub = BT_sub * BT;
-    uint32_t dsSize_sub_offset = 0;
-    const uint32_t gSize = BT;
-
-    // 初始化 buffers
-    pipe->InitBuffer(inQue1, BUFFER_NUM, dsSize_sub * sizeof(float));    // ds from Cube
-    pipe->InitBuffer(inQue2, BUFFER_NUM, dsSize_sub * sizeof(float));    // mm5/mul1 from workspace
-    pipe->InitBuffer(outQue1, BUFFER_NUM, dsSize_sub * sizeof(DataType));   // ds_temp output   32K/8K
-    pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(float));       // dg output
-
-    pipe->InitBuffer(calcBuf4, gSize * sizeof(float));        // m_A
-    pipe->InitBuffer(gBuf, gSize * sizeof(float));             // g in fp32
-    pipe->InitBuffer(dgBuf, gSize * sizeof(float));            // dg temp
-
-    auto tensorMaskA = calcBuf4.Get<float>();
-    auto tensorGFp32 = gBuf.Get<float>();
-    auto tensorDgTemp = dgBuf.Get<float>();
-
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    uint32_t vecTaskIdx = 0;
-    // 发送同步信号
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T, BT, loopIdx, bos, eos);
-        BT_sub_end = eos-bos;
-        uint32_t real_BT= eos-bos;
-        dsSize_sub = (eos-bos) * BT;
-        uint32_t bIdx = loopIdx / numChunks;
-        uint32_t chunkIdx = loopIdx % numChunks;
-
-        for (uint32_t h = 0; h < H; h++) {
-            // if (GetSubBlockIdx() == 1) {
-            //     CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-            //     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-            //     continue;
-            // }
-            ++vecTaskIdx;
-            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-                continue;
-            }
-
-            // 偏移计算
-            // g: [B, H, T]
-            uint64_t gOffset = (h * T + bos);
-            // ds, mm5, ds_temp: [B, H, T, BT]
-            uint64_t dsOffset = (h * T + bos) * BT;
-
-            // dg: [B, H, T]
-            uint64_t dgOffset = gOffset;
-
-            // 等待 Cube 完成 ds 计算
-            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-
-            // CopyIn: ds (Cube output), g
-            {
-                auto tensorDsIn = inQue1.AllocTensor<DataType>();
-                auto tensorMul1In = inQue2.AllocTensor<DataType>();
-
-                DataCopy(tensorDsIn[BT * BT], gmDsTemp[dsOffset + dsSize_sub_offset], dsSize_sub);
-                DataCopy(tensorMul1In[BT * BT], gmMul1[dsOffset + dsSize_sub_offset], dsSize_sub);
-
-                inQue1.EnQue(tensorDsIn);
-                inQue2.EnQue(tensorMul1In);
-            }
-
-            // Compute MUL1
-            {
-                auto tensorDsInFp16 = inQue1.DeQue<DataType>();
-                auto tensorDsInFp32 = tensorDsInFp16.template ReinterpretCast<float>();
-
-                auto tensorDsTempOut = outQue1.AllocTensor<DataType>();
-
-                auto tensorMul1InFp16 = inQue2.DeQue<DataType>();
-                auto tensorMul1InFp32 = tensorMul1InFp16.template ReinterpretCast<float>();
-                auto tensorDgOut = outQue2.AllocTensor<float>();
-
-                // Cast to fp32
-                Cast(tensorDsInFp32, tensorDsInFp16[BT * BT], RoundMode::CAST_NONE, dsSize_sub);
-
-                
-                Cast(tensorMul1InFp32, tensorMul1InFp16[BT * BT], RoundMode::CAST_NONE, dsSize_sub);
-                PipeBarrier<PIPE_V>();
-                // b_ds_temp = b_ds * mul1 (已经应用了掩码)
-                Mul(tensorDsInFp32, tensorDsInFp32, tensorMul1InFp32, dsSize_sub);
-                inQue2.FreeTensor(tensorMul1InFp32);
-
-                //搬入MM5,复用Mul1空间
-                auto tensorMm5InFp16Tmp = inQue2.AllocTensor<DataType>();
-                DataCopy(tensorMm5InFp16Tmp[BT * BT], gmMm5[dsOffset + dsSize_sub_offset], dsSize_sub);
-                inQue2.EnQue(tensorMm5InFp16Tmp);
-                auto tensorMm5InFp16 = inQue2.DeQue<DataType>();
-
-                auto tensorMm5InFp32 = tensorMm5InFp16.template ReinterpretCast<float>();
-                Cast(tensorMm5InFp32, tensorMm5InFp16[BT * BT], RoundMode::CAST_NONE, dsSize_sub);
-                PipeBarrier<PIPE_V>();
-                // Calcute ds_temp * mm5 and after
-
-                Mul(tensorMm5InFp32, tensorDsInFp32, tensorMm5InFp32, dsSize_sub); // b_ds2 = b_ds_temp * mm5
-                Cast(tensorDsTempOut, tensorDsInFp32, RoundMode::CAST_RINT, dsSize_sub);  //ds_tmp -> fp16, tensorDsFp32已经空闲
-
-                // axis=1: 对每行求和 -> [BT] +Add0.C
-                Duplicate(tensorDgOut, static_cast<float>(0.0), BT);
-                PipeBarrier<PIPE_V>();
-
-                // reducesum
-                uint64_t wholeReduceSumCnt = CeilDiv(real_BT, FP32_PER_REPEAT);
-                uint32_t remainCnt = real_BT % FP32_PER_REPEAT;
-                if(remainCnt > 0) {
-                    uint32_t DuplicateOffset = wholeReduceSumCnt * FP32_PER_REPEAT - FP32_PER_REPEAT;
-                    uint64_t mask[1] = {0xffffffffffffffff};
-                    mask[0] <<= remainCnt;
-                    for (uint32_t row = BT_sub_start; row < BT_sub_end; row++) {
-                        Duplicate(tensorMm5InFp32[row * BT + DuplicateOffset], 0.0f, mask, 1, 1, 8);
-                    }
-                    PipeBarrier<PIPE_V>();
-                }
-                for (uint32_t i = BT_sub_start; i < BT_sub_end; i++) {
-                    WholeReduceSum(tensorDsInFp32[i * 8], tensorMm5InFp32[i * BT],
-                                   FP32_PER_REPEAT, wholeReduceSumCnt, 1, 1, 8);
-                }
-                PipeBarrier<PIPE_V>();
-                WholeReduceSum(tensorDgOut, tensorDsInFp32, wholeReduceSumCnt, real_BT, 1, 1, 1);
-
-                // axis=0: 对每列求和 -> [BT] -Add0.D
-                PipeBarrier<PIPE_V>();
-                uint32_t remain_row = real_BT;
-                uint32_t CalcCnt = 0;
-                uint32_t Offset = 0;
-                while (remain_row > 1) {
-                    CalcCnt = (remain_row / 2) * BT;
-                    remain_row = CeilDiv(remain_row, 2);
-                    Offset = remain_row * BT;
-                    Add(tensorMm5InFp32, tensorMm5InFp32, tensorMm5InFp32[Offset], CalcCnt);
-                    PipeBarrier<PIPE_V>();
-                }
-                Sub(tensorDgOut, tensorDgOut, tensorMm5InFp32, BT);
-                PipeBarrier<PIPE_V>();
-                // 保存 tensorDgOut 供后续 Part 使用
-                if constexpr (!std::is_same<GType, float>::value) {
-                    Cast(tensorDgOut.template ReinterpretCast<GType>(), tensorDgOut, RoundMode::CAST_RINT, gSize);
-                }
-
-                inQue1.FreeTensor(tensorDsInFp16);
-                inQue2.FreeTensor(tensorMm5InFp16);
-
-                outQue1.EnQue(tensorDsTempOut);
-                outQue2.EnQue(tensorDgOut);
-            }
-            
-            // CopyOut
-            {
-                auto tensorDsTempOut = outQue1.DeQue<DataType>();
-                auto tensorDgOut = outQue2.DeQue<float>();
-
-                DataCopy(gmDsTemp[dsOffset + dsSize_sub_offset], tensorDsTempOut, dsSize_sub);
-
-                DataCopyParams dataCopyParams;
-                dataCopyParams.blockCount = 1;
-                dataCopyParams.blockLen = real_BT * sizeof(GType);
-                dataCopyParams.srcStride = 0;
-                dataCopyParams.dstStride = 0;
-                // dg 写入最终输出
-                if constexpr (std::is_same<GType, float>::value) {
-                    DataCopyPad(gmDg[dgOffset], tensorDgOut,dataCopyParams);
-                } else {
-                    // 需要 cast
-                    DataCopyPad(gmDg[dgOffset], tensorDgOut.template ReinterpretCast<GType>(), dataCopyParams);
-                }
-
-                outQue1.FreeTensor(tensorDsTempOut);
-                outQue2.FreeTensor(tensorDgOut);
-            }
-
-            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-        }
-
-    }
-
-}
-
-
-
-// ============== Part 4: dq 处理 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart4() {
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNum = GetBlockNum();
-    uint32_t coreLoops = B * numChunks;
-    
-    uint32_t dqSize = BT * K;
-    uint32_t real_BT = BT;
-
-
-    uint32_t BT_sub = real_BT;
-    uint32_t BT_sub_start = 0;
-    uint32_t BT_sub_end = BT_sub;
-    
-    uint32_t dqSize_sub = BT_sub * K;
-    uint32_t dqSize_sub_offset = BT_sub_start * K;
-    const uint32_t gSize = BT;
-    // 初始化 buffers
-    pipe->InitBuffer(inQue1, BUFFER_NUM, dqSize_sub * sizeof(float));    // dq from Cube   //64K
-    pipe->InitBuffer(inQue2, BUFFER_NUM, dqSize_sub * sizeof(float));    // q
-    pipe->InitBuffer(inQue3, BUFFER_NUM, gSize * sizeof(GType));        // g
-    pipe->InitBuffer(inQue4, BUFFER_NUM, gSize * sizeof(GType));        // g             
-    pipe->InitBuffer(outQue1, BUFFER_NUM, dqSize_sub * sizeof(DataType));   // dq output
-    pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(float));       // dg partial
-
-    pipe->InitBuffer(calcBuf3, gSize * (8) * sizeof(float));        //第一次reducesum结果：[BT, 8]
-    pipe->InitBuffer(gBuf, gSize * sizeof(float));
-    pipe->InitBuffer(dgBuf, gSize * sizeof(float));
-    
-    auto tensorShareTmpFp32 = calcBuf3.Get<float>();
-    auto tensorGFp32 = gBuf.Get<float>();
-    auto tensorDgAdd = dgBuf.Get<float>();
-
-    uint32_t vecTaskIdx = 0;
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T,
-                        BT, loopIdx, bos, eos);
-        uint32_t actual_chunk_len = eos-bos;
-        dqSize_sub = actual_chunk_len * K;
-        BT_sub_end = actual_chunk_len;
-        BT_sub = actual_chunk_len;
-        uint32_t bIdx = loopIdx / numChunks;
-        uint32_t chunkIdx = loopIdx % numChunks;
-        
-        for (uint32_t h = 0; h < H; h++) {
-            // if (GetSubBlockIdx() == 1) {
-            //     CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-            //     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-            //     continue;
-            // }
-            ++vecTaskIdx;
-            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-                continue;
-            }
-            uint64_t qkOffset = (h * T + bos) * K;
-            uint64_t gOffset = (h * T + bos);
-            
-            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-            // CopyIn
-            {
-                auto tensorDqIn = inQue1.AllocTensor<DataType>();
-                auto tensorQIn = inQue2.AllocTensor<DataType>();
-                auto tensorGIn = inQue3.AllocTensor<GType>();
-                auto tensorDgIn = inQue4.AllocTensor<GType>();
-                
-                DataCopy(tensorDqIn[dqSize_sub], gmDq[qkOffset + dqSize_sub_offset], dqSize_sub);
-
-                DataCopy(tensorQIn[dqSize_sub], gmQ[qkOffset + dqSize_sub_offset], dqSize_sub);
-
-                DataCopyParams dataCopyParams;
-                dataCopyParams.blockCount = 1;
-                dataCopyParams.blockLen = actual_chunk_len*sizeof(GType);
-                dataCopyParams.srcStride = 0;
-                dataCopyParams.dstStride = 0;
-                DataCopyPad(tensorGIn, gmG[gOffset],dataCopyParams,{false, 0, 0, 0});
-                DataCopyPad(tensorDgIn, gmDg[gOffset],dataCopyParams,{false, 0, 0, 0});
-
-                inQue1.EnQue(tensorDqIn);
-                inQue2.EnQue(tensorQIn);
-                inQue3.EnQue(tensorGIn);
-                inQue4.EnQue(tensorDgIn);
-            }
-            
-            // Compute
-            {
-                auto tensorDqInFp16 = inQue1.DeQue<DataType>();
-                auto tensorDqInFp32 = tensorDqInFp16.template ReinterpretCast<float>();
-                auto tensorQInFp16 = inQue2.DeQue<DataType>();
-                auto tensorQInFp32 = tensorQInFp16.template ReinterpretCast<float>();
-                auto tensorGIn = inQue3.DeQue<GType>();
-                auto tensorDgIn = inQue4.DeQue<GType>();
-                auto tensorDqOut = outQue1.AllocTensor<DataType>();
-                auto tensorDgOut = outQue2.AllocTensor<float>();
-
-                // Cast
-                Cast(tensorDqInFp32, tensorDqInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
-                Cast(tensorQInFp32, tensorQInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
-                if constexpr (std::is_same<GType, float>::value) {
-                    DataCopy(tensorGFp32, tensorGIn, gSize);
-                } else {
-                    Cast(tensorGFp32, tensorGIn, RoundMode::CAST_NONE, gSize);
-                }
-                PipeBarrier<PIPE_V>();
-
-                // mul3 = exp(g) * scale
-                // b_dq_temp = b_dq * mul3 (broadcast along K dimension)
-                Exp(tensorGFp32, tensorGFp32, gSize);
-                PipeBarrier<PIPE_V>();
-
-                Muls(tensorGFp32, tensorGFp32, static_cast<float>(scale), gSize);       //mul3 = exp(g) * scale
-                PipeBarrier<PIPE_V>();
-
-                Brcb(tensorShareTmpFp32, tensorGFp32, CEIL_DIV(real_BT, 8), {1, 8}); // Brcb处理数据个数需要8对齐 [BT,8]
-                PipeBarrier<PIPE_V>();
-                AscendC::Mul(tensorDqInFp32, tensorDqInFp32, tensorShareTmpFp32, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
-                AscendC::Mul(tensorDqInFp32[CAL_NUM_FLOAT], tensorDqInFp32[CAL_NUM_FLOAT], tensorShareTmpFp32, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
-
-                PipeBarrier<PIPE_V>();
-                Mul(tensorQInFp32, tensorDqInFp32, tensorQInFp32, dqSize_sub);
-
-                // Add0.A = reduceSum((q * dq), axis=1)
-                // axis=1: 对每行求和 -> [BT] +Add0.A
-
-                PipeBarrier<PIPE_V>();
-
-                // reducesum
-                uint64_t wholeReduceSumCnt = CeilDiv(K, FP32_PER_REPEAT);
-                for (uint32_t i = BT_sub_start; i < BT_sub_end; i++) {
-                    WholeReduceSum(tensorShareTmpFp32[i * 8], tensorQInFp32[i * K],
-                                   FP32_PER_REPEAT, wholeReduceSumCnt, 1, 1, 8);
-                }
-                PipeBarrier<PIPE_V>();
-                WholeReduceSum(tensorDgOut, tensorShareTmpFp32, wholeReduceSumCnt, actual_chunk_len, 1, 1, 1);
-
-                //累加tensorDgIn += + tensorDgOut
-                if constexpr (std::is_same<GType, float>::value) {
-                    DataCopy(tensorDgAdd, tensorDgIn, real_BT);
-                } else {
-                    Cast(tensorDgAdd, tensorDgIn, RoundMode::CAST_NONE, real_BT);
-                }
-
-                PipeBarrier<PIPE_V>();
-                Add(tensorDgOut, tensorDgAdd, tensorDgOut, real_BT);
-
-                PipeBarrier<PIPE_V>();
-
-                if constexpr (!std::is_same<GType, float>::value) {
-                    Cast(tensorDgOut.template ReinterpretCast<GType>(), tensorDgOut, RoundMode::CAST_RINT, gSize);
-                }
-
-                Cast(tensorDqOut, tensorDqInFp32, RoundMode::CAST_RINT, dqSize_sub);
-
-                inQue1.FreeTensor(tensorDqInFp16);
-                inQue2.FreeTensor(tensorQInFp16);
-                inQue3.FreeTensor(tensorGIn);
-                inQue4.FreeTensor(tensorDgIn);
-                outQue1.EnQue(tensorDqOut);
-                outQue2.EnQue(tensorDgOut);
-            }
-            // CopyOut: dq to final output, dg accumulate
-            {
-                auto tensorDqOut = outQue1.DeQue<DataType>();
-                auto tensorDgOut = outQue2.DeQue<GType>();
-
-                DataCopy(gmDq[qkOffset + dqSize_sub_offset], tensorDqOut, dqSize_sub);
-
-                // 累加到 dg (读取现有值, 加上新值, 写回)
-                // 简化: 直接累加 (需要在 Part 5 中处理最终值)
-                // dg 写入最终输出
-                DataCopyParams dataCopyParams;
-                dataCopyParams.blockCount = 1;
-                dataCopyParams.blockLen = BT_sub * sizeof(GType);
-                dataCopyParams.srcStride = 0;
-                dataCopyParams.dstStride = 0;
-                DataCopyPad(gmDg[gOffset + BT_sub_start], tensorDgOut,dataCopyParams);
-
-                outQue1.FreeTensor(tensorDqOut);
-                outQue2.FreeTensor(tensorDgOut);
-            }
-            
-            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-        }
-    }
-}
-
-
-// ============== Part 5: dk 处理和 dg 最终计算 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart5() {
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNum = GetBlockNum();
-    uint32_t coreLoops = B * numChunks;
-    
-    uint32_t dkSize = BT * K;
-    uint32_t gSize = BT;
-    uint32_t real_BT = BT;
-    
-    // 初始化 buffers
-    pipe->InitBuffer(inQue1, BUFFER_NUM, dkSize * sizeof(float));
-    pipe->InitBuffer(inQue2, BUFFER_NUM, dkSize * sizeof(float));
-    pipe->InitBuffer(inQue3, BUFFER_NUM, gSize * sizeof(GType));
-    pipe->InitBuffer(inQue4, BUFFER_NUM, gSize * sizeof(GType));
-    // pipe->InitBuffer(inQue5, BUFFER_NUM, 16 * sizeof(float));    // add4中间结果及广播结果
-    // pipe->InitBuffer(inQue6, BUFFER_NUM, 16 * sizeof(float));    // part5 gLast中间结果
-    pipe->InitBuffer(outQue1, BUFFER_NUM, dkSize * sizeof(DataType));
-    pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(GType));
-
-    pipe->InitBuffer(calcBuf1, gSize * 8 * sizeof(float));  //gLast
-    pipe->InitBuffer(calcBuf2, gSize * 8 * sizeof(float));  //dgLast
-    pipe->InitBuffer(calcBuf4, gSize * sizeof(float));
-    pipe->InitBuffer(gBuf, gSize * sizeof(float));
-    pipe->InitBuffer(dgBuf, gSize * 8 * sizeof(float));
-
-    auto tensorGFp32 = gBuf.Get<float>();
-    auto tensorDgFinal = dgBuf.Get<float>();
-    auto tensorGLastFp32Tmp = calcBuf1.Get<float>();
-    auto tensorDgLastFp32Tmp = calcBuf2.Get<float>();
-    auto tensorDgTmp = calcBuf4.Get<float>();
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    uint32_t vecTaskIdx = 0;
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T, BT, loopIdx, bos, eos);
-        uint32_t actual_chunk_len = eos - bos;
-        real_BT = actual_chunk_len;
-        dkSize = actual_chunk_len * K;
-        uint32_t real_BT_aligned = (real_BT + 15) / 16 * 16;
-        uint32_t bIdx = loopIdx / numChunks;
-        uint32_t chunkIdx = loopIdx % numChunks;
-        
-        for (uint32_t h = 0; h < H; h++) {
-            ++vecTaskIdx;
-            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-                continue;
-            }
-            uint64_t kOffset = (h * T + bos) * K;
-            uint64_t gOffset = (h * T + bos);
-            uint64_t dgLastOffset = (bIdx * H + h) * numChunks + chunkIdx;
-            
-            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-
-            // CopyIn
-            {
-                auto tensorDkIn = inQue1.AllocTensor<DataType>();
-                auto tensorKIn = inQue2.AllocTensor<DataType>();
-                auto tensorGIn = inQue3.AllocTensor<GType>();
-                auto tensorDgIn = inQue4.AllocTensor<GType>();
-                // auto tensorDgLastIn = inQue5.AllocTensor<float>();
-                // auto tensorGLastIn = inQue6.AllocTensor<GType>();
-                
-                DataCopy(tensorDkIn[dkSize], gmDk[kOffset], dkSize);
-                DataCopy(tensorKIn[dkSize], gmK[kOffset], dkSize);
-
-                DataCopyParams dataCopyParams;
-                dataCopyParams.blockCount = 1;
-                dataCopyParams.blockLen = actual_chunk_len*sizeof(GType);
-                dataCopyParams.srcStride = 0;
-                dataCopyParams.dstStride = 0;
-                DataCopyPad(tensorGIn, gmG[gOffset],dataCopyParams,{false, 0, 0, 0});
-                DataCopyPad(tensorDgIn, gmDg[gOffset],dataCopyParams,{false, 0, 0, 0});
-
-                inQue1.EnQue(tensorDkIn);
-                inQue2.EnQue(tensorKIn);
-                inQue3.EnQue(tensorGIn);
-                inQue4.EnQue(tensorDgIn);
-                // inQue5.EnQue(tensorDgLastIn);
-                // inQue6.EnQue(tensorGLastIn);
-            }
-            
-            // Compute
-            {
-                auto tensorDkIn = inQue1.DeQue<DataType>();
-                auto tensorDkFp32 = tensorDkIn.template ReinterpretCast<float>();
-                auto tensorKIn = inQue2.DeQue<DataType>();
-                auto tensorKFp32 = tensorKIn.template ReinterpretCast<float>();
-                auto tensorGIn = inQue3.DeQue<GType>();
-                auto tensorDgIn = inQue4.DeQue<GType>();
-                // auto tensorDgLastFp32 = inQue5.DeQue<float>();
-                // auto tensorGLast = inQue6.DeQue<GType>();
-                // auto tensorGLastFp32 = tensorGLast.template ReinterpretCast<float>();
-                auto tensorDkOut = outQue1.AllocTensor<DataType>();
-                auto tensorDgOut = outQue2.AllocTensor<GType>();
-
-                // Cast
-                Cast(tensorDkFp32, tensorDkIn[dkSize], RoundMode::CAST_NONE, dkSize);
-
-                Cast(tensorKFp32, tensorKIn[dkSize], RoundMode::CAST_NONE, dkSize);
-                PipeBarrier<PIPE_V>();
-
-                if constexpr (std::is_same<GType, float>::value) {
-                    DataCopy(tensorGFp32, tensorGIn, BT);
-                    DataCopy(tensorDgTmp, tensorDgIn, BT);
-                } else {
-                    Cast(tensorGFp32, tensorGIn, RoundMode::CAST_NONE, real_BT_aligned);
-                    // Cast(tensorGLastFp32, tensorGLast, RoundMode::CAST_NONE, 1);
-                    Cast(tensorDgTmp, tensorDgIn, RoundMode::CAST_NONE, real_BT_aligned);
-                }
-                PipeBarrier<PIPE_V>();
-
-                // uint32_t lastIdx = actual_chunk_len - 1;
-                //MUL2
-                uint32_t last_line_no = (actual_chunk_len - 1) / 8 * 8; // 最后一行的行号
-                uint32_t last_line_idx = actual_chunk_len - 1 - last_line_no;
-                Brcb(tensorDgFinal, tensorGFp32[last_line_no], 1, {1, 8}); // [8,8] 只有第last_line_idx行有效 = gLast
-                PipeBarrier<PIPE_V>();
-                Muls(tensorGFp32, tensorGFp32, -1.0f, real_BT_aligned);
-                DataCopy(tensorGLastFp32Tmp, tensorDgFinal[last_line_idx * 8], 8); // tensorDgFinal暂存dg值，后续计算dgLast
-
-                PipeBarrier<PIPE_V>();
-
-                AscendC::Add(tensorGFp32, tensorGFp32, tensorDgFinal[last_line_idx * 8], CAL_NUM_FLOAT, BT / CAL_NUM_FLOAT, {1, 1, 0, 8, 8, 0});
-                PipeBarrier<PIPE_V>();
-
-                Exp(tensorGFp32, tensorGFp32, real_BT_aligned);
-                PipeBarrier<PIPE_V>();
-
-                // dgLast:使用tensorDgLast[0]替代
-                // tensorDkFp32:        tensorDgFinal:gsize * 8 * float
-                Brcb(tensorDgFinal, tensorGFp32, CEIL_DIV(real_BT, 8), {1, 8}); // Brcb处理数据个数需要8对齐 [BT,8]
-                PipeBarrier<PIPE_V>();
-                AscendC::Mul(tensorDkFp32, tensorDkFp32, tensorDgFinal, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
-
-                AscendC::Mul(tensorDkFp32[CAL_NUM_FLOAT], tensorDkFp32[CAL_NUM_FLOAT], tensorDgFinal, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
-                PipeBarrier<PIPE_V>();
-
-                Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);      //dk -> fp16 tensorDkFp32
-
-                Mul(tensorKFp32, tensorKFp32, tensorDkFp32, dkSize);    // mul8 = dk * k
-                PipeBarrier<PIPE_V>();
-
-                // Add0.B = (dk_temp * k).reduceSum(axis=1)
-                // axis=1: 对每行求和 -> [BT] +Add0.B
-
-                // reducesum
-                uint64_t wholeReduceSumCnt = CeilDiv(K, FP32_PER_REPEAT);
-                for (uint32_t i = 0; i < actual_chunk_len; i++) {
-                    WholeReduceSum(tensorDgFinal[i * 8], tensorKFp32[i * K],
-                                   FP32_PER_REPEAT, wholeReduceSumCnt, 1, 1, 8);
-                }
-                PipeBarrier<PIPE_V>();
-                WholeReduceSum(tensorGFp32, tensorDgFinal, wholeReduceSumCnt, actual_chunk_len, 1, 1, 1);
-
-                // float totalSum = 0.0f;
-                PipeBarrier<PIPE_V>();
-
-                //Sum0: [actual_chunk_len] -> [1]
-                uint64_t sum0SumCnt = CeilDiv(actual_chunk_len, FP32_PER_REPEAT);
-                uint32_t remainCnt = actual_chunk_len % FP32_PER_REPEAT;
-                if(remainCnt > 0) {
-                    uint32_t DuplicateOffset = sum0SumCnt * FP32_PER_REPEAT - FP32_PER_REPEAT;
-                    uint64_t mask[1] = {0xffffffffffffffff};
-                    mask[0] <<= remainCnt;
-
-                    Duplicate(tensorGFp32[(sum0SumCnt-1)*FP32_PER_REPEAT], 0.0f, mask, 1, 1, 8);
-
-                    PipeBarrier<PIPE_V>();
-                }
-                WholeReduceSum(tensorDkFp32, tensorGFp32, FP32_PER_REPEAT, sum0SumCnt, 1, 1, 8);
-                // PipeBarrier<PIPE_ALL>();
-                PipeBarrier<PIPE_V>();
-                WholeReduceSum(tensorDgFinal, tensorDkFp32, sum0SumCnt, 1, 1, 1, 8);
-
-                // tensorGLastFp32[0]已经是最后一个位置的 g 值
-                float dgLast = gmDgLast.GetValue(dgLastOffset); // tensorDgTmp暂存dg值，获取最后一个位置的dgLast
-                Duplicate(tensorDgLastFp32Tmp, dgLast, 8); // 广播 dgLast
-                Exp(tensorGLastFp32Tmp, tensorGLastFp32Tmp, 8);
-                PipeBarrier<PIPE_V>();
-                Mul(tensorDgLastFp32Tmp, tensorDgLastFp32Tmp, tensorGLastFp32Tmp, 8);
-                PipeBarrier<PIPE_V>();
-                Add(tensorDgLastFp32Tmp, tensorDgLastFp32Tmp, tensorDgFinal, 8);  //add4 = tensorDgLastFp32Tmp[0]
-
-
-                Sub(tensorGFp32, tensorDgTmp, tensorGFp32, BT); //Add.0 最终结果
-
-                PipeBarrier<PIPE_V>();
-                Brcb(tensorDgFinal, tensorDgLastFp32Tmp, 1, {1, 8}); // [8,8] 只有第一行有效
-                PipeBarrier<PIPE_V>();
-                uint64_t offset = (real_BT - 1) / 8 * 8; // 每行8个float
-                uint64_t mask[1] = {0};
-                mask[0] = 1ULL << (real_BT - 1 - offset); // 计算掩码，只有最后一个位置有效
-
-                Add(tensorGFp32[offset], tensorGFp32[offset], tensorDgFinal, mask, 1, {1,1,1,8,8,8});
-
-                PipeBarrier<PIPE_V>();
-                if constexpr (std::is_same<GType, float>::value) {
-                    DataCopy(tensorDgOut, tensorGFp32, BT);
-                } else {
-                    Cast(tensorDgOut, tensorGFp32, RoundMode::CAST_RINT, BT);
-                }
-                PipeBarrier<PIPE_V>();
-
-
-                // 处理最后一个位置的 dg
-                // b_dg_last *= exp(g_last)
-                // is_last_mask: 只有最后一个位置添加 dgLastTerm
-
-                // 读取之前 Part 3/4 计算的 dg, 累加
-                // (简化处理, 实际应该从 GM 读取并累加)
-
-                inQue1.FreeTensor(tensorDkIn);
-                inQue2.FreeTensor(tensorKIn);
-                inQue3.FreeTensor(tensorGIn);
-                inQue4.FreeTensor(tensorDgIn);
-                // inQue5.FreeTensor(tensorDgLastFp32);
-                // inQue6.FreeTensor(tensorGLast);
-                outQue1.EnQue(tensorDkOut);
-                outQue2.EnQue(tensorDgOut);
-            }
-            
-            // CopyOut
-            {
-                auto tensorDkOut = outQue1.DeQue<DataType>();
-                auto tensorDgOut = outQue2.DeQue<GType>();
-
-                DataCopy(gmDk[kOffset], tensorDkOut, dkSize);
-
-                // dg 需要与之前的累加
-                // 累加到 dg (读取现有值, 加上新值, 写回)
-                // 简化: 直接累加 (需要在 Part 5 中处理最终值)
-                // dg 写入最终输出
-                DataCopyParams dataCopyParams;
-                dataCopyParams.blockCount = 1;
-                dataCopyParams.blockLen = real_BT * sizeof(GType);
-                dataCopyParams.srcStride = 0;
-                dataCopyParams.dstStride = 0;
-                DataCopyPad(gmDg[gOffset], tensorDgOut, dataCopyParams);
-                outQue1.FreeTensor(tensorDkOut);
-                outQue2.FreeTensor(tensorDgOut);
-            }
-
-            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-        }
-    }
-}
-
-
-// ============== Part 6: dq 累加 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart6() {
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNum = GetBlockNum();
-    uint32_t coreLoops = B * numChunks;
-    
-    uint32_t dqSize = BT * K;
-    
-    // 初始化 buffers
-    pipe->InitBuffer(inQue1, BUFFER_NUM, dqSize * sizeof(float));    // dq current
-    pipe->InitBuffer(inQue2, BUFFER_NUM, dqSize * sizeof(float));    // mm6 from Cube
-    pipe->InitBuffer(outQue1, BUFFER_NUM, dqSize * sizeof(DataType));
-
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    uint32_t vecTaskIdx = 0;
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T,
-                        BT, loopIdx, bos, eos);
-        uint32_t actual_chunk_len = eos - bos;
-        dqSize = actual_chunk_len * K;
-        uint32_t bIdx = loopIdx / numChunks;
-        uint32_t chunkIdx = loopIdx % numChunks;
-        
-        for (uint32_t h = 0; h < H; h++) {
-            // if (GetSubBlockIdx() == 1) {
-            //     CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-            //     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-            //     continue;
-            // }
-            ++vecTaskIdx;
-            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-                continue;
-            }
-            uint64_t dqOffset = (h * T + bos) * K;
-            
-            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-            
-            // Part 6 的 Vector 工作是将 Cube 计算的 mm6 累加到 dq
-            // CopyIn
-            {
-                auto tensorDqIn = inQue1.AllocTensor<DataType>();
-                auto tensorMM6In = inQue2.AllocTensor<DataType>();
-                
-                DataCopy(tensorDqIn[dqSize], gmDq[dqOffset], dqSize);
-                DataCopy(tensorMM6In[dqSize], gmMm6[dqOffset], dqSize);
-
-                inQue1.EnQue(tensorDqIn);
-                inQue2.EnQue(tensorMM6In);
-            }
-
-            //Compute
-            {
-                auto tensorDqIn = inQue1.DeQue<DataType>();
-                auto tensorDqFp32 = tensorDqIn.template ReinterpretCast<float>();
-                auto tensorMM6In = inQue2.DeQue<DataType>();
-                auto tensorMM6Fp32 = tensorMM6In.template ReinterpretCast<float>();
-                auto tensorDqOut = outQue1.AllocTensor<DataType>();
-                // Cast
-
-                Cast(tensorDqFp32, tensorDqIn[dqSize], RoundMode::CAST_NONE, dqSize);
-                // PipeBarrier<PIPE_V>();
-                Cast(tensorMM6Fp32, tensorMM6In[dqSize], RoundMode::CAST_NONE, dqSize);
-                PipeBarrier<PIPE_V>();
-
-                Add(tensorDqFp32, tensorDqFp32, tensorMM6Fp32, dqSize);
-
-                PipeBarrier<PIPE_V>();
-                Cast(tensorDqOut, tensorDqFp32, RoundMode::CAST_RINT, dqSize);
-
-                PipeBarrier<PIPE_V>();
-                inQue1.FreeTensor(tensorDqIn);
-                inQue2.FreeTensor(tensorMM6In);
-                outQue1.EnQue<DataType>(tensorDqOut);
-            }
-
-            //CopyOut
-            {
-                auto tensorDqOut = outQue1.DeQue<DataType>();
-                DataCopy(gmDq[dqOffset], tensorDqOut, dqSize);
-                outQue1.FreeTensor(tensorDqOut);
-            }
-            
-            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-        }
-    }
-}
-
-// ============== Part 7: dk 累加 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart7() {
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNum = GetBlockNum();
-    uint32_t coreLoops = B * numChunks;
-    
-    uint32_t dkSize = BT * K;
-    
-    // 初始化 buffers
-    pipe->InitBuffer(inQue1, BUFFER_NUM, dkSize * sizeof(float));    // dk current
-    pipe->InitBuffer(inQue2, BUFFER_NUM, dkSize * sizeof(float));    // mm6 from Cube
-    pipe->InitBuffer(outQue1, BUFFER_NUM, dkSize * sizeof(DataType));
-
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    uint32_t vecTaskIdx = 0;
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T,
-                        BT, loopIdx, bos, eos);
-        uint32_t actual_chunk_len = eos - bos;
-        dkSize = actual_chunk_len * K;
-        uint32_t bIdx = loopIdx / numChunks;
-        uint32_t chunkIdx = loopIdx % numChunks;
-        
-        for (uint32_t h = 0; h < H; h++) {
-            // if (GetSubBlockIdx() == 1) {
-            //     CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-            //     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-            //     continue;
-            // }
-            ++vecTaskIdx;
-            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-                continue;
-            }
-            uint64_t dkOffset = (h * T + bos) * K;
-            
-            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-            
-            // Part 7 的 Vector 工作是将 Cube 计算的 mm7 累加到 dk
-            // CopyIn
-            {
-                auto tensorDkIn = inQue1.AllocTensor<DataType>();
-                auto tensorMm7In = inQue2.AllocTensor<DataType>();
-                
-                DataCopy(tensorDkIn[dkSize], gmDk[dkOffset], dkSize);
-                DataCopy(tensorMm7In[dkSize], gmMm7[dkOffset], dkSize);
-
-                inQue1.EnQue(tensorDkIn);
-                inQue2.EnQue(tensorMm7In);
-            }
-
-            //Compute
-            {
-                auto tensorDkIn = inQue1.DeQue<DataType>();
-                auto tensorDkFp32 = tensorDkIn.template ReinterpretCast<float>();
-                auto tensorMm7In = inQue2.DeQue<DataType>();
-                auto tensorMm7Fp32 = tensorMm7In.template ReinterpretCast<float>();
-                auto tensorDkOut = outQue1.AllocTensor<DataType>();
-
-                // Cast
-                Cast(tensorDkFp32, tensorDkIn[dkSize], RoundMode::CAST_NONE, dkSize);
-                // PipeBarrier<PIPE_V>();
-                Cast(tensorMm7Fp32, tensorMm7In[dkSize], RoundMode::CAST_NONE, dkSize);
-                PipeBarrier<PIPE_V>();
-                Add(tensorDkFp32, tensorDkFp32, tensorMm7Fp32, dkSize);
-                PipeBarrier<PIPE_V>();
-                Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);
-
-                PipeBarrier<PIPE_V>();
-                inQue1.FreeTensor(tensorDkIn);
-                inQue2.FreeTensor(tensorMm7In);
-                outQue1.EnQue<DataType>(tensorDkOut);
-            }
-
-            //CopyOut
-            {
-                auto tensorDkOut = outQue1.DeQue<DataType>();
-                DataCopy(gmDk[dkOffset], tensorDkOut, dkSize);
-
-                outQue1.FreeTensor(tensorDkOut);
-            }
-
-            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-        }
-    }
-}
-
-#endif  // CHUNK_BWD_DQKWG_VECTOR_H
+ #ifndef CHUNK_BWD_DQKWG_VECTOR_H
+ #define CHUNK_BWD_DQKWG_VECTOR_H
+ 
+ #include "chunk_bwd_dqkwg_common.h"
+ #include "kernel_operator.h"
+ 
+ using namespace AscendC;
+ 
+ template <typename DataType, typename GType>
+ class ChunkBwdDqkwgVectorProcess {
+ public:
+     __aicore__ inline ChunkBwdDqkwgVectorProcess(
+         GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
+         GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices, GM_ADDR mask_a,
+         GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
+         GM_ADDR workspace
+     );
+     
+     __aicore__ inline void Init(const ChunkBwdDqkwgTilingData &tiling, TPipe *pipe_);
+     __aicore__ inline void Process();
+     
+ private:
+     // 5 个 Part 的处理函数
+     __aicore__ inline void ProcessPart1();  // dw = -dv @ h^T, dg_last 计算
+     __aicore__ inline void ProcessPart2();  // 等待 mm5 完成
+     __aicore__ inline void ProcessPart3();  // ds 处理, dg 部分计算
+     __aicore__ inline void ProcessPart4();  // dq 处理 + mm6 累加 (融合 Part6)
+     __aicore__ inline void ProcessPart5();  // dk 处理 + mm7 累加 (融合 Part7)
+     
+     // 辅助函数
+     __aicore__ inline void ComputeExpScalar(float input, float &output);
+     __aicore__ inline void ApplyLowerTriangularMask(LocalTensor<float> &tensor, uint32_t size);
+     __aicore__ inline void ReduceSumX(LocalTensor<float> &src, LocalTensor<float> &dst,
+                                       uint32_t rows, uint32_t cols, int axis);
+     
+ private:
+     // 输入输出指针
+     GM_ADDR ptrQ;
+     GM_ADDR ptrK;
+     GM_ADDR ptrV;
+     GM_ADDR ptrG;
+     GM_ADDR ptrH;
+     GM_ADDR ptrDo;
+     GM_ADDR ptrDh;
+     GM_ADDR ptrDv;
+     GM_ADDR ptrCuSeqLen;
+     GM_ADDR ptrChunkIndices;
+     GM_ADDR ptrMaskA;
+     GM_ADDR ptrDq;
+     GM_ADDR ptrDk;
+     GM_ADDR ptrDw;
+     GM_ADDR ptrDg;
+     GM_ADDR ptrWorkspace;
+     
+     // Tiling 参数
+     uint64_t B;
+     uint64_t H;
+     uint64_t T;
+     uint64_t K;
+     uint64_t V;
+     uint64_t BT;
+     uint64_t numChunks;
+     float scale;
+     int isVarLen;
+     uint32_t mul0RowNum = 0;
+     
+     // Workspace 偏移
+     uint64_t wsDwOffset;
+     uint64_t wsDgLastOffset;
+     uint64_t wsMm5Offset;
+     uint64_t wsDsTempOffset;
+     uint64_t wsMm6Offset;
+     uint64_t wsMm7Offset;
+     uint64_t wsMul1Offset;
+     int BUFFER_NUM = 1;
+     
+     // Pipeline
+     TPipe *pipe = nullptr;
+     
+     // Global Tensors
+     GlobalTensor<DataType> gmQ, gmK, gmV, gmDo, gmH, gmDh, gmDv;
+     GlobalTensor<DataType> gmDq, gmDk, gmDw;
+     GlobalTensor<GType> gmG, gmDg;
+     GlobalTensor<DataType> gmWorkspace;
+     GlobalTensor<float> gmDgLast;
+     GlobalTensor<DataType> gmMm5, gmDsTemp, gmMul1, gmMm6, gmMm7;
+     
+     // Queues (用于流水)
+     TQue<TPosition::VECIN, 2> inQue1;
+     TQue<TPosition::VECIN, 2> inQue2;
+     TQue<TPosition::VECIN, 2> inQue3;
+     TQue<TPosition::VECIN, 2> inQue4;  //用于Add0累加
+     TQue<TPosition::VECIN, 2> inQue5;  //用于Part5 Add4中间结果
+     TQue<TPosition::VECIN, 2> inQue6;  //用于Part5 gLast中间结果
+     TQue<TPosition::VECOUT, 2> outQue1;
+     TQue<TPosition::VECOUT, 2> outQue2;
+ 
+     
+     // Calc Buffers (UB 空间)
+     TBuf<TPosition::VECCALC> calcBuf1;  // 主计算缓冲区 (fp32)
+     TBuf<TPosition::VECCALC> calcBuf2;  // 辅助计算缓冲区 (fp32)
+     TBuf<TPosition::VECCALC> calcBuf3;  // Exp 缓冲区
+     TBuf<TPosition::VECCALC> calcBuf4;  // 中间结果
+     TBuf<TPosition::VECCALC> gBuf;      // g 值缓冲区
+     TBuf<TPosition::VECCALC> dgBuf;     // dg 值缓冲区
+     
+     // UB 空间常量
+     static constexpr uint32_t UB_BLOCK_SIZE = 32;
+     static constexpr uint32_t FP32_ELEMENTS_PER_BLOCK = 8;
+     static constexpr uint32_t FP16_ELEMENTS_PER_BLOCK = 16;
+ };
+ 
+ // ============== 构造函数 ==============
+ template <typename DataType, typename GType>
+ __aicore__ inline ChunkBwdDqkwgVectorProcess<DataType, GType>::ChunkBwdDqkwgVectorProcess(
+     GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
+     GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices, GM_ADDR mask_a,
+     GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
+     GM_ADDR workspace
+ ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
+     ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLen(cu_seqlen), ptrChunkIndices(chunk_indices), ptrMaskA(mask_a),
+     ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
+     ptrWorkspace(workspace) {}
+ 
+ // ============== 初始化 ==============
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::Init(const ChunkBwdDqkwgTilingData &tiling, TPipe *pipe_) {
+     pipe = pipe_;
+ 
+     scale = tiling.scale;
+     B = tiling.B;
+     H = tiling.H;
+     T = tiling.T;
+     K = tiling.K;
+     V = tiling.V;
+     BT = tiling.BT;
+     numChunks = tiling.numChunks;
+     wsDgLastOffset = tiling.wsDgLastOffset;
+     wsMm5Offset = tiling.wsMm5Offset;
+     wsDsTempOffset = tiling.wsDsTempOffset;
+     wsMm6Offset = tiling.wsMm6Offset;
+     wsMm7Offset = tiling.wsMm7Offset;
+     wsMul1Offset = tiling.wsMul1Offset;
+     uint64_t dgLastSize = tiling.dgLastSize;
+     isVarLen = tiling.isVarLen;
+     mul0RowNum = tiling.mul0RowNum;
+ 
+     if (BT == 64) {
+         BUFFER_NUM = 2;
+     } else {
+         BUFFER_NUM = 1;
+     }
+ 
+     gmQ.SetGlobalBuffer((__gm__ DataType *)ptrQ);
+     gmK.SetGlobalBuffer((__gm__ DataType *)ptrK);
+     gmV.SetGlobalBuffer((__gm__ DataType *)ptrV);
+     gmG.SetGlobalBuffer((__gm__ GType *)ptrG);
+     gmH.SetGlobalBuffer((__gm__ DataType *)ptrH);
+     gmDo.SetGlobalBuffer((__gm__ DataType *)ptrDo);
+     gmDh.SetGlobalBuffer((__gm__ DataType *)ptrDh);
+     gmDv.SetGlobalBuffer((__gm__ DataType *)ptrDv);
+ 
+     gmDq.SetGlobalBuffer((__gm__ DataType *)ptrDq);
+     gmDk.SetGlobalBuffer((__gm__ DataType *)ptrDk);
+     gmDw.SetGlobalBuffer((__gm__ DataType *)ptrDw);
+     gmDg.SetGlobalBuffer((__gm__ GType *)ptrDg);
+ 
+     gmWorkspace.SetGlobalBuffer((__gm__ DataType *)ptrWorkspace);
+     gmDgLast.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t*)ptrWorkspace + wsDgLastOffset));     //中间结果使用float
+ 
+     gmMm5.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm5Offset));
+     gmDsTemp.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsDsTempOffset));
+     gmMm6.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm6Offset));
+ 
+     gmMm7.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm7Offset));
+     gmMul1.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMul1Offset));
+ }
+ 
+ // ============== 主处理函数 ==============
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::Process() {
+     // Part 1: dw 和 dg_last 计算
+     ProcessPart1();
+     pipe->Reset();
+     // Part 2: 等待 mm5 (q @ k^T) 完成, 计算 mul1
+     ProcessPart2();
+     pipe->Reset();
+     // Part 3: ds 处理和 dg 部分计算
+     ProcessPart3();
+     pipe->Reset();
+     // Part 4+6 融合: dq 处理 + mm6 累加 (在 UB 中完成, 省去 dq 的 GM 往返)
+     ProcessPart4();
+     pipe->Reset();
+     // Part 5+7 融合: dk 处理 + mm7 累加 (在 UB 中完成, 省去 dk 的 GM 往返)
+     ProcessPart5();
+ }
+ 
+ // ============== Part 1: dw 和 dg_last 计算 ==============
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart1() {
+     uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+     uint32_t coreNum = GetBlockNum();
+     // printf("coreIdx %d, coreNum %d\n", coreIdx, coreNum);
+     uint32_t coreLoops = B * numChunks;
+     
+     // 分配 UB 空间
+     // Part 1 的 Vector 部分主要处理:
+     // 1. h * dh 的逐元素乘法和求和 -> dg_last
+     // 2. dw 的负号处理
+     
+     const uint32_t hDhSize = mul0RowNum * V;  // h 和 dh 的大小
+     const uint32_t dwSize = BT * K;
+     uint32_t BT_sub = BT;
+     uint32_t BT_sub_offset = 0;
+ 
+     uint32_t dwSize_sub = BT_sub * K;
+     uint32_t vecTaskIdx = 0;
+ 
+     uint32_t maxSize = (2 * hDhSize) > dwSize ? (2 * hDhSize) : dwSize;
+ 
+     // 初始化 buffers
+     pipe->InitBuffer(inQue1, BUFFER_NUM, maxSize * sizeof(DataType));  // h 和 dh 共用一个输入队列
+     pipe->InitBuffer(outQue1, BUFFER_NUM, sizeof(float) * 8);  // dg_last (对齐到 32 字节)
+     pipe->InitBuffer(outQue2, BUFFER_NUM, dwSize * sizeof(DataType));
+     pipe->InitBuffer(calcBuf1, maxSize * sizeof(float));
+     pipe->InitBuffer(calcBuf3, hDhSize * sizeof(float));
+     auto tensorHFp32 = calcBuf1.Get<float>();
+     auto tensorDhFp32 = tensorHFp32[hDhSize];
+     auto tensorSumFp32 = calcBuf3.Get<float>();
+ 
+     // 发送同步信号给 Cube
+     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+     uint32_t bos = 0;
+     uint32_t eos = 0;
+     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+         uint32_t bIdx = loopIdx / numChunks;
+         uint32_t chunkIdx = loopIdx % numChunks;
+         GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T, BT, loopIdx, bos, eos);
+         BT_sub = eos-bos;
+         dwSize_sub = BT_sub * K;
+         
+         for (uint32_t h = 0; h < H; h++) {
+             ++vecTaskIdx;
+             if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
+                 CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+                 CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+                 continue;
+             }
+             // 计算偏移
+             // h, dh: [B, H, num_chunks, K, V]
+             uint64_t hOffset = ((bIdx * H + h) * numChunks + chunkIdx) * K * V;
+             // dw (workspace): 按 [B, H, T, K] 布局
+             uint64_t dwOffset = (h * T + bos) * K;
+             // dg_last: [B, H, num_chunks]
+             uint64_t dgLastOffset = (bIdx * H + h) * numChunks + chunkIdx;
+ 
+             // ========== 计算 dg_last = sum(h * dh) ==========
+             // 等待 Cube 信号 (dw Cube 计算)
+             for(uint32_t row = 0; row < K; row += mul0RowNum) {
+                 // CopyIn: h 和 dh
+                 {
+                     auto tensorHIn = inQue1.AllocTensor<DataType>();
+                     auto tensorDhIn = tensorHIn[hDhSize];
+                     DataCopy(tensorDhIn, gmDh[hOffset + row * V], hDhSize);
+                     DataCopy(tensorHIn, gmH[hOffset + row * V], hDhSize);
+                     inQue1.EnQue(tensorHIn);
+                 }
+                 // Compute: h * dh -> reduceSum
+                 {
+                     auto tensorHIn = inQue1.DeQue<DataType>();
+                     auto tensorDhIn = tensorHIn[hDhSize];
+                     // Cast to fp32 (bf16 不支持直接 Mul)
+                     Cast(tensorHFp32, tensorHIn, RoundMode::CAST_NONE, hDhSize);
+                     Cast(tensorDhFp32, tensorDhIn, RoundMode::CAST_NONE, hDhSize);
+                     PipeBarrier<PIPE_V>();
+ 
+                     // 逐元素乘法
+                     if(row == 0) {
+                         Mul(tensorSumFp32, tensorHFp32, tensorDhFp32, hDhSize);
+                     } else {
+                         Mul(tensorHFp32, tensorHFp32, tensorDhFp32, hDhSize);
+                         PipeBarrier<PIPE_V>();
+                         Add(tensorSumFp32, tensorSumFp32, tensorHFp32, hDhSize);
+                     }
+ 
+                     PipeBarrier<PIPE_V>();
+                     inQue1.FreeTensor(tensorHIn);
+                 }
+             }
+             {
+                 uint32_t remainNum = hDhSize;
+                 while(remainNum > 64) {
+                     remainNum = remainNum / 2;
+                     Add(tensorSumFp32, tensorSumFp32, tensorSumFp32[remainNum], remainNum);
+                     PipeBarrier<PIPE_V>();
+                 }
+                 auto tensorDgLastOut = outQue1.AllocTensor<float>();
+                 WholeReduceSum(tensorDgLastOut, tensorSumFp32, 64, 1, 1, 1, 8);
+                 outQue1.EnQue(tensorDgLastOut);
+             }
+             {
+                 auto tensorDgLastOut = outQue1.DeQue<float>();
+ 
+                 DataCopyParams dataCopyParams;
+                 dataCopyParams.blockCount = 1;
+                 dataCopyParams.blockLen = 1*sizeof(float);
+                 dataCopyParams.srcStride = 0;
+                 dataCopyParams.dstStride = 0;
+                 DataCopyPad(gmDgLast[dgLastOffset], tensorDgLastOut,dataCopyParams);
+ 
+                 outQue1.FreeTensor(tensorDgLastOut);
+             }
+ 
+ 
+ 
+             // ========== 处理 dw: 取负号 ==========
+             // Cube 计算的是 dv @ h^T, 需要乘以 -1
+             // 从 workspace 读取 dw, 乘以 -1, 写回最终输出
+             CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+             // CopyIn: dw from workspace
+             {
+                 auto tensorDwIn = inQue1.AllocTensor<DataType>();
+                 DataCopy(tensorDwIn, gmDw[dwOffset], dwSize_sub);
+                 inQue1.EnQue(tensorDwIn);
+             }
+ 
+             // Compute: -dw
+             {
+                 auto tensorDwIn = inQue1.DeQue<DataType>();
+                 auto tensorDwOut = outQue2.AllocTensor<DataType>();
+                 
+                 // Cast to fp32, 乘以 -1, cast back
+                 Cast(tensorHFp32, tensorDwIn, RoundMode::CAST_NONE, dwSize_sub);
+                 PipeBarrier<PIPE_V>();
+                 Muls(tensorHFp32, tensorHFp32, -1.0f, dwSize_sub);
+                 PipeBarrier<PIPE_V>();
+                 Cast(tensorDwOut, tensorHFp32, RoundMode::CAST_RINT, dwSize_sub);
+                 inQue1.FreeTensor(tensorDwIn);
+                 outQue2.EnQue(tensorDwOut);
+             }
+             
+             // CopyOut: dw to final output
+             {
+                 auto tensorDwOut = outQue2.DeQue<DataType>();
+                 DataCopy(gmDw[dwOffset], tensorDwOut, dwSize_sub);
+ 
+                 outQue2.FreeTensor(tensorDwOut);
+             }
+ 
+             // 通知 Cube 继续
+             CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+         }
+     }
+ 
+ }
+ 
+ // ============== Part 2: 等待 mm5 完成 ==============
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart2() {
+     // Part 2 MUL1 + and(m_A)
+     
+     constexpr int32_t BLOCK_SIZE = 32; // API一次能处理256B，能计算64个float元素
+     uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+     uint32_t coreNum = GetBlockNum();
+     uint32_t coreLoops = B * numChunks;
+     uint32_t real_BT = BT;
+ 
+     uint32_t BT_sub = real_BT;
+     uint32_t BT_sub_start = 0;
+     uint32_t BT_sub_end = BT_sub;
+ 
+     uint32_t dsSize_sub = BT_sub * BT;
+     uint32_t dsSize_sub_offset = 0;
+     const uint32_t gSize = BT;
+     
+     // 初始化 buffers
+     
+     pipe->InitBuffer(inQue3, 2, gSize * sizeof(float));        // g values
+     pipe->InitBuffer(outQue1, 2, dsSize_sub * sizeof(float) / 2);   // ds_temp output   32K/8K
+ 
+     pipe->InitBuffer(calcBuf1, BT * 8 * sizeof(float));             // g in fp32
+     pipe->InitBuffer(calcBuf2, BT * sizeof(float));            // g temp [BT,1]
+     pipe->InitBuffer(calcBuf3, BT * sizeof(float));            // g temp [1,BT]
+     pipe->InitBuffer(calcBuf4, BLOCK_SIZE);
+ 
+     auto tensorBrcbTemp = calcBuf1.Get<float>();
+     auto tensorGFp32Left = calcBuf2.Get<float>();
+     auto tensorGFp32Right = calcBuf3.Get<float>();
+     auto tensorZeroFp32 = calcBuf4.template Get<float>();
+     
+     uint32_t bos = 0;
+     uint32_t eos = 0;
+     uint32_t bos_orig = 0;
+     uint32_t eos_orig = 0;
+     // 发送同步信号
+ 
+     //初始化zero
+     AscendC::Duplicate<float>(tensorZeroFp32, float(0.0), BLOCK_SIZE / sizeof(float));
+     PipeBarrier<PIPE_V>();
+     //搬入m_A
+ 
+     const uint32_t maskASize = 64*64*sizeof(float);//BT * BT / 8 * sizeof(uint8_t);
+     pipe->InitBuffer(inQue1, 1, maskASize);
+     auto tensorMaskA = inQue1.AllocTensor<float>();
+ 
+     // 构建下三角 mask: 先全部填 0, 再逐行填 1 (mask[i][j]=1 when j<=i)
+     Duplicate(tensorMaskA, 0.0f, 64 * 64);
+     PipeBarrier<PIPE_V>();
+     // 批量填充: 先填满1, 再清零上三角
+     for (uint32_t i = 0; i < 64; i++) {
+         Duplicate(tensorMaskA[i * 64], 1.0f, i + 1);
+     }
+     PipeBarrier<PIPE_V>();
+ 
+     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+         GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T, BT, loopIdx, bos, eos);
+         bos_orig = bos;
+         eos_orig = eos;
+         uint32_t vec_core_0_length = (eos_orig - bos_orig) >= (BT / 2) ? (BT / 2) : (eos_orig - bos_orig);
+         uint32_t vec_core_1_length = (eos_orig - bos_orig) >= (BT / 2) ? (eos_orig - bos_orig - (BT / 2)) : 0;
+         if (GetSubBlockIdx() == 0) {        // BT: 0..BT_sub_end
+             BT_sub_start = 0;
+             BT_sub_end = vec_core_0_length;         // [0, vec_core_0_length)
+             eos = bos + vec_core_0_length;
+         } else {       // BT: BT_sub_end+1..eos
+             BT_sub_start = vec_core_0_length;
+             BT_sub_end = eos_orig - bos_orig;
+             bos = bos + vec_core_0_length;
+         }
+         
+         uint32_t real_BT= eos-bos;
+         uint32_t real_BT_align = ALIGN_UP((eos-bos), 16);
+         dsSize_sub = (eos-bos) * BT;
+         uint32_t bIdx = loopIdx / numChunks;
+         uint32_t chunkIdx = loopIdx % numChunks;
+ 
+         for (uint32_t h = 0; h < H; h++) {
+             if (real_BT == 0) {       //sub core get 0 token
+                 continue;
+             }
+ 
+             // 偏移计算
+             // g: [B, H, T]
+             uint64_t gOffset = (h * T + bos_orig);
+             // ds, mm5, ds_temp: [B, H, T, BT]
+             uint64_t dsOffset = (h * T + bos) * BT;
+             // CopyIn: g
+             {
+                 auto tensorGIn = inQue3.AllocTensor<GType>();
+                 DataCopy(tensorGIn, gmG[gOffset], gSize);
+                 inQue3.EnQue(tensorGIn);
+             }
+ 
+             // Compute MUL1
+             {
+                 auto tensorGIn = inQue3.DeQue<GType>();
+                 auto tensorDsTempOut = outQue1.AllocTensor<float>();
+ 
+                 // g 可能已经是 fp32
+                 if constexpr (std::is_same<GType, float>::value) {
+                     DataCopy(tensorGFp32Left, tensorGIn, gSize);
+                 } else {
+                     Cast(tensorGFp32Left, tensorGIn, RoundMode::CAST_NONE, gSize);
+                 }
+                 PipeBarrier<PIPE_V>();
+ 
+                 Muls(tensorGFp32Right, tensorGFp32Left, static_cast<float>(-1), gSize);
+ 
+                 Brcb(tensorBrcbTemp, tensorGFp32Left[BT_sub_start], CEIL_DIV(real_BT, 8), {1, 8}); // Brcb处理数据个数需要8对齐 [BT,8]
+                 PipeBarrier<PIPE_V>();
+ 
+                 // copy tensorGFp32Right  chunkLen / 2行
+                 if (BT == 64) {
+ 
+                     AscendC::Add(tensorDsTempOut, tensorGFp32Right, tensorBrcbTemp, CAL_NUM_FLOAT, real_BT,
+                                 {1, 1, 0, 8, 0, 1});
+ 
+                     PipeBarrier<PIPE_V>();
+                     Mins(tensorDsTempOut, tensorDsTempOut, static_cast<float>(0.0), real_BT * BT);
+ 
+                     PipeBarrier<PIPE_V>();
+                     Exp(tensorDsTempOut, tensorDsTempOut, real_BT * BT);
+                     PipeBarrier<PIPE_V>();
+ 
+                 } else {
+                     AscendC::Copy(tensorDsTempOut, tensorGFp32Right, CAL_NUM_FLOAT, real_BT, {1, 1, 16, 0});
+                     PipeBarrier<PIPE_V>();
+                     AscendC::Copy(tensorDsTempOut[CAL_NUM_FLOAT], tensorGFp32Right[CAL_NUM_FLOAT], CAL_NUM_FLOAT,
+                                 real_BT, {1, 1, 16, 0});
+                     PipeBarrier<PIPE_V>();
+                     AscendC::Add(tensorDsTempOut, tensorDsTempOut, tensorBrcbTemp, CAL_NUM_FLOAT, real_BT,
+                                 {1, 1, 0, 16, 16, 1});
+                     PipeBarrier<PIPE_V>();
+                     AscendC::Add(tensorDsTempOut[CAL_NUM_FLOAT], tensorDsTempOut[CAL_NUM_FLOAT], tensorBrcbTemp,
+                                 CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+                     PipeBarrier<PIPE_V>();
+                     Mins(tensorDsTempOut, tensorDsTempOut, static_cast<float>(0.0), real_BT * BT);
+                     PipeBarrier<PIPE_V>();
+                     Exp(tensorDsTempOut, tensorDsTempOut, real_BT * BT);
+                 }
+ 
+                 PipeBarrier<PIPE_V>();
+ 
+                 if(BT==64) {
+                     Mul(tensorDsTempOut,tensorDsTempOut,tensorMaskA[BT_sub_start*64],32*64);
+                 } else {
+                     BinaryRepeatParams binaryRepeatParams{1,1,1,16,16,8};
+                     UnaryRepeatParams unaryRepeatParams{1,1,16,8};
+                     if (BT_sub_start == 0) {
+                         Mul(tensorDsTempOut,tensorDsTempOut,tensorMaskA,64,64,binaryRepeatParams);
+                         PipeBarrier<PIPE_V>();
+                         Muls(tensorDsTempOut[64],tensorDsTempOut[64],static_cast<float>(0),64,64,unaryRepeatParams);
+                     } else {
+                         Mul(tensorDsTempOut[64],tensorDsTempOut[64],tensorMaskA,64,64,binaryRepeatParams);
+                     }
+                     PipeBarrier<PIPE_V>();
+                 }
+ 
+                 AscendC::Muls(tensorDsTempOut, tensorDsTempOut, static_cast<float>(scale), real_BT * BT);
+                 PipeBarrier<PIPE_V>();
+ 
+                 //Ds是 fp16/bf16
+                 Cast(tensorDsTempOut.template ReinterpretCast<DataType>(), tensorDsTempOut, RoundMode::CAST_RINT, real_BT * BT);
+ 
+                 inQue3.FreeTensor(tensorGIn);
+                 outQue1.EnQue(tensorDsTempOut);
+             }
+ 
+             // CopyOut
+             {
+                 auto tensorDsTempOut = outQue1.DeQue<float>();
+                 DataCopy(gmMul1[dsOffset], tensorDsTempOut.template ReinterpretCast<DataType>(), real_BT * BT);
+ 
+                 outQue1.FreeTensor(tensorDsTempOut);
+             }
+         }
+     }
+     inQue1.FreeTensor<float>(tensorMaskA);
+ }
+ 
+ // ============== Part 3: ds 处理和 dg 部分计算 ==============
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart3() {
+     uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+     uint32_t coreNum = GetBlockNum();
+     uint32_t coreLoops = B * numChunks;
+     uint32_t real_BT = BT; // TODO：如果BT不对齐
+ 
+     uint32_t BT_sub = real_BT;
+     uint32_t BT_sub_start = 0;
+     uint32_t BT_sub_end = BT_sub;
+ 
+ 
+     uint32_t dsSize_sub = BT_sub * BT;
+     uint32_t dsSize_sub_offset = 0;
+     const uint32_t gSize = BT;
+ 
+     // 初始化 buffers
+     pipe->InitBuffer(inQue1, BUFFER_NUM, dsSize_sub * sizeof(float));    // ds from Cube
+     pipe->InitBuffer(inQue2, BUFFER_NUM, dsSize_sub * sizeof(float));    // mm5/mul1 from workspace
+     pipe->InitBuffer(outQue1, BUFFER_NUM, dsSize_sub * sizeof(DataType));   // ds_temp output   32K/8K
+     pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(float));       // dg output
+ 
+     pipe->InitBuffer(calcBuf4, gSize * sizeof(float));        // m_A
+     pipe->InitBuffer(gBuf, gSize * sizeof(float));             // g in fp32
+     pipe->InitBuffer(dgBuf, gSize * sizeof(float));            // dg temp
+ 
+     auto tensorMaskA = calcBuf4.Get<float>();
+     auto tensorGFp32 = gBuf.Get<float>();
+     auto tensorDgTemp = dgBuf.Get<float>();
+ 
+     uint32_t bos = 0;
+     uint32_t eos = 0;
+     uint32_t vecTaskIdx = 0;
+     // 发送同步信号
+     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+ 
+     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+         GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T, BT, loopIdx, bos, eos);
+         BT_sub_end = eos-bos;
+         uint32_t real_BT= eos-bos;
+         dsSize_sub = (eos-bos) * BT;
+         uint32_t bIdx = loopIdx / numChunks;
+         uint32_t chunkIdx = loopIdx % numChunks;
+ 
+         for (uint32_t h = 0; h < H; h++) {
+             // if (GetSubBlockIdx() == 1) {
+             //     CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+             //     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+             //     continue;
+             // }
+             ++vecTaskIdx;
+             if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
+                 CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+                 CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+                 continue;
+             }
+ 
+             // 偏移计算
+             // g: [B, H, T]
+             uint64_t gOffset = (h * T + bos);
+             // ds, mm5, ds_temp: [B, H, T, BT]
+             uint64_t dsOffset = (h * T + bos) * BT;
+ 
+             // dg: [B, H, T]
+             uint64_t dgOffset = gOffset;
+ 
+             // 等待 Cube 完成 ds 计算
+             CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+ 
+             // CopyIn: ds (Cube output), g
+             {
+                 auto tensorDsIn = inQue1.AllocTensor<DataType>();
+                 auto tensorMul1In = inQue2.AllocTensor<DataType>();
+ 
+                 DataCopy(tensorDsIn[BT * BT], gmDsTemp[dsOffset + dsSize_sub_offset], dsSize_sub);
+                 DataCopy(tensorMul1In[BT * BT], gmMul1[dsOffset + dsSize_sub_offset], dsSize_sub);
+ 
+                 inQue1.EnQue(tensorDsIn);
+                 inQue2.EnQue(tensorMul1In);
+             }
+ 
+             // Compute MUL1
+             {
+                 auto tensorDsInFp16 = inQue1.DeQue<DataType>();
+                 auto tensorDsInFp32 = tensorDsInFp16.template ReinterpretCast<float>();
+ 
+                 auto tensorDsTempOut = outQue1.AllocTensor<DataType>();
+ 
+                 auto tensorMul1InFp16 = inQue2.DeQue<DataType>();
+                 auto tensorMul1InFp32 = tensorMul1InFp16.template ReinterpretCast<float>();
+                 auto tensorDgOut = outQue2.AllocTensor<float>();
+ 
+                 // Cast to fp32
+                 Cast(tensorDsInFp32, tensorDsInFp16[BT * BT], RoundMode::CAST_NONE, dsSize_sub);
+ 
+                 
+                 Cast(tensorMul1InFp32, tensorMul1InFp16[BT * BT], RoundMode::CAST_NONE, dsSize_sub);
+                 PipeBarrier<PIPE_V>();
+                 // b_ds_temp = b_ds * mul1 (已经应用了掩码)
+                 Mul(tensorDsInFp32, tensorDsInFp32, tensorMul1InFp32, dsSize_sub);
+                 inQue2.FreeTensor(tensorMul1InFp32);
+ 
+                 //搬入MM5,复用Mul1空间
+                 auto tensorMm5InFp16Tmp = inQue2.AllocTensor<DataType>();
+                 DataCopy(tensorMm5InFp16Tmp[BT * BT], gmMm5[dsOffset + dsSize_sub_offset], dsSize_sub);
+                 inQue2.EnQue(tensorMm5InFp16Tmp);
+                 auto tensorMm5InFp16 = inQue2.DeQue<DataType>();
+ 
+                 auto tensorMm5InFp32 = tensorMm5InFp16.template ReinterpretCast<float>();
+                 Cast(tensorMm5InFp32, tensorMm5InFp16[BT * BT], RoundMode::CAST_NONE, dsSize_sub);
+                 PipeBarrier<PIPE_V>();
+                 // Calcute ds_temp * mm5 and after
+ 
+                 Mul(tensorMm5InFp32, tensorDsInFp32, tensorMm5InFp32, dsSize_sub); // b_ds2 = b_ds_temp * mm5
+                 Cast(tensorDsTempOut, tensorDsInFp32, RoundMode::CAST_RINT, dsSize_sub);  //ds_tmp -> fp16, tensorDsFp32已经空闲
+ 
+                 // axis=1: 对每行求和 -> [BT] +Add0.C
+                 Duplicate(tensorDgOut, static_cast<float>(0.0), BT);
+                 PipeBarrier<PIPE_V>();
+ 
+                 // reducesum
+                 uint64_t wholeReduceSumCnt = CeilDiv(real_BT, FP32_PER_REPEAT);
+                 uint32_t remainCnt = real_BT % FP32_PER_REPEAT;
+                 if(remainCnt > 0) {
+                     uint32_t DuplicateOffset = wholeReduceSumCnt * FP32_PER_REPEAT - FP32_PER_REPEAT;
+                     uint64_t mask[1] = {0xffffffffffffffff};
+                     mask[0] <<= remainCnt;
+                     for (uint32_t row = BT_sub_start; row < BT_sub_end; row++) {
+                         Duplicate(tensorMm5InFp32[row * BT + DuplicateOffset], 0.0f, mask, 1, 1, 8);
+                     }
+                     PipeBarrier<PIPE_V>();
+                 }
+                 for (uint32_t i = BT_sub_start; i < BT_sub_end; i++) {
+                     WholeReduceSum(tensorDsInFp32[i * 8], tensorMm5InFp32[i * BT],
+                                    FP32_PER_REPEAT, wholeReduceSumCnt, 1, 1, 8);
+                 }
+                 PipeBarrier<PIPE_V>();
+                 WholeReduceSum(tensorDgOut, tensorDsInFp32, wholeReduceSumCnt, real_BT, 1, 1, 1);
+ 
+                 // axis=0: 对每列求和 -> [BT] -Add0.D
+                 PipeBarrier<PIPE_V>();
+                 uint32_t remain_row = real_BT;
+                 uint32_t CalcCnt = 0;
+                 uint32_t Offset = 0;
+                 while (remain_row > 1) {
+                     CalcCnt = (remain_row / 2) * BT;
+                     remain_row = CeilDiv(remain_row, 2);
+                     Offset = remain_row * BT;
+                     Add(tensorMm5InFp32, tensorMm5InFp32, tensorMm5InFp32[Offset], CalcCnt);
+                     PipeBarrier<PIPE_V>();
+                 }
+                 Sub(tensorDgOut, tensorDgOut, tensorMm5InFp32, BT);
+                 PipeBarrier<PIPE_V>();
+                 // 保存 tensorDgOut 供后续 Part 使用
+                 if constexpr (!std::is_same<GType, float>::value) {
+                     Cast(tensorDgOut.template ReinterpretCast<GType>(), tensorDgOut, RoundMode::CAST_RINT, gSize);
+                 }
+ 
+                 inQue1.FreeTensor(tensorDsInFp16);
+                 inQue2.FreeTensor(tensorMm5InFp16);
+ 
+                 outQue1.EnQue(tensorDsTempOut);
+                 outQue2.EnQue(tensorDgOut);
+             }
+             
+             // CopyOut
+             {
+                 auto tensorDsTempOut = outQue1.DeQue<DataType>();
+                 auto tensorDgOut = outQue2.DeQue<float>();
+ 
+                 DataCopy(gmDsTemp[dsOffset + dsSize_sub_offset], tensorDsTempOut, dsSize_sub);
+ 
+                 DataCopyParams dataCopyParams;
+                 dataCopyParams.blockCount = 1;
+                 dataCopyParams.blockLen = real_BT * sizeof(GType);
+                 dataCopyParams.srcStride = 0;
+                 dataCopyParams.dstStride = 0;
+                 // dg 写入最终输出
+                 if constexpr (std::is_same<GType, float>::value) {
+                     DataCopyPad(gmDg[dgOffset], tensorDgOut,dataCopyParams);
+                 } else {
+                     // 需要 cast
+                     DataCopyPad(gmDg[dgOffset], tensorDgOut.template ReinterpretCast<GType>(), dataCopyParams);
+                 }
+ 
+                 outQue1.FreeTensor(tensorDsTempOut);
+                 outQue2.FreeTensor(tensorDgOut);
+             }
+ 
+             CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+         }
+ 
+     }
+ 
+ }
+ 
+ 
+ 
+ // ============== Part 4: dq 处理 ==============
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart4() {
+     uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+     uint32_t coreNum = GetBlockNum();
+     uint32_t coreLoops = B * numChunks;
+     
+     uint32_t dqSize = BT * K;
+     uint32_t real_BT = BT;
+ 
+ 
+     uint32_t BT_sub = real_BT;
+     uint32_t BT_sub_start = 0;
+     uint32_t BT_sub_end = BT_sub;
+     
+     uint32_t dqSize_sub = BT_sub * K;
+     uint32_t dqSize_sub_offset = BT_sub_start * K;
+     const uint32_t gSize = BT;
+     // 初始化 buffers
+     pipe->InitBuffer(inQue1, BUFFER_NUM, dqSize_sub * sizeof(float));    // dq from Cube   //64K
+     pipe->InitBuffer(inQue2, BUFFER_NUM, dqSize_sub * sizeof(float));    // q
+     pipe->InitBuffer(inQue3, BUFFER_NUM, gSize * sizeof(GType));        // g
+     pipe->InitBuffer(inQue4, BUFFER_NUM, gSize * sizeof(GType));        // g             
+     pipe->InitBuffer(outQue1, BUFFER_NUM, dqSize_sub * sizeof(DataType));   // dq output
+     pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(float));       // dg partial
+ 
+     pipe->InitBuffer(calcBuf3, gSize * (8) * sizeof(float));        //第一次reducesum结果：[BT, 8]
+     pipe->InitBuffer(gBuf, gSize * sizeof(float));
+     pipe->InitBuffer(dgBuf, gSize * sizeof(float));
+     
+     auto tensorShareTmpFp32 = calcBuf3.Get<float>();
+     auto tensorGFp32 = gBuf.Get<float>();
+     auto tensorDgAdd = dgBuf.Get<float>();
+ 
+     uint32_t vecTaskIdx = 0;
+     uint32_t bos = 0;
+     uint32_t eos = 0;
+     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+ 
+     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+         GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T,
+                         BT, loopIdx, bos, eos);
+         uint32_t actual_chunk_len = eos-bos;
+         dqSize_sub = actual_chunk_len * K;
+         BT_sub_end = actual_chunk_len;
+         BT_sub = actual_chunk_len;
+         uint32_t bIdx = loopIdx / numChunks;
+         uint32_t chunkIdx = loopIdx % numChunks;
+         
+         for (uint32_t h = 0; h < H; h++) {
+             ++vecTaskIdx;
+             if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
+                 // Fused Part4+6: consume 2 handshakes per skipped iteration
+                 CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+                 CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+                 CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+                 CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+                 continue;
+             }
+             uint64_t qkOffset = (h * T + bos) * K;
+             uint64_t gOffset = (h * T + bos);
+ 
+             // ---- Phase 1: dq processing + dg accumulation ----
+             CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+             // CopyIn
+             {
+                 auto tensorDqIn = inQue1.AllocTensor<DataType>();
+                 auto tensorQIn = inQue2.AllocTensor<DataType>();
+                 auto tensorGIn = inQue3.AllocTensor<GType>();
+                 auto tensorDgIn = inQue4.AllocTensor<GType>();
+ 
+                 DataCopy(tensorDqIn[dqSize_sub], gmDq[qkOffset + dqSize_sub_offset], dqSize_sub);
+                 DataCopy(tensorQIn[dqSize_sub], gmQ[qkOffset + dqSize_sub_offset], dqSize_sub);
+                 DataCopy(tensorGIn, gmG[gOffset], gSize);
+                 DataCopy(tensorDgIn, gmDg[gOffset], gSize);
+ 
+                 inQue1.EnQue(tensorDqIn);
+                 inQue2.EnQue(tensorQIn);
+                 inQue3.EnQue(tensorGIn);
+                 inQue4.EnQue(tensorDgIn);
+             }
+ 
+             // Compute Phase 1 + Phase 2 (flattened scope: dq_fp32 must survive into Phase 2)
+             {
+                 auto tensorDqInFp16 = inQue1.DeQue<DataType>();
+                 auto tensorDqInFp32 = tensorDqInFp16.template ReinterpretCast<float>();
+                 auto tensorQInFp16 = inQue2.DeQue<DataType>();
+                 auto tensorQInFp32 = tensorQInFp16.template ReinterpretCast<float>();
+                 auto tensorGIn = inQue3.DeQue<GType>();
+                 auto tensorDgIn = inQue4.DeQue<GType>();
+                 auto tensorDgOut = outQue2.AllocTensor<float>();
+ 
+                 Cast(tensorDqInFp32, tensorDqInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
+                 Cast(tensorQInFp32, tensorQInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
+                 if constexpr (std::is_same<GType, float>::value) {
+                     DataCopy(tensorGFp32, tensorGIn, gSize);
+                 } else {
+                     Cast(tensorGFp32, tensorGIn, RoundMode::CAST_NONE, gSize);
+                 }
+                 PipeBarrier<PIPE_V>();
+ 
+                 // mul3 = exp(g) * scale, then broadcast multiply dq
+                 Exp(tensorGFp32, tensorGFp32, gSize);
+                 PipeBarrier<PIPE_V>();
+                 Muls(tensorGFp32, tensorGFp32, static_cast<float>(scale), gSize);
+                 PipeBarrier<PIPE_V>();
+                 Brcb(tensorShareTmpFp32, tensorGFp32, CEIL_DIV(real_BT, 8), {1, 8});
+                 PipeBarrier<PIPE_V>();
+                 AscendC::Mul(tensorDqInFp32, tensorDqInFp32, tensorShareTmpFp32, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+                 AscendC::Mul(tensorDqInFp32[CAL_NUM_FLOAT], tensorDqInFp32[CAL_NUM_FLOAT], tensorShareTmpFp32, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+                 PipeBarrier<PIPE_V>();
+ 
+                 Mul(tensorQInFp32, tensorDqInFp32, tensorQInFp32, dqSize_sub);
+                 PipeBarrier<PIPE_V>();
+ 
+                 // reducesum for dg: Add0.A = reduceSum(q * dq, axis=1)
+                 uint64_t wholeReduceSumCnt = CeilDiv(K, FP32_PER_REPEAT);
+                 for (uint32_t i = BT_sub_start; i < BT_sub_end; i++) {
+                     WholeReduceSum(tensorShareTmpFp32[i * 8], tensorQInFp32[i * K],
+                                    FP32_PER_REPEAT, wholeReduceSumCnt, 1, 1, 8);
+                 }
+                 PipeBarrier<PIPE_V>();
+                 WholeReduceSum(tensorDgOut, tensorShareTmpFp32, wholeReduceSumCnt, actual_chunk_len, 1, 1, 1);
+ 
+                 if constexpr (std::is_same<GType, float>::value) {
+                     DataCopy(tensorDgAdd, tensorDgIn, real_BT);
+                 } else {
+                     Cast(tensorDgAdd, tensorDgIn, RoundMode::CAST_NONE, real_BT);
+                 }
+                 PipeBarrier<PIPE_V>();
+                 Add(tensorDgOut, tensorDgAdd, tensorDgOut, real_BT);
+                 PipeBarrier<PIPE_V>();
+ 
+                 if constexpr (!std::is_same<GType, float>::value) {
+                     Cast(tensorDgOut.template ReinterpretCast<GType>(), tensorDgOut, RoundMode::CAST_RINT, gSize);
+                 }
+ 
+                 // Free Phase 1 inputs (keep inQue1 alive - dq_fp32 stays in UB!)
+                 inQue2.FreeTensor(tensorQInFp16);
+                 inQue3.FreeTensor(tensorGIn);
+                 inQue4.FreeTensor(tensorDgIn);
+                 outQue2.EnQue(tensorDgOut);
+ 
+                 // Phase 1 CopyOut: dg only
+                 {
+                     auto tensorDgOutDeq = outQue2.DeQue<GType>();
+                     DataCopyParams dataCopyParams;
+                     dataCopyParams.blockCount = 1;
+                     dataCopyParams.blockLen = BT_sub * sizeof(GType);
+                     dataCopyParams.srcStride = 0;
+                     dataCopyParams.dstStride = 0;
+                     DataCopyPad(gmDg[gOffset + BT_sub_start], tensorDgOutDeq, dataCopyParams);
+                     outQue2.FreeTensor(tensorDgOutDeq);
+                 }
+ 
+                 // ---- Phase 2: mm6 accumulation into dq (fused from Part6) ----
+                 CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+                 CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+ 
+                 {
+                     auto tensorMm6In = inQue2.AllocTensor<DataType>();
+                     DataCopy(tensorMm6In[dqSize_sub], gmMm6[qkOffset + dqSize_sub_offset], dqSize_sub);
+                     inQue2.EnQue(tensorMm6In);
+                 }
+                 {
+                     auto tensorMm6InFp16 = inQue2.DeQue<DataType>();
+                     auto tensorMm6Fp32 = tensorMm6InFp16.template ReinterpretCast<float>();
+                     auto tensorDqOut = outQue1.AllocTensor<DataType>();
+ 
+                     Cast(tensorMm6Fp32, tensorMm6InFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
+                     PipeBarrier<PIPE_V>();
+                     Add(tensorDqInFp32, tensorDqInFp32, tensorMm6Fp32, dqSize_sub);
+                     PipeBarrier<PIPE_V>();
+                     Cast(tensorDqOut, tensorDqInFp32, RoundMode::CAST_RINT, dqSize_sub);
+ 
+                     inQue1.FreeTensor(tensorDqInFp16);
+                     inQue2.FreeTensor(tensorMm6InFp16);
+                     outQue1.EnQue(tensorDqOut);
+                 }
+                 {
+                     auto tensorDqOut = outQue1.DeQue<DataType>();
+                     DataCopy(gmDq[qkOffset + dqSize_sub_offset], tensorDqOut, dqSize_sub);
+                     outQue1.FreeTensor(tensorDqOut);
+                 }
+             }
+             CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+         }
+     }
+ }
+ 
+ 
+ // ============== Part 5: dk 处理和 dg 最终计算 ==============
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart5() {
+     uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+     uint32_t coreNum = GetBlockNum();
+     uint32_t coreLoops = B * numChunks;
+     
+     uint32_t dkSize = BT * K;
+     uint32_t gSize = BT;
+     uint32_t real_BT = BT;
+     
+     // 初始化 buffers
+     pipe->InitBuffer(inQue1, BUFFER_NUM, dkSize * sizeof(float));
+     pipe->InitBuffer(inQue2, BUFFER_NUM, dkSize * sizeof(float));
+     pipe->InitBuffer(inQue3, BUFFER_NUM, gSize * sizeof(GType));
+     pipe->InitBuffer(inQue4, BUFFER_NUM, gSize * sizeof(GType));
+     // pipe->InitBuffer(inQue5, BUFFER_NUM, 16 * sizeof(float));    // add4中间结果及广播结果
+     // pipe->InitBuffer(inQue6, BUFFER_NUM, 16 * sizeof(float));    // part5 gLast中间结果
+     pipe->InitBuffer(outQue1, BUFFER_NUM, dkSize * sizeof(DataType));
+     pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(GType));
+ 
+     pipe->InitBuffer(calcBuf1, gSize * 8 * sizeof(float));  //gLast
+     pipe->InitBuffer(calcBuf2, gSize * 8 * sizeof(float));  //dgLast
+     pipe->InitBuffer(calcBuf4, gSize * sizeof(float));
+     pipe->InitBuffer(gBuf, gSize * sizeof(float));
+     pipe->InitBuffer(dgBuf, gSize * 8 * sizeof(float));
+ 
+     auto tensorGFp32 = gBuf.Get<float>();
+     auto tensorDgFinal = dgBuf.Get<float>();
+     auto tensorGLastFp32Tmp = calcBuf1.Get<float>();
+     auto tensorDgLastFp32Tmp = calcBuf2.Get<float>();
+     auto tensorDgTmp = calcBuf4.Get<float>();
+     uint32_t bos = 0;
+     uint32_t eos = 0;
+     uint32_t vecTaskIdx = 0;
+     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+         GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T, BT, loopIdx, bos, eos);
+         uint32_t actual_chunk_len = eos - bos;
+         real_BT = actual_chunk_len;
+         dkSize = actual_chunk_len * K;
+         uint32_t real_BT_aligned = (real_BT + 15) / 16 * 16;
+         uint32_t bIdx = loopIdx / numChunks;
+         uint32_t chunkIdx = loopIdx % numChunks;
+         
+         for (uint32_t h = 0; h < H; h++) {
+             ++vecTaskIdx;
+             if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
+                 // Fused Part5+7: consume 2 handshakes per skipped iteration
+                 CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+                 CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+                 CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+                 CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+                 continue;
+             }
+             uint64_t kOffset = (h * T + bos) * K;
+             uint64_t gOffset = (h * T + bos);
+             uint64_t dgLastOffset = (bIdx * H + h) * numChunks + chunkIdx;
+             
+             CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+ 
+             // CopyIn
+             {
+                 auto tensorDkIn = inQue1.AllocTensor<DataType>();
+                 auto tensorKIn = inQue2.AllocTensor<DataType>();
+                 auto tensorGIn = inQue3.AllocTensor<GType>();
+                 auto tensorDgIn = inQue4.AllocTensor<GType>();
+                 // auto tensorDgLastIn = inQue5.AllocTensor<float>();
+                 // auto tensorGLastIn = inQue6.AllocTensor<GType>();
+                 
+                 DataCopy(tensorDkIn[dkSize], gmDk[kOffset], dkSize);
+                 DataCopy(tensorKIn[dkSize], gmK[kOffset], dkSize);
+                 DataCopy(tensorGIn, gmG[gOffset], gSize);
+                 DataCopy(tensorDgIn, gmDg[gOffset], gSize);
+                 // DataCopy(tensorDgLastIn, gmDgLast[dgLastOffset], 8); // 只需要最后一个位置的 dg 值
+                 // DataCopy(tensorGLastIn, gmG[gOffset + actual_chunk_len - 1], 16); // 只需要最后一个位置的 g 值
+ 
+                 inQue1.EnQue(tensorDkIn);
+                 inQue2.EnQue(tensorKIn);
+                 inQue3.EnQue(tensorGIn);
+                 inQue4.EnQue(tensorDgIn);
+                 // inQue5.EnQue(tensorDgLastIn);
+                 // inQue6.EnQue(tensorGLastIn);
+             }
+             
+             // Compute
+             {
+                 auto tensorDkIn = inQue1.DeQue<DataType>();
+                 auto tensorDkFp32 = tensorDkIn.template ReinterpretCast<float>();
+                 auto tensorKIn = inQue2.DeQue<DataType>();
+                 auto tensorKFp32 = tensorKIn.template ReinterpretCast<float>();
+                 auto tensorGIn = inQue3.DeQue<GType>();
+                 auto tensorDgIn = inQue4.DeQue<GType>();
+                 // auto tensorDgLastFp32 = inQue5.DeQue<float>();
+                 // auto tensorGLast = inQue6.DeQue<GType>();
+                 // auto tensorGLastFp32 = tensorGLast.template ReinterpretCast<float>();
+                 auto tensorDkOut = outQue1.AllocTensor<DataType>();
+                 auto tensorDgOut = outQue2.AllocTensor<GType>();
+ 
+                 // Cast
+                 Cast(tensorDkFp32, tensorDkIn[dkSize], RoundMode::CAST_NONE, dkSize);
+ 
+                 Cast(tensorKFp32, tensorKIn[dkSize], RoundMode::CAST_NONE, dkSize);
+                 PipeBarrier<PIPE_V>();
+ 
+                 if constexpr (std::is_same<GType, float>::value) {
+                     DataCopy(tensorGFp32, tensorGIn, BT);
+                     DataCopy(tensorDgTmp, tensorDgIn, BT);
+                 } else {
+                     Cast(tensorGFp32, tensorGIn, RoundMode::CAST_NONE, real_BT_aligned);
+                     // Cast(tensorGLastFp32, tensorGLast, RoundMode::CAST_NONE, 1);
+                     Cast(tensorDgTmp, tensorDgIn, RoundMode::CAST_NONE, real_BT_aligned);
+                 }
+                 PipeBarrier<PIPE_V>();
+ 
+                 // uint32_t lastIdx = actual_chunk_len - 1;
+                 //MUL2
+                 uint32_t last_line_no = (actual_chunk_len - 1) / 8 * 8; // 最后一行的行号
+                 uint32_t last_line_idx = actual_chunk_len - 1 - last_line_no;
+                 Brcb(tensorDgFinal, tensorGFp32[last_line_no], 1, {1, 8}); // [8,8] 只有第last_line_idx行有效 = gLast
+                 PipeBarrier<PIPE_V>();
+                 Muls(tensorGFp32, tensorGFp32, -1.0f, real_BT_aligned);
+                 DataCopy(tensorGLastFp32Tmp, tensorDgFinal[last_line_idx * 8], 8); // tensorDgFinal暂存dg值，后续计算dgLast
+ 
+                 PipeBarrier<PIPE_V>();
+ 
+                 AscendC::Add(tensorGFp32, tensorGFp32, tensorDgFinal[last_line_idx * 8], CAL_NUM_FLOAT, BT / CAL_NUM_FLOAT, {1, 1, 0, 8, 8, 0});
+                 PipeBarrier<PIPE_V>();
+ 
+                 Exp(tensorGFp32, tensorGFp32, real_BT_aligned);
+                 PipeBarrier<PIPE_V>();
+ 
+                 // dgLast:使用tensorDgLast[0]替代
+                 // tensorDkFp32:        tensorDgFinal:gsize * 8 * float
+                 Brcb(tensorDgFinal, tensorGFp32, CEIL_DIV(real_BT, 8), {1, 8}); // Brcb处理数据个数需要8对齐 [BT,8]
+                 PipeBarrier<PIPE_V>();
+                 AscendC::Mul(tensorDkFp32, tensorDkFp32, tensorDgFinal, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+ 
+                 AscendC::Mul(tensorDkFp32[CAL_NUM_FLOAT], tensorDkFp32[CAL_NUM_FLOAT], tensorDgFinal, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+                 PipeBarrier<PIPE_V>();
+ 
+                 Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);      //dk -> fp16 tensorDkFp32
+ 
+                 Mul(tensorKFp32, tensorKFp32, tensorDkFp32, dkSize);    // mul8 = dk * k
+                 PipeBarrier<PIPE_V>();
+ 
+                 // Add0.B = (dk_temp * k).reduceSum(axis=1)
+                 // axis=1: 对每行求和 -> [BT] +Add0.B
+ 
+                 // reducesum
+                 uint64_t wholeReduceSumCnt = CeilDiv(K, FP32_PER_REPEAT);
+                 for (uint32_t i = 0; i < actual_chunk_len; i++) {
+                     WholeReduceSum(tensorDgFinal[i * 8], tensorKFp32[i * K],
+                                    FP32_PER_REPEAT, wholeReduceSumCnt, 1, 1, 8);
+                 }
+                 PipeBarrier<PIPE_V>();
+                 WholeReduceSum(tensorGFp32, tensorDgFinal, wholeReduceSumCnt, actual_chunk_len, 1, 1, 1);
+ 
+                 // float totalSum = 0.0f;
+                 PipeBarrier<PIPE_V>();
+ 
+                 //Sum0: [actual_chunk_len] -> [1]
+                 uint64_t sum0SumCnt = CeilDiv(actual_chunk_len, FP32_PER_REPEAT);
+                 uint32_t remainCnt = actual_chunk_len % FP32_PER_REPEAT;
+                 if(remainCnt > 0) {
+                     uint32_t DuplicateOffset = sum0SumCnt * FP32_PER_REPEAT - FP32_PER_REPEAT;
+                     uint64_t mask[1] = {0xffffffffffffffff};
+                     mask[0] <<= remainCnt;
+ 
+                     Duplicate(tensorGFp32[(sum0SumCnt-1)*FP32_PER_REPEAT], 0.0f, mask, 1, 1, 8);
+ 
+                     PipeBarrier<PIPE_V>();
+                 }
+                 WholeReduceSum(tensorDkFp32, tensorGFp32, FP32_PER_REPEAT, sum0SumCnt, 1, 1, 8);
+                 // PipeBarrier<PIPE_ALL>();
+                 PipeBarrier<PIPE_V>();
+                 WholeReduceSum(tensorDgFinal, tensorDkFp32, sum0SumCnt, 1, 1, 1, 8);
+ 
+                 // tensorGLastFp32[0]已经是最后一个位置的 g 值
+                 float dgLast = gmDgLast.GetValue(dgLastOffset); // tensorDgTmp暂存dg值，获取最后一个位置的dgLast
+                 Duplicate(tensorDgLastFp32Tmp, dgLast, 8); // 广播 dgLast
+                 Exp(tensorGLastFp32Tmp, tensorGLastFp32Tmp, 8);
+                 PipeBarrier<PIPE_V>();
+                 Mul(tensorDgLastFp32Tmp, tensorDgLastFp32Tmp, tensorGLastFp32Tmp, 8);
+                 PipeBarrier<PIPE_V>();
+                 Add(tensorDgLastFp32Tmp, tensorDgLastFp32Tmp, tensorDgFinal, 8);  //add4 = tensorDgLastFp32Tmp[0]
+ 
+ 
+                 Sub(tensorGFp32, tensorDgTmp, tensorGFp32, BT); //Add.0 最终结果
+ 
+                 PipeBarrier<PIPE_V>();
+                 Brcb(tensorDgFinal, tensorDgLastFp32Tmp, 1, {1, 8}); // [8,8] 只有第一行有效
+                 PipeBarrier<PIPE_V>();
+                 uint64_t offset = (real_BT - 1) / 8 * 8; // 每行8个float
+                 uint64_t mask[1] = {0};
+                 mask[0] = 1ULL << (real_BT - 1 - offset); // 计算掩码，只有最后一个位置有效
+ 
+                 Add(tensorGFp32[offset], tensorGFp32[offset], tensorDgFinal, mask, 1, {1,1,1,8,8,8});
+ 
+                 PipeBarrier<PIPE_V>();
+                 if constexpr (std::is_same<GType, float>::value) {
+                     DataCopy(tensorDgOut, tensorGFp32, BT);
+                 } else {
+                     Cast(tensorDgOut, tensorGFp32, RoundMode::CAST_RINT, BT);
+                 }
+                 PipeBarrier<PIPE_V>();
+ 
+ 
+                 // 处理最后一个位置的 dg
+                 // b_dg_last *= exp(g_last)
+                 // is_last_mask: 只有最后一个位置添加 dgLastTerm
+ 
+                 // 读取之前 Part 3/4 计算的 dg, 累加
+                 // (简化处理, 实际应该从 GM 读取并累加)
+ 
+                 inQue1.FreeTensor(tensorDkIn);
+                 inQue2.FreeTensor(tensorKIn);
+                 inQue3.FreeTensor(tensorGIn);
+                 inQue4.FreeTensor(tensorDgIn);
+                 // inQue5.FreeTensor(tensorDgLastFp32);
+                 // inQue6.FreeTensor(tensorGLast);
+                 outQue1.EnQue(tensorDkOut);
+                 outQue2.EnQue(tensorDgOut);
+             }
+             
+             // CopyOut
+             {
+                 auto tensorDkOut = outQue1.DeQue<DataType>();
+                 auto tensorDgOut = outQue2.DeQue<GType>();
+ 
+                 DataCopy(gmDk[kOffset], tensorDkOut, dkSize);
+ 
+                 // dg 需要与之前的累加
+                 // 累加到 dg (读取现有值, 加上新值, 写回)
+                 // 简化: 直接累加 (需要在 Part 5 中处理最终值)
+                 // dg 写入最终输出
+                 DataCopyParams dataCopyParams;
+                 dataCopyParams.blockCount = 1;
+                 dataCopyParams.blockLen = real_BT * sizeof(GType);
+                 dataCopyParams.srcStride = 0;
+                 dataCopyParams.dstStride = 0;
+                 DataCopyPad(gmDg[gOffset], tensorDgOut, dataCopyParams);
+                 outQue1.FreeTensor(tensorDkOut);
+                 outQue2.FreeTensor(tensorDgOut);
+             }
+ 
+             // ---- Phase 2: mm7 accumulation into dk (fused from Part7) ----
+             CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+             CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+ 
+             {
+                 auto tensorDkIn = inQue1.AllocTensor<DataType>();
+                 auto tensorMm7In = inQue2.AllocTensor<DataType>();
+                 DataCopy(tensorDkIn[dkSize], gmDk[kOffset], dkSize);
+                 DataCopy(tensorMm7In[dkSize], gmMm7[kOffset], dkSize);
+                 inQue1.EnQue(tensorDkIn);
+                 inQue2.EnQue(tensorMm7In);
+             }
+             {
+                 auto tensorDkIn = inQue1.DeQue<DataType>();
+                 auto tensorDkFp32 = tensorDkIn.template ReinterpretCast<float>();
+                 auto tensorMm7In = inQue2.DeQue<DataType>();
+                 auto tensorMm7Fp32 = tensorMm7In.template ReinterpretCast<float>();
+                 auto tensorDkOut = outQue1.AllocTensor<DataType>();
+ 
+                 Cast(tensorDkFp32, tensorDkIn[dkSize], RoundMode::CAST_NONE, dkSize);
+                 Cast(tensorMm7Fp32, tensorMm7In[dkSize], RoundMode::CAST_NONE, dkSize);
+                 PipeBarrier<PIPE_V>();
+                 Add(tensorDkFp32, tensorDkFp32, tensorMm7Fp32, dkSize);
+                 PipeBarrier<PIPE_V>();
+                 Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);
+ 
+                 inQue1.FreeTensor(tensorDkIn);
+                 inQue2.FreeTensor(tensorMm7In);
+                 outQue1.EnQue(tensorDkOut);
+             }
+             {
+                 auto tensorDkOut = outQue1.DeQue<DataType>();
+                 DataCopy(gmDk[kOffset], tensorDkOut, dkSize);
+                 outQue1.FreeTensor(tensorDkOut);
+             }
+ 
+             CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+         }
+     }
+ }
+ 
+ 
+ #endif  // CHUNK_BWD_DQKWG_VECTOR_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
@@ -208,7 +208,9 @@
      // Part 1: dw 和 dg_last 计算
      ProcessPart1();
      pipe->Reset();
-     AscendC::SyncAll<false>();
+     // Part 2 does not exchange cross-core flags. The next flag phase starts
+     // only after the Part 2 SyncAll below, so Part 1's drained tokens cannot
+     // be consumed by Part 3.
      // Part 2: 等待 mm5 (q @ k^T) 完成, 计算 mul1
      ProcessPart2();
      pipe->Reset();
@@ -256,9 +258,10 @@
                  uint32_t outIdx = r * kLimit + kIdx;
                  float val = dw.GetValue(outIdx);
                  float absVal = val >= 0.0f ? val : -val;
-                bool refineSmall = absVal >= refineAbsMin && absVal <= refineAbsMax;
-                bool refineChunkHeadZero = r == 0 && absVal <= refineAbsMax;
-                if (refineSmall || refineChunkHeadZero) {
+                 bool refineSmall = absVal >= refineAbsMin && absVal <= refineAbsMax;
+                 bool refineChunkHeadZero = r == 0 && absVal <= refineAbsMax;
+                 bool refineChunkHeadRepairCols = r == 0 && kIdx < FP16_ELEMENTS_PER_BLOCK;
+                 if (refineSmall || refineChunkHeadZero || refineChunkHeadRepairCols) {
                      float sum = 0.0f;
                      for (uint32_t vIdx = 0; vIdx < vLimit; ++vIdx) {
                          float dvVal = static_cast<float>(gmDv.GetValue(dvOffset + r * vLimit + vIdx));
@@ -472,8 +475,9 @@
                  PipeBarrier<PIPE_V>();
                  Cast(tensorDwOut, tensorHFp32, RoundMode::CAST_RINT, dwSize_sub);
                  PipeBarrier<PIPE_V>();
-                 RepairDwChunkHeadBlock(tensorDwOut, tensorDwIn, tensorHFp32, tensorSumFp32,
-                                        dvOffset, hOffset, BT_sub);
+                 // RefineSmallDw scalar-recomputes the chunk-head repair block.
+                 // The vector repair path uses a different reduction order and
+                 // can move near-threshold fp16 values by a few ulps.
                  inQue1.FreeTensor(tensorDwIn);
                  outQue2.EnQue(tensorDwOut);
              }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
@@ -184,9 +184,8 @@
      gmMm5.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm5Offset));
      gmDsTemp.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsDsTempOffset));
      gmMm6.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm6Offset));
- 
      gmMm7.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm7Offset));
-     gmMul1.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMul1Offset));
+     gmMul1.SetGlobalBuffer((__gm__ DataType *)ptrDq);
  }
  
  // ============== 主处理函数 ==============

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector_legacy.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector_legacy.h
@@ -1,0 +1,1428 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_bwd_dqkwg_vector.h
+ */
+
+#ifndef CHUNK_BWD_DQKWG_VECTOR_LEGACY_H
+#define CHUNK_BWD_DQKWG_VECTOR_LEGACY_H
+
+#include "chunk_bwd_dqkwg_common.h"
+#include "kernel_operator.h"
+
+using namespace AscendC;
+
+template <typename DataType, typename GType>
+class ChunkBwdDqkwgVectorProcessLegacy {
+public:
+    __aicore__ inline ChunkBwdDqkwgVectorProcessLegacy(
+        GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
+        GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices, GM_ADDR mask_a,
+        GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
+        GM_ADDR workspace
+    );
+    
+    __aicore__ inline void Init(const ChunkBwdDqkwgTilingData &tiling, TPipe *pipe_);
+    __aicore__ inline void Process();
+    
+private:
+    // 7 个 Part 的处理函数
+    __aicore__ inline void ProcessPart1();  // dw = -dv @ h^T, dg_last 计算
+    __aicore__ inline void ProcessPart2();  // 等待 mm5 完成
+    __aicore__ inline void ProcessPart3();  // ds 处理, dg 部分计算
+    __aicore__ inline void ProcessPart4();  // dq 处理, dg 累加
+    __aicore__ inline void ProcessPart5();  // dk 处理, dg 最终计算
+    __aicore__ inline void ProcessPart6();  // dq 累加
+    __aicore__ inline void ProcessPart7();  // dk 累加
+    
+    // 辅助函数
+    __aicore__ inline void ComputeExpScalar(float input, float &output);
+    __aicore__ inline void ApplyLowerTriangularMask(LocalTensor<float> &tensor, uint32_t size);
+    __aicore__ inline void ReduceSumX(LocalTensor<float> &src, LocalTensor<float> &dst,
+                                      uint32_t rows, uint32_t cols, int axis);
+    
+private:
+    // 输入输出指针
+    GM_ADDR ptrQ;
+    GM_ADDR ptrK;
+    GM_ADDR ptrV;
+    GM_ADDR ptrG;
+    GM_ADDR ptrH;
+    GM_ADDR ptrDo;
+    GM_ADDR ptrDh;
+    GM_ADDR ptrDv;
+    GM_ADDR ptrCuSeqLen;
+    GM_ADDR ptrChunkIndices;
+    GM_ADDR ptrMaskA;
+    GM_ADDR ptrDq;
+    GM_ADDR ptrDk;
+    GM_ADDR ptrDw;
+    GM_ADDR ptrDg;
+    GM_ADDR ptrWorkspace;
+    
+    // Tiling 参数
+    uint64_t B;
+    uint64_t H;
+    uint64_t T;
+    uint64_t K;
+    uint64_t V;
+    uint64_t BT;
+    uint64_t numChunks;
+    float scale;
+    int isVarLen;
+    uint32_t mul0RowNum = 0;
+    
+    // Workspace 偏移
+    uint64_t wsDwOffset;
+    uint64_t wsDgLastOffset;
+    uint64_t wsMm5Offset;
+    uint64_t wsDsTempOffset;
+    uint64_t wsMm6Offset;
+    uint64_t wsMm7Offset;
+    uint64_t wsMul1Offset;
+    int BUFFER_NUM = 1;
+    
+    // Pipeline
+    TPipe *pipe = nullptr;
+    
+    // Global Tensors
+    GlobalTensor<DataType> gmQ, gmK, gmV, gmDo, gmH, gmDh, gmDv;
+    GlobalTensor<DataType> gmDq, gmDk, gmDw;
+    GlobalTensor<GType> gmG, gmDg;
+    GlobalTensor<DataType> gmWorkspace;
+    GlobalTensor<float> gmDgLast;
+    GlobalTensor<DataType> gmMm5, gmDsTemp, gmMul1, gmMm6, gmMm7;
+    
+    // Queues (用于流水)
+    TQue<TPosition::VECIN, 2> inQue1;
+    TQue<TPosition::VECIN, 2> inQue2;
+    TQue<TPosition::VECIN, 2> inQue3;
+    TQue<TPosition::VECIN, 2> inQue4;  //用于Add0累加
+    TQue<TPosition::VECIN, 2> inQue5;  //用于Part5 Add4中间结果
+    TQue<TPosition::VECIN, 2> inQue6;  //用于Part5 gLast中间结果
+    TQue<TPosition::VECOUT, 2> outQue1;
+    TQue<TPosition::VECOUT, 2> outQue2;
+
+    
+    // Calc Buffers (UB 空间)
+    TBuf<TPosition::VECCALC> calcBuf1;  // 主计算缓冲区 (fp32)
+    TBuf<TPosition::VECCALC> calcBuf2;  // 辅助计算缓冲区 (fp32)
+    TBuf<TPosition::VECCALC> calcBuf3;  // Exp 缓冲区
+    TBuf<TPosition::VECCALC> calcBuf4;  // 中间结果
+    TBuf<TPosition::VECCALC> gBuf;      // g 值缓冲区
+    TBuf<TPosition::VECCALC> dgBuf;     // dg 值缓冲区
+    
+    // UB 空间常量
+    static constexpr uint32_t UB_BLOCK_SIZE = 32;
+    static constexpr uint32_t FP32_ELEMENTS_PER_BLOCK = 8;
+    static constexpr uint32_t FP16_ELEMENTS_PER_BLOCK = 16;
+};
+
+// ============== 构造函数 ==============
+template <typename DataType, typename GType>
+__aicore__ inline ChunkBwdDqkwgVectorProcessLegacy<DataType, GType>::ChunkBwdDqkwgVectorProcessLegacy(
+    GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
+    GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices, GM_ADDR mask_a,
+    GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
+    GM_ADDR workspace
+) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
+    ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLen(cu_seqlen), ptrChunkIndices(chunk_indices), ptrMaskA(mask_a),
+    ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
+    ptrWorkspace(workspace) {}
+
+// ============== 初始化 ==============
+template <typename DataType, typename GType>
+__aicore__ inline void ChunkBwdDqkwgVectorProcessLegacy<DataType, GType>::Init(const ChunkBwdDqkwgTilingData &tiling, TPipe *pipe_) {
+    pipe = pipe_;
+
+    scale = tiling.scale;
+    B = tiling.B;
+    H = tiling.H;
+    T = tiling.T;
+    K = tiling.K;
+    V = tiling.V;
+    BT = tiling.BT;
+    numChunks = tiling.numChunks;
+    wsDgLastOffset = tiling.wsDgLastOffset;
+    wsMm5Offset = tiling.wsMm5Offset;
+    wsDsTempOffset = tiling.wsDsTempOffset;
+    // wsMm6Offset = tiling.wsMm6Offset;
+    // wsMm7Offset = tiling.wsMm7Offset;
+    // wsMul1Offset = tiling.wsMul1Offset;
+    uint64_t dgLastSize = tiling.dgLastSize;
+    isVarLen = tiling.isVarLen;
+    mul0RowNum = tiling.mul0RowNum;
+
+    if (BT == 64) {
+        BUFFER_NUM = 2;
+    } else {
+        BUFFER_NUM = 1;
+    }
+
+    gmQ.SetGlobalBuffer((__gm__ DataType *)ptrQ);
+    gmK.SetGlobalBuffer((__gm__ DataType *)ptrK);
+    gmV.SetGlobalBuffer((__gm__ DataType *)ptrV);
+    gmG.SetGlobalBuffer((__gm__ GType *)ptrG);
+    gmH.SetGlobalBuffer((__gm__ DataType *)ptrH);
+    gmDo.SetGlobalBuffer((__gm__ DataType *)ptrDo);
+    gmDh.SetGlobalBuffer((__gm__ DataType *)ptrDh);
+    gmDv.SetGlobalBuffer((__gm__ DataType *)ptrDv);
+
+    gmDq.SetGlobalBuffer((__gm__ DataType *)ptrDq);
+    gmDk.SetGlobalBuffer((__gm__ DataType *)ptrDk);
+    gmDw.SetGlobalBuffer((__gm__ DataType *)ptrDw);
+    gmDg.SetGlobalBuffer((__gm__ GType *)ptrDg);
+
+    gmWorkspace.SetGlobalBuffer((__gm__ DataType *)ptrWorkspace);
+    gmDgLast.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t*)ptrWorkspace + wsDgLastOffset));     //中间结果使用float
+
+    gmMm5.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm5Offset));
+    gmDsTemp.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsDsTempOffset));
+    // gmMm6.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm6Offset));
+    // gmMm7.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm7Offset));
+    gmMm6.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm5Offset));
+    gmMm7.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm5Offset));
+    // gmMul1.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMul1Offset));
+    gmMul1.SetGlobalBuffer((__gm__ DataType *)ptrDq);
+}
+
+// ============== 主处理函数 ==============
+template <typename DataType, typename GType>
+__aicore__ inline void ChunkBwdDqkwgVectorProcessLegacy<DataType, GType>::Process() {
+    // Part 1: dw 和 dg_last 计算
+    ProcessPart1();
+    pipe->Reset();
+    AscendC::SyncAll<false>();
+    // Part 2: 等待 mm5 (q @ k^T) 完成
+    ProcessPart2();
+    pipe->Reset();
+    AscendC::SyncAll<false>();
+    // Part 3: ds 处理和 dg 部分计算
+    ProcessPart3();
+    pipe->Reset();
+    AscendC::SyncAll<false>();
+    // Part 4: dq 处理
+    ProcessPart4();
+    pipe->Reset();
+    AscendC::SyncAll<false>();
+    // Part 5: dk 处理和 dg 最终计算
+    ProcessPart5();
+    pipe->Reset();
+    AscendC::SyncAll<false>();
+    // Part 6: dq 累加
+    ProcessPart6();
+    pipe->Reset();
+    AscendC::SyncAll<false>();
+    // Part 7: dk 累加
+    ProcessPart7();
+}
+
+// ============== Part 1: dw 和 dg_last 计算 ==============
+template <typename DataType, typename GType>
+__aicore__ inline void ChunkBwdDqkwgVectorProcessLegacy<DataType, GType>::ProcessPart1() {
+    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+    uint32_t coreNum = GetBlockNum();
+    // printf("coreIdx %d, coreNum %d\n", coreIdx, coreNum);
+    uint32_t coreLoops = B * numChunks;
+    
+    // 分配 UB 空间
+    // Part 1 的 Vector 部分主要处理:
+    // 1. h * dh 的逐元素乘法和求和 -> dg_last
+    // 2. dw 的负号处理
+    
+    const uint32_t hDhSize = mul0RowNum * V;  // h 和 dh 的大小
+    const uint32_t dwSize = BT * K;
+    uint32_t BT_sub = BT;
+    uint32_t BT_sub_offset = 0;
+
+    uint32_t dwSize_sub = BT_sub * K;
+    uint32_t vecTaskIdx = 0;
+
+    uint32_t maxSize = (2 * hDhSize) > dwSize ? (2 * hDhSize) : dwSize;
+
+    // 初始化 buffers
+    pipe->InitBuffer(inQue1, BUFFER_NUM, maxSize * sizeof(DataType));  // h 和 dh 共用一个输入队列
+    pipe->InitBuffer(outQue1, BUFFER_NUM, sizeof(float) * 8);  // dg_last (对齐到 32 字节)
+    pipe->InitBuffer(outQue2, BUFFER_NUM, dwSize * sizeof(DataType));
+    pipe->InitBuffer(calcBuf1, maxSize * sizeof(float));
+    pipe->InitBuffer(calcBuf3, hDhSize * sizeof(float));
+    auto tensorHFp32 = calcBuf1.Get<float>();
+    auto tensorDhFp32 = tensorHFp32[hDhSize];
+    auto tensorSumFp32 = calcBuf3.Get<float>();
+
+    // 发送同步信号给 Cube
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    uint32_t bos = 0;
+    uint32_t eos = 0;
+    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+        uint32_t bIdx = loopIdx / numChunks;
+        uint32_t chunkIdx = loopIdx % numChunks;
+        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T, BT, loopIdx, bos, eos);
+        BT_sub = eos-bos;
+        dwSize_sub = BT_sub * K;
+        
+        for (uint32_t h = 0; h < H; h++) {
+            ++vecTaskIdx;
+            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
+                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+                continue;
+            }
+            // 计算偏移
+            // h, dh: [B, H, num_chunks, K, V]
+            uint64_t hOffset = ((bIdx * H + h) * numChunks + chunkIdx) * K * V;
+            // dw (workspace): 按 [B, H, T, K] 布局
+            uint64_t dwOffset = (h * T + bos) * K;
+            // dg_last: [B, H, num_chunks]
+            uint64_t dgLastOffset = (bIdx * H + h) * numChunks + chunkIdx;
+
+            // ========== 计算 dg_last = sum(h * dh) ==========
+            // 等待 Cube 信号 (dw Cube 计算)
+            for(uint32_t row = 0; row < K; row += mul0RowNum) {
+                // CopyIn: h 和 dh
+                {
+                    auto tensorHIn = inQue1.AllocTensor<DataType>();
+                    auto tensorDhIn = tensorHIn[hDhSize];
+                    DataCopy(tensorDhIn, gmDh[hOffset + row * V], hDhSize);
+                    DataCopy(tensorHIn, gmH[hOffset + row * V], hDhSize);
+                    inQue1.EnQue(tensorHIn);
+                }
+                // Compute: h * dh -> reduceSum
+                {
+                    auto tensorHIn = inQue1.DeQue<DataType>();
+                    auto tensorDhIn = tensorHIn[hDhSize];
+                    // Cast to fp32 (bf16 不支持直接 Mul)
+                    Cast(tensorHFp32, tensorHIn, RoundMode::CAST_NONE, hDhSize);
+                    Cast(tensorDhFp32, tensorDhIn, RoundMode::CAST_NONE, hDhSize);
+                    PipeBarrier<PIPE_V>();
+
+                    // 逐元素乘法
+                    if(row == 0) {
+                        Mul(tensorSumFp32, tensorHFp32, tensorDhFp32, hDhSize);
+                    } else {
+                        Mul(tensorHFp32, tensorHFp32, tensorDhFp32, hDhSize);
+                        PipeBarrier<PIPE_V>();
+                        Add(tensorSumFp32, tensorSumFp32, tensorHFp32, hDhSize);
+                    }
+
+                    PipeBarrier<PIPE_V>();
+                    inQue1.FreeTensor(tensorHIn);
+                }
+            }
+            {
+                uint32_t remainNum = hDhSize;
+                while(remainNum > 64) {
+                    remainNum = remainNum / 2;
+                    Add(tensorSumFp32, tensorSumFp32, tensorSumFp32[remainNum], remainNum);
+                    PipeBarrier<PIPE_V>();
+                }
+                auto tensorDgLastOut = outQue1.AllocTensor<float>();
+                WholeReduceSum(tensorDgLastOut, tensorSumFp32, 64, 1, 1, 1, 8);
+                outQue1.EnQue(tensorDgLastOut);
+            }
+            {
+                auto tensorDgLastOut = outQue1.DeQue<float>();
+
+                DataCopyParams dataCopyParams;
+                dataCopyParams.blockCount = 1;
+                dataCopyParams.blockLen = 1*sizeof(float);
+                dataCopyParams.srcStride = 0;
+                dataCopyParams.dstStride = 0;
+                DataCopyPad(gmDgLast[dgLastOffset], tensorDgLastOut,dataCopyParams);
+
+                outQue1.FreeTensor(tensorDgLastOut);
+            }
+
+
+
+            // ========== 处理 dw: 取负号 ==========
+            // Cube 计算的是 dv @ h^T, 需要乘以 -1
+            // 从 workspace 读取 dw, 乘以 -1, 写回最终输出
+            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+            // CopyIn: dw from workspace
+            {
+                auto tensorDwIn = inQue1.AllocTensor<DataType>();
+                DataCopy(tensorDwIn, gmDw[dwOffset], dwSize_sub);
+                inQue1.EnQue(tensorDwIn);
+            }
+
+            // Compute: -dw
+            {
+                auto tensorDwIn = inQue1.DeQue<DataType>();
+                auto tensorDwOut = outQue2.AllocTensor<DataType>();
+                
+                // Cast to fp32, 乘以 -1, cast back
+                Cast(tensorHFp32, tensorDwIn, RoundMode::CAST_NONE, dwSize_sub);
+                PipeBarrier<PIPE_V>();
+                Muls(tensorHFp32, tensorHFp32, -1.0f, dwSize_sub);
+                PipeBarrier<PIPE_V>();
+                Cast(tensorDwOut, tensorHFp32, RoundMode::CAST_RINT, dwSize_sub);
+                inQue1.FreeTensor(tensorDwIn);
+                outQue2.EnQue(tensorDwOut);
+            }
+            
+            // CopyOut: dw to final output
+            {
+                auto tensorDwOut = outQue2.DeQue<DataType>();
+                DataCopy(gmDw[dwOffset], tensorDwOut, dwSize_sub);
+
+                outQue2.FreeTensor(tensorDwOut);
+            }
+
+            // 通知 Cube 继续
+            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+        }
+    }
+
+}
+
+// ============== Part 2: 等待 mm5 完成 ==============
+template <typename DataType, typename GType>
+__aicore__ inline void ChunkBwdDqkwgVectorProcessLegacy<DataType, GType>::ProcessPart2() {
+    // Part 2 MUL1 + and(m_A)
+    
+    constexpr int32_t BLOCK_SIZE = 32; // API一次能处理256B，能计算64个float元素
+    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+    uint32_t coreNum = GetBlockNum();
+    uint32_t coreLoops = B * numChunks;
+    uint32_t real_BT = BT;
+
+    uint32_t BT_sub = real_BT;
+    uint32_t BT_sub_start = 0;
+    uint32_t BT_sub_end = BT_sub;
+
+    uint32_t dsSize_sub = BT_sub * BT;
+    uint32_t dsSize_sub_offset = 0;
+    const uint32_t gSize = BT;
+    
+    // 初始化 buffers
+    
+    pipe->InitBuffer(inQue3, 2, gSize * sizeof(float));        // g values
+    pipe->InitBuffer(outQue1, 2, dsSize_sub * sizeof(float) / 2);   // ds_temp output   32K/8K
+
+    pipe->InitBuffer(calcBuf1, BT * 8 * sizeof(float));             // g in fp32
+    pipe->InitBuffer(calcBuf2, BT * sizeof(float));            // g temp [BT,1]
+    pipe->InitBuffer(calcBuf3, BT * sizeof(float));            // g temp [1,BT]
+    pipe->InitBuffer(calcBuf4, BLOCK_SIZE);
+
+    auto tensorBrcbTemp = calcBuf1.Get<float>();
+    auto tensorGFp32Left = calcBuf2.Get<float>();
+    auto tensorGFp32Right = calcBuf3.Get<float>();
+    auto tensorZeroFp32 = calcBuf4.template Get<float>();
+    
+    uint32_t bos = 0;
+    uint32_t eos = 0;
+    uint32_t bos_orig = 0;
+    uint32_t eos_orig = 0;
+    // 发送同步信号
+
+    //初始化zero
+    AscendC::Duplicate<float>(tensorZeroFp32, float(0.0), BLOCK_SIZE / sizeof(float));
+    PipeBarrier<PIPE_V>();
+    //搬入m_A
+
+    const uint32_t maskASize = 64*64*sizeof(float);//BT * BT / 8 * sizeof(uint8_t);
+    pipe->InitBuffer(inQue1, 1, maskASize);    // m_A from input
+    auto tensorMaskA = inQue1.AllocTensor<float>();
+
+    Duplicate(tensorMaskA,static_cast<float>(0),64 * 64);
+    PipeBarrier<PIPE_V>();
+    for(int i = 0; i < 64; i++) {
+        Duplicate(tensorMaskA[i * 64], 1.0f, i + 1);
+    }
+    PipeBarrier<PIPE_V>();
+
+    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T, BT, loopIdx, bos, eos);
+        bos_orig = bos;
+        eos_orig = eos;
+        uint32_t vec_core_0_length = (eos_orig - bos_orig) >= (BT / 2) ? (BT / 2) : (eos_orig - bos_orig);
+        uint32_t vec_core_1_length = (eos_orig - bos_orig) >= (BT / 2) ? (eos_orig - bos_orig - (BT / 2)) : 0;
+        if (GetSubBlockIdx() == 0) {        // BT: 0..BT_sub_end
+            BT_sub_start = 0;
+            BT_sub_end = vec_core_0_length;         // [0, vec_core_0_length)
+            eos = bos + vec_core_0_length;
+        } else {       // BT: BT_sub_end+1..eos
+            BT_sub_start = vec_core_0_length;
+            BT_sub_end = eos_orig - bos_orig;
+            bos = bos + vec_core_0_length;
+        }
+        
+        uint32_t real_BT= eos-bos;
+        uint32_t real_BT_align = ALIGN_UP((eos-bos), 16);
+        dsSize_sub = (eos-bos) * BT;
+        uint32_t bIdx = loopIdx / numChunks;
+        uint32_t chunkIdx = loopIdx % numChunks;
+
+        for (uint32_t h = 0; h < H; h++) {
+            if (real_BT == 0) {       //sub core get 0 token
+                continue;
+            }
+
+            // 偏移计算
+            // g: [B, H, T]
+            uint64_t gOffset = (h * T + bos_orig);
+            // ds, mm5, ds_temp: [B, H, T, BT]
+            uint64_t dsOffset = (h * T + bos) * BT;
+            // CopyIn: g
+            {
+                auto tensorGIn = inQue3.AllocTensor<GType>();
+
+                DataCopyParams dataCopyParams;
+                dataCopyParams.blockCount = 1;
+                dataCopyParams.blockLen = (eos_orig-bos_orig)*sizeof(GType);
+                dataCopyParams.srcStride = 0;
+                dataCopyParams.dstStride = 0;
+                DataCopyPad(tensorGIn, gmG[gOffset],dataCopyParams,{false, 0, 0, 0});
+
+                inQue3.EnQue(tensorGIn);
+            }
+
+            // Compute MUL1
+            {
+                auto tensorGIn = inQue3.DeQue<GType>();
+                auto tensorDsTempOut = outQue1.AllocTensor<float>();
+
+                // g 可能已经是 fp32
+                if constexpr (std::is_same<GType, float>::value) {
+                    DataCopy(tensorGFp32Left, tensorGIn, gSize);
+                } else {
+                    Cast(tensorGFp32Left, tensorGIn, RoundMode::CAST_NONE, gSize);
+                }
+                PipeBarrier<PIPE_V>();
+
+                Muls(tensorGFp32Right, tensorGFp32Left, static_cast<float>(-1), gSize);
+
+                Brcb(tensorBrcbTemp, tensorGFp32Left[BT_sub_start], CEIL_DIV(real_BT, 8), {1, 8}); // Brcb处理数据个数需要8对齐 [BT,8]
+                PipeBarrier<PIPE_V>();
+
+                // copy tensorGFp32Right  chunkLen / 2行
+                if (BT == 64) {
+
+                    AscendC::Add(tensorDsTempOut, tensorGFp32Right, tensorBrcbTemp, CAL_NUM_FLOAT, real_BT,
+                                {1, 1, 0, 8, 0, 1});
+
+                    PipeBarrier<PIPE_V>();
+                    Mins(tensorDsTempOut, tensorDsTempOut, static_cast<float>(0.0), real_BT * BT);
+
+                    PipeBarrier<PIPE_V>();
+                    Exp(tensorDsTempOut, tensorDsTempOut, real_BT * BT);
+                    PipeBarrier<PIPE_V>();
+
+                } else {
+                    AscendC::Copy(tensorDsTempOut, tensorGFp32Right, CAL_NUM_FLOAT, real_BT, {1, 1, 16, 0});
+                    PipeBarrier<PIPE_V>();
+                    AscendC::Copy(tensorDsTempOut[CAL_NUM_FLOAT], tensorGFp32Right[CAL_NUM_FLOAT], CAL_NUM_FLOAT,
+                                real_BT, {1, 1, 16, 0});
+                    PipeBarrier<PIPE_V>();
+                    AscendC::Add(tensorDsTempOut, tensorDsTempOut, tensorBrcbTemp, CAL_NUM_FLOAT, real_BT,
+                                {1, 1, 0, 16, 16, 1});
+                    PipeBarrier<PIPE_V>();
+                    AscendC::Add(tensorDsTempOut[CAL_NUM_FLOAT], tensorDsTempOut[CAL_NUM_FLOAT], tensorBrcbTemp,
+                                CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+                    PipeBarrier<PIPE_V>();
+                    Mins(tensorDsTempOut, tensorDsTempOut, static_cast<float>(0.0), real_BT * BT);
+                    PipeBarrier<PIPE_V>();
+                    Exp(tensorDsTempOut, tensorDsTempOut, real_BT * BT);
+                }
+
+                PipeBarrier<PIPE_V>();
+
+                if(BT==64) {    //TODO： MASK
+                    Mul(tensorDsTempOut,tensorDsTempOut,tensorMaskA[BT_sub_start*64],32*64);
+                    PipeBarrier<PIPE_V>();
+                } else {
+                    BinaryRepeatParams binaryRepeatParams{1,1,1,16,16,8};
+                    UnaryRepeatParams unaryRepeatParams{1,1,16,8};
+                    PipeBarrier<PIPE_V>();
+                    if (BT_sub_start == 0) {    // vec 0 : 0..64
+                        Mul(tensorDsTempOut,tensorDsTempOut,tensorMaskA,64,64,binaryRepeatParams);
+                        PipeBarrier<PIPE_V>();
+                        Muls(tensorDsTempOut[64],tensorDsTempOut[64],static_cast<float>(0),64,64,unaryRepeatParams);
+                        PipeBarrier<PIPE_V>();
+                    }
+                    else {      // vec 0 : 64..128
+                        Mul(tensorDsTempOut[64],tensorDsTempOut[64],tensorMaskA,64,64,binaryRepeatParams);
+                        PipeBarrier<PIPE_V>();
+                    }
+
+                }
+
+                AscendC::Muls(tensorDsTempOut, tensorDsTempOut, static_cast<float>(scale), real_BT * BT);
+                PipeBarrier<PIPE_V>();
+
+                //Ds是 fp16/bf16
+                Cast(tensorDsTempOut.template ReinterpretCast<DataType>(), tensorDsTempOut, RoundMode::CAST_RINT, real_BT * BT);
+
+                inQue3.FreeTensor(tensorGIn);
+                outQue1.EnQue(tensorDsTempOut);
+            }
+
+            // CopyOut
+            {
+                auto tensorDsTempOut = outQue1.DeQue<float>();
+                DataCopy(gmMul1[dsOffset], tensorDsTempOut.template ReinterpretCast<DataType>(), real_BT * BT);
+
+                outQue1.FreeTensor(tensorDsTempOut);
+            }
+        }
+    }
+    inQue1.FreeTensor<float>(tensorMaskA);
+}
+
+// ============== Part 3: ds 处理和 dg 部分计算 ==============
+template <typename DataType, typename GType>
+__aicore__ inline void ChunkBwdDqkwgVectorProcessLegacy<DataType, GType>::ProcessPart3() {
+    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+    uint32_t coreNum = GetBlockNum();
+    uint32_t coreLoops = B * numChunks;
+    uint32_t real_BT = BT; // TODO：如果BT不对齐
+
+    uint32_t BT_sub = real_BT;
+    uint32_t BT_sub_start = 0;
+    uint32_t BT_sub_end = BT_sub;
+
+
+    uint32_t dsSize_sub = BT_sub * BT;
+    uint32_t dsSize_sub_offset = 0;
+    const uint32_t gSize = BT;
+
+    // 初始化 buffers
+    pipe->InitBuffer(inQue1, BUFFER_NUM, dsSize_sub * sizeof(float));    // ds from Cube
+    pipe->InitBuffer(inQue2, BUFFER_NUM, dsSize_sub * sizeof(float));    // mm5/mul1 from workspace
+    pipe->InitBuffer(outQue1, BUFFER_NUM, dsSize_sub * sizeof(DataType));   // ds_temp output   32K/8K
+    pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(float));       // dg output
+
+    pipe->InitBuffer(calcBuf4, gSize * sizeof(float));        // m_A
+    pipe->InitBuffer(gBuf, gSize * sizeof(float));             // g in fp32
+    pipe->InitBuffer(dgBuf, gSize * sizeof(float));            // dg temp
+
+    auto tensorMaskA = calcBuf4.Get<float>();
+    auto tensorGFp32 = gBuf.Get<float>();
+    auto tensorDgTemp = dgBuf.Get<float>();
+
+    uint32_t bos = 0;
+    uint32_t eos = 0;
+    uint32_t vecTaskIdx = 0;
+    // 发送同步信号
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+
+    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T, BT, loopIdx, bos, eos);
+        BT_sub_end = eos-bos;
+        uint32_t real_BT= eos-bos;
+        dsSize_sub = (eos-bos) * BT;
+        uint32_t bIdx = loopIdx / numChunks;
+        uint32_t chunkIdx = loopIdx % numChunks;
+
+        for (uint32_t h = 0; h < H; h++) {
+            // if (GetSubBlockIdx() == 1) {
+            //     CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+            //     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+            //     continue;
+            // }
+            ++vecTaskIdx;
+            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
+                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+                continue;
+            }
+
+            // 偏移计算
+            // g: [B, H, T]
+            uint64_t gOffset = (h * T + bos);
+            // ds, mm5, ds_temp: [B, H, T, BT]
+            uint64_t dsOffset = (h * T + bos) * BT;
+
+            // dg: [B, H, T]
+            uint64_t dgOffset = gOffset;
+
+            // 等待 Cube 完成 ds 计算
+            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+
+            // CopyIn: ds (Cube output), g
+            {
+                auto tensorDsIn = inQue1.AllocTensor<DataType>();
+                auto tensorMul1In = inQue2.AllocTensor<DataType>();
+
+                DataCopy(tensorDsIn[BT * BT], gmDsTemp[dsOffset + dsSize_sub_offset], dsSize_sub);
+                DataCopy(tensorMul1In[BT * BT], gmMul1[dsOffset + dsSize_sub_offset], dsSize_sub);
+
+                inQue1.EnQue(tensorDsIn);
+                inQue2.EnQue(tensorMul1In);
+            }
+
+            // Compute MUL1
+            {
+                auto tensorDsInFp16 = inQue1.DeQue<DataType>();
+                auto tensorDsInFp32 = tensorDsInFp16.template ReinterpretCast<float>();
+
+                auto tensorDsTempOut = outQue1.AllocTensor<DataType>();
+
+                auto tensorMul1InFp16 = inQue2.DeQue<DataType>();
+                auto tensorMul1InFp32 = tensorMul1InFp16.template ReinterpretCast<float>();
+                auto tensorDgOut = outQue2.AllocTensor<float>();
+
+                // Cast to fp32
+                Cast(tensorDsInFp32, tensorDsInFp16[BT * BT], RoundMode::CAST_NONE, dsSize_sub);
+
+                
+                Cast(tensorMul1InFp32, tensorMul1InFp16[BT * BT], RoundMode::CAST_NONE, dsSize_sub);
+                PipeBarrier<PIPE_V>();
+                // b_ds_temp = b_ds * mul1 (已经应用了掩码)
+                Mul(tensorDsInFp32, tensorDsInFp32, tensorMul1InFp32, dsSize_sub);
+                inQue2.FreeTensor(tensorMul1InFp32);
+
+                //搬入MM5,复用Mul1空间
+                auto tensorMm5InFp16Tmp = inQue2.AllocTensor<DataType>();
+                DataCopy(tensorMm5InFp16Tmp[BT * BT], gmMm5[dsOffset + dsSize_sub_offset], dsSize_sub);
+                inQue2.EnQue(tensorMm5InFp16Tmp);
+                auto tensorMm5InFp16 = inQue2.DeQue<DataType>();
+
+                auto tensorMm5InFp32 = tensorMm5InFp16.template ReinterpretCast<float>();
+                Cast(tensorMm5InFp32, tensorMm5InFp16[BT * BT], RoundMode::CAST_NONE, dsSize_sub);
+                PipeBarrier<PIPE_V>();
+                // Calcute ds_temp * mm5 and after
+
+                Mul(tensorMm5InFp32, tensorDsInFp32, tensorMm5InFp32, dsSize_sub); // b_ds2 = b_ds_temp * mm5
+                Cast(tensorDsTempOut, tensorDsInFp32, RoundMode::CAST_RINT, dsSize_sub);  //ds_tmp -> fp16, tensorDsFp32已经空闲
+
+                // axis=1: 对每行求和 -> [BT] +Add0.C
+                Duplicate(tensorDgOut, static_cast<float>(0.0), BT);
+                PipeBarrier<PIPE_V>();
+
+                // reducesum
+                uint64_t wholeReduceSumCnt = CeilDiv(real_BT, FP32_PER_REPEAT);
+                uint32_t remainCnt = real_BT % FP32_PER_REPEAT;
+                if(remainCnt > 0) {
+                    uint32_t DuplicateOffset = wholeReduceSumCnt * FP32_PER_REPEAT - FP32_PER_REPEAT;
+                    uint64_t mask[1] = {0xffffffffffffffff};
+                    mask[0] <<= remainCnt;
+                    for (uint32_t row = BT_sub_start; row < BT_sub_end; row++) {
+                        Duplicate(tensorMm5InFp32[row * BT + DuplicateOffset], 0.0f, mask, 1, 1, 8);
+                    }
+                    PipeBarrier<PIPE_V>();
+                }
+                for (uint32_t i = BT_sub_start; i < BT_sub_end; i++) {
+                    WholeReduceSum(tensorDsInFp32[i * 8], tensorMm5InFp32[i * BT],
+                                   FP32_PER_REPEAT, wholeReduceSumCnt, 1, 1, 8);
+                }
+                PipeBarrier<PIPE_V>();
+                WholeReduceSum(tensorDgOut, tensorDsInFp32, wholeReduceSumCnt, real_BT, 1, 1, 1);
+
+                // axis=0: 对每列求和 -> [BT] -Add0.D
+                PipeBarrier<PIPE_V>();
+                uint32_t remain_row = real_BT;
+                uint32_t CalcCnt = 0;
+                uint32_t Offset = 0;
+                while (remain_row > 1) {
+                    CalcCnt = (remain_row / 2) * BT;
+                    remain_row = CeilDiv(remain_row, 2);
+                    Offset = remain_row * BT;
+                    Add(tensorMm5InFp32, tensorMm5InFp32, tensorMm5InFp32[Offset], CalcCnt);
+                    PipeBarrier<PIPE_V>();
+                }
+                Sub(tensorDgOut, tensorDgOut, tensorMm5InFp32, BT);
+                PipeBarrier<PIPE_V>();
+                // 保存 tensorDgOut 供后续 Part 使用
+                if constexpr (!std::is_same<GType, float>::value) {
+                    Cast(tensorDgOut.template ReinterpretCast<GType>(), tensorDgOut, RoundMode::CAST_RINT, gSize);
+                }
+
+                inQue1.FreeTensor(tensorDsInFp16);
+                inQue2.FreeTensor(tensorMm5InFp16);
+
+                outQue1.EnQue(tensorDsTempOut);
+                outQue2.EnQue(tensorDgOut);
+            }
+            
+            // CopyOut
+            {
+                auto tensorDsTempOut = outQue1.DeQue<DataType>();
+                auto tensorDgOut = outQue2.DeQue<float>();
+
+                DataCopy(gmDsTemp[dsOffset + dsSize_sub_offset], tensorDsTempOut, dsSize_sub);
+
+                DataCopyParams dataCopyParams;
+                dataCopyParams.blockCount = 1;
+                dataCopyParams.blockLen = real_BT * sizeof(GType);
+                dataCopyParams.srcStride = 0;
+                dataCopyParams.dstStride = 0;
+                // dg 写入最终输出
+                if constexpr (std::is_same<GType, float>::value) {
+                    DataCopyPad(gmDg[dgOffset], tensorDgOut,dataCopyParams);
+                } else {
+                    // 需要 cast
+                    DataCopyPad(gmDg[dgOffset], tensorDgOut.template ReinterpretCast<GType>(), dataCopyParams);
+                }
+
+                outQue1.FreeTensor(tensorDsTempOut);
+                outQue2.FreeTensor(tensorDgOut);
+            }
+
+            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+        }
+
+    }
+
+}
+
+
+
+// ============== Part 4: dq 处理 ==============
+template <typename DataType, typename GType>
+__aicore__ inline void ChunkBwdDqkwgVectorProcessLegacy<DataType, GType>::ProcessPart4() {
+    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+    uint32_t coreNum = GetBlockNum();
+    uint32_t coreLoops = B * numChunks;
+    
+    uint32_t dqSize = BT * K;
+    uint32_t real_BT = BT;
+
+
+    uint32_t BT_sub = real_BT;
+    uint32_t BT_sub_start = 0;
+    uint32_t BT_sub_end = BT_sub;
+    
+    uint32_t dqSize_sub = BT_sub * K;
+    uint32_t dqSize_sub_offset = BT_sub_start * K;
+    const uint32_t gSize = BT;
+    // 初始化 buffers
+    pipe->InitBuffer(inQue1, BUFFER_NUM, dqSize_sub * sizeof(float));    // dq from Cube   //64K
+    pipe->InitBuffer(inQue2, BUFFER_NUM, dqSize_sub * sizeof(float));    // q
+    pipe->InitBuffer(inQue3, BUFFER_NUM, gSize * sizeof(GType));        // g
+    pipe->InitBuffer(inQue4, BUFFER_NUM, gSize * sizeof(GType));        // g             
+    pipe->InitBuffer(outQue1, BUFFER_NUM, dqSize_sub * sizeof(DataType));   // dq output
+    pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(float));       // dg partial
+
+    pipe->InitBuffer(calcBuf3, gSize * (8) * sizeof(float));        //第一次reducesum结果：[BT, 8]
+    pipe->InitBuffer(gBuf, gSize * sizeof(float));
+    pipe->InitBuffer(dgBuf, gSize * sizeof(float));
+    
+    auto tensorShareTmpFp32 = calcBuf3.Get<float>();
+    auto tensorGFp32 = gBuf.Get<float>();
+    auto tensorDgAdd = dgBuf.Get<float>();
+
+    uint32_t vecTaskIdx = 0;
+    uint32_t bos = 0;
+    uint32_t eos = 0;
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+
+    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T,
+                        BT, loopIdx, bos, eos);
+        uint32_t actual_chunk_len = eos-bos;
+        dqSize_sub = actual_chunk_len * K;
+        BT_sub_end = actual_chunk_len;
+        BT_sub = actual_chunk_len;
+        uint32_t bIdx = loopIdx / numChunks;
+        uint32_t chunkIdx = loopIdx % numChunks;
+        
+        for (uint32_t h = 0; h < H; h++) {
+            // if (GetSubBlockIdx() == 1) {
+            //     CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+            //     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+            //     continue;
+            // }
+            ++vecTaskIdx;
+            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
+                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+                continue;
+            }
+            uint64_t qkOffset = (h * T + bos) * K;
+            uint64_t gOffset = (h * T + bos);
+            
+            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+            // CopyIn
+            {
+                auto tensorDqIn = inQue1.AllocTensor<DataType>();
+                auto tensorQIn = inQue2.AllocTensor<DataType>();
+                auto tensorGIn = inQue3.AllocTensor<GType>();
+                auto tensorDgIn = inQue4.AllocTensor<GType>();
+                
+                DataCopy(tensorDqIn[dqSize_sub], gmDq[qkOffset + dqSize_sub_offset], dqSize_sub);
+
+                DataCopy(tensorQIn[dqSize_sub], gmQ[qkOffset + dqSize_sub_offset], dqSize_sub);
+
+                DataCopyParams dataCopyParams;
+                dataCopyParams.blockCount = 1;
+                dataCopyParams.blockLen = actual_chunk_len*sizeof(GType);
+                dataCopyParams.srcStride = 0;
+                dataCopyParams.dstStride = 0;
+                DataCopyPad(tensorGIn, gmG[gOffset],dataCopyParams,{false, 0, 0, 0});
+                DataCopyPad(tensorDgIn, gmDg[gOffset],dataCopyParams,{false, 0, 0, 0});
+
+                inQue1.EnQue(tensorDqIn);
+                inQue2.EnQue(tensorQIn);
+                inQue3.EnQue(tensorGIn);
+                inQue4.EnQue(tensorDgIn);
+            }
+            
+            // Compute
+            {
+                auto tensorDqInFp16 = inQue1.DeQue<DataType>();
+                auto tensorDqInFp32 = tensorDqInFp16.template ReinterpretCast<float>();
+                auto tensorQInFp16 = inQue2.DeQue<DataType>();
+                auto tensorQInFp32 = tensorQInFp16.template ReinterpretCast<float>();
+                auto tensorGIn = inQue3.DeQue<GType>();
+                auto tensorDgIn = inQue4.DeQue<GType>();
+                auto tensorDqOut = outQue1.AllocTensor<DataType>();
+                auto tensorDgOut = outQue2.AllocTensor<float>();
+
+                // Cast
+                Cast(tensorDqInFp32, tensorDqInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
+                Cast(tensorQInFp32, tensorQInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
+                if constexpr (std::is_same<GType, float>::value) {
+                    DataCopy(tensorGFp32, tensorGIn, gSize);
+                } else {
+                    Cast(tensorGFp32, tensorGIn, RoundMode::CAST_NONE, gSize);
+                }
+                PipeBarrier<PIPE_V>();
+
+                // mul3 = exp(g) * scale
+                // b_dq_temp = b_dq * mul3 (broadcast along K dimension)
+                Exp(tensorGFp32, tensorGFp32, gSize);
+                PipeBarrier<PIPE_V>();
+
+                Muls(tensorGFp32, tensorGFp32, static_cast<float>(scale), gSize);       //mul3 = exp(g) * scale
+                PipeBarrier<PIPE_V>();
+
+                Brcb(tensorShareTmpFp32, tensorGFp32, CEIL_DIV(real_BT, 8), {1, 8}); // Brcb处理数据个数需要8对齐 [BT,8]
+                PipeBarrier<PIPE_V>();
+                AscendC::Mul(tensorDqInFp32, tensorDqInFp32, tensorShareTmpFp32, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+                AscendC::Mul(tensorDqInFp32[CAL_NUM_FLOAT], tensorDqInFp32[CAL_NUM_FLOAT], tensorShareTmpFp32, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+
+                PipeBarrier<PIPE_V>();
+                Mul(tensorQInFp32, tensorDqInFp32, tensorQInFp32, dqSize_sub);
+
+                // Add0.A = reduceSum((q * dq), axis=1)
+                // axis=1: 对每行求和 -> [BT] +Add0.A
+
+                PipeBarrier<PIPE_V>();
+
+                // reducesum
+                uint64_t wholeReduceSumCnt = CeilDiv(K, FP32_PER_REPEAT);
+                for (uint32_t i = BT_sub_start; i < BT_sub_end; i++) {
+                    WholeReduceSum(tensorShareTmpFp32[i * 8], tensorQInFp32[i * K],
+                                   FP32_PER_REPEAT, wholeReduceSumCnt, 1, 1, 8);
+                }
+                PipeBarrier<PIPE_V>();
+                WholeReduceSum(tensorDgOut, tensorShareTmpFp32, wholeReduceSumCnt, actual_chunk_len, 1, 1, 1);
+
+                //累加tensorDgIn += + tensorDgOut
+                if constexpr (std::is_same<GType, float>::value) {
+                    DataCopy(tensorDgAdd, tensorDgIn, real_BT);
+                } else {
+                    Cast(tensorDgAdd, tensorDgIn, RoundMode::CAST_NONE, real_BT);
+                }
+
+                PipeBarrier<PIPE_V>();
+                Add(tensorDgOut, tensorDgAdd, tensorDgOut, real_BT);
+
+                PipeBarrier<PIPE_V>();
+
+                if constexpr (!std::is_same<GType, float>::value) {
+                    Cast(tensorDgOut.template ReinterpretCast<GType>(), tensorDgOut, RoundMode::CAST_RINT, gSize);
+                }
+
+                Cast(tensorDqOut, tensorDqInFp32, RoundMode::CAST_RINT, dqSize_sub);
+
+                inQue1.FreeTensor(tensorDqInFp16);
+                inQue2.FreeTensor(tensorQInFp16);
+                inQue3.FreeTensor(tensorGIn);
+                inQue4.FreeTensor(tensorDgIn);
+                outQue1.EnQue(tensorDqOut);
+                outQue2.EnQue(tensorDgOut);
+            }
+            // CopyOut: dq to final output, dg accumulate
+            {
+                auto tensorDqOut = outQue1.DeQue<DataType>();
+                auto tensorDgOut = outQue2.DeQue<GType>();
+
+                DataCopy(gmDq[qkOffset + dqSize_sub_offset], tensorDqOut, dqSize_sub);
+
+                // 累加到 dg (读取现有值, 加上新值, 写回)
+                // 简化: 直接累加 (需要在 Part 5 中处理最终值)
+                // dg 写入最终输出
+                DataCopyParams dataCopyParams;
+                dataCopyParams.blockCount = 1;
+                dataCopyParams.blockLen = BT_sub * sizeof(GType);
+                dataCopyParams.srcStride = 0;
+                dataCopyParams.dstStride = 0;
+                DataCopyPad(gmDg[gOffset + BT_sub_start], tensorDgOut,dataCopyParams);
+
+                outQue1.FreeTensor(tensorDqOut);
+                outQue2.FreeTensor(tensorDgOut);
+            }
+            
+            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+        }
+    }
+}
+
+
+// ============== Part 5: dk 处理和 dg 最终计算 ==============
+template <typename DataType, typename GType>
+__aicore__ inline void ChunkBwdDqkwgVectorProcessLegacy<DataType, GType>::ProcessPart5() {
+    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+    uint32_t coreNum = GetBlockNum();
+    uint32_t coreLoops = B * numChunks;
+    
+    uint32_t dkSize = BT * K;
+    uint32_t gSize = BT;
+    uint32_t real_BT = BT;
+    
+    // 初始化 buffers
+    pipe->InitBuffer(inQue1, BUFFER_NUM, dkSize * sizeof(float));
+    pipe->InitBuffer(inQue2, BUFFER_NUM, dkSize * sizeof(float));
+    pipe->InitBuffer(inQue3, BUFFER_NUM, gSize * sizeof(GType));
+    pipe->InitBuffer(inQue4, BUFFER_NUM, gSize * sizeof(GType));
+    // pipe->InitBuffer(inQue5, BUFFER_NUM, 16 * sizeof(float));    // add4中间结果及广播结果
+    // pipe->InitBuffer(inQue6, BUFFER_NUM, 16 * sizeof(float));    // part5 gLast中间结果
+    pipe->InitBuffer(outQue1, BUFFER_NUM, dkSize * sizeof(DataType));
+    pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(GType));
+
+    pipe->InitBuffer(calcBuf1, gSize * 8 * sizeof(float));  //gLast
+    pipe->InitBuffer(calcBuf2, gSize * 8 * sizeof(float));  //dgLast
+    pipe->InitBuffer(calcBuf4, gSize * sizeof(float));
+    pipe->InitBuffer(gBuf, gSize * sizeof(float));
+    pipe->InitBuffer(dgBuf, gSize * 8 * sizeof(float));
+
+    auto tensorGFp32 = gBuf.Get<float>();
+    auto tensorDgFinal = dgBuf.Get<float>();
+    auto tensorGLastFp32Tmp = calcBuf1.Get<float>();
+    auto tensorDgLastFp32Tmp = calcBuf2.Get<float>();
+    auto tensorDgTmp = calcBuf4.Get<float>();
+    uint32_t bos = 0;
+    uint32_t eos = 0;
+    uint32_t vecTaskIdx = 0;
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T, BT, loopIdx, bos, eos);
+        uint32_t actual_chunk_len = eos - bos;
+        real_BT = actual_chunk_len;
+        dkSize = actual_chunk_len * K;
+        uint32_t real_BT_aligned = (real_BT + 15) / 16 * 16;
+        uint32_t bIdx = loopIdx / numChunks;
+        uint32_t chunkIdx = loopIdx % numChunks;
+        
+        for (uint32_t h = 0; h < H; h++) {
+            ++vecTaskIdx;
+            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
+                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+                continue;
+            }
+            uint64_t kOffset = (h * T + bos) * K;
+            uint64_t gOffset = (h * T + bos);
+            uint64_t dgLastOffset = (bIdx * H + h) * numChunks + chunkIdx;
+            
+            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+
+            // CopyIn
+            {
+                auto tensorDkIn = inQue1.AllocTensor<DataType>();
+                auto tensorKIn = inQue2.AllocTensor<DataType>();
+                auto tensorGIn = inQue3.AllocTensor<GType>();
+                auto tensorDgIn = inQue4.AllocTensor<GType>();
+                // auto tensorDgLastIn = inQue5.AllocTensor<float>();
+                // auto tensorGLastIn = inQue6.AllocTensor<GType>();
+                
+                DataCopy(tensorDkIn[dkSize], gmDk[kOffset], dkSize);
+                DataCopy(tensorKIn[dkSize], gmK[kOffset], dkSize);
+
+                DataCopyParams dataCopyParams;
+                dataCopyParams.blockCount = 1;
+                dataCopyParams.blockLen = actual_chunk_len*sizeof(GType);
+                dataCopyParams.srcStride = 0;
+                dataCopyParams.dstStride = 0;
+                DataCopyPad(tensorGIn, gmG[gOffset],dataCopyParams,{false, 0, 0, 0});
+                DataCopyPad(tensorDgIn, gmDg[gOffset],dataCopyParams,{false, 0, 0, 0});
+
+                inQue1.EnQue(tensorDkIn);
+                inQue2.EnQue(tensorKIn);
+                inQue3.EnQue(tensorGIn);
+                inQue4.EnQue(tensorDgIn);
+                // inQue5.EnQue(tensorDgLastIn);
+                // inQue6.EnQue(tensorGLastIn);
+            }
+            
+            // Compute
+            {
+                auto tensorDkIn = inQue1.DeQue<DataType>();
+                auto tensorDkFp32 = tensorDkIn.template ReinterpretCast<float>();
+                auto tensorKIn = inQue2.DeQue<DataType>();
+                auto tensorKFp32 = tensorKIn.template ReinterpretCast<float>();
+                auto tensorGIn = inQue3.DeQue<GType>();
+                auto tensorDgIn = inQue4.DeQue<GType>();
+                // auto tensorDgLastFp32 = inQue5.DeQue<float>();
+                // auto tensorGLast = inQue6.DeQue<GType>();
+                // auto tensorGLastFp32 = tensorGLast.template ReinterpretCast<float>();
+                auto tensorDkOut = outQue1.AllocTensor<DataType>();
+                auto tensorDgOut = outQue2.AllocTensor<GType>();
+
+                // Cast
+                Cast(tensorDkFp32, tensorDkIn[dkSize], RoundMode::CAST_NONE, dkSize);
+
+                Cast(tensorKFp32, tensorKIn[dkSize], RoundMode::CAST_NONE, dkSize);
+                PipeBarrier<PIPE_V>();
+
+                if constexpr (std::is_same<GType, float>::value) {
+                    DataCopy(tensorGFp32, tensorGIn, BT);
+                    DataCopy(tensorDgTmp, tensorDgIn, BT);
+                } else {
+                    Cast(tensorGFp32, tensorGIn, RoundMode::CAST_NONE, real_BT_aligned);
+                    // Cast(tensorGLastFp32, tensorGLast, RoundMode::CAST_NONE, 1);
+                    Cast(tensorDgTmp, tensorDgIn, RoundMode::CAST_NONE, real_BT_aligned);
+                }
+                PipeBarrier<PIPE_V>();
+
+                // uint32_t lastIdx = actual_chunk_len - 1;
+                //MUL2
+                uint32_t last_line_no = (actual_chunk_len - 1) / 8 * 8; // 最后一行的行号
+                uint32_t last_line_idx = actual_chunk_len - 1 - last_line_no;
+                Brcb(tensorDgFinal, tensorGFp32[last_line_no], 1, {1, 8}); // [8,8] 只有第last_line_idx行有效 = gLast
+                PipeBarrier<PIPE_V>();
+                Muls(tensorGFp32, tensorGFp32, -1.0f, real_BT_aligned);
+                DataCopy(tensorGLastFp32Tmp, tensorDgFinal[last_line_idx * 8], 8); // tensorDgFinal暂存dg值，后续计算dgLast
+
+                PipeBarrier<PIPE_V>();
+
+                AscendC::Add(tensorGFp32, tensorGFp32, tensorDgFinal[last_line_idx * 8], CAL_NUM_FLOAT, BT / CAL_NUM_FLOAT, {1, 1, 0, 8, 8, 0});
+                PipeBarrier<PIPE_V>();
+
+                Exp(tensorGFp32, tensorGFp32, real_BT_aligned);
+                PipeBarrier<PIPE_V>();
+
+                // dgLast:使用tensorDgLast[0]替代
+                // tensorDkFp32:        tensorDgFinal:gsize * 8 * float
+                Brcb(tensorDgFinal, tensorGFp32, CEIL_DIV(real_BT, 8), {1, 8}); // Brcb处理数据个数需要8对齐 [BT,8]
+                PipeBarrier<PIPE_V>();
+                AscendC::Mul(tensorDkFp32, tensorDkFp32, tensorDgFinal, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+
+                AscendC::Mul(tensorDkFp32[CAL_NUM_FLOAT], tensorDkFp32[CAL_NUM_FLOAT], tensorDgFinal, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+                PipeBarrier<PIPE_V>();
+
+                Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);      //dk -> fp16 tensorDkFp32
+
+                Mul(tensorKFp32, tensorKFp32, tensorDkFp32, dkSize);    // mul8 = dk * k
+                PipeBarrier<PIPE_V>();
+
+                // Add0.B = (dk_temp * k).reduceSum(axis=1)
+                // axis=1: 对每行求和 -> [BT] +Add0.B
+
+                // reducesum
+                uint64_t wholeReduceSumCnt = CeilDiv(K, FP32_PER_REPEAT);
+                for (uint32_t i = 0; i < actual_chunk_len; i++) {
+                    WholeReduceSum(tensorDgFinal[i * 8], tensorKFp32[i * K],
+                                   FP32_PER_REPEAT, wholeReduceSumCnt, 1, 1, 8);
+                }
+                PipeBarrier<PIPE_V>();
+                WholeReduceSum(tensorGFp32, tensorDgFinal, wholeReduceSumCnt, actual_chunk_len, 1, 1, 1);
+
+                // float totalSum = 0.0f;
+                PipeBarrier<PIPE_V>();
+
+                //Sum0: [actual_chunk_len] -> [1]
+                uint64_t sum0SumCnt = CeilDiv(actual_chunk_len, FP32_PER_REPEAT);
+                uint32_t remainCnt = actual_chunk_len % FP32_PER_REPEAT;
+                if(remainCnt > 0) {
+                    uint32_t DuplicateOffset = sum0SumCnt * FP32_PER_REPEAT - FP32_PER_REPEAT;
+                    uint64_t mask[1] = {0xffffffffffffffff};
+                    mask[0] <<= remainCnt;
+
+                    Duplicate(tensorGFp32[(sum0SumCnt-1)*FP32_PER_REPEAT], 0.0f, mask, 1, 1, 8);
+
+                    PipeBarrier<PIPE_V>();
+                }
+                WholeReduceSum(tensorDkFp32, tensorGFp32, FP32_PER_REPEAT, sum0SumCnt, 1, 1, 8);
+                // PipeBarrier<PIPE_ALL>();
+                PipeBarrier<PIPE_V>();
+                WholeReduceSum(tensorDgFinal, tensorDkFp32, sum0SumCnt, 1, 1, 1, 8);
+
+                // tensorGLastFp32[0]已经是最后一个位置的 g 值
+                float dgLast = gmDgLast.GetValue(dgLastOffset); // tensorDgTmp暂存dg值，获取最后一个位置的dgLast
+                Duplicate(tensorDgLastFp32Tmp, dgLast, 8); // 广播 dgLast
+                Exp(tensorGLastFp32Tmp, tensorGLastFp32Tmp, 8);
+                PipeBarrier<PIPE_V>();
+                Mul(tensorDgLastFp32Tmp, tensorDgLastFp32Tmp, tensorGLastFp32Tmp, 8);
+                PipeBarrier<PIPE_V>();
+                Add(tensorDgLastFp32Tmp, tensorDgLastFp32Tmp, tensorDgFinal, 8);  //add4 = tensorDgLastFp32Tmp[0]
+
+
+                Sub(tensorGFp32, tensorDgTmp, tensorGFp32, BT); //Add.0 最终结果
+
+                PipeBarrier<PIPE_V>();
+                Brcb(tensorDgFinal, tensorDgLastFp32Tmp, 1, {1, 8}); // [8,8] 只有第一行有效
+                PipeBarrier<PIPE_V>();
+                uint64_t offset = (real_BT - 1) / 8 * 8; // 每行8个float
+                uint64_t mask[1] = {0};
+                mask[0] = 1ULL << (real_BT - 1 - offset); // 计算掩码，只有最后一个位置有效
+
+                Add(tensorGFp32[offset], tensorGFp32[offset], tensorDgFinal, mask, 1, {1,1,1,8,8,8});
+
+                PipeBarrier<PIPE_V>();
+                if constexpr (std::is_same<GType, float>::value) {
+                    DataCopy(tensorDgOut, tensorGFp32, BT);
+                } else {
+                    Cast(tensorDgOut, tensorGFp32, RoundMode::CAST_RINT, BT);
+                }
+                PipeBarrier<PIPE_V>();
+
+
+                // 处理最后一个位置的 dg
+                // b_dg_last *= exp(g_last)
+                // is_last_mask: 只有最后一个位置添加 dgLastTerm
+
+                // 读取之前 Part 3/4 计算的 dg, 累加
+                // (简化处理, 实际应该从 GM 读取并累加)
+
+                inQue1.FreeTensor(tensorDkIn);
+                inQue2.FreeTensor(tensorKIn);
+                inQue3.FreeTensor(tensorGIn);
+                inQue4.FreeTensor(tensorDgIn);
+                // inQue5.FreeTensor(tensorDgLastFp32);
+                // inQue6.FreeTensor(tensorGLast);
+                outQue1.EnQue(tensorDkOut);
+                outQue2.EnQue(tensorDgOut);
+            }
+            
+            // CopyOut
+            {
+                auto tensorDkOut = outQue1.DeQue<DataType>();
+                auto tensorDgOut = outQue2.DeQue<GType>();
+
+                DataCopy(gmDk[kOffset], tensorDkOut, dkSize);
+
+                // dg 需要与之前的累加
+                // 累加到 dg (读取现有值, 加上新值, 写回)
+                // 简化: 直接累加 (需要在 Part 5 中处理最终值)
+                // dg 写入最终输出
+                DataCopyParams dataCopyParams;
+                dataCopyParams.blockCount = 1;
+                dataCopyParams.blockLen = real_BT * sizeof(GType);
+                dataCopyParams.srcStride = 0;
+                dataCopyParams.dstStride = 0;
+                DataCopyPad(gmDg[gOffset], tensorDgOut, dataCopyParams);
+                outQue1.FreeTensor(tensorDkOut);
+                outQue2.FreeTensor(tensorDgOut);
+            }
+
+            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+        }
+    }
+}
+
+
+// ============== Part 6: dq 累加 ==============
+template <typename DataType, typename GType>
+__aicore__ inline void ChunkBwdDqkwgVectorProcessLegacy<DataType, GType>::ProcessPart6() {
+    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+    uint32_t coreNum = GetBlockNum();
+    uint32_t coreLoops = B * numChunks;
+    
+    uint32_t dqSize = BT * K;
+    
+    // 初始化 buffers
+    pipe->InitBuffer(inQue1, BUFFER_NUM, dqSize * sizeof(float));    // dq current
+    pipe->InitBuffer(inQue2, BUFFER_NUM, dqSize * sizeof(float));    // mm6 from Cube
+    pipe->InitBuffer(outQue1, BUFFER_NUM, dqSize * sizeof(DataType));
+
+    uint32_t bos = 0;
+    uint32_t eos = 0;
+    uint32_t vecTaskIdx = 0;
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+
+    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T,
+                        BT, loopIdx, bos, eos);
+        uint32_t actual_chunk_len = eos - bos;
+        dqSize = actual_chunk_len * K;
+        uint32_t bIdx = loopIdx / numChunks;
+        uint32_t chunkIdx = loopIdx % numChunks;
+        
+        for (uint32_t h = 0; h < H; h++) {
+            // if (GetSubBlockIdx() == 1) {
+            //     CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+            //     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+            //     continue;
+            // }
+            ++vecTaskIdx;
+            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
+                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+                continue;
+            }
+            uint64_t dqOffset = (h * T + bos) * K;
+            
+            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+            
+            // Part 6 的 Vector 工作是将 Cube 计算的 mm6 累加到 dq
+            // CopyIn
+            {
+                auto tensorDqIn = inQue1.AllocTensor<DataType>();
+                auto tensorMM6In = inQue2.AllocTensor<DataType>();
+                
+                DataCopy(tensorDqIn[dqSize], gmDq[dqOffset], dqSize);
+                DataCopy(tensorMM6In[dqSize], gmMm6[dqOffset], dqSize);
+
+                inQue1.EnQue(tensorDqIn);
+                inQue2.EnQue(tensorMM6In);
+            }
+
+            //Compute
+            {
+                auto tensorDqIn = inQue1.DeQue<DataType>();
+                auto tensorDqFp32 = tensorDqIn.template ReinterpretCast<float>();
+                auto tensorMM6In = inQue2.DeQue<DataType>();
+                auto tensorMM6Fp32 = tensorMM6In.template ReinterpretCast<float>();
+                auto tensorDqOut = outQue1.AllocTensor<DataType>();
+                // Cast
+
+                Cast(tensorDqFp32, tensorDqIn[dqSize], RoundMode::CAST_NONE, dqSize);
+                // PipeBarrier<PIPE_V>();
+                Cast(tensorMM6Fp32, tensorMM6In[dqSize], RoundMode::CAST_NONE, dqSize);
+                PipeBarrier<PIPE_V>();
+
+                Add(tensorDqFp32, tensorDqFp32, tensorMM6Fp32, dqSize);
+
+                PipeBarrier<PIPE_V>();
+                Cast(tensorDqOut, tensorDqFp32, RoundMode::CAST_RINT, dqSize);
+
+                PipeBarrier<PIPE_V>();
+                inQue1.FreeTensor(tensorDqIn);
+                inQue2.FreeTensor(tensorMM6In);
+                outQue1.EnQue<DataType>(tensorDqOut);
+            }
+
+            //CopyOut
+            {
+                auto tensorDqOut = outQue1.DeQue<DataType>();
+                DataCopy(gmDq[dqOffset], tensorDqOut, dqSize);
+                outQue1.FreeTensor(tensorDqOut);
+            }
+            
+            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+        }
+    }
+}
+
+// ============== Part 7: dk 累加 ==============
+template <typename DataType, typename GType>
+__aicore__ inline void ChunkBwdDqkwgVectorProcessLegacy<DataType, GType>::ProcessPart7() {
+    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+    uint32_t coreNum = GetBlockNum();
+    uint32_t coreLoops = B * numChunks;
+    
+    uint32_t dkSize = BT * K;
+    
+    // 初始化 buffers
+    pipe->InitBuffer(inQue1, BUFFER_NUM, dkSize * sizeof(float));    // dk current
+    pipe->InitBuffer(inQue2, BUFFER_NUM, dkSize * sizeof(float));    // mm6 from Cube
+    pipe->InitBuffer(outQue1, BUFFER_NUM, dkSize * sizeof(DataType));
+
+    uint32_t bos = 0;
+    uint32_t eos = 0;
+    uint32_t vecTaskIdx = 0;
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+
+    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, H, T,
+                        BT, loopIdx, bos, eos);
+        uint32_t actual_chunk_len = eos - bos;
+        dkSize = actual_chunk_len * K;
+        uint32_t bIdx = loopIdx / numChunks;
+        uint32_t chunkIdx = loopIdx % numChunks;
+        
+        for (uint32_t h = 0; h < H; h++) {
+            // if (GetSubBlockIdx() == 1) {
+            //     CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+            //     CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+            //     continue;
+            // }
+            ++vecTaskIdx;
+            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
+                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+                continue;
+            }
+            uint64_t dkOffset = (h * T + bos) * K;
+            
+            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+            
+            // Part 7 的 Vector 工作是将 Cube 计算的 mm7 累加到 dk
+            // CopyIn
+            {
+                auto tensorDkIn = inQue1.AllocTensor<DataType>();
+                auto tensorMm7In = inQue2.AllocTensor<DataType>();
+                
+                DataCopy(tensorDkIn[dkSize], gmDk[dkOffset], dkSize);
+                DataCopy(tensorMm7In[dkSize], gmMm7[dkOffset], dkSize);
+
+                inQue1.EnQue(tensorDkIn);
+                inQue2.EnQue(tensorMm7In);
+            }
+
+            //Compute
+            {
+                auto tensorDkIn = inQue1.DeQue<DataType>();
+                auto tensorDkFp32 = tensorDkIn.template ReinterpretCast<float>();
+                auto tensorMm7In = inQue2.DeQue<DataType>();
+                auto tensorMm7Fp32 = tensorMm7In.template ReinterpretCast<float>();
+                auto tensorDkOut = outQue1.AllocTensor<DataType>();
+
+                // Cast
+                Cast(tensorDkFp32, tensorDkIn[dkSize], RoundMode::CAST_NONE, dkSize);
+                // PipeBarrier<PIPE_V>();
+                Cast(tensorMm7Fp32, tensorMm7In[dkSize], RoundMode::CAST_NONE, dkSize);
+                PipeBarrier<PIPE_V>();
+                Add(tensorDkFp32, tensorDkFp32, tensorMm7Fp32, dkSize);
+                PipeBarrier<PIPE_V>();
+                Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);
+
+                PipeBarrier<PIPE_V>();
+                inQue1.FreeTensor(tensorDkIn);
+                inQue2.FreeTensor(tensorMm7In);
+                outQue1.EnQue<DataType>(tensorDkOut);
+            }
+
+            //CopyOut
+            {
+                auto tensorDkOut = outQue1.DeQue<DataType>();
+                DataCopy(gmDk[dkOffset], tensorDkOut, dkSize);
+
+                outQue1.FreeTensor(tensorDkOut);
+            }
+
+            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+        }
+    }
+}
+
+#endif  // CHUNK_BWD_DQKWG_VECTOR_LEGACY_H


### PR DESCRIPTION
## 关联 Issue / 背景

- 关联 Issue: 无
- 背景与目标: 将 GitCode Zhang_E/old_dqkwg 分支中针对 chunk_bwd_dqkwg 的优化补丁 cherry-pick 到 GitHub main 分支。
- 本 PR 解决的问题: 优化 chunk_bwd_dqkwg 算子的 kernel 实现与 tiling/workspace 相关逻辑。

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [x] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: chunk_bwd_dqkwg
- 涉及目录 / 文件:
  - fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
  - fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.h
  - fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg.cpp
  - fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_common.h
  - fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
  - fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
- 责任人 / 提交人: @liufujiang123
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 沿用 chunk_bwd_dqkwg 现有支持范围，本 PR 不新增接口参数。
- 明确不包含的范围: 不包含新增算子、不包含 torch_custom 接口变更、不包含文档大规模调整。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:

## 修改算子测试

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `bash build.sh -u --ops=chunk_bwd_dqkwg --soc=ascend910b` | 未执行 | 本地未执行，待 CI 或对应环境补充 |
| A3 | `ascend910_93` | `bash build.sh -u --ops=chunk_bwd_dqkwg --soc=ascend910_93` | 已执行 |  |
| A5 | `ascend950` | `bash build.sh -u --ops=chunk_bwd_dqkwg --soc=ascend950` | 未执行 | 本地未执行，待 CI 或对应环境补充 |

- 精度对比: 待 CI / 目标 NPU 环境补充
- 性能对比: 本 PR 为性能优化补丁，具体性能数据待目标环境补充
- 边界 / 异常场景: 待补充
- 未覆盖风险: 本地未完成 A2 / A3 / A5 编译与测试验证，需 CI 或目标机器确认

## 整体 Example ST 验证

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python examples/flash_gated_delta_rule.py` | 未执行 | 本地未执行，待 CI 或对应环境补充 |
| A3 | `ascend910_93` | `python examples/flash_gated_delta_rule.py` | 未执行 | 本地未执行，待 CI 或对应环境补充 |
| A5 | `ascend950` | `python examples/flash_gated_delta_rule.py` | 未执行 | 本地未执行，待 CI 或对应环境补充 |

- 端到端场景说明: GDN 端到端调用链验证
- 与本 PR 修改算子的关联: 本 PR 修改 chunk_bwd_dqkwg，属于 GDN backward 链路
- 未覆盖原因及补充计划: 当前本地未执行，待目标 NPU 环境或 CI 补充验证

## 兼容性、风险与回退

- 兼容性说明: 不修改 aclnn 接口和 torch_custom 适配，理论上不影响外部调用方式。
- 风险点: 涉及 chunk_bwd_dqkwg kernel 与 tiling 逻辑，可能影响特定 shape / dtype / soc 下的性能或正确性。
- 回退方案: 回退本 PR 中 cherry-pick 的 3 个 commit。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

本 PR cherry-pick 自 GitCode Zhang_E/old_dqkwg 分支，包含以下补丁：

- 取消乒乓+深融合+阶段合并
- 处理冲突
- fix additional workspace