### PR TITLE
docs: update chunk_bwd_dv_local README for head shapes

### DIFF
--- a/examples/fast_kernel_launch_example/tests/chunk_bwd_dv_local/test_chunk_bwd_dv_local.py
+++ b/examples/fast_kernel_launch_example/tests/chunk_bwd_dv_local/test_chunk_bwd_dv_local.py
@@ -11,14 +11,11 @@
 # -----------------------------------------------------------------------------------------------------------
 
 import torch
-import torch_npu
 import ascend_ops
 import pytest
 import math
 import random
 from typing import Optional
-
-torch_npu.npu.set_device(7)
 
 def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
     return cu_seqlens[1:] - cu_seqlens[:-1]

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/README.md
@@ -11,15 +11,24 @@
 
 计算公式为：
 
-$$dV_{\text{local}} = \text{mask}\!\left(\exp(g_{\text{col}} - g_{\text{row}})\right) \odot (K Q^T) \cdot dO$$
+对每个 `doHead`，先映射到对应的 Q/K head：
+
+```text
+qkHead = doHead / hRatio
+hRatio = H_do / H_qk
+```
+
+再计算：
+
+$$dV_{\text{local}}[doHead] = \left(\text{mask}\!\left(\exp(g[doHead]_{\text{col}} - g[doHead]_{\text{row}})\right) \odot (K[qkHead] Q[qkHead]^T)\right) \cdot dO[doHead]$$
 
 分解为三个阶段：
 
 | 阶段 | 执行单元 | 计算 | 说明 |
 |------|----------|------|------|
-| Phase 1 | Cube (AIC) | $W_s = K \times Q^T$ | 矩阵乘，生成 chunk 内 attention score 矩阵 |
-| Phase 1.5 | Vector (AIV) | $W_{s\_gated} = \text{mask}(\exp(g)) \odot W_s$ | gating：exp、下三角 mask、逐元素乘 |
-| Phase 2 | Cube (AIC) | $dV = W_{s\_gated} \times dO$ | 矩阵乘，生成最终梯度输出 |
+| Phase 1 | Cube (AIC) | $W_s[qkHead] = K[qkHead] \times Q[qkHead]^T$ | 对每个 Q/K head 生成 chunk 内 attention score 矩阵 |
+| Phase 1.5 | Vector (AIV) | $W_{s\_gated}[doHead] = \text{mask}(\exp(g[doHead])) \odot W_s[qkHead]$ | 每个 dO head 使用映射到的 Q/K score 做 gating：exp、上三角含对角线 mask、逐元素乘 |
+| Phase 2 | Cube (AIC) | $dV[doHead] = W_{s\_gated}[doHead] \times dO[doHead]$ | 矩阵乘，生成最终梯度输出 |
 
 ---
 
@@ -69,10 +78,10 @@ aclnnStatus aclnnChunkBwdDvLocal(
 
 | 参数名 | 输入/输出 | 必选/可选 | 描述 | 使用说明 | 数据类型 | 数据格式 | 维度（Shape） | 非连续 Tensor |
 |---|---|---|---|---|---|---|---|---|
-| `q` | 输入 | 必选 | Query 输入张量 | 参与反向计算 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, K]` | 支持 |
-| `k` | 输入 | 必选 | Key 输入张量 | 参与反向计算 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, K]` | 支持 |
-| `dO` | 输入 | 必选 | 前向输出的梯度张量 | 参与反向计算 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, V]` | 支持 |
-| `g` | 输入 | 必选 | Gate 输入张量（门控衰减系数） | 参与 gating 计算 | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, H, T]` | 支持 |
+| `q` | 输入 | 必选 | Query 输入张量 | 参与反向计算，使用 Q/K head 数 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H_qk, T, K]` | 支持 |
+| `k` | 输入 | 必选 | Key 输入张量 | 参与反向计算，形状必须与 `q` 一致 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H_qk, T, K]` | 支持 |
+| `dO` | 输入 | 必选 | 前向输出的梯度张量 | 参与反向计算，使用 dO/dV head 数 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H_do, T, V]` | 支持 |
+| `g` | 输入 | 必选 | Gate 输入张量（门控衰减系数） | 参与 gating 计算，H 轴与 `dO` 一致 | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, H_do, T]` | 支持 |
 | `gGammaOptional` | 输入 | 可选 | 预留门控参数输入 | 当前版本不支持，须传 `None` | `FLOAT` | `ND` | - | - |
 | `aOptional` | 输入 | 可选 | 预留参数输入 | 当前版本不支持，须传 `None` | `FLOAT16`、`BFLOAT16` | `ND` | - | - |
 | `cuSeqlensOptional` | 输入 | 可选 | 变长序列的累计长度信息 | 变长模式输入，形如 `[0, T1, T1+T2, ...]`，形状为 `[N+1]`（N 为 batch 内序列段数，等于 B） | `INT64` | `ND` | 1 维 | - |
