### PR TITLE
ci: avoid stalled NPU validation runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,27 @@ jobs:
               core.setFailed(`PR #${prNumber} 仍是草稿，请先标记为 ready for review 后再运行 NPU CI。`);
               return;
             }
+            if (!ops && ciMode === 'quick') {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page: 100,
+              });
+              const inferredOps = new Set();
+              const opMarkers = new Set(['op_host', 'op_kernel', 'op_proto', 'op_tiling']);
+              for (const file of files) {
+                const parts = (file.filename || '').split('/');
+                const markerIndex = parts.findIndex((part) => opMarkers.has(part));
+                if (markerIndex > 0) {
+                  inferredOps.add(parts[markerIndex - 1]);
+                }
+              }
+              if (inferredOps.size > 0) {
+                ops = Array.from(inferredOps).sort().join(',');
+                core.notice(`Auto inferred CI ops: ${ops}`);
+              }
+            }
 
             const statuses = await github.paginate(github.rest.repos.listCommitStatusesForRef, {
               owner: context.repo.owner,
@@ -293,7 +314,7 @@ jobs:
       - name: 拉取 PR 合并后代码（第 1 次）
         id: checkout_pr_1
         continue-on-error: true
-        timeout-minutes: 10
+        timeout-minutes: 5
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
@@ -311,7 +332,7 @@ jobs:
         id: checkout_pr_2
         if: steps.checkout_pr_1.outcome == 'failure'
         continue-on-error: true
-        timeout-minutes: 10
+        timeout-minutes: 5
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
@@ -327,7 +348,7 @@ jobs:
 
       - name: 拉取 PR 合并后代码（第 3 次）
         if: steps.checkout_pr_1.outcome == 'failure' && steps.checkout_pr_2.outcome == 'failure'
-        timeout-minutes: 10
+        timeout-minutes: 5
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
@@ -338,7 +359,7 @@ jobs:
       - name: 拉取可信 CI 脚本（第 1 次）
         id: checkout_trusted_ci_1
         continue-on-error: true
-        timeout-minutes: 10
+        timeout-minutes: 5
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.repository.default_branch }}
@@ -355,7 +376,7 @@ jobs:
         id: checkout_trusted_ci_2
         if: steps.checkout_trusted_ci_1.outcome == 'failure'
         continue-on-error: true
-        timeout-minutes: 10
+        timeout-minutes: 5
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.repository.default_branch }}
@@ -370,7 +391,7 @@ jobs:
 
       - name: 拉取可信 CI 脚本（第 3 次）
         if: steps.checkout_trusted_ci_1.outcome == 'failure' && steps.checkout_trusted_ci_2.outcome == 'failure'
-        timeout-minutes: 10
+        timeout-minutes: 5
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.repository.default_branch }}

--- a/ci/detect_npu.sh
+++ b/ci/detect_npu.sh
@@ -19,6 +19,7 @@ declare -a ids=()
 declare -A names=()
 declare -A health=()
 declare -A free=()
+declare -A sink_locked=()
 
 while IFS= read -r line; do
     if [[ "$line" =~ ^\|[[:space:]]*([0-9]+)[[:space:]]+([^[:space:]\|]*[A-Za-z][^[:space:]\|]*)[[:space:]]*\|[[:space:]]*([A-Za-z]+) ]]; then
@@ -36,6 +37,43 @@ if [[ "${#ids[@]}" -eq 0 ]]; then
     exit 1
 fi
 
