### PR TITLE
add da gva 950

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_host/op_tiling/arch35/prepare_wy_repr_bwd_da_tiling_a5.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_host/op_tiling/arch35/prepare_wy_repr_bwd_da_tiling_a5.cpp
@@ -58,7 +58,7 @@ bool PrepareWyReprBwdDaTilingA5::SetTiling(gert::TilingContext *context)
     auto sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
     OP_LOGD(context->GetNodeName(), "=== sysWorkspaceSize: %ld", sysWorkspaceSize);
     int64_t maxKV = std::max(tiling_.K, tiling_.V);
-    size_t userWorkspaceSize = 2 * tiling_.B * tiling_.H * tiling_.T * (tiling_.chunkSize + maxKV);
+    size_t userWorkspaceSize = 2 * tiling_.B * tiling_.HV * tiling_.T * (tiling_.chunkSize + maxKV);
     OP_LOGD(context->GetNodeName(), "=== userWorkspaceSize: %ld", userWorkspaceSize);
     size_t *currentWorkspace = context->GetWorkspaceSizes(1);
     currentWorkspace[0] = static_cast<size_t>(sysWorkspaceSize + userWorkspaceSize);
@@ -226,31 +226,59 @@ ge::graphStatus PrepareWyReprBwdDaTilingA5::CommonTiling()
     const gert::Shape dwStorageShape = context_->GetRequiredInputShape(INPUT_DW_IDX)->GetStorageShape();
     const gert::Shape duStorageShape = context_->GetRequiredInputShape(INPUT_DU_IDX)->GetStorageShape();
     const gert::Shape gStorageShape = context_->GetRequiredInputShape(INPUT_G_IDX)->GetStorageShape();
-    OP_CHECK_IF(CompareShape(vStorageShape, kStorageShape, INPUT_V_NAME, INPUT_K_NAME, DIM_NUM_3) !=
-                    ge::GRAPH_SUCCESS,
-                , return ge::GRAPH_FAILED);
     OP_CHECK_IF(CompareShape(vStorageShape, duStorageShape, INPUT_V_NAME, INPUT_DU_NAME, DIM_NUM_4) !=
                     ge::GRAPH_SUCCESS,
                 , return ge::GRAPH_FAILED);
     OP_CHECK_IF(CompareShape(betaStorageShape, gStorageShape, INPUT_BETA_NAME, INPUT_G_NAME, DIM_NUM_3) !=
                     ge::GRAPH_SUCCESS,
                 , return ge::GRAPH_FAILED);
