### PR TITLE
fix: avoid Triton L2Norm recompiles for dynamic lengths

### DIFF
--- a/docs/triton-l2norm-compile-cache.md
+++ b/docs/triton-l2norm-compile-cache.md
@@ -1,0 +1,187 @@
+# Triton L2Norm 重复编译问题记录
+
+本文记录 `examples/flash_gated_delta_rule.py` 中 Q/K L2Norm Triton 实现的重复编译问题、根因、修复策略、验证方法和后续设计原则。
+
+## 背景
+
+`examples/flash_gated_delta_rule.py` 在 `use_qk_l2norm_in_kernel=True` 时会在 forward 中调用：
+
+- `l2norm_fwd(q)`
+- `l2norm_fwd(k)`
+
+并在 backward 中调用：
+
+- `l2norm_bwd(q, q_rstd, dq)`
+- `l2norm_bwd(k, k_rstd, dk)`
+
+这些实现位于 `fla/ops/triton/triton_core/l2norm.py`。在变长序列或多组不同 token 数的场景中，原实现会随 `T` 变化反复触发 Triton 编译/autotune，导致 CPU host 侧编译开销明显，整体表现为 host bound。
+
+参考资料：
+
+- [triton-lang/triton#5000](https://github.com/triton-lang/triton/issues/5000)
+- [Ascend/MindSpeed-MM#2655](https://gitcode.com/Ascend/MindSpeed-MM/pull/2655/diffs)
+
+## 现象
+
+原 L2Norm 路径使用了类似下面的模式：
+
+```python
+@triton.autotune(..., key=['D', 'NB'])
+@triton.jit
+def l2norm_fwd_kernel(..., T: tl.constexpr, D: tl.constexpr, BD: tl.constexpr, NB: tl.constexpr, ...):
+    ...
+```
+
+其中：
+
+- `T` 是 flatten 后的 token 数，即 `x.view(-1, x.shape[-1]).shape[0]`。
+- `NB = triton.cdiv(T, 2048)`，同样会随 `T` 变化。
+- `T: tl.constexpr` 会把序列长度写入 Triton 编译期特化参数。
+- `NB` 进入 autotune key 后，不同长度会形成不同 autotune cache key。
+
+因此在 `T=1024, 1536, 2048, ...` 等输入之间切换时，即使 `D` 没变，也可能产生新的 Triton 编译版本。训练或推理端会反复等待 host 编译，NPU 侧不能持续吃满。
+
+## 根因
+
+Triton 的 JIT 编译缓存并不只按 Python 函数名命中。缓存 key 会包含 kernel 源/IR、目标后端、dtype/stride/alignment 等调用信息，以及编译期常量和 meta 参数，例如 `tl.constexpr`、`BLOCK_SIZE`、`num_warps`、`num_stages`、autotune config 和 autotune key。
+
+`tl.constexpr` 的语义是“这个值属于编译期”。它可以让 Triton 做静态 shape 推导、循环展开、常量折叠和更激进的后端优化，但代价是该值变化时需要一个新的特化版本。这个机制本身是正确的：tile 大小、feature dim、是否使用某条静态分支等参数通常就应该成为编译期常量。
+
+本算子的问题在于，`T` 只是实际 token 数，主要用于边界检查和 block pointer 的 runtime shape，并不是决定核心计算 tile 形状的稳定参数。把它设为 `tl.constexpr` 后，变长序列中的高频变化值进入编译缓存维度；再叠加 `NB = f(T)` 进入 autotune key，就会把同一个 `D` 下的不同 `T` 扩散成多个编译版本。
+
+因此更合理的特化维度应该是：
+
+- `D`
+- `BD = next_power_of_2(D)`
+- `BT`
+- dtype、layout、目标后端等真实影响 kernel 代码形态的因素
+
+而不是动态 token 数 `T`，也不是从 `T` 推导出的 `NB`。
+
+MindSpeed-MM PR #2655 的核心方向是删除 L2Norm 的 autotune，并显式传入固定 `BT`，避免 `NB` 和 autotune key 组合引入额外编译。这个方向是正确的。本仓需要保留对不同 `D` 的泛化能力，因此没有把 forward/backward 永久写死成单个 `BT`，而是用稳定的 `D/BD` 选择 `BT`。
+
+## Triton 后端设计原则
+
+### 1. 区分算法动态量和编译特化量
+
+动态量是每次调用都会变的运行时数据，例如实际 token 数、batch 内有效长度、chunk 数、mask 边界等。这些值如果只影响边界判断和 pointer offset，应尽量作为 runtime scalar 传入。
+
+编译特化量是决定 kernel 代码形态的参数，例如 block size、tile shape、静态分支、向量宽度、feature dim 上界、pipeline stage 等。这些值变化后通常确实需要新的编译版本。
+
+### 2. `tl.constexpr` 只用于真正需要静态化的值
+
+`tl.constexpr` 能换来更好的后端优化，但它会进入编译缓存维度。对于变长输入，不能为了写法方便就把 `T`、`N_CTX`、`num_blocks` 这类高频变化值标成 `tl.constexpr`。
+
+如果某个 scalar 需要传给 kernel，但不希望它参与特化，可以使用：
+
+```python
+@triton.jit(do_not_specialize=['T'])
+```
+
+这样 `T` 仍可用于 runtime 边界判断，但不会因为 `T` 的不同值生成新的 Triton 编译版本。
+
+### 3. Autotune key 必须稳定且必要
+
+`@triton.autotune(key=[...])` 的 key 应只包含会改变最优 config 的稳定参数。把 `T` 或 `NB = f(T)` 放进 key，会导致 autotune 结果和编译缓存按动态长度拆分。
+
+对于轻量 kernel 或者目标平台上 config 空间很小的 kernel，删除 autotune 并使用清晰的启发式通常更稳。这样既减少首次运行开销，也避免动态 shape 扩散缓存。
+
+### 4. Tile 不能只按吞吐扩大
+
+更大的 `BT` 通常能减少 program 数或提高数据复用，但也会增加 UB、寄存器、临时张量和后端调度压力。Ascend 后端对片上缓冲区有明确容量约束；当 tile 过大时，kernel 可能在后端编译阶段失败，而不是运行阶段才暴露。
+
+因此 `BT` 的选择需要同时满足：
+
+- 同一 `D` 下改变 `T` 不改变 `BT`。
+- `D` 增大时能自动降低 `BT`。
+- forward/backward 分别设置上限，因为 backward 通常有更多中间量和归约开销。
+- 在目标后端上验证编译可行性，而不是只看 Python 侧公式。
+
+### 5. 缓存验证应关注“是否产生新特化”
+
+验证这种问题时，关键不是缓存目录里具体有多少文件，而是同一稳定特化维度下，改变动态量是否会生成新的编译产物。建议使用隔离的 Triton 编译缓存目录做 focused test：每个 `D` 的第一个 `T` 允许产生首次编译，第二个不同 `T` 不应继续产生新的特化版本。
+
+公开记录里只保留验证结论和覆盖范围，避免把内部机器、镜像、路径、缓存文件数等环境细节写入 issue/PR。
+
+## 修复策略
+
+当前修复采用四条原则：
+
+1. 删除 L2Norm kernel 上的 `@triton.autotune`。
+2. 对 forward/backward kernel 使用 `@triton.jit(do_not_specialize=['T'])`，让 `T` 作为运行时参数传入。
+3. 移除由 `T` 推导出的 `NB` 特化参数。
+4. `BT` 只依赖 `BD` 和安全上限，不依赖 `T`。
+
+当前选择逻辑：
+
+```python
+BT_LIST = (8, 16, 32, 64, 128)
+FWD_TARGET_BLOCK_ELEMENTS = 8 * 1024
+BWD_TARGET_BLOCK_ELEMENTS = 8 * 1024
+FWD_MAX_BT = 32
+BWD_MAX_BT = 64
+
+def _select_l2norm_bt(bd: int, target_block_elements: int, max_bt: int) -> int:
+    max_bt_by_size = max(1, target_block_elements // max(1, int(bd)))
+    max_bt = min(int(max_bt), max_bt_by_size)
+    candidates = [bt for bt in BT_LIST if bt <= max_bt]
+    return candidates[-1] if candidates else BT_LIST[0]
+```
+
+映射示例：
+
+| `BD` | forward `BT` | backward `BT` |
+| ---: | ---: | ---: |
+| 16 | 32 | 64 |
+| 32 | 32 | 64 |
+| 64 | 32 | 64 |
+| 128 | 32 | 64 |
+| 256 | 32 | 32 |
+| 512 | 16 | 16 |
+
+这不是按单个 shape 写死，而是按 feature dim 做稳定启发式选择。它满足：
+
+- 同一个 `D` 下改变 `T` 不会改变 `BT`。
+- `D` 增大时自动降低 `BT`，避免片上缓存使用过大。
+- `D=128` 的主路径仍对应参考修复中的 `32/64` 配置。
+- forward 固定上限为 `BT=32`，backward 固定上限为 `BT=64`，同时保留大 `D` 场景下自动收缩的泛化能力。
+
+## 验证
+
+### 静态检查
+
+本地执行：
+
+```bash
+python -m py_compile fla/ops/triton/triton_core/l2norm.py
+python -m py_compile examples/flash_gated_delta_rule.py fla/ops/triton/triton_core/l2norm.py
+git diff --check
+```
+
+### Focused cache 验证
+
+在 Ascend NPU 验证环境中使用隔离的 Triton 编译缓存，对同一个 `D` 连续运行两个不同 `T`。预期是每个 `D` 的第一个 `T` 允许产生首次编译，第二个 `T` 不应新增编译特化。
+
+覆盖结果：
+
+| `D` | 覆盖的 `T` 变化 | 结果 |
+| ---: | --- | --- |
+| 64 | 两个不同 token 长度 | 通过；第二个长度未产生新的编译特化 |
+| 128 | 两个不同 token 长度 | 通过；第二个长度未产生新的编译特化 |
+| 512 | 两个不同 token 长度 | 通过；第二个长度未产生新的编译特化 |
+| 768 | 两个不同 token 长度 | 通过；第二个长度未产生新的编译特化 |
+
+同时确认 forward/backward 输出均为 finite。
+
+### Example/ST 验证
+
+在 Ascend NPU 验证环境中执行 quick build，并运行小 shape 的 `examples/flash_gated_delta_rule.py` Example/ST。该流程完成 quick build、custom OPP 安装、`fla_npu` 构建和 Example/ST，退出码为 0。
+
+## 后续维护建议
+
+1. 新增 Triton kernel 时，先判断参数是算法动态量还是编译特化量。
+2. 避免把动态 token 数、batch 内实际长度、chunk 数等高频变化值标成 `tl.constexpr`。
+3. `@triton.autotune` 的 `key` 只放真正决定最优 config 的稳定参数，不要放由 `T` 推导出的 `NB`。
+4. 需要运行时 scalar 且不希望参与特化时，优先考虑 `@triton.jit(do_not_specialize=[...])`。
+5. 选择 `BT` 时同时考虑吞吐和后端片上缓存约束；forward/backward 分开设上限，并覆盖大 `D` 场景。
+6. 对变长场景增加 focused cache 验证，确认同一稳定特化维度下改变动态量不会新增编译版本。

--- a/fla/ops/triton/triton_core/l2norm.py
+++ b/fla/ops/triton/triton_core/l2norm.py
@@ -5,19 +5,23 @@ import torch.nn as nn
 import triton
 import triton.language as tl
 
-from .utils import input_guard, is_amd
-
-BT_LIST = [8, 16, 32, 64, 128]
-NUM_WARPS_AUTOTUNE = [1, 2, 4, 8, 16] if is_amd else [1, 2, 4, 8, 16, 32]
+from .utils import input_guard
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=num_warps)
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
-    key=['D']
-)
+BT_LIST = (8, 16, 32, 64, 128)
+FWD_TARGET_BLOCK_ELEMENTS = 8 * 1024
+BWD_TARGET_BLOCK_ELEMENTS = 8 * 1024
+FWD_MAX_BT = 32
+BWD_MAX_BT = 64
+
+
+def _select_l2norm_bt(bd: int, target_block_elements: int, max_bt: int) -> int:
+    max_bt_by_size = max(1, target_block_elements // max(1, int(bd)))
+    max_bt = min(int(max_bt), max_bt_by_size)
+    candidates = [bt for bt in BT_LIST if bt <= max_bt]
+    return candidates[-1] if candidates else BT_LIST[0]
+
+
 @triton.jit
 def l2norm_fwd_kernel1(
     x,
@@ -41,13 +45,6 @@ def l2norm_fwd_kernel1(
     tl.store(rstd + i_t, b_rstd)
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=num_warps)
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
-    key=['D']
-)
 @triton.jit
 def l2norm_bwd_kernel1(
     y,
@@ -72,24 +69,15 @@ def l2norm_bwd_kernel1(
     tl.store(dx + cols, b_dx, mask=mask)
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({'BT': BT}, num_warps=num_warps)
-        for num_warps in [1, 2, 4, 8, 16]
-        for BT in BT_LIST
-    ],
-    key=['D', 'NB']
-)
-@triton.jit
+@triton.jit(do_not_specialize=['T'])
 def l2norm_fwd_kernel(
     x,
     y,
     rstd,
     eps,
-    T: tl.constexpr,
+    T,
     D: tl.constexpr,
     BD: tl.constexpr,
-    NB: tl.constexpr,
     BT: tl.constexpr,
     bt_size,
 ):
@@ -109,45 +97,22 @@ def l2norm_fwd_kernel(
             tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), boundary_check=(0,))
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({'BT': BT}, num_warps=num_warps)
-        for num_warps in [1, 2, 4, 8, 16]
-        for BT in BT_LIST
-    ],
-    key=['D', 'NB']
-)
-@triton.jit
+@triton.jit(do_not_specialize=['T'])
 def l2norm_bwd_kernel(
     y,
     rstd,
     dy,
     dx,
     eps,
-    T: tl.constexpr,
+    T,
     D: tl.constexpr,
     BD: tl.constexpr,
-    NB: tl.constexpr,
     BT: tl.constexpr,
     bt_size,
 ):