+is_truthy() {
+    case "${1:-}" in
+        1|true|TRUE|yes|YES|on|ON) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+driver_sink_lock_path() {
+    local id="$1"
+    local lock_dir="${CI_NPU_DRIVER_LOCK_DIR:-/usr/local/Ascend/driver/lib64/driver}"
+    echo "${lock_dir}/sink_file_mutex_${id}.cfg"
+}
+
+has_driver_sink_lock() {
+    local id="$1"
+    if is_truthy "${CI_IGNORE_NPU_DRIVER_SINK_LOCKS:-false}"; then
+        return 1
+    fi
+    if ! command -v lslocks >/dev/null 2>&1; then
+        return 1
+    fi
+
+    local lock_path
+    lock_path="$(driver_sink_lock_path "$id")"
+    [[ -e "$lock_path" ]] || return 1
+
+    lslocks 2>/dev/null | awk -v path="$lock_path" '$NF == path { found = 1 } END { exit found ? 0 : 1 }'
+}
+
+for id in "${ids[@]}"; do
+    if has_driver_sink_lock "$id"; then
+        sink_locked["$id"]=1
+    else
+        sink_locked["$id"]=0
+    fi
+done
+
 soc_from_name() {
     local name="$1"
     case "$name" in
@@ -47,6 +85,13 @@ soc_from_name() {
 }
 
 select_device() {
+    local candidates=()
+    mapfile -t candidates < <(emit_candidates)
+    if (( ${#candidates[@]} > 0 )); then
+        echo "${candidates[0]}"
+        return
+    fi
+
     local id
     for id in "${ids[@]}"; do
         if [[ "${health[$id]}" == "OK" && "${free[$id]:-0}" == "1" ]]; then
@@ -69,28 +114,45 @@ select_device() {
     echo "${ids[0]}"
 }
 
+is_candidate_allowed() {
+    local id="$1"
+    if [[ "${sink_locked[$id]:-0}" == "1" ]]; then
+        return 1
+    fi
+    if [[ "${free[$id]:-0}" == "1" ]]; then
+        return 0
+    fi
+    is_truthy "${CI_ALLOW_BUSY_NPU:-false}"
+}
+
 emit_candidates() {
     local id
     for id in "${ids[@]}"; do
-        if [[ "${health[$id]}" == "OK" && "${free[$id]:-0}" == "1" ]]; then
+        if [[ "${health[$id]}" == "OK" && "${free[$id]:-0}" == "1" ]] && is_candidate_allowed "$id"; then
             echo "$id"
         fi
     done
-    for id in "${ids[@]}"; do
-        if [[ "${health[$id]}" != "OK" && "${free[$id]:-0}" == "1" ]]; then
-            echo "$id"
-        fi
-    done
-    for id in "${ids[@]}"; do
-        if [[ "${health[$id]}" == "OK" && "${free[$id]:-0}" != "1" ]]; then
-            echo "$id"
-        fi
-    done
-    for id in "${ids[@]}"; do
-        if [[ "${health[$id]}" != "OK" && "${free[$id]:-0}" != "1" ]]; then
-            echo "$id"
-        fi
-    done
+    if ! is_truthy "${CI_REQUIRE_HEALTHY_NPU:-false}"; then
+        for id in "${ids[@]}"; do
+            if [[ "${health[$id]}" != "OK" && "${free[$id]:-0}" == "1" ]] && is_candidate_allowed "$id"; then
+                echo "$id"
+            fi
+        done
+    fi
+    if is_truthy "${CI_ALLOW_BUSY_NPU:-false}"; then
+        for id in "${ids[@]}"; do
+            if [[ "${health[$id]}" == "OK" && "${free[$id]:-0}" != "1" ]] && is_candidate_allowed "$id"; then
+                echo "$id"
+            fi
+        done
+    fi
+    if is_truthy "${CI_ALLOW_BUSY_NPU:-false}" && ! is_truthy "${CI_REQUIRE_HEALTHY_NPU:-false}"; then
+        for id in "${ids[@]}"; do
+            if [[ "${health[$id]}" != "OK" && "${free[$id]:-0}" != "1" ]] && is_candidate_allowed "$id"; then
+                echo "$id"
+            fi
+        done
+    fi
 }
 
 emit_env_for() {
@@ -130,7 +192,7 @@ case "$mode" in
     --summary)
         echo "Detected NPU devices:"
         for id in "${ids[@]}"; do
-            echo "  - id=$id name=${names[$id]} health=${health[$id]} free=${free[$id]:-0} soc=$(soc_from_name "${names[$id]}")"
+            echo "  - id=$id name=${names[$id]} health=${health[$id]} free=${free[$id]:-0} sink_locked=${sink_locked[$id]:-0} soc=$(soc_from_name "${names[$id]}")"
         done
         echo "Selected NPU: id=$selected name=${names[$selected]} health=${health[$selected]} free=$selected_free soc=$selected_soc"
         ;;

--- a/ci/run_ci_container.sh
+++ b/ci/run_ci_container.sh
@@ -9,6 +9,7 @@ container_name="${CI_CONTAINER_NAME:-fla-npu-ci-$(date +%s)}"
 cache_root="${CI_CACHE_ROOT:-}"
 npu_lock_fd=""
 npu_lock_file=""
+container_id_file=""
 
 if [[ -z "$cache_root" ]]; then
     if [[ -d /workspace ]]; then
@@ -26,6 +27,71 @@ release_npu_lock() {
         npu_lock_fd=""
         npu_lock_file=""
     fi
+}
+
+is_truthy() {
+    case "${1:-}" in
+        1|true|TRUE|yes|YES|on|ON) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+stop_ci_container() {
+    if ! command -v docker >/dev/null 2>&1; then
+        return
+    fi
+    if docker ps -q --filter "name=^/${container_name}$" | grep -q .; then
+        echo "[CI] Stopping CI container: $container_name"
+        docker rm -f "$container_name" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${container_id_file:-}" ]]; then
+        rm -f "$container_id_file"
+    fi
+}
+
+cleanup_run() {
+    local status=$?
+    stop_ci_container
+    release_npu_lock
+    return "$status"
+}
+
+cleanup_stale_ci_containers() {
+    if ! is_truthy "${CI_CLEANUP_STALE_CONTAINERS:-true}"; then
+        return
+    fi
+    if ! command -v docker >/dev/null 2>&1; then
+        return
+    fi
+
+    local max_age_seconds="${CI_STALE_CONTAINER_SECONDS:-14400}"
+    if [[ "$max_age_seconds" == "0" ]]; then
+        return
+    fi
+    if ! [[ "$max_age_seconds" =~ ^[0-9]+$ ]]; then
+        echo "[CI][WARN] Invalid CI_STALE_CONTAINER_SECONDS=$max_age_seconds; skip stale container cleanup."
+        return
+    fi
+
+    local now
+    now="$(date +%s)"
+    local id
+    while IFS= read -r id; do
+        [[ -n "$id" ]] || continue
+        local name started_at started_epoch age
+        name="$(docker inspect -f '{{.Name}}' "$id" 2>/dev/null | sed 's#^/##')" || continue
+        started_at="$(docker inspect -f '{{.State.StartedAt}}' "$id" 2>/dev/null)" || continue
+        started_epoch="$(date -d "$started_at" +%s 2>/dev/null || echo 0)"
+        [[ "$started_epoch" =~ ^[0-9]+$ ]] || started_epoch=0
+        if (( started_epoch == 0 )); then
+            continue
+        fi
+        age=$((now - started_epoch))
+        if (( age >= max_age_seconds )); then
+            echo "[CI] Removing stale CI container: $name (${age}s old)"
+            docker rm -f "$id" >/dev/null 2>&1 || true
+        fi
+    done < <(docker ps -q --filter "name=fla-npu-ci-")
 }
 
 acquire_npu_lock() {
@@ -48,8 +114,16 @@ acquire_npu_lock() {
         local candidates=()
         mapfile -t candidates < <(bash ci/detect_npu.sh --candidates)
         if (( ${#candidates[@]} == 0 )); then
-            echo "[CI][ERROR] No NPU device was found on host." >&2
-            exit 1
+            local elapsed=$((SECONDS - started_at))
+            if [[ "$lock_wait_seconds" != "0" && "$elapsed" -ge "$lock_wait_seconds" ]]; then
+                echo "[CI][ERROR] Timed out waiting for an eligible NPU after ${lock_wait_seconds}s." >&2
+                bash ci/detect_npu.sh --summary || true
+                exit 1
+            fi
+            echo "[CI] No eligible NPU is available; retrying in ${lock_retry_seconds}s."
+            bash ci/detect_npu.sh --summary || true
+            sleep "$lock_retry_seconds"
+            continue
         fi
 
         local id
@@ -61,9 +135,6 @@ acquire_npu_lock() {
                 npu_lock_fd="$fd"
                 npu_lock_file="$candidate_lock"
                 eval "$(bash ci/detect_npu.sh --env-for "$id")"
-                trap release_npu_lock EXIT
-                trap 'release_npu_lock; exit 130' INT
-                trap 'release_npu_lock; exit 143' TERM
                 echo "[CI] Acquired NPU lock: $npu_lock_file"
                 return
             fi
@@ -79,6 +150,12 @@ acquire_npu_lock() {
         sleep "$lock_retry_seconds"
     done
 }
+
+trap cleanup_run EXIT
+trap 'stop_ci_container; release_npu_lock; exit 130' INT
+trap 'stop_ci_container; release_npu_lock; exit 143' TERM
+
+cleanup_stale_ci_containers
 
 if ! docker image inspect "$image" >/dev/null 2>&1 || [[ "${CI_REBUILD_IMAGE:-false}" == "true" ]]; then
     echo "[CI] Building Docker image: $image"
@@ -125,8 +202,31 @@ echo "[CI] Running $container_name on NPU ${NPU_SELECTED_DEVICE} (${NPU_SELECTED
 echo "[CI] third_party cache: $third_party_cache"
 echo "[CI] container TMPDIR: ${CI_TMPDIR:-auto}"
 
-docker run --rm \
+container_timeout_seconds="${CI_CONTAINER_TIMEOUT_SECONDS:-10800}"
+if [[ "$container_timeout_seconds" != "0" && ! "$container_timeout_seconds" =~ ^[0-9]+$ ]]; then
+    echo "[CI][ERROR] Invalid CI_CONTAINER_TIMEOUT_SECONDS=$container_timeout_seconds" >&2
+    exit 2
+fi
+if [[ "$container_timeout_seconds" != "0" ]] && ! command -v timeout >/dev/null 2>&1; then
+    echo "[CI][ERROR] timeout command is required when CI_CONTAINER_TIMEOUT_SECONDS is set." >&2
+    exit 1
+fi
+
+container_id_file="${TMPDIR:-/tmp}/${container_name}.cid"
+rm -f "$container_id_file"
+run_prefix=()
+if [[ "$container_timeout_seconds" != "0" ]]; then
+    run_prefix=(timeout --kill-after=30s "${container_timeout_seconds}s")
+    echo "[CI] container timeout: ${container_timeout_seconds}s"
+else
+    echo "[CI] container timeout: disabled"
+fi
+
+"${run_prefix[@]}" docker run --rm \
     --name "$container_name" \
+    --cidfile "$container_id_file" \
+    --label "org.flashserve.fla-npu-ci=true" \
+    --label "org.flashserve.fla-npu-ci.npu=${NPU_SELECTED_DEVICE}" \
     --network host \
     --ipc host \
     "${device_args[@]}" \
@@ -153,6 +253,8 @@ docker run --rm \
     -e CI_RUN_EXAMPLE_ST="${CI_RUN_EXAMPLE_ST:-true}" \
     -e CI_EXAMPLE_CASES_FILE="${CI_EXAMPLE_CASES_FILE:-ci/example_st_cases.json}" \
     -e CI_EXAMPLE_CASE_FILTER="${CI_EXAMPLE_CASE_FILTER:-}" \
+    -e CI_EXAMPLE_CASE_TIMEOUT_SECONDS="${CI_EXAMPLE_CASE_TIMEOUT_SECONDS:-1800}" \
+    -e CI_CONTAINER_TIMEOUT_SECONDS="${CI_CONTAINER_TIMEOUT_SECONDS:-10800}" \
     -e CI_TEST_OP="${CI_TEST_OP:-}" \
     -e CI_TMPDIR="${CI_TMPDIR:-}" \
     -e CI_TMPDIR_CANDIDATES="${CI_TMPDIR_CANDIDATES:-}" \

--- a/ci/run_example_st_cases.py
+++ b/ci/run_example_st_cases.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import os
+import signal
 import shlex
 import subprocess
 import sys
@@ -103,6 +105,64 @@ def _as_bool(value: Any, default: bool = False) -> bool:
     raise ValueError(f"Expected a boolean value, got {value!r}.")
 
 
+def _as_non_negative_int(value: Any, name: str) -> int:
+    try:
+        timeout = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a non-negative integer.") from exc
+    if timeout < 0:
+        raise ValueError(f"{name} must be a non-negative integer.")
+    return timeout
+
+
+def _default_timeout_seconds() -> int:
+    return _as_non_negative_int(os.environ.get("CI_EXAMPLE_CASE_TIMEOUT_SECONDS", "1800"), "CI_EXAMPLE_CASE_TIMEOUT_SECONDS")
+
+
+def _case_timeout_seconds(case: dict[str, Any], default_timeout: int) -> int:
+    value = case.get("timeout_seconds", case.get("timeout-seconds"))
+    if value is None:
+        return default_timeout
+    return _as_non_negative_int(value, f"timeout_seconds for case {case['name']}")
+
+
+def _terminate_process_group(proc: subprocess.Popen) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        if os.name == "posix":
+            os.killpg(proc.pid, signal.SIGTERM)
+        else:
+            proc.terminate()
+    except ProcessLookupError:
+        return
+    try:
+        proc.wait(timeout=30)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        if os.name == "posix":
+            os.killpg(proc.pid, signal.SIGKILL)
+        else:
+            proc.kill()
+    except ProcessLookupError:
+        return
+    proc.wait()
+
+
+def _run_command(cmd: list[str], cwd: Path, timeout_seconds: int) -> None:
+    timeout = None if timeout_seconds == 0 else timeout_seconds
+    proc = subprocess.Popen(cmd, cwd=cwd, start_new_session=(os.name == "posix"))
+    try:
+        return_code = proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        _terminate_process_group(proc)
+        raise exc
+    if return_code != 0:
+        raise subprocess.CalledProcessError(return_code, cmd)
+
+
 def _select_cases(cases: list[dict[str, Any]], case_filter: str) -> list[dict[str, Any]]:
     enabled = [case for case in cases if case.get("enabled", True)]
     if not case_filter.strip():
@@ -157,8 +217,11 @@ def main() -> int:
     parser.add_argument("--device", type=int, required=True)
     parser.add_argument("--cases-file", default="ci/example_st_cases.json")
     parser.add_argument("--case-filter", default="", help="Comma-separated case names to run")
+    parser.add_argument("--timeout-seconds", type=int, default=_default_timeout_seconds(), help="Default per-case timeout; 0 disables timeout")
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
+    if args.timeout_seconds < 0:
+        raise SystemExit("--timeout-seconds must be a non-negative integer.")
 
     repo_root = Path(__file__).resolve().parents[1]
     cases_file = (repo_root / args.cases_file).resolve()
@@ -166,17 +229,22 @@ def main() -> int:
     if not cases:
         raise SystemExit(f"No enabled Example/ST cases found in {cases_file}.")
 
-    print(f"[CI] Example/ST cases file: {cases_file}")
+    print(f"[CI] Example/ST cases file: {cases_file}", flush=True)
     for index, case in enumerate(cases, start=1):
         name = case["name"]
         description = str(case.get("description", "")).strip()
         cmd = _build_command(repo_root, args.device, case)
-        print(f"[CI] Example/ST case {index}/{len(cases)}: {name}")
+        timeout_seconds = _case_timeout_seconds(case, args.timeout_seconds)
+        print(f"[CI] Example/ST case {index}/{len(cases)}: {name}", flush=True)
         if description:
-            print(f"[CI] {description}")
-        print(f"[CI] Command: {shlex.join(cmd)}")
+            print(f"[CI] {description}", flush=True)
+        print(f"[CI] Timeout: {'disabled' if timeout_seconds == 0 else str(timeout_seconds) + 's'}", flush=True)
+        print(f"[CI] Command: {shlex.join(cmd)}", flush=True)
         if not args.dry_run:
-            subprocess.run(cmd, cwd=repo_root, check=True)
+            try:
+                _run_command(cmd, repo_root, timeout_seconds)
+            except subprocess.TimeoutExpired:
+                raise SystemExit(f"[CI][ERROR] Example/ST case {name} timed out after {timeout_seconds}s.")
     return 0
 
 


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
