### PR TITLE
feat: add example st case matrix

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@
 > - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
 > - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
 > - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
-> - NPU CI 会固定执行 `examples/flash_gated_delta_rule.py`，默认保持该用例原始 shape；通常不要填写 `example_args`，除非维护者明确要求追加已批准的泛化场景参数。
+> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段。
 > - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
 > - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过。
 > - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。
@@ -159,7 +159,7 @@ bash build_and_test.sh
 python examples/flash_gated_delta_rule.py
 ```
 
-也可以由维护者触发 CI 验证：`/run-npu-ci quick`。CI 固定执行 `examples/flash_gated_delta_rule.py`，默认保持该用例原始 shape，仅覆盖容器内逻辑设备号 `--device`。
+也可以由维护者触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。
 
 通过标准:
 
@@ -217,9 +217,9 @@ python examples/flash_gated_delta_rule.py
 
 | 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
 | --- | --- | --- | --- | --- |
-| A2 | `ascend910b` | `python examples/flash_gated_delta_rule.py` | 通过 / 未通过 / 未执行 |  |
-| A3 | `ascend910_93` | `python examples/flash_gated_delta_rule.py` | 通过 / 未通过 / 未执行 |  |
-| A5 | `ascend950` | `python examples/flash_gated_delta_rule.py` | 通过 / 未通过 / 未执行 |  |
+| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
+| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
+| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
 
 - 端到端场景说明:
 - 与本 PR 修改算子的关联:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@
 > - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
 > - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
 > - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
-> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段。
+> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
 > - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
 > - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过。
 > - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,6 +376,9 @@ jobs:
 
       - name: 使用可信 CI 脚本
         run: |
+          # CI 执行脚本必须来自默认分支，避免 PR 修改脚本后影响 runner。
+          # 但 Example/ST 用例配置属于被验证内容：新 PR 中新增或修改的 enabled 用例
+          # 必须跟随 PR head commit 一起进入容器，并被 /run-npu-ci quick 实际执行验证。
           tmp_cases="$(mktemp)"
           if [ -f repo/ci/example_st_cases.json ]; then
             cp repo/ci/example_st_cases.json "$tmp_cases"
@@ -387,6 +390,8 @@ jobs:
           rm -rf repo/ci
           cp -a trusted-ci/ci repo/ci
 
+          # 覆盖可信 CI 脚本后，再恢复 PR 自身的 case 文件。
+          # 因此后续 PR 只补充 ci/example_st_cases.json 时，NPU CI 会跑到新增用例。
           if [ -f "$tmp_cases" ]; then
             cp "$tmp_cases" repo/ci/example_st_cases.json
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,6 @@ on:
         description: "Optional comma-separated operator list"
         required: false
         default: ''
-      example_args:
-        description: "Optional extra args for examples/flash_gated_delta_rule.py; empty keeps original shape"
-        required: false
-        default: ''
-
 jobs:
   prepare:
     name: 准备 NPU CI
@@ -46,7 +41,6 @@ jobs:
       head_sha: ${{ steps.prepare.outputs.head_sha }}
       ci_mode: ${{ steps.prepare.outputs.ci_mode }}
       ops: ${{ steps.prepare.outputs.ops }}
-      example_args: ${{ steps.prepare.outputs.example_args }}
       comment_id: ${{ steps.prepare.outputs.comment_id }}
     steps:
       - name: 解析 PR 和 CI 参数
@@ -73,7 +67,6 @@ jobs:
             let prNumber;
             let ciMode = 'quick';
             let ops = '';
-            let exampleArgs = '';
             let commentId = '';
             const upsertComment = async (pr, body) => {
               if (!prNumber || !pr) {
@@ -150,7 +143,6 @@ jobs:
               prNumber = Number(core.getInput('pr_number', { required: true }));
               ciMode = core.getInput('ci_mode') || 'quick';
               ops = core.getInput('ops') || '';
-              exampleArgs = core.getInput('example_args') || '';
             } else {
               prNumber = context.payload.issue.number;
               const body = (context.payload.comment.body || '').trim();
@@ -165,8 +157,6 @@ jobs:
                   ciMode = part;
                 } else if (part.startsWith('ops=')) {
                   ops = part.slice('ops='.length);
-                } else if (part.startsWith('example_args=')) {
-                  exampleArgs = part.slice('example_args='.length);
                 }
               }
             }
@@ -179,11 +169,6 @@ jobs:
               core.setFailed(`不支持的 CI 模式：${ciMode}`);
               return;
             }
-            if (/[\r\n]/.test(exampleArgs)) {
-              core.setFailed('example_args 必须写在一行内。');
-              return;
-            }
-
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -217,6 +202,7 @@ jobs:
                   `- 请求模式：\`${ciMode}\``,
                   `- 触发人：@${actor}`,
                   '- Example ST：已覆盖',
+                  '- Example ST 用例：全部 enabled 用例',
                 ].join('\n')
               );
               core.setOutput('should_run', 'false');
@@ -225,7 +211,6 @@ jobs:
               core.setOutput('head_sha', pr.head.sha);
               core.setOutput('ci_mode', ciMode);
               core.setOutput('ops', ops);
