### PR TITLE
Fix varlen dy offset in causal conv1d backward

### DIFF
--- a/fla/ops/triton/triton_core/causal_conv1d.py
+++ b/fla/ops/triton/triton_core/causal_conv1d.py
@@ -510,10 +510,11 @@ def causal_conv1d_bwd_kernel(
             K: tl.constexpr = D // H
             HEADS_PER_BLOCK: tl.constexpr = BD // K
             head_start = (i_d * BD) // K
-            # B T H K
+            batch_off = 0 if IS_VARLEN else i_b * T * D
+            bos_off = bos if IS_VARLEN else 0
             # B H T K
             p_dy = tl.make_block_ptr(
-                dy + bos * K  + head_start * T * K,
+                dy + batch_off + head_start * T * K + bos_off * K,
                 (T_len, HEADS_PER_BLOCK, K),
                 (K, T * K, 1),
                 (i_t * BT, 0, 0),


### PR DESCRIPTION
## Summary
- Fix `dy` block pointer offset in the causal conv1d backward kernel for non-varlen inputs
- Keep `bos` offset only for varlen mode and use batch offset otherwise

## Tests
- `python3 -m compileall -q fla/ops/triton/triton_core/causal_conv1d.py`
