### PR TITLE
Fix Actions status token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         id: prepare
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.NPU_CI_BOT_TOKEN || github.token }}
+          github-token: ${{ github.token }}
           script: |
             const maintainers = new Set([
               'juyangokok',
@@ -404,7 +404,7 @@ jobs:
         if: always()
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.NPU_CI_BOT_TOKEN || github.token }}
+          github-token: ${{ github.token }}
           script: |
             const state = '${{ job.status }}' === 'success' ? 'success' : 'failure';
             const mode = ${{ toJson(needs.prepare.outputs.ci_mode) }};

--- a/.github/workflows/npu-ci-default-status.yml
+++ b/.github/workflows/npu-ci-default-status.yml
@@ -16,7 +16,7 @@ jobs:
       - name: 写入未执行状态并提示触发人
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.NPU_CI_BOT_TOKEN || github.token }}
+          github-token: ${{ github.token }}
           script: |
             const pr = context.payload.pull_request;
             if (!pr) {

--- a/.github/workflows/repository-rules.yml
+++ b/.github/workflows/repository-rules.yml
@@ -86,7 +86,7 @@ jobs:
       - name: 检查维护者审批数量
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.NPU_CI_BOT_TOKEN || github.token }}
+          github-token: ${{ github.token }}
           script: |
             const pr = context.payload.pull_request;
             if (!pr) {


### PR DESCRIPTION
## Summary
- Use the workflow `github.token` for status-writing github-script steps
- Ensure job-level `permissions: statuses: write` applies to commit status updates
- Avoid a configured `NPU_CI_BOT_TOKEN` without status permission shadowing `github.token`

## Verification
- `git diff --check`
- Parsed workflow YAML files with PyYAML