@@ -89,15 +98,17 @@ aclnnStatus aclnnChunkBwdDvLocal(
 
 | 参数名 | 输入/输出 | 描述 | 数据类型 | 数据格式 | 维度（Shape） | 非连续 Tensor |
 |---|---|---|---|---|---|---|
-| `out`（即 `dV`） | 输出 | Value 的本地梯度输出张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, V]` | 支持 |
+| `out`（即 `dV`） | 输出 | Value 的本地梯度输出张量，H 轴与 `dO` 一致 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H_do, T, V]` | 支持 |
 | `workspaceSize` | 输出 | Device 侧所需 workspace 大小 | `uint64_t` | - | 标量 | - |
 | `executor` | 输出 | 算子执行器，封装了计算流程 | `aclOpExecutor*` | - | - | - |
 
 ### 3.4 形状与约束
 
-- `q`、`k` 的形状必须为 `[B, H, T, K]`。
-- `dO` 的形状必须为 `[B, H, T, V]`。
-- `g` 的形状必须为 `[B, H, T]`。
+- `q`、`k` 的形状必须为 `[B, H_qk, T, K]`，且二者形状完全一致。
+- `dO` 的形状必须为 `[B, H_do, T, V]`。
+- `g` 的形状必须为 `[B, H_do, T]`。
+- `B`、`T` 在 `q/k` 与 `dO/g/out` 之间必须一致。
+- `H_do` 必须能被 `H_qk` 整除，即 `H_do % H_qk == 0`。
 - `K` 须为 `128`。
 - `V` 须为 `128` 或 `256`。
 - `chunkSize` 仅支持 `64` 或 `128`。
