### PR TITLE
add da A5 && full rebase performace optimize

### DIFF
--- a/fla/ops/ascendc/common/kernel_utils/vector/regbase.hpp
+++ b/fla/ops/ascendc/common/kernel_utils/vector/regbase.hpp
@@ -1,0 +1,145 @@
+
+using namespace AscendC::MicroAPI;
+
+constexpr static CastTrait ctHalf2Fp32Zero = {
+    RegLayout::ZERO,
+    SatMode::SAT,
+    MaskMergeMode::ZEROING,
+    AscendC::RoundMode::CAST_NONE,
+};
+constexpr static CastTrait ctHalf2Fp32One = {
+    RegLayout::ONE,
+    SatMode::SAT,
+    MaskMergeMode::ZEROING,
+    AscendC::RoundMode::CAST_NONE,
+};
+constexpr static CastTrait ctFp322HalfZero = {
+    RegLayout::ZERO,
+    SatMode::NO_SAT,
+    MaskMergeMode::MERGING,
+    AscendC::RoundMode::CAST_ROUND
+};
+constexpr static CastTrait ctFp322HalfOne = {
+    RegLayout::ONE,
+    SatMode::NO_SAT,
+    MaskMergeMode::ZEROING,
+    AscendC::RoundMode::CAST_ROUND
+};
+
+constexpr uint16_t PRELOAD_NUM = 2;
+
+template <typename TType, bool BroatCast = false>
+__simd_callee__ inline void LoadIn(RegTensor<TType>& dstReg, __ubuf__ TType* srcUb)
+{
+    if constexpr (BroatCast) {
+        if constexpr (!std::is_same<TType, float>()) {
+            LoadAlign<TType, LoadDist::DIST_BRC_B16>(dstReg, srcUb);
+        } else {
+            LoadAlign<TType, LoadDist::DIST_BRC_B32>(dstReg, srcUb);
+        }
+    } else {
+        LoadAlign<TType, LoadDist::DIST_NORM>(dstReg, srcUb);
+    }
+}
+
+template <typename TType>
+__simd_callee__ inline void CastHalf2Float(RegTensor<float>& dstZeroReg, RegTensor<float>& dstOneReg, RegTensor<TType>& srcReg, MaskReg& mask)
+{
+    Cast<float, TType, ctHalf2Fp32Zero>(dstZeroReg, srcReg, mask);
+    Cast<float, TType, ctHalf2Fp32One>(dstOneReg, srcReg, mask);
+}
+
+template <typename TType>
+__simd_callee__ inline void CastFloat2Half(RegTensor<TType>& dstReg, RegTensor<float>& srcZeroReg, RegTensor<float>& srcOneReg, MaskReg& mask)
+{
+    Cast<TType, float, ctFp322HalfOne>(dstReg, srcOneReg, mask);
+    Cast<TType, float, ctFp322HalfZero>(dstReg, srcZeroReg, mask);
+}
+
+template <typename TType>
+__simd_callee__ inline void HalfOrFloat2Float(RegTensor<float>& dstReg, RegTensor<TType>& srcReg, MaskReg& maskHalf, MaskReg& maskFloat)
+{
+    if constexpr (!std::is_same<TType, float>()) {
+        Cast<float, TType, ctHalf2Fp32Zero>(dstReg, srcReg, maskHalf);
+    } else {
+        Duplicate(dstReg, srcReg, maskFloat);
+    }
+}
+
+__simd_callee__ inline void MulFloatTwoReg(RegTensor<float>& dstZeroReg, RegTensor<float>& dstOneReg,
+                                           RegTensor<float>& src1ZeroReg, RegTensor<float>& src1OneReg,
+                                           RegTensor<float>& src2ZeroReg, RegTensor<float>& src2OneReg,
+                                           MaskReg& maskFloat)
+{
+    Mul(dstZeroReg, src1ZeroReg, src2ZeroReg, maskFloat);
+    Mul(dstOneReg, src1OneReg, src2OneReg, maskFloat);
+}
+
+__simd_callee__ inline void MinsFloatTwoReg(RegTensor<float>& dstZeroReg, RegTensor<float>& dstOneReg,
+                                           RegTensor<float>& srcZeroReg, RegTensor<float>& srcOneReg,
+                                           float scalarValue,
+                                           MaskReg& maskFloat)
+{
+    Mins(dstZeroReg, srcZeroReg, scalarValue, maskFloat);
+    Mins(dstOneReg, srcOneReg, scalarValue, maskFloat);
+}
+
+__simd_callee__ inline void ExpFloatTwoReg(RegTensor<float>& dstZeroReg, RegTensor<float>& dstOneReg,
+                                           RegTensor<float>& srcZeroReg, RegTensor<float>& srcOneReg,
+                                           MaskReg& maskFloat)
+{
+    Exp(dstZeroReg, srcZeroReg, maskFloat);
+    Exp(dstOneReg, srcOneReg, maskFloat);
+}
+
+__simd_callee__ inline void SubFloatTwoReg(RegTensor<float>& dstZeroReg, RegTensor<float>& dstOneReg,
+                                           RegTensor<float>& src1ZeroReg, RegTensor<float>& src1OneReg,
+                                           RegTensor<float>& src2ZeroReg, RegTensor<float>& src2OneReg,
+                                           MaskReg& maskFloat)
+{
+    Sub(dstZeroReg, src1ZeroReg, src2ZeroReg, maskFloat);
+    Sub(dstOneReg, src1OneReg, src2OneReg, maskFloat);
+}
+
+__simd_callee__ inline void AddFloatTwoReg(RegTensor<float>& dstZeroReg, RegTensor<float>& dstOneReg,
+                                           RegTensor<float>& src1ZeroReg, RegTensor<float>& src1OneReg,
+                                           RegTensor<float>& src2ZeroReg, RegTensor<float>& src2OneReg,
+                                           MaskReg& maskFloat)
+{
+    Add(dstZeroReg, src1ZeroReg, src2ZeroReg, maskFloat);
+    Add(dstOneReg, src1OneReg, src2OneReg, maskFloat);
+}
+
+template <typename TType = float, AscendC::CMPMODE mode = AscendC::CMPMODE::EQ>
+__simd_callee__ inline void CompareTwoReg(MaskReg& maskZeroReg, MaskReg& maskOneReg,
+                                           RegTensor<TType>& cmp1ZeroReg, RegTensor<TType>& cmp1OneReg,
+                                           RegTensor<TType>& cmp2ZeroReg, RegTensor<TType>& cmp2OneReg,
+                                           MaskReg& mask)
+{
+    Compare<TType, mode>(maskZeroReg, cmp1ZeroReg, cmp2ZeroReg, mask);
+    Compare<TType, mode>(maskOneReg, cmp1OneReg, cmp2OneReg, mask);
+}
+
+template <typename TType = float>
+__simd_callee__ inline void SelectTwoReg(RegTensor<TType>& dstZeroReg, RegTensor<TType>& dstOneReg,
+                                           RegTensor<TType>& src1ZeroReg, RegTensor<TType>& src1OneReg,
+                                           RegTensor<TType>& src2ZeroReg, RegTensor<TType>& src2OneReg,
+                                           MaskReg& mask1, MaskReg& mask2)
+{
+    Select<TType>(dstZeroReg, src1ZeroReg, src2ZeroReg, mask1);
+    Select<TType>(dstOneReg, src1OneReg, src2OneReg, mask2);
+}
+
+template <typename TType>
+__simd_callee__ inline void StoreUnAlignOut(__ubuf__ TType* dstUb, RegTensor<float>& srcReg, MaskReg& mask, UnalignRegForStore& uStore, uint32_t copyNum)
+{
+    RegTensor<TType> outZeroReg;
+    if constexpr (!std::is_same<TType, float32_t>()) {
+        Cast<TType, float, ctFp322HalfZero>(outZeroReg, srcReg, mask);
+        StoreUnAlign(dstUb, outZeroReg, uStore, copyNum);
+        StoreUnAlignPost(dstUb, uStore, 0);
+    } else {
+        StoreUnAlign(dstUb, srcReg, uStore, copyNum);
+        StoreUnAlignPost(dstUb, uStore, 0);
+    }
+}

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_host/op_tiling/arch35/prepare_wy_repr_bwd_da_tiling_a5.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_host/op_tiling/arch35/prepare_wy_repr_bwd_da_tiling_a5.cpp
@@ -1,0 +1,340 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file prepare_wy_repr_bwd_da_tiling_a5.cpp
+ * \brief
+ */
+
+#include "prepare_wy_repr_bwd_da_tiling_a5.h"
+#include <register/op_impl_registry.h>
+#include "tiling_base/data_copy_transpose_tiling.h"
+#include "tiling_base/tiling_templates_registry.h"
+
+namespace optiling {
+
+bool PrepareWyReprBwdDaTilingA5::SetTiling(gert::TilingContext *context)
+{
+    context_ = context;
+    CommonTiling();
+    auto cuSeqlensTensor = context->GetOptionalInputTensor(INPUT_SEQLENS_IDX);
+    if (cuSeqlensTensor == nullptr) {
+        OP_CHECK_IF(FixLenTiling() != ge::GRAPH_SUCCESS, , return false);
+        tiling_.isVariable = 0;
+    } else {
+        OP_CHECK_IF(tiling_.B != VAR_LEN_B_DIM_1,
+                    OP_LOGE(context->GetNodeName(),
+                            "If cu_seqlens is not nullptr, the dim 0 of q needs to be 1, but now is %ld.",
+                            tiling_.B),
+                    return false);
+        auto chunkIndicesTensor = context->GetOptionalInputTensor(INPUT_CHUNK_INDICES_IDX);
+        OP_CHECK_NULL_WITH_CONTEXT(context, chunkIndicesTensor);
+        OP_CHECK_IF(VariableLenTiling() != ge::GRAPH_SUCCESS, , return false);
+        tiling_.isVariable = 1;
+    }
+    context->SetTilingKey(1);
+    OP_LOGD(context->GetNodeName(), "tilingKey: %d", context->GetTilingKey());
+    PrepareWyReprBwdDaTilingDataPrint();
+
+    OP_CHECK_IF(context_->GetRawTilingData() == nullptr, OP_LOGE(context_->GetNodeName(), "RawTilingData is nullptr."),
+                return false);
+    errno_t ret = memcpy_s(context_->GetRawTilingData()->GetData(), context_->GetRawTilingData()->GetCapacity(),
+                           reinterpret_cast<void *>(&tiling_), sizeof(tiling_));
+    if (ret != EOK) {
+        OP_LOGE(context_->GetNodeName(), "memcpy_s failed, ret=%d", ret);
+        return false;
+    }
+    context_->GetRawTilingData()->SetDataSize(sizeof(tiling_));
+
+    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
+    context->SetBlockDim(ascendcPlatform.GetCoreNumAic());
+
+    auto sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
+    OP_LOGD(context->GetNodeName(), "=== sysWorkspaceSize: %ld", sysWorkspaceSize);
+    int64_t maxKV = std::max(tiling_.K, tiling_.V);
+    size_t userWorkspaceSize = 2 * tiling_.B * tiling_.H * tiling_.T * (tiling_.chunkSize + maxKV);
+    OP_LOGD(context->GetNodeName(), "=== userWorkspaceSize: %ld", userWorkspaceSize);
+    size_t *currentWorkspace = context->GetWorkspaceSizes(1);
+    currentWorkspace[0] = static_cast<size_t>(sysWorkspaceSize + userWorkspaceSize);
+    OP_LOGD(context->GetNodeName(), "=== currentWorkspace[0]: %ld", currentWorkspace[0]);
+    context->SetScheduleMode(1); // set as batchmod for template using SyncAll
+    OP_LOGD(context->GetNodeName(), "Tiling4PrepareWyReprBwdDa end.");
+    return true;
+}
+
+ge::graphStatus PrepareWyReprBwdDaTilingA5::RequiredInputDimNumCheck(const gert::StorageShape *curShape,
+                                                                     size_t validDimNum, const char *inputName)
+{
+    OP_CHECK_IF(curShape == nullptr,
+                OP_LOGE(context_->GetNodeName(), "Input %s is required, but got nullptr.", inputName),
+                return ge::GRAPH_FAILED);
+    const gert::Shape storageShape = curShape->GetStorageShape();
+    size_t dimNum = storageShape.GetDimNum();
+    OP_CHECK_IF(dimNum != validDimNum,
+                OP_LOGE(context_->GetNodeName(),
+                        "Check input %s shape failed, the dim num should be %zu, but get %zu.", inputName, validDimNum,
+                        dimNum),
+                return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus PrepareWyReprBwdDaTilingA5::CompareShape(const gert::Shape &shape1, const gert::Shape &shape2,
+                                                         const char *inputName1, const char *inputName2,
+                                                         size_t compareDimNum)
+{
+    size_t shapeDim1 = 0;
+    size_t shapeDim2 = 0;
+    for (size_t dimIndex = 0; dimIndex < compareDimNum; dimIndex++) {
+        shapeDim1 = shape1.GetDim(dimIndex);
+        shapeDim2 = shape2.GetDim(dimIndex);
+        OP_CHECK_IF(shapeDim1 != shapeDim2,
+                    OP_LOGE(context_->GetNodeName(),
+                            "Compare input shape of %s and %s failed, the length of dim %zu should be same,but got "
+                            "%zu and %zu.",
+                            inputName1, inputName2, dimIndex, shapeDim1, shapeDim2),
+                    return ge::GRAPH_FAILED);
+    }
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus PrepareWyReprBwdDaTilingA5::SetRowNumKBetaGRegbase(uint64_t ubSize, ge::DataType kType,
+                                                                   ge::DataType betaType)
+{
+    uint64_t rowNum = chunkSize / 2;
+    uint64_t sizeofKType = SIZE_FP32;
+    uint64_t sizeofBetaType = SIZE_FP32;
+    if (kType != ge::DataType::DT_FLOAT) {
+        sizeofKType = SIZE_HALF;
+    }
+    if (betaType != ge::DataType::DT_FLOAT) {
+        sizeofBetaType = SIZE_HALF;
+    }
+    while (rowNum >= 8) {
+        uint64_t useUbSize = 0;
+        useUbSize += 2 * rowNum * K * sizeofKType;
+        useUbSize += 2 * rowNum * sizeofBetaType;
+        useUbSize += 2 * rowNum * K * sizeofBetaType;
+        useUbSize += 2 * rowNum * K * sizeofKType;
+
+        if (useUbSize <= ubSize) {
+            break;
+        }
+        rowNum = rowNum / 2;
+    }
+    tiling_.rowNumKBetaG = rowNum;
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus PrepareWyReprBwdDaTilingA5::SetRowNumVBetaRegbase(uint64_t ubSize, ge::DataType kType,
+                                                                  ge::DataType betaType)
+{
+    uint64_t rowNum = chunkSize / 2;
+    uint64_t sizeofKType = SIZE_FP32;
+    uint64_t sizeofBetaType = SIZE_FP32;
+    if (kType != ge::DataType::DT_FLOAT) {
+        sizeofKType = SIZE_HALF;
+    }
+    if (betaType != ge::DataType::DT_FLOAT) {
+        sizeofBetaType = SIZE_HALF;
+    }
+    while (rowNum >= 8) {
+        uint64_t useUbSize = 0;
+        useUbSize += 2 * rowNum * V * sizeofKType;
+        useUbSize += 2 * rowNum * sizeofBetaType;
+        useUbSize += 2 * rowNum * V * sizeofKType;
+
+        if (useUbSize <= ubSize) {
+            break;
+        }
+        rowNum = rowNum / 2;
+    }
+    tiling_.rowNumVBeta = rowNum;
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus PrepareWyReprBwdDaTilingA5::SetRowNumMDuDwRegbase(uint64_t ubSize, ge::DataType kType,
+                                                                  ge::DataType betaType)
+{
+    uint64_t rowNum = chunkSize / 2;
+    uint64_t sizeofKType = SIZE_FP32;
+    uint64_t sizeofBetaType = SIZE_FP32;
+    if (kType != ge::DataType::DT_FLOAT) {
+        sizeofKType = SIZE_HALF;
+    }
+    if (betaType != ge::DataType::DT_FLOAT) {
+        sizeofBetaType = SIZE_HALF;
+    }
+    while (rowNum >= 8) {
+        uint64_t useUbSize = 0;
+        useUbSize += 2 * rowNum * chunkSize * sizeofKType;
+        useUbSize += 2 * rowNum * chunkSize * sizeofKType;
+        useUbSize += 2 * rowNum * chunkSize * sizeofKType;
+
+        if (useUbSize <= ubSize) {
+            break;
+        }
+        rowNum = rowNum / 2;
+    }
+    tiling_.rowNumMDuDw = rowNum;
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus PrepareWyReprBwdDaTilingA5::SetRowNumGRegbase(uint64_t ubSize, ge::DataType kType,
+                                                              ge::DataType betaType)
+{
+    uint64_t rowNum = chunkSize / 2;
+    uint64_t sizeofKType = SIZE_FP32;
+    uint64_t sizeofBetaType = SIZE_FP32;
+    if (kType != ge::DataType::DT_FLOAT) {
+        sizeofKType = SIZE_HALF;
+    }
+    if (betaType != ge::DataType::DT_FLOAT) {
+        sizeofBetaType = SIZE_HALF;
+    }
+    uint64_t gCVNum = 2;
+    while (rowNum >= 8) {
+        uint64_t useUbSize = 0;
+        useUbSize += 2 * rowNum * sizeofBetaType;
+        useUbSize += 2 * chunkSize * sizeofBetaType;
+        useUbSize += 2 * rowNum * chunkSize * sizeofKType;
+        useUbSize += 2 * rowNum * chunkSize * sizeofKType;
+
+        if (useUbSize <= ubSize) {
+            gCVNum += (ubSize - useUbSize) / (rowNum * chunkSize * sizeofKType);
+            gCVNum = std::min(gCVNum, MAX_CUBE_VEC_SYNC_NUM);
+            break;
+        }
+        rowNum = rowNum / 2;
+    }
+    tiling_.rowNumG = rowNum;
+    tiling_.gCVNum = gCVNum;
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus PrepareWyReprBwdDaTilingA5::CommonTiling()
+{
+    const gert::Shape kStorageShape = context_->GetRequiredInputShape(INPUT_K_IDX)->GetStorageShape();
+    const gert::Shape vStorageShape = context_->GetRequiredInputShape(INPUT_V_IDX)->GetStorageShape();
+    const gert::Shape betaStorageShape = context_->GetRequiredInputShape(INPUT_BETA_IDX)->GetStorageShape();
+    const gert::Shape AStorageShape = context_->GetRequiredInputShape(INPUT_A_IDX)->GetStorageShape();
+    const gert::Shape dwStorageShape = context_->GetRequiredInputShape(INPUT_DW_IDX)->GetStorageShape();
+    const gert::Shape duStorageShape = context_->GetRequiredInputShape(INPUT_DU_IDX)->GetStorageShape();
+    const gert::Shape gStorageShape = context_->GetRequiredInputShape(INPUT_G_IDX)->GetStorageShape();
+    OP_CHECK_IF(CompareShape(vStorageShape, kStorageShape, INPUT_V_NAME, INPUT_K_NAME, DIM_NUM_3) !=
+                    ge::GRAPH_SUCCESS,
+                , return ge::GRAPH_FAILED);
+    OP_CHECK_IF(CompareShape(vStorageShape, duStorageShape, INPUT_V_NAME, INPUT_DU_NAME, DIM_NUM_4) !=
+                    ge::GRAPH_SUCCESS,
+                , return ge::GRAPH_FAILED);
+    OP_CHECK_IF(CompareShape(betaStorageShape, gStorageShape, INPUT_BETA_NAME, INPUT_G_NAME, DIM_NUM_3) !=
+                    ge::GRAPH_SUCCESS,
+                , return ge::GRAPH_FAILED);
+    OP_CHECK_IF(CompareShape(kStorageShape, gStorageShape, INPUT_K_NAME, INPUT_G_NAME, DIM_NUM_3) !=
+                    ge::GRAPH_SUCCESS,
+                , return ge::GRAPH_FAILED);
+    OP_CHECK_IF(CompareShape(dwStorageShape, kStorageShape, INPUT_DW_NAME, INPUT_K_NAME, DIM_NUM_4) !=
+                    ge::GRAPH_SUCCESS,
+                , return ge::GRAPH_FAILED);
+    OP_CHECK_IF(CompareShape(kStorageShape, AStorageShape, INPUT_K_NAME, INPUT_A_NAME, DIM_NUM_3) !=
+                    ge::GRAPH_SUCCESS,
+                , return ge::GRAPH_FAILED);
+    B = static_cast<int64_t>(vStorageShape.GetDim(DIM_0));
+    H = static_cast<int64_t>(vStorageShape.GetDim(DIM_1));
+    T = static_cast<int64_t>(vStorageShape.GetDim(DIM_2));
+    K = static_cast<int64_t>(kStorageShape.GetDim(DIM_3));
+    V = static_cast<int64_t>(vStorageShape.GetDim(DIM_3));
+    tiling_.B = B;
+    tiling_.H = H;
+    tiling_.T = T;
+    tiling_.K = K;
+    tiling_.V = V;
+    auto attrPtr = context_->GetAttrs();
+    OP_CHECK_NULL_WITH_CONTEXT(context_, attrPtr);
+    chunkSize = static_cast<int64_t>(*(attrPtr->GetAttrPointer<int32_t>(ATTR_CHUNK_SIZE_IDX)));
+    OP_CHECK_IF(chunkSize != CHUNK_SIZE_64 && chunkSize != CHUNK_SIZE_128,
+                OP_LOGE(context_->GetNodeName(),
+                        "Check attr chunkSize failed, the chunkSize should be 64 or 128, but get %ld.", chunkSize),
+                return ge::GRAPH_FAILED);
+    tiling_.chunkSize = chunkSize;
+    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context_->GetPlatformInfo());
+    uint64_t ubSize = 0;
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
+
+    auto kDesc = context_->GetDynamicInputDesc(INPUT_K_IDX, 0);
+    OP_CHECK_NULL_WITH_CONTEXT(context_, kDesc);
+    auto kDType = kDesc->GetDataType();
+    auto betaDesc = context_->GetDynamicInputDesc(INPUT_BETA_IDX, 0);
+    OP_CHECK_NULL_WITH_CONTEXT(context_, betaDesc);
+    auto betaDType = betaDesc->GetDataType();
+
+    OP_CHECK_IF(SetRowNumKBetaGRegbase(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS,
+                OP_LOGE(context_->GetNodeName(), "SetRowNumKBetaGRegbase Failed."), return ge::GRAPH_FAILED);
+    OP_CHECK_IF(SetRowNumVBetaRegbase(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS,
+                OP_LOGE(context_->GetNodeName(), "SetRowNumVBetaRegbase Failed."), return ge::GRAPH_FAILED);
+    OP_CHECK_IF(SetRowNumMDuDwRegbase(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS,
+                OP_LOGE(context_->GetNodeName(), "SetRowNumMDuDwRegbase Failed."), return ge::GRAPH_FAILED);
+    OP_CHECK_IF(SetRowNumGRegbase(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS,
+                OP_LOGE(context_->GetNodeName(), "SetRowNumGRegbase Failed."), return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus PrepareWyReprBwdDaTilingA5::FixLenTiling()
+{
+    tiling_.chunkNum = tiling_.B * CeilDiv(tiling_.T, tiling_.chunkSize);
+    return ge::GRAPH_SUCCESS;
+}
+
+int64_t PrepareWyReprBwdDaTilingA5::CeilDiv(int64_t a, int64_t b)
+{
+    if (unlikely(b == 0)) {
+        return 0;
+    }
+    return (a + b - 1) / b;
+}
+
+ge::graphStatus PrepareWyReprBwdDaTilingA5::VariableLenTiling()
+{
+    const gert::StorageShape *chunkIndicesShape = context_->GetOptionalInputShape(INPUT_CHUNK_INDICES_IDX);
+    OP_CHECK_NULL_WITH_CONTEXT(context_, chunkIndicesShape);
+    OP_CHECK_IF(RequiredInputDimNumCheck(chunkIndicesShape, DIM_1, INPUT_CHUNK_INDICES_NAME) != ge::GRAPH_SUCCESS, ,
+                return ge::GRAPH_FAILED);
+
+    const gert::Shape chunkIndicesStorageShape = chunkIndicesShape->GetStorageShape();
+    int64_t chunkIndicesDim0 = chunkIndicesStorageShape.GetDim(DIM_0);
+    OP_CHECK_IF(chunkIndicesDim0 % 2 != 0,
+                    OP_LOGE(context_->GetNodeName(),
+                            "Check chunk_indices shape failed, the dim 0 of chunk_indices should be even, but get %ld.",
+                            chunkIndicesDim0),
+                    return ge::GRAPH_FAILED);
+    tiling_.chunkNum = chunkIndicesDim0 / 2;
+
+    return ge::GRAPH_SUCCESS;
+}
+
+void PrepareWyReprBwdDaTilingA5::PrepareWyReprBwdDaTilingDataPrint()
+{
+    auto nodeName = context_->GetNodeName();
+    OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Start to print PrepareWyReprBwdDaA5 tiling data <<<<<<<<<<<<<<<<");
+    OP_LOGD(nodeName, "=== B: %ld", tiling_.B);
+    OP_LOGD(nodeName, "=== H: %ld", tiling_.H);
+    OP_LOGD(nodeName, "=== T: %ld", tiling_.T);
+    OP_LOGD(nodeName, "=== K: %ld", tiling_.K);
+    OP_LOGD(nodeName, "=== V: %ld", tiling_.V);
+    OP_LOGD(nodeName, "=== chunkSize: %ld", tiling_.chunkSize);
+    OP_LOGD(nodeName, "=== chunkNum: %ld", tiling_.chunkNum);
+    OP_LOGD(nodeName, "=== rowNumKBetaG: %ld", tiling_.rowNumKBetaG);
+    OP_LOGD(nodeName, "=== rowNumVBeta: %ld", tiling_.rowNumVBeta);
+    OP_LOGD(nodeName, "=== rowNumMDuDw: %ld", tiling_.rowNumMDuDw);
+    OP_LOGD(nodeName, "=== rowNumG: %ld", tiling_.rowNumG);
+    OP_LOGD(nodeName, "=== isVariable: %ld", tiling_.isVariable);
+    OP_LOGD(nodeName, "=== gCVNum: %ld", tiling_.gCVNum);
+    OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Print PrepareWyReprBwdDaA5 tiling data end <<<<<<<<<<<<<<<<");
+}
+
+} // namespace optiling

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_host/op_tiling/arch35/prepare_wy_repr_bwd_da_tiling_a5.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_host/op_tiling/arch35/prepare_wy_repr_bwd_da_tiling_a5.h
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file prepare_wy_repr_bwd_da_tiling_a5.h
+ * \brief
+ */
+#ifndef PREPARE_WY_REPR_BWD_DA_TILING_A5_H
+#define PREPARE_WY_REPR_BWD_DA_TILING_A5_H
+
+#include "../prepare_wy_repr_bwd_da_tiling.h"
+#include "../../../op_kernel/arch35/prepare_wy_repr_bwd_da_tiling_data_apt.h"
+#include "log/log.h"
+#include "log/error_code.h"
+#include "register/op_impl_registry.h"
+
+namespace optiling {
+
+class PrepareWyReprBwdDaTilingA5 {
+private:
+    gert::TilingContext *context_;
+    PrepareWyReprBwdDaTilingDataA5 tiling_;
+    int64_t B = 0;
+    int64_t H = 0;
+    int64_t K = 0;
+    int64_t V = 0;
+    int64_t T = 0;
+    int64_t chunkSize = 0;
+
+public:
+    bool SetTiling(gert::TilingContext *context);
+    ge::graphStatus CommonTiling();
+    ge::graphStatus FixLenTiling();
+    ge::graphStatus VariableLenTiling();
+    ge::graphStatus RequiredInputDimNumCheck(const gert::StorageShape *curShape, size_t validDimNum,
+                                            const char *inputName);
+    ge::graphStatus CompareShape(const gert::Shape &shape1, const gert::Shape &shape2, const char *inputName1,
+                                const char *inputName2, size_t compareDimNum);
+    ge::graphStatus SetRowNumKBetaGRegbase(uint64_t ubSize, ge::DataType kType, ge::DataType betaType);
+    ge::graphStatus SetRowNumVBetaRegbase(uint64_t ubSize, ge::DataType kType, ge::DataType betaType);
+    ge::graphStatus SetRowNumMDuDwRegbase(uint64_t ubSize, ge::DataType kType, ge::DataType betaType);
+    ge::graphStatus SetRowNumGRegbase(uint64_t ubSize, ge::DataType kType, ge::DataType betaType);
+    int64_t CeilDiv(int64_t a, int64_t b);
+    void PrepareWyReprBwdDaTilingDataPrint();
+};
+
+} // namespace optiling
+
+#endif // PREPARE_WY_REPR_BWD_DA_TILING_A5_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_host/op_tiling/prepare_wy_repr_bwd_da_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_host/op_tiling/prepare_wy_repr_bwd_da_tiling.cpp
@@ -12,52 +12,13 @@
  * \brief
  */
 #include "prepare_wy_repr_bwd_da_tiling.h"
- #include <register/op_impl_registry.h>
+#include "arch35/prepare_wy_repr_bwd_da_tiling_a5.h"
+#include <register/op_impl_registry.h>
 #include "tiling_base/data_copy_transpose_tiling.h"
 #include "tiling_base/tiling_templates_registry.h"
 // #include "tiling_base/tiling_type.h"
 
 namespace optiling {
-static constexpr size_t INPUT_K_IDX = 0;
-static constexpr size_t INPUT_V_IDX = 1;
-static constexpr size_t INPUT_BETA_IDX = 2;
-static constexpr size_t INPUT_A_IDX = 3;
-static constexpr size_t INPUT_DW_IDX = 4;
-static constexpr size_t INPUT_DU_IDX = 5;
-static constexpr size_t INPUT_G_IDX = 6;
-static constexpr size_t INPUT_SEQLENS_IDX = 7;
-static constexpr size_t INPUT_CHUNK_INDICES_IDX = 8;
-
-static constexpr size_t ATTR_CHUNK_SIZE_IDX = 0;
-
-static constexpr size_t DIM_NUM_2 = 2;
-static constexpr size_t DIM_NUM_3 = 3;
-static constexpr size_t DIM_NUM_4 = 4;
-
-static constexpr size_t DIM_0 = 0;
-static constexpr size_t DIM_1 = 1;
-static constexpr size_t DIM_2 = 2;
-static constexpr size_t DIM_3 = 3;
-static constexpr int64_t CHUNK_INDICES_DIM_1_SIZE = 2;
-
-static constexpr int64_t CHUNK_SIZE_64 = 64;
-static constexpr int64_t CHUNK_SIZE_128 = 128;
-
-static constexpr int64_t VAR_LEN_B_DIM_1 = 1;
-
-static constexpr const char *const INPUT_K_NAME = "k";
-static constexpr const char *const INPUT_V_NAME = "v";
-static constexpr const char *const INPUT_BETA_NAME = "beta";
-static constexpr const char *const INPUT_A_NAME = "A";
-static constexpr const char *const INPUT_DW_NAME = "dw";
-static constexpr const char *const INPUT_DU_NAME = "du";
-static constexpr const char *const INPUT_G_NAME = "g";
-static constexpr const char *const INPUT_CHUNK_INDICES_NAME = "chunk_indices";
-
-static constexpr uint64_t SIZE_HALF = 2;
-static constexpr uint64_t SIZE_FP32 = 4;
-constexpr uint64_t ONE_BLOCK_32 = 32;
-constexpr uint64_t BIT_NUM_FOR_UINT8 = 8;
 
 class PrepareWyReprBwdDaTilingProcessor {
     gert::TilingContext *context_;
@@ -318,7 +279,7 @@ public:
         auto kDType = kDesc->GetDataType();
         auto betaDesc = context_->GetDynamicInputDesc(INPUT_BETA_IDX, 0);
         OP_CHECK_NULL_WITH_CONTEXT(context_, betaDesc); // check xDesc is not null
-        auto betaDType = kDesc->GetDataType();
+        auto betaDType = betaDesc->GetDataType();
 
         OP_CHECK_IF(SetRowNumKBetaG(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS,
                     OP_LOGE(context_->GetNodeName(), "SetRowNumKBetaG Failed."), return ge::GRAPH_FAILED);
@@ -390,6 +351,15 @@ ge::graphStatus Tiling4PrepareWyReprBwdDa(gert::TilingContext *context)
     PrepareWyReprBwdDaTilingProcessor processor(context, tiling);
 
     OP_CHECK_IF(processor.PreCheck() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+
+    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
+    if (ascendcPlatform.GetCurNpuArch() == NpuArch::DAV_3510) {
+        PrepareWyReprBwdDaTilingA5 prepareWyReprBwdDaTilingA5;
+        OP_CHECK_IF(!prepareWyReprBwdDaTilingA5.SetTiling(context),
+                    OP_LOGE(context->GetNodeName(), "SetTiling failed."), return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+
     OP_CHECK_IF(processor.CommonTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
 
     auto cuSeqlensTensor = context->GetOptionalInputTensor(INPUT_SEQLENS_IDX);
@@ -413,7 +383,6 @@ ge::graphStatus Tiling4PrepareWyReprBwdDa(gert::TilingContext *context)
 
     tiling.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
     context->GetRawTilingData()->SetDataSize(tiling.GetDataSize());
-    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
     context->SetBlockDim(ascendcPlatform.GetCoreNumAic());
 
     auto sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_host/op_tiling/prepare_wy_repr_bwd_da_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_host/op_tiling/prepare_wy_repr_bwd_da_tiling.h
@@ -22,6 +22,49 @@
 
 namespace optiling {
 
+static constexpr size_t INPUT_K_IDX = 0;
+static constexpr size_t INPUT_V_IDX = 1;
+static constexpr size_t INPUT_BETA_IDX = 2;
+static constexpr size_t INPUT_A_IDX = 3;
+static constexpr size_t INPUT_DW_IDX = 4;
+static constexpr size_t INPUT_DU_IDX = 5;
+static constexpr size_t INPUT_G_IDX = 6;
+static constexpr size_t INPUT_SEQLENS_IDX = 7;
+static constexpr size_t INPUT_CHUNK_INDICES_IDX = 8;
+
+static constexpr size_t ATTR_CHUNK_SIZE_IDX = 0;
+
+static constexpr size_t DIM_NUM_2 = 2;
+static constexpr size_t DIM_NUM_3 = 3;
+static constexpr size_t DIM_NUM_4 = 4;
+
+static constexpr size_t DIM_0 = 0;
+static constexpr size_t DIM_1 = 1;
+static constexpr size_t DIM_2 = 2;
+static constexpr size_t DIM_3 = 3;
+static constexpr int64_t CHUNK_INDICES_DIM_1_SIZE = 2;
+
+static constexpr int64_t CHUNK_SIZE_64 = 64;
+static constexpr int64_t CHUNK_SIZE_128 = 128;
+
+static constexpr int64_t VAR_LEN_B_DIM_1 = 1;
+
+static constexpr const char *const INPUT_K_NAME = "k";
+static constexpr const char *const INPUT_V_NAME = "v";
+static constexpr const char *const INPUT_BETA_NAME = "beta";
+static constexpr const char *const INPUT_A_NAME = "A";
+static constexpr const char *const INPUT_DW_NAME = "dw";
+static constexpr const char *const INPUT_DU_NAME = "du";
+static constexpr const char *const INPUT_G_NAME = "g";
+static constexpr const char *const INPUT_CHUNK_INDICES_NAME = "chunk_indices";
+static constexpr const char *const INPUT_SEQLENS_NAME = "cu_seqlens";
+
+static constexpr uint64_t SIZE_HALF = 2;
+static constexpr uint64_t SIZE_FP32 = 4;
+constexpr uint64_t ONE_BLOCK_32 = 32;
+constexpr uint64_t BIT_NUM_FOR_UINT8 = 8;
+constexpr uint64_t MAX_CUBE_VEC_SYNC_NUM = 5;
+
 BEGIN_TILING_DATA_DEF(PrepareWyReprBwdDaTilingData)
 TILING_DATA_FIELD_DEF(int64_t, B);
 TILING_DATA_FIELD_DEF(int64_t, H);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/arch35/prepare_wy_repr_bwd_da_common.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/arch35/prepare_wy_repr_bwd_da_common.h
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file prepare_wy_repr_bwd_da_common.h
+ * \brief
+ */
+
+#ifndef PREPARE_WY_REPR_BWD_DA_COMMON_H
+#define PREPARE_WY_REPR_BWD_DA_COMMON_H
+constexpr uint64_t SYNC_FLAG_2 = 2;
+constexpr uint64_t SYNC_FLAG_3 = 3;
+constexpr uint64_t SYNC_FLAG_4 = 4;
+constexpr uint64_t SYNC_FLAG_5 = 5;
+constexpr uint64_t FLAG_ID_MAX = 16;
+constexpr uint64_t ONE_BLOCK_32 = 32;
+constexpr uint32_t FP32_PER_BLOCK_8 = 8;
+constexpr uint32_t FP32_PER_REPEAT_64 = 64;
+constexpr uint32_t BIT_NUM_FOR_UINT8 = 8;
+constexpr uint32_t SIZE_FLOAT = 4;
+constexpr uint32_t CAL_NUM_FLOAT = 64; // API一次能处理256B，能计算64个float元素
+constexpr uint32_t CHUNK_SIZE_64 = 64;
+constexpr uint32_t NUM_2 = 2;
+constexpr uint32_t MAX_CUBE_VEC_SYNC_NUM = 5;
+constexpr uint32_t UB_STAGES = 2;
+constexpr uint64_t SYNC_AIV_AIC_FLAG_BEGIN = 1;
+constexpr uint64_t SYNC_AIC_AIV_FLAG_BEGIN = 6;
+
+__aicore__ void inline GetChunkOffset(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, uint64_t B, uint64_t H, uint64_t T,
+                                      uint64_t chunkSize, uint32_t loopIdx, uint32_t &bos, uint32_t &eos)
+{
+    if (cu_seqlens == nullptr) {
+        uint32_t coreLoopsInB = (T + chunkSize - 1) / chunkSize;
+        uint32_t chunkIdx = loopIdx % coreLoopsInB;
+        uint32_t bIdx = loopIdx / coreLoopsInB;
+        bos = chunkIdx * chunkSize;
+        eos = bos + chunkSize > T ? T : bos + chunkSize;
+        bos += (bIdx * H * T);
+        eos += (bIdx * H * T);
+    } else {
+        AscendC::GlobalTensor<uint64_t> cuSeqlensTensor;
+        AscendC::GlobalTensor<uint64_t> chunkIndicesTensor;
+        cuSeqlensTensor.SetGlobalBuffer((__gm__ uint64_t *)cu_seqlens);
+        chunkIndicesTensor.SetGlobalBuffer((__gm__ uint64_t *)chunk_indices);
+        uint32_t seqIdx = chunkIndicesTensor.GetValue(2 * loopIdx);
+        uint32_t chunkIdx = chunkIndicesTensor.GetValue(2 * loopIdx + 1);
+        uint32_t curSeqBegin = cuSeqlensTensor.GetValue(seqIdx);
+        uint32_t curSeqEnd = cuSeqlensTensor.GetValue(seqIdx + 1);
+        bos = curSeqBegin + chunkIdx * chunkSize;
+        eos = bos + chunkSize > curSeqEnd ? curSeqEnd : bos + chunkSize;
+    }
+
+    return;
+}
+
+__aicore__ inline int64_t CeilDiv(int64_t dividend, int64_t divisor)
+{
+    if (unlikely(divisor == 0)) {
+        return 0;
+    }
+    return (dividend + divisor - 1) / divisor;
+}
+
+__aicore__ inline void MTE2ToVSync()
+{
+    event_t eventIDMTE2ToV = static_cast<event_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_V));
+    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventIDMTE2ToV);
+    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventIDMTE2ToV);
+}
+
+#endif  // PREPARE_WY_REPR_BWD_DA_COMMON_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/arch35/prepare_wy_repr_bwd_da_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/arch35/prepare_wy_repr_bwd_da_cube.h
@@ -16,7 +16,8 @@
 #ifndef PREPARE_WY_REPR_BWD_DA_CUBE_H
 #define PREPARE_WY_REPR_BWD_DA_CUBE_H
 
-#define CATLASS_ARCH 2201
+#define CATLASS_ARCH 3510
+#include "prepare_wy_repr_bwd_da_tiling_data_apt.h"
 #include "prepare_wy_repr_bwd_da_common.h"
 #include "catlass/arch/arch.hpp"
 #include "catlass/catlass.hpp"
@@ -30,7 +31,8 @@
 #include "tla/layout.hpp"
 #include "tla/tensor.hpp"
 #include "catlass/arch/cross_core_sync.hpp"
-
+#include "kernel_utils/block/block_mmad_pingpong_tla.hpp"
+#include "kernel_utils/tile/copy_l0c_to_ub.hpp"
 
 using namespace Catlass;
 using namespace tla;
@@ -120,6 +122,8 @@ public:
         uint64_t V = 128;
         uint64_t BT = 64;
         uint64_t stage = 2;
+        uint64_t da6VecRow = 0;
+        uint64_t da6CVNum = 0;
 
         // Methods
         CATLASS_DEVICE
@@ -139,7 +143,8 @@ public:
                GM_ADDR ptrDA5T_, LayoutDA5T layoutDA5T_,
                GM_ADDR ptrDA6_, LayoutDA6 layoutDA6_,
                GM_ADDR ptrCuSeqLens_, GM_ADDR ptrChunkIndices_, uint64_t chunkNum_,
-               uint64_t B_, uint64_t T_, uint64_t H_, uint64_t K_, uint64_t V_, uint64_t BT_, uint64_t stage_)
+               uint64_t B_, uint64_t T_, uint64_t H_, uint64_t K_, uint64_t V_, uint64_t BT_, uint64_t stage_,
+               uint64_t da6VecRow_, uint64_t da6CVNum_)
             : ptrDw(ptrDw_),
               layoutDw(layoutDw_),
               ptrKbg(ptrKbg_),
@@ -173,7 +178,9 @@ public:
               K(K_),
               V(V_),
               BT(BT_),
-              stage(stage_) {}
+              stage(stage_),
+              da6VecRow(da6VecRow_),
+              da6CVNum(da6CVNum_) {}
     };
 
     // Methods
@@ -309,8 +316,19 @@ public:
             }
         }
         AscendC::SyncAll<false>();
-        {   // 计算第四个矩阵乘 dA_6 = A.T @ dA_5
+        {   // 计算第四个矩阵乘 dA_6 = A.T @ dA_5  (Cube-Vector sync, following dkb pattern)
             BlockMmadDA6 blockMmadDA6(resource);
+            AscendC::GlobalTensor<ElementDA5T> gmDA5T;
+            AscendC::GlobalTensor<ElementA> gmA;
+
+            uint32_t ubOffset = 0;
+            uint32_t ubListId = 0;
+            AscendC::LocalTensor<ElementDA6> ubDA6List[MAX_CUBE_VEC_SYNC_NUM];
+            for (uint32_t i = 0; i < params.da6CVNum; i++) {
+                ubDA6List[i] = resource.ubBuf.template GetBufferByByte<ElementDA6>(ubOffset);
+                ubOffset += params.da6VecRow * params.BT * sizeof(ElementDA6);
+            }
+            uint8_t beginSubBlockIdx = 1;
             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
                                params.BT, loopIdx, bos, eos);
@@ -319,17 +337,12 @@ public:
                 GemmCoord actualBlockShape{curChunkSize, curChunkSize, curChunkSize};
                 for (int h = 0; h < params.H; h++) {
                     // Represent the full gm
-                    AscendC::GlobalTensor<ElementDA5T> gmDA5T;
                     gmDA5T.SetGlobalBuffer((__gm__ ElementDA5T *)params.ptrDA5T + (h * params.T + bos) * params.BT);
-                    AscendC::GlobalTensor<ElementA> gmA;
                     gmA.SetGlobalBuffer((__gm__ ElementA *)params.ptrA + (h * params.T + bos) * params.BT);
-                    AscendC::GlobalTensor<ElementDA6> gmDA6;
-                    gmDA6.SetGlobalBuffer((__gm__ ElementDA6 *)params.ptrDA6 + (h * params.T + bos) * params.BT);
 
                     // Represent the full tensors
                     auto tensorDA5T = tla::MakeTensor(gmDA5T, params.layoutDA5T, Arch::PositionGM{});
                     auto tensorA = tla::MakeTensor(gmA, params.layoutA, Arch::PositionGM{});
-                    auto tensorDA6 = tla::MakeTensor(gmDA6, params.layoutDA6, Arch::PositionGM{});
 
                     // Make tiled views
                     auto tensorBlockDA5T = GetTile(tensorDA5T,
@@ -338,13 +351,25 @@ public:
                     auto tensorBlockA = GetTile(tensorA,
                                                 tla::MakeCoord(0, 0),
                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDA6 = GetTile(tensorDA6,
-                                                tla::MakeCoord(0, 0),
+
+                    using UBTensor = tla::Tensor<AscendC::LocalTensor<ElementDA6>, LayoutDA6, tuple<int, int>, AscendC::TPosition::VECCALC>;
+                    UBTensor tensorBlockDA6List[MAX_CUBE_VEC_SYNC_NUM];
+                    for (uint32_t i = 0; i < params.da6CVNum; i++) {
+                        auto tensorDA6 = tla::MakeTensor(ubDA6List[i], params.layoutDA6, Arch::PositionUB{});
+                        tensorBlockDA6List[i] = GetTile(tensorDA6, tla::MakeCoord(0, 0),
                                                 tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    // Compute block-scoped matrix multiply-add
-                    blockMmadDA6(tensorBlockDA5T, tensorBlockA, tensorBlockDA6, actualBlockShape);
-                    Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
+                    }
+
+                    // Compute block-scoped matrix multiply-add with Cube-Vector sync
+                    blockMmadDA6(tensorBlockDA5T, tensorBlockA, tensorBlockDA6List, actualBlockShape, params.da6VecRow,
+                        beginSubBlockIdx, SYNC_AIV_AIC_FLAG_BEGIN, SYNC_AIC_AIV_FLAG_BEGIN, ubListId, 2, params.da6CVNum);
+                    beginSubBlockIdx += CeilDiv(curChunkSize, params.da6VecRow);
+                    beginSubBlockIdx = beginSubBlockIdx % 2;
                 }
+            }
+            for (uint32_t i = 0; i < params.da6CVNum; i++) {
+                AscendC::CrossCoreWaitFlag<0x4, PIPE_FIX>(SYNC_AIV_AIC_FLAG_BEGIN + i);
+                AscendC::CrossCoreWaitFlag<0x4, PIPE_FIX>(SYNC_AIV_AIC_FLAG_BEGIN + FLAG_ID_MAX + i);
             }
         }
     }
@@ -360,7 +385,7 @@ public:
                                                 GM_ADDR du_, GM_ADDR g_, GM_ADDR cu_seqlens_, GM_ADDR chunk_indices_,
                                                 GM_ADDR dA_, GM_ADDR workspace_);
     __aicore__ inline void Process();
-    __aicore__ inline void Init(const PrepareWyReprBwdDaTilingData &tiling);
+    __aicore__ inline void Init(const PrepareWyReprBwdDaTilingDataA5 &tiling);
 private:
     uint64_t B = 0;
     uint64_t T = 0;
@@ -380,6 +405,8 @@ private:
     GM_ADDR chunk_indices;
     GM_ADDR dA;
     GM_ADDR workspace;
+    uint64_t da6VecRow = 0;
+    uint64_t da6CVNum = 0;
 };
 
 template <typename kType, typename betaType>
@@ -410,7 +437,7 @@ __aicore__ inline PrepareWyReprBwdDAProcess<kType, betaType>::PrepareWyReprBwdDA
 };
 
 template <typename kType, typename betaType>
-__aicore__ void inline PrepareWyReprBwdDAProcess<kType, betaType>::Init(const PrepareWyReprBwdDaTilingData &tiling) {
+__aicore__ void inline PrepareWyReprBwdDAProcess<kType, betaType>::Init(const PrepareWyReprBwdDaTilingDataA5 &tiling) {
     B = tiling.B;
     T = tiling.T;
     H = tiling.H;
@@ -418,6 +445,8 @@ __aicore__ void inline PrepareWyReprBwdDAProcess<kType, betaType>::Init(const Pr
     V = tiling.V;
     BT = tiling.chunkSize;
     chunkNum = tiling.chunkNum;
+    da6VecRow = tiling.rowNumG;
+    da6CVNum = tiling.gCVNum;
     return;
 }
 
@@ -452,33 +481,33 @@ __aicore__ void inline PrepareWyReprBwdDAProcess<kType, betaType>::Process() {
     using LayoutTagDA6 = layout::RowMajor;
     LayoutTagDA6 tagDA6 = LayoutTagDA6::MakeLayout<kType>(BT, BT);
 
-    using ArchTag = Arch::AtlasA2;
-    using DispatchPolicy = Gemm::MmadPingpong<ArchTag, true, false>;
+    using ArchTag = Arch::Ascend950;
+    using DispatchPolicy = Common::MmadPingpong<ArchTag, false, false, 2>;
     using L1TileShape = Shape<_128, _128, _256>;
     using L0TileShape = Shape<_128, _128, _128>;
 
     // 计算第一个矩阵乘 dA_1 = dw @ kbg.T
     using TileCopyDA1 =
-        Gemm::Tile::PackedTileCopyTla<ArchTag, kType, LayoutTagDw, kType, LayoutTagKbg, kType, LayoutTagDA1>;
-    using BlockMmadDA1 = Gemm::Block::BlockMmadTla<
+        Common::Tile::PackedTileCopyTla<ArchTag, kType, LayoutTagDw, kType, LayoutTagKbg, kType, LayoutTagDA1>;
+    using BlockMmadDA1 = Common::BlockMmadTla<
         DispatchPolicy, L1TileShape, L0TileShape, kType, kType, kType, void, TileCopyDA1>;
 
     // 计算第二个矩阵乘 dA_2 = du @ vb.T
     using TileCopyDA2 =
-        Gemm::Tile::PackedTileCopyTla<ArchTag, kType, LayoutTagDu, kType, LayoutTagVb, kType, LayoutTagDA2>;
-    using BlockMmadDA2 = Gemm::Block::BlockMmadTla<
+        Common::Tile::PackedTileCopyTla<ArchTag, kType, LayoutTagDu, kType, LayoutTagVb, kType, LayoutTagDA2>;
+    using BlockMmadDA2 = Common::BlockMmadTla<
         DispatchPolicy, L1TileShape, L0TileShape, kType, kType, kType, void, TileCopyDA2>;
 
     // 计算第三个矩阵乘 dA_5 = dA_4 @ A.T
     using TileCopyDA5 =
-        Gemm::Tile::PackedTileCopyTla<ArchTag, kType, LayoutTagDA4, kType, LayoutTagAT, kType, LayoutTagDA5>;
-    using BlockMmadDA5 = Gemm::Block::BlockMmadTla<
+        Common::Tile::PackedTileCopyTla<ArchTag, kType, LayoutTagDA4, kType, LayoutTagAT, kType, LayoutTagDA5>;
+    using BlockMmadDA5 = Common::BlockMmadTla<
         DispatchPolicy, L1TileShape, L0TileShape, kType, kType, kType, void, TileCopyDA5>;
 
-    // 计算第四个矩阵乘 dA_6 = A.T @ dA_5
+    // 计算第四个矩阵乘 dA_6 = A.T @ dA_5 (Cube-Vector sync, output to UB)
     using TileCopyDA6 =
-        Gemm::Tile::PackedTileCopyTla<ArchTag, kType, LayoutTagDA5T, kType, LayoutTagA, kType, LayoutTagDA6>;
-    using BlockMmadDA6 = Gemm::Block::BlockMmadTla<
+        Common::Tile::PackedTileCopyTlaToUB<ArchTag, kType, LayoutTagDA5T, kType, LayoutTagA, kType, LayoutTagDA6, void, Gemm::Tile::CopyL0CToUBMode::NO_SPLIT>;
+    using BlockMmadDA6 = Common::BlockMmadTla<
         DispatchPolicy, L1TileShape, L0TileShape, kType, kType, kType, void, TileCopyDA6>;
 
     auto layoutDw = MakeLayoutFromTag(tagDw);
@@ -526,7 +555,8 @@ __aicore__ void inline PrepareWyReprBwdDAProcess<kType, betaType>::Process() {
         cu_seqlens,
         chunk_indices,
         chunkNum,
-        B, T, H, K, V, BT, 4};
+        B, T, H, K, V, BT, 4,
+        da6VecRow, da6CVNum};
 
     kernel(param);
 }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/arch35/prepare_wy_repr_bwd_da_tiling_data_apt.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/arch35/prepare_wy_repr_bwd_da_tiling_data_apt.h
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file repare_wy_repr_bwd_da_tiling_data_apt.h
+ * \brief
+ */
+
+#ifndef PREPARE_WY_REPR_BWD_DA_TILING_DATA_H
+#define PREPARE_WY_REPR_BWD_DA_TILING_DATA_H
+#include <cstdint>
+#include "kernel_tiling/kernel_tiling.h"
+
+#pragma pack(push, 8)
+struct PrepareWyReprBwdDaTilingDataA5 {
+    int64_t B = 0;
+    int64_t H = 0;
+    int64_t T = 0;
+    int64_t K = 0;
+    int64_t V = 0;
+    int64_t chunkSize = 0;
+    int64_t chunkNum = 0;
+    int64_t rowNumKBetaG = 0;
+    int64_t rowNumVBeta = 0;
+    int64_t rowNumMDuDw = 0;
+    int64_t rowNumG = 0;
+    int64_t isVariable = 0;
+    int64_t gCVNum = 0;
+};
+#pragma pack(pop)
+
+#endif // PREPARE_WY_REPR_BWD_DA_COMMON_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/arch35/prepare_wy_repr_bwd_da_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/arch35/prepare_wy_repr_bwd_da_vector.h
@@ -1,0 +1,1316 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file prepare_wy_repr_bwd_da_vector.h
+ * \brief
+ */
+
+#ifndef PREPARE_WY_REPR_BWD_DA_VECTOR_H
+#define PREPARE_WY_REPR_BWD_DA_VECTOR_H
+#include "prepare_wy_repr_bwd_da_tiling_data_apt.h"
+#include "catlass/arch/cross_core_sync.hpp"
+#include "kernel_utils/vector/regbase.hpp"
+
+using namespace AscendC;
+using namespace AscendC::MicroAPI;
+
+template <typename kType, typename betaType>
+class PrepareWyReprBwdDAVectorProcess {
+public:
+     /** @brief constructor */
+    __aicore__ inline PrepareWyReprBwdDAVectorProcess(GM_ADDR k_, GM_ADDR v_, GM_ADDR beta_, GM_ADDR A_, GM_ADDR dw_,
+                                                      GM_ADDR du_, GM_ADDR g_, GM_ADDR cu_seqlens_,
+                                                      GM_ADDR chunk_indices_, GM_ADDR dA_, GM_ADDR workspace_);
+    __aicore__ inline void Init(const PrepareWyReprBwdDaTilingDataA5& tiling, AscendC::TPipe *pipe_);
+    __aicore__ inline void Process();
+    __aicore__ inline void ProcessVBeta();
+    __simd_vf__ inline void ProcessVBetaComputerVFOneLineOneCol(__ubuf__ kType* vBetaOut,
+                                                                __ubuf__ kType* vIn, __ubuf__ betaType* betaIn,
+                                                                uint16_t mSize, uint16_t nSize);
+    __simd_vf__ inline void ProcessVBetaComputerVFMutiLineOneCol(__ubuf__ kType* vBetaOut,
+                                                                 __ubuf__ kType* vIn, __ubuf__ betaType* betaIn,
+                                                                 uint16_t mSize, uint16_t nSize, uint16_t lastLoopCnt);
+    __simd_vf__ inline void ProcessVBetaComputerVFTwoCol(__ubuf__ kType* vBetaOut,
+                                                         __ubuf__ kType* vIn, __ubuf__ betaType* betaIn,
+                                                         uint16_t mSize, uint16_t nSize);
+    __aicore__ inline void ProcessKBetaG();
+    __aicore__ inline void ProcessMDuDw();
+    __simd_vf__ inline void ProcessMDuDwComputerVFOneLineOneCol(__ubuf__ kType* mduwOut,
+                                                                __ubuf__ kType* mduIn, __ubuf__ kType* mdwIn,
+                                                                uint16_t mSize, uint16_t nSize, uint32_t startRow);
+    __simd_vf__ inline void ProcessMDuDwComputerVFMutiLineOneCol(__ubuf__ kType* mduwOut,
+                                                                 __ubuf__ kType* mduIn, __ubuf__ kType* mdwIn,
+                                                                 uint16_t mSize, uint16_t nSize, uint32_t startRow,
+                                                                 uint16_t lastLoopCnt);
+    __simd_vf__ inline void ProcessKBetaGComputerVFOneLineOneCol(__ubuf__ kType* kBetaGOut,
+                                                                 __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+                                                                 __ubuf__ betaType* gIn,
+                                                                 uint16_t mSize, uint16_t nSize);
+    __simd_vf__ inline void ProcessKBetaGComputerVFMutiLineOneCol(__ubuf__ kType* kBetaGOut,
+                                                                  __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+                                                                  __ubuf__ betaType* gIn,
+                                                                  uint16_t mSize, uint16_t nSize, uint16_t lastLoopCnt);
+    __simd_vf__ inline void ProcessKBetaGComputerVFTwoCol(__ubuf__ kType* kBetaGOut,
+                                                          __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+                                                          __ubuf__ betaType* gIn,
+                                                          uint16_t mSize, uint16_t nSize);
+    __aicore__ inline void ProcessG();
+    __simd_vf__ inline void ProcessGComputerVFOneLineOneCol(__ubuf__ kType* dAOut, __ubuf__ kType* dA6In,
+                                                            __ubuf__ betaType* gIn, __ubuf__ betaType* gAllIn,
+                                                            uint16_t mSize, uint16_t nSize,
+                                                            uint32_t startRow, uint32_t calcColSize);
+    __simd_vf__ inline void ProcessGComputerVFMutiLineOneCol(__ubuf__ kType* dAOut, __ubuf__ kType* dA6In,
+                                                             __ubuf__ betaType* gIn, __ubuf__ betaType* gAllIn,
+                                                             uint16_t mSize, uint16_t nSize, uint32_t startRow,
+                                                             uint16_t lastLoopCnt, uint32_t calcColSize);
+private:
+    uint64_t B = 0;
+    uint64_t T = 0;
+    uint64_t H = 0;
+    uint64_t K = 0;
+    uint64_t V = 0;
+    uint64_t BT = 0;
+    uint64_t chunkNum = 0;
+    uint64_t rowNumKBetaG = 0;
+    uint64_t rowNumVBeta = 0;
+    uint64_t rowNumMDuDw = 0;
+    uint64_t rowNumG = 0;
+    uint64_t gCVNum = 0;
+    Arch::CrossCoreFlagWithReverse<> flagAicFinishStore{SYNC_FLAG_2, SYNC_FLAG_3};
+    Arch::CrossCoreFlagWithReverse<> flagAivFinishStore{SYNC_FLAG_4, SYNC_FLAG_5};
+
+    GM_ADDR k;
+    GM_ADDR v;
+    GM_ADDR beta;
+    GM_ADDR A;
+    GM_ADDR dw;
+    GM_ADDR du;
+    GM_ADDR g;
+    GM_ADDR cu_seqlens;
+    GM_ADDR chunk_indices;
+    GM_ADDR dA;
+    GM_ADDR workspace;
+    AscendC::TPipe *pipe = nullptr;
+private:
+    GlobalTensor<kType> kTensor;
+    GlobalTensor<kType> vTensor;
+    GlobalTensor<betaType> gTensor;
+    GlobalTensor<betaType> betaTensor;
+    GlobalTensor<kType> dATensor;
+    GlobalTensor<kType> dA1Tensor;
+    GlobalTensor<kType> dA2Tensor;
+    GlobalTensor<kType> dA4Tensor;
+    GlobalTensor<kType> dA5Tensor;
+    GlobalTensor<kType> dA6Tensor;
+    GlobalTensor<kType> workSpaceTensor;
+    GlobalTensor<kType> workSpace2Tensor;
+
+    TQue<AscendC::TPosition::VECIN, 1> kInQue;
+    TQue<AscendC::TPosition::VECIN, 1> vInQue;
+    TQue<AscendC::TPosition::VECIN, 1> gInQue;
+    TQue<AscendC::TPosition::VECIN, 1> betaInQue;
+    TQue<AscendC::TPosition::VECIN, 1> mduInQue;
+    TQue<AscendC::TPosition::VECIN, 1> mdwInQue;
+
+    TQue<AscendC::TPosition::VECOUT, 1> kBetaGOutQue;
+    TQue<AscendC::TPosition::VECOUT, 1> vBetaOutQue;
+    TQue<AscendC::TPosition::VECOUT, 1> mduwOutQue;
+};
+
+template <typename kType, typename betaType>
+__aicore__ inline PrepareWyReprBwdDAVectorProcess<kType, betaType>::PrepareWyReprBwdDAVectorProcess(
+    GM_ADDR k_, GM_ADDR v_, GM_ADDR beta_, GM_ADDR A_, GM_ADDR dw_, GM_ADDR du_, GM_ADDR g_, GM_ADDR cu_seqlens_,
+    GM_ADDR chunk_indices_, GM_ADDR dA_, GM_ADDR workspace_)
+    : k(k_), v(v_), beta(beta_), A(A_), dw(dw_), du(du_), g(g_),
+      cu_seqlens(cu_seqlens_), chunk_indices(chunk_indices_), dA(dA_), workspace(workspace_) {}
+
+template <typename kType, typename betaType>
+__aicore__ void inline PrepareWyReprBwdDAVectorProcess<kType, betaType>::Init(
+    const PrepareWyReprBwdDaTilingDataA5& tiling, AscendC::TPipe *pipe_) {
+    B = tiling.B;
+    T = tiling.T;
+    H = tiling.H;
+    K = tiling.K;
+    V = tiling.V;
+    BT = tiling.chunkSize;
+    chunkNum = tiling.chunkNum;
+    rowNumKBetaG = tiling.rowNumKBetaG;
+    rowNumVBeta = tiling.rowNumVBeta;
+    rowNumMDuDw = tiling.rowNumMDuDw;
+    rowNumG = tiling.rowNumG;
+    gCVNum = tiling.gCVNum;
+
+    pipe = pipe_;
+    workSpaceTensor.SetGlobalBuffer((__gm__ kType *)workspace);
+    workSpace2Tensor.SetGlobalBuffer((__gm__ kType *)workspace + B * H * T * BT);
+    dA1Tensor.SetGlobalBuffer((__gm__ kType *)dA);
+    dA2Tensor.SetGlobalBuffer((__gm__ kType *)workspace);
+    dA4Tensor.SetGlobalBuffer((__gm__ kType *)dA);
+    dA5Tensor.SetGlobalBuffer((__gm__ kType *)workspace);
+    dA6Tensor.SetGlobalBuffer((__gm__ kType *)dA);
+    return;
+}
+
+template <typename kType, typename betaType>
+__aicore__ void inline PrepareWyReprBwdDAVectorProcess<kType, betaType>::Process() {
+    ProcessKBetaG();
+    pipe->Reset();
+    AscendC::SyncAll<false>();
+    ProcessVBeta();
+    pipe->Reset();
+    AscendC::SyncAll<false>();
+    ProcessMDuDw();
+    pipe->Reset();
+    AscendC::SyncAll<false>();
+    ProcessG();
+    return;
+}
+
+// k、beta和g 的计算
+template <typename kType, typename betaType>
+__aicore__ void inline PrepareWyReprBwdDAVectorProcess<kType, betaType>::ProcessKBetaG() {
+    uint32_t coreLoops = chunkNum;
+    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+    uint32_t coreNumAic = GetBlockNum();
+    uint32_t rowNum = rowNumKBetaG;
+    uint32_t rowOffset = 0;
+    uint32_t vecTaskIdx = 0;
+    uint32_t bos = 0;
+    uint32_t eos = 0;
+    uint32_t curRowNum = rowNum;
+    // init
+    kTensor.SetGlobalBuffer((__gm__ kType *)k);
+    betaTensor.SetGlobalBuffer((__gm__ betaType *)beta);
+    gTensor.SetGlobalBuffer((__gm__ betaType *)g);
+
+    // 搬入
+    pipe->InitBuffer(kInQue, 2, rowNum * K * sizeof(kType));
+    pipe->InitBuffer(betaInQue, 2, rowNum * sizeof(betaType));
+    pipe->InitBuffer(gInQue, 2, rowNum * sizeof(betaType));
+    // 搬出
+    pipe->InitBuffer(kBetaGOutQue, 2, rowNum * K * sizeof(kType));
+
+    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
+        GetChunkOffset(cu_seqlens, chunk_indices, B, H, T, BT, loopIdx, bos, eos);
+        uint32_t curChunkSize = eos - bos;
+        for (int h = 0; h < H; h++) {
+            for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
+                ++vecTaskIdx;
+                if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
+                    continue;
+                }
+                curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
+                auto kOffset = (h * T + bos + rowOffset) * K;
+                auto betaOffset = h * T + bos + rowOffset;
+                auto gOffset = h * T + bos + rowOffset;
+                // copyin
+                {
+                    auto tensorKIn = kInQue.AllocTensor<kType>();
+                    DataCopy(tensorKIn, kTensor[kOffset], K * curRowNum);
+                    auto tensorBetaIn = betaInQue.AllocTensor<betaType>();
+                    DataCopyPad(tensorBetaIn, betaTensor[betaOffset],
+                        {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},
+                        {false, 0, 0, 0});
+                    auto tensorGIn = gInQue.AllocTensor<betaType>();
+                    DataCopyPad(tensorGIn, gTensor[gOffset],
+                        {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},
+                        {false, 0, 0, 0});
+
+                    kInQue.EnQue(tensorKIn);
+                    betaInQue.EnQue(tensorBetaIn);
+                    gInQue.EnQue(tensorGIn);
+                }
+                // compute
+                {
+                    auto tensorKIn = kInQue.DeQue<kType>();
+                    auto tensorBetaIn = betaInQue.DeQue<betaType>();
+                    auto tensorGIn = gInQue.DeQue<betaType>();
+                    auto tensorOut = kBetaGOutQue.AllocTensor<kType>();
+                    auto kBetaGOutAddr = reinterpret_cast<uint64_t>(tensorOut.GetPhyAddr());
+                    auto kInAddr = reinterpret_cast<uint64_t>(tensorKIn.GetPhyAddr());
+                    auto betaInAddr = reinterpret_cast<uint64_t>(tensorBetaIn.GetPhyAddr());
+                    auto gInAddr = reinterpret_cast<uint64_t>(tensorGIn.GetPhyAddr());
+                    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+                    if (K <= eleKNumPerVf) {
+                        if (curRowNum == 1) {
+                            ProcessKBetaGComputerVFOneLineOneCol(
+                                    (__ubuf__ kType*)kBetaGOutAddr, (__ubuf__ kType*)kInAddr,
+                                    (__ubuf__ betaType*)betaInAddr, (__ubuf__ betaType*)gInAddr,
+                                    curRowNum, K);
+                        } else {
+                            uint16_t lastLoopCnt = curRowNum % PRELOAD_NUM;
+                            ProcessKBetaGComputerVFMutiLineOneCol(
+                                    (__ubuf__ kType*)kBetaGOutAddr, (__ubuf__ kType*)kInAddr,
+                                    (__ubuf__ betaType*)betaInAddr, (__ubuf__ betaType*)gInAddr,
+                                    curRowNum, K, lastLoopCnt);
+                        }
+                    } else {
+                        ProcessKBetaGComputerVFTwoCol(
+                                    (__ubuf__ kType*)kBetaGOutAddr, (__ubuf__ kType*)kInAddr,
+                                    (__ubuf__ betaType*)betaInAddr, (__ubuf__ betaType*)gInAddr,
+                                    curRowNum, K);
+                    }
+                    kInQue.FreeTensor(tensorKIn);
+                    betaInQue.FreeTensor(tensorBetaIn);
+                    gInQue.FreeTensor(tensorGIn);
+                    kBetaGOutQue.EnQue(tensorOut);
+                }
+                //copyout
+                {
+                    auto tensorOut = kBetaGOutQue.DeQue<kType>();
+                    DataCopy(workSpace2Tensor[kOffset], tensorOut, K * curRowNum);
+                    kBetaGOutQue.FreeTensor(tensorOut);
+                }
+            }
+            Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(flagAivFinishStore);
+        }
+    }
+    return;
+}
+
+// v 和 beta 的计算
+template <typename kType, typename betaType>
+__aicore__ void inline PrepareWyReprBwdDAVectorProcess<kType, betaType>::ProcessVBeta() {
+    uint32_t coreLoops = chunkNum;
+    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+    uint32_t coreNumAic = GetBlockNum();
+    uint32_t rowNum = rowNumVBeta;
+    uint32_t rowOffset = 0;
+    uint32_t vecTaskIdx = 0;
+    uint32_t bos = 0;
+    uint32_t eos = 0;
+    uint32_t curRowNum = rowNum;
+
+    // init
+    pipe->InitBuffer(vInQue, 2, rowNum * V * sizeof(kType));
+    pipe->InitBuffer(betaInQue, 2, rowNum * sizeof(betaType));
+    pipe->InitBuffer(vBetaOutQue, 2, rowNum * V * sizeof(kType));
+
+    vTensor.SetGlobalBuffer((__gm__ kType *)v);
+    betaTensor.SetGlobalBuffer((__gm__ betaType *)beta);
+
+    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
+        GetChunkOffset(cu_seqlens, chunk_indices, B, H, T, BT, loopIdx, bos, eos);
+        uint32_t curChunkSize = eos - bos;
+        for (int h = 0; h < H; h++) {
+            for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
+                ++vecTaskIdx;
+                if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
+                    continue;
+                }
+                curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
+                auto vOffset = (h * T + bos + rowOffset) * V;
+                auto betaOffset = h * T + bos + rowOffset;
+                // copyin
+                {
+                    auto tensorVin = vInQue.AllocTensor<kType>();
+                    DataCopy(tensorVin, vTensor[vOffset], V * curRowNum);
+                    auto tensorBetain = betaInQue.AllocTensor<betaType>();
+                    DataCopyPad(tensorBetain, betaTensor[betaOffset],
+                        {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},
+                        {false, 0, 0, 0});
+                    vInQue.EnQue(tensorVin);
+                    betaInQue.EnQue(tensorBetain);
+                }
+                // compute
+                {
+                    auto tensorVin = vInQue.DeQue<kType>();
+                    auto tensorBetain = betaInQue.DeQue<betaType>();
+                    auto tensorOut = vBetaOutQue.AllocTensor<kType>();
+                    auto vBetaOutAddr = reinterpret_cast<uint64_t>(tensorOut.GetPhyAddr());
+                    auto vInAddr = reinterpret_cast<uint64_t>(tensorVin.GetPhyAddr());
+                    auto betaInAddr = reinterpret_cast<uint64_t>(tensorBetain.GetPhyAddr());
+                    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+                    if (V <= eleKNumPerVf) {
+                        if (curRowNum == 1) {
+                            ProcessVBetaComputerVFOneLineOneCol(
+                                    (__ubuf__ kType*)vBetaOutAddr, (__ubuf__ kType*)vInAddr,
+                                    (__ubuf__ betaType*)betaInAddr,
+                                    curRowNum, V);
+                        } else {
+                            uint16_t lastLoopCnt = curRowNum % PRELOAD_NUM;
+                            ProcessVBetaComputerVFMutiLineOneCol(
+                                    (__ubuf__ kType*)vBetaOutAddr, (__ubuf__ kType*)vInAddr,
+                                    (__ubuf__ betaType*)betaInAddr,
+                                    curRowNum, V, lastLoopCnt);
+                        }
+                    } else {
+                        ProcessVBetaComputerVFTwoCol(
+                                    (__ubuf__ kType*)vBetaOutAddr, (__ubuf__ kType*)vInAddr,
+                                    (__ubuf__ betaType*)betaInAddr,
+                                    curRowNum, V);
+                    }
+                    vInQue.FreeTensor(tensorVin);
+                    betaInQue.FreeTensor(tensorBetain);
+                    vBetaOutQue.EnQue(tensorOut);
+                }
+                // copyout
+                {
+                    auto tensorOut = vBetaOutQue.DeQue<kType>();
+                    DataCopy(workSpace2Tensor[vOffset], tensorOut, V * curRowNum);
+                    vBetaOutQue.FreeTensor(tensorOut);
+                }
+            }
+            Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(flagAivFinishStore);
+        }
+    }
+    return;
+}
+
+template <typename kType, typename betaType>
+__aicore__ void inline PrepareWyReprBwdDAVectorProcess<kType, betaType>::ProcessMDuDw() {
+    uint32_t coreLoops = chunkNum;
+    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+    uint32_t coreNumAic = GetBlockNum();
+    uint32_t rowNum = rowNumMDuDw;
+    uint32_t rowOffset = 0;
+    uint32_t vecTaskIdx = 0;
+    uint32_t bos = 0;
+    uint32_t eos = 0;
+    uint32_t curRowNum = rowNum;
+
+    pipe->InitBuffer(mduInQue, 2, rowNum * BT * sizeof(kType));
+    pipe->InitBuffer(mdwInQue, 2, rowNum * BT * sizeof(kType));
+    pipe->InitBuffer(mduwOutQue, 2, rowNum * BT * sizeof(kType));
+
+    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
+        GetChunkOffset(cu_seqlens, chunk_indices, B, H, T, BT, loopIdx, bos, eos);
+        uint32_t curChunkSize = eos - bos;
+        for (int h = 0; h < H; h++) {
+            for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
+                ++vecTaskIdx;
+                if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
+                    continue;
+                }
+                curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
+                auto offset = (h * T + bos + rowOffset) * BT;
+                // copyin
+                {
+                    auto tensorMduin = mduInQue.AllocTensor<kType>();
+                    DataCopy(tensorMduin, dA2Tensor[offset], curRowNum * BT);
+                    auto tensorMdwin = mdwInQue.AllocTensor<kType>();
+                    DataCopy(tensorMdwin, dA1Tensor[offset], curRowNum * BT);
+                    mduInQue.EnQue(tensorMduin);
+                    mdwInQue.EnQue(tensorMdwin);
+                }
+                // compute
+                {
+                    auto tensorMduin = mduInQue.DeQue<kType>();
+                    auto tensorMdwin = mdwInQue.DeQue<kType>();
+                    auto tensorMduwOut = mduwOutQue.AllocTensor<kType>();
+                    auto mduwOutAddr = reinterpret_cast<uint64_t>(tensorMduwOut.GetPhyAddr());
+                    auto mduInAddr = reinterpret_cast<uint64_t>(tensorMduin.GetPhyAddr());
+                    auto mdwInAddr = reinterpret_cast<uint64_t>(tensorMdwin.GetPhyAddr());
+                    if (curRowNum == 1) {
+                        ProcessMDuDwComputerVFOneLineOneCol(
+                                (__ubuf__ kType*)mduwOutAddr, (__ubuf__ kType*)mduInAddr,
+                                (__ubuf__ kType*)mdwInAddr,
+                                curRowNum, BT, rowOffset);
+                    } else {
+                        uint16_t lastLoopCnt = curRowNum % PRELOAD_NUM;
+                        ProcessMDuDwComputerVFMutiLineOneCol(
+                                (__ubuf__ kType*)mduwOutAddr, (__ubuf__ kType*)mduInAddr,
+                                (__ubuf__ kType*)mdwInAddr,
+                                curRowNum, BT, rowOffset, lastLoopCnt);
+                    }
+                    mduInQue.FreeTensor(tensorMduin);
+                    mdwInQue.FreeTensor(tensorMdwin);
+                    mduwOutQue.EnQue(tensorMduwOut);
+                }
+                //copyout
+                {
+                    auto tensorMduwOut = mduwOutQue.DeQue<kType>();
+                    DataCopy(dA4Tensor[offset], tensorMduwOut, curRowNum * BT);
+                    mduwOutQue.FreeTensor(tensorMduwOut);
+                }
+            }
+            Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(flagAivFinishStore);
+        }
+    }
+    return;
+}
+
+// g_sub_exp的处理
+template <typename kType, typename betaType>
+__aicore__ void inline PrepareWyReprBwdDAVectorProcess<kType, betaType>::ProcessG() {
+    Arch::Resource<Arch::Ascend950> resource;
+    uint32_t coreLoops = chunkNum;
+    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+    uint32_t coreNumAic = GetBlockNum();
+    uint32_t rowNum = rowNumG;
+    uint32_t vecTaskIdx = 0;
+    uint32_t bos = 0;
+    uint32_t eos = 0;
+    uint32_t curRowNum = rowNum;
+
+    uint32_t ubOffset = 0;
+    uint32_t ubListId = 0;
+    uint32_t cvListId = 0;
+    int32_t eventVMTE2 = 0;
+    int32_t eventMTE2V = 0;
+    int32_t eventMTE3V = 0;
+    int32_t eventVMTE3 = 0;
+
+    AscendC::LocalTensor<kType> tensorDA6InList[MAX_CUBE_VEC_SYNC_NUM];
+    AscendC::LocalTensor<betaType> tensorGInList[UB_STAGES];
+    AscendC::LocalTensor<betaType> tensorGAllInList[UB_STAGES];
+    AscendC::LocalTensor<kType> tensorDAOutList[UB_STAGES];
+
+    int32_t eventUbInVMTE2List[UB_STAGES];
+    int32_t eventUbInMTE2VList[UB_STAGES];
+    int32_t eventUbOutMTE3VList[UB_STAGES];
+    int32_t eventUbOutVMTE3List[UB_STAGES];
+    int32_t eventUbGAllInVMTE2List[UB_STAGES];
+    int32_t eventUbGAllInMTE2VList[UB_STAGES];
+
+    // CV buffers: dA6 from cube
+    for (uint32_t i = 0; i < gCVNum; ++i) {
+        tensorDA6InList[i] = resource.ubBuf.template GetBufferByByte<kType>(ubOffset);
+        ubOffset += rowNum * BT * sizeof(kType);
+    }
+
+    // UB stage buffers
+    for (uint32_t i = 0; i < UB_STAGES; ++i) {
+        tensorGInList[i] = resource.ubBuf.template GetBufferByByte<betaType>(ubOffset);
+        ubOffset += rowNum * sizeof(betaType);
+        tensorGAllInList[i] = resource.ubBuf.template GetBufferByByte<betaType>(ubOffset);
+        ubOffset += BT * sizeof(betaType);
+        tensorDAOutList[i] = resource.ubBuf.template GetBufferByByte<kType>(ubOffset);
+        ubOffset += rowNum * BT * sizeof(kType);
+
+        eventUbInVMTE2List[i] = eventVMTE2++;
+        eventUbInMTE2VList[i] = eventMTE2V++;
+        eventUbOutMTE3VList[i] = eventMTE3V++;
+        eventUbOutVMTE3List[i] = eventVMTE3++;
+        eventUbGAllInVMTE2List[i] = eventVMTE2++;
+        eventUbGAllInMTE2VList[i] = eventMTE2V++;
+
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventUbInVMTE2List[i]);
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(eventUbOutMTE3VList[i]);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventUbGAllInVMTE2List[i]);
+    }
+
+    for (uint32_t i = 0; i < gCVNum; i++) {
+        AscendC::CrossCoreSetFlag<0x4, PIPE_V>(SYNC_AIV_AIC_FLAG_BEGIN + i);
+    }
+
+    uint32_t ubGAllListId = 0;
+
+    gTensor.SetGlobalBuffer((__gm__ betaType *)g);
+    dATensor.SetGlobalBuffer((__gm__ kType *)dA);
+
+    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
+        GetChunkOffset(cu_seqlens, chunk_indices, B, H, T, BT, loopIdx, bos, eos);
+        uint32_t curChunkSize = eos - bos;
+        for (int h = 0; h < H; h++) {
+            uint32_t taskNum = CeilDiv(curChunkSize, rowNum);
+            taskNum = CeilDiv(taskNum, GetSubBlockNum());
+            uint32_t dealTaskNum = 0;
+
+            // copyin gAll [1, BT] once per head
+            auto& tensorGAllIn = tensorGAllInList[ubGAllListId];
+            {
+                auto gAllOffset = h * T + bos;
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbGAllInVMTE2List[ubGAllListId]);
+                DataCopyPad(tensorGAllIn, gTensor[gAllOffset],
+                    {1, curChunkSize * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},
+                    {false, 0, 0, 0});
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventUbGAllInMTE2VList[ubGAllListId]);
+            }
+            int gAllInMTE2VNum = 1;
+
+            for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
+                ++vecTaskIdx;
+                if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
+                    continue;
+                }
+                curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
+                auto gOffset = h * T + bos + rowOffset;
+                auto offset = (h * T + bos + rowOffset) * BT;
+
+                auto& tensorDA6In = tensorDA6InList[cvListId];
+                auto& tensorGIn = tensorGInList[ubListId];
+                auto& tensorDAOut = tensorDAOutList[ubListId];
+                // copyin g
+                {
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbInVMTE2List[ubListId]);
+                    DataCopyPad(tensorGIn, gTensor[gOffset],
+                        {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},
+                        {false, 0, 0, 0});
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventUbInMTE2VList[ubListId]);
+                }
+                // compute
+                {
+                    auto dA6InAddr = reinterpret_cast<uint64_t>(tensorDA6In.GetPhyAddr());
+                    auto gInAddr = reinterpret_cast<uint64_t>(tensorGIn.GetPhyAddr());
+                    auto gAllInAddr = reinterpret_cast<uint64_t>(tensorGAllIn.GetPhyAddr());
+                    auto dAOutAddr = reinterpret_cast<uint64_t>(tensorDAOut.GetPhyAddr());
+
+                    if (rowOffset == 0) {
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventUbGAllInMTE2VList[ubGAllListId]);
+                        gAllInMTE2VNum--;
+                    }
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventUbInMTE2VList[ubListId]);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(eventUbOutMTE3VList[ubListId]);
+                    AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(SYNC_AIC_AIV_FLAG_BEGIN + cvListId);
+
+                    if (curRowNum == 1) {
+                        ProcessGComputerVFOneLineOneCol(
+                                (__ubuf__ kType*)dAOutAddr, (__ubuf__ kType*)dA6InAddr,
+                                (__ubuf__ betaType*)gInAddr, (__ubuf__ betaType*)gAllInAddr,
+                                curRowNum, BT, rowOffset, curChunkSize);
+                    } else {
+                        uint16_t lastLoopCnt = curRowNum % PRELOAD_NUM;
+                        ProcessGComputerVFMutiLineOneCol(
+                                (__ubuf__ kType*)dAOutAddr, (__ubuf__ kType*)dA6InAddr,
+                                (__ubuf__ betaType*)gInAddr, (__ubuf__ betaType*)gAllInAddr,
+                                curRowNum, BT, rowOffset, lastLoopCnt, curChunkSize);
+                    }
+
+                    AscendC::CrossCoreSetFlag<0x4, PIPE_V>(SYNC_AIV_AIC_FLAG_BEGIN + cvListId);
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(eventUbOutVMTE3List[ubListId]);
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventUbInVMTE2List[ubListId]);
+                }
+                // copyout
+                {
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(eventUbOutVMTE3List[ubListId]);
+                    DataCopy(dATensor[offset], tensorDAOut, BT * curRowNum);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(eventUbOutMTE3VList[ubListId]);
+                }
+                ubListId = (ubListId + 1 < UB_STAGES) ? (ubListId + 1) : 0;
+                cvListId = (cvListId + 1 < gCVNum) ? (cvListId + 1) : 0;
+                dealTaskNum++;
+            }
+
+            for (uint32_t taskId = dealTaskNum; taskId < taskNum; taskId++) {
+                AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(SYNC_AIC_AIV_FLAG_BEGIN + cvListId);
+                AscendC::CrossCoreSetFlag<0x4, PIPE_V>(SYNC_AIV_AIC_FLAG_BEGIN + cvListId);
+                cvListId = (cvListId + 1 < gCVNum) ? (cvListId + 1) : 0;
+            }
+
+            if (gAllInMTE2VNum > 0) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventUbGAllInMTE2VList[ubGAllListId]);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventUbGAllInVMTE2List[ubGAllListId]);
+            ubGAllListId = (ubGAllListId + 1 < UB_STAGES) ? (ubGAllListId + 1) : 0;
+        }
+    }
+    for (uint32_t i = 0; i < UB_STAGES; ++i) {
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbInVMTE2List[i]);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(eventUbOutMTE3VList[i]);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbGAllInVMTE2List[i]);
+    }
+    return;
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdDAVectorProcess<kType, betaType>::ProcessKBetaGComputerVFOneLineOneCol(
+    __ubuf__ kType* kBetaGOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    __ubuf__ betaType* gIn, uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    RegTensor<kType> kInReg;
+    RegTensor<betaType> betaInReg;
+    RegTensor<betaType> gInReg;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg;
+    RegTensor<float> kBetaGFP32ZeroReg, kBetaGFP32OneReg;
+    RegTensor<float> betaFP32Reg, gFP32Reg, betaGFP32Reg;
+    RegTensor<kType> kBetaGOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(gInReg, gIn);
+    LoadIn<kType, false>(kInReg, kIn);
+
+    HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+    HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+    Exp(gFP32Reg, gFP32Reg, maskFull32);
+    Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+
+    CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+    MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaGFP32Reg, betaGFP32Reg, maskFull32);
+    CastFloat2Half<kType>(kBetaGOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+    StoreAlign(kBetaGOut, kBetaGOutReg, maskFull16);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdDAVectorProcess<kType, betaType>::ProcessKBetaGComputerVFMutiLineOneCol(
+    __ubuf__ kType* kBetaGOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    __ubuf__ betaType* gIn, uint16_t mSize, uint16_t nSize, uint16_t lastLoopCnt)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    RegTensor<kType> kInReg, kInReg1;
+    RegTensor<betaType> betaInReg, betaInReg1;
+    RegTensor<betaType> gInReg, gInReg1;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg1, kFP32OneReg1;
+    RegTensor<float> kBetaGFP32ZeroReg, kBetaGFP32OneReg, kBetaGFP32ZeroReg1, kBetaGFP32OneReg1;
+    RegTensor<float> betaFP32Reg, betaFP32Reg1;
+    RegTensor<float> gFP32Reg, gFP32Reg1;
+    RegTensor<float> betaGFP32Reg, betaGFP32Reg1;
+    RegTensor<kType> kBetaGOutReg, kBetaGOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(betaInReg1, betaIn + 1);
+    LoadIn<betaType, true>(gInReg, gIn);
+    LoadIn<betaType, true>(gInReg1, gIn + 1);
+    LoadIn<kType, false>(kInReg, kIn);
+    LoadIn<kType, false>(kInReg1, kIn + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaFP32Reg1, betaInReg1, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1) * PRELOAD_NUM);
+        LoadIn<betaType, true>(betaInReg1, betaIn + (mIdx + 1) * PRELOAD_NUM + 1);
+        HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gFP32Reg1, gInReg1, maskFull16, maskFull32);
+        LoadIn<betaType, true>(gInReg, gIn + (mIdx + 1) * PRELOAD_NUM);
+        LoadIn<betaType, true>(gInReg1, gIn + (mIdx + 1) * PRELOAD_NUM + 1);
+        Exp(gFP32Reg, gFP32Reg, maskFull32);
+        Exp(gFP32Reg1, gFP32Reg1, maskFull32);
+        Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+        Mul(betaGFP32Reg1, betaFP32Reg1, gFP32Reg1, maskFull32);
+
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        LoadIn<kType, false>(kInReg, kIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(kInReg1, kIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaGFP32Reg, betaGFP32Reg, maskFull32);
+        MulFloatTwoReg(kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, betaGFP32Reg1, betaGFP32Reg1, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg1, kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * PRELOAD_NUM), kBetaGOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), kBetaGOutReg1, maskFull16);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaFP32Reg1, betaInReg1, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gFP32Reg1, gInReg1, maskFull16, maskFull32);
+        Exp(gFP32Reg, gFP32Reg, maskFull32);
+        Exp(gFP32Reg1, gFP32Reg1, maskFull32);
+        Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+        Mul(betaGFP32Reg1, betaFP32Reg1, gFP32Reg1, maskFull32);
+
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+
+        MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaGFP32Reg, betaGFP32Reg, maskFull32);
+        MulFloatTwoReg(kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, betaGFP32Reg1, betaGFP32Reg1, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg1, kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * PRELOAD_NUM), kBetaGOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), kBetaGOutReg1, maskFull16);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<betaType, true>(betaInReg, betaIn + mIdx * PRELOAD_NUM);
+            LoadIn<betaType, true>(gInReg, gIn + mIdx * PRELOAD_NUM);
+            LoadIn<kType, false>(kInReg, kIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+            HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+            Exp(gFP32Reg, gFP32Reg, maskFull32);
+            Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaGFP32Reg, betaGFP32Reg, maskFull32);
+            CastFloat2Half<kType>(kBetaGOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * PRELOAD_NUM), kBetaGOutReg, maskFull16);
+        }
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdDAVectorProcess<kType, betaType>::ProcessKBetaGComputerVFTwoCol(
+    __ubuf__ kType* kBetaGOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    __ubuf__ betaType* gIn, uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    uint16_t mLoopCnt = mSize - 1;
+    RegTensor<kType> kInReg, kInReg1;
+    RegTensor<betaType> betaInReg;
+    RegTensor<betaType> gInReg;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg1, kFP32OneReg1;
+    RegTensor<float> kBetaGFP32ZeroReg, kBetaGFP32OneReg, kBetaGFP32ZeroReg1, kBetaGFP32OneReg1;
+    RegTensor<float> betaFP32Reg, gFP32Reg, betaGFP32Reg;
+    RegTensor<kType> kBetaGOutReg, kBetaGOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(gInReg, gIn);
+    LoadIn<kType, false>(kInReg, kIn);
+    LoadIn<kType, false>(kInReg1, kIn + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1));
+        HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+        LoadIn<betaType, true>(gInReg, gIn + (mIdx + 1));
+        Exp(gFP32Reg, gFP32Reg, maskFull32);
+        Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        LoadIn<kType, false>(kInReg, kIn + oneEleNum * ((mIdx + 1) * 2));
+        LoadIn<kType, false>(kInReg1, kIn + oneEleNum * ((mIdx + 1) * 2 + 1));
+
+        MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaGFP32Reg, betaGFP32Reg, maskFull32);
+        MulFloatTwoReg(kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, betaGFP32Reg, betaGFP32Reg, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg1, kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * 2), kBetaGOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * 2 + 1), kBetaGOutReg1, maskFull16);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+        Exp(gFP32Reg, gFP32Reg, maskFull32);
+        Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaGFP32Reg, betaGFP32Reg, maskFull32);
+        MulFloatTwoReg(kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, betaGFP32Reg, betaGFP32Reg, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg1, kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * 2), kBetaGOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * 2 + 1), kBetaGOutReg1, maskFull16);
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdDAVectorProcess<kType, betaType>::ProcessVBetaComputerVFOneLineOneCol(
+    __ubuf__ kType* vBetaOut, __ubuf__ kType* vIn, __ubuf__ betaType* betaIn,
+    uint16_t mSize, uint16_t nSize)
+{
+    RegTensor<kType> vInReg;
+    RegTensor<betaType> betaInReg;
+    RegTensor<float> vFP32ZeroReg, vFP32OneReg;
+    RegTensor<float> vBetaFP32ZeroReg, vBetaFP32OneReg;
+    RegTensor<float> betaBrcbFP32Reg;
+    RegTensor<kType> vBetaOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<kType, false>(vInReg, vIn);
+
+    HalfOrFloat2Float<betaType>(betaBrcbFP32Reg, betaInReg, maskFull16, maskFull32);
+    CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+    MulFloatTwoReg(vBetaFP32ZeroReg, vBetaFP32OneReg, vFP32ZeroReg, vFP32OneReg, betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+    CastFloat2Half<kType>(vBetaOutReg, vBetaFP32ZeroReg, vBetaFP32OneReg, maskFull32);
+    StoreAlign(vBetaOut, vBetaOutReg, maskFull16);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdDAVectorProcess<kType, betaType>::ProcessVBetaComputerVFMutiLineOneCol(
+    __ubuf__ kType* vBetaOut, __ubuf__ kType* vIn, __ubuf__ betaType* betaIn,
+    uint16_t mSize, uint16_t nSize, uint16_t lastLoopCnt)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    RegTensor<kType> vInReg, vInReg1;
+    RegTensor<betaType> betaInReg, betaInReg1;
+    RegTensor<float> vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg1, vFP32OneReg1;
+    RegTensor<float> vBetaFP32ZeroReg, vBetaFP32OneReg, vBetaFP32ZeroReg1, vBetaFP32OneReg1;
+    RegTensor<float> betaBrcbFP32Reg, betaBrcbFP32Reg1;
+    RegTensor<kType> vBetaOutReg, vBetaOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(betaInReg1, betaIn + 1);
+    LoadIn<kType, false>(vInReg, vIn);
+    LoadIn<kType, false>(vInReg1, vIn + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32Reg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32Reg1, betaInReg1, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1) * PRELOAD_NUM);
+        LoadIn<betaType, true>(betaInReg1, betaIn + (mIdx + 1) * PRELOAD_NUM + 1);
+        CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+        CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+        LoadIn<kType, false>(vInReg, vIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(vInReg1, vIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        MulFloatTwoReg(vBetaFP32ZeroReg, vBetaFP32OneReg, vFP32ZeroReg, vFP32OneReg, betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+        MulFloatTwoReg(vBetaFP32ZeroReg1, vBetaFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1, betaBrcbFP32Reg1, betaBrcbFP32Reg1, maskFull32);
+        CastFloat2Half<kType>(vBetaOutReg, vBetaFP32ZeroReg, vBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(vBetaOutReg1, vBetaFP32ZeroReg1, vBetaFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * PRELOAD_NUM), vBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), vBetaOutReg1, maskFull16);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32Reg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32Reg1, betaInReg1, maskFull16, maskFull32);
+        CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+        CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+        MulFloatTwoReg(vBetaFP32ZeroReg, vBetaFP32OneReg, vFP32ZeroReg, vFP32OneReg, betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+        MulFloatTwoReg(vBetaFP32ZeroReg1, vBetaFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1, betaBrcbFP32Reg1, betaBrcbFP32Reg1, maskFull32);
+        CastFloat2Half<kType>(vBetaOutReg, vBetaFP32ZeroReg, vBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(vBetaOutReg1, vBetaFP32ZeroReg1, vBetaFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * PRELOAD_NUM), vBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), vBetaOutReg1, maskFull16);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<betaType, true>(betaInReg, betaIn + mIdx * PRELOAD_NUM);
+            LoadIn<kType, false>(vInReg, vIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            HalfOrFloat2Float<betaType>(betaBrcbFP32Reg, betaInReg, maskFull16, maskFull32);
+            CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+            MulFloatTwoReg(vBetaFP32ZeroReg, vBetaFP32OneReg, vFP32ZeroReg, vFP32OneReg, betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+            CastFloat2Half<kType>(vBetaOutReg, vBetaFP32ZeroReg, vBetaFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * PRELOAD_NUM), vBetaOutReg, maskFull16);
+        }
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdDAVectorProcess<kType, betaType>::ProcessVBetaComputerVFTwoCol(
+    __ubuf__ kType* vBetaOut, __ubuf__ kType* vIn, __ubuf__ betaType* betaIn,
+    uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    uint16_t mLoopCnt = mSize - 1;
+    RegTensor<kType> vInReg, vInReg1;
+    RegTensor<betaType> betaInReg;
+    RegTensor<float> vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg1, vFP32OneReg1;
+    RegTensor<float> vBetaFP32ZeroReg, vBetaFP32OneReg, vBetaFP32ZeroReg1, vBetaFP32OneReg1;
+    RegTensor<float> betaBrcbFP32Reg;
+    RegTensor<kType> vBetaOutReg, vBetaOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<kType, false>(vInReg, vIn);
+    LoadIn<kType, false>(vInReg1, vIn + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32Reg, betaInReg, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1));
+        CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+        CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+        LoadIn<kType, false>(vInReg, vIn + oneEleNum * ((mIdx + 1) * 2));
+        LoadIn<kType, false>(vInReg1, vIn + oneEleNum * ((mIdx + 1) * 2 + 1));
+        MulFloatTwoReg(vBetaFP32ZeroReg, vBetaFP32OneReg, vFP32ZeroReg, vFP32OneReg, betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+        MulFloatTwoReg(vBetaFP32ZeroReg1, vBetaFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1, betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+        CastFloat2Half<kType>(vBetaOutReg, vBetaFP32ZeroReg, vBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(vBetaOutReg1, vBetaFP32ZeroReg1, vBetaFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * 2), vBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * 2 + 1), vBetaOutReg1, maskFull16);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32Reg, betaInReg, maskFull16, maskFull32);
+        CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+        CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+        MulFloatTwoReg(vBetaFP32ZeroReg, vBetaFP32OneReg, vFP32ZeroReg, vFP32OneReg, betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+        MulFloatTwoReg(vBetaFP32ZeroReg1, vBetaFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1, betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+        CastFloat2Half<kType>(vBetaOutReg, vBetaFP32ZeroReg, vBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(vBetaOutReg1, vBetaFP32ZeroReg1, vBetaFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * 2), vBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * 2 + 1), vBetaOutReg1, maskFull16);
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdDAVectorProcess<kType, betaType>::ProcessMDuDwComputerVFOneLineOneCol(
+    __ubuf__ kType* mduwOut, __ubuf__ kType* mduIn, __ubuf__ kType* mdwIn,
+    uint16_t mSize, uint16_t nSize, uint32_t startRow)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    RegTensor<kType> mduInReg, mdwInReg;
+    RegTensor<float> mduFP32ZeroReg, mduFP32OneReg;
+    RegTensor<float> mdwFP32ZeroReg, mdwFP32OneReg;
+    RegTensor<half> colIdxReg;
+    RegTensor<float> colIdxFP32ZeroReg, colIdxFP32OneReg;
+    RegTensor<float> resultFP32ZeroReg, resultFP32OneReg, zeroReg, rowIdxReg;
+    RegTensor<kType> mduwOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    MaskReg maskZeroSelect, maskOneSelect;
+    MaskReg maskStore;
+    Duplicate(zeroReg, static_cast<float>(0), maskFull32);
+    Arange(colIdxReg, 0);
+    CastHalf2Float<half>(colIdxFP32ZeroReg, colIdxFP32OneReg, colIdxReg, maskFull16);
+
+    LoadIn<kType, false>(mduInReg, mduIn);
+    LoadIn<kType, false>(mdwInReg, mdwIn);
+    Duplicate(rowIdxReg, static_cast<float>(startRow));
+    CastHalf2Float<kType>(mduFP32ZeroReg, mduFP32OneReg, mduInReg, maskFull16);
+    CastHalf2Float<kType>(mdwFP32ZeroReg, mdwFP32OneReg, mdwInReg, maskFull16);
+    AddFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, mduFP32ZeroReg, mduFP32OneReg, mdwFP32ZeroReg, mdwFP32OneReg, maskFull32);
+
+    CompareTwoReg<float, CMPMODE::GE>(maskZeroSelect, maskOneSelect, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+    SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg, resultFP32ZeroReg, resultFP32OneReg, maskZeroSelect, maskOneSelect);
+
+    CastFloat2Half<kType>(mduwOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+    uint32_t storeLen = oneEleNum;
+    maskStore = UpdateMask<kType>(storeLen);
+    StoreAlign(mduwOut, mduwOutReg, maskStore);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdDAVectorProcess<kType, betaType>::ProcessMDuDwComputerVFMutiLineOneCol(
+    __ubuf__ kType* mduwOut, __ubuf__ kType* mduIn, __ubuf__ kType* mdwIn,
+    uint16_t mSize, uint16_t nSize, uint32_t startRow, uint16_t lastLoopCnt)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    RegTensor<kType> mduInReg, mduInReg1;
+    RegTensor<kType> mdwInReg, mdwInReg1;
+    RegTensor<float> mduFP32ZeroReg, mduFP32OneReg, mduFP32ZeroReg1, mduFP32OneReg1;
+    RegTensor<float> mdwFP32ZeroReg, mdwFP32OneReg, mdwFP32ZeroReg1, mdwFP32OneReg1;
+    RegTensor<half> colIdxReg;
+    RegTensor<float> colIdxFP32ZeroReg, colIdxFP32OneReg;
+    RegTensor<float> resultFP32ZeroReg, resultFP32OneReg, resultFP32ZeroReg1, resultFP32OneReg1, zeroReg, rowIdxReg;
+    RegTensor<kType> mduwOutReg, mduwOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+    MaskReg maskZeroSelect, maskOneSelect;
+    MaskReg maskZeroSelect1, maskOneSelect1;
+    MaskReg maskStore;
+    Duplicate(zeroReg, static_cast<float>(0), maskFull32);
+    Arange(colIdxReg, 0);
+    CastHalf2Float<half>(colIdxFP32ZeroReg, colIdxFP32OneReg, colIdxReg, maskFull16);
+
+    LoadIn<kType, false>(mduInReg, mduIn);
+    LoadIn<kType, false>(mduInReg1, mduIn + oneEleNum);
+    LoadIn<kType, false>(mdwInReg, mdwIn);
+    LoadIn<kType, false>(mdwInReg1, mdwIn + oneEleNum);
+
+    Duplicate(rowIdxReg, static_cast<float>(startRow));
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        CastHalf2Float<kType>(mduFP32ZeroReg, mduFP32OneReg, mduInReg, maskFull16);
+        CastHalf2Float<kType>(mduFP32ZeroReg1, mduFP32OneReg1, mduInReg1, maskFull16);
+        LoadIn<kType, false>(mduInReg, mduIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(mduInReg1, mduIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(mdwFP32ZeroReg, mdwFP32OneReg, mdwInReg, maskFull16);
+        CastHalf2Float<kType>(mdwFP32ZeroReg1, mdwFP32OneReg1, mdwInReg1, maskFull16);
+        LoadIn<kType, false>(mdwInReg, mdwIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(mdwInReg1, mdwIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        AddFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, mduFP32ZeroReg, mduFP32OneReg, mdwFP32ZeroReg, mdwFP32OneReg, maskFull32);
+        AddFloatTwoReg(resultFP32ZeroReg1, resultFP32OneReg1, mduFP32ZeroReg1, mduFP32OneReg1, mdwFP32ZeroReg1, mdwFP32OneReg1, maskFull32);
+
+        CompareTwoReg<float, CMPMODE::GE>(maskZeroSelect, maskOneSelect, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg, resultFP32ZeroReg, resultFP32OneReg, maskZeroSelect, maskOneSelect);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+        CompareTwoReg<float, CMPMODE::GE>(maskZeroSelect1, maskOneSelect1, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg1, resultFP32OneReg1, zeroReg, zeroReg, resultFP32ZeroReg1, resultFP32OneReg1, maskZeroSelect1, maskOneSelect1);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+        CastFloat2Half<kType>(mduwOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(mduwOutReg1, resultFP32ZeroReg1, resultFP32OneReg1, maskFull32);
+        uint32_t storeLen = oneEleNum;
+        maskStore = UpdateMask<kType>(storeLen);
+        StoreAlign((__ubuf__ kType*&)mduwOut + oneEleNum * (mIdx * PRELOAD_NUM), mduwOutReg, maskStore);
+        storeLen = oneEleNum;
+        maskStore = UpdateMask<kType>(storeLen);
+        StoreAlign((__ubuf__ kType*&)mduwOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), mduwOutReg1, maskStore);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        CastHalf2Float<kType>(mduFP32ZeroReg, mduFP32OneReg, mduInReg, maskFull16);
+        CastHalf2Float<kType>(mduFP32ZeroReg1, mduFP32OneReg1, mduInReg1, maskFull16);
+        CastHalf2Float<kType>(mdwFP32ZeroReg, mdwFP32OneReg, mdwInReg, maskFull16);
+        CastHalf2Float<kType>(mdwFP32ZeroReg1, mdwFP32OneReg1, mdwInReg1, maskFull16);
+
+        AddFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, mduFP32ZeroReg, mduFP32OneReg, mdwFP32ZeroReg, mdwFP32OneReg, maskFull32);
+        AddFloatTwoReg(resultFP32ZeroReg1, resultFP32OneReg1, mduFP32ZeroReg1, mduFP32OneReg1, mdwFP32ZeroReg1, mdwFP32OneReg1, maskFull32);
+
+        CompareTwoReg<float, CMPMODE::GE>(maskZeroSelect, maskOneSelect, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg, resultFP32ZeroReg, resultFP32OneReg, maskZeroSelect, maskOneSelect);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+        CompareTwoReg<float, CMPMODE::GE>(maskZeroSelect1, maskOneSelect1, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg1, resultFP32OneReg1, zeroReg, zeroReg, resultFP32ZeroReg1, resultFP32OneReg1, maskZeroSelect1, maskOneSelect1);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+        CastFloat2Half<kType>(mduwOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(mduwOutReg1, resultFP32ZeroReg1, resultFP32OneReg1, maskFull32);
+        uint32_t storeLen = oneEleNum;
+        maskStore = UpdateMask<kType>(storeLen);
+        StoreAlign((__ubuf__ kType*&)mduwOut + oneEleNum * (mIdx * PRELOAD_NUM), mduwOutReg, maskStore);
+        storeLen = oneEleNum;
+        maskStore = UpdateMask<kType>(storeLen);
+        StoreAlign((__ubuf__ kType*&)mduwOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), mduwOutReg1, maskStore);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<kType, false>(mduInReg, mduIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            LoadIn<kType, false>(mdwInReg, mdwIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            CastHalf2Float<kType>(mduFP32ZeroReg, mduFP32OneReg, mduInReg, maskFull16);
+            CastHalf2Float<kType>(mdwFP32ZeroReg, mdwFP32OneReg, mdwInReg, maskFull16);
+            AddFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, mduFP32ZeroReg, mduFP32OneReg, mdwFP32ZeroReg, mdwFP32OneReg, maskFull32);
+
+            CompareTwoReg<float, CMPMODE::GE>(maskZeroSelect, maskOneSelect, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+            SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg, resultFP32ZeroReg, resultFP32OneReg, maskZeroSelect, maskOneSelect);
+
+            CastFloat2Half<kType>(mduwOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+            uint32_t storeLen = oneEleNum;
+            maskStore = UpdateMask<kType>(storeLen);
+            StoreAlign((__ubuf__ kType*&)mduwOut + oneEleNum * (mIdx * PRELOAD_NUM), mduwOutReg, maskStore);
+        }
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdDAVectorProcess<kType, betaType>::ProcessGComputerVFOneLineOneCol(
+    __ubuf__ kType* dAOut, __ubuf__ kType* dA6In, __ubuf__ betaType* gIn, __ubuf__ betaType* gAllIn,
+    uint16_t mSize, uint16_t nSize, uint32_t startRow, uint32_t calcColSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    RegTensor<kType> dA6InReg;
+    RegTensor<betaType> gInReg, gAllInReg;
+    RegTensor<float> dA6FP32ZeroReg, dA6FP32OneReg;
+    RegTensor<float> gFP32ZeroReg;
+    RegTensor<float> gFactorZeroReg, gFactorOneReg;
+    RegTensor<float> gAllFP32ZeroReg, gAllFP32OneReg;
+    RegTensor<float> resultFP32ZeroReg, resultFP32OneReg;
+    RegTensor<half> colIdxReg;
+    RegTensor<float> colIdxFP32ZeroReg, colIdxFP32OneReg;
+    RegTensor<float> zeroReg, negOneReg, rowIdxReg;
+    RegTensor<kType> dAOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+    MaskReg maskZeroSelect, maskOneSelect;
+    MaskReg maskStore;
+    MaskReg castDA6MaskCount16;
+    uint32_t castDA6Count = calcColSize;
+    castDA6MaskCount16 = UpdateMask<kType>(castDA6Count);
+
+    Duplicate(zeroReg, static_cast<float>(0), maskFull32);
+    Duplicate(negOneReg, static_cast<float>(-1), maskFull32);
+    Arange(colIdxReg, 0);
+    CastHalf2Float<half>(colIdxFP32ZeroReg, colIdxFP32OneReg, colIdxReg, maskFull16);
+
+    if constexpr (!std::is_same<betaType, float>()) {
+        LoadAlign(gAllInReg, gAllIn);
+        Cast<float, betaType, ctHalf2Fp32Zero>(gAllFP32ZeroReg, gAllInReg, maskFull16);
+        Cast<float, betaType, ctHalf2Fp32One>(gAllFP32OneReg, gAllInReg, maskFull16);
+    } else {
+        LoadAlign<betaType, LoadDist::DIST_DINTLV_B32>(gAllFP32ZeroReg, gAllFP32OneReg, gAllIn);
+    }
+    LoadIn<kType, false>(dA6InReg, dA6In);
+    LoadIn<betaType, true>(gInReg, gIn);
+
+    Duplicate(rowIdxReg, static_cast<float>(startRow));
+    CastHalf2Float<kType>(dA6FP32ZeroReg, dA6FP32OneReg, dA6InReg, castDA6MaskCount16);
+    HalfOrFloat2Float<betaType>(gFP32ZeroReg, gInReg, maskFull16, maskFull32);
+
+    SubFloatTwoReg(gFactorZeroReg, gFactorOneReg, gAllFP32ZeroReg, gAllFP32OneReg, gFP32ZeroReg, gFP32ZeroReg, maskFull32);
+    MinsFloatTwoReg(gFactorZeroReg, gFactorOneReg, gFactorZeroReg, gFactorOneReg, float(0.0), maskFull32);
+    ExpFloatTwoReg(gFactorZeroReg, gFactorOneReg, gFactorZeroReg, gFactorOneReg, maskFull32);
+
+    // result = -dA6 * gAll
+    MulFloatTwoReg(dA6FP32ZeroReg, dA6FP32OneReg, dA6FP32ZeroReg, dA6FP32OneReg, negOneReg, negOneReg, maskFull32);
+    MulFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, dA6FP32ZeroReg, dA6FP32OneReg, gFactorZeroReg, gFactorOneReg, maskFull32);
+
+    CompareTwoReg<float, CMPMODE::LE>(maskZeroSelect, maskOneSelect, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+    SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg, resultFP32ZeroReg, resultFP32OneReg, maskZeroSelect, maskOneSelect);
+    Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+    CastFloat2Half<kType>(dAOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+    uint32_t storeLen = oneEleNum;
+    maskStore = UpdateMask<kType>(storeLen);
+    StoreAlign((__ubuf__ kType*&)dAOut, dAOutReg, maskStore);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdDAVectorProcess<kType, betaType>::ProcessGComputerVFMutiLineOneCol(
+    __ubuf__ kType* dAOut, __ubuf__ kType* dA6In, __ubuf__ betaType* gIn, __ubuf__ betaType* gAllIn,
+    uint16_t mSize, uint16_t nSize, uint32_t startRow, uint16_t lastLoopCnt, uint32_t calcColSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    RegTensor<kType> dA6InReg, dA6InReg1;
+    RegTensor<betaType> gInReg, gInReg1, gAllInReg;
+    RegTensor<float> dA6FP32ZeroReg, dA6FP32OneReg, dA6FP32ZeroReg1, dA6FP32OneReg1;
+    RegTensor<float> gFP32ZeroReg, gFP32ZeroReg1;
+    RegTensor<float> gFactorZeroReg, gFactorOneReg, gFactorZeroReg1, gFactorOneReg1;
+    RegTensor<float> gAllFP32ZeroReg, gAllFP32OneReg;
+    RegTensor<float> resultFP32ZeroReg, resultFP32OneReg, resultFP32ZeroReg1, resultFP32OneReg1;
+    RegTensor<half> colIdxReg;
+    RegTensor<float> colIdxFP32ZeroReg, colIdxFP32OneReg;
+    RegTensor<float> zeroReg, negOneReg, rowIdxReg;
+    RegTensor<kType> dAOutReg, dAOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+    MaskReg maskZeroSelect, maskOneSelect;
+    MaskReg maskZeroSelect1, maskOneSelect1;
+    MaskReg maskStore;
+    MaskReg castDA6MaskCount16;
+
+    Duplicate(zeroReg, static_cast<float>(0), maskFull32);
+    Duplicate(negOneReg, static_cast<float>(-1), maskFull32);
+    Arange(colIdxReg, 0);
+    CastHalf2Float<half>(colIdxFP32ZeroReg, colIdxFP32OneReg, colIdxReg, maskFull16);
+
+    if constexpr (!std::is_same<betaType, float>()) {
+        LoadAlign(gAllInReg, gAllIn);
+        Cast<float, betaType, ctHalf2Fp32Zero>(gAllFP32ZeroReg, gAllInReg, maskFull16);
+        Cast<float, betaType, ctHalf2Fp32One>(gAllFP32OneReg, gAllInReg, maskFull16);
+    } else {
+        LoadAlign<betaType, LoadDist::DIST_DINTLV_B32>(gAllFP32ZeroReg, gAllFP32OneReg, gAllIn);
+    }
+    LoadIn<kType, false>(dA6InReg, dA6In);
+    LoadIn<kType, false>(dA6InReg1, dA6In + oneEleNum);
+    LoadIn<betaType, true>(gInReg, gIn);
+    LoadIn<betaType, true>(gInReg1, gIn + 1);
+
+    Duplicate(rowIdxReg, static_cast<float>(startRow));
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        uint32_t castDA6Count = calcColSize;
+        castDA6MaskCount16 = UpdateMask<kType>(castDA6Count);
+        CastHalf2Float<kType>(dA6FP32ZeroReg, dA6FP32OneReg, dA6InReg, castDA6MaskCount16);
+        castDA6Count = calcColSize;
+        castDA6MaskCount16 = UpdateMask<kType>(castDA6Count);
+        CastHalf2Float<kType>(dA6FP32ZeroReg1, dA6FP32OneReg1, dA6InReg1, castDA6MaskCount16);
+        LoadIn<kType, false>(dA6InReg, dA6In + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dA6InReg1, dA6In + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        HalfOrFloat2Float<betaType>(gFP32ZeroReg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gFP32ZeroReg1, gInReg1, maskFull16, maskFull32);
+        LoadIn<betaType, true>(gInReg, gIn + (mIdx + 1) * PRELOAD_NUM);
+        LoadIn<betaType, true>(gInReg1, gIn + (mIdx + 1) * PRELOAD_NUM + 1);
+
+        SubFloatTwoReg(gFactorZeroReg, gFactorOneReg, gAllFP32ZeroReg, gAllFP32OneReg, gFP32ZeroReg, gFP32ZeroReg, maskFull32);
+        SubFloatTwoReg(gFactorZeroReg1, gFactorOneReg1, gAllFP32ZeroReg, gAllFP32OneReg, gFP32ZeroReg1, gFP32ZeroReg1, maskFull32);
+        MinsFloatTwoReg(gFactorZeroReg, gFactorOneReg, gFactorZeroReg, gFactorOneReg, float(0.0), maskFull32);
+        MinsFloatTwoReg(gFactorZeroReg1, gFactorOneReg1, gFactorZeroReg1, gFactorOneReg1, float(0.0), maskFull32);
+        ExpFloatTwoReg(gFactorZeroReg, gFactorOneReg, gFactorZeroReg, gFactorOneReg, maskFull32);
+        ExpFloatTwoReg(gFactorZeroReg1, gFactorOneReg1, gFactorZeroReg1, gFactorOneReg1, maskFull32);
+
+        // result = -dA6 * gAll
+        MulFloatTwoReg(dA6FP32ZeroReg, dA6FP32OneReg, dA6FP32ZeroReg, dA6FP32OneReg, negOneReg, negOneReg, maskFull32);
+        MulFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, dA6FP32ZeroReg, dA6FP32OneReg, gFactorZeroReg, gFactorOneReg, maskFull32);
+        MulFloatTwoReg(dA6FP32ZeroReg1, dA6FP32OneReg1, dA6FP32ZeroReg1, dA6FP32OneReg1, negOneReg, negOneReg, maskFull32);
+        MulFloatTwoReg(resultFP32ZeroReg1, resultFP32OneReg1, dA6FP32ZeroReg1, dA6FP32OneReg1, gFactorZeroReg1, gFactorOneReg1, maskFull32);
+
+        CompareTwoReg<float, CMPMODE::LE>(maskZeroSelect, maskOneSelect, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg, resultFP32ZeroReg, resultFP32OneReg, maskZeroSelect, maskOneSelect);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+        CompareTwoReg<float, CMPMODE::LE>(maskZeroSelect1, maskOneSelect1, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg1, resultFP32OneReg1, zeroReg, zeroReg, resultFP32ZeroReg1, resultFP32OneReg1, maskZeroSelect1, maskOneSelect1);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+        CastFloat2Half<kType>(dAOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dAOutReg1, resultFP32ZeroReg1, resultFP32OneReg1, maskFull32);
+        
+        uint32_t storeLen = oneEleNum;
+        maskStore = UpdateMask<kType>(storeLen);
+        StoreAlign((__ubuf__ kType*&)dAOut + oneEleNum * (mIdx * PRELOAD_NUM), dAOutReg, maskStore);
+        storeLen = oneEleNum;
+        maskStore = UpdateMask<kType>(storeLen);
+        StoreAlign((__ubuf__ kType*&)dAOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dAOutReg1, maskStore);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        uint32_t castDA6Count = calcColSize;
+        castDA6MaskCount16 = UpdateMask<kType>(castDA6Count);
+        CastHalf2Float<kType>(dA6FP32ZeroReg, dA6FP32OneReg, dA6InReg, castDA6MaskCount16);
+        castDA6Count = calcColSize;
+        castDA6MaskCount16 = UpdateMask<kType>(castDA6Count);
+        CastHalf2Float<kType>(dA6FP32ZeroReg1, dA6FP32OneReg1, dA6InReg1, castDA6MaskCount16);
+        HalfOrFloat2Float<betaType>(gFP32ZeroReg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gFP32ZeroReg1, gInReg1, maskFull16, maskFull32);
+
+        SubFloatTwoReg(gFactorZeroReg, gFactorOneReg, gAllFP32ZeroReg, gAllFP32OneReg, gFP32ZeroReg, gFP32ZeroReg, maskFull32);
+        SubFloatTwoReg(gFactorZeroReg1, gFactorOneReg1, gAllFP32ZeroReg, gAllFP32OneReg, gFP32ZeroReg1, gFP32ZeroReg1, maskFull32);
+        MinsFloatTwoReg(gFactorZeroReg, gFactorOneReg, gFactorZeroReg, gFactorOneReg, float(0.0), maskFull32);
+        MinsFloatTwoReg(gFactorZeroReg1, gFactorOneReg1, gFactorZeroReg1, gFactorOneReg1, float(0.0), maskFull32);
+        ExpFloatTwoReg(gFactorZeroReg, gFactorOneReg, gFactorZeroReg, gFactorOneReg, maskFull32);
+        ExpFloatTwoReg(gFactorZeroReg1, gFactorOneReg1, gFactorZeroReg1, gFactorOneReg1, maskFull32);
+
+        // result = -dA6 * gAll
+        MulFloatTwoReg(dA6FP32ZeroReg, dA6FP32OneReg, dA6FP32ZeroReg, dA6FP32OneReg, negOneReg, negOneReg, maskFull32);
+        MulFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, dA6FP32ZeroReg, dA6FP32OneReg, gFactorZeroReg, gFactorOneReg, maskFull32);
+        MulFloatTwoReg(dA6FP32ZeroReg1, dA6FP32OneReg1, dA6FP32ZeroReg1, dA6FP32OneReg1, negOneReg, negOneReg, maskFull32);
+        MulFloatTwoReg(resultFP32ZeroReg1, resultFP32OneReg1, dA6FP32ZeroReg1, dA6FP32OneReg1, gFactorZeroReg1, gFactorOneReg1, maskFull32);
+
+        CompareTwoReg<float, CMPMODE::LE>(maskZeroSelect, maskOneSelect, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg, resultFP32ZeroReg, resultFP32OneReg, maskZeroSelect, maskOneSelect);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+        CompareTwoReg<float, CMPMODE::LE>(maskZeroSelect1, maskOneSelect1, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg1, resultFP32OneReg1, zeroReg, zeroReg, resultFP32ZeroReg1, resultFP32OneReg1, maskZeroSelect1, maskOneSelect1);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+        CastFloat2Half<kType>(dAOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dAOutReg1, resultFP32ZeroReg1, resultFP32OneReg1, maskFull32);
+        uint32_t storeLen = oneEleNum;
+        maskStore = UpdateMask<kType>(storeLen);
+        StoreAlign((__ubuf__ kType*&)dAOut + oneEleNum * (mIdx * PRELOAD_NUM), dAOutReg, maskStore);
+        storeLen = oneEleNum;
+        maskStore = UpdateMask<kType>(storeLen);
+        StoreAlign((__ubuf__ kType*&)dAOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dAOutReg1, maskStore);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<kType, false>(dA6InReg, dA6In + oneEleNum * (mIdx * PRELOAD_NUM));
+            LoadIn<betaType, true>(gInReg, gIn + mIdx * PRELOAD_NUM);
+
+            uint32_t castDA6Count = calcColSize;
+            castDA6MaskCount16 = UpdateMask<kType>(castDA6Count);
+            CastHalf2Float<kType>(dA6FP32ZeroReg, dA6FP32OneReg, dA6InReg, castDA6MaskCount16);
+            HalfOrFloat2Float<betaType>(gFP32ZeroReg, gInReg, maskFull16, maskFull32);
+
+            SubFloatTwoReg(gFactorZeroReg, gFactorOneReg, gAllFP32ZeroReg, gAllFP32OneReg, gFP32ZeroReg, gFP32ZeroReg, maskFull32);
+            MinsFloatTwoReg(gFactorZeroReg, gFactorOneReg, gFactorZeroReg, gFactorOneReg, float(0.0), maskFull32);
+            ExpFloatTwoReg(gFactorZeroReg, gFactorOneReg, gFactorZeroReg, gFactorOneReg, maskFull32);
+
+            // result = -dA6 * gAll
+            MulFloatTwoReg(dA6FP32ZeroReg, dA6FP32OneReg, dA6FP32ZeroReg, dA6FP32OneReg, negOneReg, negOneReg, maskFull32);
+            MulFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, dA6FP32ZeroReg, dA6FP32OneReg, gFactorZeroReg, gFactorOneReg, maskFull32);
+
+            CompareTwoReg<float, CMPMODE::LE>(maskZeroSelect, maskOneSelect, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+            SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg, resultFP32ZeroReg, resultFP32OneReg, maskZeroSelect, maskOneSelect);
+            Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+            CastFloat2Half<kType>(dAOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+            uint32_t storeLen = oneEleNum;
+            maskStore = UpdateMask<kType>(storeLen);
+            StoreAlign((__ubuf__ kType*&)dAOut + oneEleNum * (mIdx * PRELOAD_NUM), dAOutReg, maskStore);
+        }
+    }
+}
+
+#endif  // PREPARE_WY_REPR_BWD_DA_VECTOR_H
+

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/prepare_wy_repr_bwd_da.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/prepare_wy_repr_bwd_da.cpp
@@ -13,9 +13,16 @@
  */
 
 #include "kernel_operator.h"
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#include "arch35/prepare_wy_repr_bwd_da_common.h"
+#include "arch35/prepare_wy_repr_bwd_da_cube.h"
+#include "arch35/prepare_wy_repr_bwd_da_vector.h"
+#include "arch35/prepare_wy_repr_bwd_da_tiling_data_apt.h"
+#else
 #include "prepare_wy_repr_bwd_da_common.h"
 #include "prepare_wy_repr_bwd_da_cube.h"
 #include "prepare_wy_repr_bwd_da_vector.h"
+#endif
 #include "lib/matmul_intf.h"
 // #include "kernel_basic_intf.h"
 
@@ -25,6 +32,9 @@ __global__ __aicore__ void prepare_wy_repr_bwd_da(GM_ADDR k, GM_ADDR v, GM_ADDR 
                                                   GM_ADDR dA, GM_ADDR workspace, GM_ADDR tiling)
 {
     AscendC::AscendCUtils::SetOverflow(1);
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    REGISTER_TILING_DEFAULT(PrepareWyReprBwdDaTilingDataA5);
+#endif
     GET_TILING_DATA(tilingData, tiling);
     if (TILING_KEY_IS(1)) {
         KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/arch35/prepare_wy_repr_bwd_full_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/arch35/prepare_wy_repr_bwd_full_vector.h
@@ -16,6 +16,7 @@
 #ifndef PREPARE_WY_REPR_BWD_FULL_VECTOR_H
 #define PREPARE_WY_REPR_BWD_FULL_VECTOR_H
 #include "catlass/arch/cross_core_sync.hpp"
+#include "kernel_utils/vector/regbase.hpp"
 constexpr uint32_t UB_ALIGN_SIZE = 32;
 
 using namespace AscendC;
@@ -62,10 +63,24 @@ public:
     __aicore__ inline void ProcessDvbA5();
     __aicore__ inline void ProcessKKTA5();
     __aicore__ inline void Init(const PrepareWyReprBwdFullTilingDataA5 &tiling, AscendC::TPipe *pipe_);
-    __simd_vf__ inline void ProcessKBetaComputerVF(__ubuf__ kType* kBetaOut,
+    __simd_vf__ inline void ProcessKBetaComputerVFMutiLineOneCol(__ubuf__ kType* kBetaOut,
+                                                   __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+                                                   uint16_t mSize, uint16_t nSize, uint16_t lastLoopCnt);
+    __simd_vf__ inline void ProcessKBetaComputerVFOneLineOneCol(__ubuf__ kType* kBetaOut,
                                                    __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
                                                    uint16_t mSize, uint16_t nSize);
-    __simd_vf__ inline void ProcessDkbComputerVF(__ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut,
+    __simd_vf__ inline void ProcessKBetaComputerVFTwoCol(__ubuf__ kType* kBetaOut,
+                                                   __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+                                                   uint16_t mSize, uint16_t nSize);
+    __simd_vf__ inline void ProcessDkbComputerVFOneLineOneCol(__ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut,
+                                                 __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+                                                 __ubuf__ kType* dkIn, __ubuf__ kType* dkbIn,
+                                                 uint16_t mSize, uint16_t nSize);
+    __simd_vf__ inline void ProcessDkbComputerVFMutiLineOneCol(__ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut,
+                                                 __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+                                                 __ubuf__ kType* dkIn, __ubuf__ kType* dkbIn,
+                                                 uint16_t mSize, uint16_t nSize);
+    __simd_vf__ inline void ProcessDkbComputerVFTwoCol(__ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut,
                                                  __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
                                                  __ubuf__ kType* dkIn, __ubuf__ kType* dkbIn,
                                                  uint16_t mSize, uint16_t nSize);
@@ -74,7 +89,15 @@ public:
                                                   __ubuf__ betaType* betaIn, __ubuf__ betaType* gIn,
                                                   __ubuf__ kType* dkIn, __ubuf__ betaType* dBetaIn,
                                                   __ubuf__ kType* dkbgIn, uint16_t mSize, uint16_t nSize);
-    __simd_vf__ inline void ProcessDvbComputerVF(__ubuf__ kType* dvOut, __ubuf__ betaType* dBetaOut,
+    __simd_vf__ inline void ProcessDvbComputerVFOneLineOneCol(__ubuf__ kType* dvOut, __ubuf__ betaType* dBetaOut,
+                                                 __ubuf__ kType* dvbIn, __ubuf__ kType* vIn,
+                                                 __ubuf__ betaType* betaIn, __ubuf__ betaType* dbetaIn,
+                                                 uint16_t mSize, uint16_t nSize);
+    __simd_vf__ inline void ProcessDvbComputerVFMutiLineOneCol(__ubuf__ kType* dvOut, __ubuf__ betaType* dBetaOut,
+                                                 __ubuf__ kType* dvbIn, __ubuf__ kType* vIn,
+                                                 __ubuf__ betaType* betaIn, __ubuf__ betaType* dbetaIn,
+                                                 uint16_t mSize, uint16_t nSize);
+    __simd_vf__ inline void ProcessDvbComputerVFTwoCol(__ubuf__ kType* dvOut, __ubuf__ betaType* dBetaOut,
                                                  __ubuf__ kType* dvbIn, __ubuf__ kType* vIn,
                                                  __ubuf__ betaType* betaIn, __ubuf__ betaType* dbetaIn,
                                                  uint16_t mSize, uint16_t nSize);
@@ -527,167 +550,271 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
 }
 
 template <typename kType, typename betaType>
-__simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDvbComputerVF(
+__simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDvbComputerVFMutiLineOneCol(
     __ubuf__ kType* dvOut, __ubuf__ betaType* dBetaOut, __ubuf__ kType* dvbIn, __ubuf__ kType* vIn,
     __ubuf__ betaType* betaIn, __ubuf__ betaType* dbetaIn, uint16_t mSize, uint16_t nSize)
 {
     uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
-    uint32_t nKUbAligned = Align(nSize, static_cast<uint16_t>(UB_ALIGN_SIZE / sizeof(kType)));
-    uint16_t nLoopCnt = (nSize + eleKNumPerVf - 1) / eleKNumPerVf;
-    RegTensor<betaType> betaInReg;
-    RegTensor<float> betaBrcbFP32Reg, dbetaFP32Reg;
-    RegTensor<kType> vInReg;
-    RegTensor<kType> dbetaInReg;
-    RegTensor<kType> dvbInReg;
-    RegTensor<float> vFP32ZeroReg, vFP32OneReg, dbetaAddFP32Reg, dvbFP32ZeroReg, dvbFP32OneReg, reduceSumReg;
-    RegTensor<kType> dvOutReg;
-    RegTensor<betaType> dbetaOutReg;
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    uint16_t lastLoopCnt = mSize % PRELOAD_NUM;
+    RegTensor<betaType> betaInReg, betaInReg1;
+    RegTensor<kType> vInReg, vInReg1;
+    RegTensor<kType> dvbInReg, dvbInReg1;
+    RegTensor<float> betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg1;
+    RegTensor<float> vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg1, vFP32OneReg1;
+    RegTensor<float> dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg1, dvbFP32OneReg1;
+    RegTensor<betaType> dbetaInReg;
+    RegTensor<float> dbetaFP32Reg;
+    RegTensor<float> dBetaFP32Reg;
+    RegTensor<kType> dvOutReg, dvOutReg1;
 
     MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
     MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
 
-    UnalignRegForLoad uLoadBeta;
-    UnalignRegForLoad uLoadDbeta;
     UnalignRegForStore uStore;
 
-    LoadAlign(vInReg, vIn);
-    LoadAlign(dvbInReg, dvbIn);
-    uint32_t nextEleOffset = 0;
-    // 前mSize-1行
-    for (uint16_t mIdx = 0; mIdx < mSize - 1; mIdx++) {
-        // cast from bf16/fp16 to FP32
-        if constexpr (!std::is_same<betaType, float>()) {
-            LoadUnAlignPre(uLoadBeta, betaIn + mIdx);
-            LoadUnAlign(betaInReg, uLoadBeta, betaIn + mIdx);
-            Cast<float, betaType, ctHalf2Fp32Zero>(betaBrcbFP32Reg, betaInReg, maskFull16);
-            LoadUnAlignPre(uLoadDbeta, dbetaIn + mIdx);
-            LoadUnAlign(dbetaInReg, uLoadDbeta, dbetaIn + mIdx);
-            Cast<float, betaType, ctHalf2Fp32Zero>(dbetaFP32Reg, dbetaInReg, maskFull16);
-        } else {
-            LoadUnAlignPre(uLoadBeta, betaIn + mIdx);
-            LoadUnAlign(betaBrcbFP32Reg, uLoadBeta, betaIn + mIdx);
-            LoadUnAlignPre(uLoadDbeta, dbetaIn + mIdx);
-            LoadUnAlign(dbetaFP32Reg, uLoadDbeta, dbetaIn + mIdx);
-        }
-        Duplicate(betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
-        Duplicate(reduceSumReg, static_cast<float>(0), maskFull32);
-        uint32_t mOffset = mIdx * nKUbAligned;
-        for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt; vfBlockIdx++) {
-            // uint32_t eleOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            // LoadAlign(vInReg, vIn + eleOffset);
-            // LoadAlign(dvbInReg, dvbIn + eleOffset);
-            Cast<float, kType, ctHalf2Fp32Zero>(vFP32ZeroReg, vInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(vFP32OneReg, vInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32Zero>(dvbFP32ZeroReg, dvbInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(dvbFP32OneReg, dvbInReg, maskFull16);
-            uint32_t thisEleNum = min(eleKNumPerVf, nSize - vfBlockIdx * eleKNumPerVf);
-            nextEleOffset += thisEleNum;
-            LoadAlign(vInReg, vIn + nextEleOffset);
-            LoadAlign(dvbInReg, dvbIn + nextEleOffset);
-            Mul(vFP32ZeroReg, vFP32ZeroReg, dvbFP32ZeroReg, maskFull32);
-            Mul(vFP32OneReg, vFP32OneReg, dvbFP32OneReg, maskFull32);
-            Mul(dvbFP32ZeroReg, dvbFP32ZeroReg, betaBrcbFP32Reg, maskFull32);
-            Mul(dvbFP32OneReg, dvbFP32OneReg, betaBrcbFP32Reg, maskFull32);
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(betaInReg1, betaIn + 1);
+    LoadIn<kType, false>(vInReg, vIn);
+    LoadIn<kType, false>(vInReg1, vIn + oneEleNum);
+    LoadIn<kType, false>(dvbInReg, dvbIn);
+    LoadIn<kType, false>(dvbInReg1, dvbIn + oneEleNum);
 
-            Cast<kType, float, ctFp322HalfOne>(dvOutReg, dvbFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfZero>(dvOutReg, dvbFP32ZeroReg, maskFull32);
-            uint32_t dstUbOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            StoreAlign((__ubuf__ kType*&)dvOut + dstUbOffset, dvOutReg, maskFull16);
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg1, betaInReg1, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1) * PRELOAD_NUM);
+        LoadIn<betaType, true>(betaInReg1, betaIn + (mIdx + 1) * PRELOAD_NUM + 1);
+        CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+        CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+        LoadIn<kType, false>(vInReg, vIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(vInReg1, vIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(dvbFP32ZeroReg, dvbFP32OneReg, dvbInReg, maskFull16);
+        CastHalf2Float<kType>(dvbFP32ZeroReg1, dvbFP32OneReg1, dvbInReg1, maskFull16);
+        LoadIn<kType, false>(dvbInReg, dvbIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dvbInReg1, dvbIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        MulFloatTwoReg(vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg, vFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+        MulFloatTwoReg(dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+
+        MulFloatTwoReg(vFP32ZeroReg1, vFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, maskFull32);
+        MulFloatTwoReg(dvbFP32ZeroReg1, dvbFP32OneReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, betaBrcbFP32ZeroReg1, betaBrcbFP32ZeroReg1, maskFull32);
+
+        CastFloat2Half<kType>(dvOutReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dvOutReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM), dvOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dvOutReg1, maskFull16);
+
+        // Row 0: dBeta = reduceSum(v * dvb) + dbeta
+        Add(vFP32ZeroReg, vFP32ZeroReg, vFP32OneReg, maskFull32);
+        ReduceSum(dBetaFP32Reg, vFP32ZeroReg, maskFull32);
+        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM);
+        HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
+
+        // Row 1
+        Add(vFP32ZeroReg1, vFP32ZeroReg1, vFP32OneReg1, maskFull32);
+        ReduceSum(dBetaFP32Reg, vFP32ZeroReg1, maskFull32);
+        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM + 1);
+        HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM + 1, dBetaFP32Reg, maskFull32, uStore, 1);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg1, betaInReg1, maskFull16, maskFull32);
+        CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+        CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+        CastHalf2Float<kType>(dvbFP32ZeroReg, dvbFP32OneReg, dvbInReg, maskFull16);
+        CastHalf2Float<kType>(dvbFP32ZeroReg1, dvbFP32OneReg1, dvbInReg1, maskFull16);
+
+        MulFloatTwoReg(vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg, vFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+        MulFloatTwoReg(dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        MulFloatTwoReg(vFP32ZeroReg1, vFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, maskFull32);
+        MulFloatTwoReg(dvbFP32ZeroReg1, dvbFP32OneReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, betaBrcbFP32ZeroReg1, betaBrcbFP32ZeroReg1, maskFull32);
+
+        CastFloat2Half<kType>(dvOutReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dvOutReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM), dvOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dvOutReg1, maskFull16);
+
+        Add(vFP32ZeroReg, vFP32ZeroReg, vFP32OneReg, maskFull32);
+        ReduceSum(dBetaFP32Reg, vFP32ZeroReg, maskFull32);
+        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM);
+        HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
+
+        Add(vFP32ZeroReg1, vFP32ZeroReg1, vFP32OneReg1, maskFull32);
+        ReduceSum(dBetaFP32Reg, vFP32ZeroReg1, maskFull32);
+        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM + 1);
+        HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM + 1, dBetaFP32Reg, maskFull32, uStore, 1);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<betaType, true>(betaInReg, betaIn + mIdx * PRELOAD_NUM);
+            LoadIn<kType, false>(vInReg, vIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            LoadIn<kType, false>(dvbInReg, dvbIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+            CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+            CastHalf2Float<kType>(dvbFP32ZeroReg, dvbFP32OneReg, dvbInReg, maskFull16);
+            MulFloatTwoReg(vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg, vFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+            MulFloatTwoReg(dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            CastFloat2Half<kType>(dvOutReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM), dvOutReg, maskFull16);
 
             Add(vFP32ZeroReg, vFP32ZeroReg, vFP32OneReg, maskFull32);
-            Add(reduceSumReg, reduceSumReg, vFP32ZeroReg, maskFull32);
-        }
-        ReduceSum(dbetaAddFP32Reg, reduceSumReg, maskFull32);
-        Add(dbetaAddFP32Reg, dbetaAddFP32Reg, dbetaFP32Reg, maskFull32);
-
-        auto actDbetaOut = dBetaOut + mIdx;
-        if constexpr (!std::is_same<betaType, float32_t>()) {
-            Cast<betaType, float, ctFp322HalfZero>(dbetaOutReg, dbetaAddFP32Reg, maskFull32);
-            StoreUnAlign(actDbetaOut, dbetaOutReg, uStore, 1);
-            StoreUnAlignPost(actDbetaOut, uStore, 0);
-        } else {
-            StoreUnAlign(actDbetaOut, dbetaAddFP32Reg, uStore, 1);
-            StoreUnAlignPost(actDbetaOut, uStore, 0);
+            ReduceSum(dBetaFP32Reg, vFP32ZeroReg, maskFull32);
+            LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM);
+            HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+            Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+            StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
         }
     }
-    uint16_t mIdx = mSize - 1;
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDvbComputerVFOneLineOneCol(
+    __ubuf__ kType* dvOut, __ubuf__ betaType* dBetaOut, __ubuf__ kType* dvbIn, __ubuf__ kType* vIn,
+    __ubuf__ betaType* betaIn, __ubuf__ betaType* dbetaIn, uint16_t mSize, uint16_t nSize)
+{
+    RegTensor<betaType> betaInReg;
+    RegTensor<kType> vInReg;
+    RegTensor<kType> dvbInReg;
+    RegTensor<float> betaBrcbFP32ZeroReg;
+    RegTensor<float> vFP32ZeroReg, vFP32OneReg;
+    RegTensor<float> dvbFP32ZeroReg, dvbFP32OneReg;
+    RegTensor<betaType> dbetaInReg;
+    RegTensor<float> dbetaFP32Reg;
+    RegTensor<float> dBetaFP32Reg;
+    RegTensor<kType> dvOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    UnalignRegForStore uStore;
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<kType, false>(vInReg, vIn);
+    LoadIn<kType, false>(dvbInReg, dvbIn);
+    HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+    CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+    CastHalf2Float<kType>(dvbFP32ZeroReg, dvbFP32OneReg, dvbInReg, maskFull16);
+    MulFloatTwoReg(vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg, vFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+    MulFloatTwoReg(dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+    CastFloat2Half<kType>(dvOutReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+    StoreAlign((__ubuf__ kType*&)dvOut, dvOutReg, maskFull16);
+
+    Add(vFP32ZeroReg, vFP32ZeroReg, vFP32OneReg, maskFull32);
+    ReduceSum(dBetaFP32Reg, vFP32ZeroReg, maskFull32);
+    LoadIn<betaType, true>(dbetaInReg, dbetaIn);
+    HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+    Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+    StoreUnAlignOut<betaType>(dBetaOut, dBetaFP32Reg, maskFull32, uStore, 1);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDvbComputerVFTwoCol(
+    __ubuf__ kType* dvOut, __ubuf__ betaType* dBetaOut, __ubuf__ kType* dvbIn, __ubuf__ kType* vIn,
+    __ubuf__ betaType* betaIn, __ubuf__ betaType* dbetaIn, uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    uint16_t mLoopCnt = mSize - 1;
+    RegTensor<betaType> betaInReg;
+    RegTensor<kType> vInReg, vInReg1;
+    RegTensor<kType> dvbInReg, dvbInReg1;
+    RegTensor<float> betaBrcbFP32ZeroReg;
+    RegTensor<float> vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg1, vFP32OneReg1;
+    RegTensor<float> dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg1, dvbFP32OneReg1;
+    RegTensor<betaType> dbetaInReg;
+    RegTensor<float> dbetaFP32Reg;
+    RegTensor<float> dBetaFP32Reg;
+    RegTensor<kType> dvOutReg, dvOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    UnalignRegForStore uStore;
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<kType, false>(vInReg, vIn);
+    LoadIn<kType, false>(vInReg1, vIn + oneEleNum);
+    LoadIn<kType, false>(dvbInReg, dvbIn);
+    LoadIn<kType, false>(dvbInReg1, dvbIn + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1) * PRELOAD_NUM);
+        CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+        CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+        LoadIn<kType, false>(vInReg, vIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(vInReg1, vIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(dvbFP32ZeroReg, dvbFP32OneReg, dvbInReg, maskFull16);
+        CastHalf2Float<kType>(dvbFP32ZeroReg1, dvbFP32OneReg1, dvbInReg1, maskFull16);
+        LoadIn<kType, false>(dvbInReg, dvbIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dvbInReg1, dvbIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        MulFloatTwoReg(vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg, vFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+        MulFloatTwoReg(dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        MulFloatTwoReg(vFP32ZeroReg1, vFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, maskFull32);
+        MulFloatTwoReg(dvbFP32ZeroReg1, dvbFP32OneReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+
+        CastFloat2Half<kType>(dvOutReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dvOutReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM), dvOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dvOutReg1, maskFull16);
+
+        Add(vFP32ZeroReg, vFP32ZeroReg, vFP32OneReg, maskFull32);
+        ReduceSum(dBetaFP32Reg, vFP32ZeroReg, maskFull32);
+        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM);
+        HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
+
+        Add(vFP32ZeroReg1, vFP32ZeroReg1, vFP32OneReg1, maskFull32);
+        ReduceSum(dBetaFP32Reg, vFP32ZeroReg1, maskFull32);
+        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM + 1);
+        HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM + 1, dBetaFP32Reg, maskFull32, uStore, 1);
+    }
+    uint16_t mIdx = mLoopCnt;
     {
-        // cast from bf16/fp16 to FP32
-        if constexpr (!std::is_same<betaType, float>()) {
-            LoadUnAlignPre(uLoadBeta, betaIn + mIdx);
-            LoadUnAlign(betaInReg, uLoadBeta, betaIn + mIdx);
-            Cast<float, betaType, ctHalf2Fp32Zero>(betaBrcbFP32Reg, betaInReg, maskFull16);
-            LoadUnAlignPre(uLoadDbeta, dbetaIn + mIdx);
-            LoadUnAlign(dbetaInReg, uLoadDbeta, dbetaIn + mIdx);
-            Cast<float, betaType, ctHalf2Fp32Zero>(dbetaFP32Reg, dbetaInReg, maskFull16);
-        } else {
-            LoadUnAlignPre(uLoadBeta, betaIn + mIdx);
-            LoadUnAlign(betaBrcbFP32Reg, uLoadBeta, betaIn + mIdx);
-            LoadUnAlignPre(uLoadDbeta, dbetaIn + mIdx);
-            LoadUnAlign(dbetaFP32Reg, uLoadDbeta, dbetaIn + mIdx);
-        }
-        Duplicate(betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
-        Duplicate(reduceSumReg, static_cast<float>(0), maskFull32);
-        uint32_t mOffset = mIdx * nKUbAligned;
-        for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt - 1; vfBlockIdx++) {
-            // uint32_t eleOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            // LoadAlign(vInReg, vIn + eleOffset);
-            // LoadAlign(dvbInReg, dvbIn + eleOffset);
-            Cast<float, kType, ctHalf2Fp32Zero>(vFP32ZeroReg, vInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(vFP32OneReg, vInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32Zero>(dvbFP32ZeroReg, dvbInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(dvbFP32OneReg, dvbInReg, maskFull16);
-            uint32_t thisEleNum = min(eleKNumPerVf, nSize - vfBlockIdx * eleKNumPerVf);
-            nextEleOffset += thisEleNum;
-            LoadAlign(vInReg, vIn + nextEleOffset);
-            LoadAlign(dvbInReg, dvbIn + nextEleOffset);
-            Mul(vFP32ZeroReg, vFP32ZeroReg, dvbFP32ZeroReg, maskFull32);
-            Mul(vFP32OneReg, vFP32OneReg, dvbFP32OneReg, maskFull32);
-            Mul(dvbFP32ZeroReg, dvbFP32ZeroReg, betaBrcbFP32Reg, maskFull32);
-            Mul(dvbFP32OneReg, dvbFP32OneReg, betaBrcbFP32Reg, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+        CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+        CastHalf2Float<kType>(dvbFP32ZeroReg, dvbFP32OneReg, dvbInReg, maskFull16);
+        CastHalf2Float<kType>(dvbFP32ZeroReg1, dvbFP32OneReg1, dvbInReg1, maskFull16);
 
-            Cast<kType, float, ctFp322HalfOne>(dvOutReg, dvbFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfZero>(dvOutReg, dvbFP32ZeroReg, maskFull32);
-            uint32_t dstUbOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            StoreAlign((__ubuf__ kType*&)dvOut + dstUbOffset, dvOutReg, maskFull16);
+        MulFloatTwoReg(vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg, vFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+        MulFloatTwoReg(dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        MulFloatTwoReg(vFP32ZeroReg1, vFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, maskFull32);
+        MulFloatTwoReg(dvbFP32ZeroReg1, dvbFP32OneReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
 
-            Add(vFP32ZeroReg, vFP32ZeroReg, vFP32OneReg, maskFull32);
-            Add(reduceSumReg, reduceSumReg, vFP32ZeroReg, maskFull32);
-        }
-        uint16_t vfBlockIdx = nLoopCnt - 1;
-        {
-            // uint32_t eleOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            // LoadAlign(vInReg, vIn + eleOffset);
-            // LoadAlign(dvbInReg, dvbIn + eleOffset);
-            Cast<float, kType, ctHalf2Fp32Zero>(vFP32ZeroReg, vInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(vFP32OneReg, vInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32Zero>(dvbFP32ZeroReg, dvbInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(dvbFP32OneReg, dvbInReg, maskFull16);
-            Mul(vFP32ZeroReg, vFP32ZeroReg, dvbFP32ZeroReg, maskFull32);
-            Mul(vFP32OneReg, vFP32OneReg, dvbFP32OneReg, maskFull32);
-            Mul(dvbFP32ZeroReg, dvbFP32ZeroReg, betaBrcbFP32Reg, maskFull32);
-            Mul(dvbFP32OneReg, dvbFP32OneReg, betaBrcbFP32Reg, maskFull32);
+        CastFloat2Half<kType>(dvOutReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dvOutReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM), dvOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dvOutReg1, maskFull16);
 
-            Cast<kType, float, ctFp322HalfOne>(dvOutReg, dvbFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfZero>(dvOutReg, dvbFP32ZeroReg, maskFull32);
-            uint32_t dstUbOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            StoreAlign((__ubuf__ kType*&)dvOut + dstUbOffset, dvOutReg, maskFull16);
+        Add(vFP32ZeroReg, vFP32ZeroReg, vFP32OneReg, maskFull32);
+        ReduceSum(dBetaFP32Reg, vFP32ZeroReg, maskFull32);
+        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM);
+        HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
 
-            Add(vFP32ZeroReg, vFP32ZeroReg, vFP32OneReg, maskFull32);
-            Add(reduceSumReg, reduceSumReg, vFP32ZeroReg, maskFull32);
-        }
-        ReduceSum(dbetaAddFP32Reg, reduceSumReg, maskFull32);
-        Add(dbetaAddFP32Reg, dbetaAddFP32Reg, dbetaFP32Reg, maskFull32);
-
-        auto actDbetaOut = dBetaOut + mIdx;
-        if constexpr (!std::is_same<betaType, float32_t>()) {
-            Cast<betaType, float, ctFp322HalfZero>(dbetaOutReg, dbetaAddFP32Reg, maskFull32);
-            StoreUnAlign(actDbetaOut, dbetaOutReg, uStore, 1);
-            StoreUnAlignPost(actDbetaOut, uStore, 0);
-        } else {
-            StoreUnAlign(actDbetaOut, dbetaAddFP32Reg, uStore, 1);
-            StoreUnAlignPost(actDbetaOut, uStore, 0);
-        }
+        Add(vFP32ZeroReg1, vFP32ZeroReg1, vFP32OneReg1, maskFull32);
+        ReduceSum(dBetaFP32Reg, vFP32ZeroReg1, maskFull32);
+        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM + 1);
+        HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM + 1, dBetaFP32Reg, maskFull32, uStore, 1);
     }
 }
 
@@ -803,10 +930,28 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventUbInMTE2VList[ubListId]);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(eventUbOutMTE3VList[ubListId]);
                     AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(SYNC_AIC_AIV_FLAG_BEGIN + cvListId);
-                    ProcessDvbComputerVF((__ubuf__ kType*)dvOutAddr, (__ubuf__ betaType*)dBetaOutAddr,
-                                         (__ubuf__ kType*)dvbInAddr, (__ubuf__ kType*)vInAddr,
-                                         (__ubuf__ betaType*)betaInAddr, (__ubuf__ betaType*)dbetaInAddr,
-                                         curRowNum, V);
+                    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+                    if (V <= eleKNumPerVf) {
+                        if (curRowNum == 1) {
+                            ProcessDvbComputerVFOneLineOneCol(
+                                    (__ubuf__ kType*)dvOutAddr, (__ubuf__ betaType*)dBetaOutAddr,
+                                    (__ubuf__ kType*)dvbInAddr, (__ubuf__ kType*)vInAddr,
+                                    (__ubuf__ betaType*)betaInAddr, (__ubuf__ betaType*)dbetaInAddr,
+                                    curRowNum, V);
+                        } else {
+                            ProcessDvbComputerVFMutiLineOneCol(
+                                    (__ubuf__ kType*)dvOutAddr, (__ubuf__ betaType*)dBetaOutAddr,
+                                    (__ubuf__ kType*)dvbInAddr, (__ubuf__ kType*)vInAddr,
+                                    (__ubuf__ betaType*)betaInAddr, (__ubuf__ betaType*)dbetaInAddr,
+                                    curRowNum, V);
+                        }
+                    } else {
+                        ProcessDvbComputerVFTwoCol(
+                                    (__ubuf__ kType*)dvOutAddr, (__ubuf__ betaType*)dBetaOutAddr,
+                                    (__ubuf__ kType*)dvbInAddr, (__ubuf__ kType*)vInAddr,
+                                    (__ubuf__ betaType*)betaInAddr, (__ubuf__ betaType*)dbetaInAddr,
+                                    curRowNum, V);
+                    }
                     AscendC::CrossCoreSetFlag<0x4, PIPE_V>(SYNC_AIV_AIC_FLAG_BEGIN + cvListId);
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(eventUbOutVMTE3List[ubListId]);
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventUbInVMTE2List[ubListId]);
@@ -844,8 +989,8 @@ __simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proc
     uint16_t mSize, uint16_t nSize)
 {
     uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
-    uint32_t nKUbAligned = Align(nSize, static_cast<uint16_t>(UB_ALIGN_SIZE / sizeof(kType)));
     uint16_t nLoopCnt = (nSize + eleKNumPerVf - 1) / eleKNumPerVf;
+    uint16_t mLoopCnt = mSize - 1;
     RegTensor<kType> kInReg;
     RegTensor<betaType> betaInReg;
     RegTensor<betaType> gInReg;
@@ -853,231 +998,120 @@ __simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proc
     RegTensor<betaType> dbetaInReg;
     RegTensor<kType> dkbgInReg;
     RegTensor<float> betaBrcbFP32ZeroReg, dkFP32ZeroReg, dkFP32OneReg, dgFP32ZeroReg;
-    RegTensor<float> kFP32ZeroReg, kFP32OneReg, dBetaAddZeroReg, dBetaAddOneReg, dkbgFP32ZeroReg, dkbgFP32OneReg;
-    RegTensor<float> gBrcbFP32ZeroReg, gBrcbFP32OneReg, dbetaFP32ZeroReg, dbetaFP32OneReg;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, dBetaAddZeroReg, dkbgFP32ZeroReg, dkbgFP32OneReg;
+    RegTensor<float> gBrcbFP32ZeroReg, dbetaFP32ZeroReg, dbetaFP32OneReg;
     RegTensor<float> kReduceSumReg, dkReduceSumReg;
     RegTensor<kType> dkOutReg;
-    RegTensor<betaType> dBetaOutReg;
-    RegTensor<betaType> dgOutReg;
 
     MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
     MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
 
-    UnalignRegForLoad uLoadBeta;
-    UnalignRegForLoad uLoadG;
-    UnalignRegForLoad uLoadDBeta;
     UnalignRegForStore uStoreDBeta;
     UnalignRegForStore uStoreDg;
 
-    if constexpr (!std::is_same<betaType, float>()) {
-        LoadAlign(dbetaInReg, dBetaIn);
-        Cast<float, betaType, ctHalf2Fp32Zero>(dbetaFP32ZeroReg, dbetaInReg, maskFull16);
-        Cast<float, betaType, ctHalf2Fp32One>(dbetaFP32OneReg, dbetaInReg, maskFull16);
-    } else {
-        LoadAlign<betaType, LoadDist::DIST_DINTLV_B32>(dbetaFP32ZeroReg, dbetaFP32OneReg, dBetaIn);
-    }
-    LoadAlign(kInReg, kIn);
-    LoadAlign(dkbgInReg, dkbgIn);
-    LoadAlign(dkInReg, dkIn);
-    uint32_t nextEleOffset = 0;
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(gInReg, gIn);
+    LoadIn<betaType, true>(dbetaInReg, dBetaIn);
+    LoadIn<kType>(kInReg, kIn);
+    LoadIn<kType>(dkbgInReg, dkbgIn);
+    LoadIn<kType>(dkInReg, dkIn);
     // 前mSize - 1行
-    for (uint16_t mIdx = 0; mIdx < mSize - 1; mIdx++) {
-        // cast from bf16/fp16 to FP32
-        if constexpr (!std::is_same<betaType, float>()) {
-            LoadUnAlignPre(uLoadBeta, betaIn + mIdx);
-            LoadUnAlign(betaInReg, uLoadBeta, betaIn + mIdx);
-            Cast<float, betaType, ctHalf2Fp32Zero>(betaBrcbFP32ZeroReg, betaInReg, maskFull16);
-            LoadUnAlignPre(uLoadG, gIn + mIdx);
-            LoadUnAlign(gInReg, uLoadG, gIn + mIdx);
-            Cast<float, betaType, ctHalf2Fp32Zero>(gBrcbFP32ZeroReg, gInReg, maskFull16);
-            LoadUnAlignPre(uLoadDBeta, dBetaIn + mIdx);
-            LoadUnAlign(dbetaInReg, uLoadDBeta, dBetaIn + mIdx);
-            Cast<float, betaType, ctHalf2Fp32Zero>(dbetaFP32ZeroReg, dbetaInReg, maskFull16);
-        } else {
-            LoadUnAlignPre(uLoadBeta, betaIn + mIdx);
-            LoadUnAlign(betaBrcbFP32ZeroReg, uLoadBeta, betaIn + mIdx);
-            LoadUnAlignPre(uLoadG, gIn + mIdx);
-            LoadUnAlign(gBrcbFP32ZeroReg, uLoadG, gIn + mIdx);
-            LoadUnAlignPre(uLoadDBeta, dBetaIn + mIdx);
-            LoadUnAlign(dbetaFP32ZeroReg, uLoadDBeta, dBetaIn + mIdx);
-        }
-        MaskReg maskgExpReg;
-        uint32_t expNum = 1;
-        maskgExpReg = UpdateMask<betaType>(expNum);
-        Exp(gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskgExpReg);
-        Duplicate(betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-        Duplicate(gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gBrcbFP32ZeroReg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(dbetaFP32ZeroReg, dbetaInReg, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1));
+        LoadIn<betaType, true>(gInReg, gIn + (mIdx + 1));
+        LoadIn<betaType, true>(dbetaInReg, dBetaIn + (mIdx + 1));
+
+        Exp(gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
         Duplicate(kReduceSumReg, static_cast<float>(0), maskFull32);
         Duplicate(dkReduceSumReg, static_cast<float>(0), maskFull32);
-        uint32_t mOffset = mIdx * nKUbAligned;
         for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt; vfBlockIdx++) {
-            uint32_t eleOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            Cast<float, kType, ctHalf2Fp32Zero>(kFP32ZeroReg, kInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(kFP32OneReg, kInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32Zero>(dkbgFP32ZeroReg, dkbgInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(dkbgFP32OneReg, dkbgInReg, maskFull16);
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            CastHalf2Float<kType>(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgInReg, maskFull16);
             uint32_t thisEleNum = min(eleKNumPerVf, nSize - vfBlockIdx * eleKNumPerVf);
-            nextEleOffset += thisEleNum;
-            LoadAlign(kInReg, kIn + nextEleOffset);
-            LoadAlign(dkbgInReg, dkbgIn + nextEleOffset);
-            
-            Mul(dkbgFP32ZeroReg, dkbgFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
-            Mul(dkbgFP32OneReg, dkbgFP32OneReg, gBrcbFP32ZeroReg, maskFull32);
-            Mul(kFP32ZeroReg, kFP32ZeroReg, dkbgFP32ZeroReg, maskFull32);
-            Mul(kFP32OneReg, kFP32OneReg, dkbgFP32OneReg, maskFull32);
-            Mul(dkFP32ZeroReg, kFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-            Mul(dkFP32OneReg, kFP32OneReg, betaBrcbFP32ZeroReg, maskFull32);
+            LoadIn<kType>(kInReg, kIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            LoadIn<kType>(dkbgInReg, dkbgIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            MulFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
             Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
             Add(kReduceSumReg, kReduceSumReg, kFP32ZeroReg, maskFull32);
             Add(dkFP32ZeroReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
             Add(dkReduceSumReg, dkReduceSumReg, dkFP32ZeroReg, maskFull32);
-            Mul(dkbgFP32ZeroReg, dkbgFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-            Mul(dkbgFP32OneReg, dkbgFP32OneReg, betaBrcbFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
 
-            Cast<float, kType, ctHalf2Fp32Zero>(dkFP32ZeroReg, dkInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(dkFP32OneReg, dkInReg, maskFull16);
-            LoadAlign(dkInReg, dkIn + nextEleOffset);
-            Add(dkFP32ZeroReg, dkFP32ZeroReg, dkbgFP32ZeroReg, maskFull32);
-            Add(dkFP32OneReg, dkFP32OneReg, dkbgFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfOne>(dkOutReg, dkFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfZero>(dkOutReg, dkFP32ZeroReg, maskFull32);
-            uint32_t dstUbOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            StoreAlign((__ubuf__ kType*&)dkOut + dstUbOffset, dkOutReg, maskFull16);
+            CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+            LoadIn<kType>(dkInReg, dkIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + mIdx * nSize + vfBlockIdx * eleKNumPerVf, dkOutReg, maskFull16);
         }
         ReduceSum(dBetaAddZeroReg, kReduceSumReg, maskFull32);
         ReduceSum(dgFP32ZeroReg, dkReduceSumReg, maskFull32);
         Add(dBetaAddZeroReg, dBetaAddZeroReg, dbetaFP32ZeroReg, maskFull32);
-        auto actDbetaOut = dBetaOut + mIdx;
-        auto actDgOut = dgOut + mIdx;
-        if constexpr (!std::is_same<betaType, float32_t>()) {
-            Cast<betaType, float, ctFp322HalfZero>(dBetaOutReg, dBetaAddZeroReg, maskFull32);
-            StoreUnAlign(actDbetaOut, dBetaOutReg, uStoreDBeta, 1);
-            StoreUnAlignPost(actDbetaOut, uStoreDBeta, 0);
-            Cast<betaType, float, ctFp322HalfZero>(dgOutReg, dgFP32ZeroReg, maskFull32);
-            StoreUnAlign(actDgOut, dgOutReg, uStoreDg, 1);
-            StoreUnAlignPost(actDgOut, uStoreDg, 0);
-        } else {
-            StoreUnAlign(actDbetaOut, dBetaAddZeroReg, uStoreDBeta, 1);
-            StoreUnAlignPost(actDbetaOut, uStoreDBeta, 0);
-            StoreUnAlign(actDgOut, dgFP32ZeroReg, uStoreDg, 1);
-            StoreUnAlignPost(actDgOut, uStoreDg, 0);
-        }
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaAddZeroReg, maskFull32, uStoreDBeta, 1);
+        StoreUnAlignOut<betaType>(dgOut + mIdx, dgFP32ZeroReg, maskFull32, uStoreDg, 1);
     }
     // 最后一行
-    uint16_t mIdx =  mSize - 1;
+    uint16_t mIdx = mLoopCnt;
     {
-        // cast from bf16/fp16 to FP32
-        if constexpr (!std::is_same<betaType, float>()) {
-            LoadUnAlignPre(uLoadBeta, betaIn + mIdx);
-            LoadUnAlign(betaInReg, uLoadBeta, betaIn + mIdx);
-            Cast<float, betaType, ctHalf2Fp32Zero>(betaBrcbFP32ZeroReg, betaInReg, maskFull16);
-            LoadUnAlignPre(uLoadG, gIn + mIdx);
-            LoadUnAlign(gInReg, uLoadG, gIn + mIdx);
-            Cast<float, betaType, ctHalf2Fp32Zero>(gBrcbFP32ZeroReg, gInReg, maskFull16);
-            LoadUnAlignPre(uLoadDBeta, dBetaIn + mIdx);
-            LoadUnAlign(dbetaInReg, uLoadDBeta, dBetaIn + mIdx);
-            Cast<float, betaType, ctHalf2Fp32Zero>(dbetaFP32ZeroReg, dbetaInReg, maskFull16);
-        } else {
-            LoadUnAlignPre(uLoadBeta, betaIn + mIdx);
-            LoadUnAlign(betaBrcbFP32ZeroReg, uLoadBeta, betaIn + mIdx);
-            LoadUnAlignPre(uLoadG, gIn + mIdx);
-            LoadUnAlign(gBrcbFP32ZeroReg, uLoadG, gIn + mIdx);
-            LoadUnAlignPre(uLoadDBeta, dBetaIn + mIdx);
-            LoadUnAlign(dbetaFP32ZeroReg, uLoadDBeta, dBetaIn + mIdx);
-        }
-        MaskReg maskgExpReg;
-        uint32_t expNum = 1;
-        maskgExpReg = UpdateMask<betaType>(expNum);
-        Exp(gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskgExpReg);
-        Duplicate(betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-        Duplicate(gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gBrcbFP32ZeroReg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(dbetaFP32ZeroReg, dbetaInReg, maskFull16, maskFull32);
+
+        Exp(gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
         Duplicate(kReduceSumReg, static_cast<float>(0), maskFull32);
         Duplicate(dkReduceSumReg, static_cast<float>(0), maskFull32);
-        uint32_t mOffset = mIdx * nKUbAligned;
         // 最后一行的前nLoopCnt - 1
         for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt - 1; vfBlockIdx++) {
-            uint32_t eleOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            Cast<float, kType, ctHalf2Fp32Zero>(kFP32ZeroReg, kInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(kFP32OneReg, kInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32Zero>(dkbgFP32ZeroReg, dkbgInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(dkbgFP32OneReg, dkbgInReg, maskFull16);
-            uint32_t thisEleNum = min(eleKNumPerVf, nSize - vfBlockIdx * eleKNumPerVf);
-            nextEleOffset += thisEleNum;
-            LoadAlign(kInReg, kIn + nextEleOffset);
-            LoadAlign(dkbgInReg, dkbgIn + nextEleOffset);
-            
-            Mul(dkbgFP32ZeroReg, dkbgFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
-            Mul(dkbgFP32OneReg, dkbgFP32OneReg, gBrcbFP32ZeroReg, maskFull32);
-            Mul(kFP32ZeroReg, kFP32ZeroReg, dkbgFP32ZeroReg, maskFull32);
-            Mul(kFP32OneReg, kFP32OneReg, dkbgFP32OneReg, maskFull32);
-            Mul(dkFP32ZeroReg, kFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-            Mul(dkFP32OneReg, kFP32OneReg, betaBrcbFP32ZeroReg, maskFull32);
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            CastHalf2Float<kType>(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgInReg, maskFull16);
+            LoadIn<kType>(kInReg, kIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            LoadIn<kType>(dkbgInReg, dkbgIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            MulFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
             Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
             Add(kReduceSumReg, kReduceSumReg, kFP32ZeroReg, maskFull32);
             Add(dkFP32ZeroReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
             Add(dkReduceSumReg, dkReduceSumReg, dkFP32ZeroReg, maskFull32);
-            Mul(dkbgFP32ZeroReg, dkbgFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-            Mul(dkbgFP32OneReg, dkbgFP32OneReg, betaBrcbFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
 
-            Cast<float, kType, ctHalf2Fp32Zero>(dkFP32ZeroReg, dkInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(dkFP32OneReg, dkInReg, maskFull16);
-            LoadAlign(dkInReg, dkIn + nextEleOffset);
-            Add(dkFP32ZeroReg, dkFP32ZeroReg, dkbgFP32ZeroReg, maskFull32);
-            Add(dkFP32OneReg, dkFP32OneReg, dkbgFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfOne>(dkOutReg, dkFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfZero>(dkOutReg, dkFP32ZeroReg, maskFull32);
-            uint32_t dstUbOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            StoreAlign((__ubuf__ kType*&)dkOut + dstUbOffset, dkOutReg, maskFull16);
+            CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+            LoadIn<kType>(dkInReg, dkIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + mIdx * nSize + vfBlockIdx * eleKNumPerVf, dkOutReg, maskFull16);
         }
         // 最后一行最后一个loop
         uint16_t vfBlockIdx = nLoopCnt - 1;
         {
-            uint32_t eleOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            Cast<float, kType, ctHalf2Fp32Zero>(kFP32ZeroReg, kInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(kFP32OneReg, kInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32Zero>(dkbgFP32ZeroReg, dkbgInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(dkbgFP32OneReg, dkbgInReg, maskFull16);
-            
-            Mul(dkbgFP32ZeroReg, dkbgFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
-            Mul(dkbgFP32OneReg, dkbgFP32OneReg, gBrcbFP32ZeroReg, maskFull32);
-            Mul(kFP32ZeroReg, kFP32ZeroReg, dkbgFP32ZeroReg, maskFull32);
-            Mul(kFP32OneReg, kFP32OneReg, dkbgFP32OneReg, maskFull32);
-            Mul(dkFP32ZeroReg, kFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-            Mul(dkFP32OneReg, kFP32OneReg, betaBrcbFP32ZeroReg, maskFull32);
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            CastHalf2Float<kType>(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgInReg, maskFull16);
+
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            MulFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
             Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
             Add(kReduceSumReg, kReduceSumReg, kFP32ZeroReg, maskFull32);
             Add(dkFP32ZeroReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
             Add(dkReduceSumReg, dkReduceSumReg, dkFP32ZeroReg, maskFull32);
-            Mul(dkbgFP32ZeroReg, dkbgFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-            Mul(dkbgFP32OneReg, dkbgFP32OneReg, betaBrcbFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
 
-            Cast<float, kType, ctHalf2Fp32Zero>(dkFP32ZeroReg, dkInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(dkFP32OneReg, dkInReg, maskFull16);
-            Add(dkFP32ZeroReg, dkFP32ZeroReg, dkbgFP32ZeroReg, maskFull32);
-            Add(dkFP32OneReg, dkFP32OneReg, dkbgFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfOne>(dkOutReg, dkFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfZero>(dkOutReg, dkFP32ZeroReg, maskFull32);
-            uint32_t dstUbOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            StoreAlign((__ubuf__ kType*&)dkOut + dstUbOffset, dkOutReg, maskFull16);
+            CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + mIdx * nSize + vfBlockIdx * eleKNumPerVf, dkOutReg, maskFull16);
         }
         ReduceSum(dBetaAddZeroReg, kReduceSumReg, maskFull32);
         ReduceSum(dgFP32ZeroReg, dkReduceSumReg, maskFull32);
         Add(dBetaAddZeroReg, dBetaAddZeroReg, dbetaFP32ZeroReg, maskFull32);
-        auto actDbetaOut = dBetaOut + mIdx;
-        auto actDgOut = dgOut + mIdx;
-        if constexpr (!std::is_same<betaType, float32_t>()) {
-            Cast<betaType, float, ctFp322HalfZero>(dBetaOutReg, dBetaAddZeroReg, maskFull32);
-            StoreUnAlign(actDbetaOut, dBetaOutReg, uStoreDBeta, 1);
-            StoreUnAlignPost(actDbetaOut, uStoreDBeta, 0);
-            Cast<betaType, float, ctFp322HalfZero>(dgOutReg, dgFP32ZeroReg, maskFull32);
-            StoreUnAlign(actDgOut, dgOutReg, uStoreDg, 1);
-            StoreUnAlignPost(actDgOut, uStoreDg, 0);
-        } else {
-            StoreUnAlign(actDbetaOut, dBetaAddZeroReg, uStoreDBeta, 1);
-            StoreUnAlignPost(actDbetaOut, uStoreDBeta, 0);
-            StoreUnAlign(actDgOut, dgFP32ZeroReg, uStoreDg, 1);
-            StoreUnAlignPost(actDgOut, uStoreDg, 0);
-        }
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaAddZeroReg, maskFull32, uStoreDBeta, 1);
+        StoreUnAlignOut<betaType>(dgOut + mIdx, dgFP32ZeroReg, maskFull32, uStoreDg, 1);
     }
 }
 
@@ -1257,161 +1291,276 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
 }
 
 template <typename kType, typename betaType>
-__simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDkbComputerVF(
+__simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDkbComputerVFMutiLineOneCol(
     __ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
     __ubuf__ kType* dkIn, __ubuf__ kType* dkbIn, uint16_t mSize, uint16_t nSize)
 {
     uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
-    uint32_t nKUbAligned = Align(nSize, static_cast<uint16_t>(UB_ALIGN_SIZE / sizeof(kType)));
-    uint16_t nLoopCnt = (nSize + eleKNumPerVf - 1) / eleKNumPerVf;
-    RegTensor<betaType> betaInReg;
-    RegTensor<float> betaBrcbFP32ZeroReg, betaBrcbFP32OneReg, dBetaFP32Reg;
-    RegTensor<kType> kInReg;
-    RegTensor<kType> dkInReg;
-    RegTensor<kType> dkbInReg;
-    RegTensor<float> kFP32ZeroReg, kFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, reduceSumReg;
-    RegTensor<kType> dkOutReg;
-    RegTensor<betaType> dBetaOutZeroReg, dBetaOutOneReg;
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    uint16_t lastLoopCnt = mSize % PRELOAD_NUM;
+    RegTensor<betaType> betaInReg, betaInReg1;
+    RegTensor<kType> kInReg, kInReg1;
+    RegTensor<kType> dkInReg, dkInReg1;
+    RegTensor<kType> dkbInReg, dkbInReg1;
+    RegTensor<float> betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg1;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg1, kFP32OneReg1;
+    RegTensor<float> dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg1, dkFP32OneReg1;
+    RegTensor<float> dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg1, dkbFP32OneReg1;
+    RegTensor<kType> dkOutReg, dkOutReg1;
+    RegTensor<float> dBetaFP32Reg;
+    RegTensor<betaType> dBetaOutZeroReg;
 
     MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
     MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
 
-    UnalignRegForLoad uLoad;
     UnalignRegForStore uStore;
 
-    LoadAlign(kInReg, kIn);
-    LoadAlign(dkbInReg, dkbIn);
-    LoadAlign(dkInReg, dkIn);
-    uint32_t nextEleOffset = 0;
-    // 前mSize-1行
-    for (uint16_t mIdx = 0; mIdx < mSize - 1; mIdx++) {
-        // cast from bf16/fp16 to FP32
-        if constexpr (!std::is_same<betaType, float>()) {
-            LoadUnAlignPre(uLoad, betaIn + mIdx);
-            LoadUnAlign(betaInReg, uLoad, betaIn + mIdx);
-            Cast<float, betaType, ctHalf2Fp32Zero>(betaBrcbFP32ZeroReg, betaInReg, maskFull16);
-        } else {
-            LoadUnAlignPre(uLoad, betaIn + mIdx);
-            LoadUnAlign(betaBrcbFP32ZeroReg, uLoad, betaIn + mIdx);
-        }
-        Duplicate(betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-        Duplicate(reduceSumReg, static_cast<float>(0), maskFull32);
-        uint32_t mOffset = mIdx * nKUbAligned;
-        for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt; vfBlockIdx++) {
-            Cast<float, kType, ctHalf2Fp32Zero>(kFP32ZeroReg, kInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(kFP32OneReg, kInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32Zero>(dkbFP32ZeroReg, dkbInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(dkbFP32OneReg, dkbInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32Zero>(dkFP32ZeroReg, dkInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(dkFP32OneReg, dkInReg, maskFull16);
-            uint32_t thisEleNum = min(eleKNumPerVf, nSize - vfBlockIdx * eleKNumPerVf);
-            nextEleOffset += thisEleNum;
-            LoadAlign(kInReg, kIn + nextEleOffset);
-            LoadAlign(dkbInReg, dkbIn + nextEleOffset);
-            LoadAlign(dkInReg, dkIn + nextEleOffset);
-            Mul(kFP32ZeroReg, kFP32ZeroReg, dkbFP32ZeroReg, maskFull32);
-            Mul(kFP32OneReg, kFP32OneReg, dkbFP32OneReg, maskFull32);
-            Mul(dkbFP32ZeroReg, dkbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-            Mul(dkbFP32OneReg, dkbFP32OneReg, betaBrcbFP32ZeroReg, maskFull32);
-            Add(dkFP32ZeroReg, dkFP32ZeroReg, dkbFP32ZeroReg, maskFull32);
-            Add(dkFP32OneReg, dkFP32OneReg, dkbFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfOne>(dkOutReg, dkFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfZero>(dkOutReg, dkFP32ZeroReg, maskFull32);
-            uint32_t dstUbOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            StoreAlign((__ubuf__ kType*&)dkOut + dstUbOffset, dkOutReg, maskFull16);
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(betaInReg1, betaIn + 1);
+    LoadIn<kType, false>(kInReg, kIn);
+    LoadIn<kType, false>(kInReg1, kIn + oneEleNum);
+    LoadIn<kType, false>(dkInReg, dkIn);
+    LoadIn<kType, false>(dkInReg1, dkIn + oneEleNum);
+    LoadIn<kType, false>(dkbInReg, dkbIn);
+    LoadIn<kType, false>(dkbInReg1, dkbIn + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg1, betaInReg1, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1) * PRELOAD_NUM);
+        LoadIn<betaType, true>(betaInReg1, betaIn + (mIdx + 1) * PRELOAD_NUM + 1);
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        LoadIn<kType, false>(kInReg, kIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(kInReg1, kIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+        CastHalf2Float<kType>(dkFP32ZeroReg1, dkFP32OneReg1, dkInReg1, maskFull16);
+        LoadIn<kType, false>(dkInReg, dkIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dkInReg1, dkIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(dkbFP32ZeroReg, dkbFP32OneReg, dkbInReg, maskFull16);
+        CastHalf2Float<kType>(dkbFP32ZeroReg1, dkbFP32OneReg1, dkbInReg1, maskFull16);
+        LoadIn<kType, false>(dkbInReg, dkbIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dkbInReg1, dkbIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+        MulFloatTwoReg(dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+
+        MulFloatTwoReg(kFP32ZeroReg1, kFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, maskFull32);
+        MulFloatTwoReg(dkbFP32ZeroReg1, dkbFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, betaBrcbFP32ZeroReg1, betaBrcbFP32ZeroReg1, maskFull32);
+        AddFloatTwoReg(dkFP32ZeroReg1, dkFP32OneReg1, dkFP32ZeroReg1, dkFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, maskFull32);
+
+        CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dkOutReg1, dkFP32ZeroReg1, dkFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+
+        Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+        ReduceSum(dBetaFP32Reg, kFP32ZeroReg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
+
+        Add(kFP32ZeroReg1, kFP32ZeroReg1, kFP32OneReg1, maskFull32);
+        ReduceSum(dBetaFP32Reg, kFP32ZeroReg1, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM + 1, dBetaFP32Reg, maskFull32, uStore, 1);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg1, betaInReg1, maskFull16, maskFull32);
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+        CastHalf2Float<kType>(dkFP32ZeroReg1, dkFP32OneReg1, dkInReg1, maskFull16);
+        CastHalf2Float<kType>(dkbFP32ZeroReg, dkbFP32OneReg, dkbInReg, maskFull16);
+        CastHalf2Float<kType>(dkbFP32ZeroReg1, dkbFP32OneReg1, dkbInReg1, maskFull16);
+
+        MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+        MulFloatTwoReg(dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+
+        MulFloatTwoReg(kFP32ZeroReg1, kFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, maskFull32);
+        MulFloatTwoReg(dkbFP32ZeroReg1, dkbFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, betaBrcbFP32ZeroReg1, betaBrcbFP32ZeroReg1, maskFull32);
+        AddFloatTwoReg(dkFP32ZeroReg1, dkFP32OneReg1, dkFP32ZeroReg1, dkFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, maskFull32);
+
+        CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dkOutReg1, dkFP32ZeroReg1, dkFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+
+        Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+        ReduceSum(dBetaFP32Reg, kFP32ZeroReg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
+
+        Add(kFP32ZeroReg1, kFP32ZeroReg1, kFP32OneReg1, maskFull32);
+        ReduceSum(dBetaFP32Reg, kFP32ZeroReg1, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM + 1, dBetaFP32Reg, maskFull32, uStore, 1);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<betaType, true>(betaInReg, betaIn + mIdx * PRELOAD_NUM);
+            LoadIn<kType, false>(kInReg, kIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            LoadIn<kType, false>(dkInReg, dkIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            LoadIn<kType, false>(dkbInReg, dkbIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+            CastHalf2Float<kType>(dkbFP32ZeroReg, dkbFP32OneReg, dkbInReg, maskFull16);
+            MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+            MulFloatTwoReg(dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
 
             Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
-            Add(reduceSumReg, reduceSumReg, kFP32ZeroReg, maskFull32);
-        }
-        ReduceSum(dBetaFP32Reg, reduceSumReg, maskFull32);
-
-        auto actDbetaOut = dBetaOut + mIdx;
-        if constexpr (!std::is_same<betaType, float32_t>()) {
-            Cast<betaType, float, ctFp322HalfZero>(dBetaOutZeroReg, dBetaFP32Reg, maskFull32);
-            StoreUnAlign(actDbetaOut, dBetaOutZeroReg, uStore, 1);
-            StoreUnAlignPost(actDbetaOut, uStore, 0);
-        } else {
-            StoreUnAlign(actDbetaOut, dBetaFP32Reg, uStore, 1);
-            StoreUnAlignPost(actDbetaOut, uStore, 0);
+            ReduceSum(dBetaFP32Reg, kFP32ZeroReg, maskFull32);
+            StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
         }
     }
-    // 最后一行
-    uint16_t mIdx = mSize - 1;
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDkbComputerVFOneLineOneCol(
+    __ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    __ubuf__ kType* dkIn, __ubuf__ kType* dkbIn, uint16_t mSize, uint16_t nSize)
+{
+    RegTensor<betaType> betaInReg;
+    RegTensor<kType> kInReg;
+    RegTensor<kType> dkInReg;
+    RegTensor<kType> dkbInReg;
+    RegTensor<float> betaBrcbFP32ZeroReg;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg;
+    RegTensor<float> dkFP32ZeroReg, dkFP32OneReg;
+    RegTensor<float> dkbFP32ZeroReg, dkbFP32OneReg;
+    RegTensor<kType> dkOutReg;
+    RegTensor<float> dBetaFP32Reg;
+    RegTensor<betaType> dBetaOutZeroReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    UnalignRegForStore uStore;
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<kType, false>(kInReg, kIn);
+    LoadIn<kType, false>(dkInReg, dkIn);
+    LoadIn<kType, false>(dkbInReg, dkbIn);
+    HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+    CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+    CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+    CastHalf2Float<kType>(dkbFP32ZeroReg, dkbFP32OneReg, dkbInReg, maskFull16);
+    MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+    MulFloatTwoReg(dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+    AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+    CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+    StoreAlign((__ubuf__ kType*&)dkOut, dkOutReg, maskFull16);
+
+    Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+    ReduceSum(dBetaFP32Reg, kFP32ZeroReg, maskFull32);
+    StoreUnAlignOut<betaType>(dBetaOut, dBetaFP32Reg, maskFull32, uStore, 1);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDkbComputerVFTwoCol(
+    __ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    __ubuf__ kType* dkIn, __ubuf__ kType* dkbIn, uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    uint16_t mLoopCnt = mSize - 1;
+    uint16_t lastLoopCnt = mSize % PRELOAD_NUM;
+    RegTensor<betaType> betaInReg;
+    RegTensor<kType> kInReg, kInReg1;
+    RegTensor<kType> dkInReg, dkInReg1;
+    RegTensor<kType> dkbInReg, dkbInReg1;
+    RegTensor<float> betaBrcbFP32ZeroReg;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg1, kFP32OneReg1;
+    RegTensor<float> dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg1, dkFP32OneReg1;
+    RegTensor<float> dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg1, dkbFP32OneReg1;
+    RegTensor<kType> dkOutReg, dkOutReg1;
+    RegTensor<float> dBetaFP32Reg;
+    RegTensor<betaType> dBetaOutZeroReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    UnalignRegForStore uStore;
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<kType, false>(kInReg, kIn);
+    LoadIn<kType, false>(kInReg1, kIn + oneEleNum);
+    LoadIn<kType, false>(dkInReg, dkIn);
+    LoadIn<kType, false>(dkInReg1, dkIn + oneEleNum);
+    LoadIn<kType, false>(dkbInReg, dkbIn);
+    LoadIn<kType, false>(dkbInReg1, dkbIn + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1) * PRELOAD_NUM);
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        LoadIn<kType, false>(kInReg, kIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(kInReg1, kIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+        CastHalf2Float<kType>(dkFP32ZeroReg1, dkFP32OneReg1, dkInReg1, maskFull16);
+        LoadIn<kType, false>(dkInReg, dkIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dkInReg1, dkIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(dkbFP32ZeroReg, dkbFP32OneReg, dkbInReg, maskFull16);
+        CastHalf2Float<kType>(dkbFP32ZeroReg1, dkbFP32OneReg1, dkbInReg1, maskFull16);
+        LoadIn<kType, false>(dkbInReg, dkbIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dkbInReg1, dkbIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+        MulFloatTwoReg(dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+
+        MulFloatTwoReg(kFP32ZeroReg1, kFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, maskFull32);
+        MulFloatTwoReg(dkbFP32ZeroReg1, dkbFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        AddFloatTwoReg(dkFP32ZeroReg1, dkFP32OneReg1, dkFP32ZeroReg1, dkFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, maskFull32);
+
+        CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dkOutReg1, dkFP32ZeroReg1, dkFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+
+        Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+        ReduceSum(dBetaFP32Reg, kFP32ZeroReg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
+
+        Add(kFP32ZeroReg1, kFP32ZeroReg1, kFP32OneReg1, maskFull32);
+        ReduceSum(dBetaFP32Reg, kFP32ZeroReg1, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM + 1, dBetaFP32Reg, maskFull32, uStore, 1);
+    }
+    uint16_t mIdx = mLoopCnt;
     {
-        // cast from bf16/fp16 to FP32
-        if constexpr (!std::is_same<betaType, float>()) {
-            LoadUnAlignPre(uLoad, betaIn + mIdx);
-            LoadUnAlign(betaInReg, uLoad, betaIn + mIdx);
-            Cast<float, betaType, ctHalf2Fp32Zero>(betaBrcbFP32ZeroReg, betaInReg, maskFull16);
-        } else {
-            LoadUnAlignPre(uLoad, betaIn + mIdx);
-            LoadUnAlign(betaBrcbFP32ZeroReg, uLoad, betaIn + mIdx);
-        }
-        Duplicate(betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-        Duplicate(reduceSumReg, static_cast<float>(0), maskFull32);
-        uint32_t mOffset = mIdx * nKUbAligned;
-        uint32_t nextEleOffset = 0;
-        // 最后一行的前nLoopCnt - 1
-        for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt - 1; vfBlockIdx++) {
-            Cast<float, kType, ctHalf2Fp32Zero>(kFP32ZeroReg, kInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(kFP32OneReg, kInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32Zero>(dkbFP32ZeroReg, dkbInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(dkbFP32OneReg, dkbInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32Zero>(dkFP32ZeroReg, dkInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(dkFP32OneReg, dkInReg, maskFull16);
-            uint32_t thisEleNum = min(eleKNumPerVf, nSize - vfBlockIdx * eleKNumPerVf);
-            nextEleOffset += thisEleNum;
-            LoadAlign(kInReg, kIn + nextEleOffset);
-            LoadAlign(dkbInReg, dkbIn + nextEleOffset);
-            LoadAlign(dkInReg, dkIn + nextEleOffset);
-            Mul(kFP32ZeroReg, kFP32ZeroReg, dkbFP32ZeroReg, maskFull32);
-            Mul(kFP32OneReg, kFP32OneReg, dkbFP32OneReg, maskFull32);
-            Mul(dkbFP32ZeroReg, dkbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-            Mul(dkbFP32OneReg, dkbFP32OneReg, betaBrcbFP32ZeroReg, maskFull32);
-            Add(dkFP32ZeroReg, dkFP32ZeroReg, dkbFP32ZeroReg, maskFull32);
-            Add(dkFP32OneReg, dkFP32OneReg, dkbFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfOne>(dkOutReg, dkFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfZero>(dkOutReg, dkFP32ZeroReg, maskFull32);
-            uint32_t dstUbOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            StoreAlign((__ubuf__ kType*&)dkOut + dstUbOffset, dkOutReg, maskFull16);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+        CastHalf2Float<kType>(dkFP32ZeroReg1, dkFP32OneReg1, dkInReg1, maskFull16);
+        CastHalf2Float<kType>(dkbFP32ZeroReg, dkbFP32OneReg, dkbInReg, maskFull16);
+        CastHalf2Float<kType>(dkbFP32ZeroReg1, dkbFP32OneReg1, dkbInReg1, maskFull16);
 
-            Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
-            Add(reduceSumReg, reduceSumReg, kFP32ZeroReg, maskFull32);
-        }
-        // 最后一行最后一个loop
-        uint16_t vfBlockIdx = nLoopCnt - 1;
-        {
-            Cast<float, kType, ctHalf2Fp32Zero>(kFP32ZeroReg, kInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(kFP32OneReg, kInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32Zero>(dkbFP32ZeroReg, dkbInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(dkbFP32OneReg, dkbInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32Zero>(dkFP32ZeroReg, dkInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(dkFP32OneReg, dkInReg, maskFull16);
-            Mul(kFP32ZeroReg, kFP32ZeroReg, dkbFP32ZeroReg, maskFull32);
-            Mul(kFP32OneReg, kFP32OneReg, dkbFP32OneReg, maskFull32);
-            Mul(dkbFP32ZeroReg, dkbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-            Mul(dkbFP32OneReg, dkbFP32OneReg, betaBrcbFP32ZeroReg, maskFull32);
-            Add(dkFP32ZeroReg, dkFP32ZeroReg, dkbFP32ZeroReg, maskFull32);
-            Add(dkFP32OneReg, dkFP32OneReg, dkbFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfOne>(dkOutReg, dkFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfZero>(dkOutReg, dkFP32ZeroReg, maskFull32);
-            uint32_t dstUbOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            StoreAlign((__ubuf__ kType*&)dkOut + dstUbOffset, dkOutReg, maskFull16);
+        MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+        MulFloatTwoReg(dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
 
-            Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
-            Add(reduceSumReg, reduceSumReg, kFP32ZeroReg, maskFull32);
-        }
-        ReduceSum(dBetaFP32Reg, reduceSumReg, maskFull32);
+        MulFloatTwoReg(kFP32ZeroReg1, kFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, maskFull32);
+        MulFloatTwoReg(dkbFP32ZeroReg1, dkbFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        AddFloatTwoReg(dkFP32ZeroReg1, dkFP32OneReg1, dkFP32ZeroReg1, dkFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, maskFull32);
 
-        auto actDbetaOut = dBetaOut + mIdx;
-        if constexpr (!std::is_same<betaType, float32_t>()) {
-            Cast<betaType, float, ctFp322HalfZero>(dBetaOutZeroReg, dBetaFP32Reg, maskFull32);
-            StoreUnAlign(actDbetaOut, dBetaOutZeroReg, uStore, 1);
-            StoreUnAlignPost(actDbetaOut, uStore, 0);
-        } else {
-            StoreUnAlign(actDbetaOut, dBetaFP32Reg, uStore, 1);
-            StoreUnAlignPost(actDbetaOut, uStore, 0);
-        }
+        CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dkOutReg1, dkFP32ZeroReg1, dkFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+
+        Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+        ReduceSum(dBetaFP32Reg, kFP32ZeroReg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
+
+        Add(kFP32ZeroReg1, kFP32ZeroReg1, kFP32OneReg1, maskFull32);
+        ReduceSum(dBetaFP32Reg, kFP32ZeroReg1, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM + 1, dBetaFP32Reg, maskFull32, uStore, 1);
     }
 }
 
@@ -1521,10 +1670,25 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
                     AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventUbInMTE2VList[ubListId]);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(eventUbOutMTE3VList[ubListId]);
                     AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(SYNC_AIC_AIV_FLAG_BEGIN + cvListId);
-                    ProcessDkbComputerVF(
-                        (__ubuf__ kType*)dkOutAddr, (__ubuf__ betaType*)dBetaOutAddr, (__ubuf__ kType*)kInAddr, 
-                        (__ubuf__ betaType*)betaInAddr,(__ubuf__ kType*)dkInAddr, (__ubuf__ kType*)dkbInAddr, 
-                        curRowNum, K);
+                    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+                    if (K <= eleKNumPerVf) {
+                        if (curRowNum == 1) {
+                            ProcessDkbComputerVFOneLineOneCol(
+                                    (__ubuf__ kType*)dkOutAddr, (__ubuf__ betaType*)dBetaOutAddr, (__ubuf__ kType*)kInAddr,
+                                    (__ubuf__ betaType*)betaInAddr,(__ubuf__ kType*)dkInAddr, (__ubuf__ kType*)dkbInAddr,
+                                    curRowNum, K);
+                        } else {
+                            ProcessDkbComputerVFMutiLineOneCol(
+                                    (__ubuf__ kType*)dkOutAddr, (__ubuf__ betaType*)dBetaOutAddr, (__ubuf__ kType*)kInAddr,
+                                    (__ubuf__ betaType*)betaInAddr,(__ubuf__ kType*)dkInAddr, (__ubuf__ kType*)dkbInAddr,
+                                    curRowNum, K);
+                        }
+                    } else {
+                        ProcessDkbComputerVFTwoCol(
+                                    (__ubuf__ kType*)dkOutAddr, (__ubuf__ betaType*)dBetaOutAddr, (__ubuf__ kType*)kInAddr,
+                                    (__ubuf__ betaType*)betaInAddr,(__ubuf__ kType*)dkInAddr, (__ubuf__ kType*)dkbInAddr,
+                                    curRowNum, K);
+                    }
                     AscendC::CrossCoreSetFlag<0x4, PIPE_V>(SYNC_AIV_AIC_FLAG_BEGIN + cvListId);
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(eventUbOutVMTE3List[ubListId]);
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventUbInVMTE2List[ubListId]);
@@ -1555,99 +1719,148 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
 }
 
 template <typename kType, typename betaType>
-__simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessKBetaComputerVF(
+__simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessKBetaComputerVFMutiLineOneCol(
+    __ubuf__ kType* kBetaOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    uint16_t mSize, uint16_t nSize, uint16_t lastLoopCnt)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint16_t nLoopCnt = (nSize + eleKNumPerVf - 1) / eleKNumPerVf;
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    uint16_t mLoopCnt = mSize / 2 - 1;
+    RegTensor<kType> kInReg, kInReg1;
+    RegTensor<betaType> betaInReg, betaInReg1;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, kBetaFP32ZeroReg, kBetaFP32OneReg;
+    RegTensor<float> kFP32ZeroReg1, kFP32OneReg1, kBetaFP32ZeroReg1, kBetaFP32OneReg1;
+    RegTensor<float> betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg1;
+    RegTensor<kType> kBetaOutReg, kBetaOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(betaInReg1, betaIn + 1);
+    LoadIn<kType, false>(kInReg, kIn);
+    LoadIn<kType, false>(kInReg1, kIn + oneEleNum);
+    // 前mSize - 3行
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg1, betaInReg1, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1) * 2);
+        LoadIn<betaType, true>(betaInReg1, betaIn + (mIdx + 1) * 2 + 1);
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        LoadIn<kType, false>(kInReg, kIn + oneEleNum * ((mIdx + 1) * 2));
+        LoadIn<kType, false>(kInReg1, kIn + oneEleNum * ((mIdx + 1) * 2 + 1));
+        MulFloatTwoReg(kBetaFP32ZeroReg, kBetaFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        MulFloatTwoReg(kBetaFP32ZeroReg1, kBetaFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, betaBrcbFP32ZeroReg1, betaBrcbFP32ZeroReg1, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg, kBetaFP32ZeroReg, kBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg1, kBetaFP32ZeroReg1, kBetaFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2), kBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2 + 1), kBetaOutReg1, maskFull16);
+    }
+    uint16_t mIdx = mLoopCnt;
+    // 最后三行
+    {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg1, betaInReg1, maskFull16, maskFull32);
+
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+
+        MulFloatTwoReg(kBetaFP32ZeroReg, kBetaFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        MulFloatTwoReg(kBetaFP32ZeroReg1, kBetaFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, betaBrcbFP32ZeroReg1, betaBrcbFP32ZeroReg1, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg, kBetaFP32ZeroReg, kBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg1, kBetaFP32ZeroReg1, kBetaFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2), kBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2 + 1), kBetaOutReg1, maskFull16);
+
+        mIdx += 1;
+        // 最后一行
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<betaType, true>(betaInReg, betaIn + mIdx * 2);
+            LoadIn<kType, false>(kInReg, kIn + oneEleNum * (mIdx * 2));
+            HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            MulFloatTwoReg(kBetaFP32ZeroReg, kBetaFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            CastFloat2Half<kType>(kBetaOutReg, kBetaFP32ZeroReg, kBetaFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2), kBetaOutReg, maskFull16);
+        }
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessKBetaComputerVFOneLineOneCol(
     __ubuf__ kType* kBetaOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
     uint16_t mSize, uint16_t nSize)
 {
     uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
-    uint32_t nKUbAligned = Align(nSize, static_cast<uint16_t>(UB_ALIGN_SIZE / sizeof(kType)));
-    uint16_t nLoopCnt = (nSize + eleKNumPerVf - 1) / eleKNumPerVf;
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
     RegTensor<kType> kInReg;
-    RegTensor<float> kFP32ZeroReg, kFP32OneReg;
     RegTensor<betaType> betaInReg;
-    RegTensor<float> betaBrcbFP32ZeroReg, betaBrcbFP32OneReg;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, kBetaFP32ZeroReg, kBetaFP32OneReg;
+    RegTensor<float> betaBrcbFP32ZeroReg;
     RegTensor<kType> kBetaOutReg;
 
     MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
     MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
 
-    UnalignRegForLoad uLoad;
-    UnalignRegForStore uStore;
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<kType, false>(kInReg, kIn);
+    
+    HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+    CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+    MulFloatTwoReg(kBetaFP32ZeroReg, kBetaFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+    CastFloat2Half<kType>(kBetaOutReg, kBetaFP32ZeroReg, kBetaFP32OneReg, maskFull32);
+    StoreAlign(kBetaOut, kBetaOutReg, maskFull16);
+}
 
-    if constexpr (!std::is_same<betaType, float>()) {
-        LoadUnAlignPre(uLoad, betaIn);
-        LoadUnAlign(betaInReg, uLoad, betaIn);
-    } else {
-        LoadUnAlignPre(uLoad, betaIn);
-        LoadUnAlign(betaInReg, uLoad, betaIn);
-    }
-    LoadAlign(kInReg, kIn);
-    uint32_t nextEleOffset = 0;
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessKBetaComputerVFTwoCol(
+    __ubuf__ kType* kBetaOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint16_t nLoopCnt = (nSize + eleKNumPerVf - 1) / eleKNumPerVf;
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    RegTensor<kType> kInReg, kInReg1;
+    RegTensor<betaType> betaInReg, betaInReg1;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, kBetaFP32ZeroReg, kBetaFP32OneReg;
+    RegTensor<float> kFP32ZeroReg1, kFP32OneReg1, kBetaFP32ZeroReg1, kBetaFP32OneReg1;
+    RegTensor<float> betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg1;
+    RegTensor<kType> kBetaOutReg, kBetaOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<kType, false>(kInReg, kIn);
+    LoadIn<kType, false>(kInReg1, kIn + oneEleNum);
     for (uint16_t mIdx = 0; mIdx < mSize - 1; mIdx++) {
-        // cast from bf16/fp16 to FP32
-        if constexpr (!std::is_same<betaType, float>()) {
-            Cast<float, betaType, ctHalf2Fp32Zero>(betaBrcbFP32ZeroReg, betaInReg, maskFull16);
-            Duplicate(betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-            LoadUnAlignPre(uLoad, betaIn + (mIdx + 1));
-            LoadUnAlign(betaInReg, uLoad, betaIn + (mIdx + 1));
-        } else {
-            Duplicate(betaBrcbFP32ZeroReg, betaInReg, maskFull32);
-            LoadUnAlignPre(uLoad, betaIn + (mIdx + 1));
-            LoadUnAlign(betaInReg, uLoad, betaIn + (mIdx + 1));
-        }
-        uint32_t mOffset = mIdx * nKUbAligned;
-        for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt; vfBlockIdx++) {
-            uint32_t eleOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            Cast<float, kType, ctHalf2Fp32Zero>(kFP32ZeroReg, kInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(kFP32OneReg, kInReg, maskFull16);
-            uint32_t thisEleNum = min(eleKNumPerVf, nSize - vfBlockIdx * eleKNumPerVf);
-            nextEleOffset += thisEleNum;
-            LoadAlign(kInReg, kIn + nextEleOffset);
-            Mul(kFP32ZeroReg, kFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-            Mul(kFP32OneReg, kFP32OneReg, betaBrcbFP32ZeroReg, maskFull32);
-            Cast<kType, float, ctFp322HalfOne>(kBetaOutReg, kFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfZero>(kBetaOutReg, kFP32ZeroReg, maskFull32);
-            uint32_t dstUbOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            StoreAlign((__ubuf__ kType*&)kBetaOut + dstUbOffset, kBetaOutReg, maskFull16);
-        }
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1));
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        LoadIn<kType, false>(kInReg, kIn + oneEleNum * (mIdx + 1) * 2);
+        LoadIn<kType, false>(kInReg1, kIn + oneEleNum * (mIdx + 1) * 2 + 1);
+        MulFloatTwoReg(kBetaFP32ZeroReg, kBetaFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        MulFloatTwoReg(kBetaFP32ZeroReg1, kBetaFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg, kBetaFP32ZeroReg, kBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg1, kBetaFP32ZeroReg1, kBetaFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2), kBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2 + 1), kBetaOutReg1, maskFull16);
     }
     uint16_t mIdx = mSize - 1;
+    // 最后一行
     {
-        // cast from bf16/fp16 to FP32
-        if constexpr (!std::is_same<betaType, float>()) {
-            Cast<float, betaType, ctHalf2Fp32Zero>(betaBrcbFP32ZeroReg, betaInReg, maskFull16);
-            Duplicate(betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-        } else {
-            Duplicate(betaBrcbFP32ZeroReg, betaInReg, maskFull32);
-        }
-        Duplicate(betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-        uint32_t mOffset = mIdx * nKUbAligned;
-        for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt - 1; vfBlockIdx++) {
-            uint32_t eleOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            Cast<float, kType, ctHalf2Fp32Zero>(kFP32ZeroReg, kInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(kFP32OneReg, kInReg, maskFull16);
-            uint32_t thisEleNum = min(eleKNumPerVf, nSize - vfBlockIdx * eleKNumPerVf);
-            nextEleOffset += thisEleNum;
-            LoadAlign(kInReg, kIn + nextEleOffset);
-            Mul(kFP32ZeroReg, kFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-            Mul(kFP32OneReg, kFP32OneReg, betaBrcbFP32ZeroReg, maskFull32);
-            Cast<kType, float, ctFp322HalfOne>(kBetaOutReg, kFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfZero>(kBetaOutReg, kFP32ZeroReg, maskFull32);
-            uint32_t dstUbOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            StoreAlign((__ubuf__ kType*&)kBetaOut + dstUbOffset, kBetaOutReg, maskFull16);
-        }
-        uint16_t vfBlockIdx = nLoopCnt - 1;
-        {
-            uint32_t eleOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            Cast<float, kType, ctHalf2Fp32Zero>(kFP32ZeroReg, kInReg, maskFull16);
-            Cast<float, kType, ctHalf2Fp32One>(kFP32OneReg, kInReg, maskFull16);
-            Mul(kFP32ZeroReg, kFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
-            Mul(kFP32OneReg, kFP32OneReg, betaBrcbFP32ZeroReg, maskFull32);
-            Cast<kType, float, ctFp322HalfOne>(kBetaOutReg, kFP32OneReg, maskFull32);
-            Cast<kType, float, ctFp322HalfZero>(kBetaOutReg, kFP32ZeroReg, maskFull32);
-            uint32_t dstUbOffset = mOffset + vfBlockIdx * eleKNumPerVf;
-            StoreAlign((__ubuf__ kType*&)kBetaOut + dstUbOffset, kBetaOutReg, maskFull16);
-        }
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        MulFloatTwoReg(kBetaFP32ZeroReg, kBetaFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        MulFloatTwoReg(kBetaFP32ZeroReg1, kBetaFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg, kBetaFP32ZeroReg, kBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg1, kBetaFP32ZeroReg1, kBetaFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2), kBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2 + 1), kBetaOutReg1, maskFull16);
     }
 }
 
@@ -1700,9 +1913,24 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
                     auto kBetaOutAddr = reinterpret_cast<uint64_t>(tensorOut.GetPhyAddr());
                     auto kInAddr = reinterpret_cast<uint64_t>(tensorKin.GetPhyAddr());
                     auto betaInAddr = reinterpret_cast<uint64_t>(tensorBetain.GetPhyAddr());
-                    ProcessKBetaComputerVF(
-                        (__ubuf__ kType*)kBetaOutAddr, (__ubuf__ kType*)kInAddr, (__ubuf__ betaType*)betaInAddr,
-                        curRowNum, K);
+                    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+                    if (K <= eleKNumPerVf) {
+                        uint16_t lastLoopCnt = curRowNum % PRELOAD_NUM;
+                        if (curRowNum == 1) {
+                            ProcessKBetaComputerVFOneLineOneCol(
+                                    (__ubuf__ kType*)kBetaOutAddr, (__ubuf__ kType*)kInAddr, (__ubuf__ betaType*)betaInAddr,
+                                    curRowNum, K);
+                        } else {
+                            ProcessKBetaComputerVFMutiLineOneCol(
+                                    (__ubuf__ kType*)kBetaOutAddr, (__ubuf__ kType*)kInAddr, (__ubuf__ betaType*)betaInAddr,
+                                    curRowNum, K, lastLoopCnt);
+                        }
+                    } else {
+                        ProcessKBetaComputerVFTwoCol(
+                                    (__ubuf__ kType*)kBetaOutAddr, (__ubuf__ kType*)kInAddr, (__ubuf__ betaType*)betaInAddr,
+                                    curRowNum, K);
+                    }
+                    
                     kInQue.FreeTensor(tensorKin);
                     betaInQue.FreeTensor(tensorBetain);
                     kBetaOutQue.EnQue(tensorOut);

--- a/torch_custom/fla_npu/test/test_npu_prepare_wy_repr_bwd_full.py
+++ b/torch_custom/fla_npu/test/test_npu_prepare_wy_repr_bwd_full.py
@@ -72,16 +72,64 @@ def compute_dv_golden(
                 
                 # 计算 dv_chunk = A_chunk @ du_chunk * beta_chunk
                 # 步骤1: b_dv_beta = A_chunk @ du_chunk
-                b_dv_beta = torch.matmul(A_chunk.T.to(torch.float32), du_chunk.to(torch.float32))  # [chunk_size, V]
+                b_dv_beta = torch.matmul(A_chunk.T, du_chunk)  # [chunk_size, V]
                 
                 # 步骤2: dv_chunk = b_dv_beta * beta_chunk.unsqueeze(-1)
-                dv_chunk = b_dv_beta.to(torch.float32) * beta_chunk[:, None].to(torch.float32)  # [chunk_size, D]
+                dv_chunk = b_dv_beta * beta_chunk[:, None]  # [chunk_size, D]
                 
                 # 存储结果
                 dv[i_b,i_h, bos:eos, :] = dv_chunk.to(dv.dtype)
     
     return dv
 
+def compute_dv_golden_high_precision(
+    A: torch.Tensor,      # [B, HV, T, chunk_size]
+    du: torch.Tensor,     # [B, HV, T, D] - 上游梯度
+    beta: torch.Tensor,   # [B, HV, T] - beta参数
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    B: int,
+    HV: int,
+    T: int,
+    D: int,
+    chunk_size: int,  # chunk_size
+    NT: int,  # T / chunk_size
+) -> torch.Tensor:
+    """
+    CPU golden for dv:`A`/`du`/`beta` 均在 HV 维上按 `i_h` 遍历。
+    """
+    # 初始化dv,形状与du相同 [B, HV, T, D];外层按 HV 遍历
+    dv = torch.zeros_like(du).to(torch.float64)
+    for i_b in range(B):
+        for idx in range(NT):
+            bos,eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
+            # print(bos, eos, eos-bos)
+            for i_h in range(HV):
+                
+            # 遍历所有head 
+                # 获取当前chunk的A向量
+                # A形状: [B, T, H, chunk_size]
+                # 我们需要获取这个chunk对应的A向量
+                # 注意: A的每个位置存储的是该chunk对应的A向量
+                A_chunk = A[i_b,i_h, bos:eos,:eos - bos]  # [chunk_size, chunk_size]
+                
+                # 获取当前chunk的du
+                du_chunk = du[i_b,i_h, bos:eos, :]  # [chunk_size, V]
+                
+                # 获取当前chunk的beta
+                beta_chunk = beta[i_b,i_h, bos:eos]  # [chunk_size]
+                
+                # 计算 dv_chunk = A_chunk @ du_chunk * beta_chunk
+                # 步骤1: b_dv_beta = A_chunk @ du_chunk
+                b_dv_beta = torch.matmul(A_chunk.T.to(torch.float64), du_chunk.to(torch.float64))  # [chunk_size, V]
+                
+                # 步骤2: dv_chunk = b_dv_beta * beta_chunk.unsqueeze(-1)
+                dv_chunk = b_dv_beta.to(torch.float64) * beta_chunk[:, None].to(torch.float64)  # [chunk_size, D]
+                
+                # 存储结果
+                dv[i_b,i_h, bos:eos, :] = dv_chunk.to(dv.dtype)
+    
+    return dv
 
 def compute_dk_golden(
     A: torch.Tensor,      # [B, HV, T, chunk_size]
@@ -137,6 +185,60 @@ def compute_dk_golden(
                 dk[i_b, hk, bos:eos, :] = (prev + dk_chunk.to(torch.float32)).to(dk.dtype)
     return dk
 
+def compute_dk_golden_high_precision(
+    A: torch.Tensor,      # [B, HV, T, chunk_size]
+    dw: torch.Tensor,     # [B, HV, T, D] 与 FLA prepare_wy_repr_bwd 一致,按 value head 索引
+    g: torch.Tensor,     # [B, HV, T]
+    beta: torch.Tensor,   # [B, HV, T]
+    dA: torch.Tensor,      # [B, HV, T, chunk_size]
+    k: torch.Tensor,     # [B, HK, T, D]
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    B: int,
+    HK: int,
+    HV: int,
+    T: int,
+    D: int,
+    chunk_size: int,  # chunk_size
+    NT: int,  # T / chunk_size
+) -> torch.Tensor:
+    """
+    CPU golden for dk(变长)。
+    外层按 HV 遍历(与 FLA prepare_wy_repr_bwd_kernel);`k` 取 KV head `hk`,`dw` 取 value head `i_h`;
+    各 HV 对 dk 的贡献累加到对应 `hk`(与 FLA 最后 ``dk.view(..., HV//HK, K).sum`` 等价)。
+    """
+    if HV % HK != 0:
+        raise ValueError(f"compute_dk_golden: HV ({HV}) must be divisible by HK ({HK}).")
+    heads_per_kv = HV // HK
+    dk = torch.zeros_like(k).to(torch.float64)
+    for i_b in range(B):
+        for idx in range(NT):
+            bos, eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
+            for i_h in range(HV):
+                hk = _hv_to_hk(i_h, heads_per_kv)
+                A_chunk = A[i_b, i_h, bos:eos, : eos - bos]
+                beta_chunk = beta[i_b, i_h, bos:eos]
+                g_chunk = g[i_b, i_h, bos:eos]
+                g_exp_chunk = torch.exp(g_chunk.to(torch.float64))
+                k_chunk = k[i_b, hk, bos:eos, : ]
+                dA_chunk = dA[i_b, i_h, bos:eos, : eos - bos]
+                b_dk_beta = torch.matmul(dA_chunk.T.to(torch.float64), k_chunk.to(torch.float64))
+                b_k_beta = k_chunk.to(torch.float64) * beta_chunk.to(torch.float64)[:, None]
+                dw_chunk = dw[i_b, i_h, bos:eos, :]
+                b_dk_beta_g = torch.matmul(A_chunk.T.to(torch.float64), dw_chunk.to(torch.float64))
+
+                dk_chunk = torch.matmul(dA_chunk.to(torch.float64), b_k_beta.to(k.dtype).to(torch.float64)).to(k.dtype).to(torch.float64)
+                dk_chunk = dk_chunk.to(k.dtype).to(torch.float64) + (
+                    b_dk_beta.to(k.dtype).to(torch.float64) * beta_chunk[:, None].to(torch.float64)
+                )
+                dk_chunk = dk_chunk.to(k.dtype).to(torch.float64) + b_dk_beta_g.to(k.dtype).to(torch.float64) * (
+                    beta_chunk.to(torch.float64) * g_exp_chunk.to(torch.float64)
+                )[:, None]
+
+                prev = dk[i_b, hk, bos:eos, :].to(torch.float64)
+                dk[i_b, hk, bos:eos, :] = (prev + dk_chunk.to(torch.float64)).to(dk.dtype)
+    return dk
+
 def compute_dg_golden(
     A: torch.Tensor,      # [B, HV, T, chunk_size]
     dw: torch.Tensor,     # [B, HV, T, D]
@@ -169,29 +271,86 @@ def compute_dg_golden(
 
                 beta_chunk = beta[i_b,i_h, bos:eos]
                 g_chunk = g[i_b,i_h, bos:eos]
-                g_exp_chunk = torch.exp(g_chunk.to(torch.float32))
+                g_exp_chunk = torch.exp(g_chunk)
 
-                b_dk_beta_g = torch.matmul(A_chunk.T.to(torch.float32), dw_chunk.to(torch.float32))
+                b_dk_beta_g = torch.matmul(A_chunk.T, dw_chunk)
 
                 k_chunk = k[i_b, hk, bos:eos, : ]
-                b_kbg = k_chunk.to(torch.float32) * (
-                    beta_chunk.to(torch.float32) * g_exp_chunk.to(torch.float32)
+                b_kbg = k_chunk * (
+                    beta_chunk * g_exp_chunk
                 )[:,None]
                 dA_chunk = dA[i_b,i_h, bos:eos,: eos - bos]
                 if k_chunk.size(0) == 1:
-                    dot_val = torch.sum(k_chunk.to(torch.float32) * k_chunk.to(torch.float32), dim=1, keepdim=True)
+                    dot_val = torch.sum(k_chunk * k_chunk, dim=1, keepdim=True)
                     b_A = dot_val
                 else:
-                    k_f32 = k_chunk.to(torch.float32).contiguous()
+                    k_f32 = k_chunk.contiguous()
                     b_A = torch.matmul(k_f32, k_f32.T.contiguous())
-                b_A = b_A.to(torch.float32) * beta_chunk[:,None].to(torch.float32)
-                b_dA_A = dA_chunk.to(torch.float32).T * b_A.to(torch.float32)
+                b_A = b_A * beta_chunk[:,None]
+                b_dA_A = dA_chunk.T * b_A
 
-                dg_chunk = torch.sum(b_dk_beta_g.to(k.dtype).to(torch.float32) * b_kbg.to(torch.float32), dim = 1)
-                dg_chunk = dg_chunk.to(dg.dtype).to(torch.float32) +  (
+                dg_chunk = torch.sum(b_dk_beta_g.to(dg.dtype) * b_kbg.to(dg.dtype), dim = 1)
+                dg_chunk = dg_chunk.to(dg.dtype) +  (
+                    torch.sum(b_dA_A, dim = 1) - torch.sum(b_dA_A, dim = 0)
+                ).to(dg.dtype)
+                dg[i_b,i_h, bos:eos] = dg_chunk.to(g.dtype)
+    return dg
+
+def compute_dg_golden_high_precision(
+    A: torch.Tensor,      # [B, HV, T, chunk_size]
+    dw: torch.Tensor,     # [B, HV, T, D]
+    g: torch.Tensor,     # [B, HV, T]
+    beta: torch.Tensor,   # [B, HV, T]
+    dA: torch.Tensor,      # [B, HV, T, chunk_size]
+    k: torch.Tensor,     # [B, HK, T, D]
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    B: int,
+    HK: int,
+    HV: int,
+    T: int,
+    D: int,
+    chunk_size: int,  # chunk_size
+    NT: int,  # T / chunk_size
+) -> torch.Tensor:
+    """CPU golden for dg:按 HV 遍历;`dw` 取 `i_h`,`k` 取 `hk`(与 FLA kernel 一致)。"""
+    if HV % HK != 0:
+        raise ValueError(f"compute_dg_golden: HV ({HV}) must be divisible by HK ({HK}).")
+    heads_per_kv = HV // HK
+    dg = torch.zeros_like(g).to(torch.float64)
+    for i_b in range(B):
+        for idx in range(NT):
+            bos,eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
+            for i_h in range(HV):
+                hk = _hv_to_hk(i_h, heads_per_kv)
+                A_chunk = A[i_b,i_h, bos:eos,: eos - bos]
+                dw_chunk = dw[i_b, i_h, bos:eos, :]
+
+                beta_chunk = beta[i_b,i_h, bos:eos]
+                g_chunk = g[i_b,i_h, bos:eos]
+                g_exp_chunk = torch.exp(g_chunk.to(torch.float64))
+
+                b_dk_beta_g = torch.matmul(A_chunk.T.to(torch.float64), dw_chunk.to(torch.float64))
+
+                k_chunk = k[i_b, hk, bos:eos, : ]
+                b_kbg = k_chunk.to(torch.float64) * (
+                    beta_chunk.to(torch.float64) * g_exp_chunk.to(torch.float64)
+                )[:,None]
+                dA_chunk = dA[i_b,i_h, bos:eos,: eos - bos]
+                if k_chunk.size(0) == 1:
+                    dot_val = torch.sum(k_chunk.to(torch.float64) * k_chunk.to(torch.float64), dim=1, keepdim=True)
+                    b_A = dot_val
+                else:
+                    k_f32 = k_chunk.to(torch.float64).contiguous()
+                    b_A = torch.matmul(k_f32, k_f32.T.contiguous())
+                b_A = b_A.to(torch.float64) * beta_chunk[:,None].to(torch.float64)
+                b_dA_A = dA_chunk.to(torch.float64).T * b_A.to(torch.float64)
+
+                dg_chunk = torch.sum(b_dk_beta_g.to(k.dtype).to(torch.float64) * b_kbg.to(torch.float64), dim = 1)
+                dg_chunk = dg_chunk.to(dg.dtype).to(torch.float64) +  (
                     torch.sum(b_dA_A, dim = 1) - torch.sum(b_dA_A, dim = 0)
                 )
-                dg[i_b,i_h, bos:eos] = dg_chunk.to(k.dtype)
+                dg[i_b,i_h, bos:eos] = dg_chunk.to(dg.dtype)
     return dg
 
 def compute_dbeta_golden(
@@ -231,30 +390,90 @@ def compute_dbeta_golden(
 
                 beta_chunk = beta[i_b,i_h, bos:eos]
                 g_chunk = g[i_b,i_h, bos:eos]
-                g_exp_chunk = torch.exp(g_chunk.to(torch.float32))
+                g_exp_chunk = torch.exp(g_chunk)
                 k_chunk = k[i_b, hk, bos:eos, : ]
                 #   beta________0
                 # 步骤1: b_dk_beta_g = A_chunk @ dw_chunk
-                b_dk_beta_g = torch.matmul(A_chunk.T.to(torch.float32), dw_chunk.to(torch.float32))  
+                b_dk_beta_g = torch.matmul(A_chunk.T, dw_chunk)  
                 
                 # 步骤2: b_dbeta += tl.sum(b_dk_beta_g * b_k * b_g_exp[:, None], 1)
-                tmp = b_dk_beta_g * k_chunk.to(torch.float32) * g_exp_chunk.to(torch.float32)[:, None] # [chunkSize, D]
+                tmp = b_dk_beta_g * k_chunk * g_exp_chunk[:, None] # [chunkSize, D]
                 #   beta________1 
                 
-                b_dv_beta = torch.matmul(A_chunk.T.to(torch.float32), du_chunk.to(torch.float32))  # [chunkSize, V]
+                b_dv_beta = torch.matmul(A_chunk.T, du_chunk)  # [chunkSize, V]
                 #   beta________2 
                 dA_chunk = dA[i_b,i_h, bos:eos,: eos - bos]  # [chunkSize, chunkSize]
-                b_dk_beta = torch.matmul(dA_chunk.T.to(torch.float32), k_chunk.to(torch.float32))  # [chunkSize, V]
-                tmp = b_dk_beta.to(k.dtype).to(torch.float32) * k_chunk
+                b_dk_beta = torch.matmul(dA_chunk.T, k_chunk)  # [chunkSize, V]
+                tmp = b_dk_beta.to(k.dtype) * k_chunk
                 # test
-                dbeta_chunk = torch.sum(tmp, 1).to(torch.float16)
-                tmp = b_dk_beta_g.to(k.dtype).to(torch.float32) * k_chunk.to(torch.float32) * g_exp_chunk.to(torch.float32)[:, None] # [chunkSize, D]
-                dbeta_chunk = dbeta_chunk.to(k.dtype).to(torch.float32) + torch.sum(tmp, dim = 1)# [chunkSize]
-                dbeta_chunk = dbeta_chunk.to(k.dtype).to(torch.float32) + torch.sum(b_dv_beta.to(k.dtype).to(torch.float32) * v_chunk, 1)
+                dbeta_chunk = torch.sum(tmp, 1)
+                tmp = b_dk_beta_g.to(k.dtype) * k_chunk * g_exp_chunk[:, None] # [chunkSize, D]
+                dbeta_chunk = dbeta_chunk.to(k.dtype) + torch.sum(tmp, dim = 1)# [chunkSize]
+                dbeta_chunk = dbeta_chunk.to(k.dtype) + torch.sum(b_dv_beta.to(k.dtype) * v_chunk, 1)
                 # 存储结果
                 dbeta[i_b,i_h, bos:eos] = dbeta_chunk
     return dbeta
 
+def compute_dbeta_golden_high_precision(
+    A: torch.Tensor,      # [B, HV, T, chunkSize]
+    dw: torch.Tensor,     # [B, HV, T, D]
+    g: torch.Tensor,     # [B, HV, T]
+    beta: torch.Tensor,   # [B, HV, T]
+    dA: torch.Tensor,      # [B, HV, T, chunkSize]
+    k: torch.Tensor,     # [B, HK, T, D]
+    v: torch.Tensor,      # [B, HV, T, D]
+    du: torch.Tensor,     # [B, HV, T, D]
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    B: int,
+    HK: int,
+    HV: int,
+    T: int,
+    D: int,
+    chunkSize: int,  # chunkSize
+    NT: int,  # T / chunkSize
+) -> torch.Tensor:
+    """CPU golden for dbeta:按 HV 遍历;`dw` 取 `i_h`,`k` 取 `hk`。"""
+    if HV % HK != 0:
+        raise ValueError(f"compute_dbeta_golden: HV ({HV}) must be divisible by HK ({HK}).")
+    heads_per_kv = HV // HK
+    dbeta = torch.zeros_like(beta).to(torch.float64)
+    for i_b in range(B):
+        for idx in range(NT):
+            bos,eos = get_bos_eos(idx, T, chunkSize, cu_seqlens, chunk_indices)
+            for i_h in range(HV):
+                hk = _hv_to_hk(i_h, heads_per_kv)
+                A_chunk = A[i_b,i_h, bos:eos,: eos - bos]
+                v_chunk = v[i_b,i_h, bos:eos,:]
+
+                dw_chunk = dw[i_b, i_h, bos:eos, :]
+                du_chunk = du[i_b,i_h, bos:eos, :]
+
+                beta_chunk = beta[i_b,i_h, bos:eos]
+                g_chunk = g[i_b,i_h, bos:eos]
+                g_exp_chunk = torch.exp(g_chunk.to(torch.float64))
+                k_chunk = k[i_b, hk, bos:eos, : ]
+                #   beta________0
+                # 步骤1: b_dk_beta_g = A_chunk @ dw_chunk
+                b_dk_beta_g = torch.matmul(A_chunk.T.to(torch.float64), dw_chunk.to(torch.float64))  
+                
+                # 步骤2: b_dbeta += tl.sum(b_dk_beta_g * b_k * b_g_exp[:, None], 1)
+                tmp = b_dk_beta_g * k_chunk.to(torch.float64) * g_exp_chunk.to(torch.float64)[:, None] # [chunkSize, D]
+                #   beta________1 
+                
+                b_dv_beta = torch.matmul(A_chunk.T.to(torch.float64), du_chunk.to(torch.float64))  # [chunkSize, V]
+                #   beta________2 
+                dA_chunk = dA[i_b,i_h, bos:eos,: eos - bos]  # [chunkSize, chunkSize]
+                b_dk_beta = torch.matmul(dA_chunk.T.to(torch.float64), k_chunk.to(torch.float64))  # [chunkSize, V]
+                tmp = b_dk_beta.to(k.dtype).to(torch.float64) * k_chunk
+                # test
+                dbeta_chunk = torch.sum(tmp, 1).to(torch.float64)
+                tmp = b_dk_beta_g.to(k.dtype).to(torch.float64) * k_chunk.to(torch.float64) * g_exp_chunk.to(torch.float64)[:, None] # [chunkSize, D]
+                dbeta_chunk = dbeta_chunk.to(k.dtype).to(torch.float64) + torch.sum(tmp, dim = 1)# [chunkSize]
+                dbeta_chunk = dbeta_chunk.to(k.dtype).to(torch.float64) + torch.sum(b_dv_beta.to(k.dtype).to(torch.float64) * v_chunk, 1)
+                # 存储结果
+                dbeta[i_b,i_h, bos:eos] = dbeta_chunk
+    return dbeta
 
 def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
     return cu_seqlens[1:] - cu_seqlens[:-1]
@@ -482,13 +701,17 @@ def test_prepare_wy_repr_bwd_full(
     try:
         import ct
         cpu_dv = compute_dv_golden(A, du, beta, cu_seqlens, chunk_indices, B, HV, T, K, chunk_size, NT)
-        ct.isclose(dv.cpu(), cpu_dv, diff_thd=0.1)
+        cpu_dv_high_precision = compute_dv_golden_high_precision(A, du, beta, cu_seqlens, chunk_indices, B, HV, T, K, chunk_size, NT)
+        ct.dual(dv.cpu(), cpu_dv_high_precision, cpu_dv)
         cpu_dk = compute_dk_golden(A, dw, g, beta, dA,k, cu_seqlens, chunk_indices, B, HK, HV, T, K, chunk_size, NT)
-        ct.isclose(dk.cpu(), cpu_dk, diff_thd=0.1)
+        cpu_dk_high_precision = compute_dk_golden_high_precision(A, dw, g, beta, dA,k, cu_seqlens, chunk_indices, B, HK, HV, T, K, chunk_size, NT)
+        ct.dual(dk.cpu(), cpu_dk_high_precision, cpu_dk)
         cpu_dg = compute_dg_golden(A, dw, g, beta, dA,k, cu_seqlens, chunk_indices, B, HK, HV, T, K, chunk_size, NT)
-        ct.isclose(dg.cpu(), cpu_dg, diff_thd=0.1)
+        cpu_dg_high_precision = compute_dg_golden_high_precision(A, dw, g, beta, dA,k, cu_seqlens, chunk_indices, B, HK, HV, T, K, chunk_size, NT)
+        ct.dual(dg.cpu(), cpu_dg_high_precision, cpu_dg)
         cpu_dbeta = compute_dbeta_golden(A, dw, g, beta, dA,k,v,du, cu_seqlens, chunk_indices, B, HK, HV, T, K, chunk_size, NT)
-        ct.isclose(dbeta.cpu(), cpu_dbeta, diff_thd=0.1)
+        cpu_dbeta_high_precision = compute_dbeta_golden_high_precision(A, dw, g, beta, dA,k,v,du, cu_seqlens, chunk_indices, B, HK, HV, T, K, chunk_size, NT)
+        ct.dual(dbeta.cpu(), cpu_dbeta_high_precision, cpu_dbeta)
     finally:
         pass
     # torch.save(cpu_dbeta, "cpu_dbeta.pt") 
@@ -560,4 +783,4 @@ if __name__ == "__main__":
     # #L6
     # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 25)
     # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
-    # test_prepare_wy_repr_bwd_full(B = 1, HK = 8, HV = 8, T = 65536, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    # test_prepare_wy_repr_bwd_full(B = 1, HK = 8, HV = 8, T = 65536, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices, seed=42)


### PR DESCRIPTION
# Pull Request 模板

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:
1、增加da算子的regbase和cv通道
2、full算子rebase性能优化
## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @maoguolan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:

## 版本与产品编译矩阵

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

## 验证方法

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

工程 UT:

```sh
bash build.sh -u --ops=<op_name> --soc=<soc>
```

按模块精确验证:

```sh
bash build.sh --ophost_test --ops=<op_name> --soc=<soc>
bash build.sh --opapi_test --ops=<op_name> --soc=<soc>
bash build.sh --opkernel_test --ops=<op_name> --soc=<soc>
```

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

如本 PR 修改了 aclnn example 或新增了算子 example，同时执行:

```sh
bash build.sh --run_example <op_name> eager cust --vendor_name=fla_npu --soc=<soc>
```

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

## 修改算子测试

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `bash build.sh -u --ops=<op_name> --soc=ascend910b` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `bash build.sh -u --ops=<op_name> --soc=ascend910_93` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `bash build.sh -u --ops=<op_name> --soc=ascend950` | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

## 整体 Example ST 验证

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python examples/flash_gated_delta_rule.py` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python examples/flash_gated_delta_rule.py` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python examples/flash_gated_delta_rule.py` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
