### PR TITLE
feat(recompute_wu_fwd): 支持 GVA 与 V=256，统一 N=256 tile 并兼容 Ascend950 构建

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/CMakeLists.txt
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/CMakeLists.txt
@@ -23,7 +23,7 @@ if("${ASCEND_COMPUTE_UNIT}" STREQUAL "ascend950")
     add_ops_compile_options(
         OP_NAME RecomputeWUFwd
         --cce-auto-sync=off
-        COMPUTE_UNIT ascend950PR_9599
+        COMPUTE_UNIT Ascend950PR_9599
         OPTIONS -mllvm -cce-aicore-dcci-before-kernel-end=false
     )
 endif()

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling.cpp
@@ -59,7 +59,9 @@ class RecomputeWUFwdTilingProcessor {
     gert::TilingContext *context_;
     RecomputeWUFwdTilingData &tiling_;
     int64_t B = 0;
-    int64_t H = 0;
+    int64_t Hk = 0;
+    int64_t Hv = 0;
+    int64_t hvPerHk = 1;
     int64_t K = 0;
     int64_t V = 0;
     int64_t T = 0;
@@ -195,28 +197,79 @@ public:
         const gert::Shape betaStorageShape = context_->GetRequiredInputShape(INPUT_BETA_IDX)->GetStorageShape();
         const gert::Shape AStorageShape = context_->GetRequiredInputShape(INPUT_A_IDX)->GetStorageShape();
         const gert::Shape gStorageShape = context_->GetRequiredInputShape(INPUT_G_IDX)->GetStorageShape();
-        OP_CHECK_IF(CompareShape(vStorageShape, kStorageShape, INPUT_V_NAME, INPUT_K_NAME, DIM_NUM_3) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
+        B = static_cast<int64_t>(vStorageShape.GetDim(DIM_0));
+        Hk = static_cast<int64_t>(kStorageShape.GetDim(DIM_1));
+        Hv = static_cast<int64_t>(vStorageShape.GetDim(DIM_1));
+        OP_CHECK_IF(Hk <= 0 || Hv <= 0,
+                    OP_LOGE(context_->GetNodeName(),
+                            "Invalid head dim: Hk and Hv must be positive, but got Hk=%ld, Hv=%ld.", Hk, Hv),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(Hv % Hk != 0,
+                    OP_LOGE(context_->GetNodeName(),
+                            "GVA check: Hv must be divisible by Hk, but got Hk=%ld, Hv=%ld.", Hk, Hv),
+                    return ge::GRAPH_FAILED);
+        hvPerHk = Hv / Hk;
+        OP_CHECK_IF(vStorageShape.GetDim(DIM_0) != kStorageShape.GetDim(DIM_0),
+                    OP_LOGE(context_->GetNodeName(),
+                            "Compare B: v B=%ld vs k B=%ld mismatch.",
+                            vStorageShape.GetDim(DIM_0), kStorageShape.GetDim(DIM_0)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(vStorageShape.GetDim(DIM_2) != kStorageShape.GetDim(DIM_2),
+                    OP_LOGE(context_->GetNodeName(),
+                            "Compare T: v T=%ld vs k T=%ld mismatch.",
+                            vStorageShape.GetDim(DIM_2), kStorageShape.GetDim(DIM_2)),
+                    return ge::GRAPH_FAILED);
         OP_CHECK_IF(CompareShape(betaStorageShape, gStorageShape, INPUT_BETA_NAME, INPUT_G_NAME, DIM_NUM_3) !=
                         ge::GRAPH_SUCCESS,
                     , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(CompareShape(kStorageShape, gStorageShape, INPUT_K_NAME, INPUT_G_NAME, DIM_NUM_3) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(CompareShape(kStorageShape, AStorageShape, INPUT_K_NAME, INPUT_A_NAME, DIM_NUM_3) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        B = static_cast<int64_t>(vStorageShape.GetDim(DIM_0));
-        H = static_cast<int64_t>(vStorageShape.GetDim(DIM_1));
+        OP_CHECK_IF(kStorageShape.GetDim(DIM_0) != gStorageShape.GetDim(DIM_0),
+                    OP_LOGE(context_->GetNodeName(),
+                            "Compare B: k B=%ld vs g B=%ld mismatch.",
+                            kStorageShape.GetDim(DIM_0), gStorageShape.GetDim(DIM_0)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(kStorageShape.GetDim(DIM_2) != gStorageShape.GetDim(DIM_2),
+                    OP_LOGE(context_->GetNodeName(),
+                            "Compare T: k T=%ld vs g T=%ld mismatch.",
+                            kStorageShape.GetDim(DIM_2), gStorageShape.GetDim(DIM_2)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(kStorageShape.GetDim(DIM_0) != AStorageShape.GetDim(DIM_0),
+                    OP_LOGE(context_->GetNodeName(),
+                            "Compare B: k B=%ld vs A B=%ld mismatch.",
+                            kStorageShape.GetDim(DIM_0), AStorageShape.GetDim(DIM_0)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(kStorageShape.GetDim(DIM_2) != AStorageShape.GetDim(DIM_2),
+                    OP_LOGE(context_->GetNodeName(),
+                            "Compare T: k T=%ld vs A T=%ld mismatch.",
+                            kStorageShape.GetDim(DIM_2), AStorageShape.GetDim(DIM_2)),
+                    return ge::GRAPH_FAILED);
+        // A/beta/g 的 head 维必须等于 Hv（kernel 按 for h<Hv 索引这三个输入），否则会越界读
+        OP_CHECK_IF(AStorageShape.GetDim(DIM_1) != Hv,
+                    OP_LOGE(context_->GetNodeName(),
+                            "Compare head: A H=%ld must equal Hv=%ld.", AStorageShape.GetDim(DIM_1), Hv),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(betaStorageShape.GetDim(DIM_1) != Hv,
+                    OP_LOGE(context_->GetNodeName(),
+                            "Compare head: beta H=%ld must equal Hv=%ld.", betaStorageShape.GetDim(DIM_1), Hv),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(gStorageShape.GetDim(DIM_1) != Hv,
+                    OP_LOGE(context_->GetNodeName(),
+                            "Compare head: g H=%ld must equal Hv=%ld.", gStorageShape.GetDim(DIM_1), Hv),
+                    return ge::GRAPH_FAILED);
         T = static_cast<int64_t>(vStorageShape.GetDim(DIM_2));
         K = static_cast<int64_t>(kStorageShape.GetDim(DIM_3));
         V = static_cast<int64_t>(vStorageShape.GetDim(DIM_3));
         tiling_.set_B(B);
-        tiling_.set_H(H);
+        tiling_.set_Hk(Hk);
+        tiling_.set_Hv(Hv);
+        tiling_.set_hvPerHk(hvPerHk);
         tiling_.set_T(T);
         tiling_.set_K(K);
         tiling_.set_V(V);
+        OP_CHECK_IF(V != V_DIM_128 && V != V_DIM_256,
+                    OP_LOGE(context_->GetNodeName(),
+                            "Check value dim V failed: only %ld or %ld is supported, but get %ld.",
+                            V_DIM_128, V_DIM_256, V),
+                    return ge::GRAPH_FAILED);
         auto attrPtr = context_->GetAttrs();
         OP_CHECK_NULL_WITH_CONTEXT(context_, attrPtr);
         chunkSize = static_cast<int64_t>(*(attrPtr->GetAttrPointer<int32_t>(ATTR_CHUNK_SIZE_IDX)));
@@ -326,11 +379,15 @@ static void RecomputeWUFwdTilingDataPrint(gert::TilingContext *context, Recomput
     auto nodeName = context->GetNodeName();
     OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Start to print RecomputeWUFwd tiling data <<<<<<<<<<<<<<<<");
     OP_LOGD(nodeName, "=== B: %ld", tiling.get_B());
-    OP_LOGD(nodeName, "=== H: %ld", tiling.get_H());
+    OP_LOGD(nodeName, "=== Hk: %ld", tiling.get_Hk());
+    OP_LOGD(nodeName, "=== Hv: %ld", tiling.get_Hv());
+    OP_LOGD(nodeName, "=== hvPerHk: %ld", tiling.get_hvPerHk());
     OP_LOGD(nodeName, "=== T: %ld", tiling.get_T());
     OP_LOGD(nodeName, "=== K: %ld", tiling.get_K());
     OP_LOGD(nodeName, "=== V: %ld", tiling.get_V());
     OP_LOGD(nodeName, "=== chunkSize: %ld", tiling.get_chunkSize());
+    OP_LOGD(nodeName, "=== vbVecRow: %ld", tiling.get_vbVecRow());
+    OP_LOGD(nodeName, "=== kbgExpVecRow: %ld", tiling.get_kbgExpVecRow());
     OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Print RecomputeWUFwd tiling data end <<<<<<<<<<<<<<<<");
 }
 
@@ -358,8 +415,12 @@ ge::graphStatus Tiling4RecomputeWUFwd(gert::TilingContext *context)
         OP_CHECK_IF(processor.VariableLenTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
         tiling.set_isVariable(1);
     }
-    context->SetTilingKey(1);
-    OP_LOGD(context->GetNodeName(), "tilingKey: %d", context->GetTilingKey());
+    if (tiling.get_V() == V_DIM_256) {
+        context->SetTilingKey(2);
+    } else {
+        context->SetTilingKey(1);
+    }
+    OP_LOGD(context->GetNodeName(), "tilingKey: %d (V=%ld)", context->GetTilingKey(), tiling.get_V());
     RecomputeWUFwdTilingDataPrint(context, tiling);
 
     tiling.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
@@ -368,7 +429,7 @@ ge::graphStatus Tiling4RecomputeWUFwd(gert::TilingContext *context)
     context->SetBlockDim(ascendcPlatform.GetCoreNumAic());
 
     uint32_t sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
-    uint32_t userWorkspaceSize = 2 * tiling.get_B() * tiling.get_H() * tiling.get_T() * tiling.get_V();
+    uint32_t userWorkspaceSize = 2 * tiling.get_B() * tiling.get_Hv() * tiling.get_T() * tiling.get_V();
     size_t *currentWorkspace = context->GetWorkspaceSizes(1);
     currentWorkspace[0] = userWorkspaceSize + sysWorkspaceSize;
     context->SetScheduleMode(1); // set as batchmod for template using SyncAll

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling.h
@@ -22,9 +22,14 @@
 
 namespace optiling {
 
+static constexpr int64_t V_DIM_128 = 128;
+static constexpr int64_t V_DIM_256 = 256;
+
 BEGIN_TILING_DATA_DEF(RecomputeWUFwdTilingData)
 TILING_DATA_FIELD_DEF(int64_t, B);
-TILING_DATA_FIELD_DEF(int64_t, H);
+TILING_DATA_FIELD_DEF(int64_t, Hk);
+TILING_DATA_FIELD_DEF(int64_t, Hv);
+TILING_DATA_FIELD_DEF(int64_t, hvPerHk);
 TILING_DATA_FIELD_DEF(int64_t, T);
 TILING_DATA_FIELD_DEF(int64_t, K);
 TILING_DATA_FIELD_DEF(int64_t, V);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd.cpp
@@ -17,6 +17,9 @@
 #include "recompute_wu_fwd_cube.h"
 #include "recompute_wu_fwd_vector.h"
 
+template <class... Dims>
+using GemmCubeTileShape = tla::Shape<Dims...>;
+using namespace tla;
 
 using namespace AscendC;
 __global__ __aicore__ void recompute_wu_fwd(GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR g, GM_ADDR gk,
@@ -28,8 +31,39 @@ __global__ __aicore__ void recompute_wu_fwd(GM_ADDR k, GM_ADDR v, GM_ADDR beta, 
     if (TILING_KEY_IS(1)) {
         KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
         if ASCEND_IS_AIC {
-            RecomputeWUFwdProcess<DTYPE_K, DTYPE_BETA>recomputeWUFwdProcess(
+            RecomputeWUFwdProcess<DTYPE_K, DTYPE_BETA,
+                                  GemmCubeTileShape<_128, _128, _256>,
+                                  GemmCubeTileShape<_128, _128, _128>>
+                recomputeWUFwdProcess(
                 k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
+           recomputeWUFwdProcess.Init(tilingData);
+           recomputeWUFwdProcess.Process();
+        }
+        if ASCEND_IS_AIV {
+            AscendC::TPipe tPipe;
+            RecomputeWUFwdVectorProcess<DTYPE_K, DTYPE_BETA>recomputeWUFwdVectorProcess(
+                k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
+           recomputeWUFwdVectorProcess.Init(tilingData, &tPipe);
+           recomputeWUFwdVectorProcess.Process();
+        }
+    } else if (TILING_KEY_IS(2)) {
+        KERNEL_TASK_TYPE(2, KERNEL_TYPE_MIX_AIC_1_2);
+        if ASCEND_IS_AIC {
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+            // 950: 用参考算子同款 N=128 tile，V=256 由 cube.h 的 tileN 循环拆成 2 次 N=128
+            RecomputeWUFwdProcess<DTYPE_K, DTYPE_BETA,
+                                  GemmCubeTileShape<_128, _128, _256>,
+                                  GemmCubeTileShape<_128, _128, _128>>
+                recomputeWUFwdProcess(
+                k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
+#else
+            // 910B: 已验证的单次 N=256 tile
+            RecomputeWUFwdProcess<DTYPE_K, DTYPE_BETA,
+                                  GemmCubeTileShape<_128, _256, _256>,
+                                  GemmCubeTileShape<_128, _256, _64>>
+                recomputeWUFwdProcess(
+                k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
+#endif
            recomputeWUFwdProcess.Init(tilingData);
            recomputeWUFwdProcess.Process();
         }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd.cpp
@@ -49,21 +49,11 @@ __global__ __aicore__ void recompute_wu_fwd(GM_ADDR k, GM_ADDR v, GM_ADDR beta, 
     } else if (TILING_KEY_IS(2)) {
         KERNEL_TASK_TYPE(2, KERNEL_TYPE_MIX_AIC_1_2);
         if ASCEND_IS_AIC {
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
-            // 950: 用参考算子同款 N=128 tile，V=256 由 cube.h 的 tileN 循环拆成 2 次 N=128
-            RecomputeWUFwdProcess<DTYPE_K, DTYPE_BETA,
-                                  GemmCubeTileShape<_128, _128, _256>,
-                                  GemmCubeTileShape<_128, _128, _128>>
-                recomputeWUFwdProcess(
-                k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
-#else
-            // 910B: 已验证的单次 N=256 tile
             RecomputeWUFwdProcess<DTYPE_K, DTYPE_BETA,
                                   GemmCubeTileShape<_128, _256, _256>,
                                   GemmCubeTileShape<_128, _256, _64>>
                 recomputeWUFwdProcess(
                 k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
-#endif
            recomputeWUFwdProcess.Init(tilingData);
            recomputeWUFwdProcess.Process();
         }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd_cube.h
@@ -76,8 +76,10 @@ public:
         GM_ADDR ptrChunkIndices;
         uint64_t chunkNum;
         uint64_t B = 1;
+        uint64_t Hk = 1;
+        uint64_t Hv = 1;
+        uint64_t hvPerHk = 1;
         uint64_t T = 32768;
-        uint64_t H = 32;
         uint64_t K = 128;
         uint64_t V = 128;
         uint64_t chunkSize = 64;
@@ -90,13 +92,13 @@ public:
 
         CATLASS_DEVICE
         Params(GM_ADDR ptrA_, LayoutA layoutA_, GM_ADDR ptrVb_, LayoutVb layoutVb_, GM_ADDR ptrU_,
-               LayoutW layoutW_, GM_ADDR ptrKbgExp_, LayoutKbgExp layoutKbgExp_, GM_ADDR ptrW_, LayoutU layoutU_,
+               LayoutU layoutU_, GM_ADDR ptrKbgExp_, LayoutKbgExp layoutKbgExp_, GM_ADDR ptrW_, LayoutW layoutW_,
                GM_ADDR ptrCuSeqLens_, GM_ADDR ptrChunkIndices_, uint64_t chunkNum_, uint64_t B_,
-               uint64_t T_, uint64_t H_, uint64_t K_, uint64_t V_, uint64_t BT_)
+               uint64_t Hk_, uint64_t Hv_, uint64_t hvPerHk_, uint64_t T_, uint64_t K_, uint64_t V_, uint64_t BT_)
             : ptrA(ptrA_), layoutA(layoutA_), ptrVb(ptrVb_), layoutVb(layoutVb_), ptrU(ptrU_),
-              layoutW(layoutW_), ptrKbgExp(ptrKbgExp_), layoutKbgExp(layoutKbgExp_), ptrW(ptrW_), layoutU(layoutU_),
+              layoutU(layoutU_), ptrKbgExp(ptrKbgExp_), layoutKbgExp(layoutKbgExp_), ptrW(ptrW_), layoutW(layoutW_),
               ptrCuSeqLens(ptrCuSeqLens_), ptrChunkIndices(ptrChunkIndices_),
-              chunkNum(chunkNum_), B(B_), T(T_), H(H_), K(K_), V(V_), chunkSize(BT_)
+              chunkNum(chunkNum_), B(B_), Hk(Hk_), Hv(Hv_), hvPerHk(hvPerHk_), T(T_), K(K_), V(V_), chunkSize(BT_)
         {
         }
     };
@@ -125,31 +127,38 @@ public:
             AscendC::GlobalTensor<ElementVb> gmVb;
             AscendC::GlobalTensor<ElementU> gmU;
             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.Hv, params.T,
                                params.chunkSize, loopIdx, bos, eos);
                 uint32_t curChunkSize = eos - bos;
                 GemmCoord blockCoord{0, 0, 0};
-                GemmCoord actualBlockShape{curChunkSize, static_cast<uint32_t>(params.V), curChunkSize};
-                for (int h = 0; h < params.H; h++) {
+                for (int h = 0; h < params.Hv; h++) {
                     // Represent the full gm
                     gmA.SetGlobalBuffer((__gm__ ElementA *)params.ptrA + (h * params.T + bos) * params.chunkSize);
-                    gmVb.SetGlobalBuffer((__gm__ ElementVb *)params.ptrVb + (h * params.T + bos) * params.V);
-                    gmU.SetGlobalBuffer((__gm__ ElementU *)params.ptrU + (h * params.T + bos) * params.V);
 
                     // Represent the full tensors
                     auto tensorA = tla::MakeTensor(gmA, params.layoutA, Arch::PositionGM{});
-                    auto tensorVb = tla::MakeTensor(gmVb, params.layoutVb, Arch::PositionGM{});
-                    auto tensorU = tla::MakeTensor(gmU, params.layoutU, Arch::PositionGM{});
                     Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_FIX>(flagAivFinishStore);
-                    // Make tiled views
-                    auto tensorBlockA = GetTile(tensorA, tla::MakeCoord(0, 0),
-                                                 tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockVb = GetTile(tensorVb, tla::MakeCoord(0, 0),
-                                                    tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockU = GetTile(tensorU, tla::MakeCoord(0, 0),
-                                                 tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    // Compute block-scoped matrix multiply-add
-                    BlockMmadU(tensorBlockA, tensorBlockVb, tensorBlockU, actualBlockShape);
+                    // N 维步进取自 Catlass tile 的 N 维：
+                    // key=1 tileN=128 -> V=128 单次；key=2 tileN=256 -> V=256 单次
+                    uint32_t tileN = tla::get<1>(BdkL1TileShape{});
+                    for (uint32_t nOffset = 0; nOffset < params.V; nOffset += tileN) {
+                        uint32_t curN = (nOffset + tileN > params.V) ? (params.V - nOffset) : tileN;
+                        GemmCoord actualBlockShape{curChunkSize, curN, curChunkSize};
+                        gmVb.SetGlobalBuffer((__gm__ ElementVb *)params.ptrVb + (h * params.T + bos) * params.V + nOffset);
+                        gmU.SetGlobalBuffer((__gm__ ElementU *)params.ptrU + (h * params.T + bos) * params.V + nOffset);
+
+                        auto tensorVb = tla::MakeTensor(gmVb, params.layoutVb, Arch::PositionGM{});
+                        auto tensorU = tla::MakeTensor(gmU, params.layoutU, Arch::PositionGM{});
+                        // Make tiled views
+                        auto tensorBlockA = GetTile(tensorA, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                        auto tensorBlockVb = GetTile(tensorVb, tla::MakeCoord(0, 0),
+                                                        tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                        auto tensorBlockU = GetTile(tensorU, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                        // Compute block-scoped matrix multiply-add
+                        BlockMmadU(tensorBlockA, tensorBlockVb, tensorBlockU, actualBlockShape);
+                    }
                 }
             }
         }
@@ -160,15 +169,16 @@ public:
             AscendC::GlobalTensor<ElementKbgExp> gmKbgExp;
             AscendC::GlobalTensor<ElementW> gmW;
             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.Hv, params.T,
                                params.chunkSize, loopIdx, bos, eos);
                 uint32_t curChunkSize = eos - bos;
                 GemmCoord blockCoord{0, 0, 0};
                 GemmCoord actualBlockShape{curChunkSize, static_cast<uint32_t>(params.K), curChunkSize};
-                for (int h = 0; h < params.H; h++) {
+                for (int h = 0; h < params.Hv; h++) {
                     // Represent the full gm
                     gmA.SetGlobalBuffer((__gm__ ElementA *)params.ptrA + (h * params.T + bos) * params.chunkSize);
-                    gmKbgExp.SetGlobalBuffer((__gm__ ElementKbgExp *)params.ptrKbgExp + (h * params.T + bos) * params.K);
+                    gmKbgExp.SetGlobalBuffer((__gm__ ElementKbgExp *)params.ptrKbgExp +
+                                             (h * params.T + bos) * params.K);
                     gmW.SetGlobalBuffer((__gm__ ElementW *)params.ptrW + (h * params.T + bos) * params.K);
 
                     // Represent the full tensors
@@ -194,7 +204,10 @@ public:
 };
 } // namespace Catlass::Gemm::Kernel
 
-template <typename kType, typename betaType>
+template <class... Dims>
+using GemmCubeTileShape = tla::Shape<Dims...>;
+
+template <typename kType, typename betaType, typename L1TileShape, typename L0TileShape>
 class RecomputeWUFwdProcess {
 public:
     /** @brief constructor */
@@ -209,7 +222,9 @@ public:
 private:
     uint64_t B = 0;
     uint64_t T = 0;
-    uint64_t H = 0;
+    uint64_t Hv = 1;
+    uint64_t Hk = 1;
+    uint64_t hvPerHk = 1;
     uint64_t K = 0;
     uint64_t V = 0;
     uint64_t chunkSize = 0;
@@ -226,20 +241,22 @@ private:
     GM_ADDR workspace;
 };
 
-template <typename kType, typename betaType>
-__aicore__ inline RecomputeWUFwdProcess<kType, betaType>::RecomputeWUFwdProcess(
+template <typename kType, typename betaType, typename L1TileShape, typename L0TileShape>
+__aicore__ inline RecomputeWUFwdProcess<kType, betaType, L1TileShape, L0TileShape>::RecomputeWUFwdProcess(
     GM_ADDR k_, GM_ADDR v_, GM_ADDR beta_, GM_ADDR A_, GM_ADDR g_,
     GM_ADDR cu_seqlens_, GM_ADDR chunk_indices_, GM_ADDR w_, GM_ADDR u_,
     GM_ADDR workspace_)
     : k(k_), v(v_), beta(beta_), A(A_), g(g_), cu_seqlens(cu_seqlens_),
       chunk_indices(chunk_indices_), w(w_), u(u_), workspace(workspace_){};
 
-template <typename kType, typename betaType>
-__aicore__ void inline RecomputeWUFwdProcess<kType, betaType>::Init(const RecomputeWUFwdTilingData &tiling)
+template <typename kType, typename betaType, typename L1TileShape, typename L0TileShape>
+__aicore__ void inline RecomputeWUFwdProcess<kType, betaType, L1TileShape, L0TileShape>::Init(const RecomputeWUFwdTilingData &tiling)
 {
     B = tiling.B;
     T = tiling.T;
-    H = tiling.H;
+    Hv = tiling.Hv;
+    Hk = tiling.Hk;
+    hvPerHk = tiling.hvPerHk;
     K = tiling.K;
     V = tiling.V;
     chunkSize = tiling.chunkSize;
@@ -247,8 +264,8 @@ __aicore__ void inline RecomputeWUFwdProcess<kType, betaType>::Init(const Recomp
     return;
 }
 
-template <typename kType, typename betaType>
-__aicore__ void inline RecomputeWUFwdProcess<kType, betaType>::Process()
+template <typename kType, typename betaType, typename L1TileShape, typename L0TileShape>
+__aicore__ void inline RecomputeWUFwdProcess<kType, betaType, L1TileShape, L0TileShape>::Process()
 {
     //输入
     using LayoutTagA = layout::RowMajor;
@@ -268,12 +285,12 @@ __aicore__ void inline RecomputeWUFwdProcess<kType, betaType>::Process()
 
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
     using ArchTag = Arch::Ascend950;
+    // 950: UnitFlag=true 时 L0C_STAGES 必须为 1（见 block_mmad_pingpong_tla.hpp static_assert）
+    using DispatchPolicy = Gemm::MmadPingpong<ArchTag, true>;
 #else
     using ArchTag = Arch::AtlasA2;
-#endif
     using DispatchPolicy = Gemm::MmadPingpong<ArchTag, true>;
-    using L1TileShape = Shape<_128, _128, _256>;
-    using L0TileShape = Shape<_128, _128, _128>;
+#endif
 
     //计算U
     using TileCopyU =
@@ -305,7 +322,7 @@ __aicore__ void inline RecomputeWUFwdProcess<kType, betaType>::Process()
         A, layoutA, vb, layoutVb, u,        layoutU,  
         kbgExp, layoutKbgExp, w,        layoutW,
         cu_seqlens, chunk_indices, chunkNum, B,
-        T,         H,           K,  V,        chunkSize};
+        Hk, Hv, hvPerHk, T, K, V, chunkSize};
     kernel(param);
 }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd_vector.h
@@ -35,7 +35,9 @@ public:
 private:
     uint64_t B = 0;
     uint64_t T = 0;
-    uint64_t H = 0;
+    uint64_t Hv = 1;
+    uint64_t Hk = 1;
+    uint64_t hvPerHk = 1;
     uint64_t K = 0;
     uint64_t V = 0;
     uint64_t chunkSize = 0;
@@ -100,7 +102,9 @@ __aicore__ void inline RecomputeWUFwdVectorProcess<kType, betaType>::Init(
 
     B = tiling.B;
     T = tiling.T;
-    H = tiling.H;
+    Hv = tiling.Hv;
+    Hk = tiling.Hk;
+    hvPerHk = tiling.hvPerHk;
     K = tiling.K;
     V = tiling.V;
     chunkSize = tiling.chunkSize;
@@ -150,9 +154,9 @@ __aicore__ void inline RecomputeWUFwdVectorProcess<kType, betaType>::ProcessVb()
     auto tensorBetaBrcbFP32 = betaFp32BrcbBuf.Get<float32_t>();
     
     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
-        GetChunkOffset(cu_seqlens, chunk_indices, B, H, T, chunkSize, loopIdx, bos, eos);
+        GetChunkOffset(cu_seqlens, chunk_indices, B, Hv, T, chunkSize, loopIdx, bos, eos);
         uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < H; h++) {
+        for (int h = 0; h < Hv; h++) {
             ++vecTaskIdx;
             if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
                 Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(flagAivFinishStore);
@@ -249,24 +253,34 @@ __aicore__ void inline RecomputeWUFwdVectorProcess<kType, betaType>::ProcessKbgE
     auto tensorBetaBrcbFP32 = betaFp32BrcbBuf.Get<float32_t>();
     
     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
-        GetChunkOffset(cu_seqlens, chunk_indices, B, H, T, chunkSize, loopIdx, bos, eos);
+        GetChunkOffset(cu_seqlens, chunk_indices, B, Hv, T, chunkSize, loopIdx, bos, eos);
         uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < H; h++) {
+        for (int h = 0; h < Hv; h++) {
             ++vecTaskIdx;
+            uint64_t hk = h / hvPerHk;
             if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
                 Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(flagAivFinishStore);
                 continue;
             }
             for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
                 curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
-                auto kOffset = (h * T + bos + rowOffset) * K;
+                // 注意：定长场景下 GetChunkOffset 返回的 bos 已含按 Hv 计的批次偏移 bIdx*Hv*T
+                // （见 recompute_wu_fwd_common.h GetChunkOffset 的 bos += bIdx*H*T，此处 H 传入的是 Hv）。
+                // k 只有 Hk 个 head，需把批次偏移换算成 bIdx*Hk*T，即 bos - bIdx*(Hv-Hk)*T。
+                // 此换算强耦合于 GetChunkOffset 的批次偏移实现，若后者修改需同步更新此处。
+                // coreLoopsInB 必须与 GetChunkOffset 内保持一致的算法。
+                uint64_t coreLoopsInB = (T + chunkSize - 1) / chunkSize;
+                uint64_t bIdx = cu_seqlens ? 0 : (loopIdx / coreLoopsInB);
+                uint64_t bosK = cu_seqlens ? bos : (bos - bIdx * (Hv - Hk) * T);
+                auto kSrcOffset = (hk * T + bosK + rowOffset) * K;
+                auto kDstOffset = (h * T + bos + rowOffset) * K;
                 auto betaOffset = h * T + bos + rowOffset;
                 // copyin
                 {
                     auto tensorKin = kInQue.AllocTensor<kType>();
                     auto tensorBetain = betaInQue.AllocTensor<betaType>();
                     auto tensorGin = gInQue.AllocTensor<betaType>();
-                    DataCopy(tensorKin, kTensor[kOffset], K * curRowNum);
+                    DataCopy(tensorKin, kTensor[kSrcOffset], K * curRowNum);
                     DataCopyPad(tensorBetain, betaTensor[betaOffset], {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
                     DataCopyPad(tensorGin, gTensor[betaOffset], {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
                     kInQue.EnQue(tensorKin);
@@ -314,7 +328,7 @@ __aicore__ void inline RecomputeWUFwdVectorProcess<kType, betaType>::ProcessKbgE
                 // copyout
                 {
                     auto tensorOut = kBetagExpOutQue.DeQue<kType>();
-                    DataCopy(workSpaceTensor[kOffset], tensorOut, K * curRowNum);
+                    DataCopy(workSpaceTensor[kDstOffset], tensorOut, K * curRowNum);
                     kBetagExpOutQue.FreeTensor(tensorOut);
                 }
             }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/test/test.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/test/test.py
@@ -1,12 +1,13 @@
 import torch
 import torch_npu
+import os
 from typing import Optional
 import pickle
 import math
 import ct
 import random
 import fla_npu
-torch.npu.utils.set_device(3)
+torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 3)))
 
 def get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices):
     if cu_seqlens != None:
@@ -38,6 +39,7 @@ def compute_w_golden(
     D: int,
     chunk_size: int,  # chunk_size
     NT: int,  # T / chunk_size
+    Hk: int = 0,  # GVA: key head count, 0 means Hk == H
 ) -> torch.Tensor:
     """
     CPU golden implementation for dv computation (变长序列)
@@ -47,8 +49,10 @@ def compute_w_golden(
     2. 获取对应的seq_idx, chunk_indices
     3. 计算该chunk内的dv: dv_chunk = A_chunk @ du_chunk * beta_chunk
     """
-    # 初始化dv，形状与du相同 [B, T, H, D]
-    w = torch.zeros_like(k)
+    if Hk == 0:
+        Hk = H
+    hvPerHk = H // Hk
+    w = torch.zeros(B, H, T, D, dtype=v.dtype, device=v.device)
     for i_b in range(B):
         for idx in range(NT):
             bos,eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
@@ -62,7 +66,8 @@ def compute_w_golden(
                 # 我们需要获取这个chunk对应的A向量
                 # 注意: A的每个位置存储的是该chunk对应的A向量
                 A_chunk = A[i_b,i_h, bos:eos,:eos - bos]
-                k_chunk = k[i_b,i_h, bos:eos,:]
+                hk = i_h // hvPerHk
+                k_chunk = k[i_b,hk, bos:eos,:]
                 
                 # 获取当前chunk的beta
                 beta_chunk = beta[i_b,i_h, bos:eos]  # [chunk_size]
@@ -84,17 +89,14 @@ def compute_w_golden(
 
 
 def compute_u_golden(
-    k: torch.Tensor,     # [B, T, H, D]
     v: torch.Tensor,     # [B, T, H, D]
     beta: torch.Tensor,   # [B, H, T]
     A: torch.Tensor,      # [B, T, H, chunk_size]
-    g: torch.Tensor,      # [B, T, H]
     cu_seqlens: torch.Tensor,
     chunk_indices: torch.Tensor,
     B: int,
-    H: int,
+    Hv: int,
     T: int,
-    D: int,
     chunk_size: int,  # chunk_size
     NT: int,  # T / chunk_size
 ) -> torch.Tensor:
@@ -111,7 +113,7 @@ def compute_u_golden(
         for idx in range(NT):
             bos,eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
         # 遍历所有batch
-            for i_h in range(H):
+            for i_h in range(Hv):
             # 遍历所有head 
                 # 获取当前chunk的A向量
                 # A形状: [B, T, H, chunk_size]
@@ -227,7 +229,8 @@ def prepare_chunk_indices(
 
 def test_recompute_wu_fwd(
     B: int,
-    H: int,
+    Hk: int,
+    Hv: int,
     T: int,
     K: int,
     V: int,
@@ -261,11 +264,11 @@ def test_recompute_wu_fwd(
         test_recompute_wu_fwd.call_count += 1
 
     # 生成随机张量（float16）
-    k = torch.randn(B, H, T, K, dtype=ktype)
-    v = torch.randn(B, H, T, V, dtype=ktype)
-    beta = torch.randn(B, H, T, dtype=btype)
-    A = torch.randn(B, H, T, chunk_size, dtype=ktype)
-    g = torch.randn(B, H, T, dtype=btype)
+    k = torch.randn(B, Hk, T, K, dtype=ktype)
+    v = torch.randn(B, Hv, T, V, dtype=ktype)
+    beta = torch.randn(B, Hv, T, dtype=btype)
+    A = torch.randn(B, Hv, T, chunk_size, dtype=ktype)
+    g = torch.randn(B, Hv, T, dtype=btype)
 
     if chunk_indices!=None:
         NT = len(chunk_indices) // 2
@@ -297,17 +300,86 @@ def test_recompute_wu_fwd(
             cu_seqlens=None,
             chunk_indices=None
         )
-    cpu_w = compute_w_golden(k, v, beta, A, g, cu_seqlens, chunk_indices, B, H, T, K, chunk_size, NT)
-    ct.viz(w.cpu(), cpu_w.cpu())
+    print(f"==================w=========================\n")
+    cpu_w = compute_w_golden(k, v, beta, A, g, cu_seqlens, chunk_indices, B, Hv, T, K, chunk_size, NT, Hk=Hk)
+    print(f"==================cpu=========================\n")
+    ct.isclose(w.cpu(), cpu_w.cpu(), diff_thd=0.1)
+    print(f"==================ct=========================\n")
     
-    # cpu_u = compute_u_golden(k, v, beta, A, g, cu_seqlens, chunk_indices, B, H, T, K, chunk_size, NT)
-    # ct.isclose(u.cpu(), cpu_u.cpu(), diff_thd=0.1)
+    print(f"==================u=========================\n")
+    cpu_u = compute_u_golden(v, beta, A, cu_seqlens, chunk_indices, B, Hv, T, chunk_size, NT)
+    ct.isclose(u.cpu(), cpu_u.cpu(), diff_thd=0.1)
 
     
     print(f"test_recompute_wu_fwd 被调用了第 {test_recompute_wu_fwd.call_count} 次")
     return w, u
 
 if __name__ == "__main__":
+    # === GVA / VDIM256 quick cases ===
+    # 默认只打开一个小的 GVA + VDIM256 smoke，用于快速确认主路径。
+    test_recompute_wu_fwd(B=1, Hk=2, Hv=4, T=256, K=128, V=256, chunk_size=64,
+                          ktype=torch.float16, btype=torch.float16)
+
+    # GVA V=128 smoke
+    # test_recompute_wu_fwd(B=2, Hk=2, Hv=4, T=128, K=128, V=128, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+    # test_recompute_wu_fwd(B=4, Hk=4, Hv=8, T=256, K=128, V=128, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+
+    # VDIM256 non-GVA smoke
+    # test_recompute_wu_fwd(B=1, Hk=4, Hv=4, T=256, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+
+    # GVA + VDIM256 fixed-length cases
+    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=4096, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+    # test_recompute_wu_fwd(B=16, Hk=21, Hv=63, T=2048, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+    # test_recompute_wu_fwd(B=176, Hk=2, Hv=64, T=24, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+
+    # GVA V=128 fixed-length case
+    # test_recompute_wu_fwd(B=711, Hk=4, Hv=32, T=196, K=128, V=128, chunk_size=128,
+    #                       ktype=torch.float16, btype=torch.float16)
+
+    # GVA + VDIM256 variable-length cases
+    # cu_seqlens = prepare_cu_seqlens(T=16384, L=128)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=16384, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # cu_seqlens = prepare_cu_seqlens(T=16384, L=1)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+    # test_recompute_wu_fwd(B=1, Hk=21, Hv=63, T=16384, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # cu_seqlens = prepare_cu_seqlens(T=65536, L=172)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=128)
+    # test_recompute_wu_fwd(B=1, Hk=8, Hv=32, T=65536, K=128, V=256, chunk_size=128,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # cu_seqlens = prepare_cu_seqlens(T=262144, L=32)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+    # test_recompute_wu_fwd(B=1, Hk=2, Hv=64, T=262144, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # GVA V=128 variable-length cases
+    # cu_seqlens = prepare_cu_seqlens(T=65536, L=668)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=65536, K=128, V=128, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # cu_seqlens = prepare_cu_seqlens(T=65536, L=17)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=128)
+    # test_recompute_wu_fwd(B=1, Hk=4, Hv=32, T=65536, K=128, V=128, chunk_size=128,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
     # test_recompute_wu_fwd(B = 1, H = 4, T = 2048, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16)
     # #F1
     # test_recompute_wu_fwd(B = 64, H = 8, T = 1024, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16)
@@ -346,11 +418,11 @@ if __name__ == "__main__":
     # #F18
     # test_recompute_wu_fwd(B = 32, H = 16, T = 4096, K = 128, V = 128, chunk_size = 128, ktype=torch.float16, btype=torch.float16)
     # #L1
-    cu_seqlens = prepare_cu_seqlens(T = 2048, L = 500)
-    chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 128)
-    print(cu_seqlens)
-    print(chunk_indices)
-    test_recompute_wu_fwd(B = 1, H = 4, T = 2048, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.bfloat16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    # cu_seqlens = prepare_cu_seqlens(T = 2048, L = 500)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 128)
+    # print(cu_seqlens)
+    # print(chunk_indices)
+    # test_recompute_wu_fwd(B = 1, Hk = 4, Hv = 4, T = 2048, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.bfloat16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
     # #L2
     # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 33)
     # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -282,7 +282,9 @@ at::Tensor npu_chunk_fwd_o(
     c10::OptionalIntArrayRef chunk_indices
 )
 {
-    at::Tensor w = at::empty_like(k);
+    auto w_shape = v.sizes().vec();
+    w_shape[3] = k.size(3);
+    at::Tensor w = at::empty(w_shape, v.options().dtype(k.scalar_type()));
     at::Tensor u = at::empty_like(v);
     const at::Tensor &gK_ = c10::value_or_else(gK, [] { return at::Tensor(); });
     const at::Tensor &g_ = c10::value_or_else(g, [] { return at::Tensor(); });

--- a/torch_custom/fla_npu/test/test_npu_recompute_w_u_fwd.py
+++ b/torch_custom/fla_npu/test/test_npu_recompute_w_u_fwd.py
@@ -4,7 +4,7 @@ import os
 from typing import Optional
 import pickle
 import math
-# import ct
+import ct
 import random
 import fla_npu
 torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
@@ -39,17 +39,21 @@ def compute_w_golden(
     D: int,
     chunk_size: int,  # chunk_size
     NT: int,  # T / chunk_size
+    Hk: int = 0,  # GVA: key head count, 0 means Hk == H
 ) -> torch.Tensor:
     """
-    CPU golden implementation for dv computation (变长序列)
-    A的形状为 [B, T, H, chunk_size]
+    CPU golden implementation for w computation (变长序列)
+    A的形状为 [B, H, T, chunk_size]
     算法:
     1. 对于每个chunk (由chunk_indices指定)
     2. 获取对应的seq_idx, chunk_indices
-    3. 计算该chunk内的dv: dv_chunk = A_chunk @ du_chunk * beta_chunk
+    3. 计算该chunk内的w: w_chunk = A_chunk @ (k_chunk * beta_chunk)
     """
-    # 初始化dv，形状与du相同 [B, T, H, D]
-    w = torch.zeros_like(k)
+    if Hk == 0:
+        Hk = H
+    hvPerHk = H // Hk
+    # 初始化w，形状为 [B, H, T, D]（W输出K维）
+    w = torch.zeros(B, H, T, D, dtype=v.dtype, device=v.device)
     for i_b in range(B):
         for idx in range(NT):
             bos,eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
@@ -58,12 +62,13 @@ def compute_w_golden(
             for i_h in range(H):
                 # print("hello?")
             # 遍历所有head 
+                hk = i_h // hvPerHk
                 # 获取当前chunk的A向量
                 # A形状: [B, T, H, chunk_size]
                 # 我们需要获取这个chunk对应的A向量
                 # 注意: A的每个位置存储的是该chunk对应的A向量
                 A_chunk = A[i_b,i_h, bos:eos,:eos - bos]
-                k_chunk = k[i_b,i_h, bos:eos,:]
+                k_chunk = k[i_b,hk, bos:eos,:]
                 
                 # 获取当前chunk的beta
                 beta_chunk = beta[i_b,i_h, bos:eos]  # [chunk_size]
@@ -85,34 +90,30 @@ def compute_w_golden(
 
 
 def compute_u_golden(
-    k: torch.Tensor,     # [B, T, H, D]
     v: torch.Tensor,     # [B, T, H, D]
     beta: torch.Tensor,   # [B, H, T]
     A: torch.Tensor,      # [B, T, H, chunk_size]
-    g: torch.Tensor,      # [B, T, H]
     cu_seqlens: torch.Tensor,
     chunk_indices: torch.Tensor,
     B: int,
-    H: int,
+    Hv: int,
     T: int,
-    D: int,
     chunk_size: int,  # chunk_size
     NT: int,  # T / chunk_size
 ) -> torch.Tensor:
     """
-    CPU golden implementation for dv computation (变长序列)
-    A的形状为 [B, T, H, chunk_size]
+    CPU golden implementation for u computation (变长序列)
+    A的形状为 [B, H, T, chunk_size]
     算法:
     1. 对于每个chunk (由chunk_indices指定)
     2. 获取对应的seq_idx, chunk_indices
-    3. 计算该chunk内的dv: dv_chunk = A_chunk @ du_chunk * beta_chunk
+    3. 计算该chunk内的u: u_chunk = A_chunk @ (v_chunk * beta_chunk)
     """
     u = torch.zeros_like(v)
     for i_b in range(B):
         for idx in range(NT):
             bos,eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
-        # 遍历所有batch
-            for i_h in range(H):
+            for i_h in range(Hv):
             # 遍历所有head 
                 # 获取当前chunk的A向量
                 # A形状: [B, T, H, chunk_size]
@@ -228,7 +229,8 @@ def prepare_chunk_indices(
 
 def test_recompute_wu_fwd(
     B: int,
-    H: int,
+    Hk: int,
+    Hv: int,
     T: int,
     K: int,
     V: int,
@@ -262,11 +264,11 @@ def test_recompute_wu_fwd(
         test_recompute_wu_fwd.call_count += 1
 
     # 生成随机张量（float16）
-    k = torch.randn(B, H, T, K, dtype=ktype)
-    v = torch.randn(B, H, T, V, dtype=ktype)
-    beta = torch.randn(B, H, T, dtype=btype)
-    A = torch.randn(B, H, T, chunk_size, dtype=ktype)
-    g = torch.randn(B, H, T, dtype=btype)
+    k = torch.randn(B, Hk, T, K, dtype=ktype)
+    v = torch.randn(B, Hv, T, V, dtype=ktype)
+    beta = torch.randn(B, Hv, T, dtype=btype)
+    A = torch.randn(B, Hv, T, chunk_size, dtype=ktype)
+    g = torch.randn(B, Hv, T, dtype=btype)
 
     if chunk_indices!=None:
         NT = len(chunk_indices) // 2
@@ -298,13 +300,15 @@ def test_recompute_wu_fwd(
             cu_seqlens=None,
             chunk_indices=None
         )
-    cpu_w = compute_w_golden(k, v, beta, A, g, cu_seqlens, chunk_indices, B, H, T, K, chunk_size, NT)
-    # ct.viz(w.cpu(), cpu_w.cpu())
-    
-    # cpu_u = compute_u_golden(k, v, beta, A, g, cu_seqlens, chunk_indices, B, H, T, K, chunk_size, NT)
-    # ct.isclose(u.cpu(), cpu_u.cpu(), diff_thd=0.1)
 
-    
+    print("================== w ==================")
+    cpu_w = compute_w_golden(k, v, beta, A, g, cu_seqlens, chunk_indices, B, Hv, T, K, chunk_size, NT, Hk=Hk)
+    ct.isclose(w.cpu(), cpu_w.cpu(), diff_thd=0.1)
+
+    print("================== u ==================")
+    cpu_u = compute_u_golden(v, beta, A, cu_seqlens, chunk_indices, B, Hv, T, chunk_size, NT)
+    ct.isclose(u.cpu(), cpu_u.cpu(), diff_thd=0.1)
+
     print(f"test_recompute_wu_fwd 被调用了第 {test_recompute_wu_fwd.call_count} 次")
     return w, u
 
@@ -347,11 +351,11 @@ if __name__ == "__main__":
     # #F18
     # test_recompute_wu_fwd(B = 32, H = 16, T = 4096, K = 128, V = 128, chunk_size = 128, ktype=torch.float16, btype=torch.float16)
     # #L1
-    cu_seqlens = prepare_cu_seqlens(T = 2048, L = 500)
-    chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 128)
-    print(cu_seqlens)
-    print(chunk_indices)
-    test_recompute_wu_fwd(B = 1, H = 4, T = 2048, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.bfloat16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    # cu_seqlens = prepare_cu_seqlens(T = 2048, L = 500)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 128)
+    # print(cu_seqlens)
+    # print(chunk_indices)
+    # test_recompute_wu_fwd(B = 1, Hk = 4, Hv = 4, T = 2048, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.bfloat16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
     # #L2
     # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 33)
     # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
@@ -372,3 +376,68 @@ if __name__ == "__main__":
     # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 25)
     # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
     # test_recompute_wu_fwd(B = 1, H = 8, T = 65536, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+
+    # === GVA / VDIM256 quick cases ===
+    # 默认只打开一个小的 GVA + VDIM256 smoke，用于快速确认主路径。
+    test_recompute_wu_fwd(B=1, Hk=2, Hv=4, T=256, K=128, V=256, chunk_size=64,
+                          ktype=torch.float16, btype=torch.float16)
+
+    # GVA V=128 smoke
+    # test_recompute_wu_fwd(B=2, Hk=2, Hv=4, T=128, K=128, V=128, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+    # test_recompute_wu_fwd(B=4, Hk=4, Hv=8, T=256, K=128, V=128, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+
+    # VDIM256 non-GVA smoke
+    # test_recompute_wu_fwd(B=1, Hk=4, Hv=4, T=256, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+
+    # GVA + VDIM256 fixed-length cases
+    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=4096, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+    # test_recompute_wu_fwd(B=16, Hk=21, Hv=63, T=2048, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+    # test_recompute_wu_fwd(B=176, Hk=2, Hv=64, T=24, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16)
+
+    # GVA V=128 fixed-length case
+    # test_recompute_wu_fwd(B=711, Hk=4, Hv=32, T=196, K=128, V=128, chunk_size=128,
+    #                       ktype=torch.float16, btype=torch.float16)
+
+    # GVA + VDIM256 variable-length cases
+    # cu_seqlens = prepare_cu_seqlens(T=16384, L=128)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=16384, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # cu_seqlens = prepare_cu_seqlens(T=16384, L=1)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+    # test_recompute_wu_fwd(B=1, Hk=21, Hv=63, T=16384, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # cu_seqlens = prepare_cu_seqlens(T=65536, L=172)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=128)
+    # test_recompute_wu_fwd(B=1, Hk=8, Hv=32, T=65536, K=128, V=256, chunk_size=128,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # cu_seqlens = prepare_cu_seqlens(T=262144, L=32)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+    # test_recompute_wu_fwd(B=1, Hk=2, Hv=64, T=262144, K=128, V=256, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # GVA V=128 variable-length cases
+    # cu_seqlens = prepare_cu_seqlens(T=65536, L=668)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+    # test_recompute_wu_fwd(B=1, Hk=16, Hv=32, T=65536, K=128, V=128, chunk_size=64,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    # cu_seqlens = prepare_cu_seqlens(T=65536, L=17)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=128)
+    # test_recompute_wu_fwd(B=1, Hk=4, Hv=32, T=65536, K=128, V=128, chunk_size=128,
+    #                       ktype=torch.float16, btype=torch.float16,
+    #                       cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)


### PR DESCRIPTION
## 修改设计

GDN 整网推理/训练需要 `recompute_wu_fwd` 支持两类泛化：GVA（K/V head 解耦，`Hv = hvPerHk * Hk`）与 V=256。本 PR 通过动态 TilingKey（1=V128、2=V256）与模板化 Cube tile 实现，并修复 V=256 精度关键问题（layoutU/layoutW 顺序），同时补齐 Ascend950 编译目标。

### 核心改动
- Tiling：`H` 字段拆为 `Hk`/`Hv`/`hvPerHk`，新增 `Hv % Hk == 0` 等输入校验；workspace 按 `2*B*Hv*T*V` 分配；按 V 动态 `SetTilingKey(1/2)`（旧代码写死 1）。
- Vector：`ProcessKbgExp` 分离 kSrcOffset（hk 映射）/ kDstOffset（h），定长场景 bosK 跨 batch 修正；`ProcessVb` 无需修改。
- Cube：`RecomputeWUFwdProcess` 模板化 L1/L0 tile shape；Phase1/2 按 Catlass tile 的 N 维以 tileN 驱动循环；修复 Params 中 layoutU/layoutW 顺序（V=256 时 U/W stride 不同，旧顺序被 V=128 掩盖）。
- V=256 路径：910B 与 Ascend950 统一使用 Key2 `<128,256,256>/<128,256,64>` 单轮 N=256 GEMM（废弃此前 950 上 N=128 拆分的探索性方案）；Kernel 入口按 TILING_KEY 双分支实例化。
- Ascend950：op_host/CMakeLists 增加 950 编译目标；Cube 使用 `COMPUTE_UNIT Ascend950PR_9599`、MmadPingpong 仅 UnitFlag（CANN 9.0 下 UnitFlag=true 时 L0C_STAGES=2 非法）。
- OpApi/测试：`w` 输出 shape 跟随 `v` 的 `[B, Hv, T, K]`（旧 `empty_like(k)` 在 GVA 下错误）；`test/test.py` 与 `test_npu_recompute_w_u_fwd.py` 新增 GVA golden 与 V=256 smoke/生产规模用例。

### 涉及文件
- `fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/CMakeLists.txt`
- `fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling.{h,cpp}`
- `fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd.{cpp,cube.h,vector.h}`
- `fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/test/test.py`
- `torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp`
- `torch_custom/fla_npu/test/test_npu_recompute_w_u_fwd.py`

# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求触发的维护账号和触发命令。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要维护者重新触发。即使已有 2 个维护账号检视通过，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: 无（内部功能增强，无需 Issue）
- 背景与目标: GDN 整网推理/训练中 `recompute_wu_fwd` 需支持 GVA（Hv = group_size * Hk）与 V=256 两类泛化，二者可叠加。
- 本 PR 解决的问题: recompute_wu_fwd 支持 GVA 与 V=256：Hk/Hv 拆分、kSrc/kDst 分离、动态 TilingKey、layout 顺序修复、Ascend950 编译目标。

## 变更类型

- [ ] Bug 修复
- [x] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: recompute_wu_fwd
- 涉及目录 / 文件: 见上方「涉及文件」
- 责任人 / 提交人: @Coding-Pangolin
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: k 为 `[B, Hk, T, K]`，v/beta/g/A 为 `[B, Hv, T, *]`（A 最后一维 chunkSize）；输出 w `[B, Hv, T, K]`、u `[B, Hv, T, V]`；k/v/A/w/u 为 fp16/bf16，beta/g 可为 fp16/bf16/fp32；chunkSize ∈ {64,128}；V ∈ {128,256}；定长模式任意 B，变长模式 B=1（cu_seqlens/chunk_indices 成对、cu_seqlens[0]=0）。
- 明确不包含的范围: gk 接口预留但未启用（须传 None）；Ascend910_93 未验证；T=262144 超长变长边界用例需在最终合入版本补充回归。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 不涉及

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由维护者触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 8.5.0 | `bash build.sh --pkg --soc=ascend910b --ops=recompute_wu_fwd --vendor_name=fla_npu` | 通过 | build_out/ 生成 .run，安装后 kernel 完整性 OK |
| A5 | `ascend950` | 9.0 | `bash build.sh --pkg --soc=ascend950 --ops=recompute_wu_fwd --vendor_name=fla_npu` | 通过 | 合入版本修复 950 编译（COMPUTE_UNIT Ascend950PR_9599 / MmadPingpong UnitFlag）；运行验证以 910B 为准 |
| A3 | `ascend910_93` | - | `未执行` | 未执行 | 本 PR 未覆盖 910_93 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | cd torch_custom/fla_npu/test && TEST_DEVICE_ID=0 python3 test_npu_recompute_w_u_fwd.py | 通过 | 用例矩阵 G1-G6 + BL；实测 7 组大规格用例 PctRlt=100% success（w/u 均通过）；日志 recompute_wu_fwd.log |
| A2 | `ascend910b` | RUN_RECOMPUTE_GVA_V256_FULL=1 python3 test_npu_recompute_w_u_fwd.py | 通过 | B=16,Hk=21,Hv=63,T=2048,V=256 生产规模；B=176,Hk=2,Hv=64,T=24；PctRlt=100% |
| A2 | `ascend910b` | 同上（变长用例） | 通过 | T=16384（Hv=32/63）、T=65536（chunk=128）变长 PctRlt=100% |

- 精度标准：`ct` 双标杆比对，`diff_thd=0.1`，`PctThd=99.90%`，`PctRlt=100%` 判定 success。
- 已覆盖：定长/变长、MHA/GVA（Hk=2,Hv=4 / Hk=16,Hv=32 / Hk=21,Hv=63 / Hk=2,Hv=64）、V=128/256、chunkSize 64/128。
- 性能对比：不涉及（功能/精度 PR）。
- 边界/异常场景：变长 B=1、cu_seqlens[0]=0、metadata 成对；fp16/bf16 及 beta/g fp32 组合。
- 遗留：开发期（旧分支）T=262144 变长触发 AICore MTE 越界（DDR 越界），最终合入版本统一 Key2 N=256 tile 配置，需在该版本上补充大 T 边界回归。

</details>

<details>
<summary>整体 Example ST 验证</summary>

本 PR 为单算子能力扩展，未单独执行整体 example ST；依赖仓库 NPU CI 回归确认不破坏 GDN 端到端调用链。

</details>

## 兼容性、风险与回退

- 兼容性说明: aclnn/torch 接口签名不变；`w` 输出 shape 在 GVA 下由 `[B,Hk,T,K]` 修正为 `[B,Hv,T,K]`（行为修正）。
- 风险点: V=256 路径依赖 Key2 tile 配置（<128,256,256>/<128,256,64>），改配置需回归 910B/950 双平台；950 上 MmadPingpong 与 L0C_STAGES 的组合受 CANN 版本约束（UnitFlag=true 时不得设 L0C_STAGES=2）。
- 回退方案: 改动集中在 recompute_wu_fwd 单算子 tiling/kernel/OpApi 与测试，可整体 revert。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因（内部功能增强，无外部 Issue）
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 可以编译通过
- [x] 已验证 A3 / A5 编译（A5 编译已修复并入；A3 未覆盖）
- [x] 已验证修改算子的对应 test 在 A2 通过
- [ ] 已验证整体 example ST（未单独执行，依赖 NPU CI）
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用（README/设计文档随后续文档 PR 同步）
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 设计文档：`recompute_wu_fwd_GVA_VDIM256_详设文档.md`、`recompute_wu_fwd_详设文档.md`（基于合入 commit ea3e518 整理）。
- V=256 演进说明：曾尝试 950 上 N=128 拆分与 N=256 tile 导致 AICore 问题等路径，最终 910B/950 统一 Key2 `<128,256,*>` 单轮 GEMM，Phase1/2 以 tileN 驱动 N 维循环，Key1/Key2 代码路径统一。
- 测试日志：`recompute_wu_fwd.log`（7 组大规格 PctRlt=100%，本地归档）。