@@ -129,9 +140,13 @@ aclnnStatus aclnnChunkBwdDvLocal(
 
 必须满足以下条件：
 
-- `q, k`: `[B, H, T, K]`
-- `dO`: `[B, H, T, V]`
-- `g`: `[B, H, T]`
+- `q, k`: `[B, H_qk, T, K]`
+- `dO`: `[B, H_do, T, V]`
+- `g`: `[B, H_do, T]`
+- `out`: `[B, H_do, T, V]`
+- `q` 和 `k` 的形状完全一致。
+- `q/k` 与 `dO/g/out` 的 `B`、`T` 一致。
+- `H_do % H_qk == 0`，`hRatio = H_do / H_qk`。
 
 额外限制：
 
@@ -176,16 +191,17 @@ import torch_npu
 import math
 
 def test_chunk_bwd_dv_local_fixed():
-    B, H, T, K, V = 2, 4, 128, 128, 128
+    B, H_qk, h_ratio, T, K, V = 2, 4, 2, 128, 128, 128
+    H_do = H_qk * h_ratio
     chunk_size = 64
     scale = 1.0 / math.sqrt(K)
     device = "npu:0"
     dtype = torch.bfloat16
 
-    q   = torch.randn(B, H, T, K, device=device, dtype=dtype)
-    k   = torch.randn(B, H, T, K, device=device, dtype=dtype)
-    d_o = torch.randn(B, H, T, V, device=device, dtype=dtype)
-    g   = torch.randn(B, H, T,    device=device, dtype=torch.float32)
+    q   = torch.randn(B, H_qk, T, K, device=device, dtype=dtype)
+    k   = torch.randn(B, H_qk, T, K, device=device, dtype=dtype)
+    d_o = torch.randn(B, H_do, T, V, device=device, dtype=dtype)
+    g   = torch.randn(B, H_do, T,    device=device, dtype=torch.float32)
 
     # 定长模式：cu_seqlens=None, chunk_indices=None
     dv = torch_npu.npu_chunk_bwd_dv_local(
@@ -198,8 +214,8 @@ def test_chunk_bwd_dv_local_fixed():
         chunk_size=chunk_size
     )
 
-    assert dv.shape == (B, H, T, V)
-    print("dv shape:", dv.shape)  # (2, 4, 128, 128)
+    assert dv.shape == (B, H_do, T, V)
+    print("dv shape:", dv.shape)  # (2, 8, 128, 128)
 
 if __name__ == "__main__":
     test_chunk_bwd_dv_local_fixed()
@@ -225,7 +241,8 @@ def prepare_chunk_indices(cu_seqlens, chunk_size):
     return torch.tensor(result, dtype=torch.long)
 
 def test_chunk_bwd_dv_local_varlen():
-    H, K, V = 4, 128, 128
+    H_qk, h_ratio, K, V = 4, 2, 128, 128
+    H_do = H_qk * h_ratio
     chunk_size = 64
     scale = 1.0 / math.sqrt(K)
     device = "npu:0"
@@ -235,10 +252,10 @@ def test_chunk_bwd_dv_local_varlen():
     cu_seqlens = torch.tensor([0, 192, 256], dtype=torch.long)
     T = int(cu_seqlens[-1])
 
-    q   = torch.randn(1, H, T, K, device=device, dtype=dtype)
-    k   = torch.randn(1, H, T, K, device=device, dtype=dtype)
-    d_o = torch.randn(1, H, T, V, device=device, dtype=dtype)
-    g   = torch.randn(1, H, T,    device=device, dtype=torch.float32)
+    q   = torch.randn(1, H_qk, T, K, device=device, dtype=dtype)
+    k   = torch.randn(1, H_qk, T, K, device=device, dtype=dtype)
+    d_o = torch.randn(1, H_do, T, V, device=device, dtype=dtype)
+    g   = torch.randn(1, H_do, T,    device=device, dtype=torch.float32)
 
     # 每行 [batch_idx, chunk_idx]，展平后传入
     chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
@@ -253,8 +270,8 @@ def test_chunk_bwd_dv_local_varlen():
         chunk_size=chunk_size
     )
 
-    assert dv.shape == (1, H, T, V)
-    print("dv shape:", dv.shape)  # (1, 4, 256, 128)
+    assert dv.shape == (1, H_do, T, V)
+    print("dv shape:", dv.shape)  # (1, 8, 256, 128)
 
 if __name__ == "__main__":
     test_chunk_bwd_dv_local_varlen()


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> 本 PR 未修改算子实现代码，仅更新 `ChunkBwdDvLocal` README 并清理 fast-kernel 测试脚本中的临时设备绑定。如维护者认为仍需门禁，请按仓库规则触发 `NPU CI / 手动验证`。

## 关联 Issue / 背景

- 关联 Issue: 无。无需 Issue 的原因：本 PR 是文档补齐和临时测试设备绑定清理，不涉及新需求或缺陷修复闭环。
- 背景与目标: `ChunkBwdDvLocal` 已支持 Q/K 与 dO/dV 在 H 轴不等长，但 README 中仍按统一 `H` 描述输入输出 shape；同时 fast-kernel 测试脚本中遗留了本地验证用的 `torch_npu.npu.set_device(7)`。
- 本 PR 解决的问题: 更新 README 中 `H_qk`、`H_do`、`hRatio` 的文档语义和示例 shape，并删除 fast-kernel 测试脚本中的临时 NPU 设备绑定。

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: `ChunkBwdDvLocal`
- 涉及目录 / 文件:
  - `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/README.md`
  - `examples/fast_kernel_launch_example/tests/chunk_bwd_dv_local/test_chunk_bwd_dv_local.py`
- 责任人 / 提交人: @chen-linxin
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [x] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
  - 文档补充 `q/k` shape 为 `[B, H_qk, T, K]`。
  - 文档补充 `dO/g/out` shape 为 `[B, H_do, T, V]` / `[B, H_do, T]`。
  - 文档补充 `H_do % H_qk == 0` 和 `hRatio = H_do / H_qk`。
  - 本 PR 不修改实际算子代码、接口、dtype、format 或 shape 校验逻辑。
