### PR TITLE
perf: optimize ChunkBwdDvLocal pipeline

### DIFF
--- a/examples/fast_kernel_launch_example/csrc/chunk_bwd_dv_local/ascend910b/chunk_bwd_dv_local.cpp
+++ b/examples/fast_kernel_launch_example/csrc/chunk_bwd_dv_local/ascend910b/chunk_bwd_dv_local.cpp
@@ -98,7 +98,6 @@ TilingData calc_tiling_params(const at::Tensor &q, const at::Tensor &k, const at
 }
 
 template <typename QKVT, typename GT, int V>
-template <typename QKVT, typename GT, int V>
 __global__ __aicore__ void chunk_bwd_dv_local_kernel(
     GM_ADDR q, GM_ADDR k, GM_ADDR d_o, GM_ADDR g,
     GM_ADDR cu_seqlens, GM_ADDR chunk_indices,

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_host/chunk_bwd_dv_local_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_host/chunk_bwd_dv_local_tiling_processor.h
@@ -54,6 +54,7 @@ static constexpr int64_t CHUNK_INDICES_DIM_1_SIZE = 2;
 static constexpr int64_t K_SIZE_128 = 128;
 static constexpr int64_t V_SIZE_128 = 128;
 static constexpr int64_t V_SIZE_256 = 256;
+static constexpr int64_t P1_SLOT_NUM = 3;
 
 static constexpr const char *const INPUT_Q_NAME = "q";
 static constexpr const char *const INPUT_K_NAME = "k";
@@ -184,7 +185,7 @@ public:
                             tiling_.hDo, tiling_.hQk),
                     return ge::GRAPH_FAILED);
         tiling_.hRatio = tiling_.hDo / tiling_.hQk;
-        tiling_.headBufNum = 2 + 2 * tiling_.hRatio;
+        tiling_.headBufNum = P1_SLOT_NUM * (1 + tiling_.hRatio);
         tiling_.t = static_cast<int64_t>(qStorageShape.GetDim(DIM_2));
         tiling_.k = static_cast<int64_t>(qStorageShape.GetDim(DIM_3));
         tiling_.v = static_cast<int64_t>(dOStorageShape.GetDim(DIM_3));
