### PR TITLE
feat(chunk_gated_delta_rule_bwd_dhu): 支持 GVA（分组值注意力）

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/examples/test_aclnn_chunk_gated_delta_rule_bwd_dhu.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/examples/test_aclnn_chunk_gated_delta_rule_bwd_dhu.cpp
@@ -149,6 +149,8 @@ int main() {
   int64_t B = 1;
   int64_t T = 32768;
   int64_t H = 32;
+  int64_t Hk = 4;
+
   int64_t K = 128;
   int64_t V = 128;
   int64_t chunk_size = 64;
@@ -160,8 +162,8 @@ int main() {
   int64_t NT = static_cast<int64_t>(chunkIndicesHostData.size()) / 2;
   float scale = 1.0;
 
-  std::vector<int64_t> qShape = {B, H, T, K};
-  std::vector<int64_t> kShape = {B, H, T, K};
+  std::vector<int64_t> qShape = {B, Hk, T, K};
+  std::vector<int64_t> kShape = {B, Hk, T, K};
   std::vector<int64_t> wShape = {B, H, T, K};
   std::vector<int64_t> doShape = {B, H, T, V};
   std::vector<int64_t> dvShape = {B, H, T, V};

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.cpp
@@ -67,12 +67,43 @@ namespace {
 bool ChunkGatedDeltaRuleBwdDhuTiling::Init(gert::TilingContext* context) {
 
   const gert::Shape qShape = context->GetInputShape(INPUT_Q_IDX)->GetStorageShape();
+  const gert::Shape kShape = context->GetInputShape(INPUT_K_IDX)->GetStorageShape();
+  const gert::Shape wShape = context->GetInputShape(INPUT_W_IDX)->GetStorageShape();
   const gert::Shape doShape = context->GetInputShape(INPUT_DO_IDX)->GetStorageShape();
+  const gert::Shape dvShape = context->GetInputShape(INPUT_DV_IDX)->GetStorageShape();
   B = qShape.GetDim(DIM_0);
-  H = qShape.GetDim(DIM_1);
+  Hk = qShape.GetDim(DIM_1);
   T = qShape.GetDim(DIM_2);
   K = qShape.GetDim(DIM_3);
+  Hv = doShape.GetDim(DIM_1);
   V = doShape.GetDim(DIM_3);
+
+  OP_CHECK_IF(
+      kShape.GetDim(DIM_0) != static_cast<int64_t>(B) || kShape.GetDim(DIM_1) != static_cast<int64_t>(Hk) ||
+          kShape.GetDim(DIM_2) != static_cast<int64_t>(T) || kShape.GetDim(DIM_3) != static_cast<int64_t>(K),
+      OP_LOGE(context->GetNodeName(),
+              "k must match q as [B,Hk,T,K]; q [%lu,%lu,%lu,%lu], k [%ld,%ld,%ld,%ld].", B, Hk, T, K,
+              kShape.GetDim(DIM_0), kShape.GetDim(DIM_1), kShape.GetDim(DIM_2), kShape.GetDim(DIM_3)),
+      return false);
+  OP_CHECK_IF(
+      wShape.GetDim(DIM_0) != static_cast<int64_t>(B) || wShape.GetDim(DIM_1) != static_cast<int64_t>(Hv) ||
+          wShape.GetDim(DIM_2) != static_cast<int64_t>(T) || wShape.GetDim(DIM_3) != static_cast<int64_t>(K),
+      OP_LOGE(context->GetNodeName(),
+              "w must be [B,Hv,T,K] with Hv=dO.dim1; expect [%lu,%lu,%lu,%lu], got [%ld,%ld,%ld,%ld].", B, Hv, T, K,
+              wShape.GetDim(DIM_0), wShape.GetDim(DIM_1), wShape.GetDim(DIM_2), wShape.GetDim(DIM_3)),
+      return false);
+  OP_CHECK_IF(doShape.GetDim(DIM_0) != static_cast<int64_t>(B) || doShape.GetDim(DIM_2) != static_cast<int64_t>(T),
+              OP_LOGE(context->GetNodeName(), "dO batch/time must match q."), return false);
+  OP_CHECK_IF(
+      dvShape.GetDim(DIM_0) != static_cast<int64_t>(B) || dvShape.GetDim(DIM_1) != static_cast<int64_t>(Hv) ||
+          dvShape.GetDim(DIM_2) != static_cast<int64_t>(T) || dvShape.GetDim(DIM_3) != static_cast<int64_t>(V),
+      OP_LOGE(context->GetNodeName(), "dv must be [B,Hv,T,V] aligned with dO."), return false);
+  // GVA（Grouped Value Attention）：Hk 为 q/k 头数，Hv 为 value 头数（与 do/dv/w对齐）；须 Hv 是 Hk 的整数倍（见 FLA num_v_heads % num_heads）。
+  OP_CHECK_IF(Hv == 0 || Hk == 0 || (Hv % Hk) != 0,
+              OP_LOGE(context->GetNodeName(),
+                      "GVA: Hv (value heads) must be an integer multiple of Hk (q/k heads); require Hv mod Hk == 0; got Hk=%lu Hv=%lu.",
+                      Hk, Hv),
+              return false);
   
   auto attrs = context->GetAttrs();
   OP_CHECK_IF(attrs == nullptr, OP_LOGE(context->GetNodeName(), "attrs is nullptr."), return false);
@@ -86,7 +117,8 @@ bool ChunkGatedDeltaRuleBwdDhuTiling::Init(gert::TilingContext* context) {
               return false);
   
   tilingData.set_B(B);
-  tilingData.set_H(H);
+  tilingData.set_Hv(Hv);
+  tilingData.set_Hk(Hk);
   tilingData.set_T(T);
   tilingData.set_K(K);
   tilingData.set_V(V);
@@ -148,18 +180,23 @@ bool ChunkGatedDeltaRuleBwdDhuTiling::CalcUb(gert::TilingContext *context) {
   // AIC_AIV_1_2, 每个VEC处理BT/2行
   uint32_t halfBT = CeilDiv(static_cast<uint32_t>(chunkSize), NUM_2);
   uint32_t halfK = CeilDiv(static_cast<uint32_t>(K), NUM_2);
-  uint32_t gBufByte = halfBT * HALF_DTYPE_SIZE;
-  uint32_t gCastBufByte = halfBT * FP32_DTYPE_SIZE; // 256
-  uint32_t gBrcbBufByte = halfBT * BLOCK_SIZE; // 512
-  uint32_t dvBufByte = halfBT * V * HALF_DTYPE_SIZE; // 32K
-  uint32_t dvCastBufByte = halfBT * V * FP32_DTYPE_SIZE; // 64K
+  uint32_t gBrcbBufByte = halfBT * BLOCK_SIZE;
+  uint32_t dvBufByte = halfBT * V * HALF_DTYPE_SIZE;
+  uint32_t dvCastBufByte = halfBT * V * FP32_DTYPE_SIZE;
   uint32_t dqkBufByte = halfBT * K * HALF_DTYPE_SIZE;
   uint32_t dqkCastBufByte = halfBT * K * FP32_DTYPE_SIZE;
-  uint32_t dhBufByte = halfK * V * HALF_DTYPE_SIZE;
   uint32_t dhCastBufByte = halfK * V * FP32_DTYPE_SIZE;
 
-  uint32_t tBufByte = std::max(NUM_2 * dhCastBufByte,
-      gCastBufByte + gBrcbBufByte + dvBufByte + NUM_2 * dvCastBufByte);
+  // 与 chunk_gated_delta_rule_bwd_dhu_vec.h InitUB 对齐（同一 vecTbuf 内绝对偏移尖峰）：
+  // - dv2 链：gCast 后 dv2Offset = chunkSize*4，再接 gBrcb、vIn(fp16)、dvCast、bdvCast(fp32)
+  // - gatedQ 链：gCast+gExp 共 2*chunkSize*4，offsetQ 起 qLocal(fp16)+qCast(fp32)+gBCLocal
+  // - UpdateDh：分时复用 [0, 2*dhCastBufByte)，与上两链取 max
+  const uint32_t dvPeak =
+      chunkSize * FP32_DTYPE_SIZE + gBrcbBufByte + dvBufByte + NUM_2 * dvCastBufByte;
+  const uint32_t gatedQPeak =
+      NUM_2 * chunkSize * FP32_DTYPE_SIZE + dqkBufByte + dqkCastBufByte + gBrcbBufByte;
+  const uint32_t dhPeak = NUM_2 * dhCastBufByte;
+  uint32_t tBufByte = std::max(dhPeak, std::max(dvPeak, gatedQPeak));
   
   auto platformInfoPtr = context->GetPlatformInfo();
   auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
@@ -180,11 +217,15 @@ void ChunkGatedDeltaRuleBwdDhuTiling::SetWorkspaceSize(gert::TilingContext* cont
   auto platformInfoPtr = context->GetPlatformInfo();
   auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
   uint32_t totalCoreNum = ascendcPlatform.GetCoreNumAic();
-  uint32_t taskNum = B * H * tilingData.get_seqNum(); // 變長：B*H*S，等長：B*H
+  uint32_t taskNum = B * Hk * tilingData.get_seqNum();
   uint32_t usedCoreNum = taskNum > totalCoreNum ? totalCoreNum : taskNum;  
   tilingData.set_usedCoreNum(usedCoreNum);
   context->SetBlockDim(usedCoreNum);
 
+  // GVA 方案 A：粗粒度 task 为 (b,hq,seq)，组内各 value 头 h 串行（见 cube/vec 中 for h 循环）。
+  // Workspace 按物理核 coreIdx / vec 侧 cubeIdx 分片；每片仍对应「单 chunk、单条流水线」的 bdv/gatedQ/dh term，
+  // 完成该 h 的一步后再处理下一 h，同一片复用，故 per-core 步长仍为 chunkSize*V、BT*K、K*V，无需再乘 (Hv/Hk)。
+  // 若将来改为组内多头并行或双缓冲，需同时改 kernel 内偏移与下列 * usedCoreNum 的核算。
   uint64_t bdvWs = chunkSize * V * usedCoreNum;
   uint64_t qWs = K * chunkSize * usedCoreNum;
   uint64_t wDv2Ws = K * V * usedCoreNum;
@@ -203,7 +244,8 @@ void ChunkGatedDeltaRuleBwdDhuTiling::SetWorkspaceSize(gert::TilingContext* cont
 void ChunkGatedDeltaRuleBwdDhuTiling::PrintTilingData(gert::TilingContext *context) {
   OP_LOGD(context->GetNodeName(), "End Run ChunkGatedDeltaRuleBwdDhu Tiling");
   OP_LOGD(context->GetNodeName(), "B is %lu.", tilingData.get_B());
-  OP_LOGD(context->GetNodeName(), "H is %lu.", tilingData.get_H());
+  OP_LOGD(context->GetNodeName(), "Hv is %lu.", tilingData.get_Hv());
+  OP_LOGD(context->GetNodeName(), "Hk is %lu.", tilingData.get_Hk());
   OP_LOGD(context->GetNodeName(), "T is %lu.", tilingData.get_T());
   OP_LOGD(context->GetNodeName(), "K is %lu.", tilingData.get_K());
   OP_LOGD(context->GetNodeName(), "V is %lu.", tilingData.get_V());

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.h
@@ -26,7 +26,8 @@ namespace optiling {
 
 BEGIN_TILING_DATA_DEF(ChunkGatedDeltaRuleBwdDhuTilingData)
 TILING_DATA_FIELD_DEF(uint64_t, B);
-TILING_DATA_FIELD_DEF(uint64_t, H);
+TILING_DATA_FIELD_DEF(uint64_t, Hv);
+TILING_DATA_FIELD_DEF(uint64_t, Hk);
 TILING_DATA_FIELD_DEF(uint64_t, T);
 TILING_DATA_FIELD_DEF(uint64_t, K);
 TILING_DATA_FIELD_DEF(uint64_t, V);
@@ -67,7 +68,8 @@ private:
     bool IS_SCALE = false;
     bool IS_VARIABLE_LEN = false; 
     uint64_t B = 0;
-    uint64_t H = 0;
+    uint64_t Hv = 0;
+    uint64_t Hk = 0;
     uint64_t T = 0;
     uint64_t K = 0;
     uint64_t V = 0;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
@@ -97,7 +97,9 @@ protected:
     
     // tiling data
     uint64_t B = 0;
-    uint64_t H = 0;
+    uint64_t Hv = 0;
+    uint64_t Hk = 0;
+    uint64_t hvPerHk = 1; // GVA: value 头数 / qk 头数，hq = h / hvPerHk
     uint64_t T = 0;
     uint64_t K = 0;
     uint64_t V = 0;
@@ -133,7 +135,9 @@ template <typename DT, typename GT>
 __aicore__ inline void GDRBase<DT, GT>::InitTilingData(const ChunkGatedDeltaRuleBwdDhuTilingData& tilingData)
 {
     this->B = tilingData.B;
-    this->H = tilingData.H;
+    this->Hv = tilingData.Hv;
+    this->Hk = tilingData.Hk;
+    this->hvPerHk = this->Hk != 0 ? this->Hv / this->Hk : 0;
     this->T = tilingData.T;
     this->K = tilingData.K;
     this->V = tilingData.V;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_cube.h
@@ -160,7 +160,8 @@ public:
         GM_ADDR cu_seqlens; 
         uint64_t B = 0;
         uint64_t T = 0;
-        uint64_t H = 0;
+        uint64_t Hv = 0;
+        uint64_t Hk = 0;
         uint64_t K = 0;
         uint64_t V = 0;
         uint64_t BT = 0;
@@ -181,7 +182,7 @@ public:
         Params(GM_ADDR k_, LayoutK layoutK_, GM_ADDR dh_, LayoutDh layoutDh_, GM_ADDR workspace_,  LayoutBdv layoutBdv_, 
                LayoutGq layoutGq_, GM_ADDR dO_, LayoutDo layoutDo_,    
                GM_ADDR w_ , LayoutW layoutW_, GM_ADDR dv2_ , LayoutDv2 layoutDv2_, LayoutBdh layoutBdh_,
-               GM_ADDR cu_seqlens_, uint64_t B_, uint64_t T_, uint64_t H_, uint64_t K_, uint64_t V_,
+               GM_ADDR cu_seqlens_, uint64_t B_, uint64_t T_, uint64_t Hv_, uint64_t Hk_, uint64_t K_, uint64_t V_,
                uint64_t BT_, uint64_t chunkNum_, uint64_t seqNum_, uint64_t usedCoreNum_, bool isVarLen_,
                uint64_t bdvWorkspaceOffset_, uint64_t gQWorkspaceOffset_,uint64_t bdhTerm1WorkspaceOffset_, uint64_t bdhTerm2WorkspaceOffset_): 
             k(k_), 
@@ -201,7 +202,8 @@ public:
             cu_seqlens(cu_seqlens_),
             B(B_), 
             T(T_), 
-            H(H_), 
+            Hv(Hv_), 
+            Hk(Hk_), 
             K(K_), 
             V(V_), 
             BT(BT_),
@@ -257,16 +259,22 @@ public:
 
         l0CTensor = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(0);
         {
-            // 每个核完成一个batch里的一个head的一个seqence里的所有chunk
-            uint32_t totalTaskNum = params.B * params.H * params.seqNum; // 等長seqNum=1
+            // 每个核完成一个 batch 内一个 q/k 头 hq、一条序列上的所有 chunk；组内各 value 头 h 串行处理（GVA 方案 A）
+            // 性能说明：当前循环顺序为 for(h) for(chunkIdx)，同一 (hq,chunkIdx) 上 k 的 GM 片相同，但 bdv=k@dh 会对每个 h 重新 copyGmToL1A(k)；
+            // w 按 value 头分片 (gmOffsetW 依赖 h)，dh2 路径上 w 本就必须每 h 重搬，不存在跨 h 复用。
+            // 若要减少 k 的重复 MTE：需与 vec 协同改为 chunk-major（for chunkIdx for h），且 vec 侧为每个 h 单独维护跨 chunk 的 gLast/gLastExp 等状态。
+            uint32_t totalTaskNum = params.B * params.Hk * params.seqNum;
             uint32_t coreIdx = GetBlockIdx();
+            const uint32_t hvPerHk = params.Hk != 0 ? static_cast<uint32_t>(params.Hv / params.Hk) : 1;
             for (uint32_t i = coreIdx; i < totalTaskNum; i += params.usedCoreNum) {
-                uint64_t b = 0;
-                int32_t curChunkNum = 0;
-                uint64_t curSeqLen = 0;
-                CaclOffset(i, curChunkNum, curSeqLen, params);
-                uint32_t curBT = 0;
-                for (int32_t chunkIdx = curChunkNum - 1; chunkIdx >= 0; chunkIdx --) {
+                const uint32_t hq = i % params.Hk;
+                const uint32_t hGroupEnd = (hq + 1U) * hvPerHk;
+                for (uint32_t h = hq * hvPerHk; h < hGroupEnd; h++) {
+                    int32_t curChunkNum = 0;
+                    uint64_t curSeqLen = 0;
+                    CaclOffset(i, h, curChunkNum, curSeqLen, params);
+                    uint32_t curBT = 0;
+                    for (int32_t chunkIdx = curChunkNum - 1; chunkIdx >= 0; chunkIdx --) {
                     // cacl k @ dh
                     if (chunkIdx == curChunkNum -1) {
                         curBT = curSeqLen - chunkIdx * params.BT;
@@ -274,7 +282,7 @@ public:
                     } else {
                         curBT = params.BT;  // BT = 64/128 is always 16 aligned
                         // init GlobalTensor
-                        gmK.SetGlobalBuffer((__gm__ ElementK *)params.k + gmOffsetK + chunkIdx * params.BT * params.K);
+                        gmK.SetGlobalBuffer((__gm__ ElementK *)params.k + gmOffsetQK + chunkIdx * params.BT * params.K);
                          // 用的是上一次chunk迭代的结果
                         gmDh.SetGlobalBuffer((__gm__ ElementDh *)params.dh + gmOffsetH + chunkIdx * params.K * params.V);
                         gmWsBdv.SetGlobalBuffer((__gm__ ElementDh *)params.workspace + coreIdx * params.BT * params.V);
@@ -352,7 +360,7 @@ public:
                         gmDo.SetGlobalBuffer((__gm__ ElementDo *)params.dO + gmOffsetV + chunkIdx * params.BT * params.V);
                         gmDhTerm1.SetGlobalBuffer((__gm__ ElementDh *)params.workspace + params.bdhTerm1WorkspaceOffset + coreIdx * params.K * params.V);
                         
-                        gmW.SetGlobalBuffer((__gm__ ElementW *)params.w + gmOffsetK + chunkIdx * params.BT * params.K);
+                        gmW.SetGlobalBuffer((__gm__ ElementW *)params.w + gmOffsetW + chunkIdx * params.BT * params.K);
                         gmDv2.SetGlobalBuffer((__gm__ ElementDv2 *)params.dv2 + gmOffsetV + chunkIdx * params.BT * params.V);
                         gmDhTerm2.SetGlobalBuffer((__gm__ ElementDh *)params.workspace + params.bdhTerm2WorkspaceOffset + coreIdx * params.K * params.V);
 
@@ -504,52 +512,50 @@ public:
                         CrossCoreSetFlag<0x2, PIPE_FIX>(CROSS_CORE_C2V_TERM2);
                     }
                 }
+                }
             }
         }
         return;
     }
     
 private:
-    CATLASS_DEVICE void CaclOffset(const uint32_t taskIdx, int32_t& curChunkNum, uint64_t& curSeqLen, Params const& params)
+    CATLASS_DEVICE void CaclOffset(const uint32_t coarseTaskIdx, uint32_t h, int32_t& curChunkNum, uint64_t& curSeqLen, Params const& params)
     {
         uint64_t seqStartOffset = 0;
         uint64_t preChunkNum = 0;
         uint64_t b = 0;
-        uint32_t h = taskIdx % params.H; // 当前任务在第几个h 
+        const uint32_t hq = coarseTaskIdx % params.Hk;
         if (params.isVarLen) {
-            uint32_t seqIdx = taskIdx / params.H; // 当前任务在第几个seq
+            uint32_t seqIdx = coarseTaskIdx / params.Hk;
             // {0, 96, 224, 320} [0, 2, 4， 6]
             seqStartOffset = gmCuSeqlens.GetValue(seqIdx); // 当前seq在T中的起始索引
             uint64_t seqEndOffset = gmCuSeqlens.GetValue(seqIdx+1); // 当前seq在T中的结束索引
             curSeqLen = seqEndOffset - seqStartOffset;
-            uint64_t tailChunkLen = curSeqLen % params.BT; 
-            // 计算当前seq的起始chunkIdx
             uint64_t tmpStartOffset = 0;
             uint64_t tmpEndOffset = 0;
-            uint64_t tmpChunkNum = 0;
             for (uint32_t seq = 0; seq < seqIdx; seq++) {
-                tmpStartOffset = gmCuSeqlens.GetValue(seq); // 当前seq在T中的起始索引
-                tmpEndOffset = gmCuSeqlens.GetValue(seq+1); // 当前seq在T中的结束索引
+                tmpStartOffset = gmCuSeqlens.GetValue(seq);
+                tmpEndOffset = gmCuSeqlens.GetValue(seq + 1);
                 auto tmpChunkNum = ((tmpEndOffset - tmpStartOffset) + params.BT - 1) / params.BT;
                 preChunkNum += tmpChunkNum;
             }
-            curChunkNum = (curSeqLen + params.BT - 1) / params.BT; // 当前seq的chunk数
-            // calc offset
+            curChunkNum = (curSeqLen + params.BT - 1) / params.BT;
         } else {
             curChunkNum = params.chunkNum;
-            b = taskIdx / params.H;
+            b = coarseTaskIdx / params.Hk;
             curSeqLen = params.T;
         }
-        gmOffsetK = (b * params.H + h) * params.T * params.K + seqStartOffset * params.K;
-        gmOffsetH = (b * params.H + h) * params.chunkNum * params.K * params.V + 
-                    preChunkNum * params.K * params.V; // [B,H,chunk_num,K,V]
-        gmOffsetV = (b * params.H + h) * params.T * params.V + seqStartOffset * params.V;
+        gmOffsetQK = (b * params.Hk + hq) * params.T * params.K + seqStartOffset * params.K;
+        gmOffsetW = (b * params.Hv + h) * params.T * params.K + seqStartOffset * params.K;
+        gmOffsetH = (b * params.Hv + h) * params.chunkNum * params.K * params.V + 
+                    preChunkNum * params.K * params.V; // [B,Hv,chunk_num,K,V]
+        gmOffsetV = (b * params.Hv + h) * params.T * params.V + seqStartOffset * params.V;
     }
 
     AscendC::GlobalTensor<ElementInt> gmCuSeqlens;
 
-    AscendC::GlobalTensor<ElementK> gmK; // [B,H,T,K]
-    AscendC::GlobalTensor<ElementDh> gmDh; // [B,H,chunkNum,K,V]
+    AscendC::GlobalTensor<ElementK> gmK; // [B,Hk,T,K]
+    AscendC::GlobalTensor<ElementDh> gmDh; // [B,Hv,chunkNum,K,V]
     AscendC::GlobalTensor<ElementDh> gmWsBdv;
 
     AscendC::GlobalTensor<ElementGq> gmGq;
@@ -590,7 +596,8 @@ private:
     TileMmadDh1 tileMmadDh1;
     TileMmadDh2 tileMmadDh2;
 
-    uint64_t gmOffsetK = 0;
+    uint64_t gmOffsetQK = 0;
+    uint64_t gmOffsetW = 0;
     uint64_t gmOffsetV = 0;
     uint64_t gmOffsetH = 0;
 };
@@ -718,7 +725,7 @@ __aicore__ inline void GDRCube<DT, GT>::Process()
     typename GDRKernel::Params param{k, layoutK, dh, layoutDh, workspace, layoutBdv, // k @ dh -> bdv[workspace ]
                                      layoutGq, dO, layoutDo,                // gatedQ^T[workspace ] @ do -> bdh[workspace]
                                      w, layoutW, dv2, layoutDv2, layoutBdh, // w^T @ dv2 -> bdh[workspace] 
-                                     cu_seqlens, this->B, this->T, this->H, this->K, this->V, 
+                                     cu_seqlens, this->B, this->T, this->Hv, this->Hk, this->K, this->V, 
                                      this->chunkSize, this->chunkNum, this->seqNum, this->usedCoreNum, static_cast<bool>(this->isVarLen),
                                      bdvWorkspaceOffset, gQWorkspaceOffset, bdhTerm1WorkspaceOffset, bdhTerm2WorkspaceOffset};
     kernel(param);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
@@ -35,7 +35,7 @@ private:
     __aicore__ inline void InitUB();
     __aicore__ inline void InitGlobalTensor(GM_ADDR q, GM_ADDR dv, GM_ADDR g, GM_ADDR cu_seqlens, 
                                             GM_ADDR dv2, GM_ADDR dh, GM_ADDR workspace);
-    __aicore__ inline void CaclOffset(const uint32_t taskIdx, uint64_t& tailChunkLen); 
+    __aicore__ inline void CaclOffset(const uint32_t coarseTaskIdx, const uint32_t h, uint64_t& tailChunkLen);
     __aicore__ inline void CalcGatedQ(float& gLast, float& gLastExp, const bool isLastChunk); 
     __aicore__ inline void CalcDv2(const float gLast, uint64_t& curGmOffsetV, const bool isLastChunk); 
     __aicore__ inline void UpdateDh(const float gLastExp, uint64_t& curGmOffsetH, const bool isLastChunk); 
@@ -146,45 +146,51 @@ __aicore__ inline void GDRVec<DT, GT>::InitGlobalTensor(GM_ADDR q, GM_ADDR dv, G
 template <typename DT, typename GT>
 __aicore__ inline void GDRVec<DT, GT>::Process( )
 {
-    uint32_t totalTaskNum = this->B * this->H * this->seqNum;
+    // 与 cube 一致：当前 for(h) for(chunkIdx)。若改为 chunk-major 以复用 cube 侧同一片 k 的搬运，须此处同序迭代，
+    // 并用按 h 保存的 gLast/gLastExp（及等价状态）贯穿各 chunk 轮次，避免打乱 gatedQ/dv2 的跨 chunk 递推。
+    uint32_t totalTaskNum = this->B * this->Hk * this->seqNum;
     cubeIdx_ = this->coreIdx / 2; // 当前vec对应的cube核，两个vec核处理一个cube结果
     for (uint32_t i = cubeIdx_; i < totalTaskNum; i += this->usedCoreNum) {
-        uint64_t tailChunkLen = 0;
-        CaclOffset(i, tailChunkLen);
-        float gLast = 0.0;
-        float gLastExp = 0.0;
-        uint64_t curGmOffsetV = 0;
-        uint64_t curGmOffsetH = 0;
-        bool isLastChunk = false;
-        // last chunk process
-        int32_t loopNum = curChunkNum_ - 1;
-        if (tailChunkLen != 0) {
-            this->curBT = tailChunkLen;
-            TailChunkProcess(tailChunkLen);
-            loopNum = curChunkNum_ - 2;
-        }
-        // 剩下的都是对齐的
-        this->curBT = this->chunkSize;
-        this->curCalcTK = this->qBufSize;
-        this->curCalcTV = this->dvBufSize;
-        this->curCalcBT = this->halfBT; 
-        for (int32_t chunkIdx = loopNum; chunkIdx >= 0; chunkIdx --) {
-            chunkIdx_ = chunkIdx;
-            isLastChunk = chunkIdx_ == curChunkNum_ - 1 ? true : false;
-            bos_ = chunkIdx_ * this->chunkSize;
-            // gatedQ = q * gExp
-            CalcGatedQ(gLast, gLastExp, isLastChunk);
-            // 計算dv2 dv2 = bdv * exp(bg_last - bg) + dv[B,H,T,V]
-            CalcDv2(gLast, curGmOffsetV, isLastChunk);
-            if (chunkIdx_ > 0) {
-                CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_DV2); // 计算完一个chunk的dv2,通知cube可以开始计算w @ dv2 
+        const uint32_t hq = i % this->Hk;
+        const uint32_t hGroupEnd = (hq + 1U) * static_cast<uint32_t>(this->hvPerHk);
+        for (uint32_t h = hq * static_cast<uint32_t>(this->hvPerHk); h < hGroupEnd; h++) {
+            uint64_t tailChunkLen = 0;
+            CaclOffset(i, h, tailChunkLen);
+            float gLast = 0.0;
+            float gLastExp = 0.0;
+            uint64_t curGmOffsetV = 0;
+            uint64_t curGmOffsetH = 0;
+            bool isLastChunk = false;
+            // last chunk process
+            int32_t loopNum = curChunkNum_ - 1;
+            if (tailChunkLen != 0) {
+                this->curBT = tailChunkLen;
+                TailChunkProcess(tailChunkLen);
+                loopNum = curChunkNum_ - 2;
             }
-            // updated dh
-            if (chunkIdx_ == 0 && !isLastChunk) {
-                // 每個chunk更新bdh給下個chunk用，chunkIdx=0作爲最後一個chunk，所有的chunk都已經更新完了，無需更新bdh。
-                continue;
+            // 剩下的都是对齐的
+            this->curBT = this->chunkSize;
+            this->curCalcTK = this->qBufSize;
+            this->curCalcTV = this->dvBufSize;
+            this->curCalcBT = this->halfBT; 
+            for (int32_t chunkIdx = loopNum; chunkIdx >= 0; chunkIdx--) {
+                chunkIdx_ = chunkIdx;
+                isLastChunk = chunkIdx_ == curChunkNum_ - 1 ? true : false;
+                bos_ = chunkIdx_ * this->chunkSize;
+                // gatedQ = q * gExp
+                CalcGatedQ(gLast, gLastExp, isLastChunk);
+                // 計算dv2 dv2 = bdv * exp(bg_last - bg) + dv[B,H,T,V]
+                CalcDv2(gLast, curGmOffsetV, isLastChunk);
+                if (chunkIdx_ > 0) {
+                    CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_DV2); // 计算完一个chunk的dv2,通知cube可以开始计算w @ dv2 
+                }
+                // updated dh
+                if (chunkIdx_ == 0 && !isLastChunk) {
+                    // 每個chunk更新bdh給下個chunk用，chunkIdx=0作爲最後一個chunk，所有的chunk都已經更新完了，無需更新bdh。
+                    continue;
+                }
+                UpdateDh(gLastExp, curGmOffsetH, isLastChunk);
             }
-            UpdateDh(gLastExp, curGmOffsetH, isLastChunk); 
         }
     }
 }
@@ -219,37 +225,35 @@ __aicore__ inline void GDRVec<DT, GT>::TailChunkProcess(uint32_t tailChunkLen)
 }
 
 template <typename DT, typename GT>
-__aicore__ inline void GDRVec<DT, GT>::CaclOffset(const uint32_t taskIdx, uint64_t& tailChunkLen) 
+__aicore__ inline void GDRVec<DT, GT>::CaclOffset(const uint32_t coarseTaskIdx, const uint32_t h, uint64_t& tailChunkLen)
 {
     uint32_t BT = this->chunkSize;
     uint64_t b = 0;
-    uint32_t h = taskIdx % this->H; // 当前任务在第几个h
+    const uint32_t hq = coarseTaskIdx % this->Hk;
     uint64_t preChunkNum = 0;
     uint64_t seqStartOffset = 0;
     uint64_t curSeqLen = 0;
     if (this->isVarLen) {
-        uint32_t seqIdx = taskIdx / this->H; // 当前任务在第几个seq
+        uint32_t seqIdx = coarseTaskIdx / this->Hk;
         seqStartOffset = this->cuSeqlensGm.GetValue(seqIdx); // 当前seq在T中的起始索引
-        uint64_t seqEndOffset = this->cuSeqlensGm.GetValue(seqIdx+1); // 当前seq在T中的结束索引
+        uint64_t seqEndOffset = this->cuSeqlensGm.GetValue(seqIdx + 1); // 当前seq在T中的结束索引
         curSeqLen = seqEndOffset - seqStartOffset;
-        // 计算当前seq的起始chunkIdx
         uint64_t tmpStartOffset = 0;
         uint64_t tmpEndOffset = 0;
-        uint64_t tmpChunkNum = 0;
         for (uint32_t seq = 0; seq < seqIdx; seq++) {
-            tmpStartOffset = this->cuSeqlensGm.GetValue(seq); // 当前seq在T中的起始索引
-            tmpEndOffset = this->cuSeqlensGm.GetValue(seq+1); // 当前seq在T中的结束索引
+            tmpStartOffset = this->cuSeqlensGm.GetValue(seq);
+            tmpEndOffset = this->cuSeqlensGm.GetValue(seq + 1);
             auto tmpChunkNum = ((tmpEndOffset - tmpStartOffset) + BT - 1) / BT;
             preChunkNum += tmpChunkNum;
         }
-        curChunkNum_ = (curSeqLen + BT - 1) / BT; // 当前seq的chunk数
+        curChunkNum_ = (curSeqLen + BT - 1) / BT;
     } else {
         curChunkNum_ = this->chunkNum;
-        b = taskIdx / this->H;
+        b = coarseTaskIdx / this->Hk;
         curSeqLen = this->T;
     }
-    tailChunkLen = curSeqLen % BT; 
-    
+    tailChunkLen = curSeqLen % BT;
+
     dhBlockSize_ = this->K * this->V; // 16384
 
     bdvOffset_ = cubeIdx_ * BT * this->V;
@@ -257,11 +261,10 @@ __aicore__ inline void GDRVec<DT, GT>::CaclOffset(const uint32_t taskIdx, uint64
     qdoOffset_ = cubeIdx_ * dhBlockSize_;
     wV2Offset_ = cubeIdx_ * dhBlockSize_;
 
-    // calc offset
-    gmOffsetK_ = (b * this->H + h) * this->T * this->K + seqStartOffset * this->K;
-    gmOffsetV_ = (b * this->H + h) * this->T * this->V + seqStartOffset * this->V;
-    gmOffsetH_ = (b * this->H + h) * this->chunkNum * dhBlockSize_ + preChunkNum * dhBlockSize_;
-    gmOffsetG_ = (b * this->H + h) * this->T + seqStartOffset;
+    gmOffsetK_ = (b * this->Hk + hq) * this->T * this->K + seqStartOffset * this->K;
+    gmOffsetV_ = (b * this->Hv + h) * this->T * this->V + seqStartOffset * this->V;
+    gmOffsetH_ = (b * this->Hv + h) * this->chunkNum * dhBlockSize_ + preChunkNum * dhBlockSize_;
+    gmOffsetG_ = (b * this->Hv + h) * this->T + seqStartOffset;
 
     if (this->subBlockIdx == 1) {
         gatedQOffset_ += this->halfBT * this->K;
@@ -313,7 +316,7 @@ __aicore__ inline void GDRVec<DT, GT>::CalcGatedQ(float& gLast, float& gLastExp,
     if (chunkIdx_ == 0) {
         return; // chunkIdx==0时，不再需要更新dh，只需要拿到g和gLast用于计算dv2即可。
     }
-    // COPY IN Q [B,H,T,K]
+    // COPY IN Q [B,Hk,T,K]
     CopyIn(this->qCastLocal, this->qLocal, this->qGm[gmOffsetK_ + bos_ * this->K], this->curCalcTK);
     // qCastLocal[halfBT, K] * gExp[halfBT, ] K=128,256 halfBT=32,64
     uint8_t repeatTimes = Ceil(this->halfBT, 8); // halfBT is 32 or 64

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/test/test_chunk_gated_delta_rule_bwd_dhu.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/test/test_chunk_gated_delta_rule_bwd_dhu.py
@@ -1,9 +1,16 @@
+import math
 import torch
 import torch_npu
 from typing import Optional, Tuple, List
-import random
 import ct
 import fla_npu
+
+# fp16/bf16：在尽量无 NaN 的前提下抬高输出数量级（dv2 中位 ~1e-3；dh 非零元 |x| 最大可至 ~1e-3 量级）
+_LOW_PRECISION_INPUT_HALF_RANGE_QK = 6.5e-3
+_LOW_PRECISION_INPUT_HALF_RANGE_WO = 6.5e-3
+_LOW_PRECISION_INPUT_HALF_RANGE_DV = 9e-3
+# 乘在 effective_scale 之后；过小会导致 dh/dv2 过小（仅 1e-4～1e-10）
+_LOW_PRECISION_SCALE_FACTOR = 0.92
 
 def prepare_chunk_indices(cu_seqlens, chunk_size=64):
     """chunk indices生成函数(chunk_idx从0开始)"""
@@ -17,31 +24,218 @@ def prepare_chunk_indices(cu_seqlens, chunk_size=64):
     return chunk_indices
 
 
+def create_gate_g(B: int, Hv: int, T: int, gtype, narrow: bool = False):
+    """
+    构造 gate g：[B,Hv,T]（与 do/dv/w 的 value 头维一致），沿 T 单调递减，全为负。
+    narrow=True 时区间更窄，减轻 fp16/bf16 上 exp / 差分 的数值压力（与 NPU 路径对齐）。
+    """
+    if narrow:
+        lo, hi = -1e-2, -1e-6
+    else:
+        lo, hi = -5e-2, -5e-5
+    span = hi - lo
+    margin = max(span * 1e-7, 1e-12)
+    g_t = torch.linspace(
+        float(hi) - margin,
+        float(lo) + margin,
+        T,
+        dtype=torch.float64,
+    )
+    g = g_t.unsqueeze(0).unsqueeze(0).expand(B, Hv, T).contiguous().to(gtype)
+    return g
+
+
 def generate_cu_seqlens(
     cu_seqlens_len: int,
     total_length: int,
+    seg_min: int = 64,
+    seg_max: int = 128,
 ) -> List[int]:
+    """
+    生成变长 cu_seqlens：总和为 total_length，尽量使每段长度在 [seg_min, seg_max]（默认 64~128）。
+
+    - 当 64*B <= T <= 128*B 时，必可做到每段都在区间内且总和精确为 T；先公平切分再夹紧，用贪心加减1 修正总和。
+    - 否则无法满足全在区间内：先夹紧再尽量修正总和（可能个别段略超出区间）。
+    - 最后将 multiset 按「小配大」交错排列，减少相邻段长度相同或过于接近。
+    """
     batchsize = cu_seqlens_len - 1
-    remaining = total_length
-    seq_lengths = []
-    for i in range(batchsize - 1):
-        min_len = 1
-        max_len = remaining - (batchsize - 1 - i)
-        if max_len < min_len:
-            max_len = min_len
-        seq_len = random.randint(min_len, max_len)
-        seq_lengths.append(seq_len)
-        remaining -= seq_len
-    seq_lengths.append(remaining)
+    if batchsize <= 0:
+        return [0, total_length]
+
+    B = batchsize
+    T = total_length
+    # 公平切分作为初值
+    lengths = [
+        (T * (i + 1)) // B - (T * i) // B
+        for i in range(B)
+    ]
+    for i in range(B):
+        lengths[i] = max(seg_min, min(seg_max, lengths[i]))
+
+    diff = T - sum(lengths)
+    # 总和不足：优先给当前较短的段 +1（方差增长慢）
+    while diff > 0:
+        cand = [i for i in range(B) if lengths[i] < seg_max]
+        if not cand:
+            break
+        i = min(cand, key=lambda j: lengths[j])
+        lengths[i] += 1
+        diff -= 1
+    # 总和过多：优先从当前较长的段 -1
+    while diff < 0:
+        cand = [i for i in range(B) if lengths[i] > seg_min]
+        if not cand:
+            break
+        i = max(cand, key=lambda j: lengths[j])
+        lengths[i] -= 1
+        diff += 1
+    # 仍无法对齐（T 超出 [seg_min*B, seg_max*B] 等）：强制在边界上继续调
+    guard = 0
+    while diff != 0 and guard < B * (seg_max - seg_min + 64):
+        guard += 1
+        if diff > 0:
+            i = min(range(B), key=lambda j: lengths[j])
+            lengths[i] += 1
+            diff -= 1
+        else:
+            i = max(range(B), key=lambda j: lengths[j])
+            lengths[i] -= 1
+            diff += 1
+
+    # 小配大交错， multiset 不变
+    sorted_l = sorted(lengths)
+    seq_lengths: List[int] = []
+    i, j = 0, len(sorted_l) - 1
+    while i <= j:
+        if i == j:
+            seq_lengths.append(sorted_l[i])
+        else:
+            seq_lengths.append(sorted_l[i])
+            seq_lengths.append(sorted_l[j])
+        i += 1
+        j -= 1
 
     cu_seqlens = [0]
     for seq_len in seq_lengths:
         cu_seqlens.append(cu_seqlens[-1] + seq_len)
+    if cu_seqlens[-1] != total_length:
+        raise ValueError(
+            f"generate_cu_seqlens: 各段之和为 {cu_seqlens[-1]}，与期望 total_length={total_length} 不一致。"
+            f" 当前 batchsize={batchsize}、seg 约束 [{seg_min},{seg_max}]，请增加序列条数或放宽/调整 T。"
+        )
     return cu_seqlens
 
 
-def create_tensor(shape, dtype=torch.float16):
-    return torch.rand(shape, dtype=dtype)
+def rand_symmetric_uniform(shape, dtype: torch.dtype, half_range: float) -> torch.Tensor:
+    """
+    在 float32 上生成 [-half_range, half_range] 均匀分布再 cast，减轻 fp16/bf16 上直接 rand 的量化与溢出；
+    half_range 为单边幅度（全区间宽度为 2*half_range）。
+    """
+    if half_range < 0:
+        raise ValueError("half_range must be non-negative")
+    x = torch.rand(shape, dtype=torch.float32, device="cpu")
+    x = (x * 2.0 - 1.0) * float(half_range)
+    return x.to(dtype=dtype)
+
+
+def create_bwd_dhu_random_inputs(
+    B: int,
+    Hk: int,
+    Hv: int,
+    T: int,
+    K: int,
+    V: int,
+    ktype: torch.dtype,
+    gtype: torch.dtype,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    构造数值幅度受控的随机输入。
+    - fp32：幅度可稍大，与 golden（float32 累加）一致时 NPU 通常也无 NaN。
+    - fp16/bf16：自动收紧幅度并收窄 g，避免 K×V 大块 matmul 在昇腾 fp16 链上溢出为 NaN。
+    """
+    low = ktype in (torch.float16, torch.bfloat16)
+    if low:
+        hr_qk = _LOW_PRECISION_INPUT_HALF_RANGE_QK
+        hr_wo = _LOW_PRECISION_INPUT_HALF_RANGE_WO
+        hr_dv = _LOW_PRECISION_INPUT_HALF_RANGE_DV
+        narrow_g = True
+    else:
+        hr_qk = 2e-2
+        hr_wo = 2e-2
+        hr_dv = 3e-2
+        narrow_g = False
+
+    q = rand_symmetric_uniform((B, Hk, T, K), ktype, half_range=hr_qk)
+    k_tensor = rand_symmetric_uniform((B, Hk, T, K), ktype, half_range=hr_qk)
+    w = rand_symmetric_uniform((B, Hv, T, K), ktype, half_range=hr_qk)
+    d_o = rand_symmetric_uniform((B, Hv, T, V), ktype, half_range=hr_wo)
+    dv = rand_symmetric_uniform((B, Hv, T, V), ktype, half_range=hr_dv)
+    g = create_gate_g(B, Hv, T, gtype, narrow=narrow_g)
+    return q, k_tensor, w, d_o, dv, g
+
+
+def effective_scale(scale: float, K: int) -> float:
+    """不超过 1/sqrt(K) 的缩放，与常见 attention scale 一致并抑制过大 matmul 输出。"""
+    cap = 1.0 / math.sqrt(float(K))
+    return float(min(scale, cap))
+
+
+def scale_for_compute_dtype(scale: float, ktype: torch.dtype) -> float:
+    """fp16/bf16 算子路径上对 scale 的额外系数：兼顾数值动态范围与长 T 下 cube 累加不溢出。"""
+    if ktype in (torch.float16, torch.bfloat16):
+        return float(scale * _LOW_PRECISION_SCALE_FACTOR)
+    return float(scale)
+
+
+def assert_no_nan_inf(t: torch.Tensor, name: str) -> None:
+    """检查单个浮点/复数张量是否含 NaN/Inf（仅测一项时立即抛出）。"""
+    if not (torch.is_floating_point(t) or torch.is_complex(t)):
+        return
+    if torch.isfinite(t).all():
+        return
+    n_bad = int((~torch.isfinite(t)).sum().item())
+    raise RuntimeError(
+        f"{name} 含 NaN 或 Inf，异常元素个数={n_bad}，shape={tuple(t.shape)}，dtype={t.dtype}"
+    )
+
+
+def _nonfinite_detail_line(t: torch.Tensor, name: str) -> Optional[str]:
+    """若含非有限值则返回一行说明，否则返回 None。"""
+    if not (torch.is_floating_point(t) or torch.is_complex(t)):
+        return None
+    if torch.isfinite(t).all():
+        return None
+    n_bad = int((~torch.isfinite(t)).sum().item())
+    n_nan = int(torch.isnan(t).sum().item())
+    n_inf = int(torch.isinf(t).sum().item())
+    return (
+        f"  - {name}: 非有限元素={n_bad} (NaN={n_nan}, Inf={n_inf}), "
+        f"shape={tuple(t.shape)}, dtype={t.dtype}"
+    )
+
+
+def assert_finite_after_npu_golden_compare(
+    dh_npu: torch.Tensor,
+    dv2_npu: torch.Tensor,
+    dh_golden: torch.Tensor,
+    dv2_golden: torch.Tensor,
+) -> None:
+    """须在完成 dh、dv2 的 NPU 与 CPU(golden) 对比之后调用；四项全部扫描后再统一抛出（若有任一异常）。"""
+    pairs = (
+        (dh_npu, "dh_npu"),
+        (dv2_npu, "dv2_npu"),
+        (dh_golden, "dh_golden"),
+        (dv2_golden, "dv2_golden"),
+    )
+    lines: List[str] = []
+    for t, nm in pairs:
+        ln = _nonfinite_detail_line(t, nm)
+        if ln is not None:
+            lines.append(ln)
+    if lines:
+        raise RuntimeError(
+            "以下输出含 NaN/Inf（已检查全部四项后再汇总）：\n" + "\n".join(lines)
+        )
 
 
 def chunk_gated_delta_rule_bwd_dhu_torch(
@@ -57,22 +251,38 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
     chunk_size: int = 64,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
     """
-    PyTorch版本的chunk_gated_delta_rule_bwd_dhu函数
-    输入形状: [B, H, T, D]
-    支持定长序列(cu_seqlens=None)和变长序列(cu_seqlens!=None)
+    PyTorch 版 chunk_gated_delta_rule_bwd_dhu（GVA 形状）。
+    - q, k: [B, Hk, T, K]
+    - w, do, dv, (可选 g): [B, Hv, T, ·]；须 Hv % Hk == 0
+    - value 头 h 对应 q/k 头 hq = h // (Hv // Hk)
+    支持定长 (cu_seqlens=None) 与变长 (cu_seqlens!=None)。
     """
     device = q.device
     dtype = q.dtype
 
-    B, H, T, K = q.shape
+    B, Hk, T, K = q.shape
+    Hv = do.shape[1]
     V = do.shape[-1]
     BT = chunk_size
 
+    if k.shape[1] != Hk or k.shape[2] != T:
+        raise ValueError(f"k 须为 [B,Hk,T,K]，与 q 一致；q {q.shape}, k {k.shape}")
+    if w.shape[1] != Hv or dv.shape[1] != Hv or do.shape[1] != Hv:
+        raise ValueError(f"w/d_o/dv 的 dim1 须为 Hv={Hv}；w {w.shape}, d_o {do.shape}, dv {dv.shape}")
+    if Hk <= 0 or Hv % Hk != 0:
+        raise ValueError(f"GVA 要求 Hv 为 Hk 的整数倍；Hk={Hk}, Hv={Hv}")
+
+    hv_per_hk = Hv // Hk
+
     if cu_seqlens is not None:
-        total_length = cu_seqlens[-1]
+        seq_total = cu_seqlens[-1]
+        if seq_total > T:
+            raise ValueError(
+                f"cu_seqlens末元 {seq_total} 超过 q 的时间维 T={T}，无法对齐 [B,Hv,T,V] 的 dv2。"
+            )
         NT = len(chunk_indices) // 2
     else:
-        total_length = T
+        seq_total = T
         NT = (T + BT - 1) // BT
 
     if scale is None:
@@ -111,80 +321,134 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
             'global_end_t': global_end_t,
         })
 
-    dh = torch.zeros(B, H, NT, K, V, device=device, dtype=torch.float32)
-    dv2 = torch.zeros(B, H, total_length, V, device=device, dtype=dv.dtype)
+    dh = torch.zeros(B, Hv, NT, K, V, device=device, dtype=torch.float32)
+    # dv2 与 dv/do 对齐为 [B,Hv,T,V]；变长时仅改写 [0, seq_total)，其余保留 dv（padding）
+    if cu_seqlens is not None:
+        dv2 = dv.clone()
+    else:
+        dv2 = torch.zeros(B, Hv, T, V, device=device, dtype=dv.dtype)
 
-    for b in range(B):
-        for i_h in range(H):
-            if cu_seqlens is not None:
-                num_tokens = len(cu_seqlens) - 1
+    if cu_seqlens is None:
+        # 定长：对 (B, Hv) 向量化，仅沿 chunk 反向迭代。避免 B×Hv×NT 纯 Python 嵌套（大 B/Hv 时极慢甚至像卡死）。
+        hq = torch.arange(Hv, device=device, dtype=torch.long) // hv_per_hk
+        b_dh = torch.zeros(B, Hv, K, V, device=device, dtype=torch.float32)
+        for i_t in range(NT - 1, -1, -1):
+            info = chunk_info[i_t]
+            global_start_t = info["global_start_t"]
+            global_end_t = info["global_end_t"]
+            block_size_t = info["block_size_t"]
+
+            dh[:, :, i_t, :, :] = b_dh
+
+            last_idx = min((info["block_idx_in_token"] + 1) * BT, info["token_length"]) - 1
+            global_last_idx = info["bos"] + last_idx
+
+            # 先切时间维再 index_select，避免每个 chunk 物化 [B,Hv,T,K] 整段（大 B/Hv/T 时极慢、像卡死）
+            k_blk = k[:, :, global_start_t:global_end_t, :].index_select(1, hq)
+            q_blk = q[:, :, global_start_t:global_end_t, :].index_select(1, hq)
+            w_blk = w[:, :, global_start_t:global_end_t, :]
+            b_do = do[:, :, global_start_t:global_end_t, :]
+            b_dv_existing = dv[:, :, global_start_t:global_end_t, :]
+
+            b_dv = torch.matmul(k_blk.to(torch.float), b_dh.to(torch.float))
+
+            if g is not None:
+                bg_last = g[:, :, global_last_idx]
+                b_g = g[:, :, global_start_t:global_end_t]
+                gate_factor = torch.exp(bg_last.unsqueeze(-1) - b_g).unsqueeze(-1)
+                m_t = torch.arange(block_size_t, device=device, dtype=torch.float32) < float(block_size_t)
+                mask_expanded = m_t.view(1, 1, block_size_t, 1)
+                b_dv = b_dv * gate_factor * mask_expanded
+
+            b_dv = b_dv + b_dv_existing.to(torch.float32)
+            dv2[:, :, global_start_t:global_end_t, :] = b_dv.to(dv2.dtype)
+
+            b_q_t = q_blk.transpose(-1, -2)
+            b_w_t = w_blk.transpose(-1, -2)
+
+            if g is not None:
+                bg_last_exp = torch.exp(bg_last)
+                b_g_exp = torch.exp(b_g)
+                b_dh_for_update = b_dh * bg_last_exp.unsqueeze(-1).unsqueeze(-1)
+                b_q_gated = b_q_t * b_g_exp.unsqueeze(-2)
             else:
-                num_tokens = 1
-            b_dh_buffers = {}
-            for i_n in range(num_tokens):
-                b_dh_buffers[i_n] = torch.zeros(K, V, device=device, dtype=torch.float32)
-
-            for i_t in range(NT - 1, -1, -1):
-                info = chunk_info[i_t]
-                i_n = info['i_n']
-                b_dh = b_dh_buffers[i_n]
-
-                dh[b, i_h, i_t] = b_dh
-
-                global_start_t = info['global_start_t']
-                global_end_t = info['global_end_t']
-                block_size_t = info['block_size_t']
-
-                last_idx = min((info['block_idx_in_token'] + 1) * BT, info['token_length']) - 1
-                global_last_idx = info['bos'] + last_idx
-
-                bg_last = bg_last_exp = b_g = b_g_exp = None
-                if g is not None:
-                    bg_last = g[b, i_h, global_last_idx]
-                    b_g = g[b, i_h, global_start_t:global_end_t]
-                    bg_last_exp = torch.exp(bg_last)
-                    b_g_exp = torch.exp(b_g)
-
-                b_do = do[b, i_h, global_start_t:global_end_t, :]
-                b_dv_existing = dv[b, i_h, global_start_t:global_end_t, :]
-
-                b_k = k[b, i_h, global_start_t:global_end_t, :]
-                b_dv = torch.matmul(b_k.to(torch.float), b_dh.to(torch.float))
-
-                if g is not None:
-                    m_t = torch.arange(block_size_t, device=device) < block_size_t
-                    gate_factor = torch.exp(bg_last - b_g).unsqueeze(-1)
-                    mask_expanded = m_t.unsqueeze(-1).float()
-                    b_dv *= gate_factor * mask_expanded
-
-                b_dv += b_dv_existing.to(torch.float32)
-                dv2[b, i_h, global_start_t:global_end_t, :] = b_dv.to(dv2.dtype)
-
-                b_q = q[b, i_h, global_start_t:global_end_t, :]
-                b_w = w[b, i_h, global_start_t:global_end_t, :]
-
-                b_q_t = b_q.transpose(0, 1)
-                b_w_t = b_w.transpose(0, 1)
                 b_dh_for_update = b_dh.clone()
-                if g is not None:
-                    b_dh_for_update = b_dh_for_update * bg_last_exp
-
                 b_q_gated = b_q_t
-                if g is not None:
-                    b_q_gated = b_q_t * b_g_exp.unsqueeze(0)
 
-                term1 = torch.matmul(b_q_gated.to(torch.float), b_do.to(torch.float)) * scale
-                term2 = torch.matmul(b_w_t.to(torch.float), b_dv.to(torch.float))
+            term1 = torch.matmul(b_q_gated.to(torch.float), b_do.to(torch.float)) * scale
+            term2 = torch.matmul(b_w_t.to(torch.float), b_dv.to(torch.float))
+            b_dh = b_dh_for_update + term1 - term2
+    else:
+        for b in range(B):
+            for i_h in range(Hv):
+                hq = i_h // hv_per_hk
+                num_tokens = len(cu_seqlens) - 1
+                b_dh_buffers = {}
+                for i_n in range(num_tokens):
+                    b_dh_buffers[i_n] = torch.zeros(K, V, device=device, dtype=torch.float32)
 
-                new_b_dh = b_dh_for_update + term1 - term2
-                b_dh_buffers[i_n] = new_b_dh
+                for i_t in range(NT - 1, -1, -1):
+                    info = chunk_info[i_t]
+                    i_n = info['i_n']
+                    b_dh = b_dh_buffers[i_n]
 
-    return dh.to(dtype), None, dv2.to(dtype)
+                    dh[b, i_h, i_t] = b_dh
+
+                    global_start_t = info['global_start_t']
+                    global_end_t = info['global_end_t']
+                    block_size_t = info['block_size_t']
+
+                    last_idx = min((info['block_idx_in_token'] + 1) * BT, info['token_length']) - 1
+                    global_last_idx = info['bos'] + last_idx
+
+                    bg_last = bg_last_exp = b_g = b_g_exp = None
+                    if g is not None:
+                        bg_last = g[b, i_h, global_last_idx]
+                        b_g = g[b, i_h, global_start_t:global_end_t]
+                        bg_last_exp = torch.exp(bg_last)
+                        b_g_exp = torch.exp(b_g)
+
+                    b_do = do[b, i_h, global_start_t:global_end_t, :]
+                    b_dv_existing = dv[b, i_h, global_start_t:global_end_t, :]
+
+                    b_k = k[b, hq, global_start_t:global_end_t, :]
+                    b_dv = torch.matmul(b_k.to(torch.float), b_dh.to(torch.float))
+
+                    if g is not None:
+                        m_t = torch.arange(block_size_t, device=device) < block_size_t
+                        gate_factor = torch.exp(bg_last - b_g).unsqueeze(-1)
+                        mask_expanded = m_t.unsqueeze(-1).float()
+                        b_dv *= gate_factor * mask_expanded
+
+                    b_dv += b_dv_existing.to(torch.float32)
+                    dv2[b, i_h, global_start_t:global_end_t, :] = b_dv.to(dv2.dtype)
+
+                    b_q = q[b, hq, global_start_t:global_end_t, :]
+                    b_w = w[b, i_h, global_start_t:global_end_t, :]
+
+                    b_q_t = b_q.transpose(0, 1)
+                    b_w_t = b_w.transpose(0, 1)
+                    b_dh_for_update = b_dh.clone()
+                    if g is not None:
+                        b_dh_for_update = b_dh_for_update * bg_last_exp
+
+                    b_q_gated = b_q_t
+                    if g is not None:
+                        b_q_gated = b_q_t * b_g_exp.unsqueeze(0)
+
+                    term1 = torch.matmul(b_q_gated.to(torch.float), b_do.to(torch.float)) * scale
+                    term2 = torch.matmul(b_w_t.to(torch.float), b_dv.to(torch.float))
+
+                    new_b_dh = b_dh_for_update + term1 - term2
+                    b_dh_buffers[i_n] = new_b_dh
+
+    return dh, None, dv2
 
 
 def test_fix(
     B: int,
-    H: int,
+    Hk: int,
+    Hv: int,
     T: int,
     K: int,
     V: int,
@@ -194,18 +458,18 @@ def test_fix(
     gtype,
     seed: int = 0,
 ):
+    if Hv % Hk != 0:
+        raise ValueError(f"GVA: 要求 Hv % Hk == 0，当前 Hk={Hk}, Hv={Hv}")
+    scale = scale_for_compute_dtype(effective_scale(scale, K), ktype)
+    print("B, T, Hk, Hv, K, V, chunk_size = ", B, T, Hk, Hv, K, V, chunk_size)
+
     torch.manual_seed(seed)
     if not hasattr(test_fix, "call_count"):
         test_fix.call_count = 1
     else:
         test_fix.call_count += 1
 
-    q = create_tensor((B, H, T, K), dtype=ktype) * 5e-7
-    k = create_tensor((B, H, T, K), dtype=ktype) * 5e-2
-    w = create_tensor((B, H, T, K), dtype=ktype) * 5e-2
-    d_o = create_tensor((B, H, T, V), dtype=ktype) * 5e-7
-    dv = create_tensor((B, H, T, V), dtype=ktype) * 5e-1
-    g = torch.arange(B * H * T, 0, -1).reshape((B, H, T)).to(gtype) * 5e-2
+    q, k, w, d_o, dv, g = create_bwd_dhu_random_inputs(B, Hk, Hv, T, K, V, ktype, gtype)
 
     dh_golden, _, dv2_golden = chunk_gated_delta_rule_bwd_dhu_torch(
         q, k, w, d_o, dv,
@@ -232,23 +496,24 @@ def test_fix(
         dht=None,
         cu_seqlens=None, 
         chunk_indices=None,
-        use_exp2=False, 
-        transpose_state_layout=False
+        # use_exp2=False, 
+        # transpose_state_layout=False
     )
 
-    print("dh_npu shape is", dh_npu.shape)
-    print("dv2_npu shape is", dv2_npu.shape)
-
+    dh_npu_cpu = dh_npu.detach().cpu()
+    dv2_npu_cpu = dv2_npu.detach().cpu()
     print("dh comparison:")
-    ct.single(dh_npu.cpu(), dh_golden)
+    ct.single(dh_npu_cpu, dh_golden)
     print("dv2 comparison:")
-    ct.single(dv2_npu.cpu(), dv2_golden)
+    ct.single(dv2_npu_cpu, dv2_golden)
+    assert_finite_after_npu_golden_compare(dh_npu_cpu, dv2_npu_cpu, dh_golden, dv2_golden)
     print(f"test_fix 被调用了第 {test_fix.call_count} 次")
 
 
 def test_variable(
     B: int,
-    H: int,
+    Hk: int,
+    Hv: int,
     T: int,
     K: int,
     V: int,
@@ -259,22 +524,21 @@ def test_variable(
     gtype,
     seed: int = 0,
 ):
+    if Hv % Hk != 0:
+        raise ValueError(f"GVA: 要求 Hv % Hk == 0，当前 Hk={Hk}, Hv={Hv}")
+    scale = scale_for_compute_dtype(effective_scale(scale, K), ktype)
+    print("B, T, Hk, Hv, K, V, chunk_size = ", B, T, Hk, Hv, K, V, chunk_size)
     torch.manual_seed(seed)
     if not hasattr(test_variable, "call_count"):
         test_variable.call_count = 1
     else:
         test_variable.call_count += 1
 
-    q = create_tensor((B, H, T, K), dtype=ktype) * 5e-7
-    k = create_tensor((B, H, T, K), dtype=ktype) * 5e-2
-    w = create_tensor((B, H, T, K), dtype=ktype) * 5e-2
-    d_o = create_tensor((B, H, T, V), dtype=ktype) * 5e-7
-    dv = create_tensor((B, H, T, V), dtype=ktype) * 5e-1
-    g = torch.arange(B * H * T, 0, -1).reshape((B, H, T)).to(gtype) * 5e-2
+    q, k, w, d_o, dv, g = create_bwd_dhu_random_inputs(B, Hk, Hv, T, K, V, ktype, gtype)
 
     cu_seqlens = generate_cu_seqlens(cu_seqlens_len, T)
     chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
-
+    print(cu_seqlens)
     dh_golden, _, dv2_golden = chunk_gated_delta_rule_bwd_dhu_torch(
         q, k, w, d_o, dv,
         cu_seqlens=cu_seqlens, chunk_indices=chunk_indices,
@@ -299,31 +563,33 @@ def test_variable(
         dht=None,
         cu_seqlens=cu_seqlens, 
         chunk_indices=chunk_indices,
-        use_exp2=False, 
-        transpose_state_layout=False
+        # use_exp2=False, 
+        # transpose_state_layout=False
     )
 
-
+    dh_npu_cpu = dh_npu.detach().cpu()
+    dv2_npu_cpu = dv2_npu.detach().cpu()
+    print("dh_golden shape is", dh_golden.shape)
+    print("dv2_golden shape is", dv2_golden.shape)
+    print("dh_npu shape is", dh_npu_cpu.shape)
+    print("dv2_npu shape is", dv2_npu_cpu.shape)
     print("dh comparison:")
-    ct.single(dh_npu.cpu(), dh_golden)
+    ct.single(dh_npu_cpu, dh_golden)
     print("dv2 comparison:")
-    ct.single(dv2_npu.cpu(), dv2_golden)
-    print(f"test_variable 被调用了第 {test_variable.call_count} 次")
+    ct.single(dv2_npu_cpu, dv2_golden)
 
+    # NPU 与 golden 对比全部完成后，再检查 NaN/Inf，最后落盘
+    assert_finite_after_npu_golden_compare(dh_npu_cpu, dv2_npu_cpu, dh_golden, dv2_golden)
+
+    # print(f"test_variable 被调用了第 {test_variable.call_count} 次")
 
 if __name__ == "__main__":
-    # Fix length tests
-    test_fix(B=2, H=2, T=65, K=128, V=128, chunk_size=64, scale=0.0625, ktype=torch.float16, gtype=torch.float16)
-    test_fix(B=4, H=4, T=128, K=128, V=128, chunk_size=64, scale=0.0625, ktype=torch.float16, gtype=torch.float32)
-    test_fix(B=8, H=8, T=256, K=128, V=128, chunk_size=64, scale=0.0625, ktype=torch.float16, gtype=torch.float16)
-    test_fix(B=16, H=16, T=512, K=128, V=128, chunk_size=64, scale=0.0625, ktype=torch.bfloat16, gtype=torch.bfloat16)
-    test_fix(B=32, H=16, T=1024, K=128, V=128, chunk_size=64, scale=0.088, ktype=torch.bfloat16, gtype=torch.bfloat16)
+    import os
+    torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
 
-    # # # Variable length tests
-    test_variable(B=1, H=32, T=128, K=128, V=128, chunk_size=64, scale=0.011, cu_seqlens_len=2, ktype=torch.float16, gtype=torch.float16)
-    test_variable(B=1, H=16, T=256, K=128, V=128, chunk_size=64, scale=0.011, cu_seqlens_len=3, ktype=torch.float16, gtype=torch.float32)
-    test_variable(B=1, H=8, T=512, K=128, V=128, chunk_size=64, scale=0.011, cu_seqlens_len=4, ktype=torch.bfloat16, gtype=torch.bfloat16)
-    test_variable(B=1, H=4, T=1024, K=128, V=128, chunk_size=64, scale=0.011, cu_seqlens_len=5, ktype=torch.float16, gtype=torch.float16)
-    test_variable(B=1, H=32, T=2048, K=128, V=128, chunk_size=64, scale=0.011, cu_seqlens_len=8, ktype=torch.bfloat16, gtype=torch.bfloat16)
-    test_variable(B=1, H=32, T=65536, K=128, V=128, chunk_size=64, scale=0.011, cu_seqlens_len=739, ktype=torch.bfloat16, gtype=torch.bfloat16)
-    test_variable(B=1, H=32, T=65536, K=128, V=128, chunk_size=128, scale=0.011, cu_seqlens_len=739, ktype=torch.bfloat16, gtype=torch.bfloat16)
+    # GVA smoke: Hk=2, Hv=4
+    test_fix(B=1, Hk=2, Hv=4, T=256, K=128, V=128, chunk_size=64, scale=0.088, ktype=torch.bfloat16, gtype=torch.bfloat16)
+    # MHA smoke: Hk=Hv
+    test_fix(B=1, Hk=4, Hv=4, T=128, K=128, V=128, chunk_size=64, scale=0.088, ktype=torch.bfloat16, gtype=torch.bfloat16)
+    # GVA varlen smoke
+    test_variable(B=1, Hk=4, Hv=8, T=512, K=128, V=128, chunk_size=64, scale=0.011, cu_seqlens_len=4, ktype=torch.bfloat16, gtype=torch.bfloat16)

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -57,26 +57,50 @@ using namespace op_infer;
     c10::optional<bool> use_exp2, 
     c10::optional<bool> transpose_state_layout)
 {
+    // GVA：q/k 为 [B,Hk,T,K]；w、d_o、dv、g 等为 [B,Hv,T,·]，且 Hv % Hk == 0（与 device tiling 一致）
     auto q_size = q.sizes();
+    auto k_size = k.sizes();
+    auto w_size = w.sizes();
+    auto do_size = d_o.sizes();
     auto dv_size = dv.sizes();
     int64_t B = q_size[0];
-    int64_t H = q_size[1];
+    int64_t Hk = q_size[1];
     int64_t T = q_size[2];
     int64_t K = q_size[3];
+    int64_t Hv = dv_size[1];
     int64_t V = dv_size[3];
-    int64_t chunk_num = (T + chunk_size -1) / chunk_size; 
+    int64_t chunk_num = (T + chunk_size -1) / chunk_size;
+
+    TORCH_CHECK(
+        k_size[0] == B && k_size[1] == Hk && k_size[2] == T && k_size[3] == K,
+        "npu_chunk_gated_delta_rule_bwd_dhu: k must match q as [B,Hk,T,K]; q=", q_size, " k=", k_size);
+    TORCH_CHECK(
+        w_size[0] == B && w_size[1] == Hv && w_size[2] == T && w_size[3] == K,
+        "npu_chunk_gated_delta_rule_bwd_dhu: w must be [B,Hv,T,K] with Hv=dv.dim1; w=", w_size, " dv=", dv_size);
+    TORCH_CHECK(
+        do_size[0] == B && do_size[1] == Hv && do_size[2] == T && do_size[3] == V,
+        "npu_chunk_gated_delta_rule_bwd_dhu: d_o must be [B,Hv,T,V]; d_o=", do_size, " dv=", dv_size);
+    TORCH_CHECK(
+        dv_size[0] == B && dv_size[1] == Hv && dv_size[2] == T && dv_size[3] == V,
+        "npu_chunk_gated_delta_rule_bwd_dhu: dv must be [B,Hv,T,V]; dv=", dv_size);
+    TORCH_CHECK(
+        Hk > 0 && Hv > 0 && Hv % Hk == 0,
+        "npu_chunk_gated_delta_rule_bwd_dhu: GVA requires Hv divisible by Hk; Hk=",
+        Hk,
+        " Hv=",
+        Hv);
 
     if (chunk_indices.has_value()) {
         auto chunk_indices_ref = chunk_indices.value();
         chunk_num = chunk_indices_ref.size() / 2;
     }
 
-    // 创建输出tensor（PTA推荐）
+    // 创建输出 tensor：dh/dh0 与 value 头维 Hv 对齐（device 输出 [B,Hv,chunk_num,K,V]）
     at::Tensor dv2 = at::empty_like(dv);
-    at::Tensor dh = at::empty({B, H, chunk_num, K, V}, q.options());
+    at::Tensor dh = at::empty({B, Hv, chunk_num, K, V}, q.options());
     at::Tensor dh0;
     if (h0.has_value()) {
-        dh0 = at::empty({B, H, chunk_num, K, V}, q.options());
+        dh0 = at::empty({B, Hv, chunk_num, K, V}, q.options());
     } else {
         dh0 = at::Tensor();
     }
@@ -86,6 +110,24 @@ using namespace op_infer;
     const at::Tensor &gK_ = c10::value_or_else(gK, [] { return at::Tensor(); });
     const at::Tensor &h0_ = c10::value_or_else(h0, [] { return at::Tensor(); });
     const at::Tensor &dht_ = c10::value_or_else(dht, [] { return at::Tensor(); });
+
+    if (g_.defined()) {
+        TORCH_CHECK(
+            g_.dim() == 3 && g_.size(0) == B && g_.size(1) == Hv && g_.size(2) == T,
+            "npu_chunk_gated_delta_rule_bwd_dhu: g must be [B,Hv,T]; g=", g_.sizes());
+    }
+    if (h0_.defined()) {
+        TORCH_CHECK(
+            h0_.dim() == 5 && h0_.size(0) == B && h0_.size(1) == Hv && h0_.size(2) == chunk_num,
+            "npu_chunk_gated_delta_rule_bwd_dhu: h0 must be [B,Hv,chunk_num,K,V]; h0=", h0_.sizes(),
+            " chunk_num=", chunk_num);
+    }
+    if (dht_.defined()) {
+        TORCH_CHECK(
+            dht_.dim() == 5 && dht_.size(0) == B && dht_.size(1) == Hv && dht_.size(2) == chunk_num,
+            "npu_chunk_gated_delta_rule_bwd_dhu: dht must be [B,Hv,chunk_num,K,V]; dht=", dht_.sizes(),
+            " chunk_num=", chunk_num);
+    }
 
     // 调用ACLNN算子
     EXEC_NPU_CMD_EXT(


### PR DESCRIPTION
## 修改设计

GDN 反向链路 `chunk_gated_delta_rule_bwd_dhu` 从 gitcode PR #75 迁移并泛化到 GVA （Grouped Value Attention）场景：Q/K head（Hk）与 Value head（Hv）解耦，`Hv = hvPerHk * Hk` 且 `Hv % Hk == 0`。V=256 为该算子原生能力（Cube Catlass tile 已按 `<128,256,128>` 设计），本 PR 不新增 V 维 TilingKey，TilingKey 仍仅区分 g dtype。

### 核心改动
- Tiling：`H` 字段拆为 `Hk`/`Hv`，任务粒度由 `B*H*seqNum` 调整为 `B*Hk*seqNum`，组内各 value head 串行（GVA 方案 A）；新增 `Hv % Hk == 0`、A/beta/g head 对齐 Hv 等输入校验；workspace 按 Hv 分配。
- Kernel（Cube/Vec）：读 `q`/`k` 按 `hq = h / hvPerHk` 映射偏移，读/写 `w`/`d_o`/`dv`/`g`/`dh`/`dv2` 全部使用 Hv 索引，修正 GVA 下 q/k 读错 head 与多 V head 覆盖 workspace 的问题。
- OpApi：`dh` 输出 shape 对齐 Hv（`[B, Hv, chunkNum, K, V]`），不再按 `q.size(1)` 分配；golden 与测试按 Hk/Hv 参数化。
- 测试：新增 GVA golden 与 smoke 用例，覆盖定长/变长、V=128/256、Hk≠Hv 组合（含生产规模 `Hk=21, Hv=63`、`B=176`）。

### 涉及文件
- `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.{h,cpp}`
- `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_{base,cube,vec}.h`
- `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/examples/test_aclnn_chunk_gated_delta_rule_bwd_dhu.cpp`
- `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/test/test_chunk_gated_delta_rule_bwd_dhu.py`
- `torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp`

# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: 无（内部功能增强，无需 Issue）
- 背景与目标: GDN 整网推理/训练中反向算子需支持 GVA（Hv = group_size * Hk）与 V=256 两类泛化，二者可叠加。
- 本 PR 解决的问题: chunk_gated_delta_rule_bwd_dhu 算子 GVA 支持：Hk/Hv 拆分、cube/vec 头映射、OpApi 输出对齐 Hv、GVA golden 测试。

## 变更类型

- [ ] Bug 修复
- [x] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: chunk_gated_delta_rule_bwd_dhu
- 涉及目录 / 文件: 见上方「涉及文件」
- 责任人 / 提交人: @Coding-Pangolin
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: q/k 为 `[B, Hk, T, K]`（bf16/fp16）；w/d_o/dv 为 `[B, Hv, T, V]`、g 为 `[B, Hv, T]`（fp32 或与 q 同 dtype）；输出 dh `[B, Hv, chunkNum, K, V]`、dv2 `[B, Hv, T, V]`；chunk_size ∈ {64,128}；K ≤ 128，V ≤ 256；定长模式任意 B，变长模式 B=1（cu_seqlens/chunk_indices 成对提供）。
- 明确不包含的范围: gK、h0/dht 仍不启用（须传 None）；use_exp2/transpose_state_layout 保持默认；本 PR 仅在 Ascend910B 验证，Ascend910_93 / Ascend950 未覆盖。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 不涉及

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 8.5.0 | `bash build.sh --pkg --soc=ascend910b --ops=chunk_gated_delta_rule_bwd_dhu --vendor_name=fla_npu` | 通过 | build_out/ 生成 .run，安装后 ascend910b/chunk_gated_delta_rule_bwd_dhu kernel 完整 |
| A3 | `ascend910_93` | - | `未执行` | 未执行 | 本 PR 仅验证 910B；A3 编译/运行待后续补充 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | cd torch_custom/fla_npu/test && TEST_DEVICE_ID=7 bash run_bwd_dhu_gva_cases.sh | 通过 | GVA 双标杆矩阵 11+1 项：10 PASS + 1 SKIP，FAIL 0；日志 bwd_dhu_gva_aclnn_20260625_v5.log（NPU2） |
| A2 | `ascend910b` | BWD_HU_CASE=smoke_varlen_t256_v256 TEST_DEVICE_ID=7 bash run_bwd_dhu_gva_cases.sh | 通过 | smoke_varlen_t256_v256 dh/dv2 MARE_ratio=0.0 |
| A2 | `ascend910b` | BWD_HU_CASE=fixed_b16_t2048_v256 TEST_DEVICE_ID=7 bash run_bwd_dhu_gva_cases.sh | 通过 | 生产规模 GVA Hk=21/Hv=63，dh/dv2 MARE_ratio 1.08/1.15 |
| A2 | `ascend910b` | BWD_HU_CASE=fixed_b176_t24_v256 TEST_DEVICE_ID=7 bash run_bwd_dhu_gva_cases.sh | 通过 | 大 batch B=176/Hk=2/Hv=64，MARE_ratio=0.0 |

- 精度标准（L1 dual）：`MARE_ratio ≤ 5.0`、`MERE_ratio ≤ 1.5`、`RMSE_ratio ≤ 1.5`、`ERR_COUNT_ratio ≤ 2.0`，`dh` 与 `dv2` 均须 PASS；比对接口 `ct.dual(npu_out, fp64, npu_bench)`。
- 已测 PASS 10 项：smoke_varlen_t256_v256、smoke_fixed_t4096_v256、varlen_t16384_v256_cu2/cu128、varlen_t65536_v256_cu17/cu172/cu668、fixed_b16_t2048_v256、fixed_b176_t24_v256、fixed_b711_t196_v256。
- 主动 SKIP 1 项：varlen_t262144_v256_cu32（CPU fp64 golden 超长过慢）。
- 性能对比：不涉及（功能/精度 PR）。
- 边界/异常场景：变长 B=1；g=fp32 覆盖 TilingKey=2；V=256 全矩阵覆盖。
- 未覆盖风险：T=262144 超长变长、910_93/950 平台、GPU 双标杆全量矩阵（后续 GPU dump dual 工作中补齐）。

</details>

<details>
<summary>整体 Example ST 验证</summary>

本 PR 为单算子能力扩展，未单独执行整体 example ST；依赖仓库 NPU CI 的 `ci/example_st_cases.json` （case1_current_default）回归，确认不破坏 GDN 端到端调用链。

</details>

## 兼容性、风险与回退

- 兼容性说明: aclnn/torch 接口签名不变；仅扩展 Hk≠Hv 场景并修正 dh 输出 shape 对齐 Hv（行为修正）。
- 风险点: GVA 场景 g=fp32 依赖 kernel 双 entry（KERNEL_TASK_TYPE 1/2），编译需保证双 tiling key 均打包；个别物理卡可能 507033 无法 set_device，需换空闲卡；超长变长用例 CPU golden 耗时高。
- 回退方案: 改动集中在单算子 tiling/kernel/OpApi 输出 shape，可整体 revert，不影响其他算子。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因（内部功能增强，无外部 Issue）
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 可以编译通过
- [ ] 已验证 A3 / A5 编译（本 PR 仅验证 910B，A3/A5 待补充）
- [x] 已验证修改算子的对应 test 在 A2 通过
- [ ] 已验证整体 example ST（未单独执行，依赖 NPU CI）
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用（README/设计文档随后续文档 PR 同步）
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 设计文档：`bwd_dhu_GVA_VDIM256.md`（Hk/Hv 拆分、GVA 方案 A、V=256 原生支持说明）。
- 与 recompute_wu_fwd 的差异：bwd_dhu 的 V=256 无需额外 TilingKey（Cube tile 原生 `<128,256,128>`），TilingKey 仅区分 g dtype（1=与 q 同 dtype，2=fp32）。
- 测试日志：`torch_custom/fla_npu/test/bwd_dhu_gva_aclnn_20260625_v5.log`（NPU2，10 PASS + 1 SKIP）；整合结论 `bwd_dhu_gva_aclnn_consolidated.md`。