### PR TITLE
fix: 把cout改成loge

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_api/aclnn_chunk_bwd_dqkwg.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_api/aclnn_chunk_bwd_dqkwg.cpp
@@ -161,23 +161,18 @@ aclnnStatus aclnnChunkBwdDqkwgGetWorkspaceSize(
     auto uniqueExecutor = CREATE_EXECUTOR();
     CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);
     auto executorPtr = uniqueExecutor.get();
-    // 固定写法，参数检查
-    // std::cout << "-------------------------aclnnChunkBwdDqkwgGetWorkspaceSize  333" << std::endl;
+
     auto ret = CheckParams(params);
     CHECK_RET(ret == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
     CHECK_COND(ParamsDataContiguous(params, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
                "ParamsDataContiguous failed.");
-    // std::cout << "-------------------------aclnnChunkBwdDqkwgGetWorkspaceSize  444" << std::endl;
     auto result = l0op::ChunkBwdDqkwg(params.q, params.k, params.v, params.g, params.h, params.dox, params.dh, params.dv, params.cuSeqlensOptional, params.chunkIndicesOptional, params.w, params.gGamma, params.scale, params.chunkSize, params.dqOut, params.dkOut, params.dwOut, params.dgOut, executorPtr);
-    // std::cout << "-------------------------aclnnChunkBwdDqkwgGetWorkspaceSize  555" << std::endl;
-    
+
     CHECK_RET(result[0] != nullptr, ACLNN_ERR_PARAM_NULLPTR);
     CHECK_RET(result[1] != nullptr, ACLNN_ERR_PARAM_NULLPTR);
     CHECK_RET(result[2] != nullptr, ACLNN_ERR_PARAM_NULLPTR);
     CHECK_RET(result[3] != nullptr, ACLNN_ERR_PARAM_NULLPTR);
-    // std::cout << "-------------------------aclnnChunkBwdDqkwgGetWorkspaceSize  666" << std::endl;
-    
-    // If the output tensor is non-contiguous, convert the calculated contiguous tensor to non-contiguous.
+
     auto viewCopyResult = l0op::ViewCopy(result[0], params.dqOut, executorPtr);
     CHECK_RET(viewCopyResult != nullptr, ACLNN_ERR_INNER_NULLPTR);
 
@@ -189,13 +184,10 @@ aclnnStatus aclnnChunkBwdDqkwgGetWorkspaceSize(
 
     viewCopyResult = l0op::ViewCopy(result[3], params.dgOut, executorPtr);
     CHECK_RET(viewCopyResult != nullptr, ACLNN_ERR_INNER_NULLPTR);
-    // std::cout << "-------------------------aclnnChunkBwdDqkwgGetWorkspaceSize  777" << std::endl;
-    
-    // Standard syntax, get the size of workspace needed during computation.
+
     *workspaceSize = uniqueExecutor->GetWorkspaceSize();
     uniqueExecutor.ReleaseTo(executor);
-    // std::cout << "-------------------------aclnnChunkBwdDqkwgGetWorkspaceSize  888" << std::endl;
-    
+
     return ACLNN_SUCCESS;
 }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_api/chunk_bwd_dqkwg.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_api/chunk_bwd_dqkwg.cpp
@@ -38,34 +38,25 @@ const std::array<const aclTensor *, 4> ChunkBwdDqkwg(
     const aclTensor *dgOut,
     aclOpExecutor *executor)
 {
-// std::cout << "2222222222--2222200\n";
     L0_DFX(ChunkBwdDqkwg, q, k, v, g, h, dox, dh, dv, cuSeqlensOptional, chunkIndicesOptional, w, gGamma, scale, chunkSize, dqOut, dkOut, dwOut, dgOut);
-// std::cout << "2222222222--2222200111\n";
-    
+
     const aclTensor *actualCuSeqQLen = nullptr;
     if (cuSeqlensOptional) {
-// printf("dh %p, dv %p, cuSeqlensOptional : %p, chunkIndicesOptional %p\n",dh,dv,cuSeqlensOptional,chunkIndicesOptional);
         actualCuSeqQLen = executor->ConvertToTensor(cuSeqlensOptional, DataType::DT_INT64);
-// std::cout << "2222222222--2222200222-A" << actualCuSeqQLen <<"\n";
         const_cast<aclTensor *>(actualCuSeqQLen)->SetStorageFormat(Format::FORMAT_ND);
-// std::cout << "2222222222--2222200222-B\n";
         const_cast<aclTensor *>(actualCuSeqQLen)->SetViewFormat(Format::FORMAT_ND);
-// std::cout << "2222222222--2222200222-C\n";
         const_cast<aclTensor *>(actualCuSeqQLen)->SetOriginalFormat(Format::FORMAT_ND);
     } else {
         actualCuSeqQLen = nullptr;
     }
-// std::cout << "2222222222--2222200222\n";
 
     const aclTensor *actualChunkIndices = nullptr;
     if (chunkIndicesOptional) {
-// std::cout << "2222222222--2222200222\n";
         actualChunkIndices = executor->ConvertToTensor(chunkIndicesOptional, DataType::DT_INT64);
         const_cast<aclTensor *>(actualChunkIndices)->SetStorageFormat(Format::FORMAT_ND);
         const_cast<aclTensor *>(actualChunkIndices)->SetViewFormat(Format::FORMAT_ND);
         const_cast<aclTensor *>(actualChunkIndices)->SetOriginalFormat(Format::FORMAT_ND);
     } else {
-// std::cout << "1111111111\n";
         actualChunkIndices = nullptr;
     }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
@@ -28,7 +28,6 @@ constexpr int64_t CONST_K = 128;
 constexpr int64_t CONST_V = 128;
 constexpr int64_t CONST_BT = 64;
 
-// 数据类型大小
 constexpr size_t FP16_SIZE = 2;
 constexpr size_t FP32_SIZE = 4;
 
@@ -57,9 +56,8 @@ ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* contex
     int64_t K = kStorageShape.GetDim(3);
     int64_t V = vStorageShape.GetDim(3);
     int64_t BT = CONST_BT;
-    // HV = n * HK, n is derived from q and v shapes automatically
     if (HK == 0 || HV % HK != 0) {
-        std::cout << "HV must be a multiple of HK, but HV = " << HV << ", HK = " << HK << "." << std::endl;
+        OP_LOGE(context, "HV must be a multiple of HK, but HV = %ld, HK = %ld.", HV, HK);
         return ge::GRAPH_FAILED;
     }
     int64_t n_ratio = HV / HK;
@@ -68,22 +66,19 @@ ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* contex
     const int32_t* chunkSizePtr = attr->GetAttrPointer<int32_t>(ATTR_CHUNK_SIZE_ITEM);
     if (chunkSizePtr != nullptr) {
         BT = *chunkSizePtr;
-        // std::cout << "[tiling] BT: " << BT << "\n";
         if (BT != 64 && BT != 128) {
-            std::cout << "BT should be 64 or 128 ." << std::endl;
+            OP_LOGE(context, "BT should be 64 or 128.");
             return ge::GRAPH_FAILED;
         }
-        
     }
 
-
     if (context->GetOptionalInputTensor(10) != nullptr || context->GetOptionalInputTensor(11) != nullptr) {
-        std::cout << "w and g_gamma should be set at nullptr." << std::endl;
+        OP_LOGE(context, "w and g_gamma should be set at nullptr.");
         return ge::GRAPH_FAILED;
     }
 
     auto cuSeqlensTensor = context->GetOptionalInputTensor(8);
-    int64_t numChunks = CeilDiv(T, BT);  // = 32
+    int64_t numChunks = CeilDiv(T, BT);
     int isVarLen = 0;
     if (cuSeqlensTensor != nullptr) {
         auto cuChunkIndicesTensor = context->GetOptionalInputTensor(9);
@@ -92,17 +87,16 @@ ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* contex
         const gert::Shape chunkIndicesStorageShape = chunkIndicesShape->GetStorageShape();
         numChunks = chunkIndicesStorageShape.GetDim(0);
         if (numChunks % 2 != 0) {
-            std::cout << "numChunks should be even, but now is " << chunkIndicesStorageShape.GetDim(1) << "!" << std::endl;
+            OP_LOGE(context, "numChunks should be even, but now is %ld.", chunkIndicesStorageShape.GetDim(1));
             return ge::GRAPH_FAILED;
         }
         numChunks /= 2;
         isVarLen = 1;
     }
     if (isVarLen == 1 && B != 1) {
-        std::cout << "varlen mode only support B = 1, but now B = " << B << "." << std::endl;
+        OP_LOGE(context, "varlen mode only support B = 1, but now B = %ld.", B);
         return ge::GRAPH_FAILED;
     }
-        // std::cout << "[tiling] isVarLen: " << isVarLen << "\n";
     {
         // 检查输入维度是否符合预期
         // q, k: [B, HK, T, K]
@@ -117,96 +111,58 @@ ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* contex
             doxStorageShape.GetDim(0) != B || doxStorageShape.GetDim(1) != HV || doxStorageShape.GetDim(2) != T || doxStorageShape.GetDim(3) != V ||
             dhStorageShape.GetDim(0) != B || dhStorageShape.GetDim(1) != HV || dhStorageShape.GetDim(2) != numChunks || dhStorageShape.GetDim(3) != K || dhStorageShape.GetDim(4) != V ||
             dvStorageShape.GetDim(0) != B || dvStorageShape.GetDim(1) != HV || dvStorageShape.GetDim(2) != T || dvStorageShape.GetDim(3) != V) {
-            std::cout << "Input tensor shapes do not match expected dimensions!" << std::endl;
-            std::cout << "Expected: q,k [B,HK,T,K], v,dox,dv [B,HV,T,V], g [B,HV,T], h,dh [B,HV,NC,K,V]" << std::endl;
+            OP_LOGE(context, "Input tensor shapes do not match expected dimensions: q,k [B,HK,T,K], v,dox,dv [B,HV,T,V], g [B,HV,T], h,dh [B,HV,NC,K,V].");
             return ge::GRAPH_FAILED;
         }
         if (K != 128) {
-            std::cout << "K should be 128, but now K = " << K << "." << std::endl;
+            OP_LOGE(context, "K should be 128, but now K = %ld.", K);
             return ge::GRAPH_FAILED;
         }
         if (V != 128 && V != 256) {
-            std::cout << "V should be 128 or 256, but now V = " << V << "." << std::endl;
+            OP_LOGE(context, "V should be 128 or 256, but now V = %ld.", V);
             return ge::GRAPH_FAILED;
         }
-
     }
-    
-    // std::cout << "[tiling] B: " << B << ", HV: " << HV << ", HK: " << HK << ", T: " << T << ", K: " << K << ", V: " << V << ", BT: " << BT << ", numChunks: " << numChunks << std::endl;
-    
-    
-    // 计算 scale = 1.0 / sqrt(K)
-    // float scale = 1.0f / std::sqrt(static_cast<float>(K));
+
     const int ATTR_SCALE_ITEM = 0;
-    
     const float* scalePtr = attr->GetAttrPointer<float>(ATTR_SCALE_ITEM);
     if (scalePtr == nullptr) {
-        std::cout << "scale should not be nullptr!" << std::endl;
+        OP_LOGE(context, "scale should not be nullptr.");
         return ge::GRAPH_FAILED;
     }
     float scale = *scalePtr;
-    // std::cout << "[tiling] scale is " << scale << std::endl;
-    
-    // 获取平台信息
+
     auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
     auto sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
     const int64_t aicNum = ascendcPlatform.GetCoreNumAic();
-    
-    // 设置 TilingKey
+
     context->SetTilingKey(1);
-    
-    size_t dgLastSize = B * HV * numChunks * 1 * FP32_SIZE;         // b_dg_last (fp32)
+
+    size_t dgLastSize = B * HV * numChunks * 1 * FP32_SIZE;
     dgLastSize = ((dgLastSize + 31) / 32) * 32;
-    
+
     size_t mm5Size = B * HV * T * K * FP16_SIZE;
     size_t dsTempSize = B * HV * T * BT * FP16_SIZE;
-    // size_t mm6Size = B * HV * T * K * FP16_SIZE;                   // mm6
-    // size_t mm7Size = B * HV * T * K * FP16_SIZE;                   // mm7
-    // size_t mul1Size = B * HV * T * BT * FP16_SIZE;                   // mul1
 
-    
-    // Workspace 偏移计算
     size_t offset = 0;
-    
-    // size_t wsDwOffset = offset;
-    // offset += dwSize;
-    
+
     size_t wsDgLastOffset = offset;
-// std::cout << "[tiling] offset: " << offset << ", dgLastSize: "<<dgLastSize<<"\n";
     offset += dgLastSize;
 
     size_t wsMm5Offset = offset;
-// std::cout << "[tiling] offset: " << offset << ", mm5Size: "<<mm5Size<<"\n";
     offset += mm5Size;
-    
+
     size_t wsDsTempOffset = offset;
-// std::cout << "[tiling] offset: " << offset << ", dsTempSize: "<<dsTempSize<<"\n";
     offset += dsTempSize;
 
-//     size_t wsMm6Offset = offset;
-// // std::cout << "[tiling] offset: " << mm6Size << ", mm6Size: "<<mm6Size<<"\n";
-//     offset += mm6Size;
-
-//     size_t wsMm7Offset = offset;
-// // std::cout << "[tiling] offset: " << offset << ", mm7Size: "<<mm7Size<<"\n";
-//     offset += mm7Size;
-
-//     size_t wsMul1Offset = offset;
-// // std::cout << "[tiling] offset: " << offset << ", mul1Size: "<<mul1Size<<"\n";
-//     offset += mul1Size;
-    
     size_t totalUserWorkspace = offset;
-    // std::cout << "[tiling] totalUserWorkspace: " << totalUserWorkspace << ", sysWorkspaceSize: " << sysWorkspaceSize << "\n";
-    
-    // 设置 workspace 大小
+
     size_t* workspaces = context->GetWorkspaceSizes(1);
     workspaces[0] = static_cast<size_t>(sysWorkspaceSize + totalUserWorkspace);
-    
-    // 设置 block 数量
+
     context->SetBlockDim(aicNum);
-    context->SetScheduleMode(1); // set as batchmod for template using SyncAll
-    
-    // 填充 TilingData
+    context->SetScheduleMode(1);
+
     ChunkBwdDqkwgTilingData tilingData;
     tilingData.set_B(B);
     tilingData.set_HV(HV);
@@ -218,25 +174,19 @@ ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* contex
     tilingData.set_numChunks(numChunks);
     tilingData.set_scale(scale);
     tilingData.set_mul0RowNum(V == 256 ? 16 : 32);
-    
-    // tilingData.set_wsDwOffset(wsDwOffset);
+
     tilingData.set_wsDgLastOffset(wsDgLastOffset);
     tilingData.set_dgLastSize(dgLastSize);
     tilingData.set_wsMm5Offset(wsMm5Offset);
     tilingData.set_wsDsTempOffset(wsDsTempOffset);
     tilingData.set_totalWorkspaceSize(totalUserWorkspace);
-    // tilingData.set_wsMm6Offset(wsMm6Offset);
-    // tilingData.set_wsMm7Offset(wsMm7Offset);
-    // tilingData.set_wsMul1Offset(wsMul1Offset);
-    
-    // 检查是否有 cu_seqlens 输入来判断 IS_VARLEN
+
     tilingData.set_isVarLen(isVarLen);
-    
-    // 保存 tiling data
-    tilingData.SaveToBuffer(context->GetRawTilingData()->GetData(), 
+
+    tilingData.SaveToBuffer(context->GetRawTilingData()->GetData(),
                             context->GetRawTilingData()->GetCapacity());
     context->GetRawTilingData()->SetDataSize(tilingData.GetDataSize());
-    
+
     return ge::GRAPH_SUCCESS;
 }
 


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @alvazu
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [x] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [x] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [x] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
