### PR TITLE
Fix review gate for fork PRs

### DIFF
--- a/.github/workflows/repository-rules.yml
+++ b/.github/workflows/repository-rules.yml
@@ -76,39 +76,23 @@ jobs:
             });
 
   required-reviewers:
-    name: 维护者检视状态更新
+    name: 仓库规则 / 维护者检视门禁
     if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
-      statuses: write
     steps:
       - name: 检查维护者审批数量
         uses: actions/github-script@v7
         with:
-          github-token: ${{ github.token }}
           script: |
             const pr = context.payload.pull_request;
             if (!pr) {
               core.notice('没有找到 Pull Request 事件信息。');
               return;
             }
-            const contextName = '仓库规则 / 维护者检视门禁';
-            const targetUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const setGateStatus = async (state, description) => {
-              await github.rest.repos.createCommitStatus({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                sha: pr.head.sha,
-                state,
-                context: contextName,
-                description,
-                target_url: targetUrl,
-              });
-            };
             if (pr.draft) {
-              await setGateStatus('pending', '等待 PR 标记为 ready for review');
-              core.notice('草稿 PR 暂不检查检视门禁，标记为 ready for review 后再检查。');
+              core.setFailed('等待 PR 标记为 ready for review');
               return;
             }
 
@@ -211,10 +195,8 @@ jobs:
                 reasons.push('等待 @weinachuan ABI 审批');
               }
               const description = reasons.join('；').slice(0, 140);
-              await setGateStatus('pending', description);
-              core.notice(description);
+              core.setFailed(description);
               return;
             }
 
-            await setGateStatus('success', '维护者审批门禁通过');
             core.notice('维护者审批门禁通过。');


### PR DESCRIPTION
## Summary
- Stop posting the maintainer review gate through the Commit Status API
- Use the trusted Actions job result as the gate for fork PRs
- Keep the check name aligned with the existing gate context: `???? / ???????`

## Why
Fork PR head commits can reject manual `POST /statuses/{sha}` calls from the base repo `GITHUB_TOKEN` with `Resource not accessible by integration`. The workflow can still publish its own Actions check, so the gate now fails or passes through the job conclusion instead of a manual commit status.

## Verification
- `git diff --check`
- Parsed `.github/workflows/repository-rules.yml` with PyYAML