### PR TITLE
prepare_wy_repr_bwd_full <<<>>>适配

### DIFF
--- a/examples/fast_kernel_launch_example/csrc/prepare_wy_repr_bwd_full/ascend910b/CMakeLists.txt
+++ b/examples/fast_kernel_launch_example/csrc/prepare_wy_repr_bwd_full/ascend910b/CMakeLists.txt
@@ -1,0 +1,10 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# ----------------------------------------------------------------------------
+
+add_sources("--npu-arch=dav-2201")

--- a/examples/fast_kernel_launch_example/csrc/prepare_wy_repr_bwd_full/ascend910b/prepare_wy_repr_bwd_full.cpp
+++ b/examples/fast_kernel_launch_example/csrc/prepare_wy_repr_bwd_full/ascend910b/prepare_wy_repr_bwd_full.cpp
@@ -1,0 +1,344 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file prepare_wy_repr_bwd_full.cpp
+ * \brief Prepare WY representation backward full operator with fast kernel launch.
+ */
+
+#include <ATen/Operators.h>
+#include <torch/all.h>
+#include <torch/library.h>
+
+#include <tuple>
+#include <vector>
+
+#include "acl/acl.h"
+#include "kernel_operator.h"
+#include "platform/platform_ascendc.h"
+#include "torch_npu/csrc/core/npu/NPUStream.h"
+#include "torch_npu/csrc/framework/OpCommand.h"
+
+#include "fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/prepare_wy_repr_bwd_full_tiling_processor.h"
+#include "fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full.cpp"
+
+namespace ascend_ops {
+namespace PrepareWyReprBwdFull {
+
+using TilingData = GDN::PrepareWyReprBwdFullTilingData;
+
+TORCH_LIBRARY_FRAGMENT(EXTENSION_MODULE_NAME, m)
+{
+    m.def("prepare_wy_repr_bwd_full(Tensor k, Tensor v, Tensor beta, Tensor A, Tensor dA, Tensor dw, Tensor du, Tensor g, int chunk_size, *, int[]? cu_seqlens=None, int[]? chunk_indices=None) -> (Tensor, Tensor, Tensor, Tensor)");
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> prepare_wy_repr_bwd_full_meta(
+    const at::Tensor &k, const at::Tensor &v, const at::Tensor &beta, const at::Tensor &A, const at::Tensor &dA,
+    const at::Tensor &dw, const at::Tensor &du, const at::Tensor &g, int64_t chunk_size,
+    at::OptionalIntArrayRef cu_seqlens, at::OptionalIntArrayRef chunk_indices)
+{
+    (void)A;
+    (void)dA;
+    (void)dw;
+    (void)du;
+    (void)chunk_size;
+    (void)cu_seqlens;
+    (void)chunk_indices;
+    return std::make_tuple(at::empty_like(k), at::empty_like(v), at::empty_like(beta), at::empty_like(g));
+}
+
+TORCH_LIBRARY_IMPL(EXTENSION_MODULE_NAME, Meta, m)
+{
+    m.impl("prepare_wy_repr_bwd_full", prepare_wy_repr_bwd_full_meta);
+}
+
+struct PrepareWyReprBwdFullTilingResult {
+    TilingData tiling;
+    uint32_t blockDim;
+    size_t workspaceSize;
+};
+
+int64_t ToPrepareWyReprBwdFullDtype(at::ScalarType dtype)
+{
+    if (dtype == at::kBFloat16) {
+        return optiling::PREPARE_WY_REPR_BWD_FULL_DTYPE_BF16;
+    }
+    if (dtype == at::kFloat) {
+        return optiling::PREPARE_WY_REPR_BWD_FULL_DTYPE_FP32;
+    }
+    if (dtype == at::kHalf) {
+        return optiling::PREPARE_WY_REPR_BWD_FULL_DTYPE_FP16;
+    }
+    TORCH_CHECK(false, "Unsupported dtype: ", dtype);
+    return optiling::PREPARE_WY_REPR_BWD_FULL_DTYPE_FP16;
+}
+
+void CheckInputRank(const at::Tensor &tensor, int64_t rank, const char *name)
+{
+    TORCH_CHECK(tensor.dim() == rank, name, " should be ", rank, "D, but got ", tensor.dim(), "D.");
+}
+
+void CheckSameDevice(const at::Tensor &base, const at::Tensor &tensor, const char *name)
+{
+    TORCH_CHECK(tensor.device() == base.device(), name, " should be on the same device as k.");
+}
+
+void CheckInputs(const at::Tensor &k, const at::Tensor &v, const at::Tensor &beta, const at::Tensor &A,
+                 const at::Tensor &dA, const at::Tensor &dw, const at::Tensor &du, const at::Tensor &g,
+                 at::OptionalIntArrayRef cu_seqlens, at::OptionalIntArrayRef chunk_indices)
+{
+    CheckInputRank(k, 4, "k");
+    CheckInputRank(v, 4, "v");
+    CheckInputRank(beta, 3, "beta");
+    CheckInputRank(A, 4, "A");
+    CheckInputRank(dA, 4, "dA");
+    CheckInputRank(dw, 4, "dw");
+    CheckInputRank(du, 4, "du");
+    CheckInputRank(g, 3, "g");
+
+    CheckSameDevice(k, v, "v");
+    CheckSameDevice(k, beta, "beta");
+    CheckSameDevice(k, A, "A");
+    CheckSameDevice(k, dA, "dA");
+    CheckSameDevice(k, dw, "dw");
+    CheckSameDevice(k, du, "du");
+    CheckSameDevice(k, g, "g");
+
+    auto kDtype = k.scalar_type();
+    auto betaDtype = beta.scalar_type();
+    TORCH_CHECK(kDtype == at::kHalf || kDtype == at::kBFloat16,
+                "k/v/A/dA/dw/du only support float16 or bfloat16, but got ", kDtype);
+    TORCH_CHECK(v.scalar_type() == kDtype && A.scalar_type() == kDtype && dA.scalar_type() == kDtype &&
+                    dw.scalar_type() == kDtype && du.scalar_type() == kDtype,
+                "v/A/dA/dw/du should have the same dtype as k.");
+    TORCH_CHECK(betaDtype == kDtype || betaDtype == at::kFloat,
+                "beta/g should have the same dtype as k or float32, but beta is ", betaDtype, " and k is ", kDtype);
+    TORCH_CHECK(g.scalar_type() == betaDtype, "g should have the same dtype as beta.");
+    TORCH_CHECK(cu_seqlens.has_value() == chunk_indices.has_value(),
+                "cu_seqlens and chunk_indices should be both provided or both None.");
+}
+
+PrepareWyReprBwdFullTilingResult CalcTilingParams(
+    const at::Tensor &k, const at::Tensor &v, const at::Tensor &beta, const at::Tensor &A, const at::Tensor &dA,
+    const at::Tensor &dw, const at::Tensor &du, const at::Tensor &g, int64_t chunk_size,
+    at::OptionalIntArrayRef cu_seqlens, at::OptionalIntArrayRef chunk_indices)
+{
+    auto kSizes = k.sizes();
+    auto vSizes = v.sizes();
+    auto betaSizes = beta.sizes();
+    auto aSizes = A.sizes();
+    auto dASizes = dA.sizes();
+    auto dwSizes = dw.sizes();
+    auto duSizes = du.sizes();
+    auto gSizes = g.sizes();
+
+    gert::StorageShape kShape({kSizes[0], kSizes[1], kSizes[2], kSizes[3]},
+                              {kSizes[0], kSizes[1], kSizes[2], kSizes[3]});
+    gert::StorageShape vShape({vSizes[0], vSizes[1], vSizes[2], vSizes[3]},
+                              {vSizes[0], vSizes[1], vSizes[2], vSizes[3]});
+    gert::StorageShape betaShape({betaSizes[0], betaSizes[1], betaSizes[2]},
+                                 {betaSizes[0], betaSizes[1], betaSizes[2]});
+    gert::StorageShape aShape({aSizes[0], aSizes[1], aSizes[2], aSizes[3]},
+                              {aSizes[0], aSizes[1], aSizes[2], aSizes[3]});
+    gert::StorageShape dAShape({dASizes[0], dASizes[1], dASizes[2], dASizes[3]},
+                               {dASizes[0], dASizes[1], dASizes[2], dASizes[3]});
+    gert::StorageShape dwShape({dwSizes[0], dwSizes[1], dwSizes[2], dwSizes[3]},
+                               {dwSizes[0], dwSizes[1], dwSizes[2], dwSizes[3]});
+    gert::StorageShape duShape({duSizes[0], duSizes[1], duSizes[2], duSizes[3]},
+                               {duSizes[0], duSizes[1], duSizes[2], duSizes[3]});
+    gert::StorageShape gShape({gSizes[0], gSizes[1], gSizes[2]}, {gSizes[0], gSizes[1], gSizes[2]});
+
+    gert::StorageShape *cuSeqlensShapePtr = nullptr;
+    gert::StorageShape *chunkIndicesShapePtr = nullptr;
+    gert::StorageShape cuSeqlensShape;
+    gert::StorageShape chunkIndicesShape;
+    std::vector<int64_t> cuSeqlensHost;
+    std::vector<int64_t> chunkIndicesHost;
+
+    if (cu_seqlens.has_value()) {
+        cuSeqlensHost = std::vector<int64_t>(cu_seqlens.value().begin(), cu_seqlens.value().end());
+        int64_t dim0 = static_cast<int64_t>(cuSeqlensHost.size());
+        cuSeqlensShape = gert::StorageShape({dim0}, {dim0});
+        cuSeqlensShapePtr = &cuSeqlensShape;
+    }
+    if (chunk_indices.has_value()) {
+        chunkIndicesHost = std::vector<int64_t>(chunk_indices.value().begin(), chunk_indices.value().end());
+        int64_t dim0 = static_cast<int64_t>(chunkIndicesHost.size());
+        chunkIndicesShape = gert::StorageShape({dim0}, {dim0});
+        chunkIndicesShapePtr = &chunkIndicesShape;
+    }
+
+    auto ascendcPlatform = platform_ascendc::PlatformAscendCManager::GetInstance();
+    TORCH_CHECK(ascendcPlatform != nullptr, "PlatformAscendCManager is null.");
+    uint64_t ubSize = 0;
+    ascendcPlatform->GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
+    uint32_t coreNum = static_cast<uint32_t>(ascendcPlatform->GetCoreNumAic());
+    size_t sysWorkspaceSize = static_cast<size_t>(ascendcPlatform->GetLibApiWorkSpaceSize());
+
+    optiling::PrepareWyReprBwdFullTilingContext ctx{
+        "prepare_wy_repr_bwd_full",
+        &kShape,
+        &vShape,
+        &betaShape,
+        &aShape,
+        &dAShape,
+        &dwShape,
+        &duShape,
+        &gShape,
+        cuSeqlensShapePtr,
+        chunkIndicesShapePtr,
+        cuSeqlensHost.empty() ? nullptr : cuSeqlensHost.data(),
+        chunkIndicesHost.empty() ? nullptr : chunkIndicesHost.data(),
+        chunk_size,
+        ToPrepareWyReprBwdFullDtype(k.scalar_type()),
+        ToPrepareWyReprBwdFullDtype(beta.scalar_type()),
+        ubSize,
+        coreNum,
+        sysWorkspaceSize,
+    };
+
+    TilingData tiling{};
+    optiling::PrepareWyReprBwdFullTilingProcessor processor(ctx, tiling);
+    TORCH_CHECK(processor.Process() == ge::GRAPH_SUCCESS, "prepare_wy_repr_bwd_full tiling failed.");
+    return PrepareWyReprBwdFullTilingResult{tiling, processor.GetBlockDim(), processor.GetWorkspaceSize()};
+}
+
+template <typename KType, typename BetaType>
+__global__ __aicore__ void prepare_wy_repr_bwd_full_kernel(
+    GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR dA, GM_ADDR dw, GM_ADDR du, GM_ADDR g,
+    GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR dk, GM_ADDR dv, GM_ADDR dbeta, GM_ADDR dg,
+    GM_ADDR workspace, const GDN::PrepareWyReprBwdFullTilingData tilingData)
+{
+    AscendC::AscendCUtils::SetOverflow(1);
+    AscendC::SetSysWorkspaceForce(workspace);
+    GM_ADDR userWorkspace = AscendC::GetUserWorkspace(workspace);
+    if (userWorkspace == nullptr) {
+        return;
+    }
+    if (tilingData.V == optiling::V_DIM_256) {
+        KERNEL_TASK_TYPE(2, KERNEL_TYPE_MIX_AIC_1_2);
+    } else {
+        KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
+    }
+    GDN::PrepareWyReprBwdFullKernelImpl<KType, BetaType>(
+        k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg, userWorkspace, &tilingData);
+}
+
+template <typename KType, typename BetaType>
+void LaunchPrepareWyReprBwdFull(uint32_t blockDim, aclrtStream stream, GM_ADDR k, GM_ADDR v, GM_ADDR beta,
+                                GM_ADDR A, GM_ADDR dA, GM_ADDR dw, GM_ADDR du, GM_ADDR g, GM_ADDR cu_seqlens,
+                                GM_ADDR chunk_indices, GM_ADDR dk, GM_ADDR dv, GM_ADDR dbeta, GM_ADDR dg,
+                                GM_ADDR workspace, const GDN::PrepareWyReprBwdFullTilingData &tiling)
+{
+    prepare_wy_repr_bwd_full_kernel<KType, BetaType><<<blockDim, nullptr, stream>>>(
+        k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg, workspace, tiling);
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> prepare_wy_repr_bwd_full_npu(
+    const at::Tensor &k, const at::Tensor &v, const at::Tensor &beta, const at::Tensor &A, const at::Tensor &dA,
+    const at::Tensor &dw, const at::Tensor &du, const at::Tensor &g, int64_t chunk_size,
+    at::OptionalIntArrayRef cu_seqlens, at::OptionalIntArrayRef chunk_indices)
+{
+    const c10::OptionalDeviceGuard guard(k.device());
+    CheckInputs(k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices);
+
+    auto outputs = prepare_wy_repr_bwd_full_meta(k, v, beta, A, dA, dw, du, g, chunk_size, cu_seqlens, chunk_indices);
+    auto dk = std::get<0>(outputs);
+    auto dv = std::get<1>(outputs);
+    auto dbeta = std::get<2>(outputs);
+    auto dg = std::get<3>(outputs);
+    auto stream = c10_npu::getCurrentNPUStream().stream(false);
+
+    PrepareWyReprBwdFullTilingResult tilingResult =
+        CalcTilingParams(k, v, beta, A, dA, dw, du, g, chunk_size, cu_seqlens, chunk_indices);
+
+    GM_ADDR kPtr = (GM_ADDR)k.data_ptr();
+    GM_ADDR vPtr = (GM_ADDR)v.data_ptr();
+    GM_ADDR betaPtr = (GM_ADDR)beta.data_ptr();
+    GM_ADDR APtr = (GM_ADDR)A.data_ptr();
+    GM_ADDR dAPtr = (GM_ADDR)dA.data_ptr();
+    GM_ADDR dwPtr = (GM_ADDR)dw.data_ptr();
+    GM_ADDR duPtr = (GM_ADDR)du.data_ptr();
+    GM_ADDR gPtr = (GM_ADDR)g.data_ptr();
+    GM_ADDR dkPtr = (GM_ADDR)dk.data_ptr();
+    GM_ADDR dvPtr = (GM_ADDR)dv.data_ptr();
+    GM_ADDR dbetaPtr = (GM_ADDR)dbeta.data_ptr();
+    GM_ADDR dgPtr = (GM_ADDR)dg.data_ptr();
+
+    GM_ADDR cuSeqlensPtr = nullptr;
+    GM_ADDR chunkIndicesPtr = nullptr;
+    std::vector<int64_t> cuSeqlensVec;
+    std::vector<int64_t> chunkIndicesVec;
+    at::Tensor cuSeqlensTensor;
+    at::Tensor chunkIndicesTensor;
+
+    if (cu_seqlens.has_value()) {
+        cuSeqlensVec = std::vector<int64_t>(cu_seqlens.value().begin(), cu_seqlens.value().end());
+        cuSeqlensTensor = at::tensor(cuSeqlensVec, at::dtype(at::kLong).device(k.device()));
+        cuSeqlensPtr = (GM_ADDR)cuSeqlensTensor.data_ptr();
+    }
+    if (chunk_indices.has_value()) {
+        chunkIndicesVec = std::vector<int64_t>(chunk_indices.value().begin(), chunk_indices.value().end());
+        chunkIndicesTensor = at::tensor(chunkIndicesVec, at::dtype(at::kLong).device(k.device()));
+        chunkIndicesPtr = (GM_ADDR)chunkIndicesTensor.data_ptr();
+    }
+
+    void *workspacePtr = nullptr;
+    if (tilingResult.workspaceSize > 0) {
+        auto ret = aclrtMalloc(&workspacePtr, tilingResult.workspaceSize, ACL_MEM_MALLOC_HUGE_FIRST);
+        TORCH_CHECK(ret == ACL_SUCCESS, "allocate workspace failed. ERROR: ", ret);
+    }
+    GM_ADDR workspaceGm = (GM_ADDR)workspacePtr;
+
+    auto kDtype = k.scalar_type();
+    auto betaDtype = beta.scalar_type();
+    auto tiling = tilingResult.tiling;
+    auto blockDim = tilingResult.blockDim;
+
+    auto aclCall = [=]() -> int {
+        if (kDtype == at::kBFloat16 && betaDtype == at::kBFloat16) {
+            LaunchPrepareWyReprBwdFull<bfloat16_t, bfloat16_t>(
+                blockDim, stream, kPtr, vPtr, betaPtr, APtr, dAPtr, dwPtr, duPtr, gPtr, cuSeqlensPtr,
+                chunkIndicesPtr, dkPtr, dvPtr, dbetaPtr, dgPtr, workspaceGm, tiling);
+        } else if (kDtype == at::kHalf && betaDtype == at::kHalf) {
+            LaunchPrepareWyReprBwdFull<half, half>(
+                blockDim, stream, kPtr, vPtr, betaPtr, APtr, dAPtr, dwPtr, duPtr, gPtr, cuSeqlensPtr,
+                chunkIndicesPtr, dkPtr, dvPtr, dbetaPtr, dgPtr, workspaceGm, tiling);
+        } else if (kDtype == at::kBFloat16 && betaDtype == at::kFloat) {
+            LaunchPrepareWyReprBwdFull<bfloat16_t, float>(
+                blockDim, stream, kPtr, vPtr, betaPtr, APtr, dAPtr, dwPtr, duPtr, gPtr, cuSeqlensPtr,
+                chunkIndicesPtr, dkPtr, dvPtr, dbetaPtr, dgPtr, workspaceGm, tiling);
+        } else if (kDtype == at::kHalf && betaDtype == at::kFloat) {
+            LaunchPrepareWyReprBwdFull<half, float>(
+                blockDim, stream, kPtr, vPtr, betaPtr, APtr, dAPtr, dwPtr, duPtr, gPtr, cuSeqlensPtr,
+                chunkIndicesPtr, dkPtr, dvPtr, dbetaPtr, dgPtr, workspaceGm, tiling);
+        } else {
+            TORCH_CHECK(false, "Unsupported dtype combination: k=", kDtype, ", beta=", betaDtype);
+        }
+        return 0;
+    };
+
+    at_npu::native::OpCommand::RunOpApi("PrepareWyReprBwdFull", aclCall);
+    auto syncRet = aclrtSynchronizeStream(stream);
+    TORCH_CHECK(syncRet == ACL_SUCCESS, "aclrtSynchronizeStream failed. ERROR: ", syncRet);
+
+    if (workspacePtr != nullptr) {
+        aclrtFree(workspacePtr);
+    }
+
+    return std::make_tuple(std::move(dk), std::move(dv), std::move(dbeta), std::move(dg));
+}
+
+TORCH_LIBRARY_IMPL(EXTENSION_MODULE_NAME, PrivateUse1, m)
+{
+    m.impl("prepare_wy_repr_bwd_full", prepare_wy_repr_bwd_full_npu);
+}
+
+} // namespace PrepareWyReprBwdFull
+} // namespace ascend_ops

--- a/examples/fast_kernel_launch_example/tests/prepare_wy_repr_bwd_full/test_prepare_wy_repr_bwd_full.py
+++ b/examples/fast_kernel_launch_example/tests/prepare_wy_repr_bwd_full/test_prepare_wy_repr_bwd_full.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import pytest
+import torch
+import torch_npu
+
+import ascend_ops
+
+
+def cdiv(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def prepare_chunk_indices(cu_seqlens, chunk_size):
+    indices = []
+    for seq_idx in range(len(cu_seqlens) - 1):
+        seq_len = cu_seqlens[seq_idx + 1] - cu_seqlens[seq_idx]
+        for chunk_idx in range(cdiv(seq_len, chunk_size)):
+            indices.extend([seq_idx, chunk_idx])
+    return indices
+
+
+def get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices):
+    if cu_seqlens is None:
+        bos = idx * chunk_size
+        eos = min(bos + chunk_size, T)
+        return bos, eos
+    seq_idx = chunk_indices[idx * 2]
+    chunk_idx = chunk_indices[idx * 2 + 1]
+    bos = cu_seqlens[seq_idx] + chunk_idx * chunk_size
+    eos = min(bos + chunk_size, cu_seqlens[seq_idx + 1])
+    return bos, eos
+
+
+def make_inputs(B, HK, HV, T, K, V, chunk_size, k_dtype, beta_dtype, variable=False):
+    torch.manual_seed(0)
+    actual_B = 1 if variable else B
+    k = torch.rand(actual_B, HK, T, K, dtype=k_dtype) * 0.1
+    v = torch.rand(actual_B, HV, T, V, dtype=k_dtype) * 0.1
+    beta = torch.rand(actual_B, HV, T, dtype=beta_dtype) * 0.1
+    A = torch.rand(actual_B, HV, T, chunk_size, dtype=k_dtype) * 0.1
+    dA = torch.rand(actual_B, HV, T, chunk_size, dtype=k_dtype) * 0.1
+    dw = torch.rand(actual_B, HK, T, K, dtype=k_dtype) * 0.1
+    du = torch.rand(actual_B, HV, T, V, dtype=k_dtype) * 0.1
+    g = torch.rand(actual_B, HV, T, dtype=beta_dtype) * 0.1
+    if not variable:
+        return k, v, beta, A, dA, dw, du, g, None, None
+    cu_seqlens = [0, T // 3, T]
+    chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    return k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices
+
+
+def prepare_wy_repr_bwd_full_ref(k, v, beta, A, dA, dw, du, g, chunk_size, cu_seqlens=None, chunk_indices=None):
+    out_k_dtype = k.dtype
+    out_beta_dtype = beta.dtype
+    k_f = k.to(torch.float64)
+    v_f = v.to(torch.float64)
+    beta_f = beta.to(torch.float64)
+    A_f = A.to(torch.float64)
+    dA_f = dA.to(torch.float64)
+    dw_f = dw.to(torch.float64)
+    du_f = du.to(torch.float64)
+    g_f = g.to(torch.float64)
+
+    B, HK, T, K = k.shape
+    _, HV, _, V = v.shape
+    heads_per_kv = HV // HK
+    NT = len(chunk_indices) // 2 if chunk_indices is not None else cdiv(T, chunk_size)
+
+    dk = torch.zeros_like(k_f)
+    dv = torch.zeros_like(v_f)
+    dbeta = torch.zeros_like(beta_f)
+    dg = torch.zeros_like(g_f)
+
+    for b in range(B):
+        for idx in range(NT):
+            bos, eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
+            for hv in range(HV):
+                hk = hv // heads_per_kv
+                A_chunk = A_f[b, hv, bos:eos, : eos - bos]
+                dA_chunk = dA_f[b, hv, bos:eos, : eos - bos]
+                k_chunk = k_f[b, hk, bos:eos, :]
+                v_chunk = v_f[b, hv, bos:eos, :]
+                beta_chunk = beta_f[b, hv, bos:eos]
+                g_exp_chunk = torch.exp(g_f[b, hv, bos:eos])
+                dw_chunk = dw_f[b, hk, bos:eos, :]
+                du_chunk = du_f[b, hv, bos:eos, :]
+
+                dv_chunk = (A_chunk.T @ du_chunk) * beta_chunk[:, None]
+                dv[b, hv, bos:eos, :] = dv_chunk
+
+                b_dk_beta = dA_chunk.T @ k_chunk
+                b_k_beta = k_chunk * beta_chunk[:, None]
+                b_dk_beta_g = A_chunk.T @ dw_chunk
+                dk_chunk = dA_chunk @ b_k_beta
+                dk_chunk = dk_chunk + b_dk_beta * beta_chunk[:, None]
+                dk_chunk = dk_chunk + b_dk_beta_g * (beta_chunk * g_exp_chunk)[:, None]
+                dk[b, hk, bos:eos, :] += dk_chunk
+
+                kkt = k_chunk @ k_chunk.T
+                b_A = kkt * beta_chunk[:, None]
+                b_dA_A = dA_chunk.T * b_A
+                b_kbg = k_chunk * (beta_chunk * g_exp_chunk)[:, None]
+                dg_chunk = torch.sum(b_dk_beta_g * b_kbg, dim=1)
+                dg_chunk = dg_chunk + (torch.sum(b_dA_A, dim=1) - torch.sum(b_dA_A, dim=0))
+                dg[b, hv, bos:eos] = dg_chunk
+
+                b_dv_beta = A_chunk.T @ du_chunk
+                dbeta_chunk = torch.sum(b_dk_beta * k_chunk, dim=1)
+                dbeta_chunk = dbeta_chunk + torch.sum(b_dk_beta_g * k_chunk * g_exp_chunk[:, None], dim=1)
+                dbeta_chunk = dbeta_chunk + torch.sum(b_dv_beta * v_chunk, dim=1)
+                dbeta[b, hv, bos:eos] = dbeta_chunk
+
+    return dk.to(out_k_dtype), dv.to(out_k_dtype), dbeta.to(out_beta_dtype), dg.to(out_beta_dtype)
+
+
+def assert_close_tuple(actual, expected):
+    for actual_tensor, expected_tensor in zip(actual, expected):
+        actual_f32 = actual_tensor.cpu().to(torch.float32)
+        expected_f32 = expected_tensor.cpu().to(torch.float32)
+        max_diff = torch.max(torch.abs(actual_f32 - expected_f32)).item()
+        assert torch.allclose(actual_f32, expected_f32, rtol=8e-2, atol=8e-2), f"max diff: {max_diff:.6f}"
+
+
+def test_prepare_wy_repr_bwd_full_interface_exist():
+    print(torch.ops.ascend_ops.prepare_wy_repr_bwd_full)
+    assert hasattr(torch.ops.ascend_ops, "prepare_wy_repr_bwd_full")
+
+
+FIXED_CONFIGS = [
+    (1, 2, 2, 65, 128, 128, 64, torch.float16, torch.float16),
+    (1, 2, 2, 129, 128, 128, 128, torch.float16, torch.float32),
+    (1, 2, 4, 65, 128, 128, 64, torch.float16, torch.float16),
+    (1, 1, 4, 65, 128, 128, 64, torch.float16, torch.float16),
+    (1, 2, 2, 65, 128, 128, 64, torch.bfloat16, torch.float32),
+]
+
+VARIABLE_CONFIGS = [
+    (1, 2, 2, 65, 128, 256, 64, torch.float16, torch.float16),
+]
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU device not found")
+@pytest.mark.parametrize("B,HK,HV,T,K,V,chunk_size,k_dtype,beta_dtype", FIXED_CONFIGS)
+def test_prepare_wy_repr_bwd_full_fixed(B, HK, HV, T, K, V, chunk_size, k_dtype, beta_dtype):
+    inputs = make_inputs(B, HK, HV, T, K, V, chunk_size, k_dtype, beta_dtype, variable=False)
+    k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices = inputs
+    expected = prepare_wy_repr_bwd_full_ref(k, v, beta, A, dA, dw, du, g, chunk_size, cu_seqlens, chunk_indices)
+    actual = torch.ops.ascend_ops.prepare_wy_repr_bwd_full(
+        k.npu(), v.npu(), beta.npu(), A.npu(), dA.npu(), dw.npu(), du.npu(), g.npu(), chunk_size
+    )
+    assert_close_tuple(actual, expected)
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU device not found")
+@pytest.mark.parametrize("B,HK,HV,T,K,V,chunk_size,k_dtype,beta_dtype", VARIABLE_CONFIGS)
+def test_prepare_wy_repr_bwd_full_variable(B, HK, HV, T, K, V, chunk_size, k_dtype, beta_dtype):
+    inputs = make_inputs(B, HK, HV, T, K, V, chunk_size, k_dtype, beta_dtype, variable=True)
+    k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices = inputs
+    expected = prepare_wy_repr_bwd_full_ref(k, v, beta, A, dA, dw, du, g, chunk_size, cu_seqlens, chunk_indices)
+    actual = torch.ops.ascend_ops.prepare_wy_repr_bwd_full(
+        k.npu(),
+        v.npu(),
+        beta.npu(),
+        A.npu(),
+        dA.npu(),
+        dw.npu(),
+        du.npu(),
+        g.npu(),
+        chunk_size,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    assert_close_tuple(actual, expected)
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU device not found")
+def test_prepare_wy_repr_bwd_full_variable_metadata_pair_required():
+    inputs = make_inputs(1, 2, 2, 65, 128, 128, 64, torch.float16, torch.float16, variable=True)
+    k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices = inputs
+    npu_args = (k.npu(), v.npu(), beta.npu(), A.npu(), dA.npu(), dw.npu(), du.npu(), g.npu(), 64)
+
+    with pytest.raises(RuntimeError, match="cu_seqlens and chunk_indices"):
+        torch.ops.ascend_ops.prepare_wy_repr_bwd_full(*npu_args, cu_seqlens=cu_seqlens, chunk_indices=None)
+
+    with pytest.raises(RuntimeError, match="cu_seqlens and chunk_indices"):
+        torch.ops.ascend_ops.prepare_wy_repr_bwd_full(*npu_args, cu_seqlens=None, chunk_indices=chunk_indices)

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/prepare_wy_repr_bwd_full_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/prepare_wy_repr_bwd_full_tiling.cpp
@@ -1,401 +1,64 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
- * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
- * the BSD 3-Clause License (the "License").
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- */
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 /*!
- * \file chunk_bwd_dv_local_tiling.cpp
+ * \file prepare_wy_repr_bwd_full_tiling.cpp
  * \brief
  */
 
 #include "prepare_wy_repr_bwd_full_tiling.h"
 #include "arch35/prepare_wy_repr_bwd_full_tiling_a5.h"
 #include <register/op_impl_registry.h>
-#include "tiling_base/data_copy_transpose_tiling.h"
-#include "tiling_base/tiling_templates_registry.h"
+#include "platform/platform_ascendc.h"
 
 namespace optiling {
 
+namespace {
 
-class PrepareWyReprBwdFullTilingProcessor {
-    gert::TilingContext *context_;
-    PrepareWyReprBwdFullTilingData &tiling_;
-    int64_t B = 0;
-    int64_t HK = 0;
-    int64_t HV = 0;
-    int64_t K = 0;
-    int64_t V = 0;
-    int64_t T = 0;
-    int64_t chunkSize = 0;
-
-public:
-    explicit PrepareWyReprBwdFullTilingProcessor(gert::TilingContext *context, PrepareWyReprBwdFullTilingData &tiling)
-        : context_(context), tiling_(tiling)
-    {
+int64_t ToPrepareWyReprBwdFullDtype(ge::DataType dtype)
+{
+    if (dtype == ge::DT_BF16) {
+        return PREPARE_WY_REPR_BWD_FULL_DTYPE_BF16;
     }
-
-    ge::graphStatus RequiredInputDimNumCheck(const gert::StorageShape *curShape, size_t validDimNum,
-                                             const char *inputName)
-    {
-        OP_CHECK_IF(curShape == nullptr,
-                    OP_LOGE(context_->GetNodeName(), "Input %s is required, but got nullptr.", inputName),
-                    return ge::GRAPH_FAILED);
-        const gert::Shape storageShape = curShape->GetStorageShape();
-        size_t dimNum = storageShape.GetDimNum();
-        OP_CHECK_IF(dimNum != validDimNum,
-                    OP_LOGE(context_->GetNodeName(),
-                            "Check input %s shape failed, the dim num should be %zu, but get %zu.", inputName,
-                            validDimNum, dimNum),
-                    return ge::GRAPH_FAILED);
-        return ge::GRAPH_SUCCESS;
+    if (dtype == ge::DT_FLOAT) {
+        return PREPARE_WY_REPR_BWD_FULL_DTYPE_FP32;
     }
+    return PREPARE_WY_REPR_BWD_FULL_DTYPE_FP16;
+}
 
-    ge::graphStatus PreCheck()
-    {
-        const ge::char_t *nodeName = context_->GetNodeName();
-        OP_CHECK_IF(RequiredInputDimNumCheck(context_->GetRequiredInputShape(INPUT_K_IDX), DIM_NUM_4, INPUT_K_NAME) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(RequiredInputDimNumCheck(context_->GetRequiredInputShape(INPUT_V_IDX), DIM_NUM_4, INPUT_V_NAME) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(RequiredInputDimNumCheck(context_->GetRequiredInputShape(INPUT_BETA_IDX), DIM_NUM_3,
-                                             INPUT_BETA_NAME) != ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(RequiredInputDimNumCheck(context_->GetRequiredInputShape(INPUT_A_IDX), DIM_NUM_4, INPUT_A_NAME) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(RequiredInputDimNumCheck(context_->GetRequiredInputShape(INPUT_DA_IDX), DIM_NUM_4, INPUT_DA_NAME) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(RequiredInputDimNumCheck(context_->GetRequiredInputShape(INPUT_DW_IDX), DIM_NUM_4, INPUT_DW_NAME) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(RequiredInputDimNumCheck(context_->GetRequiredInputShape(INPUT_DU_IDX), DIM_NUM_4, INPUT_DU_NAME) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(RequiredInputDimNumCheck(context_->GetRequiredInputShape(INPUT_G_IDX), DIM_NUM_3, INPUT_G_NAME) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-
-        return ge::GRAPH_SUCCESS;
-    }
-
-    ge::graphStatus CompareShape(const gert::Shape &shape1, const gert::Shape &shape2, const char *inputName1,
-                                 const char *inputName2, size_t compareDimNum)
-    {
-        size_t shapeDim1 = 0;
-        size_t shapeDim2 = 0;
-        for (size_t dimIndex = 0; dimIndex < compareDimNum; dimIndex++) {
-            shapeDim1 = shape1.GetDim(dimIndex);
-            shapeDim2 = shape2.GetDim(dimIndex);
-            OP_CHECK_IF(shapeDim1 != shapeDim2,
-                        OP_LOGE(context_->GetNodeName(),
-                                "Compare input shape of %s and %s failed, the length of dim %zu should be same,but got "
-                                "%zu and %zu.",
-                                inputName1, inputName2, dimIndex, shapeDim1, shapeDim2),
-                        return ge::GRAPH_FAILED);
-        }
-        return ge::GRAPH_SUCCESS;
-    }
-    uint64_t AlignUp(uint64_t value, uint64_t align)
-    {
-        return (value + align - 1) / align * align;
-    }
-
-    uint64_t GetTypeSize(ge::DataType dtype)
-    {
-        return dtype == ge::DataType::DT_FLOAT ? SIZE_FP32 : SIZE_HALF;
-    }
-
-    uint64_t GetFusedUseUbSize(uint64_t rowNum, uint64_t ubK, uint64_t ubV, uint64_t sizeofKType)
-    {
-        constexpr uint64_t SAFETY_MARGIN = 16 * 1024;
-        uint64_t persistentBytes = 0;
-        persistentBytes += AlignUp(chunkSize * SIZE_FP32, ONE_BLOCK_32); // beta fp32
-        persistentBytes += AlignUp(chunkSize * SIZE_FP32, ONE_BLOCK_32); // exp(g) fp32
-        persistentBytes += AlignUp(chunkSize * SIZE_FP32, ONE_BLOCK_32); // dbeta accumulator
-        persistentBytes += AlignUp(chunkSize * SIZE_FP32, ONE_BLOCK_32); // dg accumulator
-
-        uint64_t queueBytes = 0;
-        queueBytes += 2 * AlignUp(rowNum * ubK * sizeofKType, ONE_BLOCK_32);
-        queueBytes += 2 * AlignUp(rowNum * ubV * sizeofKType, ONE_BLOCK_32);
-
-        uint64_t group1TempBytes = 0;
-        group1TempBytes += AlignUp(5 * rowNum * K * SIZE_FP32, ONE_BLOCK_32);
-        group1TempBytes += AlignUp(rowNum * ONE_BLOCK_32, ONE_BLOCK_32); // beta brcb
-        group1TempBytes += AlignUp(rowNum * ONE_BLOCK_32, ONE_BLOCK_32); // exp(g) brcb
-        group1TempBytes += AlignUp(rowNum * ONE_BLOCK_32, ONE_BLOCK_32); // reduce scratch
-
-        uint64_t group2VTempBytes = 0;
-        group2VTempBytes += AlignUp(2 * rowNum * V * SIZE_FP32, ONE_BLOCK_32);
-        group2VTempBytes += AlignUp(rowNum * ONE_BLOCK_32, ONE_BLOCK_32);
-
-        uint64_t group2KktTempBytes = 0;
-        group2KktTempBytes += AlignUp(chunkSize * chunkSize * SIZE_FP32, ONE_BLOCK_32);
-        group2KktTempBytes += AlignUp(2 * rowNum * chunkSize * SIZE_FP32, ONE_BLOCK_32);
-        group2KktTempBytes += AlignUp(chunkSize * ONE_BLOCK_32, ONE_BLOCK_32);
-
-        uint64_t maxTempBytes = group1TempBytes > group2VTempBytes ? group1TempBytes : group2VTempBytes;
-        maxTempBytes = maxTempBytes > group2KktTempBytes ? maxTempBytes : group2KktTempBytes;
-        return persistentBytes + queueBytes + maxTempBytes + SAFETY_MARGIN;
-    }
-
-    uint64_t GetFusedRowNum(uint64_t ubSize, ge::DataType kType)
-    {
-        uint64_t rowNum = chunkSize / 2;
-        uint64_t sizeofKType = GetTypeSize(kType);
-        uint64_t ubK = K > chunkSize ? K : chunkSize;
-        uint64_t ubV = V > chunkSize ? V : chunkSize;
-        while (rowNum >= 8) {
-            uint64_t useUbSize = GetFusedUseUbSize(rowNum, ubK, ubV, sizeofKType);
-            if (useUbSize <= ubSize) {
-                break;
-            }
-            rowNum = rowNum / 2;
-        }
-        return rowNum;
-    }
-
-    ge::graphStatus SetFusedTiling(uint64_t ubSize, ge::DataType kType, uint64_t usedCoreNum)
-    {
-        uint64_t fusedRowNum = GetFusedRowNum(ubSize, kType);
-        tiling_.set_fusedKVecRow(fusedRowNum);
-        tiling_.set_fusedVVecRow(fusedRowNum);
-        tiling_.set_fusedKktVecRow(fusedRowNum);
-        tiling_.set_workspaceBufferCount(2);
-        tiling_.set_usedCoreNum(usedCoreNum);
-
-        uint64_t sizeofKType = GetTypeSize(kType);
-        uint64_t maxKV = K > V ? K : V;
-        uint64_t slotSize = 0;
-        slotSize += 3 * AlignUp(chunkSize * K * sizeofKType, ONE_BLOCK_32);
-        slotSize += AlignUp(chunkSize * maxKV * sizeofKType, ONE_BLOCK_32);
-        slotSize += AlignUp(chunkSize * chunkSize * sizeofKType, ONE_BLOCK_32);
-        tiling_.set_workspaceSlotSize(slotSize);
-        return ge::GRAPH_SUCCESS;
-    }
-    ge::graphStatus CommonTiling()
-    {
-        const gert::Shape kStorageShape = context_->GetRequiredInputShape(INPUT_K_IDX)->GetStorageShape();
-        const gert::Shape vStorageShape = context_->GetRequiredInputShape(INPUT_V_IDX)->GetStorageShape();
-        const gert::Shape betaStorageShape = context_->GetRequiredInputShape(INPUT_BETA_IDX)->GetStorageShape();
-        const gert::Shape AStorageShape = context_->GetRequiredInputShape(INPUT_A_IDX)->GetStorageShape();
-        const gert::Shape dAStorageShape = context_->GetRequiredInputShape(INPUT_DA_IDX)->GetStorageShape();
-        const gert::Shape dwStorageShape = context_->GetRequiredInputShape(INPUT_DW_IDX)->GetStorageShape();
-        const gert::Shape duStorageShape = context_->GetRequiredInputShape(INPUT_DU_IDX)->GetStorageShape();
-        const gert::Shape gStorageShape = context_->GetRequiredInputShape(INPUT_G_IDX)->GetStorageShape();
-        /* Benchmark (test_npu_prepare_wy_repr_bwd_full): k [B,HK,T,K], v/dw/… [B,HV,T,…], HV % HK == 0. */
-        const int64_t HV = static_cast<int64_t>(vStorageShape.GetDim(DIM_1));
-        const int64_t HK = static_cast<int64_t>(kStorageShape.GetDim(DIM_1));
-        OP_CHECK_IF(vStorageShape.GetDim(DIM_0) != kStorageShape.GetDim(DIM_0),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare input shape of %s and %s failed: batch dim 0 must match (got %zu vs %zu).",
-                            INPUT_V_NAME, INPUT_K_NAME, vStorageShape.GetDim(DIM_0), kStorageShape.GetDim(DIM_0)),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(vStorageShape.GetDim(DIM_2) != kStorageShape.GetDim(DIM_2),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare input shape of %s and %s failed: time dim 2 must match (got %zu vs %zu).",
-                            INPUT_V_NAME, INPUT_K_NAME, vStorageShape.GetDim(DIM_2), kStorageShape.GetDim(DIM_2)),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(HV <= 0 || HK <= 0,
-                    OP_LOGE(context_->GetNodeName(), "HV and HK must be positive (HV=%ld, HK=%ld).", HV, HK),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(HV % HK != 0,
-                    OP_LOGE(context_->GetNodeName(),
-                            "HV (%ld) must be a positive multiple of HK (%ld) for GQA (remainder %ld).", HV, HK,
-                            HV % HK),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(CompareShape(vStorageShape, duStorageShape, INPUT_V_NAME, INPUT_DU_NAME, DIM_NUM_4) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(CompareShape(betaStorageShape, gStorageShape, INPUT_BETA_NAME, INPUT_G_NAME, DIM_NUM_3) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(kStorageShape.GetDim(DIM_0) != gStorageShape.GetDim(DIM_0),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare input shape of %s and %s failed: batch dim 0 must match (got %zu vs %zu).",
-                            INPUT_K_NAME, INPUT_G_NAME, kStorageShape.GetDim(DIM_0), gStorageShape.GetDim(DIM_0)),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(kStorageShape.GetDim(DIM_2) != gStorageShape.GetDim(DIM_2),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare input shape of %s and %s failed: time dim 2 must match (got %zu vs %zu).",
-                            INPUT_K_NAME, INPUT_G_NAME, kStorageShape.GetDim(DIM_2), gStorageShape.GetDim(DIM_2)),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(vStorageShape.GetDim(DIM_1) != gStorageShape.GetDim(DIM_1),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare input shape of %s and %s failed: head dim 1 must match HV (got %zu vs %zu).",
-                            INPUT_V_NAME, INPUT_G_NAME, vStorageShape.GetDim(DIM_1), gStorageShape.GetDim(DIM_1)),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(CompareShape(AStorageShape, dAStorageShape, INPUT_A_NAME, INPUT_DA_NAME, DIM_NUM_4) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(CompareShape(dwStorageShape, kStorageShape, INPUT_DW_NAME, INPUT_K_NAME, DIM_NUM_3) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(dwStorageShape.GetDim(DIM_3) != kStorageShape.GetDim(DIM_3),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare input shape of %s and %s failed: last dim K must match (got %zu vs %zu).",
-                            INPUT_DW_NAME, INPUT_K_NAME, dwStorageShape.GetDim(DIM_3), kStorageShape.GetDim(DIM_3)),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(kStorageShape.GetDim(DIM_0) != AStorageShape.GetDim(DIM_0),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare input shape of %s and %s failed: batch dim 0 must match (got %zu vs %zu).",
-                            INPUT_K_NAME, INPUT_A_NAME, kStorageShape.GetDim(DIM_0), AStorageShape.GetDim(DIM_0)),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(kStorageShape.GetDim(DIM_2) != AStorageShape.GetDim(DIM_2),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare input shape of %s and %s failed: time dim 2 must match (got %zu vs %zu).",
-                            INPUT_K_NAME, INPUT_A_NAME, kStorageShape.GetDim(DIM_2), AStorageShape.GetDim(DIM_2)),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(vStorageShape.GetDim(DIM_1) != AStorageShape.GetDim(DIM_1),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare input shape of %s and %s failed: head dim 1 must match HV (got %zu vs %zu).",
-                            INPUT_V_NAME, INPUT_A_NAME, vStorageShape.GetDim(DIM_1), AStorageShape.GetDim(DIM_1)),
-                    return ge::GRAPH_FAILED);
-        B = static_cast<int64_t>(vStorageShape.GetDim(DIM_0));
-        T = static_cast<int64_t>(vStorageShape.GetDim(DIM_2));
-        K = static_cast<int64_t>(kStorageShape.GetDim(DIM_3));
-        V = static_cast<int64_t>(vStorageShape.GetDim(DIM_3));
-        tiling_.set_B(B);
-        tiling_.set_HV(HV);
-        tiling_.set_HK(HK);
-        tiling_.set_T(T);
-        tiling_.set_K(K);
-        tiling_.set_V(V);
-        OP_CHECK_IF(V != V_DIM_128 && V != V_DIM_256,
-                    OP_LOGE(context_->GetNodeName(),
-                            "Check value dim V failed: only %ld or %ld is supported, but get %ld.", V_DIM_128, V_DIM_256, V),
-                    return ge::GRAPH_FAILED);
-        auto attrPtr = context_->GetAttrs();
-        OP_CHECK_NULL_WITH_CONTEXT(context_, attrPtr);
-        chunkSize = static_cast<int64_t>(*(attrPtr->GetAttrPointer<int32_t>(ATTR_CHUNK_SIZE_IDX)));
-        OP_CHECK_IF(chunkSize != CHUNK_SIZE_64 && chunkSize != CHUNK_SIZE_128,
-                    OP_LOGE(context_->GetNodeName(),
-                            "Check attr chunkSize failed, the chunkSize should be 64 or 128, but get %ld.", chunkSize),
-                    return ge::GRAPH_FAILED);
-        tiling_.set_chunkSize(chunkSize);
-        const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context_->GetPlatformInfo());
-        uint64_t ubSize = 0;
-        ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
-
-        auto kDesc = context_->GetDynamicInputDesc(INPUT_K_IDX, 0);
-        OP_CHECK_NULL_WITH_CONTEXT(context_, kDesc); // check xDesc is not null
-        auto kDType = kDesc->GetDataType();
-        OP_CHECK_IF(SetFusedTiling(ubSize, kDType, platform_ascendc::PlatformAscendC(context_->GetPlatformInfo()).GetCoreNumAic()) !=
-                        ge::GRAPH_SUCCESS,
-                    OP_LOGE(context_->GetNodeName(), "SetFusedTiling Failed."),
-                    return ge::GRAPH_FAILED);
-        return ge::GRAPH_SUCCESS;
-    }
-
-    int64_t CeilDiv(int64_t a, int64_t b)
-    {
-        if (unlikely(b == 0)) {
-            return 0;
-        }
-        return (a + b - 1) / b;
-    }
-
-    ge::graphStatus FixLenTiling()
-    {
-        tiling_.set_chunkNum(tiling_.get_B() * CeilDiv(tiling_.get_T(), tiling_.get_chunkSize()));
-        return ge::GRAPH_SUCCESS;
-    }
-
-    ge::graphStatus VariableLenTiling()
-    {
-        const gert::StorageShape *chunkIndicesShape = context_->GetOptionalInputShape(INPUT_CHUNK_INDICES_IDX);
-        const gert::StorageShape *seqlensShape = context_->GetOptionalInputShape(INPUT_SEQLENS_IDX);
-        auto cuSeqlensTensor = context_->GetOptionalInputTensor(INPUT_SEQLENS_IDX);
-        auto chunkIndicesTensor = context_->GetOptionalInputTensor(INPUT_CHUNK_INDICES_IDX);
-        OP_CHECK_NULL_WITH_CONTEXT(context_, cuSeqlensTensor);
-        OP_CHECK_NULL_WITH_CONTEXT(context_, chunkIndicesShape);
-        OP_CHECK_NULL_WITH_CONTEXT(context_, seqlensShape);
-        OP_CHECK_IF(RequiredInputDimNumCheck(chunkIndicesShape, DIM_1, INPUT_CHUNK_INDICES_NAME) != ge::GRAPH_SUCCESS, ,
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(RequiredInputDimNumCheck(seqlensShape, DIM_1, INPUT_SEQLENS_NAME) != ge::GRAPH_SUCCESS, ,
-                    return ge::GRAPH_FAILED);
-
-        const gert::Shape seqlensStorageShape = seqlensShape->GetStorageShape();
-        int64_t seqlensDim0 = seqlensStorageShape.GetDim(DIM_0);
-        OP_CHECK_IF(seqlensDim0 < 2,
-                    OP_LOGE(context_->GetNodeName(),
-                            "Check seqlens shape failed, the dim 0 of seqlens should be larger than 1, but get %ld.",
-                            seqlensDim0),
-                    return ge::GRAPH_FAILED);
-        const int64_t* cuSeqlens = cuSeqlensTensor->GetData<int64_t>();
-        OP_CHECK_NULL_WITH_CONTEXT(context_, cuSeqlens);
-        if(cuSeqlens[0] != 0){
-            OP_LOGE(context_->GetNodeName(),
-                                "Check seqlens data failed, the seqlens[0] should be 0, but get %ld.",
-                                cuSeqlens[0]);
-            return ge::GRAPH_FAILED;
-        }
-        std::vector<int64_t> expectChunkIndices;
-        for(int64_t i = 1; i < seqlensDim0; i++){
-            int64_t curSeqLen = cuSeqlens[i] - cuSeqlens[i - 1];
-            OP_CHECK_IF(curSeqLen <= 0,
-                        OP_LOGE(context_->GetNodeName(),
-                                "Check seqlens data failed, the seqlens[%ld]:[%ld] should be larger than seqlens[%ld]:[%ld]",
-                                i, cuSeqlens[i], i - 1, cuSeqlens[i - 1]),
-                        return ge::GRAPH_FAILED);
-            for(int64_t j = 0;j < curSeqLen; j += chunkSize){
-                expectChunkIndices.push_back(i - 1);
-                expectChunkIndices.push_back(j / chunkSize);
-            }
-        }
-
-        
-        const gert::Shape chunkIndicesStorageShape = chunkIndicesShape->GetStorageShape();
-        int64_t chunkIndicesDim0 = chunkIndicesStorageShape.GetDim(DIM_0);
-        OP_CHECK_IF(chunkIndicesDim0 != expectChunkIndices.size(),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Check chunk_indices shape failed, the len of chunk_indices should be %ld, but get %ld.",
-                            expectChunkIndices.size(), chunkIndicesDim0),
-                    return ge::GRAPH_FAILED);
-        const int64_t* chunkIndices = chunkIndicesTensor->GetData<int64_t>();
-        OP_CHECK_NULL_WITH_CONTEXT(context_, chunkIndices);
-        for(int64_t i = 0; i < expectChunkIndices.size(); i++){
-            OP_CHECK_IF(expectChunkIndices[i] != chunkIndices[i],
-                        OP_LOGE(context_->GetNodeName(),
-                                "Check chunk_indices data failed, the chunk_indices[%ld] should be %ld, but get %ld.",
-                                i, expectChunkIndices[i], chunkIndices[i]),
-                        return ge::GRAPH_FAILED);
-        }
-        tiling_.set_chunkNum(chunkIndicesStorageShape.GetDim(DIM_0) / 2);
-        return ge::GRAPH_SUCCESS;
-    }
-};
-
-static void PrepareWyReprBwdFullTilingDataPrint(gert::TilingContext *context, PrepareWyReprBwdFullTilingData &tiling)
+void PrepareWyReprBwdFullTilingDataPrint(gert::TilingContext *context, const PrepareWyReprBwdFullTilingData &tiling)
 {
     auto nodeName = context->GetNodeName();
     OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Start to print PrepareWyReprBwdFull tiling data <<<<<<<<<<<<<<<<");
-    OP_LOGD(nodeName, "=== B: %ld", tiling.get_B());
-    OP_LOGD(nodeName, "=== HV: %ld", tiling.get_HV());
-    OP_LOGD(nodeName, "=== HK: %ld", tiling.get_HK());
-    OP_LOGD(nodeName, "=== T: %ld", tiling.get_T());
-    OP_LOGD(nodeName, "=== K: %ld", tiling.get_K());
-    OP_LOGD(nodeName, "=== V: %ld", tiling.get_V());
-    OP_LOGD(nodeName, "=== chunkSize: %ld", tiling.get_chunkSize());
-    OP_LOGD(nodeName, "=== fusedKVecRow: %ld", tiling.get_fusedKVecRow());
-    OP_LOGD(nodeName, "=== workspaceSlotSize: %ld", tiling.get_workspaceSlotSize());
-    OP_LOGD(nodeName, "=== workspaceBufferCount: %ld", tiling.get_workspaceBufferCount());
+    OP_LOGD(nodeName, "=== B: %ld", tiling.B);
+    OP_LOGD(nodeName, "=== HV: %ld", tiling.HV);
+    OP_LOGD(nodeName, "=== HK: %ld", tiling.HK);
+    OP_LOGD(nodeName, "=== T: %ld", tiling.T);
+    OP_LOGD(nodeName, "=== K: %ld", tiling.K);
+    OP_LOGD(nodeName, "=== V: %ld", tiling.V);
+    OP_LOGD(nodeName, "=== chunkNum: %ld", tiling.chunkNum);
+    OP_LOGD(nodeName, "=== chunkSize: %ld", tiling.chunkSize);
+    OP_LOGD(nodeName, "=== fusedKVecRow: %ld", tiling.fusedKVecRow);
+    OP_LOGD(nodeName, "=== fusedVVecRow: %ld", tiling.fusedVVecRow);
+    OP_LOGD(nodeName, "=== fusedKktVecRow: %ld", tiling.fusedKktVecRow);
+    OP_LOGD(nodeName, "=== workspaceSlotSize: %ld", tiling.workspaceSlotSize);
+    OP_LOGD(nodeName, "=== workspaceBufferCount: %ld", tiling.workspaceBufferCount);
+    OP_LOGD(nodeName, "=== usedCoreNum: %ld", tiling.usedCoreNum);
+    OP_LOGD(nodeName, "=== isVariable: %ld", tiling.isVariable);
     OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Print PrepareWyReprBwdFull tiling data end <<<<<<<<<<<<<<<<");
 }
+
+} // namespace
 
 ge::graphStatus Tiling4PrepareWyReprBwdFull(gert::TilingContext *context)
 {
     OP_LOGD(context->GetNodeName(), "Tiling4PrepareWyReprBwdFull start.");
-    PrepareWyReprBwdFullTilingData tiling;
-    PrepareWyReprBwdFullTilingProcessor processor(context, tiling);
-
-    OP_CHECK_IF(processor.PreCheck() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
     const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
 
     if (ascendcPlatform.GetCurNpuArch() == NpuArch::DAV_3510) {
@@ -404,42 +67,60 @@ ge::graphStatus Tiling4PrepareWyReprBwdFull(gert::TilingContext *context)
                     OP_LOGE(context->GetNodeName(), "SetTiling failed."), return ge::GRAPH_FAILED);
         return ge::GRAPH_SUCCESS;
     }
-    
-    OP_CHECK_IF(processor.CommonTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+
+    PrepareWyReprBwdFullTilingData *tiling = context->GetTilingData<PrepareWyReprBwdFullTilingData>();
+    OP_CHECK_NULL_WITH_CONTEXT(context, tiling);
+
+    auto attrPtr = context->GetAttrs();
+    OP_CHECK_NULL_WITH_CONTEXT(context, attrPtr);
+
+    auto kDesc = context->GetInputDesc(INPUT_K_IDX);
+    auto betaDesc = context->GetInputDesc(INPUT_BETA_IDX);
+    OP_CHECK_NULL_WITH_CONTEXT(context, kDesc);
+    OP_CHECK_NULL_WITH_CONTEXT(context, betaDesc);
+
+    uint64_t ubSize = 0;
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
 
     auto cuSeqlensTensor = context->GetOptionalInputTensor(INPUT_SEQLENS_IDX);
-    if (cuSeqlensTensor == nullptr) {
-        OP_CHECK_IF(processor.FixLenTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
-        tiling.set_isVariable(0);
-    } else {
-        OP_CHECK_IF(tiling.get_B() != VAR_LEN_B_DIM_1,
-                    OP_LOGE(context->GetNodeName(),
-                            "If cu_seqlens is not nullptr, the dim 0 of q needs to be 1, but now is %ld.",
-                            tiling.get_B()),
-                    return ge::GRAPH_FAILED);
-        auto chunkIndicesTensor = context->GetOptionalInputTensor(INPUT_CHUNK_INDICES_IDX);
-        OP_CHECK_NULL_WITH_CONTEXT(context, chunkIndicesTensor);
-        OP_CHECK_IF(processor.VariableLenTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
-        tiling.set_isVariable(1);
-    }
-    if (tiling.get_V() == V_DIM_256) {
-        context->SetTilingKey(2);
-    } else {
-        context->SetTilingKey(1);
-    }
-    OP_LOGD(context->GetNodeName(), "tilingKey: %d (V=%ld)", context->GetTilingKey(), tiling.get_V());
-    PrepareWyReprBwdFullTilingDataPrint(context, tiling);
+    auto chunkIndicesTensor = context->GetOptionalInputTensor(INPUT_CHUNK_INDICES_IDX);
+    const int64_t *cuSeqlensData = cuSeqlensTensor == nullptr ? nullptr : cuSeqlensTensor->GetData<int64_t>();
+    const int64_t *chunkIndicesData =
+        chunkIndicesTensor == nullptr ? nullptr : chunkIndicesTensor->GetData<int64_t>();
 
-    tiling.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
-    context->GetRawTilingData()->SetDataSize(tiling.GetDataSize());
-    context->SetBlockDim(ascendcPlatform.GetCoreNumAic());
+    PrepareWyReprBwdFullTilingContext ctx{
+        context->GetNodeName(),
+        context->GetRequiredInputShape(INPUT_K_IDX),
+        context->GetRequiredInputShape(INPUT_V_IDX),
+        context->GetRequiredInputShape(INPUT_BETA_IDX),
+        context->GetRequiredInputShape(INPUT_A_IDX),
+        context->GetRequiredInputShape(INPUT_DA_IDX),
+        context->GetRequiredInputShape(INPUT_DW_IDX),
+        context->GetRequiredInputShape(INPUT_DU_IDX),
+        context->GetRequiredInputShape(INPUT_G_IDX),
+        context->GetOptionalInputShape(INPUT_SEQLENS_IDX),
+        context->GetOptionalInputShape(INPUT_CHUNK_INDICES_IDX),
+        cuSeqlensData,
+        chunkIndicesData,
+        static_cast<int64_t>(*(attrPtr->GetAttrPointer<int32_t>(ATTR_CHUNK_SIZE_IDX))),
+        ToPrepareWyReprBwdFullDtype(kDesc->GetDataType()),
+        ToPrepareWyReprBwdFullDtype(betaDesc->GetDataType()),
+        ubSize,
+        static_cast<uint32_t>(ascendcPlatform.GetCoreNumAic()),
+        static_cast<size_t>(ascendcPlatform.GetLibApiWorkSpaceSize()),
+    };
 
-    uint32_t sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
-    uint64_t userWorkspaceSize =
-        tiling.get_usedCoreNum() * tiling.get_workspaceBufferCount() * tiling.get_workspaceSlotSize();
+    PrepareWyReprBwdFullTilingProcessor processor(ctx, *tiling);
+    OP_CHECK_IF(processor.Process() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+
+    context->SetTilingKey(processor.GetTilingKey());
+    context->SetBlockDim(processor.GetBlockDim());
     size_t *currentWorkspace = context->GetWorkspaceSizes(1);
-    currentWorkspace[0] = userWorkspaceSize + sysWorkspaceSize;
-    context->SetScheduleMode(1); // set as batchmod for template using SyncAll
+    currentWorkspace[0] = processor.GetWorkspaceSize();
+    context->SetScheduleMode(1);
+
+    OP_LOGD(context->GetNodeName(), "tilingKey: %d (V=%ld)", context->GetTilingKey(), tiling->V);
+    PrepareWyReprBwdFullTilingDataPrint(context, *tiling);
     OP_LOGD(context->GetNodeName(), "Tiling4PrepareWyReprBwdFull end.");
     return ge::GRAPH_SUCCESS;
 }
@@ -449,8 +130,6 @@ ge::graphStatus TilingPrepareForPrepareWyReprBwdFull(gert::TilingParseContext *c
     (void)context;
     return ge::GRAPH_SUCCESS;
 }
-
-struct PrepareWyReprBwdFullCompileInfo {};
 
 IMPL_OP_OPTILING(PrepareWyReprBwdFull)
     .Tiling(Tiling4PrepareWyReprBwdFull)

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/prepare_wy_repr_bwd_full_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/prepare_wy_repr_bwd_full_tiling.h
@@ -1,90 +1,28 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
- * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
- * the BSD 3-Clause License (the "License").
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- */
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 /*!
  * \file prepare_wy_repr_bwd_full_tiling.h
- * \brief
+ * \brief Compatibility include for prepare_wy_repr_bwd_full tiling data.
  */
+
 #ifndef PREPARE_WY_REPR_BWD_FULL_TILING_H
 #define PREPARE_WY_REPR_BWD_FULL_TILING_H
 
 #include <exe_graph/runtime/tiling_context.h>
 #include <graph/utils/type_utils.h>
 
-#include "register/tilingdata_base.h"
-#include "tiling/tiling_api.h"
+#include "../prepare_wy_repr_bwd_full_tiling_processor.h"
 
 namespace optiling {
-static constexpr size_t INPUT_K_IDX = 0;
-static constexpr size_t INPUT_V_IDX = 1;
-static constexpr size_t INPUT_BETA_IDX = 2;
-static constexpr size_t INPUT_A_IDX = 3;
-static constexpr size_t INPUT_DA_IDX = 4;
-static constexpr size_t INPUT_DW_IDX = 5;
-static constexpr size_t INPUT_DU_IDX = 6;
-static constexpr size_t INPUT_G_IDX = 7;
-static constexpr size_t INPUT_SEQLENS_IDX = 8;
-static constexpr size_t INPUT_CHUNK_INDICES_IDX = 9;
 
-static constexpr size_t ATTR_CHUNK_SIZE_IDX = 0;
-
-static constexpr size_t DIM_NUM_3 = 3;
-static constexpr size_t DIM_NUM_4 = 4;
-
-static constexpr size_t DIM_0 = 0;
-static constexpr size_t DIM_1 = 1;
-static constexpr size_t DIM_2 = 2;
-static constexpr size_t DIM_3 = 3;
-static constexpr int64_t CHUNK_INDICES_DIM_1_SIZE = 2;
-
-static constexpr int64_t CHUNK_SIZE_64 = 64;
-static constexpr int64_t CHUNK_SIZE_128 = 128;
-
-/** Value head dimension V supported by cube/vector tiling. */
-static constexpr int64_t V_DIM_128 = 128;
-static constexpr int64_t V_DIM_256 = 256;
-
-static constexpr int64_t VAR_LEN_B_DIM_1 = 1;
-
-static constexpr const char *const INPUT_K_NAME = "k";
-static constexpr const char *const INPUT_V_NAME = "v";
-static constexpr const char *const INPUT_BETA_NAME = "beta";
-static constexpr const char *const INPUT_A_NAME = "A";
-static constexpr const char *const INPUT_DA_NAME = "dA";
-static constexpr const char *const INPUT_DW_NAME = "dw";
-static constexpr const char *const INPUT_DU_NAME = "du";
-static constexpr const char *const INPUT_G_NAME = "g";
-static constexpr const char *const INPUT_CHUNK_INDICES_NAME = "chunk_indices";
-static constexpr const char *const INPUT_SEQLENS_NAME = "cu_seqlens";
-static constexpr uint64_t SIZE_HALF = 2;
-static constexpr uint64_t SIZE_FP32 = 4;
-constexpr uint64_t ONE_BLOCK_32 = 32;
-constexpr uint64_t MAX_CUBE_VEC_SYNC_NUM = 5;
-
-BEGIN_TILING_DATA_DEF(PrepareWyReprBwdFullTilingData)
-TILING_DATA_FIELD_DEF(int64_t, B);
-TILING_DATA_FIELD_DEF(int64_t, HV);
-TILING_DATA_FIELD_DEF(int64_t, HK);
-TILING_DATA_FIELD_DEF(int64_t, T);
-TILING_DATA_FIELD_DEF(int64_t, K);
-TILING_DATA_FIELD_DEF(int64_t, V);
-TILING_DATA_FIELD_DEF(int64_t, chunkNum);
-TILING_DATA_FIELD_DEF(int64_t, chunkSize);
-TILING_DATA_FIELD_DEF(int64_t, fusedKVecRow);   // fused K-path vector tile rows
-TILING_DATA_FIELD_DEF(int64_t, fusedVVecRow);   // fused V-path vector tile rows
-TILING_DATA_FIELD_DEF(int64_t, fusedKktVecRow); // fused KKT-path vector tile rows
-TILING_DATA_FIELD_DEF(int64_t, workspaceSlotSize);
-TILING_DATA_FIELD_DEF(int64_t, workspaceBufferCount);
-TILING_DATA_FIELD_DEF(int64_t, usedCoreNum);
-TILING_DATA_FIELD_DEF(int64_t, isVariable);
-END_TILING_DATA_DEF;
-REGISTER_TILING_DATA_CLASS(PrepareWyReprBwdFull, PrepareWyReprBwdFullTilingData)
+struct PrepareWyReprBwdFullCompileInfo {};
 
 } // namespace optiling
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/prepare_wy_repr_bwd_full_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/prepare_wy_repr_bwd_full_tiling_processor.h
@@ -1,0 +1,483 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file prepare_wy_repr_bwd_full_tiling_processor.h
+ * \brief Tiling processor shared by aclnn tiling and fast kernel launch.
+ */
+
+#ifndef PREPARE_WY_REPR_BWD_FULL_TILING_PROCESSOR_H
+#define PREPARE_WY_REPR_BWD_FULL_TILING_PROCESSOR_H
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <exe_graph/runtime/storage_shape.h>
+#include <register/op_impl_registry.h>
+#include "tiling_base/data_copy_transpose_tiling.h"
+#include "tiling_base/tiling_templates_registry.h"
+
+#include "../op_kernel/prepare_wy_repr_bwd_full_struct.h"
+
+using GDN::PrepareWyReprBwdFullTilingData;
+
+namespace optiling {
+
+static constexpr size_t INPUT_K_IDX = 0;
+static constexpr size_t INPUT_V_IDX = 1;
+static constexpr size_t INPUT_BETA_IDX = 2;
+static constexpr size_t INPUT_A_IDX = 3;
+static constexpr size_t INPUT_DA_IDX = 4;
+static constexpr size_t INPUT_DW_IDX = 5;
+static constexpr size_t INPUT_DU_IDX = 6;
+static constexpr size_t INPUT_G_IDX = 7;
+static constexpr size_t INPUT_SEQLENS_IDX = 8;
+static constexpr size_t INPUT_CHUNK_INDICES_IDX = 9;
+
+static constexpr size_t ATTR_CHUNK_SIZE_IDX = 0;
+
+static constexpr size_t DIM_NUM_3 = 3;
+static constexpr size_t DIM_NUM_4 = 4;
+
+static constexpr size_t DIM_0 = 0;
+static constexpr size_t DIM_1 = 1;
+static constexpr size_t DIM_2 = 2;
+static constexpr size_t DIM_3 = 3;
+
+static constexpr int64_t CHUNK_SIZE_64 = 64;
+static constexpr int64_t CHUNK_SIZE_128 = 128;
+static constexpr int64_t V_DIM_128 = 128;
+static constexpr int64_t V_DIM_256 = 256;
+static constexpr int64_t VAR_LEN_B_DIM_1 = 1;
+
+static constexpr int64_t PREPARE_WY_REPR_BWD_FULL_DTYPE_FP16 = 0;
+static constexpr int64_t PREPARE_WY_REPR_BWD_FULL_DTYPE_BF16 = 1;
+static constexpr int64_t PREPARE_WY_REPR_BWD_FULL_DTYPE_FP32 = 2;
+
+static constexpr const char *const INPUT_K_NAME = "k";
+static constexpr const char *const INPUT_V_NAME = "v";
+static constexpr const char *const INPUT_BETA_NAME = "beta";
+static constexpr const char *const INPUT_A_NAME = "A";
+static constexpr const char *const INPUT_DA_NAME = "dA";
+static constexpr const char *const INPUT_DW_NAME = "dw";
+static constexpr const char *const INPUT_DU_NAME = "du";
+static constexpr const char *const INPUT_G_NAME = "g";
+static constexpr const char *const INPUT_CHUNK_INDICES_NAME = "chunk_indices";
+static constexpr const char *const INPUT_SEQLENS_NAME = "cu_seqlens";
+
+static constexpr uint64_t SIZE_HALF = 2;
+static constexpr uint64_t SIZE_FP32 = 4;
+static constexpr uint64_t ONE_BLOCK_32 = 32;
+static constexpr uint64_t MAX_CUBE_VEC_SYNC_NUM = 5;
+
+struct PrepareWyReprBwdFullTilingContext {
+    const char *nodeName;
+    const gert::StorageShape *kShape;
+    const gert::StorageShape *vShape;
+    const gert::StorageShape *betaShape;
+    const gert::StorageShape *aShape;
+    const gert::StorageShape *dAShape;
+    const gert::StorageShape *dwShape;
+    const gert::StorageShape *duShape;
+    const gert::StorageShape *gShape;
+    const gert::StorageShape *cuSeqlensShape;
+    const gert::StorageShape *chunkIndicesShape;
+    const int64_t *cuSeqlensData;
+    const int64_t *chunkIndicesData;
+    int64_t chunkSize;
+    int64_t kDataType;
+    int64_t betaDataType;
+    uint64_t ubSize;
+    uint32_t aicCoreNum;
+    size_t sysWorkspaceSize;
+};
+
+class PrepareWyReprBwdFullTilingProcessor {
+    PrepareWyReprBwdFullTilingContext &ctx_;
+    PrepareWyReprBwdFullTilingData &tiling_;
+    size_t workspaceSize_ = 0;
+    uint32_t blockDim_ = 0;
+
+public:
+    explicit PrepareWyReprBwdFullTilingProcessor(PrepareWyReprBwdFullTilingContext &ctx,
+                                                 PrepareWyReprBwdFullTilingData &tiling)
+        : ctx_(ctx), tiling_(tiling)
+    {
+    }
+
+    size_t GetWorkspaceSize() const
+    {
+        return workspaceSize_;
+    }
+
+    uint32_t GetBlockDim() const
+    {
+        return blockDim_;
+    }
+
+    uint32_t GetTilingKey() const
+    {
+        return 1U;
+    }
+
+    bool IsVariableLength() const
+    {
+        return ctx_.cuSeqlensShape != nullptr || ctx_.chunkIndicesShape != nullptr;
+    }
+
+    ge::graphStatus RequiredInputDimNumCheck(const gert::StorageShape *curShape, size_t validDimNum,
+                                             const char *inputName)
+    {
+        OP_CHECK_IF(curShape == nullptr,
+                    OP_LOGE(ctx_.nodeName, "Input %s is required, but got nullptr.", inputName),
+                    return ge::GRAPH_FAILED);
+        const gert::Shape storageShape = curShape->GetStorageShape();
+        size_t dimNum = storageShape.GetDimNum();
+        OP_CHECK_IF(dimNum != validDimNum,
+                    OP_LOGE(ctx_.nodeName,
+                            "Check input %s shape failed, the dim num should be %zu, but get %zu.", inputName,
+                            validDimNum, dimNum),
+                    return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus PreCheck()
+    {
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.kShape, DIM_NUM_4, INPUT_K_NAME) != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.vShape, DIM_NUM_4, INPUT_V_NAME) != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.betaShape, DIM_NUM_3, INPUT_BETA_NAME) != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.aShape, DIM_NUM_4, INPUT_A_NAME) != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.dAShape, DIM_NUM_4, INPUT_DA_NAME) != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.dwShape, DIM_NUM_4, INPUT_DW_NAME) != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.duShape, DIM_NUM_4, INPUT_DU_NAME) != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.gShape, DIM_NUM_3, INPUT_G_NAME) != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus CompareShape(const gert::Shape &shape1, const gert::Shape &shape2, const char *inputName1,
+                                 const char *inputName2, size_t compareDimNum)
+    {
+        size_t shapeDim1 = 0;
+        size_t shapeDim2 = 0;
+        for (size_t dimIndex = 0; dimIndex < compareDimNum; dimIndex++) {
+            shapeDim1 = shape1.GetDim(dimIndex);
+            shapeDim2 = shape2.GetDim(dimIndex);
+            OP_CHECK_IF(shapeDim1 != shapeDim2,
+                        OP_LOGE(ctx_.nodeName,
+                                "Compare input shape of %s and %s failed, the length of dim %zu should be same,but got "
+                                "%zu and %zu.",
+                                inputName1, inputName2, dimIndex, shapeDim1, shapeDim2),
+                        return ge::GRAPH_FAILED);
+        }
+        return ge::GRAPH_SUCCESS;
+    }
+
+    uint64_t AlignUp(uint64_t value, uint64_t align) const
+    {
+        return (value + align - 1) / align * align;
+    }
+
+    uint64_t DtypeSize(int64_t dtype) const
+    {
+        return dtype == PREPARE_WY_REPR_BWD_FULL_DTYPE_FP32 ? SIZE_FP32 : SIZE_HALF;
+    }
+
+    uint64_t GetFusedUseUbSize(uint64_t rowNum, uint64_t ubK, uint64_t ubV, uint64_t sizeofKType)
+    {
+        constexpr uint64_t SAFETY_MARGIN = 16 * 1024;
+        uint64_t persistentBytes = 0;
+        persistentBytes += AlignUp(tiling_.chunkSize * SIZE_FP32, ONE_BLOCK_32);
+        persistentBytes += AlignUp(tiling_.chunkSize * SIZE_FP32, ONE_BLOCK_32);
+        persistentBytes += AlignUp(tiling_.chunkSize * SIZE_FP32, ONE_BLOCK_32);
+        persistentBytes += AlignUp(tiling_.chunkSize * SIZE_FP32, ONE_BLOCK_32);
+
+        uint64_t queueBytes = 0;
+        queueBytes += 2 * AlignUp(rowNum * ubK * sizeofKType, ONE_BLOCK_32);
+        queueBytes += 2 * AlignUp(rowNum * ubV * sizeofKType, ONE_BLOCK_32);
+
+        uint64_t group1TempBytes = 0;
+        group1TempBytes += AlignUp(5 * rowNum * tiling_.K * SIZE_FP32, ONE_BLOCK_32);
+        group1TempBytes += AlignUp(rowNum * ONE_BLOCK_32, ONE_BLOCK_32);
+        group1TempBytes += AlignUp(rowNum * ONE_BLOCK_32, ONE_BLOCK_32);
+        group1TempBytes += AlignUp(rowNum * ONE_BLOCK_32, ONE_BLOCK_32);
+
+        uint64_t group2VTempBytes = 0;
+        group2VTempBytes += AlignUp(2 * rowNum * tiling_.V * SIZE_FP32, ONE_BLOCK_32);
+        group2VTempBytes += AlignUp(rowNum * ONE_BLOCK_32, ONE_BLOCK_32);
+
+        uint64_t group2KktTempBytes = 0;
+        group2KktTempBytes += AlignUp(tiling_.chunkSize * tiling_.chunkSize * SIZE_FP32, ONE_BLOCK_32);
+        group2KktTempBytes += AlignUp(2 * rowNum * tiling_.chunkSize * SIZE_FP32, ONE_BLOCK_32);
+        group2KktTempBytes += AlignUp(tiling_.chunkSize * ONE_BLOCK_32, ONE_BLOCK_32);
+
+        uint64_t maxTempBytes = std::max(group1TempBytes, group2VTempBytes);
+        maxTempBytes = std::max(maxTempBytes, group2KktTempBytes);
+        return persistentBytes + queueBytes + maxTempBytes + SAFETY_MARGIN;
+    }
+
+    uint64_t GetFusedRowNum(uint64_t ubSize)
+    {
+        uint64_t rowNum = tiling_.chunkSize / 2;
+        uint64_t sizeofKType = DtypeSize(ctx_.kDataType);
+        uint64_t ubK = static_cast<uint64_t>(std::max(tiling_.K, tiling_.chunkSize));
+        uint64_t ubV = static_cast<uint64_t>(std::max(tiling_.V, tiling_.chunkSize));
+        while (rowNum >= 8) {
+            uint64_t useUbSize = GetFusedUseUbSize(rowNum, ubK, ubV, sizeofKType);
+            if (useUbSize <= ubSize) {
+                break;
+            }
+            rowNum = rowNum / 2;
+        }
+        return rowNum;
+    }
+
+    ge::graphStatus SetFusedTiling()
+    {
+        uint64_t fusedRowNum = GetFusedRowNum(ctx_.ubSize);
+        tiling_.fusedKVecRow = static_cast<int64_t>(fusedRowNum);
+        tiling_.fusedVVecRow = static_cast<int64_t>(fusedRowNum);
+        tiling_.fusedKktVecRow = static_cast<int64_t>(fusedRowNum);
+        tiling_.workspaceBufferCount = 2;
+        tiling_.usedCoreNum = static_cast<int64_t>(ctx_.aicCoreNum);
+
+        uint64_t sizeofKType = DtypeSize(ctx_.kDataType);
+        uint64_t maxKV = static_cast<uint64_t>(std::max(tiling_.K, tiling_.V));
+        uint64_t slotSize = 0;
+        slotSize += 3 * AlignUp(tiling_.chunkSize * tiling_.K * sizeofKType, ONE_BLOCK_32);
+        slotSize += AlignUp(tiling_.chunkSize * maxKV * sizeofKType, ONE_BLOCK_32);
+        slotSize += AlignUp(tiling_.chunkSize * tiling_.chunkSize * sizeofKType, ONE_BLOCK_32);
+        tiling_.workspaceSlotSize = static_cast<int64_t>(slotSize);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus CommonTiling()
+    {
+        const gert::Shape kStorageShape = ctx_.kShape->GetStorageShape();
+        const gert::Shape vStorageShape = ctx_.vShape->GetStorageShape();
+        const gert::Shape betaStorageShape = ctx_.betaShape->GetStorageShape();
+        const gert::Shape aStorageShape = ctx_.aShape->GetStorageShape();
+        const gert::Shape dAStorageShape = ctx_.dAShape->GetStorageShape();
+        const gert::Shape dwStorageShape = ctx_.dwShape->GetStorageShape();
+        const gert::Shape duStorageShape = ctx_.duShape->GetStorageShape();
+        const gert::Shape gStorageShape = ctx_.gShape->GetStorageShape();
+
+        const int64_t hv = static_cast<int64_t>(vStorageShape.GetDim(DIM_1));
+        const int64_t hk = static_cast<int64_t>(kStorageShape.GetDim(DIM_1));
+        OP_CHECK_IF(vStorageShape.GetDim(DIM_0) != kStorageShape.GetDim(DIM_0),
+                    OP_LOGE(ctx_.nodeName,
+                            "Compare input shape of %s and %s failed: batch dim 0 must match (got %zu vs %zu).",
+                            INPUT_V_NAME, INPUT_K_NAME, vStorageShape.GetDim(DIM_0), kStorageShape.GetDim(DIM_0)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(vStorageShape.GetDim(DIM_2) != kStorageShape.GetDim(DIM_2),
+                    OP_LOGE(ctx_.nodeName,
+                            "Compare input shape of %s and %s failed: time dim 2 must match (got %zu vs %zu).",
+                            INPUT_V_NAME, INPUT_K_NAME, vStorageShape.GetDim(DIM_2), kStorageShape.GetDim(DIM_2)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(hv <= 0 || hk <= 0,
+                    OP_LOGE(ctx_.nodeName, "HV and HK must be positive (HV=%ld, HK=%ld).", hv, hk),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(hv % hk != 0,
+                    OP_LOGE(ctx_.nodeName,
+                            "HV (%ld) must be a positive multiple of HK (%ld) for GQA (remainder %ld).", hv, hk,
+                            hv % hk),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(CompareShape(vStorageShape, duStorageShape, INPUT_V_NAME, INPUT_DU_NAME, DIM_NUM_4) !=
+                        ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(CompareShape(betaStorageShape, gStorageShape, INPUT_BETA_NAME, INPUT_G_NAME, DIM_NUM_3) !=
+                        ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(kStorageShape.GetDim(DIM_0) != gStorageShape.GetDim(DIM_0),
+                    OP_LOGE(ctx_.nodeName,
+                            "Compare input shape of %s and %s failed: batch dim 0 must match (got %zu vs %zu).",
+                            INPUT_K_NAME, INPUT_G_NAME, kStorageShape.GetDim(DIM_0), gStorageShape.GetDim(DIM_0)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(kStorageShape.GetDim(DIM_2) != gStorageShape.GetDim(DIM_2),
+                    OP_LOGE(ctx_.nodeName,
+                            "Compare input shape of %s and %s failed: time dim 2 must match (got %zu vs %zu).",
+                            INPUT_K_NAME, INPUT_G_NAME, kStorageShape.GetDim(DIM_2), gStorageShape.GetDim(DIM_2)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(vStorageShape.GetDim(DIM_1) != gStorageShape.GetDim(DIM_1),
+                    OP_LOGE(ctx_.nodeName,
+                            "Compare input shape of %s and %s failed: head dim 1 must match HV (got %zu vs %zu).",
+                            INPUT_V_NAME, INPUT_G_NAME, vStorageShape.GetDim(DIM_1), gStorageShape.GetDim(DIM_1)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(CompareShape(aStorageShape, dAStorageShape, INPUT_A_NAME, INPUT_DA_NAME, DIM_NUM_4) !=
+                        ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(CompareShape(dwStorageShape, kStorageShape, INPUT_DW_NAME, INPUT_K_NAME, DIM_NUM_3) !=
+                        ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(dwStorageShape.GetDim(DIM_3) != kStorageShape.GetDim(DIM_3),
+                    OP_LOGE(ctx_.nodeName,
+                            "Compare input shape of %s and %s failed: last dim K must match (got %zu vs %zu).",
+                            INPUT_DW_NAME, INPUT_K_NAME, dwStorageShape.GetDim(DIM_3), kStorageShape.GetDim(DIM_3)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(kStorageShape.GetDim(DIM_0) != aStorageShape.GetDim(DIM_0),
+                    OP_LOGE(ctx_.nodeName,
+                            "Compare input shape of %s and %s failed: batch dim 0 must match (got %zu vs %zu).",
+                            INPUT_K_NAME, INPUT_A_NAME, kStorageShape.GetDim(DIM_0), aStorageShape.GetDim(DIM_0)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(kStorageShape.GetDim(DIM_2) != aStorageShape.GetDim(DIM_2),
+                    OP_LOGE(ctx_.nodeName,
+                            "Compare input shape of %s and %s failed: time dim 2 must match (got %zu vs %zu).",
+                            INPUT_K_NAME, INPUT_A_NAME, kStorageShape.GetDim(DIM_2), aStorageShape.GetDim(DIM_2)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(vStorageShape.GetDim(DIM_1) != aStorageShape.GetDim(DIM_1),
+                    OP_LOGE(ctx_.nodeName,
+                            "Compare input shape of %s and %s failed: head dim 1 must match HV (got %zu vs %zu).",
+                            INPUT_V_NAME, INPUT_A_NAME, vStorageShape.GetDim(DIM_1), aStorageShape.GetDim(DIM_1)),
+                    return ge::GRAPH_FAILED);
+
+        tiling_.B = static_cast<int64_t>(vStorageShape.GetDim(DIM_0));
+        tiling_.HV = hv;
+        tiling_.HK = hk;
+        tiling_.T = static_cast<int64_t>(vStorageShape.GetDim(DIM_2));
+        tiling_.K = static_cast<int64_t>(kStorageShape.GetDim(DIM_3));
+        tiling_.V = static_cast<int64_t>(vStorageShape.GetDim(DIM_3));
+
+        OP_CHECK_IF(tiling_.V != V_DIM_128 && tiling_.V != V_DIM_256,
+                    OP_LOGE(ctx_.nodeName,
+                            "Check value dim V failed: only %ld or %ld is supported, but get %ld.", V_DIM_128,
+                            V_DIM_256, tiling_.V),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(ctx_.chunkSize != CHUNK_SIZE_64 && ctx_.chunkSize != CHUNK_SIZE_128,
+                    OP_LOGE(ctx_.nodeName,
+                            "Check attr chunkSize failed, the chunkSize should be 64 or 128, but get %ld.",
+                            ctx_.chunkSize),
+                    return ge::GRAPH_FAILED);
+        tiling_.chunkSize = ctx_.chunkSize;
+
+        OP_CHECK_IF(SetFusedTiling() != ge::GRAPH_SUCCESS,
+                    OP_LOGE(ctx_.nodeName, "SetFusedTiling Failed."), return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    int64_t CeilDiv(int64_t a, int64_t b) const
+    {
+        if (b == 0) {
+            return 0;
+        }
+        return (a + b - 1) / b;
+    }
+
+    ge::graphStatus FixLenTiling()
+    {
+        tiling_.chunkNum = tiling_.B * CeilDiv(tiling_.T, tiling_.chunkSize);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus VariableLenTiling()
+    {
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.chunkIndicesShape, DIM_1, INPUT_CHUNK_INDICES_NAME) !=
+                        ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.cuSeqlensShape, DIM_1, INPUT_SEQLENS_NAME) != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(ctx_.cuSeqlensData == nullptr,
+                    OP_LOGE(ctx_.nodeName, "Input %s data is required for variable-length tiling, but got nullptr.",
+                            INPUT_SEQLENS_NAME),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(ctx_.chunkIndicesData == nullptr,
+                    OP_LOGE(ctx_.nodeName, "Input %s data is required for variable-length tiling, but got nullptr.",
+                            INPUT_CHUNK_INDICES_NAME),
+                    return ge::GRAPH_FAILED);
+
+        const gert::Shape seqlensStorageShape = ctx_.cuSeqlensShape->GetStorageShape();
+        int64_t seqlensDim0 = seqlensStorageShape.GetDim(DIM_0);
+        OP_CHECK_IF(seqlensDim0 < 2,
+                    OP_LOGE(ctx_.nodeName,
+                            "Check seqlens shape failed, the dim 0 of seqlens should be larger than 1, but get %ld.",
+                            seqlensDim0),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(ctx_.cuSeqlensData[0] != 0,
+                    OP_LOGE(ctx_.nodeName, "Check seqlens data failed, the seqlens[0] should be 0, but get %ld.",
+                            ctx_.cuSeqlensData[0]),
+                    return ge::GRAPH_FAILED);
+
+        std::vector<int64_t> expectChunkIndices;
+        for (int64_t i = 1; i < seqlensDim0; i++) {
+            int64_t curSeqLen = ctx_.cuSeqlensData[i] - ctx_.cuSeqlensData[i - 1];
+            OP_CHECK_IF(curSeqLen <= 0,
+                        OP_LOGE(ctx_.nodeName,
+                                "Check seqlens data failed, the seqlens[%ld]:[%ld] should be larger than seqlens[%ld]:[%ld]",
+                                i, ctx_.cuSeqlensData[i], i - 1, ctx_.cuSeqlensData[i - 1]),
+                        return ge::GRAPH_FAILED);
+            for (int64_t j = 0; j < curSeqLen; j += tiling_.chunkSize) {
+                expectChunkIndices.push_back(i - 1);
+                expectChunkIndices.push_back(j / tiling_.chunkSize);
+            }
+        }
+
+        const gert::Shape chunkIndicesStorageShape = ctx_.chunkIndicesShape->GetStorageShape();
+        int64_t chunkIndicesDim0 = chunkIndicesStorageShape.GetDim(DIM_0);
+        OP_CHECK_IF(chunkIndicesDim0 != static_cast<int64_t>(expectChunkIndices.size()),
+                    OP_LOGE(ctx_.nodeName,
+                            "Check chunk_indices shape failed, the len of chunk_indices should be %zu, but get %ld.",
+                            expectChunkIndices.size(), chunkIndicesDim0),
+                    return ge::GRAPH_FAILED);
+        for (int64_t i = 0; i < static_cast<int64_t>(expectChunkIndices.size()); i++) {
+            OP_CHECK_IF(expectChunkIndices[i] != ctx_.chunkIndicesData[i],
+                        OP_LOGE(ctx_.nodeName,
+                                "Check chunk_indices data failed, the chunk_indices[%ld] should be %ld, but get %ld.",
+                                i, expectChunkIndices[i], ctx_.chunkIndicesData[i]),
+                        return ge::GRAPH_FAILED);
+        }
+        tiling_.chunkNum = chunkIndicesStorageShape.GetDim(DIM_0) / 2;
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus WorkspaceTiling()
+    {
+        blockDim_ = ctx_.aicCoreNum;
+        uint64_t userWorkspaceSize = static_cast<uint64_t>(tiling_.usedCoreNum) *
+                                     static_cast<uint64_t>(tiling_.workspaceBufferCount) *
+                                     static_cast<uint64_t>(tiling_.workspaceSlotSize);
+        workspaceSize_ = ctx_.sysWorkspaceSize + userWorkspaceSize;
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus Process()
+    {
+        OP_CHECK_IF(PreCheck() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(CommonTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+        if (IsVariableLength()) {
+            OP_CHECK_IF(ctx_.cuSeqlensShape == nullptr || ctx_.chunkIndicesShape == nullptr,
+                        OP_LOGE(ctx_.nodeName,
+                                "Variable-length tiling requires both cu_seqlens and chunk_indices to be provided."),
+                        return ge::GRAPH_FAILED);
+            OP_CHECK_IF(tiling_.B != VAR_LEN_B_DIM_1,
+                        OP_LOGE(ctx_.nodeName,
+                                "If cu_seqlens is not nullptr, the dim 0 of q needs to be 1, but now is %ld.",
+                                tiling_.B),
+                        return ge::GRAPH_FAILED);
+            OP_CHECK_IF(VariableLenTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+            tiling_.isVariable = 1;
+        } else {
+            OP_CHECK_IF(FixLenTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+            tiling_.isVariable = 0;
+        }
+        OP_CHECK_IF(WorkspaceTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+};
+
+} // namespace optiling
+
+#endif // PREPARE_WY_REPR_BWD_FULL_TILING_PROCESSOR_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full.cpp
@@ -1,51 +1,81 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
- * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
- * the BSD 3-Clause License (the "License").
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- */
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 /*!
  * \file prepare_wy_repr_bwd_full.cpp
- * \brief
+ * \brief Prepare WY representation backward full kernel entry.
  */
+
 #include "kernel_operator.h"
+#ifndef TORCH_MODE
 #include "lib/matmul_intf.h"
+#endif
+
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
 #include "arch35/prepare_wy_repr_bwd_full_tiling_data_apt.h"
 #include "arch35/prepare_wy_repr_bwd_full_common.h"
 #include "arch35/prepare_wy_repr_bwd_full_cube.h"
 #include "arch35/prepare_wy_repr_bwd_full_vector.h"
 #else
+#include "prepare_wy_repr_bwd_full_struct.h"
+using namespace GDN;
 #include "prepare_wy_repr_bwd_full_common.h"
 #include "prepare_wy_repr_bwd_full_cube.h"
 #include "prepare_wy_repr_bwd_full_vector.h"
 #endif
 
 using namespace AscendC;
-/** Cube GEMM tile shape: must be `tla::Shape` (BlockMmadTla); keep explicit to avoid ambiguity with Catlass. */
-template <class... Dims>
-using GemmCubeTileShape = tla::Shape<Dims...>;
-using namespace tla;
 
-__global__ __aicore__ void prepare_wy_repr_bwd_full(GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR dA,
-                                                    GM_ADDR dw, GM_ADDR du, GM_ADDR g, GM_ADDR cu_seqlens,
-                                                    GM_ADDR chunk_indices, GM_ADDR dk, GM_ADDR dv, GM_ADDR dbeta,
-                                                    GM_ADDR dg, GM_ADDR workspace, GM_ADDR tiling)
+#if !defined(__CCE_AICORE__) || __CCE_AICORE__ != 310
+namespace GDN {
+
+template <typename KType, typename BetaType>
+__aicore__ inline void PrepareWyReprBwdFullKernelImpl(
+    GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR dA, GM_ADDR dw, GM_ADDR du, GM_ADDR g,
+    GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR dk, GM_ADDR dv, GM_ADDR dbeta, GM_ADDR dg,
+    GM_ADDR workspace, const PrepareWyReprBwdFullTilingData *tilingData)
+{
+    if ASCEND_IS_AIC {
+        ::PrepareWyReprBwdFullProcess<KType, BetaType> prepareWyReprBwdFullProcess(
+            k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg, workspace);
+        prepareWyReprBwdFullProcess.Init(*tilingData);
+        prepareWyReprBwdFullProcess.Process();
+    }
+
+    if ASCEND_IS_AIV {
+        AscendC::TPipe tPipe;
+        ::PrepareWyReprBwdFullVectorProcess<KType, BetaType> prepareWyReprBwdFullVectorProcess(
+            k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg, workspace);
+        prepareWyReprBwdFullVectorProcess.Init(*tilingData, &tPipe);
+        prepareWyReprBwdFullVectorProcess.Process();
+    }
+}
+
+} // namespace GDN
+#endif
+
+#ifndef TORCH_MODE
+extern "C" __global__ __aicore__ void prepare_wy_repr_bwd_full(
+    GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR dA, GM_ADDR dw, GM_ADDR du, GM_ADDR g,
+    GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR dk, GM_ADDR dv, GM_ADDR dbeta, GM_ADDR dg,
+    GM_ADDR workspace, GM_ADDR tiling)
 {
     AscendC::AscendCUtils::SetOverflow(1);
+
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
     REGISTER_TILING_DEFAULT(PrepareWyReprBwdFullTilingDataA5);
-#endif
     GET_TILING_DATA(tilingData, tiling);
     if (TILING_KEY_IS(1)) {
         KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
         if ASCEND_IS_AIC {
-            PrepareWyReprBwdFullProcess<DTYPE_K, DTYPE_BETA>
-                prepareWyReprBwdFullProcess(k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg,
-                                            workspace);
+            PrepareWyReprBwdFullProcess<DTYPE_K, DTYPE_BETA> prepareWyReprBwdFullProcess(
+                k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg, workspace);
             prepareWyReprBwdFullProcess.Init(tilingData);
             prepareWyReprBwdFullProcess.Process();
         }
@@ -59,9 +89,8 @@ __global__ __aicore__ void prepare_wy_repr_bwd_full(GM_ADDR k, GM_ADDR v, GM_ADD
     } else if (TILING_KEY_IS(2)) {
         KERNEL_TASK_TYPE(2, KERNEL_TYPE_MIX_AIC_1_2);
         if ASCEND_IS_AIC {
-            PrepareWyReprBwdFullProcess<DTYPE_K, DTYPE_BETA>
-                prepareWyReprBwdFullProcess(k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg,
-                                            workspace);
+            PrepareWyReprBwdFullProcess<DTYPE_K, DTYPE_BETA> prepareWyReprBwdFullProcess(
+                k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg, workspace);
             prepareWyReprBwdFullProcess.Init(tilingData);
             prepareWyReprBwdFullProcess.Process();
         }
@@ -73,5 +102,14 @@ __global__ __aicore__ void prepare_wy_repr_bwd_full(GM_ADDR k, GM_ADDR v, GM_ADD
             prepareWyReprBwdFullVectorProcess.Process();
         }
     }
-    return;
+#else
+    REGISTER_TILING_DEFAULT(GDN::PrepareWyReprBwdFullTilingData);
+    GET_TILING_DATA_WITH_STRUCT(GDN::PrepareWyReprBwdFullTilingData, tilingData, tiling);
+    if (TILING_KEY_IS(1)) {
+        KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
+        GDN::PrepareWyReprBwdFullKernelImpl<DTYPE_K, DTYPE_BETA>(
+            k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg, workspace, &tilingData);
+    }
+#endif
 }
+#endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full_struct.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file prepare_wy_repr_bwd_full_struct.h
+ * \brief Shared tiling data for prepare_wy_repr_bwd_full.
+ */
+
+#ifndef PREPARE_WY_REPR_BWD_FULL_STRUCT_H
+#define PREPARE_WY_REPR_BWD_FULL_STRUCT_H
+
+#include <cstdint>
+
+namespace GDN {
+
+struct PrepareWyReprBwdFullTilingData {
+    int64_t B;
+    int64_t HV;
+    int64_t HK;
+    int64_t T;
+    int64_t K;
+    int64_t V;
+    int64_t chunkNum;
+    int64_t chunkSize;
+    int64_t fusedKVecRow;
+    int64_t fusedVVecRow;
+    int64_t fusedKktVecRow;
+    int64_t workspaceSlotSize;
+    int64_t workspaceBufferCount;
+    int64_t usedCoreNum;
+    int64_t isVariable;
+};
+
+} // namespace GDN
+
+#endif // PREPARE_WY_REPR_BWD_FULL_STRUCT_H


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: 无
- 背景与目标: 为 prepare_wy_repr_bwd_full 增加 `<<<>>>` 直接调用链路。
- 本 PR 解决的问题: 支持在 `examples/fast_kernel_launch_example` 中通过 `torch.ops.ascend_ops.chunk_fwd_o` 验证 `prepare_wy_repr_bwd_full` 的 fast kernel launch 调用，同时保持原链路不变。

## 变更类型

- [ ] Bug 修复
- [x] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。
- 涉及算子名称:
  - `prepare_wy_repr_bwd_full`
  - fast kernel launch 入口：`torch.ops.ascend_ops.prepare_wy_repr_bwd_full`
  - 原 aclnn / torch_custom 入口保持不变：`torch.ops.npu.npu_prepare_wy_repr_bwd_full`

- 涉及目录 / 文件:
  - `examples/fast_kernel_launch_example/csrc/prepare_wy_repr_bwd_full/ascend910b/CMakeLists.txt`
  - `examples/fast_kernel_launch_example/csrc/prepare_wy_repr_bwd_full/ascend910b/prepare_wy_repr_bwd_full.cpp`
  - `examples/fast_kernel_launch_example/tests/prepare_wy_repr_bwd_full/test_prepare_wy_repr_bwd_full.py`
  - `fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/prepare_wy_repr_bwd_full_tiling.cpp`
  - `fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/prepare_wy_repr_bwd_full_tiling.h`
  - `fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/prepare_wy_repr_bwd_full_tiling_processor.h`
  - `fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full.cpp`
  - `fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full_struct.h`

- 责任人 / 提交人: @Ensley0304

- 修改范围:
  - [x] `op_host` / 算子定义
  - [x] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [x] `example / ST` 测试
  - [ ] 文档
  
- 输入 / 输出 / shape / dtype / format 支持范围:
  - 输入：`k, v, beta, A, dA, dw, du, g, chunk_size`，可选 `cu_seqlens, chunk_indices`
  - 输出：`dk, dv, dbeta, dg`
  - 支持定长和变长场景；变长场景要求 `cu_seqlens` 与 `chunk_indices` 成对传入
  - fast launch 测试覆盖：
    - 定长：`B=1`，`HK/HV` 包含 `2/2`、`2/4`、`1/4`，`T=65/129`，`K=128`，`V=128`，`chunk_size=64/128`
    - 变长：`B=1`，`HK=2`，`HV=2`，`T=65`，`K=128`，`V=256`，`chunk_size=64`
    - dtype：`k/v/A/dA/dw/du` 覆盖 `fp16`、`bf16`；`beta/g/dbeta/dg` 覆盖 `fp16`、`fp32`
  - format：沿用原算子输入输出 format 约束，本 PR 不新增 format 语义

- 明确不包含的范围:
  - 不修改 `aclnn` 接口定义
  - 不修改 `torch_custom` 注册接口
  - 不修改 Triton 算子
  - 不适配 A5 / 950 路径
  - 不修改其他 GDN 算子

- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:

- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过

- ABI 不兼容风险说明:
  - 无。仅新增 `examples/fast_kernel_launch_example` 下的 `<<<>>>` fast launch 调用入口，并将原 host tiling / fast launch wrapper 共用的 tiling 逻辑抽取到 processor；原 aclnn / torch_custom 调用接口保持兼容。


<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

<<<>>>调用验证
<img width="1195" height="322" alt="image" src="https://github.com/user-attachments/assets/0fa4fa98-effd-4154-9f95-b16c4994e65c" />

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因: 新增特性
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [x] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [x] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
