### PR TITLE
Auto-select CI TMPDIR by free space

### DIFF
--- a/ci/run_checks.sh
+++ b/ci/run_checks.sh
@@ -4,6 +4,83 @@ set -euo pipefail
 repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_dir"
 
+select_ci_tmpdir() {
+    local min_free_kb="${CI_TMPDIR_MIN_KB:-65536}"
+    local candidates=()
+
+    if [[ -n "${CI_TMPDIR:-}" ]]; then
+        candidates=("$CI_TMPDIR")
+    elif [[ -n "${CI_TMPDIR_CANDIDATES:-}" ]]; then
+        local old_ifs="$IFS"
+        IFS=':'
+        read -r -a candidates <<< "$CI_TMPDIR_CANDIDATES"
+        IFS="$old_ifs"
+    else
+        [[ -n "${TMPDIR:-}" ]] && candidates+=("$TMPDIR")
+        candidates+=("$repo_dir/.ci-tmp")
+
+        local root
+        for root in /workspace /mnt /home /tmp /var/tmp; do
+            [[ -d "$root" ]] && candidates+=("$root/fla-npu-ci-tmp")
+        done
+
+        local mount
+        for mount in /mnt/*; do
+            [[ -d "$mount" ]] && candidates+=("$mount/fla-npu-ci-tmp")
+        done
+    fi
+
+    local best_dir=""
+    local best_free_kb=-1
+    local candidate
+    local -A seen=()
+    local checked=()
+
+    for candidate in "${candidates[@]}"; do
+        [[ -n "$candidate" ]] || continue
+        if [[ -n "${seen[$candidate]:-}" ]]; then
+            continue
+        fi
+        seen["$candidate"]=1
+
+        if ! mkdir -p "$candidate" 2>/dev/null; then
+            checked+=("$candidate=create-failed")
+            continue
+        fi
+        if [[ ! -w "$candidate" ]]; then
+            checked+=("$candidate=not-writable")
+            continue
+        fi
+
+        local free_kb
+        free_kb="$(df -Pk "$candidate" 2>/dev/null | awk 'NR == 2 { print $4 }')"
+        if [[ ! "$free_kb" =~ ^[0-9]+$ ]]; then
+            checked+=("$candidate=df-failed")
+            continue
+        fi
+        checked+=("$candidate=${free_kb}KB")
+        if (( free_kb > best_free_kb )); then
+            best_dir="$candidate"
+            best_free_kb="$free_kb"
+        fi
+    done
+
+    if [[ -z "$best_dir" ]]; then
+        echo "[CI][ERROR] No writable TMPDIR candidate found. Checked: ${checked[*]:-<none>}" >&2
+        return 1
+    fi
+    if (( best_free_kb < min_free_kb )); then
+        echo "[CI][ERROR] No TMPDIR candidate has at least ${min_free_kb} KB free. Checked: ${checked[*]}" >&2
+        return 1
+    fi
+
+    echo "$best_dir"
+}
+
+ci_tmpdir="$(select_ci_tmpdir)"
+export TMPDIR="$ci_tmpdir"
+echo "[CI] TMPDIR=$TMPDIR ($(df -h "$TMPDIR" | awk 'NR == 2 { print $4 " free" }'))"
+
 bash ci/cleanup_ci_logs.sh
 
 if [[ -f /usr/local/Ascend/ascend-toolkit/latest/set_env.sh ]]; then

--- a/ci/run_ci_container.sh
+++ b/ci/run_ci_container.sh
@@ -123,6 +123,7 @@ done
 
 echo "[CI] Running $container_name on NPU ${NPU_SELECTED_DEVICE} (${NPU_SELECTED_NAME}, health=${NPU_SELECTED_HEALTH}, free=${NPU_SELECTED_FREE})"
 echo "[CI] third_party cache: $third_party_cache"
+echo "[CI] container TMPDIR: ${CI_TMPDIR:-auto}"
 
 docker run --rm \
     --name "$container_name" \
@@ -153,5 +154,8 @@ docker run --rm \
     -e CI_EXAMPLE_CASES_FILE="${CI_EXAMPLE_CASES_FILE:-ci/example_st_cases.json}" \
     -e CI_EXAMPLE_CASE_FILTER="${CI_EXAMPLE_CASE_FILTER:-}" \
     -e CI_TEST_OP="${CI_TEST_OP:-}" \
+    -e CI_TMPDIR="${CI_TMPDIR:-}" \
+    -e CI_TMPDIR_CANDIDATES="${CI_TMPDIR_CANDIDATES:-}" \
+    -e CI_TMPDIR_MIN_KB="${CI_TMPDIR_MIN_KB:-}" \
     "$image" \
     bash ci/run_checks.sh


### PR DESCRIPTION
## Summary
- Auto-select a CI `TMPDIR` from writable candidates by free disk space
- Include existing `/workspace`, `/mnt`, `/mnt/*`, `/home`, `/tmp`, and `/var/tmp` locations as automatic candidates
- Skip missing or unwritable candidate paths instead of failing because they do not exist
- Add overrides through `CI_TMPDIR`, `CI_TMPDIR_CANDIDATES`, and `CI_TMPDIR_MIN_KB`

## Why
The custom OPP `.run` installer may fail when its temp directory resolves to a full filesystem such as `/root`. CI should adapt to the runner/container disk layout instead of assuming a fixed path.

## Verification
- `git diff --check`
- `bash -n ci/run_checks.sh ci/run_ci_container.sh`