### PR TITLE
support recompute_wu_fwd GVA and VDIM256

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling.cpp
@@ -59,7 +59,9 @@ class RecomputeWUFwdTilingProcessor {
     gert::TilingContext *context_;
     RecomputeWUFwdTilingData &tiling_;
     int64_t B = 0;
-    int64_t H = 0;
+    int64_t Hk = 0;
+    int64_t Hv = 0;
+    int64_t hvPerHk = 1;
     int64_t K = 0;
     int64_t V = 0;
     int64_t T = 0;
@@ -195,28 +197,62 @@ public:
         const gert::Shape betaStorageShape = context_->GetRequiredInputShape(INPUT_BETA_IDX)->GetStorageShape();
         const gert::Shape AStorageShape = context_->GetRequiredInputShape(INPUT_A_IDX)->GetStorageShape();
         const gert::Shape gStorageShape = context_->GetRequiredInputShape(INPUT_G_IDX)->GetStorageShape();
-        OP_CHECK_IF(CompareShape(vStorageShape, kStorageShape, INPUT_V_NAME, INPUT_K_NAME, DIM_NUM_3) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
+        B = static_cast<int64_t>(vStorageShape.GetDim(DIM_0));
+        Hk = static_cast<int64_t>(kStorageShape.GetDim(DIM_1));
+        Hv = static_cast<int64_t>(vStorageShape.GetDim(DIM_1));
+        OP_CHECK_IF(Hv % Hk != 0,
+                    OP_LOGE(context_->GetNodeName(),
+                            "GVA check: Hv must be divisible by Hk, but got Hk=%ld, Hv=%ld.", Hk, Hv),
+                    return ge::GRAPH_FAILED);
+        hvPerHk = Hv / Hk;
+        OP_CHECK_IF(vStorageShape.GetDim(DIM_0) != kStorageShape.GetDim(DIM_0),
+                    OP_LOGE(context_->GetNodeName(),
+                            "Compare B: v B=%ld vs k B=%ld mismatch.",
+                            vStorageShape.GetDim(DIM_0), kStorageShape.GetDim(DIM_0)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(vStorageShape.GetDim(DIM_2) != kStorageShape.GetDim(DIM_2),
+                    OP_LOGE(context_->GetNodeName(),
+                            "Compare T: v T=%ld vs k T=%ld mismatch.",
+                            vStorageShape.GetDim(DIM_2), kStorageShape.GetDim(DIM_2)),
+                    return ge::GRAPH_FAILED);
         OP_CHECK_IF(CompareShape(betaStorageShape, gStorageShape, INPUT_BETA_NAME, INPUT_G_NAME, DIM_NUM_3) !=
                         ge::GRAPH_SUCCESS,
                     , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(CompareShape(kStorageShape, gStorageShape, INPUT_K_NAME, INPUT_G_NAME, DIM_NUM_3) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(CompareShape(kStorageShape, AStorageShape, INPUT_K_NAME, INPUT_A_NAME, DIM_NUM_3) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        B = static_cast<int64_t>(vStorageShape.GetDim(DIM_0));
-        H = static_cast<int64_t>(vStorageShape.GetDim(DIM_1));
+        OP_CHECK_IF(kStorageShape.GetDim(DIM_0) != gStorageShape.GetDim(DIM_0),
+                    OP_LOGE(context_->GetNodeName(),
+                            "Compare B: k B=%ld vs g B=%ld mismatch.",
+                            kStorageShape.GetDim(DIM_0), gStorageShape.GetDim(DIM_0)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(kStorageShape.GetDim(DIM_2) != gStorageShape.GetDim(DIM_2),
+                    OP_LOGE(context_->GetNodeName(),
+                            "Compare T: k T=%ld vs g T=%ld mismatch.",
+                            kStorageShape.GetDim(DIM_2), gStorageShape.GetDim(DIM_2)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(kStorageShape.GetDim(DIM_0) != AStorageShape.GetDim(DIM_0),
+                    OP_LOGE(context_->GetNodeName(),
+                            "Compare B: k B=%ld vs A B=%ld mismatch.",
+                            kStorageShape.GetDim(DIM_0), AStorageShape.GetDim(DIM_0)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(kStorageShape.GetDim(DIM_2) != AStorageShape.GetDim(DIM_2),
+                    OP_LOGE(context_->GetNodeName(),
+                            "Compare T: k T=%ld vs A T=%ld mismatch.",
+                            kStorageShape.GetDim(DIM_2), AStorageShape.GetDim(DIM_2)),
+                    return ge::GRAPH_FAILED);
         T = static_cast<int64_t>(vStorageShape.GetDim(DIM_2));
         K = static_cast<int64_t>(kStorageShape.GetDim(DIM_3));
         V = static_cast<int64_t>(vStorageShape.GetDim(DIM_3));
         tiling_.set_B(B);
-        tiling_.set_H(H);
+        tiling_.set_Hk(Hk);
+        tiling_.set_Hv(Hv);
+        tiling_.set_hvPerHk(hvPerHk);
         tiling_.set_T(T);
         tiling_.set_K(K);
         tiling_.set_V(V);
+        OP_CHECK_IF(V != V_DIM_128 && V != V_DIM_256,
+                    OP_LOGE(context_->GetNodeName(),
+                            "Check value dim V failed: only %ld or %ld is supported, but get %ld.",
+                            V_DIM_128, V_DIM_256, V),
+                    return ge::GRAPH_FAILED);
         auto attrPtr = context_->GetAttrs();
         OP_CHECK_NULL_WITH_CONTEXT(context_, attrPtr);
         chunkSize = static_cast<int64_t>(*(attrPtr->GetAttrPointer<int32_t>(ATTR_CHUNK_SIZE_IDX)));
@@ -239,6 +275,9 @@ public:
                     return ge::GRAPH_FAILED);
         OP_CHECK_IF(SetKbgExpVecRow(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS,
                     OP_LOGE(context_->GetNodeName(), "SetKBeteVecRow Failed."), return ge::GRAPH_FAILED);
+        if (V == V_DIM_256) {
+            tiling_.set_vbVecRow(chunkSize / 4);
+        }
         return ge::GRAPH_SUCCESS;
     }
 
@@ -326,11 +365,15 @@ static void RecomputeWUFwdTilingDataPrint(gert::TilingContext *context, Recomput
     auto nodeName = context->GetNodeName();
     OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Start to print RecomputeWUFwd tiling data <<<<<<<<<<<<<<<<");
     OP_LOGD(nodeName, "=== B: %ld", tiling.get_B());
-    OP_LOGD(nodeName, "=== H: %ld", tiling.get_H());
+    OP_LOGD(nodeName, "=== Hk: %ld", tiling.get_Hk());
+    OP_LOGD(nodeName, "=== Hv: %ld", tiling.get_Hv());
+    OP_LOGD(nodeName, "=== hvPerHk: %ld", tiling.get_hvPerHk());
     OP_LOGD(nodeName, "=== T: %ld", tiling.get_T());
     OP_LOGD(nodeName, "=== K: %ld", tiling.get_K());
     OP_LOGD(nodeName, "=== V: %ld", tiling.get_V());
     OP_LOGD(nodeName, "=== chunkSize: %ld", tiling.get_chunkSize());
+    OP_LOGD(nodeName, "=== vbVecRow: %ld", tiling.get_vbVecRow());
+    OP_LOGD(nodeName, "=== kbgExpVecRow: %ld", tiling.get_kbgExpVecRow());
     OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Print RecomputeWUFwd tiling data end <<<<<<<<<<<<<<<<");
 }
 
@@ -358,8 +401,12 @@ ge::graphStatus Tiling4RecomputeWUFwd(gert::TilingContext *context)
         OP_CHECK_IF(processor.VariableLenTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
         tiling.set_isVariable(1);
     }
-    context->SetTilingKey(1);
-    OP_LOGD(context->GetNodeName(), "tilingKey: %d", context->GetTilingKey());
+    if (tiling.get_V() == V_DIM_256) {
+        context->SetTilingKey(2);
+    } else {
+        context->SetTilingKey(1);
+    }
+    OP_LOGD(context->GetNodeName(), "tilingKey: %d (V=%ld)", context->GetTilingKey(), tiling.get_V());
     RecomputeWUFwdTilingDataPrint(context, tiling);
 
     tiling.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
@@ -368,7 +415,7 @@ ge::graphStatus Tiling4RecomputeWUFwd(gert::TilingContext *context)
     context->SetBlockDim(ascendcPlatform.GetCoreNumAic());
 
     uint32_t sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
-    uint32_t userWorkspaceSize = 2 * tiling.get_B() * tiling.get_H() * tiling.get_T() * tiling.get_V();
+    uint32_t userWorkspaceSize = 2 * tiling.get_B() * tiling.get_Hv() * tiling.get_T() * tiling.get_V();
     size_t *currentWorkspace = context->GetWorkspaceSizes(1);
     currentWorkspace[0] = userWorkspaceSize + sysWorkspaceSize;
     context->SetScheduleMode(1); // set as batchmod for template using SyncAll

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling.h
@@ -22,9 +22,14 @@
 
 namespace optiling {
 
+static constexpr int64_t V_DIM_128 = 128;
+static constexpr int64_t V_DIM_256 = 256;
+
 BEGIN_TILING_DATA_DEF(RecomputeWUFwdTilingData)
 TILING_DATA_FIELD_DEF(int64_t, B);
-TILING_DATA_FIELD_DEF(int64_t, H);
+TILING_DATA_FIELD_DEF(int64_t, Hk);
+TILING_DATA_FIELD_DEF(int64_t, Hv);
+TILING_DATA_FIELD_DEF(int64_t, hvPerHk);
 TILING_DATA_FIELD_DEF(int64_t, T);
 TILING_DATA_FIELD_DEF(int64_t, K);
 TILING_DATA_FIELD_DEF(int64_t, V);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd.cpp
@@ -17,6 +17,9 @@
 #include "recompute_wu_fwd_cube.h"
 #include "recompute_wu_fwd_vector.h"
 
+template <class... Dims>
+using GemmCubeTileShape = tla::Shape<Dims...>;
+using namespace tla;
 
 using namespace AscendC;
 __global__ __aicore__ void recompute_wu_fwd(GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR g, GM_ADDR gk,
@@ -28,7 +31,28 @@ __global__ __aicore__ void recompute_wu_fwd(GM_ADDR k, GM_ADDR v, GM_ADDR beta, 
     if (TILING_KEY_IS(1)) {
         KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
         if ASCEND_IS_AIC {
-            RecomputeWUFwdProcess<DTYPE_K, DTYPE_BETA>recomputeWUFwdProcess(
+            RecomputeWUFwdProcess<DTYPE_K, DTYPE_BETA,
+                                  GemmCubeTileShape<_128, _128, _256>,
+                                  GemmCubeTileShape<_128, _128, _128>>
+                recomputeWUFwdProcess(
+                k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
+           recomputeWUFwdProcess.Init(tilingData);
+           recomputeWUFwdProcess.Process();
+        }
+        if ASCEND_IS_AIV {
+            AscendC::TPipe tPipe;
+            RecomputeWUFwdVectorProcess<DTYPE_K, DTYPE_BETA>recomputeWUFwdVectorProcess(
+                k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
+           recomputeWUFwdVectorProcess.Init(tilingData, &tPipe);
+           recomputeWUFwdVectorProcess.Process();
+        }
+    } else if (TILING_KEY_IS(2)) {
+        KERNEL_TASK_TYPE(2, KERNEL_TYPE_MIX_AIC_1_2);
+        if ASCEND_IS_AIC {
+            RecomputeWUFwdProcess<DTYPE_K, DTYPE_BETA,
+                                  GemmCubeTileShape<_128, _128, _256>,
+                                  GemmCubeTileShape<_128, _128, _128>>
+                recomputeWUFwdProcess(
                 k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
            recomputeWUFwdProcess.Init(tilingData);
            recomputeWUFwdProcess.Process();

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd_cube.h
@@ -76,8 +76,10 @@ public:
         GM_ADDR ptrChunkIndices;
         uint64_t chunkNum;
         uint64_t B = 1;
+        uint64_t Hk = 1;
+        uint64_t Hv = 32;
+        uint64_t hvPerHk = 1;
         uint64_t T = 32768;
-        uint64_t H = 32;
         uint64_t K = 128;
         uint64_t V = 128;
         uint64_t chunkSize = 64;
@@ -90,13 +92,13 @@ public:
 
         CATLASS_DEVICE
         Params(GM_ADDR ptrA_, LayoutA layoutA_, GM_ADDR ptrVb_, LayoutVb layoutVb_, GM_ADDR ptrU_,
-               LayoutW layoutW_, GM_ADDR ptrKbgExp_, LayoutKbgExp layoutKbgExp_, GM_ADDR ptrW_, LayoutU layoutU_,
+               LayoutU layoutU_, GM_ADDR ptrKbgExp_, LayoutKbgExp layoutKbgExp_, GM_ADDR ptrW_, LayoutW layoutW_,
                GM_ADDR ptrCuSeqLens_, GM_ADDR ptrChunkIndices_, uint64_t chunkNum_, uint64_t B_,
-               uint64_t T_, uint64_t H_, uint64_t K_, uint64_t V_, uint64_t BT_)
+               uint64_t Hk_, uint64_t Hv_, uint64_t hvPerHk_, uint64_t T_, uint64_t K_, uint64_t V_, uint64_t BT_)
             : ptrA(ptrA_), layoutA(layoutA_), ptrVb(ptrVb_), layoutVb(layoutVb_), ptrU(ptrU_),
-              layoutW(layoutW_), ptrKbgExp(ptrKbgExp_), layoutKbgExp(layoutKbgExp_), ptrW(ptrW_), layoutU(layoutU_),
+              layoutU(layoutU_), ptrKbgExp(ptrKbgExp_), layoutKbgExp(layoutKbgExp_), ptrW(ptrW_), layoutW(layoutW_),
               ptrCuSeqLens(ptrCuSeqLens_), ptrChunkIndices(ptrChunkIndices_),
-              chunkNum(chunkNum_), B(B_), T(T_), H(H_), K(K_), V(V_), chunkSize(BT_)
+              chunkNum(chunkNum_), B(B_), Hk(Hk_), Hv(Hv_), hvPerHk(hvPerHk_), T(T_), K(K_), V(V_), chunkSize(BT_)
         {
         }
     };
@@ -125,31 +127,35 @@ public:
             AscendC::GlobalTensor<ElementVb> gmVb;
             AscendC::GlobalTensor<ElementU> gmU;
             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.Hv, params.T,
                                params.chunkSize, loopIdx, bos, eos);
                 uint32_t curChunkSize = eos - bos;
                 GemmCoord blockCoord{0, 0, 0};
-                GemmCoord actualBlockShape{curChunkSize, static_cast<uint32_t>(params.V), curChunkSize};
-                for (int h = 0; h < params.H; h++) {
+                for (int h = 0; h < params.Hv; h++) {
                     // Represent the full gm
                     gmA.SetGlobalBuffer((__gm__ ElementA *)params.ptrA + (h * params.T + bos) * params.chunkSize);
-                    gmVb.SetGlobalBuffer((__gm__ ElementVb *)params.ptrVb + (h * params.T + bos) * params.V);
-                    gmU.SetGlobalBuffer((__gm__ ElementU *)params.ptrU + (h * params.T + bos) * params.V);
 
                     // Represent the full tensors
                     auto tensorA = tla::MakeTensor(gmA, params.layoutA, Arch::PositionGM{});
-                    auto tensorVb = tla::MakeTensor(gmVb, params.layoutVb, Arch::PositionGM{});
-                    auto tensorU = tla::MakeTensor(gmU, params.layoutU, Arch::PositionGM{});
                     Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_FIX>(flagAivFinishStore);
-                    // Make tiled views
-                    auto tensorBlockA = GetTile(tensorA, tla::MakeCoord(0, 0),
-                                                 tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockVb = GetTile(tensorVb, tla::MakeCoord(0, 0),
-                                                    tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockU = GetTile(tensorU, tla::MakeCoord(0, 0),
-                                                 tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    // Compute block-scoped matrix multiply-add
-                    BlockMmadU(tensorBlockA, tensorBlockVb, tensorBlockU, actualBlockShape);
+                    for (uint32_t nOffset = 0; nOffset < params.V; nOffset += params.K) {
+                        uint32_t curN = (nOffset + params.K > params.V) ? (params.V - nOffset) : params.K;
+                        GemmCoord actualBlockShape{curChunkSize, curN, curChunkSize};
+                        gmVb.SetGlobalBuffer((__gm__ ElementVb *)params.ptrVb + (h * params.T + bos) * params.V + nOffset);
+                        gmU.SetGlobalBuffer((__gm__ ElementU *)params.ptrU + (h * params.T + bos) * params.V + nOffset);
+
+                        auto tensorVb = tla::MakeTensor(gmVb, params.layoutVb, Arch::PositionGM{});
+                        auto tensorU = tla::MakeTensor(gmU, params.layoutU, Arch::PositionGM{});
+                        // Make tiled views
+                        auto tensorBlockA = GetTile(tensorA, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                        auto tensorBlockVb = GetTile(tensorVb, tla::MakeCoord(0, 0),
+                                                        tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                        auto tensorBlockU = GetTile(tensorU, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                        // Compute block-scoped matrix multiply-add
+                        BlockMmadU(tensorBlockA, tensorBlockVb, tensorBlockU, actualBlockShape);
+                    }
                 }
             }
         }
@@ -160,15 +166,16 @@ public:
             AscendC::GlobalTensor<ElementKbgExp> gmKbgExp;
             AscendC::GlobalTensor<ElementW> gmW;
             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.Hv, params.T,
                                params.chunkSize, loopIdx, bos, eos);
                 uint32_t curChunkSize = eos - bos;
                 GemmCoord blockCoord{0, 0, 0};
                 GemmCoord actualBlockShape{curChunkSize, static_cast<uint32_t>(params.K), curChunkSize};
-                for (int h = 0; h < params.H; h++) {
+                for (int h = 0; h < params.Hv; h++) {
                     // Represent the full gm
                     gmA.SetGlobalBuffer((__gm__ ElementA *)params.ptrA + (h * params.T + bos) * params.chunkSize);
-                    gmKbgExp.SetGlobalBuffer((__gm__ ElementKbgExp *)params.ptrKbgExp + (h * params.T + bos) * params.K);
+                    gmKbgExp.SetGlobalBuffer((__gm__ ElementKbgExp *)params.ptrKbgExp +
+                                             (h * params.T + bos) * params.K);
                     gmW.SetGlobalBuffer((__gm__ ElementW *)params.ptrW + (h * params.T + bos) * params.K);
 
                     // Represent the full tensors
@@ -194,7 +201,10 @@ public:
 };
 } // namespace Catlass::Gemm::Kernel
 
-template <typename kType, typename betaType>
+template <class... Dims>
+using GemmCubeTileShape = tla::Shape<Dims...>;
+
+template <typename kType, typename betaType, typename L1TileShape, typename L0TileShape>
 class RecomputeWUFwdProcess {
 public:
     /** @brief constructor */
@@ -209,7 +219,9 @@ public:
 private:
     uint64_t B = 0;
     uint64_t T = 0;
-    uint64_t H = 0;
+    uint64_t Hv = 1;
+    uint64_t Hk = 1;
+    uint64_t hvPerHk = 1;
     uint64_t K = 0;
     uint64_t V = 0;
     uint64_t chunkSize = 0;
@@ -226,20 +238,22 @@ private:
     GM_ADDR workspace;
 };
 
-template <typename kType, typename betaType>
-__aicore__ inline RecomputeWUFwdProcess<kType, betaType>::RecomputeWUFwdProcess(
+template <typename kType, typename betaType, typename L1TileShape, typename L0TileShape>
+__aicore__ inline RecomputeWUFwdProcess<kType, betaType, L1TileShape, L0TileShape>::RecomputeWUFwdProcess(
     GM_ADDR k_, GM_ADDR v_, GM_ADDR beta_, GM_ADDR A_, GM_ADDR g_,
     GM_ADDR cu_seqlens_, GM_ADDR chunk_indices_, GM_ADDR w_, GM_ADDR u_,
     GM_ADDR workspace_)
     : k(k_), v(v_), beta(beta_), A(A_), g(g_), cu_seqlens(cu_seqlens_),
       chunk_indices(chunk_indices_), w(w_), u(u_), workspace(workspace_){};
 
-template <typename kType, typename betaType>
-__aicore__ void inline RecomputeWUFwdProcess<kType, betaType>::Init(const RecomputeWUFwdTilingData &tiling)
+template <typename kType, typename betaType, typename L1TileShape, typename L0TileShape>
+__aicore__ void inline RecomputeWUFwdProcess<kType, betaType, L1TileShape, L0TileShape>::Init(const RecomputeWUFwdTilingData &tiling)
 {
     B = tiling.B;
     T = tiling.T;
-    H = tiling.H;
+    Hv = tiling.Hv;
+    Hk = tiling.Hk;
+    hvPerHk = tiling.hvPerHk;
     K = tiling.K;
     V = tiling.V;
     chunkSize = tiling.chunkSize;
@@ -247,8 +261,8 @@ __aicore__ void inline RecomputeWUFwdProcess<kType, betaType>::Init(const Recomp
     return;
 }
 
-template <typename kType, typename betaType>
-__aicore__ void inline RecomputeWUFwdProcess<kType, betaType>::Process()
+template <typename kType, typename betaType, typename L1TileShape, typename L0TileShape>
+__aicore__ void inline RecomputeWUFwdProcess<kType, betaType, L1TileShape, L0TileShape>::Process()
 {
     //输入
     using LayoutTagA = layout::RowMajor;
@@ -272,8 +286,6 @@ __aicore__ void inline RecomputeWUFwdProcess<kType, betaType>::Process()
     using ArchTag = Arch::AtlasA2;
 #endif
     using DispatchPolicy = Gemm::MmadPingpong<ArchTag, true>;
-    using L1TileShape = Shape<_128, _128, _256>;
-    using L0TileShape = Shape<_128, _128, _128>;
 
     //计算U
     using TileCopyU =
@@ -305,7 +317,7 @@ __aicore__ void inline RecomputeWUFwdProcess<kType, betaType>::Process()
         A, layoutA, vb, layoutVb, u,        layoutU,  
         kbgExp, layoutKbgExp, w,        layoutW,
         cu_seqlens, chunk_indices, chunkNum, B,
-        T,         H,           K,  V,        chunkSize};
+        Hk, Hv, hvPerHk, T, K, V, chunkSize};
     kernel(param);
 }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd_vector.h
@@ -35,7 +35,9 @@ public:
 private:
     uint64_t B = 0;
     uint64_t T = 0;
-    uint64_t H = 0;
+    uint64_t Hv = 1;
+    uint64_t Hk = 1;
+    uint64_t hvPerHk = 1;
     uint64_t K = 0;
     uint64_t V = 0;
     uint64_t chunkSize = 0;
@@ -100,7 +102,9 @@ __aicore__ void inline RecomputeWUFwdVectorProcess<kType, betaType>::Init(
 
     B = tiling.B;
     T = tiling.T;
-    H = tiling.H;
+    Hv = tiling.Hv;
+    Hk = tiling.Hk;
+    hvPerHk = tiling.hvPerHk;
     K = tiling.K;
     V = tiling.V;
     chunkSize = tiling.chunkSize;
@@ -150,9 +154,9 @@ __aicore__ void inline RecomputeWUFwdVectorProcess<kType, betaType>::ProcessVb()
     auto tensorBetaBrcbFP32 = betaFp32BrcbBuf.Get<float32_t>();
     
     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
-        GetChunkOffset(cu_seqlens, chunk_indices, B, H, T, chunkSize, loopIdx, bos, eos);
+        GetChunkOffset(cu_seqlens, chunk_indices, B, Hv, T, chunkSize, loopIdx, bos, eos);
         uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < H; h++) {
+        for (int h = 0; h < Hv; h++) {
             ++vecTaskIdx;
             if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
                 Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(flagAivFinishStore);
@@ -249,24 +253,29 @@ __aicore__ void inline RecomputeWUFwdVectorProcess<kType, betaType>::ProcessKbgE
     auto tensorBetaBrcbFP32 = betaFp32BrcbBuf.Get<float32_t>();
     
     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
-        GetChunkOffset(cu_seqlens, chunk_indices, B, H, T, chunkSize, loopIdx, bos, eos);
+        GetChunkOffset(cu_seqlens, chunk_indices, B, Hv, T, chunkSize, loopIdx, bos, eos);
         uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < H; h++) {
+        for (int h = 0; h < Hv; h++) {
             ++vecTaskIdx;
+            uint64_t hk = h / hvPerHk;
             if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
                 Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(flagAivFinishStore);
                 continue;
             }
             for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
                 curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
-                auto kOffset = (h * T + bos + rowOffset) * K;
+                uint64_t coreLoopsInB = (T + chunkSize - 1) / chunkSize;
+                uint64_t bIdx = cu_seqlens ? 0 : (loopIdx / coreLoopsInB);
+                uint64_t bosK = cu_seqlens ? bos : (bos - bIdx * (Hv - Hk) * T);
+                auto kSrcOffset = (hk * T + bosK + rowOffset) * K;
+                auto kDstOffset = (h * T + bos + rowOffset) * K;
                 auto betaOffset = h * T + bos + rowOffset;
                 // copyin
                 {
                     auto tensorKin = kInQue.AllocTensor<kType>();
                     auto tensorBetain = betaInQue.AllocTensor<betaType>();
                     auto tensorGin = gInQue.AllocTensor<betaType>();
-                    DataCopy(tensorKin, kTensor[kOffset], K * curRowNum);
+                    DataCopy(tensorKin, kTensor[kSrcOffset], K * curRowNum);
                     DataCopyPad(tensorBetain, betaTensor[betaOffset], {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
                     DataCopyPad(tensorGin, gTensor[betaOffset], {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
                     kInQue.EnQue(tensorKin);
@@ -314,7 +323,7 @@ __aicore__ void inline RecomputeWUFwdVectorProcess<kType, betaType>::ProcessKbgE
                 // copyout
                 {
                     auto tensorOut = kBetagExpOutQue.DeQue<kType>();
-                    DataCopy(workSpaceTensor[kOffset], tensorOut, K * curRowNum);
+                    DataCopy(workSpaceTensor[kDstOffset], tensorOut, K * curRowNum);
                     kBetagExpOutQue.FreeTensor(tensorOut);
                 }
             }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/test/test.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/test/test.py
@@ -1,12 +1,13 @@
 import torch
 import torch_npu
+import os
 from typing import Optional
 import pickle
 import math
 import ct
 import random
 import fla_npu
-torch.npu.utils.set_device(3)
+torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 3)))
 
 def get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices):
     if cu_seqlens != None:
@@ -38,6 +39,7 @@ def compute_w_golden(
     D: int,
     chunk_size: int,  # chunk_size
     NT: int,  # T / chunk_size
+    Hk: int = 0,  # GVA: key head count, 0 means Hk == H
 ) -> torch.Tensor:
     """
     CPU golden implementation for dv computation (变长序列)
@@ -47,8 +49,10 @@ def compute_w_golden(
     2. 获取对应的seq_idx, chunk_indices
     3. 计算该chunk内的dv: dv_chunk = A_chunk @ du_chunk * beta_chunk
     """
-    # 初始化dv，形状与du相同 [B, T, H, D]
-    w = torch.zeros_like(k)
+    if Hk == 0:
+        Hk = H
+    hvPerHk = H // Hk
+    w = torch.zeros(B, H, T, D, dtype=v.dtype, device=v.device)
     for i_b in range(B):
         for idx in range(NT):
             bos,eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
@@ -62,7 +66,8 @@ def compute_w_golden(
                 # 我们需要获取这个chunk对应的A向量
                 # 注意: A的每个位置存储的是该chunk对应的A向量
                 A_chunk = A[i_b,i_h, bos:eos,:eos - bos]
-                k_chunk = k[i_b,i_h, bos:eos,:]
+                hk = i_h // hvPerHk
+                k_chunk = k[i_b,hk, bos:eos,:]
                 
                 # 获取当前chunk的beta
                 beta_chunk = beta[i_b,i_h, bos:eos]  # [chunk_size]
@@ -84,17 +89,14 @@ def compute_w_golden(
 
 
 def compute_u_golden(
-    k: torch.Tensor,     # [B, T, H, D]
     v: torch.Tensor,     # [B, T, H, D]
     beta: torch.Tensor,   # [B, H, T]
     A: torch.Tensor,      # [B, T, H, chunk_size]
-    g: torch.Tensor,      # [B, T, H]
     cu_seqlens: torch.Tensor,
     chunk_indices: torch.Tensor,
     B: int,
-    H: int,
+    Hv: int,
     T: int,
-    D: int,
     chunk_size: int,  # chunk_size
     NT: int,  # T / chunk_size
 ) -> torch.Tensor:
@@ -111,7 +113,7 @@ def compute_u_golden(
         for idx in range(NT):
             bos,eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
         # 遍历所有batch
-            for i_h in range(H):
+            for i_h in range(Hv):
             # 遍历所有head 
                 # 获取当前chunk的A向量
                 # A形状: [B, T, H, chunk_size]
@@ -227,7 +229,8 @@ def prepare_chunk_indices(
 
 def test_recompute_wu_fwd(
     B: int,
-    H: int,
+    Hk: int,
+    Hv: int,
     T: int,
     K: int,
     V: int,
@@ -261,11 +264,11 @@ def test_recompute_wu_fwd(
         test_recompute_wu_fwd.call_count += 1
 
     # 生成随机张量（float16）
-    k = torch.randn(B, H, T, K, dtype=ktype)
-    v = torch.randn(B, H, T, V, dtype=ktype)
-    beta = torch.randn(B, H, T, dtype=btype)
-    A = torch.randn(B, H, T, chunk_size, dtype=ktype)
-    g = torch.randn(B, H, T, dtype=btype)
+    k = torch.randn(B, Hk, T, K, dtype=ktype)
+    v = torch.randn(B, Hv, T, V, dtype=ktype)
+    beta = torch.randn(B, Hv, T, dtype=btype)
+    A = torch.randn(B, Hv, T, chunk_size, dtype=ktype)
+    g = torch.randn(B, Hv, T, dtype=btype)
 
     if chunk_indices!=None:
         NT = len(chunk_indices) // 2
@@ -297,17 +300,86 @@ def test_recompute_wu_fwd(
             cu_seqlens=None,
             chunk_indices=None
         )
-    cpu_w = compute_w_golden(k, v, beta, A, g, cu_seqlens, chunk_indices, B, H, T, K, chunk_size, NT)
-    ct.viz(w.cpu(), cpu_w.cpu())
+    print(f"==================w=========================\n")
+    cpu_w = compute_w_golden(k, v, beta, A, g, cu_seqlens, chunk_indices, B, Hv, T, K, chunk_size, NT, Hk=Hk)
+    print(f"==================cpu=========================\n")
+    ct.isclose(w.cpu(), cpu_w.cpu(), diff_thd=0.1)
+    print(f"==================ct=========================\n")
     
-    # cpu_u = compute_u_golden(k, v, beta, A, g, cu_seqlens, chunk_indices, B, H, T, K, chunk_size, NT)
-    # ct.isclose(u.cpu(), cpu_u.cpu(), diff_thd=0.1)
+    print(f"==================u=========================\n")
+    cpu_u = compute_u_golden(v, beta, A, cu_seqlens, chunk_indices, B, Hv, T, chunk_size, NT)
+    ct.isclose(u.cpu(), cpu_u.cpu(), diff_thd=0.1)
 
     
     print(f"test_recompute_wu_fwd 被调用了第 {test_recompute_wu_fwd.call_count} 次")
     return w, u
 
 if __name__ == "__main__":
+    # === GVA / VDIM256 quick cases ===
+    # 默认只打开一个小的 GVA + VDIM256 smoke，用于快速确认主路径。
+    test_recompute_wu_fwd(B=1, Hk=2, Hv=4, T=256, K=128, V=256, chunk_size=64,
+                          ktype=torch.float16, btype=torch.float16)
+
+    # GVA V=128 smoke
+    # test_recompute_wu_fwd(B=2, Hk=2, Hv=4, T=128, K=128, V=128, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+    # test_recompute_wu_fwd(B=4, Hk=4, Hv=8, T=256, K=128, V=128, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+
+    # VDIM256 non-GVA smoke
+    # test_recompute_wu_fwd(B=1, Hk=4, Hv=4, T=256, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+
+    # GVA + VDIM256 fixed-length cases
+    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=4096, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+    # test_recompute_wu_fwd(B=16, Hk=21, Hv=63, T=2048, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+    # test_recompute_wu_fwd(B=176, Hk=2, Hv=64, T=24, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+
+    # GVA V=128 fixed-length case
+    # test_recompute_wu_fwd(B=711, Hk=4, Hv=32, T=196, K=128, V=128, chunk_size=128,
+    #                       ktype=torch.float16, btype=torch.float16)
+
+    # GVA + VDIM256 variable-length cases
+    # cu_seqlens = prepare_cu_seqlens(T=16384, L=128)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=16384, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # cu_seqlens = prepare_cu_seqlens(T=16384, L=1)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+    # test_recompute_wu_fwd(B=1, Hk=21, Hv=63, T=16384, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # cu_seqlens = prepare_cu_seqlens(T=65536, L=172)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=128)
+    # test_recompute_wu_fwd(B=1, Hk=8, Hv=32, T=65536, K=128, V=256, chunk_size=128,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # cu_seqlens = prepare_cu_seqlens(T=262144, L=32)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+    # test_recompute_wu_fwd(B=1, Hk=2, Hv=64, T=262144, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # GVA V=128 variable-length cases
+    # cu_seqlens = prepare_cu_seqlens(T=65536, L=668)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=65536, K=128, V=128, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # cu_seqlens = prepare_cu_seqlens(T=65536, L=17)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=128)
+    # test_recompute_wu_fwd(B=1, Hk=4, Hv=32, T=65536, K=128, V=128, chunk_size=128,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
     # test_recompute_wu_fwd(B = 1, H = 4, T = 2048, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16)
     # #F1
     # test_recompute_wu_fwd(B = 64, H = 8, T = 1024, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16)
@@ -346,11 +418,11 @@ if __name__ == "__main__":
     # #F18
     # test_recompute_wu_fwd(B = 32, H = 16, T = 4096, K = 128, V = 128, chunk_size = 128, ktype=torch.float16, btype=torch.float16)
     # #L1
-    cu_seqlens = prepare_cu_seqlens(T = 2048, L = 500)
-    chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 128)
-    print(cu_seqlens)
-    print(chunk_indices)
-    test_recompute_wu_fwd(B = 1, H = 4, T = 2048, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.bfloat16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    # cu_seqlens = prepare_cu_seqlens(T = 2048, L = 500)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 128)
+    # print(cu_seqlens)
+    # print(chunk_indices)
+    # test_recompute_wu_fwd(B = 1, Hk = 4, Hv = 4, T = 2048, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.bfloat16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
     # #L2
     # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 33)
     # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -282,7 +282,9 @@ at::Tensor npu_chunk_fwd_o(
     c10::OptionalIntArrayRef chunk_indices
 )
 {
-    at::Tensor w = at::empty_like(k);
+    auto w_shape = v.sizes().vec();
+    w_shape[3] = k.size(3);
+    at::Tensor w = at::empty(w_shape, v.options().dtype(k.scalar_type()));
     at::Tensor u = at::empty_like(v);
     const at::Tensor &gK_ = c10::value_or_else(gK, [] { return at::Tensor(); });
     const at::Tensor &g_ = c10::value_or_else(g, [] { return at::Tensor(); });

--- a/torch_custom/fla_npu/test/test_npu_recompute_w_u_fwd.py
+++ b/torch_custom/fla_npu/test/test_npu_recompute_w_u_fwd.py
@@ -385,73 +385,67 @@ if __name__ == "__main__":
     # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
     # test_recompute_wu_fwd(B = 1, H = 8, T = 65536, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
 
-    # GVA tests (Hk != Hv)
-    # test_recompute_wu_fwd(B=2, Hk=2, Hv=4, T=128, K=128, V=128, chunk_size=64, ktype=torch.float16, btype=torch.float16)
-    # test_recompute_wu_fwd(B=4, Hk=4, Hv=8, T=256, K=128, V=128, chunk_size=64, ktype=torch.float16, btype=torch.float16)
+    # === GVA / VDIM256 quick cases ===
+    # 默认只打开一个小的 GVA + VDIM256 smoke，用于快速确认主路径。
+    test_recompute_wu_fwd(B=1, Hk=2, Hv=4, T=256, K=128, V=256, chunk_size=64,
+                          ktype=torch.float16, btype=torch.float16)
 
-    # === GVA 泛化测试 ===
+    # GVA V=128 smoke
+    # test_recompute_wu_fwd(B=2, Hk=2, Hv=4, T=128, K=128, V=128, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+    # test_recompute_wu_fwd(B=4, Hk=4, Hv=8, T=256, K=128, V=128, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
 
-    # -- 变长序列 --
-    # V1: Vdim=256 暂不支持
-    # cu_seqlens = prepare_cu_seqlens(T = 16384, L = 128)
-    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
-    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=16384, K=128, V=256, chunk_size=64, ktype=torch.float16, btype=torch.float16, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+    # VDIM256 non-GVA smoke
+    # test_recompute_wu_fwd(B=1, Hk=4, Hv=4, T=256, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
 
-    # V2: Vdim=256 暂不支持
-    # cu_seqlens = prepare_cu_seqlens(T = 16384, L = 1)
-    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
-    # test_recompute_wu_fwd(B=1, Hk=21, Hv=63, T=16384, K=128, V=256, chunk_size=64, ktype=torch.float16, btype=torch.float16, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+    # GVA + VDIM256 fixed-length cases
+    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=4096, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+    # test_recompute_wu_fwd(B=16, Hk=21, Hv=63, T=2048, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+    # test_recompute_wu_fwd(B=176, Hk=2, Hv=64, T=24, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
 
-    # V3: Vdim=256 暂不支持
-    # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 172)
-    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 128)
-    # test_recompute_wu_fwd(B=1, Hk=8, Hv=32, T=65536, K=128, V=256, chunk_size=128, ktype=torch.float16, btype=torch.float16, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+    # GVA V=128 fixed-length case
+    # test_recompute_wu_fwd(B=711, Hk=4, Hv=32, T=196, K=128, V=128, chunk_size=128,
+    #                       ktype=torch.float16, btype=torch.float16)
 
-    # V4
-    # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 668)
-    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
-    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=65536, K=128, V=128, chunk_size=64, ktype=torch.float16, btype=torch.float16, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+    # GVA + VDIM256 variable-length cases
+    # cu_seqlens = prepare_cu_seqlens(T=16384, L=128)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=16384, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
 
-    # V5
-    # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 17)
-    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 128)
-    # test_recompute_wu_fwd(B=1, Hk=4, Hv=32, T=65536, K=128, V=128, chunk_size=128, ktype=torch.float16, btype=torch.float16, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+    # cu_seqlens = prepare_cu_seqlens(T=16384, L=1)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+    # test_recompute_wu_fwd(B=1, Hk=21, Hv=63, T=16384, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
 
-    # V6: Vdim=256 暂不支持
-    # cu_seqlens = prepare_cu_seqlens(T = 262144, L = 32)
-    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
-    # test_recompute_wu_fwd(B=1, Hk=2, Hv=64, T=262144, K=128, V=256, chunk_size=64, ktype=torch.float16, btype=torch.float16, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+    # cu_seqlens = prepare_cu_seqlens(T=65536, L=172)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=128)
+    # test_recompute_wu_fwd(B=1, Hk=8, Hv=32, T=65536, K=128, V=256, chunk_size=128,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
 
-    # -- 定长序列 --
-    # baseline V=128 check
-    # test_recompute_wu_fwd(B=1, Hk=4, Hv=4, T=256, K=128, V=128, chunk_size=64,
-    #                   ktype=torch.float16, btype=torch.float16)
-    # non-GVA V=256 check with diagnostics
-    k = torch.randn(1, 4, 256, 128, dtype=torch.float16)
-    v = torch.randn(1, 4, 256, 256, dtype=torch.float16)
-    beta = torch.randn(1, 4, 256, dtype=torch.float16)
-    A = torch.randn(1, 4, 256, 64, dtype=torch.float16)
-    g = torch.randn(1, 4, 256, dtype=torch.float16)
-    w, u = torch.ops.npu.npu_recompute_w_u_fwd(k.npu(), v.npu(), beta.npu(), A.npu(), 64, g=g.npu(), gk=None, cu_seqlens=None, chunk_indices=None)
-    cpu_w = compute_w_golden(k, v, beta, A, g, None, None, 1, 4, 256, 128, 64, 4, Hk=4)
-    cpu_u = compute_u_golden(v, beta, A, None, None, 1, 4, 256, 64, 4)
-    ct.isclose(w.cpu(), cpu_w.cpu(), diff_thd=0.1)
-    ct.isclose(u.cpu(), cpu_u.cpu(), diff_thd=0.1)
-    print("W[0,0,0,:4]:", w.cpu()[0,0,0,:4])
-    print("cpu_W[0,0,0,:4]:", cpu_w[0,0,0,:4])
-    print("U[0,0,0,:4]:", u.cpu()[0,0,0,:4])
-    print("cpu_U[0,0,0,:4]:", cpu_u[0,0,0,:4])
-    # F_G1: Vdim=256 暂不支持
-    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=4096, K=128, V=256, chunk_size=64, ktype=torch.float16, btype=torch.float16)
-    # V256 GVA test
-    # test_recompute_wu_fwd(B=1, Hk=2, Hv=4, T=256, K=128, V=256, chunk_size=64,
-    #                   ktype=torch.float16, btype=torch.float16)
+    # cu_seqlens = prepare_cu_seqlens(T=262144, L=32)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+    # test_recompute_wu_fwd(B=1, Hk=2, Hv=64, T=262144, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
 
-    # F_G2: Vdim=256 暂不支持
-    # test_recompute_wu_fwd(B=16, Hk=21, Hv=63, T=2048, K=128, V=256, chunk_size=64, ktype=torch.float16, btype=torch.float16)
+    # GVA V=128 variable-length cases
+    # cu_seqlens = prepare_cu_seqlens(T=65536, L=668)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=65536, K=128, V=128, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
 
-    # F_G3
-    # test_recompute_wu_fwd(B=711, Hk=4, Hv=32, T=196, K=128, V=128, chunk_size=128, ktype=torch.float16, btype=torch.float16)
-
-    # F_G4: Vdim=256 暂不支持
-    # test_recompute_wu_fwd(B=176, Hk=2, Hv=64, T=24, K=128, V=256, chunk_size=64, ktype=torch.float16, btype=torch.float16)
+    # cu_seqlens = prepare_cu_seqlens(T=65536, L=17)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=128)
+    # test_recompute_wu_fwd(B=1, Hk=4, Hv=32, T=65536, K=128, V=128, chunk_size=128,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)

--- a/torch_custom/fla_npu/test/test_npu_recompute_w_u_fwd.py
+++ b/torch_custom/fla_npu/test/test_npu_recompute_w_u_fwd.py
@@ -4,10 +4,10 @@ import os
 from typing import Optional
 import pickle
 import math
-# import ct
+import ct
 import random
 import fla_npu
-torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
+torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 3)))
 
 def get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices):
     if cu_seqlens != None:
@@ -39,6 +39,7 @@ def compute_w_golden(
     D: int,
     chunk_size: int,  # chunk_size
     NT: int,  # T / chunk_size
+    Hk: int = 0,  # GVA: key head count, 0 means Hk == H
 ) -> torch.Tensor:
     """
     CPU golden implementation for dv computation (变长序列)
@@ -48,8 +49,11 @@ def compute_w_golden(
     2. 获取对应的seq_idx, chunk_indices
     3. 计算该chunk内的dv: dv_chunk = A_chunk @ du_chunk * beta_chunk
     """
-    # 初始化dv，形状与du相同 [B, T, H, D]
-    w = torch.zeros_like(k)
+    if Hk == 0:
+        Hk = H
+    hvPerHk = H // Hk
+    # 初始化w，形状与k相同 [B, T, H, D]（W输出K维）
+    w = torch.zeros(B, H, T, D, dtype=v.dtype, device=v.device)
     for i_b in range(B):
         for idx in range(NT):
             bos,eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
@@ -58,12 +62,13 @@ def compute_w_golden(
             for i_h in range(H):
                 # print("hello?")
             # 遍历所有head 
+                hk = i_h // hvPerHk
                 # 获取当前chunk的A向量
                 # A形状: [B, T, H, chunk_size]
                 # 我们需要获取这个chunk对应的A向量
                 # 注意: A的每个位置存储的是该chunk对应的A向量
                 A_chunk = A[i_b,i_h, bos:eos,:eos - bos]
-                k_chunk = k[i_b,i_h, bos:eos,:]
+                k_chunk = k[i_b,hk, bos:eos,:]
                 
                 # 获取当前chunk的beta
                 beta_chunk = beta[i_b,i_h, bos:eos]  # [chunk_size]
@@ -85,17 +90,14 @@ def compute_w_golden(
 
 
 def compute_u_golden(
-    k: torch.Tensor,     # [B, T, H, D]
     v: torch.Tensor,     # [B, T, H, D]
     beta: torch.Tensor,   # [B, H, T]
     A: torch.Tensor,      # [B, T, H, chunk_size]
-    g: torch.Tensor,      # [B, T, H]
     cu_seqlens: torch.Tensor,
     chunk_indices: torch.Tensor,
     B: int,
-    H: int,
+    Hv: int,
     T: int,
-    D: int,
     chunk_size: int,  # chunk_size
     NT: int,  # T / chunk_size
 ) -> torch.Tensor:
@@ -111,8 +113,7 @@ def compute_u_golden(
     for i_b in range(B):
         for idx in range(NT):
             bos,eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
-        # 遍历所有batch
-            for i_h in range(H):
+            for i_h in range(Hv):
             # 遍历所有head 
                 # 获取当前chunk的A向量
                 # A形状: [B, T, H, chunk_size]
@@ -228,7 +229,8 @@ def prepare_chunk_indices(
 
 def test_recompute_wu_fwd(
     B: int,
-    H: int,
+    Hk: int,
+    Hv: int,
     T: int,
     K: int,
     V: int,
@@ -262,11 +264,11 @@ def test_recompute_wu_fwd(
         test_recompute_wu_fwd.call_count += 1
 
     # 生成随机张量（float16）
-    k = torch.randn(B, H, T, K, dtype=ktype)
-    v = torch.randn(B, H, T, V, dtype=ktype)
-    beta = torch.randn(B, H, T, dtype=btype)
-    A = torch.randn(B, H, T, chunk_size, dtype=ktype)
-    g = torch.randn(B, H, T, dtype=btype)
+    k = torch.randn(B, Hk, T, K, dtype=ktype)
+    v = torch.randn(B, Hv, T, V, dtype=ktype)
+    beta = torch.randn(B, Hv, T, dtype=btype)
+    A = torch.randn(B, Hv, T, chunk_size, dtype=ktype)
+    g = torch.randn(B, Hv, T, dtype=btype)
 
     if chunk_indices!=None:
         NT = len(chunk_indices) // 2
@@ -298,11 +300,21 @@ def test_recompute_wu_fwd(
             cu_seqlens=None,
             chunk_indices=None
         )
-    cpu_w = compute_w_golden(k, v, beta, A, g, cu_seqlens, chunk_indices, B, H, T, K, chunk_size, NT)
+
+    print(f"==================w=========================\n")
+    cpu_w = compute_w_golden(k, v, beta, A, g, cu_seqlens, chunk_indices, B, Hv, T, K, chunk_size, NT, Hk=Hk)
+    print(f"==================cpu=========================\n")
+    ct.isclose(w.cpu(), cpu_w.cpu(), diff_thd=0.1)
+    # ct.single(w.cpu(), cpu_w)
     # ct.viz(w.cpu(), cpu_w.cpu())
+    print(f"==================ct=========================\n")
+
+    print(f"==================u=========================\n")
+
+    cpu_u = compute_u_golden(v, beta, A, cu_seqlens, chunk_indices, B, Hv, T, chunk_size, NT)
+    ct.isclose(u.cpu(), cpu_u.cpu(), diff_thd=0.1)
+
     
-    # cpu_u = compute_u_golden(k, v, beta, A, g, cu_seqlens, chunk_indices, B, H, T, K, chunk_size, NT)
-    # ct.isclose(u.cpu(), cpu_u.cpu(), diff_thd=0.1)
 
     
     print(f"test_recompute_wu_fwd 被调用了第 {test_recompute_wu_fwd.call_count} 次")
@@ -347,11 +359,11 @@ if __name__ == "__main__":
     # #F18
     # test_recompute_wu_fwd(B = 32, H = 16, T = 4096, K = 128, V = 128, chunk_size = 128, ktype=torch.float16, btype=torch.float16)
     # #L1
-    cu_seqlens = prepare_cu_seqlens(T = 2048, L = 500)
-    chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 128)
-    print(cu_seqlens)
-    print(chunk_indices)
-    test_recompute_wu_fwd(B = 1, H = 4, T = 2048, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.bfloat16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    # cu_seqlens = prepare_cu_seqlens(T = 2048, L = 500)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 128)
+    # print(cu_seqlens)
+    # print(chunk_indices)
+    # test_recompute_wu_fwd(B = 1, Hk = 4, Hv = 4, T = 2048, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.bfloat16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
     # #L2
     # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 33)
     # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
@@ -372,3 +384,74 @@ if __name__ == "__main__":
     # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 25)
     # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
     # test_recompute_wu_fwd(B = 1, H = 8, T = 65536, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+
+    # GVA tests (Hk != Hv)
+    # test_recompute_wu_fwd(B=2, Hk=2, Hv=4, T=128, K=128, V=128, chunk_size=64, ktype=torch.float16, btype=torch.float16)
+    # test_recompute_wu_fwd(B=4, Hk=4, Hv=8, T=256, K=128, V=128, chunk_size=64, ktype=torch.float16, btype=torch.float16)
+
+    # === GVA 泛化测试 ===
+
+    # -- 变长序列 --
+    # V1: Vdim=256 暂不支持
+    # cu_seqlens = prepare_cu_seqlens(T = 16384, L = 128)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
+    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=16384, K=128, V=256, chunk_size=64, ktype=torch.float16, btype=torch.float16, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # V2: Vdim=256 暂不支持
+    # cu_seqlens = prepare_cu_seqlens(T = 16384, L = 1)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
+    # test_recompute_wu_fwd(B=1, Hk=21, Hv=63, T=16384, K=128, V=256, chunk_size=64, ktype=torch.float16, btype=torch.float16, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # V3: Vdim=256 暂不支持
+    # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 172)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 128)
+    # test_recompute_wu_fwd(B=1, Hk=8, Hv=32, T=65536, K=128, V=256, chunk_size=128, ktype=torch.float16, btype=torch.float16, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # V4
+    # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 668)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
+    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=65536, K=128, V=128, chunk_size=64, ktype=torch.float16, btype=torch.float16, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # V5
+    # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 17)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 128)
+    # test_recompute_wu_fwd(B=1, Hk=4, Hv=32, T=65536, K=128, V=128, chunk_size=128, ktype=torch.float16, btype=torch.float16, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # V6: Vdim=256 暂不支持
+    # cu_seqlens = prepare_cu_seqlens(T = 262144, L = 32)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
+    # test_recompute_wu_fwd(B=1, Hk=2, Hv=64, T=262144, K=128, V=256, chunk_size=64, ktype=torch.float16, btype=torch.float16, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # -- 定长序列 --
+    # baseline V=128 check
+    # test_recompute_wu_fwd(B=1, Hk=4, Hv=4, T=256, K=128, V=128, chunk_size=64,
+    #                   ktype=torch.float16, btype=torch.float16)
+    # non-GVA V=256 check with diagnostics
+    k = torch.randn(1, 4, 256, 128, dtype=torch.float16)
+    v = torch.randn(1, 4, 256, 256, dtype=torch.float16)
+    beta = torch.randn(1, 4, 256, dtype=torch.float16)
+    A = torch.randn(1, 4, 256, 64, dtype=torch.float16)
+    g = torch.randn(1, 4, 256, dtype=torch.float16)
+    w, u = torch.ops.npu.npu_recompute_w_u_fwd(k.npu(), v.npu(), beta.npu(), A.npu(), 64, g=g.npu(), gk=None, cu_seqlens=None, chunk_indices=None)
+    cpu_w = compute_w_golden(k, v, beta, A, g, None, None, 1, 4, 256, 128, 64, 4, Hk=4)
+    cpu_u = compute_u_golden(v, beta, A, None, None, 1, 4, 256, 64, 4)
+    ct.isclose(w.cpu(), cpu_w.cpu(), diff_thd=0.1)
+    ct.isclose(u.cpu(), cpu_u.cpu(), diff_thd=0.1)
+    print("W[0,0,0,:4]:", w.cpu()[0,0,0,:4])
+    print("cpu_W[0,0,0,:4]:", cpu_w[0,0,0,:4])
+    print("U[0,0,0,:4]:", u.cpu()[0,0,0,:4])
+    print("cpu_U[0,0,0,:4]:", cpu_u[0,0,0,:4])
+    # F_G1: Vdim=256 暂不支持
+    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=4096, K=128, V=256, chunk_size=64, ktype=torch.float16, btype=torch.float16)
+    # V256 GVA test
+    # test_recompute_wu_fwd(B=1, Hk=2, Hv=4, T=256, K=128, V=256, chunk_size=64,
+    #                   ktype=torch.float16, btype=torch.float16)
+
+    # F_G2: Vdim=256 暂不支持
+    # test_recompute_wu_fwd(B=16, Hk=21, Hv=63, T=2048, K=128, V=256, chunk_size=64, ktype=torch.float16, btype=torch.float16)
+
+    # F_G3
+    # test_recompute_wu_fwd(B=711, Hk=4, Hv=32, T=196, K=128, V=128, chunk_size=128, ktype=torch.float16, btype=torch.float16)
+
+    # F_G4: Vdim=256 暂不支持
+    # test_recompute_wu_fwd(B=176, Hk=2, Hv=64, T=24, K=128, V=256, chunk_size=64, ktype=torch.float16, btype=torch.float16)


### PR DESCRIPTION
Add grouped value attention shape/index handling and stable V=256 tiling dispatch for recompute_wu_fwd, including validation coverage for the migrated operator path.

# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求触发的维护账号和触发命令。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要维护者重新触发。即使已有 2 个维护账号检视通过，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @Coding-Pangolin
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由维护者触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