@@ -258,7 +259,7 @@ public:
         OP_CHECK_IF(CommonTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
         if (IsVariableLength()) {
             OP_CHECK_IF(tiling_.b != V_L_B,
-                        OP_LOGE(ctx_.nodeName, "B cannot be 1 when cu_seqlens is nullptr."),
+                        OP_LOGE(ctx_.nodeName, "B must be 1 when cu_seqlens is not nullptr."),
                         return ge::GRAPH_FAILED);
             OP_CHECK_IF(VariableLenTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
         } else {

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_cube.h
@@ -145,6 +145,10 @@ __aicore__ inline void ChunkBwdDvLocalCube<QKVT, GT, Strategy, V>::Process()
 
     IndexResult indexResult;
     int64_t coreBaseOffset = coreIdx * headBufNum * strategy.chunkSize * strategy.chunkSize;
+    int64_t p1SlotNum = headBufNum / (hRatio + 1);
+    if (p1SlotNum <= 0) {
+        p1SlotNum = NUM_2;
+    }
     for (int64_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += blockNum) {
         int64_t curBatchId = static_cast<int64_t>(loopIdx) / strategy.chunkNumForT;
         strategy.calculate(loopIdx, indexResult);
@@ -154,9 +158,40 @@ __aicore__ inline void ChunkBwdDvLocalCube<QKVT, GT, Strategy, V>::Process()
         Catlass::GemmCoord actualBlockShapeV{static_cast<uint32_t>(indexResult.chunkLen),
                                              static_cast<uint32_t>(V),
                                              static_cast<uint32_t>(indexResult.chunkLen)};
-        for (int64_t qkHead = 0; qkHead < H_qk; qkHead++) {
-            int64_t p1Slot = qkHead % 2;
-            {
+        for (int64_t scheduleIdx = 0; scheduleIdx < H_qk + p1SlotNum; scheduleIdx++) {
+            if (scheduleIdx >= p1SlotNum) {
+                int64_t qkHead = scheduleIdx - p1SlotNum;
+                if (qkHead < H_qk) {
+                    for (int64_t doGroup = 0; doGroup < hRatio; doGroup++) {
+                        AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_1);
+                    }
+                    BlockMmadV blockMmadV(resource);
+                    for (int64_t doGroup = 0; doGroup < hRatio; doGroup++) {
+                        int64_t doHead = qkHead * hRatio + doGroup;
+                        int64_t gatedSlot = p1SlotNum + (qkHead % p1SlotNum) * hRatio + doGroup;
+                        auto tensorA_V = tla::MakeTensor(
+                            workspaceGm[coreBaseOffset + gatedSlot * strategy.chunkSize * strategy.chunkSize],
+                            layoutA_V, Catlass::Arch::PositionGM{});
+                        auto tensorB_V =
+                            tla::MakeTensor(dOGm[curBatchId * H_do * T * V + doHead * T * V + indexResult.curTokenId * V],
+                                            layoutB_V, Catlass::Arch::PositionGM{});
+                        auto tensorC_V =
+                            tla::MakeTensor(dVGm[curBatchId * H_do * T * V + doHead * T * V + indexResult.curTokenId * V],
+                                            layoutC_V, Catlass::Arch::PositionGM{});
+                        auto tensorBlockA_V =
+                            GetTile(tensorA_V, tla::MakeCoord(0, 0), tla::MakeShape(actualBlockShapeV.m(), actualBlockShapeV.k()));
+                        auto tensorBlockB_V =
+                            GetTile(tensorB_V, tla::MakeCoord(0, 0), tla::MakeShape(actualBlockShapeV.k(), actualBlockShapeV.n()));
+                        auto tensorBlockC_V =
+                            GetTile(tensorC_V, tla::MakeCoord(0, 0), tla::MakeShape(actualBlockShapeV.m(), actualBlockShapeV.n()));
+                        blockMmadV(tensorBlockA_V, tensorBlockB_V, tensorBlockC_V, actualBlockShapeV);
+                    }
+                }
+            }
+
+            if (scheduleIdx < H_qk) {
+                int64_t qkHead = scheduleIdx;
+                int64_t p1Slot = qkHead % p1SlotNum;
                 BlockMmadQK blockMmadQK(resource);
                 auto tensorA =
                     tla::MakeTensor(kGm[curBatchId * H_qk * T * K + qkHead * T * K + indexResult.curTokenId * K], layoutA_QK,
@@ -174,33 +209,7 @@ __aicore__ inline void ChunkBwdDvLocalCube<QKVT, GT, Strategy, V>::Process()
                 auto tensorBlockC =
                     GetTile(tensorC, tla::MakeCoord(0, 0), tla::MakeShape(actualBlockShapeQK.m(), actualBlockShapeQK.n()));
                 blockMmadQK(tensorBlockA, tensorBlockB, tensorBlockC, actualBlockShapeQK);
-            }
-            AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_3);
-            for (int64_t doGroup = 0; doGroup < hRatio; doGroup++) {
-                AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_1);
-            }
-            {
-                BlockMmadV blockMmadV(resource);
-                for (int64_t doGroup = 0; doGroup < hRatio; doGroup++) {
-                    int64_t doHead = qkHead * hRatio + doGroup;
-                    int64_t gatedSlot = 2 + (qkHead % 2) * hRatio + doGroup;
-                    auto tensorA_V = tla::MakeTensor(
-                        workspaceGm[coreBaseOffset + gatedSlot * strategy.chunkSize * strategy.chunkSize],
-                        layoutA_V, Catlass::Arch::PositionGM{});
-                    auto tensorB_V =
-                        tla::MakeTensor(dOGm[curBatchId * H_do * T * V + doHead * T * V + indexResult.curTokenId * V],
-                                        layoutB_V, Catlass::Arch::PositionGM{});
-                    auto tensorC_V =
-                        tla::MakeTensor(dVGm[curBatchId * H_do * T * V + doHead * T * V + indexResult.curTokenId * V],
-                                        layoutC_V, Catlass::Arch::PositionGM{});
-                    auto tensorBlockA_V =
-                        GetTile(tensorA_V, tla::MakeCoord(0, 0), tla::MakeShape(actualBlockShapeV.m(), actualBlockShapeV.k()));
-                    auto tensorBlockB_V =
-                        GetTile(tensorB_V, tla::MakeCoord(0, 0), tla::MakeShape(actualBlockShapeV.k(), actualBlockShapeV.n()));
-                    auto tensorBlockC_V =
-                        GetTile(tensorC_V, tla::MakeCoord(0, 0), tla::MakeShape(actualBlockShapeV.m(), actualBlockShapeV.n()));
-                    blockMmadV(tensorBlockA_V, tensorBlockB_V, tensorBlockC_V, actualBlockShapeV);
-                }
+                AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_3);
             }
         }
     }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_vector.h
@@ -172,12 +172,16 @@ __aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessChunk(c
     AscendC::LocalTensor<float> kqFp32LocalTensor = kqFp32TBuf.template Get<float>();
 
     int64_t coreBaseOffset = coreIdx * headBufNum * strategy.chunkSize * strategy.chunkSize;
+    int64_t p1SlotNum = headBufNum / (hRatio + 1);
+    if (p1SlotNum <= 0) {
+        p1SlotNum = NUM_2;
+    }
     AscendC::PipeBarrier<PIPE_V>();
     for (int64_t doHead = 0; doHead < H_do; doHead++) {
         int64_t qkHead = doHead / hRatio;
         int64_t doGroup = doHead % hRatio;
-        int64_t p1Slot = qkHead % 2;
-        int64_t gatedSlot = 2 + (qkHead % 2) * hRatio + doGroup;
+        int64_t p1Slot = qkHead % p1SlotNum;
+        int64_t gatedSlot = p1SlotNum + (qkHead % p1SlotNum) * hRatio + doGroup;
         int64_t baseReadOffset = coreBaseOffset + p1Slot * strategy.chunkSize * strategy.chunkSize;
         int64_t baseWriteOffset = coreBaseOffset + gatedSlot * strategy.chunkSize * strategy.chunkSize;
         ++vecTaskIdx;


### PR DESCRIPTION
## 关联 Issue / 背景

- 关联 Issue: 无
- 背景与目标: ChunkBwdDvLocal 当前深融合优化版本已完成本地完整验证，需要合入性能优化。
- 本 PR 解决的问题: 通过增加 P1 workspace slot 并调整 AIC/AIV 调度，让 QK Mmad 与 gated A -> dV Mmad 形成跨 head 流水，降低等待开销；同时修正 host tiling 日志文案，并删除 fast-kernel 示例中的重复模板声明。

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [x] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: ChunkBwdDvLocal
- 涉及目录 / 文件:
  - fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_host/chunk_bwd_dv_local_tiling_processor.h
  - fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_cube.h
  - fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_vector.h
  - examples/fast_kernel_launch_example/csrc/chunk_bwd_dv_local/ascend910b/chunk_bwd_dv_local.cpp
- 责任人 / 提交人: @chen-linxin
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不改变现有接口与 shape/dtype 支持范围，覆盖 B 定长、cu_seqlens 变长、V=128/256、h_ratio=1/2/4。
- 明确不包含的范围: 不包含 A3/A5 kernel 适配，不修改 def/aclnn/torch 接口。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无。

## 修改算子测试

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | CANN 8.5 | 完整验证脚本内执行 `bash build.sh --pkg --soc=ascend910b --ops=chunk_bwd_dv_local` | 通过 | /workspace/clx/work_test/ChunkBwdDvLocal/20260623_004807_full_validation/custom_operator/test.log |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/tests/test.py` | 通过 | 29 个 case 全部 success，覆盖定长、变长、V=256、GVA h_ratio=2/4；/workspace/clx/work_test/ChunkBwdDvLocal/20260623_004807_full_validation/custom_operator/test.log |

- 精度对比: Custom Operator 29 个 case 全部 PASS；Fast-Kernel-Launch pytest 13 个 case 全部 PASS。
- 性能对比:

| case | baseline(us) | current(us) | 提升 | 加速比 |
| --- | ---: | ---: | ---: | ---: |
| fixed | 3196.583984 | 2637.032715 | 17.50% | 1.2122x |
| varlen | 5326.086914 | 4446.508789 | 16.51% | 1.1978x |

- 边界 / 异常场景: 覆盖 `B=1` 变长、`cu_seqlens`、`V=256`、`h_ratio=2/4`。

## 整体 Example ST 验证

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python examples/flash_gated_delta_rule.py` | 通过 | /workspace/clx/work_test/ChunkBwdDvLocal/20260623_004807_full_validation/example_st/test.log |

## 其他验证

- Fast-Kernel-Launch: `cd examples/fast_kernel_launch_example && bash build_and_test.sh chunk_bwd_dv_local`，13 passed，日志 /workspace/clx/work_test/ChunkBwdDvLocal/20260623_004807_full_validation/fast_kernel_launch/test.log
- 完整测试报告: /workspace/clx/work_test/ChunkBwdDvLocal/20260623_004807_full_validation/test_report.md
- 性能结果归档: /workspace/clx/work_test/ChunkBwdDvLocal/20260623_004807_full_validation/performance/duration_summary.md

## 环境说明

- 测试环境使用 `source /data/zs/run/8.5/ascend-toolkit/set_env.sh` 和 conda `wnc`。
- Example ST 按 PR 模板要求使用 `torch_npu 2.7.1.post5`，并重建 `torch_custom/fla_npu` 后通过。
- 首轮 fast-kernel 在 device 7 遇到外部任务占用导致 set_device 失败；最终完整通过轮实际使用 NPU 5。测试用临时 device 绑定已在提交前移除。
