### PR TITLE
fix dv  <<<>>> vdim 256

### DIFF
--- a/examples/fast_kernel_launch_example/csrc/chunk_bwd_dv_local/ascend910b/chunk_bwd_dv_local.cpp
+++ b/examples/fast_kernel_launch_example/csrc/chunk_bwd_dv_local/ascend910b/chunk_bwd_dv_local.cpp
@@ -97,7 +97,7 @@ TilingData calc_tiling_params(const at::Tensor &q, const at::Tensor &k, const at
     return tilingData;
 }
 
-template <typename QKVT, typename GT>
+template <typename QKVT, typename GT, int V>
 __global__ __aicore__ void chunk_bwd_dv_local_kernel(
     GM_ADDR q, GM_ADDR k, GM_ADDR d_o, GM_ADDR g,
     GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
@@ -112,13 +112,13 @@ __global__ __aicore__ void chunk_bwd_dv_local_kernel(
     KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
     if (cu_seqlens == nullptr) {
         GDN::FixedLengthStrategy fixedStrategy{tilingData.chunkSize, tilingData.t, tilingData.chunkNumForT};
-        GDN::ChunkBwdDvLocalKernelImpl<QKVT, GT>(q, k, d_o, g, nullptr, nullptr, cu_seqlens, chunk_indices, d_v,
-                                                 userWS, &tilingData, fixedStrategy);
+        GDN::ChunkBwdDvLocalKernelImpl<QKVT, GT, V>(q, k, d_o, g, nullptr, nullptr, cu_seqlens, chunk_indices, d_v,
+                                                     userWS, &tilingData, fixedStrategy);
     } else {
         GDN::VariableLengthStrategy variableStrategy{tilingData.chunkSize, tilingData.t, tilingData.chunkNumForT,
                                                      cu_seqlens, chunk_indices};
-        GDN::ChunkBwdDvLocalKernelImpl<QKVT, GT>(q, k, d_o, g, nullptr, nullptr, cu_seqlens, chunk_indices, d_v,
-                                                 userWS, &tilingData, variableStrategy);
+        GDN::ChunkBwdDvLocalKernelImpl<QKVT, GT, V>(q, k, d_o, g, nullptr, nullptr, cu_seqlens, chunk_indices, d_v,
+                                                     userWS, &tilingData, variableStrategy);
     }
 }
 
@@ -178,23 +178,43 @@ at::Tensor chunk_bwd_dv_local_npu(const at::Tensor & q, const at::Tensor & k, co
         if (q_dtype == at::kBFloat16 && g_dtype == at::kBFloat16) {
             using QKVT = bfloat16_t;
             using GT = bfloat16_t;
-            chunk_bwd_dv_local_kernel<QKVT, GT><<<blockDim, nullptr, stream>>>(
-                q_ptr, k_ptr, d_o_ptr, g_ptr, cu_seqlens_ptr, chunk_indices_ptr, dv_ptr, workspace_gm, tiling);
+            if (tiling.v == 128) {
+                chunk_bwd_dv_local_kernel<QKVT, GT, 128><<<blockDim, nullptr, stream>>>(
+                    q_ptr, k_ptr, d_o_ptr, g_ptr, cu_seqlens_ptr, chunk_indices_ptr, dv_ptr, workspace_gm, tiling);
+            } else if (tiling.v == 256) {
+                chunk_bwd_dv_local_kernel<QKVT, GT, 256><<<blockDim, nullptr, stream>>>(
+                    q_ptr, k_ptr, d_o_ptr, g_ptr, cu_seqlens_ptr, chunk_indices_ptr, dv_ptr, workspace_gm, tiling);
+            }
         } else if (q_dtype == at::kHalf && g_dtype == at::kHalf) {
             using QKVT = half;
             using GT = half;
-            chunk_bwd_dv_local_kernel<QKVT, GT><<<blockDim, nullptr, stream>>>(
-                q_ptr, k_ptr, d_o_ptr, g_ptr, cu_seqlens_ptr, chunk_indices_ptr, dv_ptr, workspace_gm, tiling);
+            if (tiling.v == 128) {
+                chunk_bwd_dv_local_kernel<QKVT, GT, 128><<<blockDim, nullptr, stream>>>(
+                    q_ptr, k_ptr, d_o_ptr, g_ptr, cu_seqlens_ptr, chunk_indices_ptr, dv_ptr, workspace_gm, tiling);
+            } else if (tiling.v == 256) {
+                chunk_bwd_dv_local_kernel<QKVT, GT, 256><<<blockDim, nullptr, stream>>>(
+                    q_ptr, k_ptr, d_o_ptr, g_ptr, cu_seqlens_ptr, chunk_indices_ptr, dv_ptr, workspace_gm, tiling);
+            }
         } else if (q_dtype == at::kBFloat16 && g_dtype == at::kFloat) {
             using QKVT = bfloat16_t;
             using GT = float;
-            chunk_bwd_dv_local_kernel<QKVT, GT><<<blockDim, nullptr, stream>>>(
-                q_ptr, k_ptr, d_o_ptr, g_ptr, cu_seqlens_ptr, chunk_indices_ptr, dv_ptr, workspace_gm, tiling);
+            if (tiling.v == 128) {
+                chunk_bwd_dv_local_kernel<QKVT, GT, 128><<<blockDim, nullptr, stream>>>(
+                    q_ptr, k_ptr, d_o_ptr, g_ptr, cu_seqlens_ptr, chunk_indices_ptr, dv_ptr, workspace_gm, tiling);
+            } else if (tiling.v == 256) {
+                chunk_bwd_dv_local_kernel<QKVT, GT, 256><<<blockDim, nullptr, stream>>>(
+                    q_ptr, k_ptr, d_o_ptr, g_ptr, cu_seqlens_ptr, chunk_indices_ptr, dv_ptr, workspace_gm, tiling);
+            }
         } else if (q_dtype == at::kHalf && g_dtype == at::kFloat) {
             using QKVT = half;
             using GT = float;
-            chunk_bwd_dv_local_kernel<QKVT, GT><<<blockDim, nullptr, stream>>>(
-                q_ptr, k_ptr, d_o_ptr, g_ptr, cu_seqlens_ptr, chunk_indices_ptr, dv_ptr, workspace_gm, tiling);
+            if (tiling.v == 128) {
+                chunk_bwd_dv_local_kernel<QKVT, GT, 128><<<blockDim, nullptr, stream>>>(
+                    q_ptr, k_ptr, d_o_ptr, g_ptr, cu_seqlens_ptr, chunk_indices_ptr, dv_ptr, workspace_gm, tiling);
+            } else if (tiling.v == 256) {
+                chunk_bwd_dv_local_kernel<QKVT, GT, 256><<<blockDim, nullptr, stream>>>(
+                    q_ptr, k_ptr, d_o_ptr, g_ptr, cu_seqlens_ptr, chunk_indices_ptr, dv_ptr, workspace_gm, tiling);
+            }
         } else {
             TORCH_CHECK(false, "Unsupported dtype combination: q=", q_dtype, ", g=", g_dtype);
         }


### PR DESCRIPTION
# Pull Request 模板

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人:
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [x] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:

## 版本与产品编译矩阵

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

## 验证方法

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

不涉及算子代码修改，只验证<<<>>>端到端功能正常
<img width="1525" height="557" alt="image" src="https://github.com/user-attachments/assets/3cfc4020-3d9d-4b1d-b5c6-a2445580be8b" />


### 3. 修改算子 test 验证
不涉及算子代码修改，只验证<<<>>>端到端功能正常
<img width="1561" height="338" alt="image" src="https://github.com/user-attachments/assets/7288f644-fe4d-420d-a5b6-ab15f0e33ea8" />


### 4. 整体 example ST 验证
不涉及算子代码修改，不涉及此项验证

## 整体 Example ST 验证
不涉及算子代码修改，不涉及此项验证

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [x] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [x] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