- 明确不包含的范围:
  - 不修改 `op_host`、`op_kernel`、`op_api`、`torch_custom` 或构建脚本。
  - 不新增或调整测试 case。
  - 不修改 CI 用例或 example ST 行为。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 不涉及。仅修改 README 和删除测试脚本中的临时 `torch_npu.npu.set_device(7)`。

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 未修改算子代码、编译脚本或可执行接口，A2 / A3 / A5 编译矩阵不涉及。

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

### 1. 环境确认

- CANN 版本: 不涉及。原因：未修改算子代码或构建产物。
- 产品 / 芯片类型: 不涉及。原因：未修改算子代码或构建产物。
- 机器或 CI 链接: 不涉及。

### 2. 编译验证

不涉及。原因：本 PR 仅更新 README，并清理测试脚本中的临时设备绑定，不修改 `op_host`、`op_kernel`、`op_api`、`torch_custom` 或构建脚本。

### 3. 修改算子 test 验证

不涉及。原因：本 PR 未修改算子代码或测试 case；仅删除 fast-kernel 测试脚本中本地验证遗留的 `torch_npu.npu.set_device(7)`。

### 4. 整体 example ST 验证

不涉及。原因：本 PR 未修改端到端执行链路、算子实现或 example ST 用例。

### 5. 静态检查

```sh
git diff --check
```

结果: 通过，未发现空白或 diff 格式问题。

</details>

<details>
<summary>修改算子测试</summary>

本 PR 未修改算子代码，以下编译和测试项均为不涉及。

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 不涉及 | 不涉及，未修改算子代码 | 不涉及 | 不涉及 |
| A3 | `ascend910_93` | 不涉及 | 不涉及，未修改算子代码 | 不涉及 | 不涉及 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 不涉及 | 不涉及，未修改算子代码 | 不涉及 | 不涉及 |
| A3 | `ascend910_93` | 不涉及 | 不涉及，未修改算子代码 | 不涉及 | 不涉及 |
| A5 | `ascend950` | 不涉及 | 不涉及，未修改算子代码 | 不涉及 | 不涉及 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 不涉及，未修改算子代码 | 不涉及 | 不涉及 |
| A3 | `ascend910_93` | 不涉及，未修改算子代码 | 不涉及 | 不涉及 |
| A5 | `ascend950` | 不涉及，未修改算子代码 | 不涉及 | 不涉及 |

- 精度对比: 不涉及，未修改数值计算逻辑。
- 性能对比: 不涉及，未修改 kernel 或调用链路。
- 边界 / 异常场景: 不涉及，未修改测试 case 或算子行为。
- 未覆盖风险: 低。风险集中在 README 表述准确性和删除临时设备绑定是否符合测试规范。

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example ST 不涉及。原因：本 PR 未修改算子实现、端到端调用链路或 ST 用例。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 不涉及，未修改算子代码 | 不涉及 | 不涉及 |
| A3 | `ascend910_93` | 不涉及，未修改算子代码 | 不涉及 | 不涉及 |
| A5 | `ascend950` | 不涉及，未修改算子代码 | 不涉及 | 不涉及 |

- 端到端场景说明: 不涉及。
- 与本 PR 修改算子的关联: 仅文档描述 `ChunkBwdDvLocal` 的 H 轴 shape 语义，不修改执行链路。
- 未覆盖原因及补充计划: 未修改算子代码，暂无补充测试计划；如维护者要求，可触发 NPU CI 做确认。

</details>

## 兼容性、风险与回退

- 兼容性说明: 不修改 ABI、接口、shape 校验、kernel、tiling、构建脚本或测试 case，兼容性不受影响。
- 风险点:
  - README 对 `H_qk/H_do/hRatio` 的描述需要与当前实现保持一致。
  - 删除 fast-kernel 测试脚本中的临时 `torch_npu.npu.set_device(7)` 后，测试运行环境需要按项目规则在验证时临时选择设备，验证完成后不提交设备绑定。
- 回退方案: 如文档描述或测试脚本清理不符合维护要求，直接 revert 本 PR，恢复 README 和 fast-kernel 测试脚本原内容。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

未勾选的编译 / 测试项均为不涉及，原因见上方验证矩阵：本 PR 未修改算子代码、构建脚本、执行链路或测试 case。

## 其他信息

无。
