### PR TITLE
full 算子 add vdim 256 && GVA

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/arch35/prepare_wy_repr_bwd_full_tiling_a5.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/arch35/prepare_wy_repr_bwd_full_tiling_a5.cpp
@@ -38,8 +38,12 @@ bool PrepareWyReprBwdFullTilingA5::SetTiling(gert::TilingContext *context)
         OP_CHECK_IF(VariableLenTiling() != ge::GRAPH_SUCCESS, , return false);
         tiling_.isVariable = 1;
     }
-    context->SetTilingKey(1);
-    OP_LOGD(context->GetNodeName(), "tilingKey: %d", context->GetTilingKey());
+    if (tiling_.V == V_DIM_256) {
+        context->SetTilingKey(2);
+    } else {
+        context->SetTilingKey(1);
+    }
+    OP_LOGD(context->GetNodeName(), "tilingKey: %d (V=%ld)", context->GetTilingKey(), tiling_.V);
     PrepareWyReprBwdFullTilingDataPrint();
 
     OP_CHECK_IF(context_->GetRawTilingData() == nullptr, OP_LOGE(context_->GetNodeName(), "RawTilingData is nullptr."),
@@ -55,10 +59,13 @@ bool PrepareWyReprBwdFullTilingA5::SetTiling(gert::TilingContext *context)
     const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
     context->SetBlockDim(ascendcPlatform.GetCoreNumAic());
 
-    uint32_t sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
-    uint32_t userWorkspaceSize = 2 * tiling_.B * tiling_.HV * tiling_.T * tiling_.V;
+    auto sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
+    OP_LOGD(context->GetNodeName(), "=== sysWorkspaceSize: %ld", sysWorkspaceSize);
+    size_t userWorkspaceSize = 2 * tiling_.B * tiling_.HV * tiling_.T * (tiling_.V + tiling_.K);
+    OP_LOGD(context->GetNodeName(), "=== userWorkspaceSize: %ld", userWorkspaceSize);
     size_t *currentWorkspace = context->GetWorkspaceSizes(1);
-    currentWorkspace[0] = userWorkspaceSize + sysWorkspaceSize;
+    currentWorkspace[0] = static_cast<size_t>(userWorkspaceSize + sysWorkspaceSize);
+    OP_LOGD(context->GetNodeName(), "=== currentWorkspace[0]: %ld", currentWorkspace[0]);
     context->SetScheduleMode(1); // set as batchmod for template using SyncAll
     OP_LOGD(context->GetNodeName(), "Tiling4PrepareWyReprBwdFull end.");
     return true;
@@ -118,7 +125,7 @@ ge::graphStatus PrepareWyReprBwdFullTilingA5::CommonTiling()
     OP_CHECK_IF(CompareShape(AStorageShape, dAStorageShape, INPUT_A_NAME, INPUT_DA_NAME, DIM_NUM_4) !=
                     ge::GRAPH_SUCCESS,
                 , return ge::GRAPH_FAILED);
-    OP_CHECK_IF(CompareShape(dwStorageShape, vStorageShape, INPUT_DW_NAME, INPUT_V_NAME, DIM_NUM_3) !=
+    OP_CHECK_IF(CompareShape(dwStorageShape, kStorageShape, INPUT_DW_NAME, INPUT_K_NAME, DIM_NUM_3) !=
                     ge::GRAPH_SUCCESS,
                 , return ge::GRAPH_FAILED);
     OP_CHECK_IF(dwStorageShape.GetDim(DIM_3) != kStorageShape.GetDim(DIM_3),
@@ -151,6 +158,10 @@ ge::graphStatus PrepareWyReprBwdFullTilingA5::CommonTiling()
     tiling_.T = T;
     tiling_.K = K;
     tiling_.V = V;
+    OP_CHECK_IF(V != V_DIM_128 && V != V_DIM_256,
+                    OP_LOGE(context_->GetNodeName(),
+                            "Check value dim V failed: only %ld or %ld is supported, but get %ld.", V_DIM_128, V_DIM_256, V),
+                    return ge::GRAPH_FAILED);
     auto attrPtr = context_->GetAttrs();
     OP_CHECK_NULL_WITH_CONTEXT(context_, attrPtr);
     chunkSize = static_cast<int64_t>(*(attrPtr->GetAttrPointer<int32_t>(ATTR_CHUNK_SIZE_IDX)));
@@ -175,6 +186,8 @@ ge::graphStatus PrepareWyReprBwdFullTilingA5::CommonTiling()
     OP_CHECK_IF(SetDkbVecRowRegbase(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS, OP_LOGE(context_->GetNodeName(), "SetDkbVecRow Failed."),
                 return ge::GRAPH_FAILED);
     OP_CHECK_IF(SetDkbgVecRowRegbase(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS, OP_LOGE(context_->GetNodeName(), "SetDkbgVecRow Failed."),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(SetDkGatherVecRowRegbase(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS, OP_LOGE(context_->GetNodeName(), "SetDkGatherVecRow Failed."),
                 return ge::GRAPH_FAILED);
     OP_CHECK_IF(SetDvbVecRowRegbase(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS, OP_LOGE(context_->GetNodeName(), "SetDvbVecRow Failed."),
                 return ge::GRAPH_FAILED);
@@ -383,6 +396,32 @@ ge::graphStatus PrepareWyReprBwdFullTilingA5::SetDkbgVecRowRegbase(uint64_t ubSi
     return ge::GRAPH_SUCCESS;
 }
 
+ge::graphStatus PrepareWyReprBwdFullTilingA5::SetDkGatherVecRowRegbase(uint64_t ubSize, ge::DataType kType, ge::DataType betaType)
+{
+    uint64_t rowNum = chunkSize / 2;
+    uint64_t sizeofKType = SIZE_FP32;
+    uint64_t sizeofBetaType = SIZE_FP32;
+    if (kType != ge::DataType::DT_FLOAT) {
+        sizeofKType = SIZE_HALF;
+    }
+    if (betaType != ge::DataType::DT_FLOAT) {
+        sizeofBetaType = SIZE_HALF;
+    }
+    while (rowNum >= 8) {
+        uint64_t useUbSize = 0;
+        useUbSize += 2 * rowNum * K * sizeofKType;
+        useUbSize += 2 * rowNum * K * sizeofKType;
+        useUbSize += 2 * rowNum * K * sizeofKType;
+
+        if (useUbSize <= ubSize) {
+            break;
+        }
+        rowNum = rowNum / 2;
+    }
+    tiling_.dkGatherVecRow = rowNum;
+    return ge::GRAPH_SUCCESS;
+}
+
 ge::graphStatus PrepareWyReprBwdFullTilingA5::SetDvbVecRowRegbase(uint64_t ubSize, ge::DataType kType, ge::DataType betaType)
 {
     uint64_t rowNum = chunkSize / 2;
@@ -474,6 +513,7 @@ void PrepareWyReprBwdFullTilingA5::PrepareWyReprBwdFullTilingDataPrint()
     OP_LOGD(nodeName, "=== kBeteVecRow: %ld", tiling_.kBeteVecRow);
     OP_LOGD(nodeName, "=== dkbVecRow: %ld", tiling_.dkbVecRow);
     OP_LOGD(nodeName, "=== dkbgVecRow: %ld", tiling_.dkbgVecRow);
+    OP_LOGD(nodeName, "=== dkGatherVecRow: %ld", tiling_.dkGatherVecRow);
     OP_LOGD(nodeName, "=== dvbVecRow: %ld", tiling_.dvbVecRow);
     OP_LOGD(nodeName, "=== kktVecRow: %ld", tiling_.kktVecRow);
     OP_LOGD(nodeName, "=== isVariable: %ld", tiling_.isVariable);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/arch35/prepare_wy_repr_bwd_full_tiling_a5.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/arch35/prepare_wy_repr_bwd_full_tiling_a5.h
@@ -52,6 +52,7 @@ public:
     ge::graphStatus SetKBeteVecRowRegbase(uint64_t ubSize, ge::DataType kType, ge::DataType betaType);
     ge::graphStatus SetDkbVecRowRegbase(uint64_t ubSize, ge::DataType kType, ge::DataType betaType);
     ge::graphStatus SetDkbgVecRowRegbase(uint64_t ubSize, ge::DataType kType, ge::DataType betaType);
+    ge::graphStatus SetDkGatherVecRowRegbase(uint64_t ubSize, ge::DataType kType, ge::DataType betaType);
     ge::graphStatus SetDvbVecRowRegbase(uint64_t ubSize, ge::DataType kType, ge::DataType betaType);
     ge::graphStatus SetKKTVecRowRegbase(uint64_t ubSize, ge::DataType kType, ge::DataType betaType);
     int64_t CeilDiv(int64_t a, int64_t b);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/prepare_wy_repr_bwd_full_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/prepare_wy_repr_bwd_full_tiling.cpp
@@ -234,7 +234,7 @@ public:
         OP_CHECK_IF(CompareShape(AStorageShape, dAStorageShape, INPUT_A_NAME, INPUT_DA_NAME, DIM_NUM_4) !=
                         ge::GRAPH_SUCCESS,
                     , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(CompareShape(dwStorageShape, vStorageShape, INPUT_DW_NAME, INPUT_V_NAME, DIM_NUM_3) !=
+        OP_CHECK_IF(CompareShape(dwStorageShape, kStorageShape, INPUT_DW_NAME, INPUT_K_NAME, DIM_NUM_3) !=
                         ge::GRAPH_SUCCESS,
                     , return ge::GRAPH_FAILED);
         OP_CHECK_IF(dwStorageShape.GetDim(DIM_3) != kStorageShape.GetDim(DIM_3),

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/arch35/prepare_wy_repr_bwd_full_common.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/arch35/prepare_wy_repr_bwd_full_common.h
@@ -53,4 +53,13 @@ __aicore__ void inline GetChunkOffset(GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
 
     return;
 }
+
+__aicore__ void inline GetKBosByVBos(uint32_t vBos, uint64_t T, uint64_t HV, uint64_t HK, uint64_t &kBos)
+{
+    uint64_t batchIdx = vBos / (HV * T);
+    uint64_t timeBos = vBos - batchIdx * HV * T;
+    kBos = batchIdx * HK * T + timeBos;
+
+    return;
+}
 #endif // PREPARE_WY_REPR_BWD_FULL_COMMON_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/arch35/prepare_wy_repr_bwd_full_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/arch35/prepare_wy_repr_bwd_full_cube.h
@@ -113,6 +113,8 @@ public:
         uint64_t B = 1;
         uint64_t T = 32768;
         uint64_t HV = 32;
+        uint64_t HK = 32;
+        uint64_t groupSize = 1;
         uint64_t K = 128;
         uint64_t V = 128;
         uint64_t chunkSize = 64;
@@ -141,7 +143,7 @@ public:
                LayoutDw layoutDw_, GM_ADDR ptrDkbg_, LayoutDkbg layoutDkbg_, GM_ADDR ptrDu_, LayoutDkbg layoutDu_,
                GM_ADDR ptrDvb_, LayoutDkbg layoutDvb_, GM_ADDR ptrKT_, LayoutKT layoutKT_, GM_ADDR ptrKKT_,
                LayoutKKT layoutKKT_, GM_ADDR ptrCuSeqLens_, GM_ADDR ptrChunkIndices_, uint64_t chunkNum_, uint64_t B_,
-               uint64_t T_, uint64_t H_, uint64_t K_, uint64_t V_, uint64_t BT_, uint64_t stage_,
+               uint64_t T_, uint64_t HV_, uint64_t HK_, uint64_t groupSize_, uint64_t K_, uint64_t V_, uint64_t BT_, uint64_t stage_,
                uint64_t kBeteVecRow_, uint64_t dkbVecRow_, uint64_t dkbgVecRow_, uint64_t dvbVecRow_, uint64_t kktVecRow_,
                uint64_t kBetaCVNum_, uint64_t dkbCVNum_, uint64_t dkbgCVNum_, uint64_t dvbCVNum_, uint64_t kktCVNum_)
             : ptrKbeta(ptrptrKbeta_), layoutKbeta(layoutKbeta_), ptrDA(ptrDA_), layoutDA(layoutDA_), ptrDk(ptrDk_),
@@ -150,7 +152,7 @@ public:
               layoutDw(layoutDw_), ptrDkbg(ptrDkbg_), layoutDkbg(layoutDkbg_), ptrDu(ptrDu_), layoutDu(layoutDu_),
               ptrDvb(ptrDvb_), layoutDvb(layoutDvb_), ptrKT(ptrKT_), layoutKT(layoutKT_), ptrKKT(ptrKKT_),
               layoutKKT(layoutKKT_), ptrCuSeqLens(ptrCuSeqLens_), ptrChunkIndices(ptrChunkIndices_),
-              chunkNum(chunkNum_), B(B_), T(T_), HV(H_), K(K_), V(V_), chunkSize(BT_), stage(stage_),
+              chunkNum(chunkNum_), B(B_), T(T_), HV(HV_), HK(HK_), groupSize(groupSize_), K(K_), V(V_), chunkSize(BT_), stage(stage_),
               kBeteVecRow(kBeteVecRow_), dkbVecRow(dkbVecRow_), dkbgVecRow(dkbgVecRow_), dvbVecRow(dvbVecRow_), kktVecRow(kktVecRow_),
               kBetaCVNum(kBetaCVNum_), dkbCVNum(dkbCVNum_), dkbgCVNum(dkbgCVNum_), dvbCVNum(dvbCVNum_), kktCVNum(kktCVNum_)
         {
@@ -175,6 +177,7 @@ public:
         uint32_t coreLoops = params.chunkNum;
         uint32_t bos = 0;
         uint32_t eos = 0;
+        uint64_t kBos = 0;
         { //处理第一部分cube DA @ Kbeta     V->C
             AscendC::CrossCoreSetFlag<0x2, PIPE_MTE2>(SYNC_FLAG_5);
             AscendC::CrossCoreSetFlag<0x2, PIPE_MTE2>(SYNC_FLAG_5);
@@ -190,11 +193,11 @@ public:
                 uint32_t curChunkSize = eos - bos;
                 GemmCoord blockCoord{0, 0, 0};
                 GemmCoord actualBlockShape{curChunkSize, static_cast<uint32_t>(params.K), curChunkSize};
-                for (int h = 0; h < params.HV; h++) {
+                for (uint64_t h_v = 0; h_v < params.HV; h_v++) {
                     // Represent the full gm
-                    gmDA.SetGlobalBuffer((__gm__ ElementDA *)params.ptrDA + (h * params.T + bos) * params.chunkSize);
-                    gmKbeta.SetGlobalBuffer((__gm__ ElementKbeta *)params.ptrKbeta + (h * params.T + bos) * params.K);
-                    gmDk.SetGlobalBuffer((__gm__ ElementDk *)params.ptrDk + (h * params.T + bos) * params.K);
+                    gmDA.SetGlobalBuffer((__gm__ ElementDA *)params.ptrDA + (h_v * params.T + bos) * params.chunkSize);
+                    gmKbeta.SetGlobalBuffer((__gm__ ElementKbeta *)params.ptrKbeta + (h_v * params.T + bos) * params.K);
+                    gmDk.SetGlobalBuffer((__gm__ ElementDk *)params.ptrDk + (h_v * params.T + bos) * params.K);
 
                     // Represent the full tensors
                     auto tensorDA = tla::MakeTensor(gmDA, params.layoutDA, Arch::PositionGM{});
@@ -232,13 +235,18 @@ public:
             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
                                params.chunkSize, loopIdx, bos, eos);
+                kBos = bos;
+                if (params.ptrCuSeqLens == nullptr && params.HV != params.HK) {
+                    GetKBosByVBos(bos, params.T, params.HV, params.HK, kBos);
+                }
                 uint32_t curChunkSize = eos - bos;
                 GemmCoord blockCoord{0, 0, 0};
                 GemmCoord actualBlockShape{curChunkSize, static_cast<uint32_t>(params.K), curChunkSize};
-                for (int h = 0; h < params.HV; h++) {
+                for (uint64_t h_v = 0; h_v < params.HV; h_v++) {
+                    uint64_t h_k = h_v / params.groupSize;
                     // Represent the full gm
-                    gmDAT.SetGlobalBuffer((__gm__ ElementDAT *)params.ptrDAT + (h * params.T + bos) * params.chunkSize);
-                    gmK.SetGlobalBuffer((__gm__ ElementK *)params.ptrK + (h * params.T + bos) * params.K);
+                    gmDAT.SetGlobalBuffer((__gm__ ElementDAT *)params.ptrDAT + (h_v * params.T + bos) * params.chunkSize);
+                    gmK.SetGlobalBuffer((__gm__ ElementK *)params.ptrK + (h_k * params.T + kBos) * params.K);
                     
                     // Represent the full tensors
                     auto tensorDAT = tla::MakeTensor(gmDAT, params.layoutDAT, Arch::PositionGM{});
@@ -287,13 +295,18 @@ public:
             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
                                params.chunkSize, loopIdx, bos, eos);
+                kBos = bos;
+                if (params.ptrCuSeqLens == nullptr && params.HV != params.HK) {
+                    GetKBosByVBos(bos, params.T, params.HV, params.HK, kBos);
+                }
                 uint32_t curChunkSize = eos - bos;
                 GemmCoord blockCoord{0, 0, 0};
                 GemmCoord actualBlockShape{curChunkSize, static_cast<uint32_t>(params.K), curChunkSize};
-                for (int h = 0; h < params.HV; h++) {
+                for (uint64_t h_v = 0; h_v < params.HV; h_v++) {
+                    uint64_t h_k = h_v / params.groupSize;
                     // Represent the full gm
-                    gmAT.SetGlobalBuffer((__gm__ ElementAT *)params.ptrAT + (h * params.T + bos) * params.chunkSize);
-                    gmDw.SetGlobalBuffer((__gm__ ElementDw *)params.ptrDw + (h * params.T + bos) * params.K);
+                    gmAT.SetGlobalBuffer((__gm__ ElementAT *)params.ptrAT + (h_v * params.T + bos) * params.chunkSize);
+                    gmDw.SetGlobalBuffer((__gm__ ElementDw *)params.ptrDw + (h_k * params.T + kBos) * params.K);
 
                     // Represent the full tensors
                     auto tensorAT = tla::MakeTensor(gmAT, params.layoutAT, Arch::PositionGM{});
@@ -344,10 +357,10 @@ public:
                 uint32_t curChunkSize = eos - bos;
                 GemmCoord blockCoord{0, 0, 0};
                 GemmCoord actualBlockShape{curChunkSize, static_cast<uint32_t>(params.V), curChunkSize};
-                for (int h = 0; h < params.HV; h++) {
+                for (uint64_t h_v = 0; h_v < params.HV; h_v++) {
                     // Represent the full gm
-                    gmAT.SetGlobalBuffer((__gm__ ElementAT *)params.ptrAT + (h * params.T + bos) * params.chunkSize);
-                    gmDu.SetGlobalBuffer((__gm__ ElementDu *)params.ptrDu + (h * params.T + bos) * params.V);
+                    gmAT.SetGlobalBuffer((__gm__ ElementAT *)params.ptrAT + (h_v * params.T + bos) * params.chunkSize);
+                    gmDu.SetGlobalBuffer((__gm__ ElementDu *)params.ptrDu + (h_v * params.T + bos) * params.V);
 
                     // Represent the full tensors
                     auto tensorAT = tla::MakeTensor(gmAT, params.layoutAT, Arch::PositionGM{});
@@ -394,15 +407,15 @@ public:
             }
             uint8_t beginSubBlockIdx = 1;
             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HK, params.T,
                                params.chunkSize, loopIdx, bos, eos);
                 uint32_t curChunkSize = eos - bos;
                 GemmCoord blockCoord{0, 0, 0};
                 GemmCoord actualBlockShape{curChunkSize, curChunkSize, static_cast<uint32_t>(params.K)};
-                for (int h = 0; h < params.HV; h++) {
+                for (uint64_t h_k = 0; h_k < params.HK; h_k++) {
                     // Represent the full gm
-                    gmK.SetGlobalBuffer((__gm__ ElementK *)params.ptrK + (h * params.T + bos) * params.K);
-                    gmKT.SetGlobalBuffer((__gm__ ElementKT *)params.ptrKT + (h * params.T + bos) * params.K);
+                    gmK.SetGlobalBuffer((__gm__ ElementK *)params.ptrK + (h_k * params.T + bos) * params.K);
+                    gmKT.SetGlobalBuffer((__gm__ ElementKT *)params.ptrKT + (h_k * params.T + bos) * params.K);
 
                     // Represent the full tensors
                     auto tensorK = tla::MakeTensor(gmK, params.layoutK, Arch::PositionGM{});
@@ -451,9 +464,14 @@ public:
     __aicore__ inline void Init(const PrepareWyReprBwdFullTilingDataA5 &tiling);
 
 private:
+    template <class L1TileShape, class L0TileShape>
+    __aicore__ inline void ProcessImpl();
+
     uint64_t B = 0;
     uint64_t T = 0;
     uint64_t HV = 0;
+    uint64_t HK = 0;
+    uint64_t groupSize = 0;
     uint64_t K = 0;
     uint64_t V = 0;
     uint64_t chunkSize = 0;
@@ -473,6 +491,7 @@ private:
     GM_ADDR dbeta;
     GM_ADDR dg;
     GM_ADDR workspace;
+    GM_ADDR workspaceDk;
     uint64_t kBeteVecRow = 0;
     uint64_t dkbVecRow = 0;
     uint64_t dkbgVecRow = 0;
@@ -494,11 +513,14 @@ __aicore__ inline PrepareWyReprBwdFullProcess<kType, betaType>::PrepareWyReprBwd
       chunk_indices(chunk_indices_), dk(dk_), dv(dv_), dbeta(dbeta_), dg(dg_), workspace(workspace_){};
 
 template <typename kType, typename betaType>
-__aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType>::Init(const PrepareWyReprBwdFullTilingDataA5 &tiling)
+__aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType>::Init(
+    const PrepareWyReprBwdFullTilingDataA5 &tiling)
 {
     B = tiling.B;
     T = tiling.T;
     HV = tiling.HV;
+    HK = tiling.HK;
+    groupSize = HV / HK;
     K = tiling.K;
     V = tiling.V;
     chunkSize = tiling.chunkSize;
@@ -513,11 +535,24 @@ __aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType>::Init(const 
     dkbgCVNum = tiling.dkbgCVNum;
     dvbCVNum = tiling.dvbCVNum;
     kktCVNum = tiling.kktCVNum;
+    // dk 暂时先存放到workspace中，以HV存放
+    GM_ADDR workspaceDk = workspace + (B * HV * T * V * sizeof(kType));
     return;
 }
 
 template <typename kType, typename betaType>
 __aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType>::Process()
+{
+    if (V == 256) {
+        ProcessImpl<Shape<_128, _256, _256>, Shape<_128, _256, _64>>();
+    } else {
+        ProcessImpl<Shape<_128, _128, _256>, Shape<_128, _128, _128>>();
+    }
+}
+
+template <typename kType, typename betaType>
+template <class L1TileShape, class L0TileShape>
+__aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType>::ProcessImpl()
 {
     //输入
     using LayoutTagA = layout::RowMajor;
@@ -563,9 +598,6 @@ __aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType>::Process()
 
     using LayoutTagKKT = layout::RowMajor;
     LayoutTagKKT tagKKT = LayoutTagKKT::MakeLayout<kType>(chunkSize, chunkSize);
-
-    using L1TileShape = Shape<_128, _128, _256>;
-    using L0TileShape = Shape<_128, _128, _128>;
 
     using ArchTag = Arch::Ascend950;
     using DispatchPolicy = Common::MmadPingpong<ArchTag, false, false, 2>;
@@ -616,10 +648,10 @@ __aicore__ void inline PrepareWyReprBwdFullProcess<kType, betaType>::Process()
     MatmulKernel kernel;
 
     typename MatmulKernel::Params param{
-        workspace, layoutKbeta, dA, layoutDA, dk,        layoutDK,  dA,         layoutDAT,     k,        layoutK,
+        workspace, layoutKbeta, dA, layoutDA, workspaceDk,        layoutDK,  dA,         layoutDAT,     k,        layoutK,
         workspace, layoutDkb,   A,  layoutAT, dw,        layoutDw,  workspace,  layoutDkbg,    du,       layoutDu,
         workspace, layoutDvb,   k,  layoutKT, workspace, layoutKKT, cu_seqlens, chunk_indices, chunkNum, B,
-        T,         HV,           K,  V,        chunkSize, 4,
+        T,         HV,          HK, groupSize,  K,  V,        chunkSize, 4,
         kBeteVecRow, dkbVecRow, dkbgVecRow, dvbVecRow, kktVecRow, kBetaCVNum, dkbCVNum, dkbgCVNum, dvbCVNum, kktCVNum};
     kernel(param);
 }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/arch35/prepare_wy_repr_bwd_full_tiling_data_apt.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/arch35/prepare_wy_repr_bwd_full_tiling_data_apt.h
@@ -30,6 +30,7 @@ struct PrepareWyReprBwdFullTilingDataA5 {
     int64_t kBeteVecRow = 0; // kBeta计算流程时vector单次处理的行数
     int64_t dkbVecRow = 0;   // dk计算流程时vector单次处理的行数
     int64_t dkbgVecRow = 0;  // dkbg计算流程时vector单次处理的行数
+    int64_t dkGatherVecRow = 0;  // dk合并(HV->HK)计算流程时vector单次处理的行数
     int64_t dvbVecRow = 0;   // dvb计算流程时vector单次处理的行数
     int64_t kktVecRow = 0;   // kkt计算流程时vector单次处理的行数
     int64_t isVariable = 0;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/arch35/prepare_wy_repr_bwd_full_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/arch35/prepare_wy_repr_bwd_full_vector.h
@@ -60,6 +60,16 @@ public:
     __aicore__ inline void ProcessKBetaA5();
     __aicore__ inline void ProcessDkbA5();
     __aicore__ inline void ProcessDkbgA5();
+    __aicore__ inline void ProcessDkGatherA5();
+    __simd_vf__ inline void ProcessDkGatherComputerVFOneLineOneCol(__ubuf__ kType* dkOut,
+                                                  __ubuf__ kType* dkIn1, __ubuf__ kType* dkIn2,
+                                                  uint16_t mSize, uint16_t nSize);
+    __simd_vf__ inline void ProcessDkGatherComputerVFMutiLineOneCol(__ubuf__ kType* dkOut,
+                                                  __ubuf__ kType* dkIn1, __ubuf__ kType* dkIn2,
+                                                  uint16_t mSize, uint16_t nSize);
+    __simd_vf__ inline void ProcessDkGatherComputerVFTwoCol(__ubuf__ kType* dkOut,
+                                                  __ubuf__ kType* dkIn1, __ubuf__ kType* dkIn2,
+                                                  uint16_t mSize, uint16_t nSize);
     __aicore__ inline void ProcessDvbA5();
     __aicore__ inline void ProcessKKTA5();
     __aicore__ inline void Init(const PrepareWyReprBwdFullTilingDataA5 &tiling, AscendC::TPipe *pipe_);
@@ -84,6 +94,11 @@ public:
                                                  __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
                                                  __ubuf__ kType* dkIn, __ubuf__ kType* dkbIn,
                                                  uint16_t mSize, uint16_t nSize);
+    __simd_vf__ inline void ProcessDkbgComputerGatherDkVF(__ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut, 
+                                                  __ubuf__ betaType* dgOut, __ubuf__ kType* kIn, 
+                                                  __ubuf__ betaType* betaIn, __ubuf__ betaType* gIn,
+                                                  __ubuf__ kType* dkIn, __ubuf__ kType* dkGatherIn, __ubuf__ betaType* dBetaIn,
+                                                  __ubuf__ kType* dkbgIn, uint16_t mSize, uint16_t nSize);
     __simd_vf__ inline void ProcessDkbgComputerVF(__ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut, 
                                                   __ubuf__ betaType* dgOut, __ubuf__ kType* kIn, 
                                                   __ubuf__ betaType* betaIn, __ubuf__ betaType* gIn,
@@ -114,6 +129,8 @@ private:
     uint64_t B = 0;
     uint64_t T = 0;
     uint64_t HV = 0;
+    uint64_t HK = 0;
+    uint64_t groupSize = 0;
     uint64_t K = 0;
     uint64_t V = 0;
     uint64_t chunkSize = 0;
@@ -121,6 +138,7 @@ private:
     uint64_t kBeteVecRow = 0;
     uint64_t dkbVecRow = 0;
     uint64_t dkbgVecRow = 0;
+    uint64_t dkGatherVecRow = 0;
     uint64_t dvbVecRow = 0;
     uint64_t kktVecRow = 0;
     uint64_t kBetaCVNum = 0;
@@ -159,6 +177,7 @@ private:
     GlobalTensor<betaType> dgTensor;
     GlobalTensor<kType> dATensor;
     GlobalTensor<kType> workSpaceTensor;
+    GlobalTensor<kType> workSpaceDkTensor;
 
     TQue<AscendC::TPosition::VECIN, 1> kInQue;
     TQue<AscendC::TPosition::VECIN, 1> betaInQue;
@@ -193,6 +212,8 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Init(
     B = tiling.B;
     T = tiling.T;
     HV = tiling.HV;
+    HK = tiling.HK;
+    groupSize = HV / HK;
     K = tiling.K;
     V = tiling.V;
     chunkSize = tiling.chunkSize;
@@ -200,6 +221,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Init(
     kBeteVecRow = tiling.kBeteVecRow;
     dkbVecRow = tiling.dkbVecRow;
     dkbgVecRow = tiling.dkbgVecRow;
+    dkGatherVecRow = tiling.dkGatherVecRow;
     dvbVecRow = tiling.dvbVecRow;
     kktVecRow = tiling.kktVecRow;
     kBetaCVNum = tiling.kBetaCVNum;
@@ -207,6 +229,8 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Init(
     dkbgCVNum = tiling.dkbgCVNum;
     dvbCVNum = tiling.dvbCVNum;
     kktCVNum = tiling.kktCVNum;
+
+    workSpaceDkTensor.SetGlobalBuffer((__gm__ kType *)workspace + B * HV * T * V);
 
     return;
 }
@@ -221,6 +245,9 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
     AscendC::SyncAll<false>();
     ProcessDkbgA5();
     AscendC::SyncAll<false>();
+    if (groupSize > 1) {
+        ProcessDkGatherA5();
+    }
     ProcessDvbA5();
     AscendC::SyncAll<false>();
     ProcessKKTA5();
@@ -467,76 +494,86 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
         GetChunkOffset(cu_seqlens, chunk_indices, B, HV, T, chunkSize, loopIdx, bos, eos);
         uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < HV; h++) {
+        for (uint64_t h_k = 0; h_k < HK; h_k++) {
             ++vecTaskIdx;
             if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
                 continue;
             }
-            auto& tensorBeta = tensorBetaInList[ubBetaDgListId];
-            auto& tensorDg = tensorDgInList[ubBetaDgListId];
-            {// copyin beta/dg
-                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbBetaInVMTE2List[ubBetaDgListId]);
-                DataCopyPad(tensorBeta, betaTensor[h * T + bos], {1, curChunkSize * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
-                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventUbBetaInMTE2VList[ubBetaDgListId]);
-                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbDgInVMTE2List[ubBetaDgListId]);
-                DataCopyPad(tensorDg, dgTensor[h * T + bos], {1, curChunkSize * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
-                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventUbDgInMTE2VList[ubBetaDgListId]);
-            }
-            Duplicate(tensorReducesum0, 0.0f, chunkSize);
-            for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
-                auto& tensordaIn = tensorDaInList[ubListId];
-                auto& tensorKKTin = tensorKKTInList[cvListId];
-                // copyin da
-                {
-                    auto dAOffset = (h * T + bos + rowOffset) * chunkSize;
-                    curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
-                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbDaInVMTE2List[ubListId]);
-                    DataCopy(tensordaIn, dATensor[dAOffset], chunkSize * curRowNum);
-                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventUbDaInMTE2VList[ubListId]);
+            uint32_t tmpCvListId = cvListId;
+            for (uint64_t i = 0; i < groupSize; i++) {
+                uint64_t h_v = h_k * groupSize + i;
+                auto& tensorBeta = tensorBetaInList[ubBetaDgListId];
+                auto& tensorDg = tensorDgInList[ubBetaDgListId];
+                {// copyin beta/dg
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbBetaInVMTE2List[ubBetaDgListId]);
+                    DataCopyPad(tensorBeta, betaTensor[h_v * T + bos], {1, curChunkSize * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventUbBetaInMTE2VList[ubBetaDgListId]);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbDgInVMTE2List[ubBetaDgListId]);
+                    DataCopyPad(tensorDg, dgTensor[h_v * T + bos], {1, curChunkSize * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventUbDgInMTE2VList[ubBetaDgListId]);
                 }
-                // compute
-                {
-                    auto betaInAddr = reinterpret_cast<uint64_t>(tensorBeta.GetPhyAddr());
-                    auto daInAddr = reinterpret_cast<uint64_t>(tensordaIn.GetPhyAddr());
-                    auto kKTinAddr = reinterpret_cast<uint64_t>(tensorKKTin.GetPhyAddr());
-                    auto reducesum1Addr = reinterpret_cast<uint64_t>(tensorReducesum1[rowOffset].GetPhyAddr());
-                    auto reducesum0Addr = reinterpret_cast<uint64_t>(tensorReducesum0.GetPhyAddr());
+                Duplicate(tensorReducesum0, 0.0f, chunkSize);
+                tmpCvListId = cvListId;
+                for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
+                    auto& tensordaIn = tensorDaInList[ubListId];
+                    auto& tensorKKTin = tensorKKTInList[tmpCvListId];
+                    // copyin da
+                    {
+                        auto dAOffset = (h_v * T + bos + rowOffset) * chunkSize;
+                        curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
+                        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbDaInVMTE2List[ubListId]);
+                        DataCopy(tensordaIn, dATensor[dAOffset], chunkSize * curRowNum);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventUbDaInMTE2VList[ubListId]);
+                    }
+                    // compute
+                    {
+                        auto betaInAddr = reinterpret_cast<uint64_t>(tensorBeta.GetPhyAddr());
+                        auto daInAddr = reinterpret_cast<uint64_t>(tensordaIn.GetPhyAddr());
+                        auto kKTinAddr = reinterpret_cast<uint64_t>(tensorKKTin.GetPhyAddr());
+                        auto reducesum1Addr = reinterpret_cast<uint64_t>(tensorReducesum1[rowOffset].GetPhyAddr());
+                        auto reducesum0Addr = reinterpret_cast<uint64_t>(tensorReducesum0.GetPhyAddr());
 
-                    if (rowOffset == 0) {
-                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventUbBetaInMTE2VList[ubBetaDgListId]);
+                        if (rowOffset == 0) {
+                            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventUbBetaInMTE2VList[ubBetaDgListId]);
+                        }
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventUbDaInMTE2VList[ubListId]);
+                        if (i == 0) {
+                            AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(SYNC_AIC_AIV_FLAG_BEGIN + tmpCvListId);
+                        }
+                        ProcessKKTComputerVF((__ubuf__ kType*)kKTinAddr, (__ubuf__ betaType*)betaInAddr,
+                            (__ubuf__ kType*)daInAddr, (__ubuf__ float*)reducesum1Addr, (__ubuf__ float*)reducesum0Addr,
+                            curChunkSize, curRowNum, chunkSize);
+                        if (i == groupSize - 1) {
+                            AscendC::CrossCoreSetFlag<0x4, PIPE_V>(SYNC_AIV_AIC_FLAG_BEGIN + tmpCvListId);
+                        }
+                        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventUbDaInVMTE2List[ubListId]);
+                        if (rowOffset + rowNum >= curChunkSize) {
+                            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventUbBetaInVMTE2List[ubBetaDgListId]);
+                        }
                     }
-                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventUbDaInMTE2VList[ubListId]);
-                    AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(SYNC_AIC_AIV_FLAG_BEGIN + cvListId);
-                    ProcessKKTComputerVF((__ubuf__ kType*)kKTinAddr, (__ubuf__ betaType*)betaInAddr,
-                        (__ubuf__ kType*)daInAddr, (__ubuf__ float*)reducesum1Addr, (__ubuf__ float*)reducesum0Addr,
-                        curChunkSize, curRowNum, chunkSize);
-                    AscendC::CrossCoreSetFlag<0x4, PIPE_V>(SYNC_AIV_AIC_FLAG_BEGIN + cvListId);
-                    AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventUbDaInVMTE2List[ubListId]);
-                    if (rowOffset + rowNum >= curChunkSize) {
-                        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventUbBetaInVMTE2List[ubBetaDgListId]);
-                    }
+                    ubListId = (ubListId + 1 < UB_STAGES) ? (ubListId + 1) : 0;
+                    tmpCvListId = (tmpCvListId + 1 < kktCVNum) ? (tmpCvListId + 1) : 0;
                 }
-                ubListId = (ubListId + 1 < UB_STAGES) ? (ubListId + 1) : 0;
-                cvListId = (cvListId + 1 < kktCVNum) ? (cvListId + 1) : 0;
+                auto& tensorOutDg = tensorDgOutList[ubBetaDgListId];
+                auto dgInAddr = reinterpret_cast<uint64_t>(tensorDg.GetPhyAddr());
+                auto dgOutAddr = reinterpret_cast<uint64_t>(tensorOutDg.GetPhyAddr());
+                auto reducesum1Addr = reinterpret_cast<uint64_t>(tensorReducesum1[rowOffset].GetPhyAddr());
+                auto reducesum0Addr = reinterpret_cast<uint64_t>(tensorReducesum0.GetPhyAddr());
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventUbDgInMTE2VList[ubBetaDgListId]);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(eventUbOutMTE3VList[ubBetaDgListId]);
+                ProcessKKTComputerVFSub((__ubuf__ betaType*)dgOutAddr, (__ubuf__ betaType*)dgInAddr,
+                            (__ubuf__ float*)reducesum1Addr, (__ubuf__ float*)reducesum0Addr,
+                            curChunkSize);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(eventUbOutVMTE3List[ubBetaDgListId]);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventUbDgInVMTE2List[ubBetaDgListId]);
+                {//copyout
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(eventUbOutVMTE3List[ubBetaDgListId]);
+                    DataCopyPad(dgTensor[h_v * T + bos], tensorOutDg, {1, curChunkSize * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0});
+                    AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(eventUbOutMTE3VList[ubBetaDgListId]);
+                }
+                ubBetaDgListId = (ubBetaDgListId + 1 < UB_STAGES) ? (ubBetaDgListId + 1) : 0;
             }
-            auto& tensorOutDg = tensorDgOutList[ubBetaDgListId];
-            auto dgInAddr = reinterpret_cast<uint64_t>(tensorDg.GetPhyAddr());
-            auto dgOutAddr = reinterpret_cast<uint64_t>(tensorOutDg.GetPhyAddr());
-            auto reducesum1Addr = reinterpret_cast<uint64_t>(tensorReducesum1[rowOffset].GetPhyAddr());
-            auto reducesum0Addr = reinterpret_cast<uint64_t>(tensorReducesum0.GetPhyAddr());
-            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventUbDgInMTE2VList[ubBetaDgListId]);
-            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(eventUbOutMTE3VList[ubBetaDgListId]);
-            ProcessKKTComputerVFSub((__ubuf__ betaType*)dgOutAddr, (__ubuf__ betaType*)dgInAddr,
-                        (__ubuf__ float*)reducesum1Addr, (__ubuf__ float*)reducesum0Addr,
-                        curChunkSize);
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(eventUbOutVMTE3List[ubBetaDgListId]);
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventUbDgInVMTE2List[ubBetaDgListId]);
-            {//copyout
-                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(eventUbOutVMTE3List[ubBetaDgListId]);
-                DataCopyPad(dgTensor[h * T + bos], tensorOutDg, {1, curChunkSize * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0});
-                AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(eventUbOutMTE3VList[ubBetaDgListId]);
-            }
-            ubBetaDgListId = (ubBetaDgListId + 1 < UB_STAGES) ? (ubBetaDgListId + 1) : 0;
+            cvListId = tmpCvListId;
         }
     }
     for (uint32_t i = 0; i < UB_STAGES; ++i) {
@@ -734,7 +771,7 @@ __simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proc
     RegTensor<float> dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg1, dvbFP32OneReg1;
     RegTensor<betaType> dbetaInReg;
     RegTensor<float> dbetaFP32Reg;
-    RegTensor<float> dBetaFP32Reg;
+    RegTensor<float> dBetaFP32Reg, dBetaFP32Reg1;
     RegTensor<kType> dvOutReg, dvOutReg1;
 
     MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
@@ -750,7 +787,7 @@ __simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proc
 
     for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
         HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
-        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1) * PRELOAD_NUM);
+        LoadIn<betaType, true>(betaInReg, betaIn + mIdx + 1);
         CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
         CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
         LoadIn<kType, false>(vInReg, vIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
@@ -772,17 +809,14 @@ __simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proc
 
         Add(vFP32ZeroReg, vFP32ZeroReg, vFP32OneReg, maskFull32);
         ReduceSum(dBetaFP32Reg, vFP32ZeroReg, maskFull32);
-        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM);
+        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx);
         HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
-        Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
-        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
 
         Add(vFP32ZeroReg1, vFP32ZeroReg1, vFP32OneReg1, maskFull32);
-        ReduceSum(dBetaFP32Reg, vFP32ZeroReg1, maskFull32);
-        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM + 1);
-        HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+        ReduceSum(dBetaFP32Reg1, vFP32ZeroReg1, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dBetaFP32Reg1, maskFull32);
         Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
-        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM + 1, dBetaFP32Reg, maskFull32, uStore, 1);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaFP32Reg, maskFull32, uStore, 1);
     }
     uint16_t mIdx = mLoopCnt;
     {
@@ -804,17 +838,14 @@ __simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proc
 
         Add(vFP32ZeroReg, vFP32ZeroReg, vFP32OneReg, maskFull32);
         ReduceSum(dBetaFP32Reg, vFP32ZeroReg, maskFull32);
-        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM);
+        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx);
         HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