-              core.setOutput('example_args', exampleArgs);
               core.setOutput('comment_id', commentId);
               return;
             }
@@ -240,6 +225,7 @@ jobs:
                   `- 触发人：@${actor}`,
                   '- 当前状态：排队或运行中',
                   '- Example ST：必跑',
+                  '- Example ST 用例：全部 enabled 用例',
                   latestExecutionCi.target_url ? `- 运行链接：[查看已有 NPU CI](${latestExecutionCi.target_url})` : '',
                 ].filter(Boolean).join('\n')
               );
@@ -249,7 +235,6 @@ jobs:
               core.setOutput('head_sha', pr.head.sha);
               core.setOutput('ci_mode', ciMode);
               core.setOutput('ops', ops);
-              core.setOutput('example_args', exampleArgs);
               core.setOutput('comment_id', commentId);
               return;
             }
@@ -272,6 +257,7 @@ jobs:
                 `- 模式：\`${ciMode}\``,
                 `- 触发人：@${actor}`,
                 '- Example ST：必跑',
+                '- Example ST 用例：全部 enabled 用例',
                 ops ? `- 算子：\`${ops}\`` : '',
                 `- 运行链接：[NPU CI #${context.runNumber}](${targetUrl})`,
               ].filter(Boolean).join('\n')
@@ -283,7 +269,6 @@ jobs:
             core.setOutput('head_sha', pr.head.sha);
             core.setOutput('ci_mode', ciMode);
             core.setOutput('ops', ops);
-            core.setOutput('example_args', exampleArgs);
             core.setOutput('comment_id', commentId);
 
   ascend-npu:
@@ -300,7 +285,6 @@ jobs:
       CI_MODE: ${{ needs.prepare.outputs.ci_mode }}
       CI_OPS: ${{ needs.prepare.outputs.ops }}
       CI_RUN_EXAMPLE_ST: 'true'
-      CI_EXAMPLE_ARGS: ${{ needs.prepare.outputs.example_args }}
       CI_IMAGE: fla-npu-ci:8.5.0-910b
     steps:
       - name: 拉取 PR 代码（第 1 次）
@@ -429,6 +413,7 @@ jobs:
               `- 模式：\`${mode}\``,
               `- 触发人：@${context.actor}`,
               '- Example ST：必跑',
+              '- Example ST 用例：全部 enabled 用例',
               ops ? `- 算子：\`${ops}\`` : '',
               `- 运行链接：[NPU CI #${context.runNumber}](${targetUrl})`,
             ].filter(Boolean).join('\n');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,8 +376,20 @@ jobs:
 
       - name: 使用可信 CI 脚本
         run: |
+          tmp_cases="$(mktemp)"
+          if [ -f repo/ci/example_st_cases.json ]; then
+            cp repo/ci/example_st_cases.json "$tmp_cases"
+            python3 -m json.tool "$tmp_cases" >/dev/null
+          else
+            rm -f "$tmp_cases"
+          fi
+
           rm -rf repo/ci
           cp -a trusted-ci/ci repo/ci
+
+          if [ -f "$tmp_cases" ]; then
+            cp "$tmp_cases" repo/ci/example_st_cases.json
+          fi
 
       - name: 运行 NPU CI 容器
         working-directory: repo

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ export PYTORCH_VERSION=2.7.1
 python examples/flash_gated_delta_rule.py
 ```
 
+NPU CI 的 Example/ST 用例由 [`ci/example_st_cases.json`](ci/example_st_cases.json) 管理。当前默认启用 `case1_current_default`，shape 与上面的直接运行默认值一致；后续 GVA、`Vdim=256` 等泛化场景可以在该文件中新增用例，显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段。
+
 ## 维护文档
 
 NPU CI 维护说明见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ export PYTORCH_VERSION=2.7.1
 python examples/flash_gated_delta_rule.py
 ```
 
-NPU CI 的 Example/ST 用例由 [`ci/example_st_cases.json`](ci/example_st_cases.json) 管理。当前默认启用 `case1_current_default`，shape 与上面的直接运行默认值一致；后续 GVA、`Vdim=256` 等泛化场景可以在该文件中新增用例，显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段。
+NPU CI 的 Example/ST 用例由 [`ci/example_st_cases.json`](ci/example_st_cases.json) 管理。当前默认启用 `case1_current_default`，shape 与上面的直接运行默认值一致；后续 GVA、`Vdim=256` 等泛化场景可以在该文件中新增用例，显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
+
+当前端到端 Example/ST 已支持 `gate_source=g`；`gk` / `g+gk` 先作为用例 schema 预留，待 NPU fwd_h 路径支持后再启用。
 
 ## 维护文档
 

--- a/ci/example_st_cases.json
+++ b/ci/example_st_cases.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "case1_current_default",
+    "description": "Current flash_gated_delta_rule Example/ST smoke shape.",
+    "script": "examples/flash_gated_delta_rule.py",
+    "enabled": true,
+    "B": 1,
+    "T": 65536,
+    "chunk_size": 64,
+    "query_head": 32,
+    "value_head": 32,
+    "Kdim": 128,
+    "Vdim": 128,
+    "dtype": "bf16",
+    "mean_len": 1024,
+    "varlen": true,
+    "demo_model": false
+  }
+]