-    OP_CHECK_IF(CompareShape(kStorageShape, gStorageShape, INPUT_K_NAME, INPUT_G_NAME, DIM_NUM_3) !=
-                    ge::GRAPH_SUCCESS,
-                , return ge::GRAPH_FAILED);
-    OP_CHECK_IF(CompareShape(dwStorageShape, kStorageShape, INPUT_DW_NAME, INPUT_K_NAME, DIM_NUM_4) !=
-                    ge::GRAPH_SUCCESS,
-                , return ge::GRAPH_FAILED);
-    OP_CHECK_IF(CompareShape(kStorageShape, AStorageShape, INPUT_K_NAME, INPUT_A_NAME, DIM_NUM_3) !=
-                    ge::GRAPH_SUCCESS,
-                , return ge::GRAPH_FAILED);
+
+    // GVA: K uses HK heads while the other tensors use HV heads. Batch/time dimensions must still match.
+    OP_CHECK_IF(vStorageShape.GetDim(DIM_0) != kStorageShape.GetDim(DIM_0) ||
+                    vStorageShape.GetDim(DIM_2) != kStorageShape.GetDim(DIM_2),
+                OP_LOGE(context_->GetNodeName(),
+                        "Compare input shape of %s and %s failed: batch/time dims must match.", INPUT_V_NAME,
+                        INPUT_K_NAME),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(kStorageShape.GetDim(DIM_0) != gStorageShape.GetDim(DIM_0) ||
+                    kStorageShape.GetDim(DIM_2) != gStorageShape.GetDim(DIM_2),
+                OP_LOGE(context_->GetNodeName(),
+                        "Compare input shape of %s and %s failed: batch/time dims must match.", INPUT_K_NAME,
+                        INPUT_G_NAME),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(dwStorageShape.GetDim(DIM_0) != kStorageShape.GetDim(DIM_0) ||
+                    dwStorageShape.GetDim(DIM_2) != kStorageShape.GetDim(DIM_2) ||
+                    dwStorageShape.GetDim(DIM_3) != kStorageShape.GetDim(DIM_3),
+                OP_LOGE(context_->GetNodeName(),
+                        "Compare input shape of %s and %s failed: batch/time/K dims must match.", INPUT_DW_NAME,
+                        INPUT_K_NAME),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(kStorageShape.GetDim(DIM_0) != AStorageShape.GetDim(DIM_0) ||
+                    kStorageShape.GetDim(DIM_2) != AStorageShape.GetDim(DIM_2),
+                OP_LOGE(context_->GetNodeName(),
+                        "Compare input shape of %s and %s failed: batch/time dims must match.", INPUT_K_NAME,
+                        INPUT_A_NAME),
+                return ge::GRAPH_FAILED);
+
     B = static_cast<int64_t>(vStorageShape.GetDim(DIM_0));
-    H = static_cast<int64_t>(vStorageShape.GetDim(DIM_1));
+    HV = static_cast<int64_t>(vStorageShape.GetDim(DIM_1));
+    HK = static_cast<int64_t>(kStorageShape.GetDim(DIM_1));
+    OP_CHECK_IF(HK <= 0 || HV % HK != 0,
+                OP_LOGE(context_->GetNodeName(),
+                        "HV (%ld) must be a positive multiple of HK (%ld) for GVA.", HV, HK),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(betaStorageShape.GetDim(DIM_1) != vStorageShape.GetDim(DIM_1) ||
+                    AStorageShape.GetDim(DIM_1) != vStorageShape.GetDim(DIM_1) ||
+                    dwStorageShape.GetDim(DIM_1) != vStorageShape.GetDim(DIM_1),
+                OP_LOGE(context_->GetNodeName(),
+                        "The head dim of beta/A/dw must match HV (%ld).", HV),
+                return ge::GRAPH_FAILED);
     T = static_cast<int64_t>(vStorageShape.GetDim(DIM_2));
     K = static_cast<int64_t>(kStorageShape.GetDim(DIM_3));
     V = static_cast<int64_t>(vStorageShape.GetDim(DIM_3));
     tiling_.B = B;
-    tiling_.H = H;
+    tiling_.HV = HV;
+    tiling_.HK = HK;
     tiling_.T = T;
     tiling_.K = K;
     tiling_.V = V;
@@ -322,7 +350,8 @@ void PrepareWyReprBwdDaTilingA5::PrepareWyReprBwdDaTilingDataPrint()
     auto nodeName = context_->GetNodeName();
     OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Start to print PrepareWyReprBwdDaA5 tiling data <<<<<<<<<<<<<<<<");
     OP_LOGD(nodeName, "=== B: %ld", tiling_.B);
-    OP_LOGD(nodeName, "=== H: %ld", tiling_.H);
+    OP_LOGD(nodeName, "=== HV: %ld", tiling_.HV);
+    OP_LOGD(nodeName, "=== HK: %ld", tiling_.HK);
     OP_LOGD(nodeName, "=== T: %ld", tiling_.T);
     OP_LOGD(nodeName, "=== K: %ld", tiling_.K);
     OP_LOGD(nodeName, "=== V: %ld", tiling_.V);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_host/op_tiling/arch35/prepare_wy_repr_bwd_da_tiling_a5.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_host/op_tiling/arch35/prepare_wy_repr_bwd_da_tiling_a5.h
@@ -27,7 +27,8 @@ private:
     gert::TilingContext *context_;
     PrepareWyReprBwdDaTilingDataA5 tiling_;
     int64_t B = 0;
-    int64_t H = 0;
+    int64_t HV = 0;
+    int64_t HK = 0;
     int64_t K = 0;
     int64_t V = 0;
     int64_t T = 0;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/arch35/prepare_wy_repr_bwd_da_common.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/arch35/prepare_wy_repr_bwd_da_common.h
@@ -32,7 +32,7 @@ constexpr uint32_t UB_STAGES = 2;
 constexpr uint64_t SYNC_AIV_AIC_FLAG_BEGIN = 1;
 constexpr uint64_t SYNC_AIC_AIV_FLAG_BEGIN = 6;
 
-__aicore__ void inline GetChunkOffset(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, uint64_t B, uint64_t H, uint64_t T,
+__aicore__ void inline GetChunkOffset(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, uint64_t B, uint64_t HV, uint64_t T,
                                       uint64_t chunkSize, uint32_t loopIdx, uint32_t &bos, uint32_t &eos)
 {
     if (cu_seqlens == nullptr) {
@@ -41,8 +41,8 @@ __aicore__ void inline GetChunkOffset(GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
         uint32_t bIdx = loopIdx / coreLoopsInB;
         bos = chunkIdx * chunkSize;
         eos = bos + chunkSize > T ? T : bos + chunkSize;
-        bos += (bIdx * H * T);
-        eos += (bIdx * H * T);
+        bos += (bIdx * HV * T);
+        eos += (bIdx * HV * T);
     } else {
         AscendC::GlobalTensor<uint64_t> cuSeqlensTensor;
         AscendC::GlobalTensor<uint64_t> chunkIndicesTensor;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/arch35/prepare_wy_repr_bwd_da_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/arch35/prepare_wy_repr_bwd_da_cube.h
@@ -117,7 +117,8 @@ public:
         uint64_t chunkNum;
         uint64_t B = 1;
         uint64_t T = 32768;
-        uint64_t H = 32;
+        uint64_t HV = 32;
+        uint64_t HK = 32;
         uint64_t K = 128;
         uint64_t V = 128;
         uint64_t BT = 64;
@@ -143,7 +144,8 @@ public:
                GM_ADDR ptrDA5T_, LayoutDA5T layoutDA5T_,
                GM_ADDR ptrDA6_, LayoutDA6 layoutDA6_,
                GM_ADDR ptrCuSeqLens_, GM_ADDR ptrChunkIndices_, uint64_t chunkNum_,
-               uint64_t B_, uint64_t T_, uint64_t H_, uint64_t K_, uint64_t V_, uint64_t BT_, uint64_t stage_,
+               uint64_t B_, uint64_t T_, uint64_t HV_, uint64_t HK_, uint64_t K_, uint64_t V_, uint64_t BT_,
+               uint64_t stage_,
                uint64_t da6VecRow_, uint64_t da6CVNum_)
             : ptrDw(ptrDw_),
               layoutDw(layoutDw_),
@@ -174,7 +176,8 @@ public:
               chunkNum(chunkNum_),
               B(B_),
               T(T_),
-              H(H_),
+              HV(HV_),
+              HK(HK_),
               K(K_),
               V(V_),
               BT(BT_),
@@ -203,19 +206,19 @@ public:
         {   // 计算第一个矩阵乘 dA_1 = dw @ kbg.T     V->C
             BlockMmadDA1 blockMmadDA1(resource);
             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
                                params.BT, loopIdx, bos, eos);
                 uint32_t curChunkSize = eos - bos;
                 GemmCoord blockCoord{0, 0, 0};
                 GemmCoord actualBlockShape{curChunkSize, curChunkSize, static_cast<uint32_t>(params.K)};
-                for (int h = 0; h < params.H; h++) {
+                for (int h_v = 0; h_v < params.HV; h_v++) {
                     // Represent the full gm
                     AscendC::GlobalTensor<ElementDw> gmDw;
-                    gmDw.SetGlobalBuffer((__gm__ ElementDw *)params.ptrDw + (h * params.T + bos) * params.K);
+                    gmDw.SetGlobalBuffer((__gm__ ElementDw *)params.ptrDw + (h_v * params.T + bos) * params.K);
                     AscendC::GlobalTensor<ElementKbg> gmKbg;
-                    gmKbg.SetGlobalBuffer((__gm__ ElementKbg *)params.ptrKbg + (h * params.T + bos) * params.K);
+                    gmKbg.SetGlobalBuffer((__gm__ ElementKbg *)params.ptrKbg + (h_v * params.T + bos) * params.K);
                     AscendC::GlobalTensor<ElementDA1> gmDA1;
-                    gmDA1.SetGlobalBuffer((__gm__ ElementDA1 *)params.ptrDA1 + (h * params.T + bos) * params.BT);
+                    gmDA1.SetGlobalBuffer((__gm__ ElementDA1 *)params.ptrDA1 + (h_v * params.T + bos) * params.BT);
                     // Represent the full tensors
                     auto tensorDw = tla::MakeTensor(gmDw, params.layoutDw, Arch::PositionGM{});
                     auto tensorKbg = tla::MakeTensor(gmKbg, params.layoutKbg, Arch::PositionGM{});
@@ -241,19 +244,19 @@ public:
         {   // 计算第二个矩阵乘 dA_2 = du @ vb.T     V->C
             BlockMmadDA2 blockMmadDA2(resource);
             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
                                params.BT, loopIdx, bos, eos);
                 uint32_t curChunkSize = eos - bos;
                 GemmCoord blockCoord{0, 0, 0};
                 GemmCoord actualBlockShape{curChunkSize, curChunkSize, static_cast<uint32_t>(params.V)};
-                for (int h = 0; h < params.H; h++) {
+                for (int h_v = 0; h_v < params.HV; h_v++) {
                     // Represent the full gm
                     AscendC::GlobalTensor<ElementDu> gmDu;
-                    gmDu.SetGlobalBuffer((__gm__ ElementDu *)params.ptrDu + (h * params.T + bos) * params.V);
+                    gmDu.SetGlobalBuffer((__gm__ ElementDu *)params.ptrDu + (h_v * params.T + bos) * params.V);
                     AscendC::GlobalTensor<ElementVb> gmVb;
-                    gmVb.SetGlobalBuffer((__gm__ ElementVb *)params.ptrVb + (h * params.T + bos) * params.V);
+                    gmVb.SetGlobalBuffer((__gm__ ElementVb *)params.ptrVb + (h_v * params.T + bos) * params.V);
                     AscendC::GlobalTensor<ElementDA2> gmDA2;
-                    gmDA2.SetGlobalBuffer((__gm__ ElementDA2 *)params.ptrDA2 + (h * params.T + bos) * params.BT);
+                    gmDA2.SetGlobalBuffer((__gm__ ElementDA2 *)params.ptrDA2 + (h_v * params.T + bos) * params.BT);
 
                     // Represent the full tensors
                     auto tensorDu = tla::MakeTensor(gmDu, params.layoutDu, Arch::PositionGM{});
@@ -280,19 +283,19 @@ public:
         {   // 计算第三个矩阵乘 dA_5 = dA_4 @ A.T     V->C
             BlockMmadDA5 blockMmadDA5(resource);
             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
                                params.BT, loopIdx, bos, eos);
                 uint32_t curChunkSize = eos - bos;
                 GemmCoord blockCoord{0, 0, 0};
                 GemmCoord actualBlockShape{curChunkSize, curChunkSize, curChunkSize};
-                for (int h = 0; h < params.H; h++) {
+                for (int h_v = 0; h_v < params.HV; h_v++) {
                     // Represent the full gm
                     AscendC::GlobalTensor<ElementDA4> gmDA4;
-                    gmDA4.SetGlobalBuffer((__gm__ ElementDA4 *)params.ptrDA4 + (h * params.T + bos) * params.BT);
+                    gmDA4.SetGlobalBuffer((__gm__ ElementDA4 *)params.ptrDA4 + (h_v * params.T + bos) * params.BT);
                     AscendC::GlobalTensor<ElementAT> gmAT;
-                    gmAT.SetGlobalBuffer((__gm__ ElementAT *)params.ptrAT + (h * params.T + bos) * params.BT);
+                    gmAT.SetGlobalBuffer((__gm__ ElementAT *)params.ptrAT + (h_v * params.T + bos) * params.BT);
                     AscendC::GlobalTensor<ElementDA5> gmDA5;
-                    gmDA5.SetGlobalBuffer((__gm__ ElementDA5 *)params.ptrDA5 + (h * params.T + bos) * params.BT);
+                    gmDA5.SetGlobalBuffer((__gm__ ElementDA5 *)params.ptrDA5 + (h_v * params.T + bos) * params.BT);
 
                     // Represent the full tensors
                     auto tensorDA4 = tla::MakeTensor(gmDA4, params.layoutDA4, Arch::PositionGM{});
@@ -330,15 +333,15 @@ public:
             }
             uint8_t beginSubBlockIdx = 1;
             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.H, params.T,
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
                                params.BT, loopIdx, bos, eos);
                 uint32_t curChunkSize = eos - bos;
                 GemmCoord blockCoord{0, 0, 0};
                 GemmCoord actualBlockShape{curChunkSize, curChunkSize, curChunkSize};
-                for (int h = 0; h < params.H; h++) {
+                for (int h_v = 0; h_v < params.HV; h_v++) {
                     // Represent the full gm
-                    gmDA5T.SetGlobalBuffer((__gm__ ElementDA5T *)params.ptrDA5T + (h * params.T + bos) * params.BT);
-                    gmA.SetGlobalBuffer((__gm__ ElementA *)params.ptrA + (h * params.T + bos) * params.BT);
+                    gmDA5T.SetGlobalBuffer((__gm__ ElementDA5T *)params.ptrDA5T + (h_v * params.T + bos) * params.BT);
+                    gmA.SetGlobalBuffer((__gm__ ElementA *)params.ptrA + (h_v * params.T + bos) * params.BT);
 
                     // Represent the full tensors
                     auto tensorDA5T = tla::MakeTensor(gmDA5T, params.layoutDA5T, Arch::PositionGM{});
@@ -389,7 +392,8 @@ public:
 private:
     uint64_t B = 0;
     uint64_t T = 0;
-    uint64_t H = 0;
+    uint64_t HV = 0;
+    uint64_t HK = 0;
     uint64_t K = 0;
     uint64_t V = 0;
     uint64_t BT = 0;
@@ -440,7 +444,8 @@ template <typename kType, typename betaType>
 __aicore__ void inline PrepareWyReprBwdDAProcess<kType, betaType>::Init(const PrepareWyReprBwdDaTilingDataA5 &tiling) {
     B = tiling.B;
     T = tiling.T;
-    H = tiling.H;
+    HV = tiling.HV;
+    HK = tiling.HK;
     K = tiling.K;
     V = tiling.V;
     BT = tiling.chunkSize;
@@ -531,8 +536,8 @@ __aicore__ void inline PrepareWyReprBwdDAProcess<kType, betaType>::Process() {
 
     MatmulKernel kernel;
 
-    // ptrVb/ptrKbg 必须指向 Vector 写入的 workspace 区域：vb / kbg=workSpace2Tensor(基址+B*H*T*BT 元素)
-    GM_ADDR ptrVb = reinterpret_cast<GM_ADDR>(reinterpret_cast<__gm__ kType*>(workspace) + (B * H * T * BT));
+    // ptrVb/ptrKbg 指向 Vector 按 HV 展开后写入的 workspace 区域。
+    GM_ADDR ptrVb = reinterpret_cast<GM_ADDR>(reinterpret_cast<__gm__ kType*>(workspace) + (B * HV * T * BT));
     GM_ADDR ptrKbg = ptrVb;
     GM_ADDR ptrDA1 = dA;
     GM_ADDR ptrDA2 = workspace;
@@ -555,7 +560,7 @@ __aicore__ void inline PrepareWyReprBwdDAProcess<kType, betaType>::Process() {
         cu_seqlens,
         chunk_indices,
         chunkNum,
-        B, T, H, K, V, BT, 4,
+        B, T, HV, HK, K, V, BT, 4,
         da6VecRow, da6CVNum};
 
     kernel(param);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/arch35/prepare_wy_repr_bwd_da_tiling_data_apt.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/arch35/prepare_wy_repr_bwd_da_tiling_data_apt.h
@@ -20,7 +20,8 @@
 #pragma pack(push, 8)
 struct PrepareWyReprBwdDaTilingDataA5 {
     int64_t B = 0;
-    int64_t H = 0;
+    int64_t HV = 0;
+    int64_t HK = 0;
     int64_t T = 0;
     int64_t K = 0;
     int64_t V = 0;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/arch35/prepare_wy_repr_bwd_da_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_kernel/arch35/prepare_wy_repr_bwd_da_vector.h
@@ -73,7 +73,8 @@ public:
 private:
     uint64_t B = 0;
     uint64_t T = 0;
-    uint64_t H = 0;
+    uint64_t HV = 0;
+    uint64_t HK = 0;
     uint64_t K = 0;
     uint64_t V = 0;
     uint64_t BT = 0;
@@ -136,7 +137,8 @@ __aicore__ void inline PrepareWyReprBwdDAVectorProcess<kType, betaType>::Init(
     const PrepareWyReprBwdDaTilingDataA5& tiling, AscendC::TPipe *pipe_) {
     B = tiling.B;
     T = tiling.T;
-    H = tiling.H;
+    HV = tiling.HV;
+    HK = tiling.HK;
     K = tiling.K;
     V = tiling.V;
     BT = tiling.chunkSize;
@@ -149,7 +151,7 @@ __aicore__ void inline PrepareWyReprBwdDAVectorProcess<kType, betaType>::Init(
 
     pipe = pipe_;
     workSpaceTensor.SetGlobalBuffer((__gm__ kType *)workspace);
-    workSpace2Tensor.SetGlobalBuffer((__gm__ kType *)workspace + B * H * T * BT);
+    workSpace2Tensor.SetGlobalBuffer((__gm__ kType *)workspace + B * HV * T * BT);
     dA1Tensor.SetGlobalBuffer((__gm__ kType *)dA);
     dA2Tensor.SetGlobalBuffer((__gm__ kType *)workspace);
     dA4Tensor.SetGlobalBuffer((__gm__ kType *)dA);
@@ -198,18 +200,26 @@ __aicore__ void inline PrepareWyReprBwdDAVectorProcess<kType, betaType>::Process
     pipe->InitBuffer(kBetaGOutQue, 2, rowNum * K * sizeof(kType));
 
     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
-        GetChunkOffset(cu_seqlens, chunk_indices, B, H, T, BT, loopIdx, bos, eos);
+        GetChunkOffset(cu_seqlens, chunk_indices, B, HV, T, BT, loopIdx, bos, eos);
         uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < H; h++) {
+        uint64_t keyBos = bos;
+        if (cu_seqlens == nullptr && HV != HK) {
+            uint64_t batchIdx = bos / (HV * T);
+            uint64_t timeBos = bos - batchIdx * HV * T;
+            keyBos = batchIdx * HK * T + timeBos;
+        }
+        uint64_t groupSize = HV / HK;
+        for (int h_v = 0; h_v < HV; h_v++) {
+            uint64_t h_k = h_v / groupSize;
             for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
                 ++vecTaskIdx;
                 if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
                     continue;
                 }
                 curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
-                auto kOffset = (h * T + bos + rowOffset) * K;
-                auto betaOffset = h * T + bos + rowOffset;
-                auto gOffset = h * T + bos + rowOffset;
+                auto kOffset = (h_k * T + keyBos + rowOffset) * K;
+                auto betaOffset = h_v * T + bos + rowOffset;
+                auto gOffset = h_v * T + bos + rowOffset;
                 // copyin
                 {
                     auto tensorKIn = kInQue.AllocTensor<kType>();
@@ -265,7 +275,8 @@ __aicore__ void inline PrepareWyReprBwdDAVectorProcess<kType, betaType>::Process
                 //copyout
                 {
                     auto tensorOut = kBetaGOutQue.DeQue<kType>();
-                    DataCopy(workSpace2Tensor[kOffset], tensorOut, K * curRowNum);
+                    auto kbgOffset = (h_v * T + bos + rowOffset) * K;
+                    DataCopy(workSpace2Tensor[kbgOffset], tensorOut, K * curRowNum);
                     kBetaGOutQue.FreeTensor(tensorOut);
                 }
             }
@@ -297,17 +308,17 @@ __aicore__ void inline PrepareWyReprBwdDAVectorProcess<kType, betaType>::Process
     betaTensor.SetGlobalBuffer((__gm__ betaType *)beta);
 
     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
-        GetChunkOffset(cu_seqlens, chunk_indices, B, H, T, BT, loopIdx, bos, eos);
+        GetChunkOffset(cu_seqlens, chunk_indices, B, HV, T, BT, loopIdx, bos, eos);
         uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < H; h++) {
+        for (int h_v = 0; h_v < HV; h_v++) {
             for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
                 ++vecTaskIdx;
                 if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
                     continue;
                 }
                 curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
-                auto vOffset = (h * T + bos + rowOffset) * V;
-                auto betaOffset = h * T + bos + rowOffset;
+                auto vOffset = (h_v * T + bos + rowOffset) * V;
+                auto betaOffset = h_v * T + bos + rowOffset;
                 // copyin
                 {
                     auto tensorVin = vInQue.AllocTensor<kType>();
@@ -381,16 +392,16 @@ __aicore__ void inline PrepareWyReprBwdDAVectorProcess<kType, betaType>::Process
     pipe->InitBuffer(mduwOutQue, 2, rowNum * BT * sizeof(kType));
 
     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
-        GetChunkOffset(cu_seqlens, chunk_indices, B, H, T, BT, loopIdx, bos, eos);
+        GetChunkOffset(cu_seqlens, chunk_indices, B, HV, T, BT, loopIdx, bos, eos);
         uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < H; h++) {
+        for (int h_v = 0; h_v < HV; h_v++) {
             for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
                 ++vecTaskIdx;
                 if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
                     continue;
                 }
                 curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
-                auto offset = (h * T + bos + rowOffset) * BT;
+                auto offset = (h_v * T + bos + rowOffset) * BT;
                 // copyin
                 {
                     auto tensorMduin = mduInQue.AllocTensor<kType>();
@@ -507,9 +518,9 @@ __aicore__ void inline PrepareWyReprBwdDAVectorProcess<kType, betaType>::Process
     dATensor.SetGlobalBuffer((__gm__ kType *)dA);
 
     for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
-        GetChunkOffset(cu_seqlens, chunk_indices, B, H, T, BT, loopIdx, bos, eos);
+        GetChunkOffset(cu_seqlens, chunk_indices, B, HV, T, BT, loopIdx, bos, eos);
         uint32_t curChunkSize = eos - bos;
-        for (int h = 0; h < H; h++) {
+        for (int h_v = 0; h_v < HV; h_v++) {
             uint32_t taskNum = CeilDiv(curChunkSize, rowNum);
             taskNum = CeilDiv(taskNum, GetSubBlockNum());
             uint32_t dealTaskNum = 0;
@@ -517,7 +528,7 @@ __aicore__ void inline PrepareWyReprBwdDAVectorProcess<kType, betaType>::Process
             // copyin gAll [1, BT] once per head
             auto& tensorGAllIn = tensorGAllInList[ubGAllListId];
             {
-                auto gAllOffset = h * T + bos;
+                auto gAllOffset = h_v * T + bos;
                 AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbGAllInVMTE2List[ubGAllListId]);
                 DataCopyPad(tensorGAllIn, gTensor[gAllOffset],
                     {1, curChunkSize * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},
@@ -532,8 +543,8 @@ __aicore__ void inline PrepareWyReprBwdDAVectorProcess<kType, betaType>::Process
                     continue;
                 }
                 curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
-                auto gOffset = h * T + bos + rowOffset;
-                auto offset = (h * T + bos + rowOffset) * BT;
+                auto gOffset = h_v * T + bos + rowOffset;
+                auto offset = (h_v * T + bos + rowOffset) * BT;
 
                 auto& tensorDA6In = tensorDA6InList[cvListId];
                 auto& tensorGIn = tensorGInList[ubListId];
@@ -1313,4 +1324,3 @@ __simd_vf__ inline void PrepareWyReprBwdDAVectorProcess<kType, betaType>::Proces
 }
 
 #endif  // PREPARE_WY_REPR_BWD_DA_VECTOR_H
-


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [x] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @WOE-Y
- 修改范围:
  - [x] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [x] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [x] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