-        Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
-        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
 
         Add(vFP32ZeroReg1, vFP32ZeroReg1, vFP32OneReg1, maskFull32);
-        ReduceSum(dBetaFP32Reg, vFP32ZeroReg1, maskFull32);
-        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM + 1);
-        HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+        ReduceSum(dBetaFP32Reg1, vFP32ZeroReg1, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dBetaFP32Reg1, maskFull32);
         Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
-        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM + 1, dBetaFP32Reg, maskFull32, uStore, 1);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaFP32Reg, maskFull32, uStore, 1);
     }
 }
 
@@ -887,7 +918,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
         GetChunkOffset(cu_seqlens, chunk_indices, B, HV, T, chunkSize, loopIdx, bos, eos);
         uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < HV; h++) {
+        for (uint64_t h_v = 0; h_v < HV; h_v++) {
             uint32_t taskNum = CeilDiv(curChunkSize, rowNum);
             taskNum = CeilDiv(taskNum, GetSubBlockNum());
             uint32_t dealTaskNum = 0;
@@ -897,8 +928,8 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
                     continue;
                 }
                 curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
-                auto vOffset = (h * T + bos + rowOffset) * V;
-                auto betaOffset = h * T + bos + rowOffset;
+                auto vOffset = (h_v * T + bos + rowOffset) * V;
+                auto betaOffset = h_v * T + bos + rowOffset;
                 
                 auto& tensorDvbin = tensorDvbinList[cvListId];
                 auto& tensorVin = tensorVinList[ubListId];
@@ -982,6 +1013,148 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
 }
 
 template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDkbgComputerGatherDkVF(
+    __ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut, __ubuf__ betaType* dgOut,
+    __ubuf__ kType* kIn, __ubuf__ betaType* betaIn, __ubuf__ betaType* gIn,
+    __ubuf__ kType* dkIn, __ubuf__ kType* dkGatherIn, __ubuf__ betaType* dBetaIn, __ubuf__ kType* dkbgIn,
+    uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint16_t nLoopCnt = (nSize + eleKNumPerVf - 1) / eleKNumPerVf;
+    uint16_t mLoopCnt = mSize - 1;
+    RegTensor<kType> kInReg;
+    RegTensor<betaType> betaInReg;
+    RegTensor<betaType> gInReg;
+    RegTensor<kType> dkInReg, dkGatherInReg;
+    RegTensor<betaType> dbetaInReg;
+    RegTensor<kType> dkbgInReg;
+    RegTensor<float> betaBrcbFP32ZeroReg, dkFP32ZeroReg, dkFP32OneReg, dkGatherFP32ZeroReg, dkGatherFP32OneReg, dgFP32ZeroReg;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, dBetaAddZeroReg, dkbgFP32ZeroReg, dkbgFP32OneReg;
+    RegTensor<float> gBrcbFP32ZeroReg, dbetaFP32ZeroReg, dbetaFP32OneReg;
+    RegTensor<float> kReduceSumReg, dkReduceSumReg;
+    RegTensor<kType> dkOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    UnalignRegForStore uStoreDBeta;
+    UnalignRegForStore uStoreDg;
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(gInReg, gIn);
+    LoadIn<betaType, true>(dbetaInReg, dBetaIn);
+    LoadIn<kType>(kInReg, kIn);
+    LoadIn<kType>(dkbgInReg, dkbgIn);
+    LoadIn<kType>(dkInReg, dkIn);
+    LoadIn<kType>(dkGatherInReg, dkGatherIn);
+    // 前mSize - 1行
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gBrcbFP32ZeroReg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(dbetaFP32ZeroReg, dbetaInReg, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1));
+        LoadIn<betaType, true>(gInReg, gIn + (mIdx + 1));
+        LoadIn<betaType, true>(dbetaInReg, dBetaIn + (mIdx + 1));
+
+        Exp(gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+        Duplicate(kReduceSumReg, static_cast<float>(0), maskFull32);
+        Duplicate(dkReduceSumReg, static_cast<float>(0), maskFull32);
+        for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt; vfBlockIdx++) {
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            CastHalf2Float<kType>(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgInReg, maskFull16);
+            LoadIn<kType>(kInReg, kIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            LoadIn<kType>(dkbgInReg, dkbgIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            MulFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+            Add(kReduceSumReg, kReduceSumReg, kFP32ZeroReg, maskFull32);
+            Add(dkFP32ZeroReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            Add(dkReduceSumReg, dkReduceSumReg, dkFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+
+            CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+            LoadIn<kType>(dkInReg, dkIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            CastHalf2Float<kType>(dkGatherFP32ZeroReg, dkGatherFP32OneReg, dkGatherInReg, maskFull16);
+            LoadIn<kType>(dkGatherInReg, dkGatherIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkGatherFP32ZeroReg, dkGatherFP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + mIdx * nSize + vfBlockIdx * eleKNumPerVf, dkOutReg, maskFull16);
+        }
+        ReduceSum(dBetaAddZeroReg, kReduceSumReg, maskFull32);
+        ReduceSum(dgFP32ZeroReg, dkReduceSumReg, maskFull32);
+        Add(dBetaAddZeroReg, dBetaAddZeroReg, dbetaFP32ZeroReg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaAddZeroReg, maskFull32, uStoreDBeta, 1);
+        StoreUnAlignOut<betaType>(dgOut + mIdx, dgFP32ZeroReg, maskFull32, uStoreDg, 1);
+    }
+    // 最后一行
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gBrcbFP32ZeroReg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(dbetaFP32ZeroReg, dbetaInReg, maskFull16, maskFull32);
+
+        Exp(gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+        Duplicate(kReduceSumReg, static_cast<float>(0), maskFull32);
+        Duplicate(dkReduceSumReg, static_cast<float>(0), maskFull32);
+        // 最后一行的前nLoopCnt - 1
+        for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt - 1; vfBlockIdx++) {
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            CastHalf2Float<kType>(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgInReg, maskFull16);
+            LoadIn<kType>(kInReg, kIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            LoadIn<kType>(dkbgInReg, dkbgIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            MulFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+            Add(kReduceSumReg, kReduceSumReg, kFP32ZeroReg, maskFull32);
+            Add(dkFP32ZeroReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            Add(dkReduceSumReg, dkReduceSumReg, dkFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+
+            CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+            LoadIn<kType>(dkInReg, dkIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            CastHalf2Float<kType>(dkGatherFP32ZeroReg, dkGatherFP32OneReg, dkGatherInReg, maskFull16);
+            LoadIn<kType>(dkGatherInReg, dkGatherIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkGatherFP32ZeroReg, dkGatherFP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + mIdx * nSize + vfBlockIdx * eleKNumPerVf, dkOutReg, maskFull16);
+        }
+        // 最后一行最后一个loop
+        uint16_t vfBlockIdx = nLoopCnt - 1;
+        {
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            CastHalf2Float<kType>(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgInReg, maskFull16);
+
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            MulFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+            Add(kReduceSumReg, kReduceSumReg, kFP32ZeroReg, maskFull32);
+            Add(dkFP32ZeroReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            Add(dkReduceSumReg, dkReduceSumReg, dkFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+
+            CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+            CastHalf2Float<kType>(dkGatherFP32ZeroReg, dkGatherFP32OneReg, dkGatherInReg, maskFull16);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkGatherFP32ZeroReg, dkGatherFP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + mIdx * nSize + vfBlockIdx * eleKNumPerVf, dkOutReg, maskFull16);
+        }
+        ReduceSum(dBetaAddZeroReg, kReduceSumReg, maskFull32);
+        ReduceSum(dgFP32ZeroReg, dkReduceSumReg, maskFull32);
+        Add(dBetaAddZeroReg, dBetaAddZeroReg, dbetaFP32ZeroReg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaAddZeroReg, maskFull32, uStoreDBeta, 1);
+        StoreUnAlignOut<betaType>(dgOut + mIdx, dgFP32ZeroReg, maskFull32, uStoreDg, 1);
+    }
+}
+
+template <typename kType, typename betaType>
 __simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDkbgComputerVF(
     __ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut, __ubuf__ betaType* dgOut,
     __ubuf__ kType* kIn, __ubuf__ betaType* betaIn, __ubuf__ betaType* gIn,
@@ -1030,7 +1203,6 @@ __simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proc
         for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt; vfBlockIdx++) {
             CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
             CastHalf2Float<kType>(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgInReg, maskFull16);
-            uint32_t thisEleNum = min(eleKNumPerVf, nSize - vfBlockIdx * eleKNumPerVf);
             LoadIn<kType>(kInReg, kIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
             LoadIn<kType>(dkbgInReg, dkbgIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
 
@@ -1127,6 +1299,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
     uint32_t wholeReduceSumCnt = CeilDiv(K, FP32_PER_REPEAT_64);
     uint32_t bos = 0;
     uint32_t eos = 0;
+    uint64_t kBos = 0;
     uint32_t curRowNum = rowNum;
 
     uint32_t ubOffset = 0;
@@ -1136,7 +1309,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
     AscendC::LocalTensor<kType> tensorKinList[UB_STAGES];
     AscendC::LocalTensor<betaType> tensorBetaInList[UB_STAGES];
     AscendC::LocalTensor<betaType> tensorGInList[UB_STAGES];
-    AscendC::LocalTensor<kType> tensorDkInList[UB_STAGES];
+    AscendC::LocalTensor<kType> tensorWorkspaceDkInList[UB_STAGES];
     AscendC::LocalTensor<betaType> tensorDbetaInList[UB_STAGES];
     AscendC::LocalTensor<kType> tensorDkOutList[UB_STAGES];
     AscendC::LocalTensor<betaType> tensorDbetaOutList[UB_STAGES];
@@ -1162,7 +1335,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
         ubOffset += rowNum * sizeof(betaType);
         tensorGInList[i] = resource.ubBuf.template GetBufferByByte<betaType>(ubOffset);
         ubOffset += rowNum * sizeof(betaType);
-        tensorDkInList[i] = resource.ubBuf.template GetBufferByByte<kType>(ubOffset);
+        tensorWorkspaceDkInList[i] = resource.ubBuf.template GetBufferByByte<kType>(ubOffset);
         ubOffset += rowNum * K * sizeof(kType);
         tensorDbetaInList[i] = resource.ubBuf.template GetBufferByByte<betaType>(ubOffset);
         ubOffset += rowNum * sizeof(betaType);
@@ -1189,8 +1362,12 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
 
     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
         GetChunkOffset(cu_seqlens, chunk_indices, B, HV, T, chunkSize, loopIdx, bos, eos);
+        kBos = bos;
+        if (cu_seqlens == nullptr && HV != HK) {
+            GetKBosByVBos(bos, T, HV, HK, kBos);
+        }
         uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < HV; h++) {
+        for (uint64_t h_v = 0; h_v < HV; h_v++) {
             uint32_t taskNum = CeilDiv(curChunkSize, rowNum);
             taskNum = CeilDiv(taskNum, GetSubBlockNum());
             uint32_t dealTaskNum = 0;
@@ -1200,15 +1377,19 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
                 if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
                     continue;
                 }
+                uint64_t h_k = h_v / groupSize;
+                uint64_t needGatherDk = h_v % groupSize;
                 curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
-                auto kOffset = (h * T + bos + rowOffset) * K;
-                auto betaOffset = h * T + bos + rowOffset;
+                auto kOffset = (h_k * T + kBos + rowOffset) * K;
+                auto betaOffset = h_v * T + bos + rowOffset;
+                auto dkInOffset = (h_v * T + bos + rowOffset) * K;
+                auto dkOutOffset = (h_k * T + kBos + rowOffset) * K;
 
                 auto& tensorDkbgIn = tensorDkbgInList[cvListId];
                 auto& tensorKin = tensorKinList[ubListId];
                 auto& tensorBetaIn = tensorBetaInList[ubListId];
                 auto& tensorGIn = tensorGInList[ubListId];
-                auto& tensorDkIn = tensorDkInList[ubListId];
+                auto& tensorWorkspaceDkIn = tensorWorkspaceDkInList[ubListId];
                 auto& tensorDbetaIn = tensorDbetaInList[ubListId];
                 auto& tensorDkOut = tensorDkOutList[ubListId];
                 auto& tensorDbetaOut = tensorDbetaOutList[ubListId];
@@ -1224,7 +1405,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
                     DataCopyPad(tensorGIn, gTensor[betaOffset],
                                 {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},
                                 {false, 0, 0, 0});
-                    DataCopy(tensorDkIn, dkTensor[kOffset], K * curRowNum);
+                    DataCopy(tensorWorkspaceDkIn, workSpaceDkTensor[dkInOffset], K * curRowNum);
                     DataCopyPad(tensorDbetaIn, dbetaTensor[betaOffset],
                                 {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},
                                 {false, 0, 0, 0});
@@ -1236,7 +1417,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
                     auto kInAddr = reinterpret_cast<uint64_t>(tensorKin.GetPhyAddr());
                     auto betaInAddr = reinterpret_cast<uint64_t>(tensorBetaIn.GetPhyAddr());
                     auto gInAddr = reinterpret_cast<uint64_t>(tensorGIn.GetPhyAddr());
-                    auto dkInAddr = reinterpret_cast<uint64_t>(tensorDkIn.GetPhyAddr());
+                    auto dkWorkspaceInAddr = reinterpret_cast<uint64_t>(tensorWorkspaceDkIn.GetPhyAddr());
                     auto dBetaInAddr = reinterpret_cast<uint64_t>(tensorDbetaIn.GetPhyAddr());
                     auto dkOutAddr = reinterpret_cast<uint64_t>(tensorDkOut.GetPhyAddr());
                     auto dBetaOutAddr = reinterpret_cast<uint64_t>(tensorDbetaOut.GetPhyAddr());
@@ -1252,7 +1433,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
                         (__ubuf__ kType*)kInAddr,
                         (__ubuf__ betaType*)betaInAddr,
                         (__ubuf__ betaType*)gInAddr,
-                        (__ubuf__ kType*)dkInAddr,
+                        (__ubuf__ kType*)dkWorkspaceInAddr,
                         (__ubuf__ betaType*)dBetaInAddr,
                         (__ubuf__ kType*)dkbgInAddr,
                         curRowNum, K);
@@ -1263,7 +1444,11 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
                 // copyout
                 {
                     AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(eventUbOutVMTE3List[ubListId]);
-                    DataCopy(dkTensor[kOffset], tensorDkOut, K * curRowNum);
+                    if (needGatherDk) {
+                        DataCopy(workSpaceDkTensor[dkInOffset], tensorDkOut, K * curRowNum);
+                    } else {
+                        DataCopy(dkTensor[dkOutOffset], tensorDkOut, K * curRowNum);
+                    }
                     DataCopyPad(dbetaTensor[betaOffset], tensorDbetaOut,
                                 {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0});
                     DataCopyPad(dgTensor[betaOffset], tensorDgOut,
@@ -1282,12 +1467,321 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
             }
         }
     }
+    
+    for (uint32_t i = 0; i < UB_STAGES; ++i) {
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbInVMTE2List[i]);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(eventUbOutMTE3VList[i]);
+    }
+    return;
+}
+
+template <typename kType, typename betaType>
+__aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDkGatherA5()
+{
+    Arch::Resource<Arch::Ascend950> resource;
+    uint32_t coreLoops = chunkNum;
+    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+    uint32_t coreNumAic = GetBlockNum();
+    uint32_t rowNum = dkGatherVecRow;
+    uint32_t vecTaskIdx = 0;
+    uint32_t bos = 0;
+    uint32_t eos = 0;
+    uint64_t kBos = 0;
+    uint32_t curRowNum = rowNum;
+
+    uint32_t ubOffset = 0;
+    uint32_t ubListId = 0;
+    uint32_t dkOutUbListId = 0;
+    AscendC::LocalTensor<kType> tensorWsDkInList[UB_STAGES];
+    AscendC::LocalTensor<kType> tensorDkGatherInList[UB_STAGES];
+    AscendC::LocalTensor<kType> tensorDkOutList[UB_STAGES];
+
+    int32_t eventVMTE2 = 0;
+    int32_t eventMTE2V = 0;
+    int32_t eventMTE3V = 0;
+    int32_t eventVMTE3 = 0;
+    int32_t eventUbInVMTE2List[UB_STAGES];
+    int32_t eventUbInMTE2VList[UB_STAGES];
+    int32_t eventUbOutMTE3VList[UB_STAGES];
+    int32_t eventUbOutVMTE3List[UB_STAGES];
+
+    for (uint32_t i = 0; i < UB_STAGES; ++i) {
+        tensorWsDkInList[i] = resource.ubBuf.template GetBufferByByte<kType>(ubOffset);
+        ubOffset += rowNum * K * sizeof(kType);
+        tensorDkGatherInList[i] = resource.ubBuf.template GetBufferByByte<kType>(ubOffset);
+        ubOffset += rowNum * K * sizeof(kType);
+        tensorDkOutList[i] = resource.ubBuf.template GetBufferByByte<kType>(ubOffset);
+        ubOffset += rowNum * K * sizeof(kType);
+
+        eventUbInVMTE2List[i] = eventVMTE2++;
+        eventUbInMTE2VList[i] = eventMTE2V++;
+        eventUbOutMTE3VList[i] = eventMTE3V++;
+        eventUbOutVMTE3List[i] = eventVMTE3++;
+
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventUbInVMTE2List[i]);
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(eventUbOutMTE3VList[i]);
+    }
+
+    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
+        GetChunkOffset(cu_seqlens, chunk_indices, B, HV, T, chunkSize, loopIdx, bos, eos);
+        kBos = bos;
+        if (cu_seqlens == nullptr && HV != HK) {
+            GetKBosByVBos(bos, T, HV, HK, kBos);
+        }
+        uint32_t curChunkSize = eos - bos;
+        for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
+            ++vecTaskIdx;
+            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
+                continue;
+            }
+            for (uint64_t h_v = 0; h_v < HV; h_v++) {
+                uint64_t h_k = h_v / groupSize;
+                uint64_t needGatherDk = h_v % groupSize;
+                if (!needGatherDk) {
+                    continue;
+                }
+
+                curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
+                auto dkInOffset = (h_v * T + bos + rowOffset) * K;
+                auto dkOutOffset = (h_k * T + kBos + rowOffset) * K;
+
+                auto& tensorWsDkIn = tensorWsDkInList[ubListId];
+                auto& tensorDkGatherIn = tensorDkGatherInList[dkOutUbListId];
+                auto& tensorDkOut = tensorDkOutList[dkOutUbListId];
+
+                // copyin
+                {
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbInVMTE2List[ubListId]);
+                    DataCopy(tensorWsDkIn, workSpaceDkTensor[dkInOffset], K * curRowNum);
+                    if (needGatherDk == 1) {
+                        DataCopy(tensorDkGatherIn, dkTensor[dkOutOffset], K * curRowNum);
+                    }
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventUbInMTE2VList[ubListId]);
+                }
+                // compute
+                {
+                    auto dkOutAddr = reinterpret_cast<uint64_t>(tensorDkOut.GetPhyAddr());
+                    auto wsDkInAddr = reinterpret_cast<uint64_t>(tensorWsDkIn.GetPhyAddr());
+                    auto dkGatherInAddr = reinterpret_cast<uint64_t>(tensorDkGatherIn.GetPhyAddr());
+                    if (needGatherDk != 1) {
+                        dkGatherInAddr = dkOutAddr;
+                    }
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventUbInMTE2VList[ubListId]);
+                    if (needGatherDk == 1) {
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(eventUbOutMTE3VList[dkOutUbListId]);
+                    }
+                    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+                    if (K <= eleKNumPerVf) {
+                        if (curRowNum == 1) {
+                            ProcessDkGatherComputerVFOneLineOneCol(
+                                (__ubuf__ kType*)dkOutAddr,
+                                (__ubuf__ kType*)wsDkInAddr, (__ubuf__ kType*)dkGatherInAddr,
+                                curRowNum, K);
+                        } else {
+                            ProcessDkGatherComputerVFMutiLineOneCol(
+                                (__ubuf__ kType*)dkOutAddr,
+                                (__ubuf__ kType*)wsDkInAddr, (__ubuf__ kType*)dkGatherInAddr,
+                                curRowNum, K);
+                        }
+                    } else {
+                        ProcessDkGatherComputerVFTwoCol(
+                            (__ubuf__ kType*)dkOutAddr,
+                            (__ubuf__ kType*)wsDkInAddr, (__ubuf__ kType*)dkGatherInAddr,
+                            curRowNum, K);
+                    }
+                    if (needGatherDk == groupSize - 1) {
+                        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(eventUbOutVMTE3List[dkOutUbListId]);
+                    }
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventUbInVMTE2List[ubListId]);
+                }
+                // copyout
+                {
+                    if (needGatherDk == groupSize - 1) {
+                        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(eventUbOutVMTE3List[dkOutUbListId]);
+                        DataCopy(dkTensor[dkOutOffset], tensorDkOut, K * curRowNum);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(eventUbOutMTE3VList[dkOutUbListId]);
+                    }
+                }
+                ubListId = (ubListId + 1 < UB_STAGES) ? (ubListId + 1) : 0;
+                if (needGatherDk == groupSize - 1) {
+                    dkOutUbListId = (dkOutUbListId + 1 < UB_STAGES) ? (dkOutUbListId + 1) : 0;
+                }
+            }
+        }
+    }
 
     for (uint32_t i = 0; i < UB_STAGES; ++i) {
         AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbInVMTE2List[i]);
         AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(eventUbOutMTE3VList[i]);
     }
     return;
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDkGatherComputerVFOneLineOneCol(
+    __ubuf__ kType* dkOut, __ubuf__ kType* dkIn1, __ubuf__ kType* dkIn2,
+    uint16_t mSize, uint16_t nSize)
+{
+    RegTensor<kType> dk1Reg, dk2Reg;
+    RegTensor<float> dk1FP32ZeroReg, dk1FP32OneReg;
+    RegTensor<float> dk2FP32ZeroReg, dk2FP32OneReg;
+    RegTensor<kType> dkOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<kType, false>(dk1Reg, dkIn1);
+    LoadIn<kType, false>(dk2Reg, dkIn2);
+    CastHalf2Float<kType>(dk1FP32ZeroReg, dk1FP32OneReg, dk1Reg, maskFull16);
+    CastHalf2Float<kType>(dk2FP32ZeroReg, dk2FP32OneReg, dk2Reg, maskFull16);
+    AddFloatTwoReg(dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg, dk1FP32OneReg, dk2FP32ZeroReg, dk2FP32OneReg, maskFull32);
+    CastFloat2Half<kType>(dkOutReg, dk1FP32ZeroReg, dk1FP32OneReg, maskFull32);
+    StoreAlign((__ubuf__ kType*&)dkOut, dkOutReg, maskFull16);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDkGatherComputerVFMutiLineOneCol(
+    __ubuf__ kType* dkOut, __ubuf__ kType* dkIn1, __ubuf__ kType* dkIn2,
+    uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    uint16_t lastLoopCnt = mSize % PRELOAD_NUM;
+    RegTensor<kType> dk1Reg, dk1Reg1;
+    RegTensor<kType> dk2Reg, dk2Reg1;
+    RegTensor<float> dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg1, dk1FP32OneReg1;
+    RegTensor<float> dk2FP32ZeroReg, dk2FP32OneReg, dk2FP32ZeroReg1, dk2FP32OneReg1;
+    RegTensor<kType> dkOutReg, dkOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<kType, false>(dk1Reg, dkIn1);
+    LoadIn<kType, false>(dk1Reg1, dkIn1 + oneEleNum);
+    LoadIn<kType, false>(dk2Reg, dkIn2);
+    LoadIn<kType, false>(dk2Reg1, dkIn2 + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        CastHalf2Float<kType>(dk1FP32ZeroReg, dk1FP32OneReg, dk1Reg, maskFull16);
+        CastHalf2Float<kType>(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1Reg1, maskFull16);
+        LoadIn<kType, false>(dk1Reg, dkIn1 + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dk1Reg1, dkIn1 + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(dk2FP32ZeroReg, dk2FP32OneReg, dk2Reg, maskFull16);
+        CastHalf2Float<kType>(dk2FP32ZeroReg1, dk2FP32OneReg1, dk2Reg1, maskFull16);
+        LoadIn<kType, false>(dk2Reg, dkIn2 + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dk2Reg1, dkIn2 + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        AddFloatTwoReg(dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg, dk1FP32OneReg, dk2FP32ZeroReg, dk2FP32OneReg, maskFull32);
+        AddFloatTwoReg(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, dk2FP32ZeroReg1, dk2FP32OneReg1, maskFull32);
+
+        CastFloat2Half<kType>(dkOutReg, dk1FP32ZeroReg, dk1FP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dkOutReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        CastHalf2Float<kType>(dk1FP32ZeroReg, dk1FP32OneReg, dk1Reg, maskFull16);
+        CastHalf2Float<kType>(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1Reg1, maskFull16);
+        CastHalf2Float<kType>(dk2FP32ZeroReg, dk2FP32OneReg, dk2Reg, maskFull16);
+        CastHalf2Float<kType>(dk2FP32ZeroReg1, dk2FP32OneReg1, dk2Reg1, maskFull16);
+
+        AddFloatTwoReg(dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg, dk1FP32OneReg, dk2FP32ZeroReg, dk2FP32OneReg, maskFull32);
+        AddFloatTwoReg(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, dk2FP32ZeroReg1, dk2FP32OneReg1, maskFull32);
+
+        CastFloat2Half<kType>(dkOutReg, dk1FP32ZeroReg, dk1FP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dkOutReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<kType, false>(dk1Reg, dkIn1 + oneEleNum * (mIdx * PRELOAD_NUM));
+            LoadIn<kType, false>(dk2Reg, dkIn2 + oneEleNum * (mIdx * PRELOAD_NUM));
+            CastHalf2Float<kType>(dk1FP32ZeroReg, dk1FP32OneReg, dk1Reg, maskFull16);
+            CastHalf2Float<kType>(dk2FP32ZeroReg, dk2FP32OneReg, dk2Reg, maskFull16);
+            AddFloatTwoReg(dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg, dk1FP32OneReg, dk2FP32ZeroReg, dk2FP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dk1FP32ZeroReg, dk1FP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        }
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::ProcessDkGatherComputerVFTwoCol(
+    __ubuf__ kType* dkOut, __ubuf__ kType* dkIn1, __ubuf__ kType* dkIn2,
+    uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, nSize);
+    uint16_t mLoopCnt = mSize - 1;
+    uint16_t lastLoopCnt = mSize % PRELOAD_NUM;
+    RegTensor<kType> dk1Reg, dk1Reg1;
+    RegTensor<kType> dk2Reg, dk2Reg1;
+    RegTensor<float> dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg1, dk1FP32OneReg1;
+    RegTensor<float> dk2FP32ZeroReg, dk2FP32OneReg, dk2FP32ZeroReg1, dk2FP32OneReg1;
+    RegTensor<kType> dkOutReg, dkOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<kType, false>(dk1Reg, dkIn1);
+    LoadIn<kType, false>(dk1Reg1, dkIn1 + oneEleNum);
+    LoadIn<kType, false>(dk2Reg, dkIn2);
+    LoadIn<kType, false>(dk2Reg1, dkIn2 + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        CastHalf2Float<kType>(dk1FP32ZeroReg, dk1FP32OneReg, dk1Reg, maskFull16);
+        CastHalf2Float<kType>(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1Reg1, maskFull16);
+        LoadIn<kType, false>(dk1Reg, dkIn1 + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dk1Reg1, dkIn1 + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(dk2FP32ZeroReg, dk2FP32OneReg, dk2Reg, maskFull16);
+        CastHalf2Float<kType>(dk2FP32ZeroReg1, dk2FP32OneReg1, dk2Reg1, maskFull16);
+        LoadIn<kType, false>(dk2Reg, dkIn2 + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dk2Reg1, dkIn2 + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        AddFloatTwoReg(dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg, dk1FP32OneReg, dk2FP32ZeroReg, dk2FP32OneReg, maskFull32);
+        AddFloatTwoReg(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, dk2FP32ZeroReg1, dk2FP32OneReg1, maskFull32);
+
+        CastFloat2Half<kType>(dkOutReg, dk1FP32ZeroReg, dk1FP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dkOutReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        CastHalf2Float<kType>(dk1FP32ZeroReg, dk1FP32OneReg, dk1Reg, maskFull16);
+        CastHalf2Float<kType>(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1Reg1, maskFull16);
+        CastHalf2Float<kType>(dk2FP32ZeroReg, dk2FP32OneReg, dk2Reg, maskFull16);
+        CastHalf2Float<kType>(dk2FP32ZeroReg1, dk2FP32OneReg1, dk2Reg1, maskFull16);
+
+        AddFloatTwoReg(dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg, dk1FP32OneReg, dk2FP32ZeroReg, dk2FP32OneReg, maskFull32);
+        AddFloatTwoReg(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, dk2FP32ZeroReg1, dk2FP32OneReg1, maskFull32);
+
+        CastFloat2Half<kType>(dkOutReg, dk1FP32ZeroReg, dk1FP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dkOutReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<kType, false>(dk1Reg, dkIn1 + oneEleNum * (mIdx * PRELOAD_NUM));
+            LoadIn<kType, false>(dk1Reg1, dkIn1 + oneEleNum * (mIdx * PRELOAD_NUM + 1));
+            LoadIn<kType, false>(dk2Reg, dkIn2 + oneEleNum * (mIdx * PRELOAD_NUM));
+            LoadIn<kType, false>(dk2Reg1, dkIn2 + oneEleNum * (mIdx * PRELOAD_NUM + 1));
+            CastHalf2Float<kType>(dk1FP32ZeroReg, dk1FP32OneReg, dk1Reg, maskFull16);
+            CastHalf2Float<kType>(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1Reg1, maskFull16);
+            CastHalf2Float<kType>(dk2FP32ZeroReg, dk2FP32OneReg, dk2Reg, maskFull16);
+            CastHalf2Float<kType>(dk2FP32ZeroReg1, dk2FP32OneReg1, dk2Reg1, maskFull16);
+            AddFloatTwoReg(dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg, dk1FP32OneReg, dk2FP32ZeroReg, dk2FP32OneReg, maskFull32);
+            AddFloatTwoReg(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, dk2FP32ZeroReg1, dk2FP32OneReg1, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dk1FP32ZeroReg, dk1FP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+            StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+        }
+    }
 }
 
 template <typename kType, typename betaType>
@@ -1478,7 +1972,7 @@ __simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proc
     RegTensor<float> dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg1, dkFP32OneReg1;
     RegTensor<float> dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg1, dkbFP32OneReg1;
     RegTensor<kType> dkOutReg, dkOutReg1;
-    RegTensor<float> dBetaFP32Reg;
+    RegTensor<float> dBetaFP32Reg, dBetaFP32Reg1;
     RegTensor<betaType> dBetaOutZeroReg;
 
     MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
@@ -1496,7 +1990,7 @@ __simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proc
 
     for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
         HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
-        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1) * PRELOAD_NUM);
+        LoadIn<betaType, true>(betaInReg, betaIn + mIdx + 1);
         CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
         CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
         LoadIn<kType, false>(kInReg, kIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
@@ -1525,11 +2019,11 @@ __simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proc
 
         Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
         ReduceSum(dBetaFP32Reg, kFP32ZeroReg, maskFull32);
-        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
 
         Add(kFP32ZeroReg1, kFP32ZeroReg1, kFP32OneReg1, maskFull32);
-        ReduceSum(dBetaFP32Reg, kFP32ZeroReg1, maskFull32);
-        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM + 1, dBetaFP32Reg, maskFull32, uStore, 1);
+        ReduceSum(dBetaFP32Reg1, kFP32ZeroReg1, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dBetaFP32Reg1, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaFP32Reg, maskFull32, uStore, 1);
     }
     uint16_t mIdx = mLoopCnt;
     {
@@ -1556,11 +2050,11 @@ __simd_vf__ inline void PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proc
 
         Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
         ReduceSum(dBetaFP32Reg, kFP32ZeroReg, maskFull32);
-        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
 
         Add(kFP32ZeroReg1, kFP32ZeroReg1, kFP32OneReg1, maskFull32);
-        ReduceSum(dBetaFP32Reg, kFP32ZeroReg1, maskFull32);
-        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM + 1, dBetaFP32Reg, maskFull32, uStore, 1);
+        ReduceSum(dBetaFP32Reg1, kFP32ZeroReg1, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dBetaFP32Reg1, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaFP32Reg, maskFull32, uStore, 1);
     }
 }
 
@@ -1576,6 +2070,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
     uint32_t vecTaskIdx = 0;
     uint32_t bos = 0;
     uint32_t eos = 0;
+    uint64_t kBos = 0;
     uint32_t curRowNum = rowNum;
 
     uint32_t ubOffset = 0;
@@ -1631,8 +2126,12 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
     
     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
         GetChunkOffset(cu_seqlens, chunk_indices, B, HV, T, chunkSize, loopIdx, bos, eos);
+        kBos = bos;
+        if (cu_seqlens == nullptr && HV != HK) {
+            GetKBosByVBos(bos, T, HV, HK, kBos);
+        }
         uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < HV; h++) {
+        for (uint64_t h_v = 0; h_v < HV; h_v++) {
             uint32_t taskNum = CeilDiv(curChunkSize, rowNum);
             taskNum = CeilDiv(taskNum, GetSubBlockNum());
             uint32_t dealTaskNum = 0;
@@ -1641,9 +2140,11 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
                 if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
                     continue;
                 }
+                uint64_t h_k = h_v / groupSize;
                 curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
-                auto kOffset = (h * T + bos + rowOffset) * K;
-                auto betaOffset = h * T + bos + rowOffset;
+                auto kOffset = (h_k * T + kBos + rowOffset) * K;
+                auto betaOffset = h_v * T + bos + rowOffset;
+                auto dkOffset = (h_v * T + bos + rowOffset) * K;
 
                 auto& tensorDkbin = tensorDkbinList[cvListId];
                 auto& tensorKin = tensorKinList[ubListId];
@@ -1656,7 +2157,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
                     AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbInVMTE2List[ubListId]);
                     DataCopy(tensorKin, kTensor[kOffset], K * curRowNum);
                     DataCopyPad(tensorBetain, betaTensor[betaOffset], {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},{false, 0, 0, 0});
-                    DataCopy(tensorDkin, dkTensor[kOffset], K * curRowNum);
+                    DataCopy(tensorDkin, workSpaceDkTensor[dkOffset], K * curRowNum);
                     AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventUbInMTE2VList[ubListId]);
                 }
                 // compute
@@ -1696,7 +2197,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
                 // copyout
                 {
                     AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(eventUbOutVMTE3List[ubListId]);
-                    DataCopy(dkTensor[kOffset], tensorDkOut, K * curRowNum);
+                    DataCopy(workSpaceDkTensor[dkOffset], tensorDkOut, K * curRowNum);
                     DataCopyPad(dbetaTensor[betaOffset], tensorDbetaOut, {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0});
                     AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(eventUbOutMTE3VList[ubListId]);
                 }
@@ -1875,6 +2376,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
     uint32_t vecTaskIdx = 0;
     uint32_t bos = 0;
     uint32_t eos = 0;
+    uint64_t kBos = 0;
     uint32_t curRowNum = rowNum;
 
     // init
@@ -1884,17 +2386,23 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
     
     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
         GetChunkOffset(cu_seqlens, chunk_indices, B, HV, T, chunkSize, loopIdx, bos, eos);
+        kBos = bos;
+        if (cu_seqlens == nullptr && HV != HK) {
+            GetKBosByVBos(bos, T, HV, HK, kBos);
+        }
         uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < HV; h++) {
+        for (uint64_t h_v = 0; h_v < HV; h_v++) {
             AscendC::CrossCoreWaitFlag(SYNC_FLAG_5);
             for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
                 ++vecTaskIdx;
                 if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
                     continue;
                 }
+                uint64_t h_k = h_v / groupSize;
                 curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
-                auto kOffset = (h * T + bos + rowOffset) * K;
-                auto betaOffset = h * T + bos + rowOffset;
+                auto kOffset = (h_k * T + kBos + rowOffset) * K;
+                auto betaOffset = h_v * T + bos + rowOffset;
+                auto kBetaOffset = (h_v * T + bos + rowOffset) * K;
                 // copyin
                 {
                     auto tensorKin = kInQue.AllocTensor<kType>();
@@ -1938,7 +2446,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
                 // copyout
                 {
                     auto tensorOut = kBetaOutQue.DeQue<kType>();
-                    DataCopy(workSpaceTensor[kOffset], tensorOut, K * curRowNum);
+                    DataCopy(workSpaceTensor[kBetaOffset], tensorOut, K * curRowNum);
                     kBetaOutQue.FreeTensor(tensorOut);
                 }
             }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full.cpp
@@ -25,14 +25,11 @@
 #endif
 
 using namespace AscendC;
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
-// Arch35 cube path: tile shapes come from tiling (PrepareWyReprBwdFullTilingDataA5), not template parameters.
-#else
 /** Cube GEMM tile shape: must be `tla::Shape` (BlockMmadTla); keep explicit to avoid ambiguity with Catlass. */
 template <class... Dims>
 using GemmCubeTileShape = tla::Shape<Dims...>;
 using namespace tla;
-#endif
+
 __global__ __aicore__ void prepare_wy_repr_bwd_full(GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR dA,
                                                     GM_ADDR dw, GM_ADDR du, GM_ADDR g, GM_ADDR cu_seqlens,
                                                     GM_ADDR chunk_indices, GM_ADDR dk, GM_ADDR dv, GM_ADDR dbeta,
@@ -46,13 +43,9 @@ __global__ __aicore__ void prepare_wy_repr_bwd_full(GM_ADDR k, GM_ADDR v, GM_ADD
     if (TILING_KEY_IS(1)) {
         KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
         if ASCEND_IS_AIC {
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
-            PrepareWyReprBwdFullProcess<DTYPE_K, DTYPE_BETA> prepareWyReprBwdFullProcess(
-                k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg, workspace);
-#else
-            PrepareWyReprBwdFullProcess<DTYPE_K, DTYPE_BETA> prepareWyReprBwdFullProcess(
-                k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg, workspace);
-#endif
+            PrepareWyReprBwdFullProcess<DTYPE_K, DTYPE_BETA>
+                prepareWyReprBwdFullProcess(k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg,
+                                            workspace);
             prepareWyReprBwdFullProcess.Init(tilingData);
             prepareWyReprBwdFullProcess.Process();
         }
@@ -66,13 +59,9 @@ __global__ __aicore__ void prepare_wy_repr_bwd_full(GM_ADDR k, GM_ADDR v, GM_ADD
     } else if (TILING_KEY_IS(2)) {
         KERNEL_TASK_TYPE(2, KERNEL_TYPE_MIX_AIC_1_2);
         if ASCEND_IS_AIC {
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
-            PrepareWyReprBwdFullProcess<DTYPE_K, DTYPE_BETA> prepareWyReprBwdFullProcess(
-                k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg, workspace);
-#else
-            PrepareWyReprBwdFullProcess<DTYPE_K, DTYPE_BETA> prepareWyReprBwdFullProcess(
-                k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg, workspace);
-#endif
+            PrepareWyReprBwdFullProcess<DTYPE_K, DTYPE_BETA>
+                prepareWyReprBwdFullProcess(k, v, beta, A, dA, dw, du, g, cu_seqlens, chunk_indices, dk, dv, dbeta, dg,
+                                            workspace);
             prepareWyReprBwdFullProcess.Init(tilingData);
             prepareWyReprBwdFullProcess.Process();
         }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full_cube.h
@@ -402,7 +402,7 @@ public:
                 gmAT.SetGlobalBuffer((__gm__ ElementAT *)params.ptrAT + valueBase * params.chunkSize);
                 gmK.SetGlobalBuffer((__gm__ ElementK *)params.ptrK + keyBase * params.K);
                 gmKT.SetGlobalBuffer((__gm__ ElementKT *)params.ptrKT + keyBase * params.K);
-                gmDw.SetGlobalBuffer((__gm__ ElementDw *)params.ptrDw + valueBase * params.K);
+                gmDw.SetGlobalBuffer((__gm__ ElementDw *)params.ptrDw + keyBase * params.K);
                 gmDu.SetGlobalBuffer((__gm__ ElementDu *)params.ptrDu + valueBase * params.V);
 
                 auto tensorDA = tla::MakeTensor(gmDA, params.layoutDA, Arch::PositionGM{});

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/test/test.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/test/test.py
@@ -1,11 +1,17 @@
 import torch
 import torch_npu
+import os
 from typing import Optional
 import pickle
 import math
-import ct
+# import ct
 import random
-torch.npu.utils.set_device(2)
+torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
+import fla_npu
+# import custom_ops
+
+torch.npu.config.allow_internal_format = False
+torch.npu.set_compile_mode(jit_compile=False)
 
 def get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices):
     if cu_seqlens != None:
@@ -24,13 +30,13 @@ def get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices):
     return bos,eos
 
 def compute_dv_golden(
-    A: torch.Tensor,      # [B, T, H, chunk_size] - 每个chunk的A值
-    du: torch.Tensor,     # [B, T, H, D] - 上游梯度
-    beta: torch.Tensor,   # [B, H, T] - beta参数
+    A: torch.Tensor,      # [B, T, VH, chunk_size] - 每个chunk的A值
+    du: torch.Tensor,     # [B, T, VH, D] - 上游梯度
+    beta: torch.Tensor,   # [B, VH, T] - beta参数
     cu_seqlens: torch.Tensor,
     chunk_indices: torch.Tensor,
     B: int,
-    H: int,
+    VH: int,
     T: int,
     D: int,
     chunk_size: int,  # chunk_size
@@ -38,58 +44,54 @@ def compute_dv_golden(
 ) -> torch.Tensor:
     """
     CPU golden implementation for dv computation (变长序列)
-    A的形状为 [B, T, H, chunk_size]
+    A的形状为 [B, T, VH, chunk_size]
     算法:
     1. 对于每个chunk (由chunk_indices指定)
     2. 获取对应的seq_idx, chunk_indices
     3. 计算该chunk内的dv: dv_chunk = A_chunk @ du_chunk * beta_chunk
     """
-    # 初始化dv，形状与du相同 [B, T, H, D]
+    # 初始化dv，形状与du相同 [B, T, VH, D]
     dv = torch.zeros_like(du)
     for i_b in range(B):
         for idx in range(NT):
             bos,eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
             # print(bos, eos, eos-bos)
         # 遍历所有batch
-            for i_h in range(H):
-                
-            # 遍历所有head 
+            for i_h in range(VH):
+
+            # 遍历所有head
                 # 获取当前chunk的A向量
-                # A形状: [B, T, H, chunk_size]
+                # A形状: [B, T, VH, chunk_size]
                 # 我们需要获取这个chunk对应的A向量
                 # 注意: A的每个位置存储的是该chunk对应的A向量
                 A_chunk = A[i_b,i_h, bos:eos,:eos - bos]  # [chunk_size, chunk_size]
-                
+
                 # 获取当前chunk的du
                 du_chunk = du[i_b,i_h, bos:eos, :]  # [chunk_size, V]
-                
+
                 # 获取当前chunk的beta
                 beta_chunk = beta[i_b,i_h, bos:eos]  # [chunk_size]
-                
+
                 # 计算 dv_chunk = A_chunk @ du_chunk * beta_chunk
                 # 步骤1: b_dv_beta = A_chunk @ du_chunk
-                b_dv_beta = torch.matmul(A_chunk.T.to(torch.float32), du_chunk.to(torch.float32))  # [chunk_size, V]
-                
+                b_dv_beta = torch.matmul(A_chunk.T, du_chunk)  # [chunk_size, V]
+
                 # 步骤2: dv_chunk = b_dv_beta * beta_chunk.unsqueeze(-1)
-                dv_chunk = b_dv_beta.to(torch.float32) * beta_chunk[:, None].to(torch.float32)  # [chunk_size, D]
-                
+                dv_chunk = b_dv_beta * beta_chunk[:, None]  # [chunk_size, D]
+
                 # 存储结果
                 dv[i_b,i_h, bos:eos, :] = dv_chunk.to(dv.dtype)
-    
+
     return dv
 
-
-def compute_dk_golden(
-    A: torch.Tensor,      # [B, T, H, chunk_size] - 每个chunk的A值
-    dw: torch.Tensor,     # [B, T, H, D]
-    g: torch.Tensor,     # [B, H, T]
-    beta: torch.Tensor,   # [B, H, T] - beta参数
-    dA: torch.Tensor,      # [B, T, H, chunk_size]
-    k: torch.Tensor,     # [B, T, H, D]
+def compute_dv_golden_high_precision(
+    A: torch.Tensor,      # [B, T, VH, chunk_size] - 每个chunk的A值
+    du: torch.Tensor,     # [B, T, VH, D] - 上游梯度
+    beta: torch.Tensor,   # [B, VH, T] - beta参数
     cu_seqlens: torch.Tensor,
     chunk_indices: torch.Tensor,
     B: int,
-    H: int,
+    VH: int,
     T: int,
     D: int,
     chunk_size: int,  # chunk_size
@@ -97,34 +99,96 @@ def compute_dk_golden(
 ) -> torch.Tensor:
     """
     CPU golden implementation for dv computation (变长序列)
-    A的形状为 [B, T, H, chunk_size]
+    A的形状为 [B, T, VH, chunk_size]
+    算法:
+    1. 对于每个chunk (由chunk_indices指定)
+    2. 获取对应的seq_idx, chunk_indices
+    3. 计算该chunk内的dv: dv_chunk = A_chunk @ du_chunk * beta_chunk
+    """
+    # 初始化dv，形状与du相同 [B, T, VH, D]
+    dv = torch.zeros_like(du).to(torch.float64)
+    for i_b in range(B):
+        for idx in range(NT):
+            bos,eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
+            # print(bos, eos, eos-bos)
+        # 遍历所有batch
+            for i_h in range(VH):
+
+            # 遍历所有head
+                # 获取当前chunk的A向量
+                # A形状: [B, T, VH, chunk_size]
+                # 我们需要获取这个chunk对应的A向量
+                # 注意: A的每个位置存储的是该chunk对应的A向量
+                A_chunk = A[i_b,i_h, bos:eos,:eos - bos]  # [chunk_size, chunk_size]
+
+                # 获取当前chunk的du
+                du_chunk = du[i_b,i_h, bos:eos, :]  # [chunk_size, V]
+
+                # 获取当前chunk的beta
+                beta_chunk = beta[i_b,i_h, bos:eos]  # [chunk_size]
+
+                # 计算 dv_chunk = A_chunk @ du_chunk * beta_chunk
+                # 步骤1: b_dv_beta = A_chunk @ du_chunk
+                b_dv_beta = torch.matmul(A_chunk.T.to(torch.float64), du_chunk.to(torch.float64))  # [chunk_size, V]
+
+                # 步骤2: dv_chunk = b_dv_beta * beta_chunk.unsqueeze(-1)
+                dv_chunk = b_dv_beta.to(torch.float64) * beta_chunk[:, None].to(torch.float64)  # [chunk_size, D]
+
+                # 存储结果
+                dv[i_b,i_h, bos:eos, :] = dv_chunk.to(dv.dtype)
+
+    return dv
+
+def compute_dk_golden(
+    A: torch.Tensor,      # [B, T, VH, chunk_size] - 每个chunk的A值
+    dw: torch.Tensor,     # [B, T, KH, D]
+    g: torch.Tensor,     # [B, VH, T]
+    beta: torch.Tensor,   # [B, VH, T] - beta参数
+    dA: torch.Tensor,      # [B, T, VH, chunk_size]
+    k: torch.Tensor,     # [B, T, KH, D]
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    B: int,
+    KH: int,
+    VH: int,
+    T: int,
+    D: int,
+    chunk_size: int,  # chunk_size
+    NT: int,  # T / chunk_size
+) -> torch.Tensor:
+    """
+    CPU golden implementation for dk computation (变长序列)
+    A的形状为 [B, T, VH, chunk_size]
+    k/dw使用KH head, 其余使用VH head
     算法:
     1. 对于每个chunk (由chunk_indices指定)
     2. 获取对应的seq_idx, chunk_indices
     3. 计算该chunk内的dv: dv_chunk = A_chunk @ du_chunk * beta_chunk
     """
     dk = torch.zeros_like(k)
+    ratio = VH // KH
     for i_b in range(B):
         for idx in range(NT):
             bos,eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
         # 遍历所有batch
-            for i_h in range(H):
-            # 遍历所有head 
+            for i_h in range(VH):
+            # 遍历所有head
+                i_h_k = i_h // ratio
                 # 获取当前chunk的A向量
-                # A形状: [B, T, H, chunk_size]
+                # A形状: [B, T, VH, chunk_size]
                 # 我们需要获取这个chunk对应的A向量
                 # 注意: A的每个位置存储的是该chunk对应的A向量
                 A_chunk = A[i_b,i_h, bos:eos,: eos - bos]  # [chunk_size, chunk_size]
-                
+
                 # 获取当前chunk的dw
-                dw_chunk = dw[i_b,i_h, bos:eos, :]  # [chunk_size, D]
-           
+                dw_chunk = dw[i_b,i_h_k, bos:eos, :]  # [chunk_size, D]
+
                 # 获取当前chunk的beta,g
                 beta_chunk = beta[i_b,i_h, bos:eos]  # [chunk_size]
                 g_chunk = g[i_b,i_h, bos:eos]  # [chunk_size]
                 g_exp_chunk = torch.exp(g_chunk.to(torch.float32))
                 #   k________0
-                k_chunk = k[i_b, i_h, bos:eos, : ]
+                k_chunk = k[i_b, i_h_k, bos:eos, : ]
                 dA_chunk = dA[i_b,i_h, bos:eos,:eos-bos]  # [chunk_size, chunk_size]
                 b_dk_beta = torch.matmul(dA_chunk.T.to(torch.float32), k_chunk.to(torch.float32))  # [chunk_size, D]
                 #   k________1
@@ -133,164 +197,394 @@ def compute_dk_golden(
                 #   k________2
                 # 步骤1: b_dk_beta_g = A_chunk @ dw_chunk
                 b_dk_beta_g = torch.matmul(A_chunk.T.to(torch.float32), dw_chunk.to(torch.float32))  # [chunk_size, D]
-                
-                # 步骤2: dk_chunk = b_dk_beta_g * beta_chunk[:, None] * g_exp_chunk[:, None] 
+
+                # 步骤2: dk_chunk = b_dk_beta_g * beta_chunk[:, None] * g_exp_chunk[:, None]
                 dk_chunk = torch.matmul(dA_chunk.to(torch.float32), b_k_beta.to(k.dtype).to(torch.float32)).to(k.dtype).to(torch.float32)  # [chunk_size, D]
                 dk_chunk = dk_chunk.to(k.dtype).to(torch.float32) + (b_dk_beta.to(k.dtype).to(torch.float32) * beta_chunk[:, None].to(torch.float32))
                 dk_chunk = dk_chunk.to(k.dtype).to(torch.float32) + b_dk_beta_g.to(k.dtype).to(torch.float32) * (beta_chunk.to(torch.float32) * g_exp_chunk.to(torch.float32))[:,None]  # [chunk_size, D]
                 # 存储结果
-                dk[i_b,i_h, bos:eos, :] = dk_chunk
+                dk[i_b,i_h_k, bos:eos, :] += dk_chunk
     return dk
 
-def compute_dg_golden(
-    A: torch.Tensor,      # [B, T, H, chunk_size] - 每个chunk的A值
-    dw: torch.Tensor,     # [B, T, H, D]
-    g: torch.Tensor,     # [B, H, T]
-    beta: torch.Tensor,   # [B, H, T] - beta参数
-    dA: torch.Tensor,      # [B, T, H, chunk_size]
-    k: torch.Tensor,     # [B, T, H, D]
+def compute_dk_golden_high_precision(
+    A: torch.Tensor,      # [B, T, VH, chunk_size] - 每个chunk的A值
+    dw: torch.Tensor,     # [B, T, KH, D]
+    g: torch.Tensor,     # [B, VH, T]
+    beta: torch.Tensor,   # [B, VH, T] - beta参数
+    dA: torch.Tensor,      # [B, T, VH, chunk_size]
+    k: torch.Tensor,     # [B, T, KH, D]
     cu_seqlens: torch.Tensor,
     chunk_indices: torch.Tensor,
     B: int,
-    H: int,
+    KH: int,
+    VH: int,
     T: int,
     D: int,
     chunk_size: int,  # chunk_size
     NT: int,  # T / chunk_size
 ) -> torch.Tensor:
     """
-    CPU golden implementation for dv computation (变长序列)
-    A的形状为 [B, T, H, chunk_size]
+    CPU golden implementation for dk computation (变长序列)
+    A的形状为 [B, T, VH, chunk_size]
+    k/dw使用KH head, 其余使用VH head
+    算法:
+    1. 对于每个chunk (由chunk_indices指定)
+    2. 获取对应的seq_idx, chunk_indices
+    3. 计算该chunk内的dv: dv_chunk = A_chunk @ du_chunk * beta_chunk
+    """
+    dk = torch.zeros_like(k).to(torch.float64)
+    ratio = VH // KH
+    for i_b in range(B):
+        for idx in range(NT):
+            bos,eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
+        # 遍历所有batch
+            for i_h in range(VH):
+            # 遍历所有head
+                i_h_k = i_h // ratio
+                # 获取当前chunk的A向量
+                # A形状: [B, T, VH, chunk_size]
+                # 我们需要获取这个chunk对应的A向量
+                # 注意: A的每个位置存储的是该chunk对应的A向量
+                A_chunk = A[i_b,i_h, bos:eos,: eos - bos]  # [chunk_size, chunk_size]
+
+                # 获取当前chunk的dw
+                dw_chunk = dw[i_b,i_h_k, bos:eos, :]  # [chunk_size, D]
+
+                # 获取当前chunk的beta,g
+                beta_chunk = beta[i_b,i_h, bos:eos]  # [chunk_size]
+                g_chunk = g[i_b,i_h, bos:eos]  # [chunk_size]
+                g_exp_chunk = torch.exp(g_chunk.to(torch.float64))
+                #   k________0
+                k_chunk = k[i_b, i_h_k, bos:eos, : ]
+                dA_chunk = dA[i_b,i_h, bos:eos,:eos-bos]  # [chunk_size, chunk_size]
+                b_dk_beta = torch.matmul(dA_chunk.T.to(torch.float64), k_chunk.to(torch.float64))  # [chunk_size, D]
+                #   k________1
+                b_kt_beta = k_chunk.T.to(torch.float64) * beta_chunk.to(torch.float64)[None,: ]
+                b_k_beta = k_chunk.to(torch.float64) * beta_chunk.to(torch.float64)[:, None]
+                #   k________2
+                # 步骤1: b_dk_beta_g = A_chunk @ dw_chunk
+                b_dk_beta_g = torch.matmul(A_chunk.T.to(torch.float64), dw_chunk.to(torch.float64))  # [chunk_size, D]
+
+                # 步骤2: dk_chunk = b_dk_beta_g * beta_chunk[:, None] * g_exp_chunk[:, None]
+                dk_chunk = torch.matmul(dA_chunk.to(torch.float64), b_k_beta.to(k.dtype).to(torch.float64)).to(k.dtype).to(torch.float64)  # [chunk_size, D]
+                dk_chunk = dk_chunk.to(k.dtype).to(torch.float64) + (b_dk_beta.to(k.dtype).to(torch.float64) * beta_chunk[:, None].to(torch.float64))
+                dk_chunk = dk_chunk.to(k.dtype).to(torch.float64) + b_dk_beta_g.to(k.dtype).to(torch.float64) * (beta_chunk.to(torch.float64) * g_exp_chunk.to(torch.float64))[:,None]  # [chunk_size, D]
+                # 存储结果
+                dk[i_b,i_h_k, bos:eos, :] += dk_chunk
+    return dk
+
+def compute_dg_golden(
+    A: torch.Tensor,      # [B, T, VH, chunk_size] - 每个chunk的A值
+    dw: torch.Tensor,     # [B, T, KH, D]
+    g: torch.Tensor,     # [B, VH, T]
+    beta: torch.Tensor,   # [B, VH, T] - beta参数
+    dA: torch.Tensor,      # [B, T, VH, chunk_size]
+    k: torch.Tensor,     # [B, T, KH, D]
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    B: int,
+    KH: int,
+    VH: int,
+    T: int,
+    D: int,
+    chunk_size: int,  # chunk_size
+    NT: int,  # T / chunk_size
+) -> torch.Tensor:
+    """
+    CPU golden implementation for dg computation (变长序列)
+    A的形状为 [B, T, VH, chunk_size]
+    k/dw使用KH head, 其余使用VH head
     算法:
     1. 对于每个chunk (由chunk_indices指定)
     2. 获取对应的seq_idx, chunk_indices
     3. 计算该chunk内的dv: dv_chunk = A_chunk @ du_chunk * beta_chunk
     """
     dg = torch.zeros_like(g)
+    ratio = VH // KH
     for i_b in range(B):
         for idx in range(NT):
             bos,eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
         # 遍历所有batch
-            for i_h in range(H):
+            for i_h in range(VH):
 
-            # 遍历所有head 
+            # 遍历所有head
+                i_h_k = i_h // ratio
                 # 获取当前chunk的A向量
-                # A形状: [B, T, H, chunk_size]
+                # A形状: [B, T, VH, chunk_size]
                 # 我们需要获取这个chunk对应的A向量
                 # 注意: A的每个位置存储的是该chunk对应的A向量
                 A_chunk = A[i_b,i_h, bos:eos,: eos - bos]  # [chunk_size, chunk_size]
-                
+
                 # 获取当前chunk的dw
-                dw_chunk = dw[i_b,i_h, bos:eos, :]  # [chunk_size, D]
-            
+                dw_chunk = dw[i_b,i_h_k, bos:eos, :]  # [chunk_size, D]
+
                 # 获取当前chunk的beta,g
-                # beta形状: [B, H, T]
+                # beta形状: [B, VH, T]
                 beta_chunk = beta[i_b,i_h, bos:eos]  # [chunk_size]
                 g_chunk = g[i_b,i_h, bos:eos]  # [chunk_size]
-                g_exp_chunk = torch.exp(g_chunk.to(torch.float32))
-                
+                g_exp_chunk = torch.exp(g_chunk)
+
                 #   g________0
                 # 步骤1: b_dk_beta_g = A_chunk @ dw_chunk
-                b_dk_beta_g = torch.matmul(A_chunk.T.to(torch.float32), dw_chunk.to(torch.float32))  
- 
+                b_dk_beta_g = torch.matmul(A_chunk.T, dw_chunk)
+
                 # 步骤2: b_dg += tl.sum(b_dk_beta_g * b_k * b_g_exp[:, None] * b_beta[:, None], 1)
-                k_chunk = k[i_b, i_h, bos:eos, : ]
-                b_kbg = k_chunk.to(torch.float32) * (beta_chunk.to(torch.float32) * g_exp_chunk.to(torch.float32))[:,None]
-                #   g________1 
+                k_chunk = k[i_b, i_h_k, bos:eos, : ]
+                b_kbg = k_chunk * (beta_chunk * g_exp_chunk)[:,None]
+                #   g________1
                 dA_chunk = dA[i_b,i_h, bos:eos,: eos - bos]  # [chunk_size, chunk_size]
                 if k_chunk.size(0) == 1:
                     # 形状 [1, K] -> 计算外积等价于平方和
                     # 结果应为 [1, 1]
-                    dot_val = torch.sum(k_chunk.to(torch.float32) * k_chunk.to(torch.float32), dim=1, keepdim=True)  # [1, 1]
+                    dot_val = torch.sum(k_chunk * k_chunk, dim=1, keepdim=True)  # [1, 1]
                     b_A = dot_val
                 else:
                     # 正常走 matmul 路径
-                    k_f32 = k_chunk.to(torch.float32).contiguous()
+                    k_f32 = k_chunk.contiguous()
                     b_A = torch.matmul(k_f32, k_f32.T.contiguous())
-                # b_A = torch.matmul(k_chunk.to(torch.float32).contiguous(), k_chunk.to(torch.float32).T).to(k.dtype).to(torch.float32).contiguous()  # [chunk_size, chunk_size]
-                b_A = b_A.to(torch.float32) * beta_chunk[:,None].to(torch.float32)
-                b_dA_A = dA_chunk.to(torch.float32).T * b_A.to(torch.float32)
+                b_A = b_A * beta_chunk[:,None]
+                b_dA_A = dA_chunk.T * b_A
 
                 # test
-                dg_chunk = torch.sum(b_dk_beta_g.to(k.dtype).to(torch.float32) * b_kbg.to(torch.float32), dim = 1)# [chunk_size]
-                dg_chunk = dg_chunk.to(dg.dtype).to(torch.float32) +  (torch.sum(b_dA_A, dim = 1) - torch.sum(b_dA_A, dim = 0))
+                dg_chunk = torch.sum(b_dk_beta_g.to(dg.dtype) * b_kbg.to(dg.dtype), dim = 1)# [chunk_size]
+                dg_chunk = dg_chunk.to(dg.dtype) +  (torch.sum(b_dA_A, dim = 1) - torch.sum(b_dA_A, dim = 0)).to(dg.dtype)
                 # 存储结果
-                dg[i_b,i_h, bos:eos] = dg_chunk.to(k.dtype)
+                dg[i_b,i_h, bos:eos] = dg_chunk.to(g.dtype)
     return dg
 
-def compute_dbeta_golden(
-    A: torch.Tensor,      # [B, T, H, chunkSize] - 每个chunk的A值
-    dw: torch.Tensor,     # [B, T, H, D]
-    g: torch.Tensor,     # [B, H, T]
-    beta: torch.Tensor,   # [B, H, T] - beta参数
-    dA: torch.Tensor,      # [B, T, H, chunkSize]
-    k: torch.Tensor,     # [B, T, H, D]
-    v: torch.Tensor,      # [B, T, H, D]
-    du: torch.Tensor,     # [B, T, H, D]
+def compute_dg_golden_high_precision(
+    A: torch.Tensor,      # [B, T, VH, chunk_size] - 每个chunk的A值
+    dw: torch.Tensor,     # [B, T, KH, D]
+    g: torch.Tensor,     # [B, VH, T]
+    beta: torch.Tensor,   # [B, VH, T] - beta参数
+    dA: torch.Tensor,      # [B, T, VH, chunk_size]
+    k: torch.Tensor,     # [B, T, KH, D]
     cu_seqlens: torch.Tensor,
     chunk_indices: torch.Tensor,
     B: int,
-    H: int,
+    KH: int,
+    VH: int,
+    T: int,
+    D: int,
+    chunk_size: int,  # chunk_size
+    NT: int,  # T / chunk_size
+) -> torch.Tensor:
+    """
+    CPU golden implementation for dg computation (变长序列)
+    A的形状为 [B, T, VH, chunk_size]
+    k/dw使用KH head, 其余使用VH head
+    算法:
+    1. 对于每个chunk (由chunk_indices指定)
+    2. 获取对应的seq_idx, chunk_indices
+    3. 计算该chunk内的dv: dv_chunk = A_chunk @ du_chunk * beta_chunk
+    """
+    dg = torch.zeros_like(g).to(torch.float64)
+    ratio = VH // KH
+    for i_b in range(B):
+        for idx in range(NT):
+            bos,eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
+        # 遍历所有batch
+            for i_h in range(VH):
+
+            # 遍历所有head
+                i_h_k = i_h // ratio
+                # 获取当前chunk的A向量
+                # A形状: [B, T, VH, chunk_size]
+                # 我们需要获取这个chunk对应的A向量
+                # 注意: A的每个位置存储的是该chunk对应的A向量
+                A_chunk = A[i_b,i_h, bos:eos,: eos - bos]  # [chunk_size, chunk_size]
+
+                # 获取当前chunk的dw
+                dw_chunk = dw[i_b,i_h_k, bos:eos, :]  # [chunk_size, D]
+
+                # 获取当前chunk的beta,g
+                # beta形状: [B, VH, T]
+                beta_chunk = beta[i_b,i_h, bos:eos]  # [chunk_size]
+                g_chunk = g[i_b,i_h, bos:eos]  # [chunk_size]
+                g_exp_chunk = torch.exp(g_chunk.to(torch.float64))
+
+                #   g________0
+                # 步骤1: b_dk_beta_g = A_chunk @ dw_chunk
+                b_dk_beta_g = torch.matmul(A_chunk.T.to(torch.float64), dw_chunk.to(torch.float64))
+
+                # 步骤2: b_dg += tl.sum(b_dk_beta_g * b_k * b_g_exp[:, None] * b_beta[:, None], 1)
+                k_chunk = k[i_b, i_h_k, bos:eos, : ]
+                b_kbg = k_chunk.to(torch.float64) * (beta_chunk.to(torch.float64) * g_exp_chunk.to(torch.float64))[:,None]
+                #   g________1
+                dA_chunk = dA[i_b,i_h, bos:eos,: eos - bos]  # [chunk_size, chunk_size]
+                if k_chunk.size(0) == 1:
+                    # 形状 [1, K] -> 计算外积等价于平方和
+                    # 结果应为 [1, 1]
+                    dot_val = torch.sum(k_chunk.to(torch.float64) * k_chunk.to(torch.float64), dim=1, keepdim=True)  # [1, 1]
+                    b_A = dot_val
+                else:
+                    # 正常走 matmul 路径
+                    k_f32 = k_chunk.to(torch.float64).contiguous()
+                    b_A = torch.matmul(k_f32, k_f32.T.contiguous())
+                # b_A = torch.matmul(k_chunk.to(torch.float64).contiguous(), k_chunk.to(torch.float64).T).to(k.dtype).to(torch.float64).contiguous()  # [chunk_size, chunk_size]
+                b_A = b_A.to(torch.float64) * beta_chunk[:,None].to(torch.float64)
+                b_dA_A = dA_chunk.to(torch.float64).T * b_A.to(torch.float64)
+
+                # test
+                dg_chunk = torch.sum(b_dk_beta_g.to(k.dtype).to(torch.float64) * b_kbg.to(torch.float64), dim = 1)# [chunk_size]
+                dg_chunk = dg_chunk.to(dg.dtype).to(torch.float64) +  (torch.sum(b_dA_A, dim = 1) - torch.sum(b_dA_A, dim = 0))
+                # 存储结果
+                dg[i_b,i_h, bos:eos] = dg_chunk.to(dg.dtype)
+    return dg
+
+def compute_dbeta_golden(
+    A: torch.Tensor,      # [B, T, VH, chunkSize] - 每个chunk的A值
+    dw: torch.Tensor,     # [B, T, KH, D]
+    g: torch.Tensor,     # [B, VH, T]
+    beta: torch.Tensor,   # [B, VH, T] - beta参数
+    dA: torch.Tensor,      # [B, T, VH, chunkSize]
+    k: torch.Tensor,     # [B, T, KH, D]
+    v: torch.Tensor,      # [B, T, VH, D]
+    du: torch.Tensor,     # [B, T, VH, D]
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    B: int,
+    KH: int,
+    VH: int,
     T: int,
     D: int,
     chunkSize: int,  # chunkSize
     NT: int,  # T / chunkSize
 ) -> torch.Tensor:
     """
-    CPU golden implementation for dv computation (变长序列)
-    A的形状为 [B, T, H, chunkSize]
+    CPU golden implementation for dbeta computation (变长序列)
+    A的形状为 [B, T, VH, chunkSize]
+    k/dw使用KH head, 其余使用VH head
     算法:
     1. 对于每个chunk (由chunk_indices指定)
     2. 获取对应的seq_idx, chunk_indices
     3. 计算该chunk内的dv: dv_chunk = A_chunk @ du_chunk * beta_chunk
     """
     dbeta = torch.zeros_like(beta)
+    ratio = VH // KH
     for i_b in range(B):
         for idx in range(NT):
         # 遍历所有batch
             bos,eos = get_bos_eos(idx, T, chunkSize, cu_seqlens, chunk_indices)
-            for i_h in range(H):
-            # 遍历所有head 
+            for i_h in range(VH):
+            # 遍历所有head
+                i_h_k = i_h // ratio
                 # 获取当前chunk的A向量
-                # A形状: [B, T, H, chunkSize]
+                # A形状: [B, T, VH, chunkSize]
                 # 我们需要获取这个chunk对应的A向量
                 # 注意: A的每个位置存储的是该chunk对应的A向量
                 A_chunk = A[i_b,i_h, bos:eos,: eos - bos]  # [chunkSize, chunkSize]
                 v_chunk = v[i_b,i_h, bos:eos,:]  # [chunkSize, V]
-                
+
                 # 获取当前chunk的dw
-                dw_chunk = dw[i_b,i_h, bos:eos, :]  # [chunkSize, D]
+                dw_chunk = dw[i_b,i_h_k, bos:eos, :]  # [chunkSize, D]
                 du_chunk = du[i_b,i_h, bos:eos, :]  # [chunkSize, D]
 
 
                 # 获取当前chunk的beta,g
-                # beta形状: [B, H, T]
+                # beta形状: [B, VH, T]
                 beta_chunk = beta[i_b,i_h, bos:eos]  # [chunkSize]
                 g_chunk = g[i_b,i_h, bos:eos]  # [chunkSize]
-                g_exp_chunk = torch.exp(g_chunk.to(torch.float32))
-                k_chunk = k[i_b, i_h, bos:eos, : ]
+                g_exp_chunk = torch.exp(g_chunk)
+                k_chunk = k[i_b, i_h_k, bos:eos, : ]
                 #   beta________0
                 # 步骤1: b_dk_beta_g = A_chunk @ dw_chunk
-                b_dk_beta_g = torch.matmul(A_chunk.T.to(torch.float32), dw_chunk.to(torch.float32))  
-                
+                b_dk_beta_g = torch.matmul(A_chunk.T, dw_chunk)
+
                 # 步骤2: b_dbeta += tl.sum(b_dk_beta_g * b_k * b_g_exp[:, None], 1)
-                tmp = b_dk_beta_g * k_chunk.to(torch.float32) * g_exp_chunk.to(torch.float32)[:, None] # [chunkSize, D]
-                #   beta________1 
-                
-                b_dv_beta = torch.matmul(A_chunk.T.to(torch.float32), du_chunk.to(torch.float32))  # [chunkSize, V]
-                #   beta________2 
+                tmp = b_dk_beta_g * k_chunk * g_exp_chunk[:, None] # [chunkSize, D]
+                #   beta________1
+
+                b_dv_beta = torch.matmul(A_chunk.T, du_chunk)  # [chunkSize, V]
+                #   beta________2
                 dA_chunk = dA[i_b,i_h, bos:eos,: eos - bos]  # [chunkSize, chunkSize]
-                b_dk_beta = torch.matmul(dA_chunk.T.to(torch.float32), k_chunk.to(torch.float32))  # [chunkSize, V]
-                tmp = b_dk_beta.to(k.dtype).to(torch.float32) * k_chunk
+                b_dk_beta = torch.matmul(dA_chunk.T, k_chunk)  # [chunkSize, V]
+                tmp = b_dk_beta.to(k.dtype) * k_chunk
                 # test
-                dbeta_chunk = torch.sum(tmp, 1).to(torch.float16)
-                tmp = b_dk_beta_g.to(k.dtype).to(torch.float32) * k_chunk.to(torch.float32) * g_exp_chunk.to(torch.float32)[:, None] # [chunkSize, D]
-                dbeta_chunk = dbeta_chunk.to(k.dtype).to(torch.float32) + torch.sum(tmp, dim = 1)# [chunkSize]
-                dbeta_chunk = dbeta_chunk.to(k.dtype).to(torch.float32) + torch.sum(b_dv_beta.to(k.dtype).to(torch.float32) * v_chunk, 1)
+                dbeta_chunk = torch.sum(tmp, 1)
+                tmp = b_dk_beta_g.to(k.dtype) * k_chunk * g_exp_chunk[:, None] # [chunkSize, D]
+                dbeta_chunk = dbeta_chunk.to(k.dtype) + torch.sum(tmp, dim = 1)# [chunkSize]
+                dbeta_chunk = dbeta_chunk.to(k.dtype) + torch.sum(b_dv_beta.to(k.dtype) * v_chunk, 1)
                 # 存储结果
                 dbeta[i_b,i_h, bos:eos] = dbeta_chunk
     return dbeta
 
+def compute_dbeta_golden_high_precision(
+    A: torch.Tensor,      # [B, T, VH, chunkSize] - 每个chunk的A值
+    dw: torch.Tensor,     # [B, T, KH, D]
+    g: torch.Tensor,     # [B, VH, T]
+    beta: torch.Tensor,   # [B, VH, T] - beta参数
+    dA: torch.Tensor,      # [B, T, VH, chunkSize]
+    k: torch.Tensor,     # [B, T, KH, D]
+    v: torch.Tensor,      # [B, T, VH, D]
+    du: torch.Tensor,     # [B, T, VH, D]
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    B: int,
+    KH: int,
+    VH: int,
+    T: int,
+    D: int,
+    chunkSize: int,  # chunkSize
+    NT: int,  # T / chunkSize
+) -> torch.Tensor:
+    """
+    CPU golden implementation for dbeta computation (变长序列)
+    A的形状为 [B, T, VH, chunkSize]
+    k/dw使用KH head, 其余使用VH head
+    算法:
+    1. 对于每个chunk (由chunk_indices指定)
+    2. 获取对应的seq_idx, chunk_indices
+    3. 计算该chunk内的dv: dv_chunk = A_chunk @ du_chunk * beta_chunk
+    """
+    dbeta = torch.zeros_like(beta).to(torch.float64)
+    ratio = VH // KH
+    for i_b in range(B):
+        for idx in range(NT):
+        # 遍历所有batch
+            bos,eos = get_bos_eos(idx, T, chunkSize, cu_seqlens, chunk_indices)
+            for i_h in range(VH):
+            # 遍历所有head
+                i_h_k = i_h // ratio
+                # 获取当前chunk的A向量
+                # A形状: [B, T, VH, chunkSize]
+                # 我们需要获取这个chunk对应的A向量
+                # 注意: A的每个位置存储的是该chunk对应的A向量
+                A_chunk = A[i_b,i_h, bos:eos,: eos - bos]  # [chunkSize, chunkSize]
+                v_chunk = v[i_b,i_h, bos:eos,:]  # [chunkSize, V]
+
+                # 获取当前chunk的dw
+                dw_chunk = dw[i_b,i_h_k, bos:eos, :]  # [chunkSize, D]
+                du_chunk = du[i_b,i_h, bos:eos, :]  # [chunkSize, D]
+
+
+                # 获取当前chunk的beta,g
+                # beta形状: [B, VH, T]
+                beta_chunk = beta[i_b,i_h, bos:eos]  # [chunkSize]
+                g_chunk = g[i_b,i_h, bos:eos]  # [chunkSize]
+                g_exp_chunk = torch.exp(g_chunk.to(torch.float64))
+                k_chunk = k[i_b, i_h_k, bos:eos, : ]
+                #   beta________0
+                # 步骤1: b_dk_beta_g = A_chunk @ dw_chunk
+                b_dk_beta_g = torch.matmul(A_chunk.T.to(torch.float64), dw_chunk.to(torch.float64))
+
+                # 步骤2: b_dbeta += tl.sum(b_dk_beta_g * b_k * b_g_exp[:, None], 1)
+                tmp = b_dk_beta_g * k_chunk.to(torch.float64) * g_exp_chunk.to(torch.float64)[:, None] # [chunkSize, D]
+                #   beta________1
+
+                b_dv_beta = torch.matmul(A_chunk.T.to(torch.float64), du_chunk.to(torch.float64))  # [chunkSize, V]
+                #   beta________2
+                dA_chunk = dA[i_b,i_h, bos:eos,: eos - bos]  # [chunkSize, chunkSize]
+                b_dk_beta = torch.matmul(dA_chunk.T.to(torch.float64), k_chunk.to(torch.float64))  # [chunkSize, V]
+                tmp = b_dk_beta.to(k.dtype).to(torch.float64) * k_chunk
+                # test
+                dbeta_chunk = torch.sum(tmp, 1).to(torch.float64)
+                tmp = b_dk_beta_g.to(k.dtype).to(torch.float64) * k_chunk.to(torch.float64) * g_exp_chunk.to(torch.float64)[:, None] # [chunkSize, D]
+                dbeta_chunk = dbeta_chunk.to(k.dtype).to(torch.float64) + torch.sum(tmp, dim = 1)# [chunkSize]
+                dbeta_chunk = dbeta_chunk.to(k.dtype).to(torch.float64) + torch.sum(b_dv_beta.to(k.dtype).to(torch.float64) * v_chunk, 1)
+                # 存储结果
+                dbeta[i_b,i_h, bos:eos] = dbeta_chunk
+    return dbeta
 
 def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
     return cu_seqlens[1:] - cu_seqlens[:-1]
@@ -386,7 +680,8 @@ def prepare_chunk_indices(
 
 def test_prepare_wy_repr_bwd_full(
     B: int,
-    H: int,
+    KH: int,
+    VH: int,
     T: int,
     K: int,
     V: int,
@@ -402,7 +697,8 @@ def test_prepare_wy_repr_bwd_full(
 
     参数:
         B (int): Batch size
-        H (int): Head number
+        KH (int): Key head number
+        VH (int): Value head number
         T (int): Sequence length
         K (int): Key dimension
         V (int): Value dimension
@@ -420,18 +716,18 @@ def test_prepare_wy_repr_bwd_full(
         test_prepare_wy_repr_bwd_full.call_count += 1
 
     # 生成随机张量（float16）
-    k = torch.rand(B, H, T, K, dtype=ktype)
-    v = torch.rand(B, H, T, V, dtype=ktype)
-    beta = torch.rand(B, H, T, dtype=btype)
-    A = torch.rand(B, H, T, chunk_size, dtype=ktype)
-    dA = torch.rand(B, H, T, chunk_size, dtype=ktype)
-    dw = torch.rand(B, H, T, K, dtype=ktype)
-    du = torch.rand(B, H, T, V, dtype=ktype)
-    g = torch.rand(B, H, T, dtype=btype)
+    k = torch.rand(B, KH, T, K, dtype=ktype)
+    v = torch.rand(B, VH, T, V, dtype=ktype)
+    beta = torch.rand(B, VH, T, dtype=btype)
+    A = torch.rand(B, VH, T, chunk_size, dtype=ktype)
+    dA = torch.rand(B, VH, T, chunk_size, dtype=ktype)
+    dw = torch.rand(B, KH, T, K, dtype=ktype)
+    du = torch.rand(B, VH, T, V, dtype=ktype)
+    g = torch.rand(B, VH, T, dtype=btype)
 
     # 将张量移到 NPU 并调用反向算子
     if chunk_indices != None:
-        dk, dv, dbeta, dg = torch_npu.npu_prepare_wy_repr_bwd_full(
+        dk, dv, dbeta, dg = torch.ops.npu.npu_prepare_wy_repr_bwd_full(
             k.npu(),
             v.npu(),
             beta.npu(),
@@ -445,7 +741,7 @@ def test_prepare_wy_repr_bwd_full(
             chunk_size=chunk_size
         )
     else:
-        dk, dv, dbeta, dg = torch_npu.npu_prepare_wy_repr_bwd_full(
+        dk, dv, dbeta, dg = torch.ops.npu.npu_prepare_wy_repr_bwd_full(
             k.npu(),
             v.npu(),
             beta.npu(),
@@ -462,83 +758,119 @@ def test_prepare_wy_repr_bwd_full(
         NT = len(chunk_indices) // 2
     else:
         NT = (T + chunk_size - 1) // chunk_size
-    # cpu_dv = compute_dv_golden(A, du, beta, cu_seqlens, chunk_indices, B, H, T, K, chunk_size, NT)
-    # ct.isclose(dv.cpu(), cpu_dv.cpu(), diff_thd=0.1)
-    # # torch.save(cpu_dv, "cpu_dv.pt")
     
-    # cpu_dk = compute_dk_golden(A, dw, g, beta, dA,k, cu_seqlens, chunk_indices, B, H, T, K, chunk_size, NT)
-    # ct.isclose(dk, cpu_dk, diff_thd=0.1)
-    # # torch.save(cpu_dk, "cpu_dk.pt")
-    
-    # cpu_dg = compute_dg_golden(A, dw, g, beta, dA,k, cu_seqlens, chunk_indices, B, H, T, K, chunk_size, NT)
-    # ct.isclose(dg, cpu_dg, diff_thd=0.1)
-    # # torch.save(cpu_dg, "cpu_dg.pt")
-    
-    # cpu_dbeta = compute_dbeta_golden(A, dw, g, beta, dA,k,v,du, cu_seqlens, chunk_indices, B, H, T, K, chunk_size, NT)
-    # ct.isclose(dbeta, cpu_dbeta, diff_thd=0.1)
-    # # torch.save(cpu_dbeta, "cpu_dbeta.pt") 
+    try:
+        import ct
+        cpu_dv = compute_dv_golden(A, du, beta, cu_seqlens, chunk_indices, B, VH, T, K, chunk_size, NT)
+        cpu_dv_high_precision = compute_dv_golden_high_precision(A, du, beta, cu_seqlens, chunk_indices, B, VH, T, K, chunk_size, NT)
+        ct.dual(dv.cpu(), cpu_dv_high_precision, cpu_dv)
+        cpu_dk = compute_dk_golden(A, dw, g, beta, dA,k, cu_seqlens, chunk_indices, B, KH, VH, T, K, chunk_size, NT)
+        cpu_dk_high_precision = compute_dk_golden_high_precision(A, dw, g, beta, dA,k, cu_seqlens, chunk_indices, B, KH, VH, T, K, chunk_size, NT)
+        ct.dual(dk.cpu(), cpu_dk_high_precision, cpu_dk)
+        cpu_dg = compute_dg_golden(A, dw, g, beta, dA,k, cu_seqlens, chunk_indices, B, KH, VH, T, K, chunk_size, NT)
+        cpu_dg_high_precision = compute_dg_golden_high_precision(A, dw, g, beta, dA,k, cu_seqlens, chunk_indices, B, KH, VH, T, K, chunk_size, NT)
+        ct.dual(dg.cpu(), cpu_dg_high_precision, cpu_dg)
+        cpu_dbeta = compute_dbeta_golden(A, dw, g, beta, dA,k,v,du, cu_seqlens, chunk_indices, B, KH, VH, T, K, chunk_size, NT)
+        cpu_dbeta_high_precision = compute_dbeta_golden_high_precision(A, dw, g, beta, dA,k,v,du, cu_seqlens, chunk_indices, B, KH, VH, T, K, chunk_size, NT)
+        ct.dual(dbeta.cpu(), cpu_dbeta_high_precision, cpu_dbeta)
+    finally:
+        pass
     
     print(f"test_prepare_wy_repr_bwd_full 被调用了第 {test_prepare_wy_repr_bwd_full.call_count} 次")
     return dk, dv, dbeta, dg
 
 if __name__ == "__main__":
     # #F1
-    # test_prepare_wy_repr_bwd_full(B = 64, H = 8, T = 1024, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16)
+    # test_prepare_wy_repr_bwd_full(B = 64, KH = 8, VH = 8, T = 1024, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16)
     # #F2
-    # test_prepare_wy_repr_bwd_full(B = 32, H = 16, T = 2048, K = 128, V = 128, chunk_size = 64, ktype=torch.bfloat16, btype=torch.bfloat16)
+    # test_prepare_wy_repr_bwd_full(B = 32, KH = 16, VH = 16, T = 2048, K = 128, V = 128, chunk_size = 64, ktype=torch.bfloat16, btype=torch.bfloat16)
     # #F3
-    # test_prepare_wy_repr_bwd_full(B = 16, H = 32, T = 4096, K = 128, V = 128, chunk_size = 128, ktype=torch.float16, btype=torch.float32)
+    # test_prepare_wy_repr_bwd_full(B = 16, KH = 32, VH = 32, T = 4096, K = 128, V = 128, chunk_size = 128, ktype=torch.float16, btype=torch.float32)
     # #F4
-    # test_prepare_wy_repr_bwd_full(B = 8, H = 32, T = 8192, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.bfloat16)
+    # test_prepare_wy_repr_bwd_full(B = 8, KH = 32, VH = 32, T = 8192, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.bfloat16)
     # #F5
-    # test_prepare_wy_repr_bwd_full(B = 128, H = 4, T = 1024, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16)
+    # test_prepare_wy_repr_bwd_full(B = 128, KH = 4, VH = 4, T = 1024, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16)
     # #F6
-    # test_prepare_wy_repr_bwd_full(B = 64, H = 8, T = 2048, K = 128, V = 128, chunk_size = 64, ktype=torch.bfloat16, btype=torch.float32)
+    # test_prepare_wy_repr_bwd_full(B = 64, KH = 8, VH = 8, T = 2048, K = 128, V = 128, chunk_size = 64, ktype=torch.bfloat16, btype=torch.float32)
     # #F7
-    # test_prepare_wy_repr_bwd_full(B = 32, H = 16, T = 4096, K = 128, V = 128, chunk_size = 128, ktype=torch.float16, btype=torch.float16)
-    # #F8    
-    # test_prepare_wy_repr_bwd_full(B = 16, H = 32, T = 8192, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.bfloat16)
+    # test_prepare_wy_repr_bwd_full(B = 32, KH = 16, VH = 16, T = 4096, K = 128, V = 128, chunk_size = 128, ktype=torch.float16, btype=torch.float16)
+    # #F8
+    # test_prepare_wy_repr_bwd_full(B = 16, KH = 32, VH = 32, T = 8192, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.bfloat16)
     # #F9
-    # test_prepare_wy_repr_bwd_full(B = 64, H = 8, T = 4096, K = 128, V = 128, chunk_size = 128, ktype=torch.float16, btype=torch.float16)
+    # test_prepare_wy_repr_bwd_full(B = 64, KH = 8, VH = 8, T = 4096, K = 128, V = 128, chunk_size = 128, ktype=torch.float16, btype=torch.float16)
     # #F10
-    # test_prepare_wy_repr_bwd_full(B = 32, H = 16, T = 8192, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.bfloat16)
+    # test_prepare_wy_repr_bwd_full(B = 32, KH = 16, VH = 16, T = 8192, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.bfloat16)
     # #F11
-    # test_prepare_wy_repr_bwd_full(B = 16, H = 32, T = 16384, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float32)
+    # test_prepare_wy_repr_bwd_full(B = 16, KH = 32, VH = 32, T = 16384, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float32)
     # #F12
-    # test_prepare_wy_repr_bwd_full(B = 8, H = 32, T = 32768, K = 128, V = 128, chunk_size = 64, ktype=torch.bfloat16, btype=torch.bfloat16)
+    # test_prepare_wy_repr_bwd_full(B = 8, KH = 32, VH = 32, T = 32768, K = 128, V = 128, chunk_size = 64, ktype=torch.bfloat16, btype=torch.bfloat16)
     # #F13
-    # test_prepare_wy_repr_bwd_full(B = 64, H = 8, T = 1024, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16)
+    # test_prepare_wy_repr_bwd_full(B = 64, KH = 8, VH = 8, T = 1024, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16)
     # #F14
-    # test_prepare_wy_repr_bwd_full(B = 32, H = 16, T = 2048, K = 128, V = 128, chunk_size = 64, ktype=torch.bfloat16, btype=torch.bfloat16)
+    # test_prepare_wy_repr_bwd_full(B = 32, KH = 16, VH = 16, T = 2048, K = 128, V = 128, chunk_size = 64, ktype=torch.bfloat16, btype=torch.bfloat16)
     # #F15
-    # test_prepare_wy_repr_bwd_full(B = 16, H = 32, T = 4096, K = 128, V = 128, chunk_size = 128, ktype=torch.float16, btype=torch.float32)
+    # test_prepare_wy_repr_bwd_full(B = 16, KH = 32, VH = 32, T = 4096, K = 128, V = 128, chunk_size = 128, ktype=torch.float16, btype=torch.float32)
     # #F16
-    # test_prepare_wy_repr_bwd_full(B = 8, H = 32, T = 8192, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.bfloat16)
+    # test_prepare_wy_repr_bwd_full(B = 8, KH = 32, VH = 32, T = 8192, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.bfloat16)
     # #F17
-    # test_prepare_wy_repr_bwd_full(B = 64, H = 8, T = 2048, K = 128, V = 128, chunk_size = 64, ktype=torch.bfloat16, btype=torch.bfloat16)
+    # test_prepare_wy_repr_bwd_full(B = 64, KH = 8, VH = 8, T = 2048, K = 128, V = 128, chunk_size = 64, ktype=torch.bfloat16, btype=torch.bfloat16)
     # #F18
-    # test_prepare_wy_repr_bwd_full(B = 32, H = 16, T = 4096, K = 128, V = 128, chunk_size = 128, ktype=torch.float16, btype=torch.float16)
+    # test_prepare_wy_repr_bwd_full(B = 32, KH = 16, VH = 16, T = 4096, K = 128, V = 128, chunk_size = 128, ktype=torch.float16, btype=torch.float16)
     #L1
     cu_seqlens = prepare_cu_seqlens(T = 65536, L = 64)
     chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
-    test_prepare_wy_repr_bwd_full(B = 1, H = 32, T = 65536, K = 128, V = 128, chunk_size = 64, ktype=torch.bfloat16, btype=torch.bfloat16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    test_prepare_wy_repr_bwd_full(B = 1, KH = 32, VH = 32, T = 65536, K = 128, V = 128, chunk_size = 64, ktype=torch.bfloat16, btype=torch.bfloat16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
     # #L2
     # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 33)
     # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
-    # test_prepare_wy_repr_bwd_full(B = 1, H = 16, T = 65536, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    # test_prepare_wy_repr_bwd_full(B = 1, KH = 16, VH = 16, T = 65536, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
     # #L3
     # cu_seqlens = prepare_cu_seqlens(T = 131072, L = 333)
     # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
-    # test_prepare_wy_repr_bwd_full(B = 1, H = 8, T = 131072, K = 128, V = 128, chunk_size = 64, ktype=torch.bfloat16, btype=torch.bfloat16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    # test_prepare_wy_repr_bwd_full(B = 1, KH = 8, VH = 8, T = 131072, K = 128, V = 128, chunk_size = 64, ktype=torch.bfloat16, btype=torch.bfloat16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
     # # L4
     # cu_seqlens = prepare_cu_seqlens(T = 262144, L = 567)
     # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
-    # test_prepare_wy_repr_bwd_full(B = 1, H = 4, T = 262144, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float32, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    # test_prepare_wy_repr_bwd_full(B = 1, KH = 4, VH = 4, T = 262144, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float32, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
     # #L5
     # cu_seqlens = prepare_cu_seqlens(T = 32768, L = 7)
     # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
-    # test_prepare_wy_repr_bwd_full(B = 1, H = 16, T = 32768, K = 128, V = 128, chunk_size = 64, ktype=torch.bfloat16, btype=torch.bfloat16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    # test_prepare_wy_repr_bwd_full(B = 1, KH = 16, VH = 16, T = 32768, K = 128, V = 128, chunk_size = 64, ktype=torch.bfloat16, btype=torch.bfloat16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
     # #L6
     # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 25)
     # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
-    # test_prepare_wy_repr_bwd_full(B = 1, H = 8, T = 65536, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    # test_prepare_wy_repr_bwd_full(B = 1, KH = 8, VH = 8, T = 65536, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float16, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    
+    # # 二阶段泛化用例
+    # # L7
+    # cu_seqlens = prepare_cu_seqlens(T = 16384, L = 128)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
+    # test_prepare_wy_repr_bwd_full(B = 1, VH = 32, KH = 16, T = 16384, K = 128, V = 256, chunk_size = 64, ktype=torch.float16, btype=torch.float32, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    # # L8
+    # cu_seqlens = prepare_cu_seqlens(T = 16384, L = 2)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
+    # test_prepare_wy_repr_bwd_full(B = 1, VH = 63, KH = 21, T = 16384, K = 128, V = 256, chunk_size = 64, ktype=torch.bfloat16, btype=torch.float32, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    # # L9
+    # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 172)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 128)
+    # test_prepare_wy_repr_bwd_full(B = 1, VH = 32, KH = 8, T = 65536, K = 128, V = 256, chunk_size = 128, ktype=torch.bfloat16, btype=torch.float32, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    # # L10
+    # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 668)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
+    # test_prepare_wy_repr_bwd_full(B = 1, VH = 32, KH = 16, T = 65536, K = 128, V = 128, chunk_size = 64, ktype=torch.float16, btype=torch.float32, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    # # L11
+    # cu_seqlens = prepare_cu_seqlens(T = 65536, L = 17)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 128)
+    # test_prepare_wy_repr_bwd_full(B = 1, VH = 32, KH = 4, T = 65536, K = 128, V = 128, chunk_size = 128, ktype=torch.bfloat16, btype=torch.float32, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    # # L12
+    # cu_seqlens = prepare_cu_seqlens(T = 262144, L = 32)
+    # chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size = 64)
+    # test_prepare_wy_repr_bwd_full(B = 1, VH = 64, KH = 2, T = 262144, K = 128, V = 256, chunk_size = 64, ktype=torch.float16, btype=torch.float32, cu_seqlens = cu_seqlens, chunk_indices=chunk_indices)
+    # # F19
+    # test_prepare_wy_repr_bwd_full(B = 1, VH = 32, KH = 16, T = 4096, K = 128, V = 256, chunk_size = 64, ktype=torch.float16, btype=torch.float32)
+    # # F20
+    # test_prepare_wy_repr_bwd_full(B = 16, VH = 63, KH = 21, T = 2048, K = 128, V = 256, chunk_size = 64, ktype=torch.bfloat16, btype=torch.float32)
+    # # F21
+    # test_prepare_wy_repr_bwd_full(B = 711, VH = 32, KH = 4, T = 196, K = 128, V = 128, chunk_size = 128, ktype=torch.float16, btype=torch.float32)
+    # # F22
+    # test_prepare_wy_repr_bwd_full(B = 176, VH = 64, KH = 2, T = 24, K = 128, V = 256, chunk_size = 64, ktype=torch.bfloat16, btype=torch.float32)


### PR DESCRIPTION
modify test

# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [x] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @maoguolan
- 修改范围:
  - [x] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