--- a/ci/example_st_cases.json
+++ b/ci/example_st_cases.json
@@ -13,7 +13,12 @@
     "Vdim": 128,
     "dtype": "bf16",
     "mean_len": 1024,
+    "gate_source": "g",
+    "gate_function": "logsigmoid",
     "varlen": true,
+    "initial_state": "none",
+    "output_final_state": false,
+    "qk_l2norm": true,
     "demo_model": false
   }
 ]

--- a/ci/run_checks.sh
+++ b/ci/run_checks.sh
@@ -171,22 +171,9 @@ if [[ "${CI_RUN_EXAMPLE_ST:-true}" == "true" ]]; then
     install_custom_opp_package
     check_example_python_deps
     build_torch_custom
-    run_example_case() {
-        local example_case="$1"
-        local example_args=()
-        if [[ -n "${example_case//[[:space:]]/}" ]]; then
-            read -r -a example_args <<< "$example_case"
-        fi
-        echo "[CI] Running Example ST: examples/flash_gated_delta_rule.py --device $ci_test_device ${example_args[*]}"
-        python3 examples/flash_gated_delta_rule.py --device "$ci_test_device" "${example_args[@]}"
-    }
-
-    if [[ -n "${CI_EXAMPLE_CASES:-}" ]]; then
-        IFS=';' read -r -a example_case_list <<< "$CI_EXAMPLE_CASES"
-        for example_case in "${example_case_list[@]}"; do
-            run_example_case "$example_case"
-        done
-    else
-        run_example_case "${CI_EXAMPLE_ARGS:-}"
+    example_st_args=(--device "$ci_test_device" --cases-file "${CI_EXAMPLE_CASES_FILE:-ci/example_st_cases.json}")
+    if [[ -n "${CI_EXAMPLE_CASE_FILTER:-}" ]]; then
+        example_st_args+=(--case-filter "$CI_EXAMPLE_CASE_FILTER")
     fi
+    python3 ci/run_example_st_cases.py "${example_st_args[@]}"
 fi

--- a/ci/run_ci_container.sh
+++ b/ci/run_ci_container.sh
@@ -150,8 +150,8 @@ docker run --rm \
     -e CI_BUILD_TORCH_CUSTOM="${CI_BUILD_TORCH_CUSTOM:-false}" \
     -e CI_RUN_TORCH_TESTS="${CI_RUN_TORCH_TESTS:-false}" \
     -e CI_RUN_EXAMPLE_ST="${CI_RUN_EXAMPLE_ST:-true}" \
-    -e CI_EXAMPLE_ARGS="${CI_EXAMPLE_ARGS:-}" \
-    -e CI_EXAMPLE_CASES="${CI_EXAMPLE_CASES:-}" \
+    -e CI_EXAMPLE_CASES_FILE="${CI_EXAMPLE_CASES_FILE:-ci/example_st_cases.json}" \
+    -e CI_EXAMPLE_CASE_FILTER="${CI_EXAMPLE_CASE_FILTER:-}" \
     -e CI_TEST_OP="${CI_TEST_OP:-}" \
     "$image" \
     bash ci/run_checks.sh