-    i_t_start = tl.program_id(0)
-    num_blocks = bt_size
-
-    total_i_t = T // BT
-    base_tasks_per_block = total_i_t // num_blocks
-    remainder_tasks = total_i_t % num_blocks
-
-    if i_t_start < remainder_tasks:
-        tasks_this_block = base_tasks_per_block + 1
-        start_i_t = i_t_start * tasks_this_block
-    else:
-        tasks_this_block = base_tasks_per_block
-        start_i_t = i_t_start * base_tasks_per_block + remainder_tasks
-
-    for task_idx in range(tasks_this_block):
-        i_t = start_i_t + task_idx
-        block_start = i_t * BT
+    i_t = tl.program_id(0)
+    for offset in range(0, bt_size):
+        block_start = (i_t * bt_size + offset) * BT
         if block_start < T:
             p_y = tl.make_block_ptr(y, (T, D), (D, 1), (block_start, 0), (BT, BD), (1, 0))
             p_rstd = tl.make_block_ptr(rstd, (T,), (1,), (block_start,), (BT,), (0,))
@@ -183,7 +148,7 @@ def l2norm_fwd(
 
     rstd = torch.empty((T,), dtype=torch.float32, device=x.device)
     if D <= 512:
-        NB = triton.cdiv(T, 2048)
+        BT = _select_l2norm_bt(BD, FWD_TARGET_BLOCK_ELEMENTS, FWD_MAX_BT)
         bt_size = 32
 
         def grid(meta):
@@ -198,7 +163,7 @@ def l2norm_fwd(
             T=T,
             D=D,
             BD=BD,
-            NB=NB,
+            BT=BT,
             bt_size=bt_size,
         )
     else:
@@ -233,9 +198,14 @@ def l2norm_bwd(
         raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
 
     if D <= 512:
-        NB = triton.cdiv(T, 2048)
+        BT = _select_l2norm_bt(BD, BWD_TARGET_BLOCK_ELEMENTS, BWD_MAX_BT)
         bt_size = 40
-        l2norm_bwd_kernel[(bt_size,)](
+
+        def grid(meta):
+            new_bt = meta['BT'] * bt_size
+            return (triton.cdiv(T, new_bt), )
+
+        l2norm_bwd_kernel[grid](
             y=y,
             rstd=rstd,
             dy=dy,
@@ -244,7 +214,7 @@ def l2norm_bwd(
             T=T,
             D=D,
             BD=BD,
-            NB=NB,
+            BT=BT,
             bt_size=bt_size,
         )
     else:


### PR DESCRIPTION
## 关联 Issue / 背景

- 关联 Issue: #41
- 背景与目标: `examples/flash_gated_delta_rule.py` 的 Q/K L2Norm Triton 路径在变长 `T` 场景下会重复生成编译/autotune 版本，导致 host bound。
- 本 PR 解决的问题: 去掉动态 token 数 `T` 和由 `T` 派生的 `NB` 对 Triton 编译缓存的影响，使同一 `D` 下改变 `T` 不再新增编译特化。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [x] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: Triton L2Norm (`l2norm_fwd`, `l2norm_bwd`)
- 涉及目录 / 文件:
  - `fla/ops/triton/triton_core/l2norm.py`
  - `docs/triton-l2norm-compile-cache.md`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [x] `Triton` 算子
  - [ ] 单算子测试
  - [x] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不改变公开接口、shape、dtype 或 format 支持范围。
- 明确不包含的范围: 不修改 GDN 主算法、不修改 Ascend C kernel、不修改 torch_custom ABI。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无。

## 验证方法

### 1. 静态检查

```sh
python -m py_compile fla/ops/triton/triton_core/l2norm.py examples/flash_gated_delta_rule.py
git diff --check
```

结果: 通过。

### 2. Focused cache 验证

在 Ascend NPU 验证环境中使用隔离编译缓存，对同一个 `D` 连续运行两个不同 `T`。验证目标是：每个 `D` 的第一个 `T` 允许产生首次编译，第二个 `T` 不应新增编译特化。

覆盖范围:

| `D` | `T` 变化 | 结果 |
| ---: | --- | --- |
| 64 | 两个不同 token 长度 | 通过；第二个长度未新增编译特化 |
| 128 | 两个不同 token 长度 | 通过；第二个长度未新增编译特化 |
| 512 | 两个不同 token 长度 | 通过；第二个长度未新增编译特化 |
| 768 | 两个不同 token 长度 | 通过；第二个长度未新增编译特化 |

同时确认 forward/backward 输出均为 finite。

### 3. 整体 Example/ST 验证

在 Ascend NPU 验证环境中执行 quick build，并运行小 shape 的 `examples/flash_gated_delta_rule.py` Example/ST。

结果: quick build、custom OPP 安装、`fla_npu` 构建和 Example/ST 均通过，退出码为 0。

## 修改算子测试结果

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | CANN 8.5 family | quick build + focused cache + Example/ST | 通过 | 内部验证环境通过 |
| A3 | `ascend910_93` | - | 未执行 | 未执行 | 当前无可用环境 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | - | 未执行 | 未执行 | 本 PR 验证基于 CANN 8.5 family |
| A3 | `ascend910_93` | - | 未执行 | 未执行 | 当前无可用环境 |
| A5 | `ascend950` | - | 未执行 | 未执行 | 当前无可用环境 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | focused cache L2Norm forward/backward 验证 | 通过 | 输出 finite；同一 `D` 下第二个 `T` 未新增编译特化 |
| A3 | `ascend910_93` | 未执行 | 未执行 | 当前无可用环境 |
| A5 | `ascend950` | 未执行 | 未执行 | 当前无可用环境 |

- 精度对比: focused cache 验证中 forward/backward 输出 finite；本 PR 不改变数学公式。
- 性能对比: 目标是减少同一 `D` 下不同 `T` 触发的 host 编译开销。
- 边界 / 异常场景: 覆盖小 `D` 和较大 `D`；`BT` 随 `BD` 自动收缩，forward 上限 `32`，backward 上限 `64`。
- 未覆盖风险: A3/A5 环境未执行，需要后续 CI 或维护者环境补充。

## 整体 Example ST 验证

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | quick build + `examples/flash_gated_delta_rule.py` 小 shape Example/ST | 通过 | 端到端执行成功，退出码 0 |
| A3 | `ascend910_93` | 未执行 | 未执行 | 当前无可用环境 |
| A5 | `ascend950` | 未执行 | 未执行 | 当前无可用环境 |

- 端到端场景说明: 验证 `use_qk_l2norm_in_kernel=True` 相关 L2Norm 调用链。
- 与本 PR 修改算子的关联: forward/backward 都会经过 `l2norm.py` 中的 Triton L2Norm kernel。
- 未覆盖原因及补充计划: A3/A5 需等待对应 NPU CI 或维护者环境补充。

## 兼容性、风险与回退

- 兼容性说明: Python API、tensor shape、dtype、返回值均不变。
- 风险点: `BT` 启发式会影响 Triton kernel tile 选择；已在 A2 类环境覆盖多个 `D`，但新芯片或更大 `D` 仍建议补充 focused cache 验证。
- 回退方案: 回退本 PR 即可恢复原 L2Norm Triton 实现。
- 回退责任确认:
  - [x] 若本 PR 未满足准入要求或引入 bug，PR 提交人承诺第一时间回退或配合维护者完成回退

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

新增 `docs/triton-l2norm-compile-cache.md`，记录 Triton 后端为什么会因 `tl.constexpr` / autotune key 产生动态长度特化，以及后续新增 Triton kernel 时的设计原则。