### PR TITLE
chunk_gated_delta_rule_fwd_h支持<<<>>>调用

### DIFF
--- a/examples/fast_kernel_launch_example/csrc/chunk_gated_delta_rule_fwd_h/ascend910b/CMakeLists.txt
+++ b/examples/fast_kernel_launch_example/csrc/chunk_gated_delta_rule_fwd_h/ascend910b/CMakeLists.txt
@@ -1,0 +1,10 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# ----------------------------------------------------------------------------
+
+add_sources("--npu-arch=dav-2201")

--- a/examples/fast_kernel_launch_example/csrc/chunk_gated_delta_rule_fwd_h/ascend910b/chunk_gated_delta_rule_fwd_h.cpp
+++ b/examples/fast_kernel_launch_example/csrc/chunk_gated_delta_rule_fwd_h/ascend910b/chunk_gated_delta_rule_fwd_h.cpp
@@ -1,0 +1,305 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_fwd_h.cpp
+ * \brief chunk_gated_delta_rule_fwd_h operator with fast kernel launch (<<<>>>).
+ */
+
+#include <ATen/Operators.h>
+#include <torch/all.h>
+#include <torch/library.h>
+#include "torch_npu/csrc/core/npu/NPUStream.h"
+#include "torch_npu/csrc/framework/OpCommand.h"
+#include "kernel_operator.h"
+#include "platform/platform_ascendc.h"
+#include <type_traits>
+#include <vector>
+
+// Plain tiling struct (global ChunkGatedDeltaRuleFwdHTilingData) must be visible before the kernel header.
+#include "fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h_struct.h"
+#include "fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling_processor.h"
+#include "fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp"
+
+#include "lib/matmul_intf.h"
+
+using namespace Catlass;
+
+namespace ascend_ops {
+namespace ChunkGatedDeltaRuleFwdH {
+
+TORCH_LIBRARY_FRAGMENT(EXTENSION_MODULE_NAME, m)
+{
+    m.def(
+        "chunk_gated_delta_rule_fwd_h(Tensor k, Tensor w, Tensor u, Tensor g, *, Tensor? initial_state=None, "
+        "bool output_final_state=False, int chunk_size=64, int[]? cu_seqlens=None, int[]? chunk_indices=None) "
+        "-> (Tensor, Tensor, Tensor)");
+}
+
+static int64_t DtypeToEnum(at::ScalarType dtype)
+{
+    if (dtype == at::kBFloat16) {
+        return optiling::GDN_FWD_H_DTYPE_BF16;
+    }
+    if (dtype == at::kHalf) {
+        return optiling::GDN_FWD_H_DTYPE_FP16;
+    }
+    return optiling::GDN_FWD_H_DTYPE_FP32;
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_fwd_h_meta(
+    const at::Tensor &k, const at::Tensor &w, const at::Tensor &u, const at::Tensor &g,
+    const c10::optional<at::Tensor> &initial_state, bool output_final_state, int64_t chunk_size,
+    at::OptionalIntArrayRef cu_seqlens, at::OptionalIntArrayRef chunk_indices)
+{
+    auto k_sizes = k.sizes();
+    auto u_sizes = u.sizes();
+    int64_t B = k_sizes[0];
+    int64_t T = k_sizes[2];
+    int64_t K = k_sizes[3];
+    int64_t HV = u_sizes[1];
+    int64_t V = u_sizes[3];
+
+    int64_t NT = 0;
+    if (chunk_indices.has_value()) {
+        NT = static_cast<int64_t>(chunk_indices.value().size()) / 2;
+    } else {
+        NT = (T + chunk_size - 1) / chunk_size;
+    }
+
+    at::Tensor h_out = at::zeros({B, HV, NT, K, V}, k.options());
+    at::Tensor v_new_out = at::empty_like(u);
+    at::Tensor final_state_out;
+    if (output_final_state) {
+        int64_t N = cu_seqlens.has_value() ? static_cast<int64_t>(cu_seqlens.value().size()) - 1 : B;
+        // The kernel writes the final state in STATE_TYPE: float32 when there is no initial state,
+        // otherwise the initial state's dtype. Allocate accordingly to avoid a dtype/size mismatch.
+        auto state_options = initial_state.has_value() ? initial_state.value().options() : k.options().dtype(at::kFloat);
+        final_state_out = at::empty({N, HV, K, V}, state_options);
+    } else {
+        final_state_out = at::empty({1}, k.options());
+    }
+    return std::make_tuple(h_out, v_new_out, final_state_out);
+}
+
+TORCH_LIBRARY_IMPL(EXTENSION_MODULE_NAME, Meta, m)
+{
+    m.impl("chunk_gated_delta_rule_fwd_h", chunk_gated_delta_rule_fwd_h_meta);
+}
+
+static ::ChunkGatedDeltaRuleFwdHTilingData calc_tiling_params(
+    const at::Tensor &k, const at::Tensor &u, const at::Tensor &g,
+    const c10::optional<at::Tensor> &initial_state, bool output_final_state, int64_t chunk_size,
+    at::OptionalIntArrayRef cu_seqlens, uint32_t &blockDim, size_t &workspaceSize)
+{
+    optiling::ChunkGatedDeltaRuleFwdHTilingContext ctx{};
+    ctx.seqlen = k.size(2);
+    ctx.kNumHead = k.size(1);
+    ctx.kHeadDim = k.size(3);
+    ctx.vNumHead = u.size(1);
+    ctx.vHeadDim = u.size(3);
+    ctx.shapeBatchDim = k.size(0);
+    ctx.hasCuSeqlens = cu_seqlens.has_value();
+    ctx.cuSeqlensDim0 = cu_seqlens.has_value() ? static_cast<int64_t>(cu_seqlens.value().size()) : 0;
+    ctx.dataType = DtypeToEnum(k.scalar_type());
+    ctx.gDataType = DtypeToEnum(g.scalar_type());
+    ctx.useInitialState = initial_state.has_value();
+    ctx.stateDataType =
+        initial_state.has_value() ? DtypeToEnum(initial_state.value().scalar_type()) : optiling::GDN_FWD_H_DTYPE_FP32;
+    ctx.storeFinalState = output_final_state;
+    ctx.chunkSize = chunk_size;
+
+    auto ascendcPlatform = platform_ascendc::PlatformAscendCManager::GetInstance();
+    ctx.aicCoreNum = ascendcPlatform->GetCoreNumAic();
+    ctx.libApiWorkSpaceSize = ascendcPlatform->GetLibApiWorkSpaceSize();
+
+    ::ChunkGatedDeltaRuleFwdHTilingData tiling{};
+    optiling::ChunkGatedDeltaRuleFwdHTilingProcessor processor(ctx);
+    processor.Process(tiling, blockDim, workspaceSize);
+    return tiling;
+}
+
+template <typename INPUT_TYPE, typename G_TYPE, typename STATE_TYPE>
+__global__ __aicore__ void chunk_gated_delta_rule_fwd_h_kernel(
+    GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g, GM_ADDR inital_state, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
+    GM_ADDR h, GM_ADDR v_new, GM_ADDR final_state, GM_ADDR workspace, GM_ADDR tiling)
+{
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+    AscendC::SetSysWorkspaceForce(workspace);
+    GM_ADDR user = AscendC::GetUserWorkspace(workspace);
+    if (user == nullptr) {
+        return;
+    }
+
+    using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<INPUT_TYPE, G_TYPE, STATE_TYPE, float>;
+    GDNFwdHKernel gdnFwdH;
+    gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+    gdnFwdH.Process();
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_fwd_h_npu(
+    const at::Tensor &k, const at::Tensor &w, const at::Tensor &u, const at::Tensor &g,
+    const c10::optional<at::Tensor> &initial_state, bool output_final_state, int64_t chunk_size,
+    at::OptionalIntArrayRef cu_seqlens, at::OptionalIntArrayRef chunk_indices)
+{
+    const c10::OptionalDeviceGuard guard(k.device());
+
+    auto outs = chunk_gated_delta_rule_fwd_h_meta(
+        k, w, u, g, initial_state, output_final_state, chunk_size, cu_seqlens, chunk_indices);
+    at::Tensor h_out = std::get<0>(outs);
+    at::Tensor v_new_out = std::get<1>(outs);
+    at::Tensor final_state_out = std::get<2>(outs);
+
+    auto stream = c10_npu::getCurrentNPUStream().stream(false);
+
+    uint32_t blockDim = 0;
+    size_t workspaceSize = 0;
+    auto tiling = calc_tiling_params(
+        k, u, g, initial_state, output_final_state, chunk_size, cu_seqlens, blockDim, workspaceSize);
+
+    auto k_ptr = (GM_ADDR)k.data_ptr();
+    auto w_ptr = (GM_ADDR)w.data_ptr();
+    auto u_ptr = (GM_ADDR)u.data_ptr();
+    auto g_ptr = (GM_ADDR)g.data_ptr();
+    auto h_ptr = (GM_ADDR)h_out.data_ptr();
+    auto v_new_ptr = (GM_ADDR)v_new_out.data_ptr();
+    auto final_state_ptr = (GM_ADDR)final_state_out.data_ptr();
+
+    GM_ADDR initial_state_ptr = nullptr;
+    if (initial_state.has_value()) {
+        initial_state_ptr = (GM_ADDR)initial_state.value().data_ptr();
+    }
+
+    GM_ADDR cu_seqlens_ptr = nullptr;
+    GM_ADDR chunk_indices_ptr = nullptr;
+    std::vector<int64_t> cu_seqlens_vec;
+    std::vector<int64_t> chunk_indices_vec;
+    at::Tensor cu_seqlens_tensor;
+    at::Tensor chunk_indices_tensor;
+    if (cu_seqlens.has_value()) {
+        cu_seqlens_vec = std::vector<int64_t>(cu_seqlens.value().begin(), cu_seqlens.value().end());
+        cu_seqlens_tensor = at::tensor(cu_seqlens_vec, at::dtype(at::kLong).device(k.device()));
+        cu_seqlens_ptr = (GM_ADDR)cu_seqlens_tensor.data_ptr();
+    }
+    if (chunk_indices.has_value()) {
+        chunk_indices_vec = std::vector<int64_t>(chunk_indices.value().begin(), chunk_indices.value().end());
+        chunk_indices_tensor = at::tensor(chunk_indices_vec, at::dtype(at::kLong).device(k.device()));
+        chunk_indices_ptr = (GM_ADDR)chunk_indices_tensor.data_ptr();
+    }
+
+    void *workspace_ptr = nullptr;
+    if (workspaceSize > 0) {
+        auto ret = aclrtMalloc(&workspace_ptr, workspaceSize, ACL_MEM_MALLOC_HUGE_FIRST);
+        TORCH_CHECK(ret == ACL_SUCCESS, "allocate workspace failed. ERROR: ", ret);
+        // The kernel uses AscendC::SyncAll(), whose cross-core counter lives in the system
+        // workspace region. A raw aclrtMalloc buffer is not zero-initialized, so the counter must
+        // be cleared before launch, otherwise the cores desync and trigger an aicore exception.
+        ret = aclrtMemsetAsync(workspace_ptr, workspaceSize, 0, workspaceSize, stream);
+        TORCH_CHECK(ret == ACL_SUCCESS, "memset workspace failed. ERROR: ", ret);
+    }
+    auto workspace_gm = (GM_ADDR)workspace_ptr;
+
+    // The kernel reads the tiling data from GM, so copy the plain tiling struct to a device buffer.
+    void *tiling_ptr = nullptr;
+    const size_t tiling_bytes = sizeof(::ChunkGatedDeltaRuleFwdHTilingData);
+    {
+        auto ret = aclrtMalloc(&tiling_ptr, tiling_bytes, ACL_MEM_MALLOC_HUGE_FIRST);
+        TORCH_CHECK(ret == ACL_SUCCESS, "allocate tiling buffer failed. ERROR: ", ret);
+        ret = aclrtMemcpy(tiling_ptr, tiling_bytes, &tiling, tiling_bytes, ACL_MEMCPY_HOST_TO_DEVICE);
+        TORCH_CHECK(ret == ACL_SUCCESS, "copy tiling to device failed. ERROR: ", ret);
+    }
+    auto tiling_gm = (GM_ADDR)tiling_ptr;
+
+    auto in_dtype = k.scalar_type();
+    auto g_dtype = g.scalar_type();
+    auto state_dtype = initial_state.has_value() ? initial_state.value().scalar_type() : at::kFloat;
+
+    auto acl_call = [=]() -> int {
+        bool gIsFp32 = (g_dtype == at::kFloat);
+        bool stateIsFp32 = (!initial_state.has_value()) || (state_dtype == at::kFloat);
+        if (in_dtype == at::kBFloat16) {
+            using INPUT_TYPE = bfloat16_t;
+            if (stateIsFp32) {
+                if (gIsFp32) {
+                    chunk_gated_delta_rule_fwd_h_kernel<INPUT_TYPE, float, float><<<blockDim, nullptr, stream>>>(
+                        k_ptr, w_ptr, u_ptr, g_ptr, initial_state_ptr, cu_seqlens_ptr, chunk_indices_ptr,
+                        h_ptr, v_new_ptr, final_state_ptr, workspace_gm, tiling_gm);
+                } else {
+                    chunk_gated_delta_rule_fwd_h_kernel<INPUT_TYPE, INPUT_TYPE, float><<<blockDim, nullptr, stream>>>(
+                        k_ptr, w_ptr, u_ptr, g_ptr, initial_state_ptr, cu_seqlens_ptr, chunk_indices_ptr,
+                        h_ptr, v_new_ptr, final_state_ptr, workspace_gm, tiling_gm);
+                }
+            } else {
+                if (gIsFp32) {
+                    chunk_gated_delta_rule_fwd_h_kernel<INPUT_TYPE, float, INPUT_TYPE><<<blockDim, nullptr, stream>>>(
+                        k_ptr, w_ptr, u_ptr, g_ptr, initial_state_ptr, cu_seqlens_ptr, chunk_indices_ptr,
+                        h_ptr, v_new_ptr, final_state_ptr, workspace_gm, tiling_gm);
+                } else {
+                    chunk_gated_delta_rule_fwd_h_kernel<INPUT_TYPE, INPUT_TYPE, INPUT_TYPE><<<blockDim, nullptr, stream>>>(
+                        k_ptr, w_ptr, u_ptr, g_ptr, initial_state_ptr, cu_seqlens_ptr, chunk_indices_ptr,
+                        h_ptr, v_new_ptr, final_state_ptr, workspace_gm, tiling_gm);
+                }
+            }
+        } else if (in_dtype == at::kHalf) {
+            using INPUT_TYPE = half;
+            if (stateIsFp32) {
+                if (gIsFp32) {
+                    chunk_gated_delta_rule_fwd_h_kernel<INPUT_TYPE, float, float><<<blockDim, nullptr, stream>>>(
+                        k_ptr, w_ptr, u_ptr, g_ptr, initial_state_ptr, cu_seqlens_ptr, chunk_indices_ptr,
+                        h_ptr, v_new_ptr, final_state_ptr, workspace_gm, tiling_gm);
+                } else {
+                    chunk_gated_delta_rule_fwd_h_kernel<INPUT_TYPE, INPUT_TYPE, float><<<blockDim, nullptr, stream>>>(
+                        k_ptr, w_ptr, u_ptr, g_ptr, initial_state_ptr, cu_seqlens_ptr, chunk_indices_ptr,
+                        h_ptr, v_new_ptr, final_state_ptr, workspace_gm, tiling_gm);
+                }
+            } else {
+                if (gIsFp32) {
+                    chunk_gated_delta_rule_fwd_h_kernel<INPUT_TYPE, float, INPUT_TYPE><<<blockDim, nullptr, stream>>>(
+                        k_ptr, w_ptr, u_ptr, g_ptr, initial_state_ptr, cu_seqlens_ptr, chunk_indices_ptr,
+                        h_ptr, v_new_ptr, final_state_ptr, workspace_gm, tiling_gm);
+                } else {
+                    chunk_gated_delta_rule_fwd_h_kernel<INPUT_TYPE, INPUT_TYPE, INPUT_TYPE><<<blockDim, nullptr, stream>>>(
+                        k_ptr, w_ptr, u_ptr, g_ptr, initial_state_ptr, cu_seqlens_ptr, chunk_indices_ptr,
+                        h_ptr, v_new_ptr, final_state_ptr, workspace_gm, tiling_gm);
+                }
+            }
+        } else {
+            TORCH_CHECK(false, "Unsupported input dtype: ", in_dtype);
+        }
+        return 0;
+    };
+
+    at_npu::native::OpCommand::RunOpApi("ChunkGatedDeltaRuleFwdH", acl_call);
+
+    // The tiling/workspace buffers are raw aclrtMalloc (not stream-ordered), so make sure the
+    // kernel finished before freeing them.
+    aclrtSynchronizeStream(stream);
+
+    if (workspace_ptr != nullptr) {
+        aclrtFree(workspace_ptr);
+        workspace_ptr = nullptr;
+    }
+    if (tiling_ptr != nullptr) {
+        aclrtFree(tiling_ptr);
+        tiling_ptr = nullptr;
+    }
+
+    if (output_final_state) {
+        return std::make_tuple(h_out, v_new_out, final_state_out);
+    }
+    return std::make_tuple(h_out, v_new_out, at::Tensor());
+}
+
+TORCH_LIBRARY_IMPL(EXTENSION_MODULE_NAME, PrivateUse1, m)
+{
+    m.impl("chunk_gated_delta_rule_fwd_h", chunk_gated_delta_rule_fwd_h_npu);
+}
+
+} // namespace ChunkGatedDeltaRuleFwdH
+} // namespace ascend_ops

--- a/examples/fast_kernel_launch_example/tests/chunk_gated_delta_rule_fwd_h/dump_model_data.py
+++ b/examples/fast_kernel_launch_example/tests/chunk_gated_delta_rule_fwd_h/dump_model_data.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------------------------------------
+# Dump realistic chunk_gated_delta_rule_fwd_h INPUT fixtures from the model pipeline.
+#
+# The fwd_h operator only behaves numerically well when its inputs (k, w, u, g) follow the distribution
+# produced by the upstream GDN pipeline (l2-normalised key, cumsum gate, WY representation). Feeding random
+# tensors makes the chunk recurrence diverge and the CPU golden becomes unreliable.
+#
+# This script reproduces the exact prefix of `flash_chunk_gated_delta_rule_fwd`:
+#   g = chunk_local_cumsum(g)          (triton)
+#   A = chunk_scaled_dot_kkt_fwd(...)  (triton)
+#   A = solve_tril(A)                  (triton)
+#   w, u = WY representation           (computed here with the repo's recompute_w_u CPU golden)
+# and saves model-distributed k / w / u / g (+ optional initial_state) plus the varlen metadata.
+#
+# The golden h / v_new / final_state are NOT produced by any custom op here; the consuming pytest computes
+# them from these realistic inputs with the fp32 CPU reference (forward_h_trans_cpu), which is the repo's
+# accepted golden for fwd_h. That keeps this dump free of the custom-op / vendor toolchain and lets the
+# fixtures be consumed from a different python/torch env.
+#
+# Run inside the README env (python3.10 + torch2.7.1 + torch_npu + triton-ascend):
+#   ASCEND_RT_VISIBLE_DEVICES=4 python dump_model_data.py
+# -----------------------------------------------------------------------------------------------------------
+
+import sys
+import math
+from pathlib import Path
+
+import torch
+import torch_npu  # noqa: F401
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from examples.flash_gated_delta_rule import (  # noqa: E402
+    _make_gate,
+    _chunk_list,
+    _chunk_tensor,
+    _ensure_varlen_metadata,
+    chunk_local_cumsum,
+    chunk_scaled_dot_kkt_fwd,
+    l2norm_fwd,
+    solve_tril,
+)
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+
+
+def _get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices):
+    if cu_seqlens is not None:
+        seq_idx = chunk_indices[idx * 2]
+        chunk_idx = chunk_indices[idx * 2 + 1]
+        bos = cu_seqlens[seq_idx] + chunk_idx * chunk_size
+        eos = min(bos + chunk_size, cu_seqlens[seq_idx + 1])
+    else:
+        bos = idx * chunk_size
+        eos = min(bos + chunk_size, T)
+    return bos, eos
+
+
+def compute_w_golden(k, v, beta, A, g, cu_seqlens, chunk_indices, B, H, T, D, chunk_size, NT, Hk):
+    """Repo CPU golden for w: w_chunk = A_chunk @ (k_chunk * beta * exp(g)). Layouts:
+    k [B,Hk,T,D], A [B,H,T,cs], beta [B,H,T], g [B,H,T]."""
+    hv_per_hk = H // Hk
+    w = torch.zeros(B, H, T, D, dtype=v.dtype)
+    for i_b in range(B):
+        for idx in range(NT):
+            bos, eos = _get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
+            for i_h in range(H):
+                hk = i_h // hv_per_hk
+                A_chunk = A[i_b, i_h, bos:eos, : eos - bos].float()
+                k_chunk = k[i_b, hk, bos:eos, :].float()
+                beta_chunk = beta[i_b, i_h, bos:eos].float()
+                g_exp = torch.exp(g[i_b, i_h, bos:eos].float())
+                kbg = k_chunk * (beta_chunk * g_exp)[:, None]
+                w[i_b, i_h, bos:eos, :] = torch.matmul(A_chunk, kbg).to(w.dtype)
+    return w
+
+
+def compute_u_golden(v, beta, A, cu_seqlens, chunk_indices, B, Hv, T, chunk_size, NT):
+    """Repo CPU golden for u: u_chunk = A_chunk @ (v_chunk * beta). Layouts as above."""
+    u = torch.zeros_like(v)
+    for i_b in range(B):
+        for idx in range(NT):
+            bos, eos = _get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
+            for i_h in range(Hv):
+                A_chunk = A[i_b, i_h, bos:eos, : eos - bos].float()
+                v_chunk = v[i_b, i_h, bos:eos, :].float()
+                beta_chunk = beta[i_b, i_h, bos:eos].float()
+                vb = v_chunk * beta_chunk[:, None]
+                u[i_b, i_h, bos:eos, :] = torch.matmul(A_chunk, vb).to(u.dtype)
+    return u
+
+
+def _gen_cu_seqlens(total_tokens: int, batch: int, device) -> torch.Tensor:
+    import random
+    random.seed(total_tokens * 131 + batch)
+    cu = [0]
+    avg = total_tokens // batch
+    for _ in range(batch - 1):
+        diff = random.randint(max(1, avg // 2), max(1, avg * 3 // 2))
+        nxt = min(cu[-1] + diff, total_tokens - (batch - len(cu)))
+        cu.append(max(cu[-1] + 1, nxt))
+    cu.append(total_tokens)
+    return torch.tensor(cu, dtype=torch.int64, device=device)
+
+
+def build_case(name, *, HV, T, K, V, chunk_size, dtype, use_init, varlen, batch, seed, device):
+    torch.manual_seed(seed)
+    B = 1
+
+    # After the upstream GQA repeat_interleave, the key reaching fwd_h always has value_heads,
+    # so kNumHead == vNumHead == HV here (head_ratio == 1), matching the real model distribution.
+    k = torch.randn(B, HV, T, K, dtype=dtype, device=device)
+    v = torch.randn(B, HV, T, V, dtype=dtype, device=device)
+    beta = torch.rand(B, T, HV, dtype=dtype, device=device).sigmoid()
+    g = _make_gate((B, T, HV), dtype, device, "logsigmoid")
+
+    # use_qk_l2norm_in_kernel=True -> key is l2-normalised before the chunk pipeline.
+    k, _ = l2norm_fwd(k)
+
+    cu_seqlens = None
+    cu_list = None
+    chunk_indices = None
+    chunk_list = None
+    if varlen:
+        cu_seqlens = _gen_cu_seqlens(T, batch, device)
+        cu_seqlens, cu_list, chunk_indices, chunk_list = _ensure_varlen_metadata(
+            g=g, cu_seqlens=cu_seqlens, cu_seqlens_list=None,
+            chunk_indices=None, chunk_indices_list=None, chunk_size=chunk_size,
+        )
+
+    g = chunk_local_cumsum(
+        g, chunk_size=chunk_size, cu_seqlens=cu_seqlens,
+        chunk_indices_out=chunk_indices, head_first=False,
+    )
+    A = chunk_scaled_dot_kkt_fwd(
+        k=k, g=g, beta=beta, cu_seqlens=cu_seqlens,
+        chunk_indices=_chunk_tensor(chunk_indices, chunk_size),
+        chunk_size=chunk_size, output_dtype=torch.float32,
+    )
+    A = solve_tril(A=A, cu_seqlens=cu_seqlens, chunk_indices_out=chunk_indices, output_dtype=k.dtype)
+
+    # Match the flash pipeline layout before the WY recompute.
+    g = g.transpose(1, 2).contiguous()        # [B, HV, T]
+    beta_t = beta.transpose(1, 2).contiguous()  # [B, HV, T]
+    A = A.transpose(1, 2).contiguous()        # [B, HV, T, chunk_size]
+
+    # Move to CPU and compute the WY representation with the repo golden (no custom op needed).
+    k_c, v_c, beta_c, A_c, g_c = (t.detach().cpu() for t in (k, v, beta_t, A, g))
+    flat_chunk_indices = _chunk_list(chunk_list, chunk_size)
+    NT = (len(flat_chunk_indices) // 2) if flat_chunk_indices is not None else (T + chunk_size - 1) // chunk_size
+    w_c = compute_w_golden(k_c, v_c, beta_c, A_c, g_c, cu_list, flat_chunk_indices, B, HV, T, K, chunk_size, NT, Hk=HV)
+    u_c = compute_u_golden(v_c, beta_c, A_c, cu_list, flat_chunk_indices, B, HV, T, chunk_size, NT)
+
+    initial_state = None
+    if use_init:
+        N = (len(cu_list) - 1) if cu_list is not None else B
+        initial_state = torch.randn(N, HV, K, V, dtype=dtype)
+
+    payload = {
+        "name": name,
+        "chunk_size": int(chunk_size),
+        "dtype": str(dtype).replace("torch.", ""),
+        "cu_seqlens": cu_list,
+        "chunk_indices": flat_chunk_indices,
+        "k": k_c,
+        "w": w_c,
+        "u": u_c,
+        "g": g_c,
+        "initial_state": initial_state,
+    }
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    out_path = DATA_DIR / f"{name}.pt"
+    torch.save(payload, out_path)
+    print(
+        f"[dump] {name}: k={tuple(k_c.shape)} w={tuple(w_c.shape)} u={tuple(u_c.shape)} g={tuple(g_c.shape)} "
+        f"init={None if initial_state is None else tuple(initial_state.shape)} "
+        f"cu={cu_list} -> {out_path.name}",
+        flush=True,
+    )
+
+
+CASES = [
+    dict(name="fix_bf16_noinit", HV=4, T=256, K=128, V=128, chunk_size=64, dtype=torch.bfloat16, use_init=False, varlen=False, batch=1, seed=0),
+    dict(name="fix_fp16_noinit", HV=4, T=256, K=128, V=128, chunk_size=64, dtype=torch.float16, use_init=False, varlen=False, batch=1, seed=1),
+    dict(name="fix_bf16_init", HV=4, T=256, K=128, V=128, chunk_size=64, dtype=torch.bfloat16, use_init=True, varlen=False, batch=1, seed=2),
+    dict(name="fix_fp16_init", HV=4, T=256, K=128, V=128, chunk_size=64, dtype=torch.float16, use_init=True, varlen=False, batch=1, seed=3),
+    dict(name="var_bf16_noinit", HV=4, T=320, K=128, V=128, chunk_size=64, dtype=torch.bfloat16, use_init=False, varlen=True, batch=3, seed=4),
+    dict(name="var_fp16_init", HV=4, T=320, K=128, V=128, chunk_size=64, dtype=torch.float16, use_init=True, varlen=True, batch=3, seed=5),
+]
+
+
+def main():
+    device = "npu"
+    torch.npu.set_compile_mode(jit_compile=False)
+    for cfg in CASES:
+        build_case(device=device, **cfg)
+    print("[dump] done. files in", DATA_DIR)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/fast_kernel_launch_example/tests/chunk_gated_delta_rule_fwd_h/test_chunk_gated_delta_rule_fwd_h.py
+++ b/examples/fast_kernel_launch_example/tests/chunk_gated_delta_rule_fwd_h/test_chunk_gated_delta_rule_fwd_h.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import math
+import random
+from pathlib import Path
+from typing import Optional
+
+import pytest
+import torch
+import torch_npu
+import ascend_ops
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+
+
+# --------------------------------------------------------------------------------------
+# helpers (ported from fla/ops/.../chunk_gated_delta_rule_fwd_h/tests/pta/test_fwd_h.py)
+# --------------------------------------------------------------------------------------
+def cdiv(a, b):
+    return (a + b - 1) // b
+
+
+def prepare_lens(cu_seqlens: torch.Tensor) -> torch.Tensor:
+    return cu_seqlens[1:] - cu_seqlens[:-1]
+
+
+def prepare_chunk_indices(cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Tensor:
+    indices = torch.cat([torch.arange(n) for n in cdiv(prepare_lens(cu_seqlens), chunk_size).tolist()])
+    return torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(cu_seqlens)
+
+
+def gen_seqlen(seqlen: int, batch: int) -> torch.Tensor:
+    cu_seqlens = [0]
+    avg_len = seqlen // batch
+    for _ in range(batch - 1):
+        diff = random.randint(max(1, avg_len // 2), max(1, avg_len * 3 // 2))
+        cu_seqlens.append(min(cu_seqlens[-1] + diff, seqlen - (batch - len(cu_seqlens))))
+    cu_seqlens.append(seqlen)
+    return torch.tensor(cu_seqlens, dtype=torch.int64)
+
+
+def gen_decay_data(shape_batch, v_num_head, seqlen, chunk_size, token_batch, cu_seqlens):
+    """Cumulative-sum decay within each chunk, kept negative so exp() stays stable."""
+    base = torch.randint(-15, -5, [v_num_head])
+    bias = torch.empty([shape_batch, v_num_head, seqlen]).uniform_(-2, 0)
+    g = base[None, :, None] + bias
+    for sb in range(shape_batch):
+        for vh in range(v_num_head):
+            for tb in range(token_batch):
+                start = int(cu_seqlens[tb]) if cu_seqlens is not None else 0
+                end = int(cu_seqlens[tb + 1]) if cu_seqlens is not None else seqlen
+                chunks = math.ceil((end - start) / chunk_size)
+                for c in range(chunks):
+                    cs = start + chunk_size * c
+                    ce = min(cs + chunk_size, end)
+                    g[sb, vh, cs:ce] = g[sb, vh, cs:ce].cumsum(0)
+    return g
+
+
+def forward_h_trans_cpu(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: torch.Tensor,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    chunk_size: int = 64,
+    cu_seqlens: Optional[torch.Tensor] = None,
+):
+    dtype_ = k.dtype
+    state_type_ = initial_state.dtype if initial_state is not None else torch.float32
+
+    k = k.to(torch.float32)
+    w = w.to(torch.float32)
+    u = u.to(torch.float32)
+    g = g.to(torch.float32)
+
+    B, HK, T, K = k.shape
+    HV, V = u.shape[1], u.shape[3]
+    BT = chunk_size
+
+    chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size) if cu_seqlens is not None else None
+    if cu_seqlens is None:
+        N, NT = B, (T + BT - 1) // BT
+        chunk_offsets = None
+    else:
+        N, NT = len(cu_seqlens) - 1, len(chunk_indices)
+        chunk_offsets = torch.cat(
+            [cu_seqlens.new_tensor([0]), cdiv(prepare_lens(cu_seqlens), BT)]
+        ).cumsum(-1)
+    if initial_state is not None:
+        initial_state = initial_state.reshape([N, HV, K, V]).contiguous().to(torch.float32)
+
+    S = torch.zeros((B, HV, NT, K, V), dtype=torch.float32)
+    v_new_output = torch.zeros((B, HV, T, V), dtype=torch.float32)
+    final_state = torch.zeros((N, HV, K, V), dtype=torch.float32)
+
+    head_ratio = HV // HK
+    for n in range(N):
+        if cu_seqlens is None:
+            bos, eos, boh = 0, T, 0
+            NT_inner = NT
+        else:
+            bos, eos = int(cu_seqlens[n]), int(cu_seqlens[n + 1])
+            NT_inner = (eos - bos + BT - 1) // BT
+            boh = int(chunk_offsets[n])
+        bidx = 0 if cu_seqlens is not None else n
+        for h in range(HV):
+            for i in range(NT_inner):
+                actual_len = min(bos + (i + 1) * BT, eos) - (bos + i * BT)
+                k_sel = torch.zeros((BT, K), dtype=torch.float32)
+                w_sel = torch.zeros((BT, w.shape[-1]), dtype=torch.float32)
+                u_sel = torch.zeros((BT, V), dtype=torch.float32)
+                g_sel = torch.zeros((BT,), dtype=torch.float32)
+                k_sel[:actual_len] = k[bidx, h // head_ratio, bos + i * BT: bos + i * BT + actual_len, :]
+                w_sel[:actual_len] = w[bidx, h, bos + i * BT: bos + i * BT + actual_len, :]
+                u_sel[:actual_len] = u[bidx, h, bos + i * BT: bos + i * BT + actual_len, :]
+                g_sel[:actual_len] = g[bidx, h, bos + i * BT: bos + i * BT + actual_len]
+                if initial_state is not None and i == 0:
+                    S[bidx, h, boh + i] = initial_state[n, h]
+                v_new = u_sel - w_sel @ S[bidx, h, boh + i]
+                decay = (g_sel[actual_len - 1, None, None]).exp()
+                new_state = S[bidx, h, boh + i] * decay + k_sel.transpose(-1, -2) @ (
+                    v_new * (g_sel[actual_len - 1, None] - g_sel).exp()[..., None]
+                )
+                if i != NT_inner - 1:
+                    S[bidx, h, boh + i + 1] = new_state
+                else:
+                    final_state[n, h] = new_state
+                v_new_output[bidx, h, bos + i * BT: bos + i * BT + actual_len, :] = v_new[:actual_len, :]
+
+    S = S.to(dtype_)
+    v_new_output = v_new_output.to(dtype_)
+    final_state = final_state.to(state_type_)
+    return S, v_new_output, final_state
+
+
+def assert_close(real, ref, diff_thd, pct_thd=0.05, max_diff_hd=0.1, name=""):
+    """Mirror the repo's data_compare semantics: allow at most pct_thd fraction of elements to
+    exceed the per-element relative threshold, and no single element may exceed max_diff_hd."""
+    real = real.detach().cpu().to(torch.float32).flatten()
+    ref = ref.detach().cpu().to(torch.float32).flatten()
+    abs_diff = (real - ref).abs()
+    denom = torch.maximum(real.abs(), ref.abs()) + 1e-9
+    rel = torch.where(abs_diff < diff_thd, abs_diff, abs_diff / denom)
+    fail_ratio = float((rel > diff_thd).float().mean().item())
+    max_err = float(rel.max().item())
+    assert fail_ratio <= pct_thd, \
+        f"{name} mismatch: fail ratio {fail_ratio:.4f} > {pct_thd} (diff_thd={diff_thd})"
+    assert max_err < max_diff_hd, \
+        f"{name} mismatch: max relative error {max_err:.4f} >= {max_diff_hd}"
+
+
+# --------------------------------------------------------------------------------------
+# tests
+# --------------------------------------------------------------------------------------
+def test_interface_exist():
+    print(torch.ops.ascend_ops.chunk_gated_delta_rule_fwd_h)
+    assert hasattr(torch.ops.ascend_ops, "chunk_gated_delta_rule_fwd_h"), \
+        "operator chunk_gated_delta_rule_fwd_h is not registered under torch.ops.ascend_ops"
+
+
+# --------------------------------------------------------------------------------------
+# model-distributed fixtures (produced by dump_model_data.py)
+#
+# fwd_h is a chunk recurrence: random k/w/u/g make the per-chunk states blow up, so the CPU
+# golden loses all significant digits and any comparison becomes meaningless. Instead we drive
+# the test with inputs sampled from the real GDN pipeline (l2-normalised key, cumsum gate, WY
+# representation), where the recurrence stays bounded and the fp32 reference is trustworthy.
+# Regenerate with: ASCEND_RT_VISIBLE_DEVICES=4 python dump_model_data.py
+# --------------------------------------------------------------------------------------
+FIXTURES = sorted(DATA_DIR.glob("*.pt")) if DATA_DIR.exists() else []
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU device not found")
+@pytest.mark.skipif(len(FIXTURES) == 0, reason="no model-dump fixtures found, run dump_model_data.py first")
+@pytest.mark.parametrize("fixture_path", FIXTURES, ids=[p.stem for p in FIXTURES])
+def test_model_dump(fixture_path):
+    payload = torch.load(fixture_path, map_location="cpu")
+    in_dtype = getattr(torch, payload["dtype"])
+    chunk_size = int(payload["chunk_size"])
+    cu_list = payload["cu_seqlens"]
+    chunk_list = payload["chunk_indices"]
+
+    k = payload["k"]
+    w = payload["w"]
+    u = payload["u"]
+    g = payload["g"].to(torch.float32)
+    initial_state = payload["initial_state"]
+    out_final = True
+
+    cu_tensor = torch.tensor(cu_list, dtype=torch.int64) if cu_list is not None else None
+
+    h_ref, v_ref, fs_ref = forward_h_trans_cpu(
+        k, w, u, g, initial_state, out_final, chunk_size, cu_seqlens=cu_tensor)
+
+    h, v_new, final_state = torch.ops.ascend_ops.chunk_gated_delta_rule_fwd_h(
+        k.npu(), w.npu(), u.npu(), g.npu(),
+        initial_state=initial_state.npu() if initial_state is not None else None,
+        output_final_state=out_final, chunk_size=chunk_size,
+        cu_seqlens=cu_list, chunk_indices=chunk_list)
+
+    diff_thd = 1e-2 if in_dtype == torch.bfloat16 else 4e-3
+    assert_close(h, h_ref, diff_thd, name="h")
+    assert_close(v_new, v_ref, diff_thd, name="v_new")
+    assert_close(final_state, fs_ref, diff_thd, name="final_state")

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.cpp
@@ -16,8 +16,21 @@
 #include <register/op_impl_registry.h>
 #include "tiling_base/data_copy_transpose_tiling.h"
 #include "tiling_base/tiling_templates_registry.h"
+#include "chunk_gated_delta_rule_fwd_h_tiling_processor.h"
 
 namespace optiling {
+
+// Maps a ge::DataType to the {fp16:0, bf16:1, fp32:2} convention shared with the kernel.
+static int64_t GdnFwdHDtypeToEnum(ge::DataType dtype)
+{
+    if (dtype == ge::DT_BF16) {
+        return GDN_FWD_H_DTYPE_BF16;
+    }
+    if (dtype == ge::DT_FLOAT16) {
+        return GDN_FWD_H_DTYPE_FP16;
+    }
+    return GDN_FWD_H_DTYPE_FP32;
+}
 static constexpr size_t INPUT_K_IDX = 0;
 static constexpr size_t INPUT_W_IDX = 1;
 static constexpr size_t INPUT_U_IDX = 2;
@@ -63,98 +76,66 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdH(gert::TilingContext *context)
     gert::Shape kStorageShape = context->GetOptionalInputShape(INPUT_K_IDX)->GetStorageShape();
     gert::Shape uStorageShape = context->GetOptionalInputShape(INPUT_U_IDX)->GetStorageShape();
 
-    int64_t seqlen = kStorageShape.GetDim(DIM_SEQLEN);
-    int64_t kNumHead = kStorageShape.GetDim(DIM_HEAD_NUM);
-    int64_t vNumHead = uStorageShape.GetDim(DIM_HEAD_NUM);
-    int64_t kHeadDim = kStorageShape.GetDim(DIM_HEAD_DIM);
-    int64_t vHeadDim = uStorageShape.GetDim(DIM_HEAD_DIM);
-    int64_t batch, isVariedLen, shapeBatch, tokenBatch;
-
     auto cuSeqlensTensor = context->GetOptionalInputTensor(INPUT_SEQLENS_IDX);
-    if (cuSeqlensTensor == nullptr) {
-        isVariedLen = false;
-        shapeBatch = kStorageShape.GetDim(DIM_BATCH);
-        tokenBatch = 1;
-        batch = shapeBatch;
-    } else {
-        isVariedLen = true;
-        shapeBatch = 1;
-        tokenBatch = cuSeqlensTensor->GetStorageShape().GetDim(DIM_BATCH) - 1;
-        batch = tokenBatch;
-    }
-
     auto initialStateTensor = context->GetOptionalInputTensor(INPUT_INITIAL_STATE_IDX);
     bool useInitialState = initialStateTensor != nullptr;
-    int64_t stateDataType = 2;
-    if (useInitialState) {
-        auto stateDType = initialStateTensor->GetDataType();
-        if (stateDType == ge::DT_BF16) {
-            stateDataType = 1;
-        } else if (stateDType == ge::DT_FLOAT16) {
-            stateDataType = 0;
-        }
-    }
-
-    auto gDType = context->GetOptionalInputTensor(INPUT_G_IDX)->GetDataType();
-    int64_t gDataType = 2;
-    if (gDType == ge::DT_BF16) {
-        gDataType = 1;
-    } else if (gDType == ge::DT_FLOAT16) {
-        gDataType = 0;
-    }
 
     auto attrPtr = context->GetAttrs();
     bool storeFinalState = *(attrPtr->GetAttrPointer<bool>(ATTR_STORE_FINAL_STATE_IDX));
     int64_t chunkSize = *(attrPtr->GetAttrPointer<int64_t>(ATTR_CHUNK_SIZE_IDX));
 
-    auto dtype = context->GetInputTensor(0)->GetDataType();
-    uint64_t dataType =  dtype == ge::DT_BF16 ? 1 : 0;
-
     const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
-    uint32_t aicCoreNum = ascendcPlatform.GetCoreNumAic();
-    context->SetBlockDim(aicCoreNum);
 
-    constexpr size_t WORKSPACE_RSV_BYTE = 16 * 1024 * 1024;
-    constexpr size_t GM_ALIGN = 512;
-    constexpr int64_t PING_PONG_STAGES = 2;
+    ChunkGatedDeltaRuleFwdHTilingContext tilingCtx{};
+    tilingCtx.seqlen = kStorageShape.GetDim(DIM_SEQLEN);
+    tilingCtx.kNumHead = kStorageShape.GetDim(DIM_HEAD_NUM);
+    tilingCtx.kHeadDim = kStorageShape.GetDim(DIM_HEAD_DIM);
+    tilingCtx.vNumHead = uStorageShape.GetDim(DIM_HEAD_NUM);
+    tilingCtx.vHeadDim = uStorageShape.GetDim(DIM_HEAD_DIM);
+    tilingCtx.shapeBatchDim = kStorageShape.GetDim(DIM_BATCH);
+    tilingCtx.hasCuSeqlens = cuSeqlensTensor != nullptr;
+    tilingCtx.cuSeqlensDim0 =
+        cuSeqlensTensor != nullptr ? cuSeqlensTensor->GetStorageShape().GetDim(DIM_BATCH) : 0;
+    tilingCtx.dataType = GdnFwdHDtypeToEnum(context->GetInputTensor(0)->GetDataType());
+    tilingCtx.gDataType = GdnFwdHDtypeToEnum(context->GetOptionalInputTensor(INPUT_G_IDX)->GetDataType());
+    tilingCtx.useInitialState = useInitialState;
+    tilingCtx.stateDataType =
+        useInitialState ? GdnFwdHDtypeToEnum(initialStateTensor->GetDataType()) : GDN_FWD_H_DTYPE_FP32;
+    tilingCtx.storeFinalState = storeFinalState;
+    tilingCtx.chunkSize = chunkSize;
+    tilingCtx.aicCoreNum = ascendcPlatform.GetCoreNumAic();
+    tilingCtx.libApiWorkSpaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
 
-    size_t workspaceOffset = ascendcPlatform.GetLibApiWorkSpaceSize();
-    workspaceOffset += WORKSPACE_RSV_BYTE;
+    ::ChunkGatedDeltaRuleFwdHTilingData plainTiling{};
+    uint32_t blockDim = 0;
+    size_t workspaceSize = 0;
+    ChunkGatedDeltaRuleFwdHTilingProcessor processor(tilingCtx);
+    processor.Process(plainTiling, blockDim, workspaceSize);
 
-    tiling.set_vWorkspaceOffset(workspaceOffset);
-    workspaceOffset += (aicCoreNum * chunkSize * vHeadDim * sizeof(float) * PING_PONG_STAGES + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
-
-    tiling.set_vUpdateWorkspaceOffset(workspaceOffset);
-    workspaceOffset += (aicCoreNum * chunkSize * vHeadDim * sizeof(float) * PING_PONG_STAGES + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
-
-    tiling.set_hWorkspaceOffset(workspaceOffset);
-    workspaceOffset += (aicCoreNum * kHeadDim * vHeadDim * sizeof(float) * PING_PONG_STAGES + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
-
-    tiling.set_numSeqWorkspaceOffset(workspaceOffset);
-    workspaceOffset += ((tokenBatch + 1) * sizeof(int64_t) + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
-
-    tiling.set_numChunksWorkspaceOffset(workspaceOffset);
-    workspaceOffset += ((tokenBatch + 1) * sizeof(int64_t) + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
-
-    workspaceOffset += WORKSPACE_RSV_BYTE;
+    context->SetBlockDim(blockDim);
     size_t *currentWorkspace = context->GetWorkspaceSizes(1);
-    currentWorkspace[0] = (workspaceOffset - 0);
+    currentWorkspace[0] = workspaceSize;
 
-    tiling.set_batch(batch);
-    tiling.set_seqlen(seqlen);
-    tiling.set_kNumHead(kNumHead);
-    tiling.set_vNumHead(vNumHead);
-    tiling.set_kHeadDim(kHeadDim);
-    tiling.set_vHeadDim(vHeadDim);
-    tiling.set_chunkSize(chunkSize);
-    tiling.set_useInitialState(useInitialState);
-    tiling.set_storeFinalState(storeFinalState);
-    tiling.set_dataType(dataType);
-    tiling.set_stateDataType(stateDataType);
-    tiling.set_gDataType(gDataType);
-    tiling.set_isVariedLen(isVariedLen);
-    tiling.set_shapeBatch(shapeBatch);
-    tiling.set_tokenBatch(tokenBatch);
+    tiling.set_batch(plainTiling.batch);
+    tiling.set_seqlen(plainTiling.seqlen);
+    tiling.set_kNumHead(plainTiling.kNumHead);
+    tiling.set_vNumHead(plainTiling.vNumHead);
+    tiling.set_kHeadDim(plainTiling.kHeadDim);
+    tiling.set_vHeadDim(plainTiling.vHeadDim);
+    tiling.set_chunkSize(plainTiling.chunkSize);
+    tiling.set_useInitialState(plainTiling.useInitialState);
+    tiling.set_storeFinalState(plainTiling.storeFinalState);
+    tiling.set_dataType(plainTiling.dataType);
+    tiling.set_stateDataType(plainTiling.stateDataType);
+    tiling.set_gDataType(plainTiling.gDataType);
+    tiling.set_isVariedLen(plainTiling.isVariedLen);
+    tiling.set_shapeBatch(plainTiling.shapeBatch);
+    tiling.set_tokenBatch(plainTiling.tokenBatch);
+    tiling.set_vWorkspaceOffset(plainTiling.vWorkspaceOffset);
+    tiling.set_vUpdateWorkspaceOffset(plainTiling.vUpdateWorkspaceOffset);
+    tiling.set_hWorkspaceOffset(plainTiling.hWorkspaceOffset);
+    tiling.set_numSeqWorkspaceOffset(plainTiling.numSeqWorkspaceOffset);
+    tiling.set_numChunksWorkspaceOffset(plainTiling.numChunksWorkspaceOffset);
 
     tiling.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
     context->GetRawTilingData()->SetDataSize(tiling.GetDataSize());

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling_processor.h
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_fwd_h_tiling_processor.h
+ * \brief Tiling computation decoupled from gert::TilingContext, reusable by both the
+ *        aclnn tiling entry and the fast kernel launch C++ extension.
+ *
+ * The caller is responsible for resolving framework-specific information (shapes, dtypes,
+ * platform core number, lib-api workspace size) into the plain context struct below. The
+ * processor then fills the plain ChunkGatedDeltaRuleFwdHTilingData together with the block
+ * dim and the total workspace size, mirroring exactly the original Tiling4ChunkGatedDeltaRuleFwdH.
+ */
+
+#ifndef CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H
+#define CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H
+
+#include <cstddef>
+#include <cstdint>
+
+#include "../op_kernel/chunk_gated_delta_rule_fwd_h_struct.h"
+
+namespace optiling {
+
+// dtype enum convention shared with the kernel: 0 - fp16, 1 - bf16, 2 - fp32
+static constexpr int64_t GDN_FWD_H_DTYPE_FP16 = 0;
+static constexpr int64_t GDN_FWD_H_DTYPE_BF16 = 1;
+static constexpr int64_t GDN_FWD_H_DTYPE_FP32 = 2;
+
+static constexpr size_t GDN_FWD_H_WORKSPACE_RSV_BYTE = 16 * 1024 * 1024;
+static constexpr size_t GDN_FWD_H_GM_ALIGN = 512;
+static constexpr int64_t GDN_FWD_H_PING_PONG_STAGES = 2;
+
+// Plain, framework-agnostic inputs needed to compute the tiling.
+struct ChunkGatedDeltaRuleFwdHTilingContext {
+    // shapes
+    int64_t seqlen;        // k.dim(2)
+    int64_t kNumHead;      // k.dim(1)
+    int64_t kHeadDim;      // k.dim(3)
+    int64_t vNumHead;      // u.dim(1)
+    int64_t vHeadDim;      // u.dim(3)
+    int64_t shapeBatchDim; // k.dim(0)
+    // variable length
+    bool hasCuSeqlens;
+    int64_t cuSeqlensDim0; // length of cu_seqlens (only used when hasCuSeqlens)
+    // dtypes (use GDN_FWD_H_DTYPE_*)
+    int64_t dataType;      // input (k/w/u) dtype: fp16 or bf16
+    int64_t gDataType;     // g dtype
+    bool useInitialState;
+    int64_t stateDataType; // initial/final state dtype
+    // attrs
+    bool storeFinalState;
+    int64_t chunkSize;
+    // platform
+    uint32_t aicCoreNum;
+    size_t libApiWorkSpaceSize;
+};
+
+class ChunkGatedDeltaRuleFwdHTilingProcessor {
+public:
+    explicit ChunkGatedDeltaRuleFwdHTilingProcessor(const ChunkGatedDeltaRuleFwdHTilingContext &ctx) : ctx_(ctx) {}
+
+    // Fills the plain tiling struct, the block dim and the total workspace size.
+    void Process(::ChunkGatedDeltaRuleFwdHTilingData &tiling, uint32_t &blockDim, size_t &workspaceSize) const
+    {
+        int64_t isVariedLen;
+        int64_t shapeBatch;
+        int64_t tokenBatch;
+        int64_t batch;
+
+        if (!ctx_.hasCuSeqlens) {
+            isVariedLen = 0;
+            shapeBatch = ctx_.shapeBatchDim;
+            tokenBatch = 1;
+            batch = shapeBatch;
+        } else {
+            isVariedLen = 1;
+            shapeBatch = 1;
+            tokenBatch = ctx_.cuSeqlensDim0 - 1;
+            batch = tokenBatch;
+        }
+
+        blockDim = ctx_.aicCoreNum;
+        const int64_t aicCoreNum = static_cast<int64_t>(ctx_.aicCoreNum);
+        const int64_t chunkSize = ctx_.chunkSize;
+        const int64_t kHeadDim = ctx_.kHeadDim;
+        const int64_t vHeadDim = ctx_.vHeadDim;
+
+        size_t workspaceOffset = ctx_.libApiWorkSpaceSize;
+        workspaceOffset += GDN_FWD_H_WORKSPACE_RSV_BYTE;
+
+        tiling.vWorkspaceOffset = static_cast<int64_t>(workspaceOffset);
+        workspaceOffset += AlignUp(static_cast<size_t>(aicCoreNum * chunkSize * vHeadDim * static_cast<int64_t>(sizeof(float)) * GDN_FWD_H_PING_PONG_STAGES));
+
+        tiling.vUpdateWorkspaceOffset = static_cast<int64_t>(workspaceOffset);
+        workspaceOffset += AlignUp(static_cast<size_t>(aicCoreNum * chunkSize * vHeadDim * static_cast<int64_t>(sizeof(float)) * GDN_FWD_H_PING_PONG_STAGES));
+
+        tiling.hWorkspaceOffset = static_cast<int64_t>(workspaceOffset);
+        workspaceOffset += AlignUp(static_cast<size_t>(aicCoreNum * kHeadDim * vHeadDim * static_cast<int64_t>(sizeof(float)) * GDN_FWD_H_PING_PONG_STAGES));
+
+        tiling.numSeqWorkspaceOffset = static_cast<int64_t>(workspaceOffset);
+        workspaceOffset += AlignUp(static_cast<size_t>((tokenBatch + 1) * static_cast<int64_t>(sizeof(int64_t))));
+
+        tiling.numChunksWorkspaceOffset = static_cast<int64_t>(workspaceOffset);
+        workspaceOffset += AlignUp(static_cast<size_t>((tokenBatch + 1) * static_cast<int64_t>(sizeof(int64_t))));
+
+        workspaceOffset += GDN_FWD_H_WORKSPACE_RSV_BYTE;
+        workspaceSize = workspaceOffset;
+
+        tiling.batch = batch;
+        tiling.seqlen = ctx_.seqlen;
+        tiling.kNumHead = ctx_.kNumHead;
+        tiling.vNumHead = ctx_.vNumHead;
+        tiling.kHeadDim = ctx_.kHeadDim;
+        tiling.vHeadDim = ctx_.vHeadDim;
+        tiling.chunkSize = chunkSize;
+        tiling.useInitialState = ctx_.useInitialState;
+        tiling.storeFinalState = ctx_.storeFinalState;
+        tiling.dataType = ctx_.dataType;
+        tiling.gDataType = ctx_.gDataType;
+        tiling.stateDataType = ctx_.stateDataType;
+        tiling.isVariedLen = isVariedLen;
+        tiling.shapeBatch = shapeBatch;
+        tiling.tokenBatch = tokenBatch;
+    }
+
+private:
+    // Mirrors the original "(x + GM_ALIGN) / GM_ALIGN * GM_ALIGN" alignment.
+    static size_t AlignUp(size_t x)
+    {
+        return (x + GDN_FWD_H_GM_ALIGN) / GDN_FWD_H_GM_ALIGN * GDN_FWD_H_GM_ALIGN;
+    }
+
+    const ChunkGatedDeltaRuleFwdHTilingContext &ctx_;
+};
+
+} // namespace optiling
+
+#endif // CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h_struct.h
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_fwd_h_struct.h
+ * \brief Plain tiling data struct for chunk_gated_delta_rule_fwd_h.
+ *
+ * The aclnn/ascendc framework auto-generates a kernel-side tiling struct named
+ * ChunkGatedDeltaRuleFwdHTilingData (global scope) from the BEGIN_TILING_DATA_DEF
+ * macro in chunk_gated_delta_rule_fwd_h_tiling.h. The fast kernel launch extension
+ * compiles the kernel standalone (without that auto-generated header), so it provides
+ * the same plain struct here. The field order/types mirror the macro definition so the
+ * kernel/scheduler can read it the same way, and so the struct can be passed by value
+ * to the kernel via the <<<>>> launch (its address is a valid GM_ADDR on Atlas A2).
+ */
+
+#ifndef CHUNK_GATED_DELTA_RULE_FWD_H_STRUCT_H
+#define CHUNK_GATED_DELTA_RULE_FWD_H_STRUCT_H
+
+#include <cstdint>
+
+struct ChunkGatedDeltaRuleFwdHTilingData {
+    int64_t batch;
+    int64_t seqlen;
+    int64_t kNumHead;
+    int64_t vNumHead;
+    int64_t kHeadDim;
+    int64_t vHeadDim;
+    int64_t chunkSize;
+    bool useInitialState;
+    bool storeFinalState;
+    int64_t dataType;
+    int64_t gDataType;
+    int64_t stateDataType;
+    int64_t isVariedLen;
+    int64_t shapeBatch;
+    int64_t tokenBatch;
+    int64_t vWorkspaceOffset;
+    int64_t vUpdateWorkspaceOffset;
+    int64_t hWorkspaceOffset;
+    int64_t numSeqWorkspaceOffset;
+    int64_t numChunksWorkspaceOffset;
+};
+
+#endif // CHUNK_GATED_DELTA_RULE_FWD_H_STRUCT_H


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @fazhenyao
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