--- a/ci/run_example_st_cases.py
+++ b/ci/run_example_st_cases.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+FIELD_ARGS = (
+    (("B", "batch"), "--batch"),
+    (("T", "tokens"), "--tokens"),
+    (("chunk_size", "chunk-size"), "--chunk-size"),
+    (("query_head", "query_heads", "query-heads"), "--query-heads"),
+    (("value_head", "value_heads", "value-heads"), "--value-heads"),
+    (("Kdim", "key_dim", "key-dim", "dim"), "--key-dim"),
+    (("Vdim", "value_dim", "value-dim"), "--value-dim"),
+    (("dtype",), "--dtype"),
+    (("mean_len", "mean-len"), "--mean-len"),
+    (("conv_kernel", "conv-kernel"), "--conv-kernel"),
+)
+
+
+def _read_cases(path: Path) -> list[dict[str, Any]]:
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        data = data.get("cases")
+    if not isinstance(data, list):
+        raise ValueError(f"{path} must contain a JSON list or an object with a cases list.")
+    cases: list[dict[str, Any]] = []
+    names: set[str] = set()
+    for index, case in enumerate(data, start=1):
+        if not isinstance(case, dict):
+            raise ValueError(f"case #{index} must be a JSON object.")
+        name = str(case.get("name", "")).strip()
+        if not name:
+            raise ValueError(f"case #{index} is missing a non-empty name.")
+        if name in names:
+            raise ValueError(f"duplicate Example/ST case name: {name}")
+        names.add(name)
+        cases.append(case)
+    return cases
+
+
+def _case_get(case: dict[str, Any], aliases: tuple[str, ...]) -> Any:
+    for key in aliases:
+        if key in case:
+            return case[key]
+    return None
+
+
+def _normalize_extra_args(value: Any) -> list[str]:
+    if value in (None, ""):
+        return []
+    if isinstance(value, str):
+        return shlex.split(value)
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return value
+    raise ValueError("extra_args must be a string or a list of strings.")
+
+
+def _select_cases(cases: list[dict[str, Any]], case_filter: str) -> list[dict[str, Any]]:
+    enabled = [case for case in cases if case.get("enabled", True)]
+    if not case_filter.strip():
+        return enabled
+
+    wanted = [name.strip() for name in case_filter.split(",") if name.strip()]
+    by_name = {case["name"]: case for case in cases}
+    missing = [name for name in wanted if name not in by_name]
+    if missing:
+        raise ValueError(f"unknown Example/ST case(s): {', '.join(missing)}")
+
+    disabled = [name for name in wanted if not by_name[name].get("enabled", True)]
+    if disabled:
+        raise ValueError(f"requested Example/ST case(s) are disabled: {', '.join(disabled)}")
+    return [by_name[name] for name in wanted]
+
+
+def _build_command(repo_root: Path, device: int, case: dict[str, Any]) -> list[str]:
+    script = repo_root / str(case.get("script", "examples/flash_gated_delta_rule.py"))
+    cmd = [
+        sys.executable,
+        str(script),
+        "--device",
+        str(device),
+        "--case-name",
+        str(case["name"]),
+    ]
+    for aliases, arg_name in FIELD_ARGS:
+        value = _case_get(case, aliases)
+        if value is not None:
+            cmd.extend([arg_name, str(value)])
+
+    if case.get("demo_model", False):
+        cmd.append("--demo-model")
+    if case.get("varlen", True) is False:
+        cmd.append("--no-varlen")
+    cmd.extend(_normalize_extra_args(case.get("extra_args")))
+    return cmd
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run configured Example/ST cases.")
+    parser.add_argument("--device", type=int, required=True)
+    parser.add_argument("--cases-file", default="ci/example_st_cases.json")
+    parser.add_argument("--case-filter", default="", help="Comma-separated case names to run")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    cases_file = (repo_root / args.cases_file).resolve()
+    cases = _select_cases(_read_cases(cases_file), args.case_filter)
+    if not cases:
+        raise SystemExit(f"No enabled Example/ST cases found in {cases_file}.")
+
+    print(f"[CI] Example/ST cases file: {cases_file}")
+    for index, case in enumerate(cases, start=1):
+        name = case["name"]
+        description = str(case.get("description", "")).strip()
+        cmd = _build_command(repo_root, args.device, case)
+        print(f"[CI] Example/ST case {index}/{len(cases)}: {name}")
+        if description:
+            print(f"[CI] {description}")
+        print(f"[CI] Command: {shlex.join(cmd)}")
+        if not args.dry_run:
+            subprocess.run(cmd, cwd=repo_root, check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/run_example_st_cases.py
+++ b/ci/run_example_st_cases.py
@@ -18,7 +18,14 @@ FIELD_ARGS = (
     (("Vdim", "value_dim", "value-dim"), "--value-dim"),
     (("dtype",), "--dtype"),
     (("mean_len", "mean-len"), "--mean-len"),
+    (("gate_source", "gate-source", "gate"), "--gate-source"),
+    (("gate_function", "gate-function", "gate_fn", "gate-fn"), "--gate-function"),
+    (("initial_state", "initial-state"), "--initial-state"),
     (("conv_kernel", "conv-kernel"), "--conv-kernel"),
+)
+
+BOOLEAN_FLAGS = (
+    (("output_final_state", "output-final-state", "final_state", "final-state"), "--output-final-state"),
 )
 
 
@@ -61,6 +68,41 @@ def _normalize_extra_args(value: Any) -> list[str]:
     raise ValueError("extra_args must be a string or a list of strings.")
 
 
+def _normalize_initial_state(value: Any) -> str:
+    if isinstance(value, bool):
+        return "random" if value else "none"
+    value = str(value).strip().lower()
+    aliases = {
+        "": "none",
+        "false": "none",
+        "no": "none",
+        "none": "none",
+        "null": "none",
+        "true": "random",
+        "yes": "random",
+        "rand": "random",
+        "random": "random",
+        "zero": "zeros",
+        "zeros": "zeros",
+    }
+    if value not in aliases:
+        raise ValueError("initial_state must be one of none, zeros, random, true, or false.")
+    return aliases[value]
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    value = str(value).strip().lower()
+    if value in ("1", "true", "yes", "on"):
+        return True
+    if value in ("0", "false", "no", "off", ""):
+        return False
+    raise ValueError(f"Expected a boolean value, got {value!r}.")
+
+
 def _select_cases(cases: list[dict[str, Any]], case_filter: str) -> list[dict[str, Any]]:
     enabled = [case for case in cases if case.get("enabled", True)]
     if not case_filter.strip():
@@ -91,12 +133,21 @@ def _build_command(repo_root: Path, device: int, case: dict[str, Any]) -> list[s
     for aliases, arg_name in FIELD_ARGS:
         value = _case_get(case, aliases)
         if value is not None:
+            if arg_name == "--initial-state":
+                value = _normalize_initial_state(value)
+            elif arg_name in ("--gate-source", "--gate-function"):
+                value = str(value).strip().lower()
             cmd.extend([arg_name, str(value)])
 
-    if case.get("demo_model", False):
+    if _as_bool(case.get("demo_model")):
         cmd.append("--demo-model")
-    if case.get("varlen", True) is False:
+    for aliases, arg_name in BOOLEAN_FLAGS:
+        if _as_bool(_case_get(case, aliases)):
+            cmd.append(arg_name)
+    if not _as_bool(case.get("varlen"), default=True):
         cmd.append("--no-varlen")
+    if not _as_bool(case.get("qk_l2norm", case.get("qk-l2norm")), default=True):
+        cmd.append("--no-qk-l2norm")
     cmd.extend(_normalize_extra_args(case.get("extra_args")))
     return cmd
 

--- a/docs/Fla-npu仓CI部署教程.md
+++ b/docs/Fla-npu仓CI部署教程.md
@@ -14,8 +14,8 @@
 2. **宿主机物理 NPU 和容器内逻辑 NPU 不是同一个编号。**
    脚本会在宿主机上自动选择一张物理卡，例如 `ASCEND_RT_VISIBLE_DEVICES=2`。进入容器后，这张卡通常映射成逻辑设备 `0`。所以 CI 中传给 PyTorch example 的设备号默认是 `CI_CONTAINER_DEVICE=0`。
 
-3. **Example ST 必跑，而且不改用例原始 shape。**
-   CI 固定执行 `examples/flash_gated_delta_rule.py`。默认不传 `--tokens`、`--heads`、`--dim`、`--value-dim` 等 shape 参数，只额外传容器内逻辑设备号 `--device 0`。
+3. **Example ST 必跑，shape 由用例文件统一管理。**
+   CI 默认执行 `ci/example_st_cases.json` 中 `enabled=true` 的用例。当前 `case1_current_default` 保持原始 shape；后续 GVA、`Vdim=256` 等场景通过新增用例显式配置 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等字段。
 
 4. **Ascend PyTorch 必须使用 `v26.1.0-beta.1` release family。**
    该 release 修复了 GDN 自定义适配中 `aclnn_extension` 未传 stream 导致算子间数据同步不生效的问题。镜像中直接安装 GitCode release 页面提供的 `torch_npu` wheel，该 wheel 已包含 `torchnpugen`，不要再拉 `op-plugin` 仓库重新编译。
@@ -294,7 +294,15 @@ CI_MODE=quick CI_RUN_EXAMPLE_ST=true bash ci/run_ci_container.sh
 - 编译整包
 - 安装 `.run` 自定义 OPP 包
 - 编译并安装 `torch_custom/fla_npu`
-- 执行 `examples/flash_gated_delta_rule.py`，保持用例原始 shape，仅覆盖 `--device 0`
+- 执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，仅覆盖容器内逻辑设备号 `--device 0`
+
+本地排障时可以只跑某个用例：
+
+```sh
+CI_EXAMPLE_CASE_FILTER=case1_current_default CI_MODE=quick CI_RUN_EXAMPLE_ST=true bash ci/run_ci_container.sh
+```
+
+正式 GitHub NPU CI 不暴露用例子集选择，默认跑全部 `enabled=true` 用例，避免只跑部分用例却满足合入门禁。
 
 ## 第 6 步：生成 self-hosted runner token
 
@@ -475,7 +483,6 @@ bash scripts/github/apply_branch_protection.sh main
    - `pr_number`: PR 编号，例如 `23`
    - `ci_mode`: `quick` 或 `full`
    - `ops`: 可选，逗号分隔的算子列表
-   - `example_args`: 可选，默认留空，留空时保持 `examples/flash_gated_delta_rule.py` 原始 shape；通常不要填写，除非维护者明确要求追加已批准的泛化场景参数
 5. 点击绿色 `Run workflow`
 
 方式二：在 PR 评论区发送命令。

--- a/docs/Fla-npu仓CI部署教程.md
+++ b/docs/Fla-npu仓CI部署教程.md
@@ -15,7 +15,7 @@
    脚本会在宿主机上自动选择一张物理卡，例如 `ASCEND_RT_VISIBLE_DEVICES=2`。进入容器后，这张卡通常映射成逻辑设备 `0`。所以 CI 中传给 PyTorch example 的设备号默认是 `CI_CONTAINER_DEVICE=0`。
 
 3. **Example ST 必跑，shape 由用例文件统一管理。**
-   CI 默认执行 `ci/example_st_cases.json` 中 `enabled=true` 的用例。当前 `case1_current_default` 保持原始 shape；后续 GVA、`Vdim=256` 等场景通过新增用例显式配置 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等字段。
+   CI 默认执行 `ci/example_st_cases.json` 中 `enabled=true` 的用例。当前 `case1_current_default` 保持原始 shape；后续 GVA、`Vdim=256` 等场景通过新增用例显式配置 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
 
 4. **Ascend PyTorch 必须使用 `v26.1.0-beta.1` release family。**
    该 release 修复了 GDN 自定义适配中 `aclnn_extension` 未传 stream 导致算子间数据同步不生效的问题。镜像中直接安装 GitCode release 页面提供的 `torch_npu` wheel，该 wheel 已包含 `torchnpugen`，不要再拉 `op-plugin` 仓库重新编译。

--- a/examples/flash_gated_delta_rule.py
+++ b/examples/flash_gated_delta_rule.py
@@ -635,6 +635,11 @@ class DemoGatedDeltaNet(nn.Module):
         self.hidden_size = hidden_size
         self.num_v_heads = num_value_heads
         self.num_k_heads = num_key_heads
+        if self.num_v_heads % self.num_k_heads != 0:
+            raise ValueError(
+                "num_value_heads must be an integer multiple of num_key_heads "
+                f"for the current grouped-value smoke path, got {self.num_v_heads} and {self.num_k_heads}."
+            )
         self.head_k_dim = key_head_dim
         self.head_v_dim = value_head_dim
         self.key_dim = self.head_k_dim * self.num_k_heads
@@ -786,14 +791,21 @@ def _main():
     import fla_npu  # noqa: F401
 
     parser = argparse.ArgumentParser()
+    parser.add_argument("--case-name", default="", help="Example/ST case name for CI logs")
     parser.add_argument("--device", type=int, default=2)
-    parser.add_argument("--heads", type=int, default=32)
+    parser.add_argument("--batch", type=int, default=1)
+    parser.add_argument("--heads", type=int, default=32, help="legacy alias for --query-heads and --value-heads")
+    parser.add_argument("--query-heads", type=int, default=None)
+    parser.add_argument("--value-heads", type=int, default=None)
     parser.add_argument("--tokens", type=int, default=65536)
-    parser.add_argument("--dim", type=int, default=128)
+    parser.add_argument("--dim", type=int, default=128, help="legacy alias for --key-dim")
+    parser.add_argument("--key-dim", type=int, default=None)
     parser.add_argument("--value-dim", type=int, default=128)
     parser.add_argument("--chunk-size", type=int, default=64)
     parser.add_argument("--dtype", choices=["fp16", "bf16"], default="bf16")
     parser.add_argument("--mean-len", type=int, default=1024)
+    parser.add_argument("--varlen", dest="varlen", action="store_true", default=True)
+    parser.add_argument("--no-varlen", dest="varlen", action="store_false")
     parser.add_argument(
         "--demo-model",
         action="store_true",
@@ -806,27 +818,54 @@ def _main():
     torch.npu.set_compile_mode(jit_compile=False)
 
     dtype = torch.float16 if args.dtype == "fp16" else torch.bfloat16
-    varlen = True
-    batch = 1
+    query_heads = args.query_heads if args.query_heads is not None else args.heads
+    value_heads = args.value_heads if args.value_heads is not None else args.heads
+    key_dim = args.key_dim if args.key_dim is not None else args.dim
+    value_dim = args.value_dim
+    batch = args.batch
     device = f"npu:{args.device}"
+    positive_values = {
+        "batch": batch,
+        "tokens": args.tokens,
+        "query_heads": query_heads,
+        "value_heads": value_heads,
+        "key_dim": key_dim,
+        "value_dim": value_dim,
+        "chunk_size": args.chunk_size,
+        "mean_len": args.mean_len,
+    }
+    for name, value in positive_values.items():
+        if value <= 0:
+            raise ValueError(f"{name} must be positive, got {value}.")
+    if args.varlen and batch != 1:
+        raise ValueError("varlen smoke currently requires batch=1. Use --no-varlen for B > 1 cases.")
+    if value_heads % query_heads != 0:
+        raise ValueError(
+            "value_heads must be an integer multiple of query_heads for the current grouped-value smoke path, "
+            f"got query_heads={query_heads}, value_heads={value_heads}."
+        )
 
     if args.demo_model:
-        hidden_size = args.heads * args.dim
+        if batch != 1:
+            raise ValueError("demo_model smoke currently requires batch=1.")
+        hidden_size = query_heads * key_dim
         if hidden_size <= 0:
-            raise ValueError("hidden_size = heads * dim 非法")
-        cu_seqlens = _build_mean_1k_cu_seqlens(
-            total_tokens=args.tokens,
-            chunk_size=args.chunk_size,
-            device=device,
-            mean_len=args.mean_len,
-        )
-        x = torch.randn(1, args.tokens, hidden_size, dtype=dtype, device=device, requires_grad=True)
+            raise ValueError("hidden_size = query_heads * key_dim 非法")
+        cu_seqlens = None
+        if args.varlen:
+            cu_seqlens = _build_mean_1k_cu_seqlens(
+                total_tokens=args.tokens,
+                chunk_size=args.chunk_size,
+                device=device,
+                mean_len=args.mean_len,
+            )
+        x = torch.randn(batch, args.tokens, hidden_size, dtype=dtype, device=device, requires_grad=True)
         net = DemoGatedDeltaNet(
             hidden_size,
-            num_value_heads=args.heads,
-            num_key_heads=args.heads,
-            key_head_dim=args.dim,
-            value_head_dim=args.value_dim,
+            num_value_heads=value_heads,
+            num_key_heads=query_heads,
+            key_head_dim=key_dim,
+            value_head_dim=value_dim,
             conv_kernel_dim=args.conv_kernel,
             chunk_size=args.chunk_size,
         ).to(device=device, dtype=dtype)
@@ -846,14 +885,14 @@ def _main():
         )
         return
 
-    q = torch.randn(batch, args.heads, args.tokens, args.dim, dtype=dtype, device=device)
-    k = torch.randn(batch, args.heads, args.tokens, args.dim, dtype=dtype, device=device)
-    v = torch.randn(batch, args.heads, args.tokens, args.value_dim, dtype=dtype, device=device)
-    beta = torch.rand(batch, args.tokens, args.heads, dtype=dtype, device=device).sigmoid()
-    g = F.logsigmoid(torch.randn(batch, args.tokens, args.heads, dtype=dtype, device=device))
+    q = torch.randn(batch, query_heads, args.tokens, key_dim, dtype=dtype, device=device)
+    k = torch.randn(batch, query_heads, args.tokens, key_dim, dtype=dtype, device=device)
+    v = torch.randn(batch, value_heads, args.tokens, value_dim, dtype=dtype, device=device)
+    beta = torch.rand(batch, args.tokens, value_heads, dtype=dtype, device=device).sigmoid()
+    g = F.logsigmoid(torch.randn(batch, args.tokens, value_heads, dtype=dtype, device=device))
 
     cu_seqlens = None
-    if varlen:
+    if args.varlen:
         cu_seqlens = _build_mean_1k_cu_seqlens(
             total_tokens=args.tokens,
             chunk_size=args.chunk_size,
@@ -871,14 +910,16 @@ def _main():
 
     print(
         "config:",
+        f"case={args.case_name or '<direct>'}",
         f"B={batch}",
-        f"H={args.heads}",
+        f"QH={query_heads}",
+        f"VH={value_heads}",
         f"T={args.tokens}",
-        f"K={args.dim}",
-        f"V={args.value_dim}",
+        f"K={key_dim}",
+        f"V={value_dim}",
         f"chunk_size={args.chunk_size}",
         f"dtype={args.dtype}",
-        f"varlen={varlen}",
+        f"varlen={args.varlen}",
         f"device={device}",
     )
 
@@ -889,9 +930,16 @@ def _main():
     g.requires_grad_(True)
 
     torch.npu.synchronize()
+    attn_q = q
+    attn_k = k
+    if query_heads != value_heads:
+        repeat = value_heads // query_heads
+        attn_q = q.repeat_interleave(repeat, dim=1)
+        attn_k = k.repeat_interleave(repeat, dim=1)
+        print("grouped value heads:", f"repeat={repeat}", f"attn_heads={attn_q.shape[1]}")
     o, final_state = flash_gated_delta_rule(
-        q,
-        k,
+        attn_q,
+        attn_k,
         v,
         g=g,
         beta=beta,

--- a/examples/flash_gated_delta_rule.py
+++ b/examples/flash_gated_delta_rule.py
@@ -13,6 +13,7 @@ if str(_REPO_ROOT) not in sys.path:
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import torch_npu
 
 from fla.ops.triton.triton_core.causal_conv1d import causal_conv1d_triton
@@ -25,6 +26,21 @@ from fla.ops.triton.triton_core.utils import autocast_custom_bwd, autocast_custo
 
 _disable_compile = getattr(getattr(torch, "compiler", None), "disable", lambda fn: fn)
 _DEFAULT_VARLEN_CHUNK_SIZES = (16, 32, 64, 128, 608 * 2)
+
+
+def _make_gate(shape: tuple[int, ...], dtype: torch.dtype, device: str, gate_function: str) -> torch.Tensor:
+    if gate_function == "logsigmoid":
+        return F.logsigmoid(torch.randn(*shape, dtype=dtype, device=device))
+    if gate_function == "negative_linear":
+        lo, hi = -5e-2, -5e-5
+        steps = shape[1] if len(shape) >= 2 else shape[-1]
+        g_t = torch.linspace(hi, lo, steps, dtype=torch.float32, device=device).to(dtype)
+        if len(shape) == 3:
+            return g_t.view(1, steps, 1).expand(*shape).contiguous()
+        return g_t.view(1, 1, steps, 1).expand(*shape).contiguous()
+    if gate_function == "zeros":
+        return torch.zeros(*shape, dtype=dtype, device=device)
+    raise ValueError(f"Unsupported gate_function: {gate_function}")
 
 
 def cdiv_torch(a, b):
@@ -785,7 +801,6 @@ def _build_mean_1k_cu_seqlens(
 def _main():
     import argparse
 
-    import torch.nn.functional as F
     import torch_npu
 
     import fla_npu  # noqa: F401
@@ -804,6 +819,12 @@ def _main():
     parser.add_argument("--chunk-size", type=int, default=64)
     parser.add_argument("--dtype", choices=["fp16", "bf16"], default="bf16")
     parser.add_argument("--mean-len", type=int, default=1024)
+    parser.add_argument("--gate-source", choices=["g", "gk", "g+gk"], default="g")
+    parser.add_argument("--gate-function", choices=["logsigmoid", "negative_linear", "zeros"], default="logsigmoid")
+    parser.add_argument("--initial-state", choices=["none", "zeros", "random"], default="none")
+    parser.add_argument("--output-final-state", action="store_true")
+    parser.add_argument("--qk-l2norm", dest="qk_l2norm", action="store_true", default=True)
+    parser.add_argument("--no-qk-l2norm", dest="qk_l2norm", action="store_false")
     parser.add_argument("--varlen", dest="varlen", action="store_true", default=True)
     parser.add_argument("--no-varlen", dest="varlen", action="store_false")
     parser.add_argument(
@@ -844,8 +865,24 @@ def _main():
             "value_heads must be an integer multiple of query_heads for the current grouped-value smoke path, "
             f"got query_heads={query_heads}, value_heads={value_heads}."
         )
+    if args.gate_source != "g":
+        raise NotImplementedError(
+            f"gate_source={args.gate_source} is reserved in the Example/ST schema, but the current NPU "
+            "fwd_h path only supports g and requires gk=None."
+        )
 
     if args.demo_model:
+        if (
+            args.gate_source != "g"
+            or args.gate_function != "logsigmoid"
+            or args.initial_state != "none"
+            or args.output_final_state
+            or not args.qk_l2norm
+        ):
+            raise ValueError(
+                "demo_model smoke currently uses its built-in gate, state and qk-l2norm path. "
+                "Use demo_model=false for gate/initial_state/output_final_state/qk_l2norm case coverage."
+            )
         if batch != 1:
             raise ValueError("demo_model smoke currently requires batch=1.")
         hidden_size = query_heads * key_dim
@@ -889,7 +926,7 @@ def _main():
     k = torch.randn(batch, query_heads, args.tokens, key_dim, dtype=dtype, device=device)
     v = torch.randn(batch, value_heads, args.tokens, value_dim, dtype=dtype, device=device)
     beta = torch.rand(batch, args.tokens, value_heads, dtype=dtype, device=device).sigmoid()
-    g = F.logsigmoid(torch.randn(batch, args.tokens, value_heads, dtype=dtype, device=device))
+    g = _make_gate((batch, args.tokens, value_heads), dtype, device, args.gate_function)
 
     cu_seqlens = None
     if args.varlen:
@@ -920,6 +957,11 @@ def _main():
         f"chunk_size={args.chunk_size}",
         f"dtype={args.dtype}",
         f"varlen={args.varlen}",
+        f"gate_source={args.gate_source}",
+        f"gate_function={args.gate_function}",
+        f"initial_state={args.initial_state}",
+        f"output_final_state={args.output_final_state}",
+        f"qk_l2norm={args.qk_l2norm}",
         f"device={device}",
     )
 
@@ -937,14 +979,24 @@ def _main():
         attn_q = q.repeat_interleave(repeat, dim=1)
         attn_k = k.repeat_interleave(repeat, dim=1)
         print("grouped value heads:", f"repeat={repeat}", f"attn_heads={attn_q.shape[1]}")
+    initial_state = None
+    if args.initial_state != "none":
+        state_count = len(cu_seqlens) - 1 if cu_seqlens is not None else batch
+        state_shape = (state_count, value_heads, key_dim, value_dim)
+        if args.initial_state == "zeros":
+            initial_state = torch.zeros(state_shape, dtype=dtype, device=device)
+        else:
+            initial_state = torch.randn(state_shape, dtype=dtype, device=device)
+        print("initial_state:", tuple(initial_state.shape), initial_state.dtype, initial_state.device)
     o, final_state = flash_gated_delta_rule(
         attn_q,
         attn_k,
         v,
         g=g,
         beta=beta,
-        output_final_state=False,
-        use_qk_l2norm_in_kernel=True,
+        initial_state=initial_state,
+        output_final_state=args.output_final_state,
+        use_qk_l2norm_in_kernel=args.qk_l2norm,
         cu_seqlens=cu_seqlens,
         chunk_size=args.chunk_size,
     )


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求触发的维护账号和触发命令。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要维护者重新触发。即使已有 2 个维护账号检视通过，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会固定执行 `examples/flash_gated_delta_rule.py`，默认保持该用例原始 shape；通常不要填写 `example_args`，除非维护者明确要求追加已批准的泛化场景参数。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由维护者触发 CI 验证：`/run-npu-ci quick`。CI 固定执行 `examples/flash_gated_delta_rule.py`，默认保持该用例原始 shape，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python examples/flash_gated_delta_rule.py` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python examples/flash_gated_delta_rule.py` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python examples/flash_gated_delta_rule.py` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
