### PR TITLE
feat(recompute_wu_fwd): 新增 ascend910b fast kernel launch（kernel<<<>>> 直调）支持

### DIFF
--- a/examples/fast_kernel_launch_example/CMakeLists.txt
+++ b/examples/fast_kernel_launch_example/CMakeLists.txt
@@ -36,7 +36,9 @@ set(INCLUDE_DIRECTORIES
     ${CMAKE_CURRENT_SOURCE_DIR}/../..
     ${CMAKE_CURRENT_SOURCE_DIR}/../../common/include
     ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/common
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/gdn/chunk_gdn_fwd
     ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel
     ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/catlass/include
 )
 

--- a/examples/fast_kernel_launch_example/csrc/recompute_wu_fwd/ascend910b/CMakeLists.txt
+++ b/examples/fast_kernel_launch_example/csrc/recompute_wu_fwd/ascend910b/CMakeLists.txt
@@ -1,0 +1,10 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# ----------------------------------------------------------------------------
+
+add_sources("--npu-arch=dav-2201")

--- a/examples/fast_kernel_launch_example/csrc/recompute_wu_fwd/ascend910b/recompute_wu_fwd.cpp
+++ b/examples/fast_kernel_launch_example/csrc/recompute_wu_fwd/ascend910b/recompute_wu_fwd.cpp
@@ -1,0 +1,331 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file recompute_wu_fwd.cpp
+ * \brief Recompute w/u forward operator with fast kernel launch.
+ */
+
+#include <algorithm>
+#include <tuple>
+#include <vector>
+#include <ATen/Operators.h>
+#include <torch/all.h>
+#include <torch/library.h>
+#include "acl/acl.h"
+#include "torch_npu/csrc/core/npu/NPUStream.h"
+#include "torch_npu/csrc/framework/OpCommand.h"
+#include "kernel_operator.h"
+#include "platform/platform_ascendc.h"
+
+#include "fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling_processor.h"
+#include "fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd.cpp"
+
+namespace ascend_ops {
+namespace RecomputeWUFwd {
+
+using TilingData = GDN::RecomputeWUFwdTilingData;
+
+TORCH_LIBRARY_FRAGMENT(EXTENSION_MODULE_NAME, m)
+{
+    m.def("recompute_wu_fwd(Tensor k, Tensor v, Tensor beta, Tensor A, int chunk_size, *, Tensor? g=None, Tensor? gk=None, int[]? cu_seqlens=None, int[]? chunk_indices=None) -> (Tensor, Tensor)");
+}
+
+std::tuple<at::Tensor, at::Tensor> recompute_wu_fwd_meta(
+    const at::Tensor &k, const at::Tensor &v, const at::Tensor &beta, const at::Tensor &A, int64_t chunk_size,
+    const c10::optional<at::Tensor> &g, const c10::optional<at::Tensor> &gk, at::OptionalIntArrayRef cu_seqlens,
+    at::OptionalIntArrayRef chunk_indices)
+{
+    (void)beta;
+    (void)A;
+    (void)chunk_size;
+    (void)g;
+    (void)gk;
+    (void)cu_seqlens;
+    (void)chunk_indices;
+    auto wShape = v.sizes().vec();
+    wShape[3] = k.size(3);
+    at::Tensor w = at::empty(wShape, v.options().dtype(k.scalar_type()));
+    at::Tensor u = at::empty_like(v);
+    return std::make_tuple(w, u);
+}
+
+TORCH_LIBRARY_IMPL(EXTENSION_MODULE_NAME, Meta, m)
+{
+    m.impl("recompute_wu_fwd", recompute_wu_fwd_meta);
+}
+
+struct RecomputeWUFwdTilingResult {
+    TilingData tiling;
+    uint32_t blockDim;
+    size_t workspaceSize;
+};
+
+void CheckInputRank(const at::Tensor &tensor, int64_t rank, const char *name)
+{
+    TORCH_CHECK(tensor.dim() == rank, name, " should be ", rank, "D, but got ", tensor.dim(), "D.");
+}
+
+void CheckSameDevice(const at::Tensor &base, const at::Tensor &tensor, const char *name)
+{
+    TORCH_CHECK(tensor.device() == base.device(), name, " should be on the same device as k.");
+}
+
+void CheckInputs(const at::Tensor &k, const at::Tensor &v, const at::Tensor &beta, const at::Tensor &A,
+                 const at::Tensor &g, at::OptionalIntArrayRef cu_seqlens, at::OptionalIntArrayRef chunk_indices)
+{
+    CheckInputRank(k, 4, "k");
+    CheckInputRank(v, 4, "v");
+    CheckInputRank(beta, 3, "beta");
+    CheckInputRank(A, 4, "A");
+    CheckInputRank(g, 3, "g");
+
+    CheckSameDevice(k, v, "v");
+    CheckSameDevice(k, beta, "beta");
+    CheckSameDevice(k, A, "A");
+    CheckSameDevice(k, g, "g");
+
+    auto kDtype = k.scalar_type();
+    auto betaDtype = beta.scalar_type();
+    TORCH_CHECK(kDtype == at::kHalf || kDtype == at::kBFloat16,
+              "k/v/A only support float16 or bfloat16, but got ", kDtype);
+    TORCH_CHECK(v.scalar_type() == kDtype && A.scalar_type() == kDtype,
+              "v/A should have the same dtype as k.");
+    TORCH_CHECK(betaDtype == kDtype || betaDtype == at::kFloat,
+              "beta/g should have the same dtype as k or float32, but beta is ", betaDtype, " and k is ", kDtype);
+    TORCH_CHECK(g.scalar_type() == betaDtype, "g should have the same dtype as beta.");
+    TORCH_CHECK(cu_seqlens.has_value() == chunk_indices.has_value(),
+              "cu_seqlens and chunk_indices should be both provided or both None.");
+}
+
+ge::DataType ToGeDtype(at::ScalarType dtype)
+{
+    if (dtype == at::kBFloat16) {
+        return ge::DT_BF16;
+    }
+    if (dtype == at::kHalf) {
+        return ge::DT_FLOAT16;
+    }
+    if (dtype == at::kFloat) {
+        return ge::DT_FLOAT;
+    }
+    TORCH_CHECK(false, "Unsupported dtype: ", dtype);
+    return ge::DT_FLOAT16;
+}
+
+RecomputeWUFwdTilingResult CalcTilingParams(
+    const at::Tensor &k, const at::Tensor &v, const at::Tensor &beta, const at::Tensor &A, const at::Tensor &g,
+    int64_t chunk_size, at::OptionalIntArrayRef cu_seqlens, at::OptionalIntArrayRef chunk_indices)
+{
+    auto kSizes = k.sizes();
+    auto vSizes = v.sizes();
+    auto betaSizes = beta.sizes();
+    auto aSizes = A.sizes();
+    auto gSizes = g.sizes();
+
+    gert::StorageShape kShape({kSizes[0], kSizes[1], kSizes[2], kSizes[3]},
+                              {kSizes[0], kSizes[1], kSizes[2], kSizes[3]});
+    gert::StorageShape vShape({vSizes[0], vSizes[1], vSizes[2], vSizes[3]},
+                              {vSizes[0], vSizes[1], vSizes[2], vSizes[3]});
+    gert::StorageShape betaShape({betaSizes[0], betaSizes[1], betaSizes[2]},
+                                 {betaSizes[0], betaSizes[1], betaSizes[2]});
+    gert::StorageShape aShape({aSizes[0], aSizes[1], aSizes[2], aSizes[3]},
+                              {aSizes[0], aSizes[1], aSizes[2], aSizes[3]});
+    gert::StorageShape gShape({gSizes[0], gSizes[1], gSizes[2]}, {gSizes[0], gSizes[1], gSizes[2]});
+
+    gert::StorageShape *cuSeqlensShapePtr = nullptr;
+    gert::StorageShape *chunkIndicesShapePtr = nullptr;
+    gert::StorageShape cuSeqlensShape;
+    gert::StorageShape chunkIndicesShape;
+
+    std::vector<int64_t> cuSeqlensVec;
+    std::vector<int64_t> chunkIndicesVec;
+    const int64_t *cuSeqlensData = nullptr;
+    const int64_t *chunkIndicesData = nullptr;
+
+    if (cu_seqlens.has_value()) {
+        cuSeqlensVec = std::vector<int64_t>(cu_seqlens.value().begin(), cu_seqlens.value().end());
+        int64_t cuDim0 = static_cast<int64_t>(cuSeqlensVec.size());
+        cuSeqlensShape = gert::StorageShape({cuDim0}, {cuDim0});
+        cuSeqlensShapePtr = &cuSeqlensShape;
+        cuSeqlensData = cuSeqlensVec.data();
+    }
+    if (chunk_indices.has_value()) {
+        chunkIndicesVec = std::vector<int64_t>(chunk_indices.value().begin(), chunk_indices.value().end());
+        int64_t ciDim0 = static_cast<int64_t>(chunkIndicesVec.size());
+        chunkIndicesShape = gert::StorageShape({ciDim0}, {ciDim0});
+        chunkIndicesShapePtr = &chunkIndicesShape;
+        chunkIndicesData = chunkIndicesVec.data();
+    }
+
+    auto ascendcPlatform = platform_ascendc::PlatformAscendCManager::GetInstance();
+    TORCH_CHECK(ascendcPlatform != nullptr, "PlatformAscendCManager is null.");
+    uint32_t coreNum = static_cast<uint32_t>(ascendcPlatform->GetCoreNumAic());
+    size_t sysWorkspaceSize = static_cast<size_t>(ascendcPlatform->GetLibApiWorkSpaceSize());
+    uint64_t ubSize = 0;
+    ascendcPlatform->GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
+
+    TilingData tiling{};
+    optiling::RecomputeWUFwdTilingContext ctx{
+        "recompute_wu_fwd",
+        &kShape,
+        &vShape,
+        &betaShape,
+        &aShape,
+        &gShape,
+        cuSeqlensShapePtr,
+        chunkIndicesShapePtr,
+        cuSeqlensData,
+        chunkIndicesData,
+        static_cast<int32_t>(chunk_size),
+        ToGeDtype(k.scalar_type()),
+        ToGeDtype(beta.scalar_type()),
+        ubSize,
+        sysWorkspaceSize,
+    };
+
+    optiling::RecomputeWUFwdTilingProcessor processor(ctx, tiling);
+    TORCH_CHECK(processor.Process() == ge::GRAPH_SUCCESS, "recompute_wu_fwd tiling failed.");
+    return RecomputeWUFwdTilingResult{tiling, coreNum, processor.GetWorkspaceSize()};
+}
+
+template <typename KType, typename BetaType, int VDim>
+__global__ __aicore__ void recompute_wu_fwd_kernel(GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR g,
+                                                   GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR w, GM_ADDR u,
+                                                   GM_ADDR workspace, const GDN::RecomputeWUFwdTilingData tilingData)
+{
+    AscendC::SetSysWorkspaceForce(workspace);
+    GM_ADDR user = AscendC::GetUserWorkspace(workspace);
+    if (user == nullptr) {
+        return;
+    }
+    if (tilingData.V == optiling::RECOMPUTE_WU_FWD_V_DIM_256) {
+        KERNEL_TASK_TYPE(2, KERNEL_TYPE_MIX_AIC_1_2);
+    } else {
+        KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
+    }
+    AscendC::AscendCUtils::SetOverflow(1);
+    GDN::RecomputeWUFwdKernelImpl<KType, BetaType, VDim>(
+        k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, user, &tilingData);
+}
+
+template <typename KType, typename BetaType, int VDim>
+void LaunchRecomputeWUFwd(uint32_t blockDim, aclrtStream stream, GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A,
+                          GM_ADDR g, GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR w, GM_ADDR u, GM_ADDR workspace,
+                          const GDN::RecomputeWUFwdTilingData &tiling)
+{
+    recompute_wu_fwd_kernel<KType, BetaType, VDim><<<blockDim, nullptr, stream>>>(
+        k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace, tiling);
+}
+
+template <typename KType, typename BetaType>
+void DispatchByV(uint32_t blockDim, aclrtStream stream, GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR g,
+                 GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR w, GM_ADDR u, GM_ADDR workspace,
+                 const GDN::RecomputeWUFwdTilingData &tiling)
+{
+    if (tiling.V == 256) {
+        LaunchRecomputeWUFwd<KType, BetaType, 256>(blockDim, stream, k, v, beta, A, g, cu_seqlens, chunk_indices, w, u,
+                                                   workspace, tiling);
+    } else {
+        LaunchRecomputeWUFwd<KType, BetaType, 128>(blockDim, stream, k, v, beta, A, g, cu_seqlens, chunk_indices, w, u,
+                                                 workspace, tiling);
+    }
+}
+
+std::tuple<at::Tensor, at::Tensor> recompute_wu_fwd_npu(
+    const at::Tensor &k, const at::Tensor &v, const at::Tensor &beta, const at::Tensor &A, int64_t chunk_size,
+    const c10::optional<at::Tensor> &g, const c10::optional<at::Tensor> &gk, at::OptionalIntArrayRef cu_seqlens,
+    at::OptionalIntArrayRef chunk_indices)
+{
+    TORCH_CHECK(g.has_value(), "recompute_wu_fwd requires g to be provided.");
+    TORCH_CHECK(!gk.has_value(), "gk is not supported and must be None.");
+
+    const c10::OptionalDeviceGuard guard(k.device());
+    const at::Tensor &gTensor = g.value();
+    CheckInputs(k, v, beta, A, gTensor, cu_seqlens, chunk_indices);
+    auto outputs = recompute_wu_fwd_meta(k, v, beta, A, chunk_size, g, gk, cu_seqlens, chunk_indices);
+    auto w = std::get<0>(outputs);
+    auto u = std::get<1>(outputs);
+    auto stream = c10_npu::getCurrentNPUStream().stream(false);
+
+    RecomputeWUFwdTilingResult tilingResult = CalcTilingParams(k, v, beta, A, gTensor, chunk_size, cu_seqlens, chunk_indices);
+
+    GM_ADDR kPtr = (GM_ADDR)k.data_ptr();
+    GM_ADDR vPtr = (GM_ADDR)v.data_ptr();
+    GM_ADDR betaPtr = (GM_ADDR)beta.data_ptr();
+    GM_ADDR aPtr = (GM_ADDR)A.data_ptr();
+    GM_ADDR gPtr = (GM_ADDR)gTensor.data_ptr();
+    GM_ADDR wPtr = (GM_ADDR)w.data_ptr();
+    GM_ADDR uPtr = (GM_ADDR)u.data_ptr();
+
+    GM_ADDR cuSeqlensPtr = nullptr;
+    GM_ADDR chunkIndicesPtr = nullptr;
+    std::vector<int64_t> cuSeqlensVec;
+    std::vector<int64_t> chunkIndicesVec;
+    at::Tensor cuSeqlensTensor;
+    at::Tensor chunkIndicesTensor;
+
+    if (cu_seqlens.has_value()) {
+        cuSeqlensVec = std::vector<int64_t>(cu_seqlens.value().begin(), cu_seqlens.value().end());
+        cuSeqlensTensor = at::tensor(cuSeqlensVec, at::dtype(at::kLong).device(k.device()));
+        cuSeqlensPtr = (GM_ADDR)cuSeqlensTensor.data_ptr();
+    }
+    if (chunk_indices.has_value()) {
+        chunkIndicesVec = std::vector<int64_t>(chunk_indices.value().begin(), chunk_indices.value().end());
+        chunkIndicesTensor = at::tensor(chunkIndicesVec, at::dtype(at::kLong).device(k.device()));
+        chunkIndicesPtr = (GM_ADDR)chunkIndicesTensor.data_ptr();
+    }
+
+    void *workspacePtr = nullptr;
+    if (tilingResult.workspaceSize > 0) {
+        auto ret = aclrtMalloc(&workspacePtr, tilingResult.workspaceSize, ACL_MEM_MALLOC_HUGE_FIRST);
+        TORCH_CHECK(ret == ACL_SUCCESS, "allocate workspace failed. ERROR: ", ret);
+    }
+    GM_ADDR workspaceGm = (GM_ADDR)workspacePtr;
+
+    auto kDtype = k.scalar_type();
+    auto betaDtype = beta.scalar_type();
+    auto tiling = tilingResult.tiling;
+    auto blockDim = tilingResult.blockDim;
+
+    auto aclCall = [=]() -> int {
+        if (kDtype == at::kBFloat16 && betaDtype == at::kBFloat16) {
+            DispatchByV<bfloat16_t, bfloat16_t>(blockDim, stream, kPtr, vPtr, betaPtr, aPtr, gPtr, cuSeqlensPtr,
+                                                chunkIndicesPtr, wPtr, uPtr, workspaceGm, tiling);
+        } else if (kDtype == at::kHalf && betaDtype == at::kHalf) {
+            DispatchByV<half, half>(blockDim, stream, kPtr, vPtr, betaPtr, aPtr, gPtr, cuSeqlensPtr, chunkIndicesPtr,
+                                    wPtr, uPtr, workspaceGm, tiling);
+        } else if (kDtype == at::kBFloat16 && betaDtype == at::kFloat) {
+            DispatchByV<bfloat16_t, float>(blockDim, stream, kPtr, vPtr, betaPtr, aPtr, gPtr, cuSeqlensPtr,
+                                           chunkIndicesPtr, wPtr, uPtr, workspaceGm, tiling);
+        } else if (kDtype == at::kHalf && betaDtype == at::kFloat) {
+            DispatchByV<half, float>(blockDim, stream, kPtr, vPtr, betaPtr, aPtr, gPtr, cuSeqlensPtr, chunkIndicesPtr,
+                                     wPtr, uPtr, workspaceGm, tiling);
+        } else {
+            TORCH_CHECK(false, "Unsupported dtype combination: k=", kDtype, ", beta=", betaDtype);
+        }
+        return 0;
+    };
+
+    at_npu::native::OpCommand::RunOpApi("RecomputeWUFwd", aclCall);
+
+    if (workspacePtr != nullptr) {
+        aclrtFree(workspacePtr);
+    }
+
+    return std::make_tuple(w, u);
+}
+
+TORCH_LIBRARY_IMPL(EXTENSION_MODULE_NAME, PrivateUse1, m)
+{
+    m.impl("recompute_wu_fwd", recompute_wu_fwd_npu);
+}
+
+} // namespace RecomputeWUFwd
+} // namespace ascend_ops

--- a/examples/fast_kernel_launch_example/tests/recompute_wu_fwd/test_recompute_wu_fwd.py
+++ b/examples/fast_kernel_launch_example/tests/recompute_wu_fwd/test_recompute_wu_fwd.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import random
+
+import pytest
+import torch
+import torch_npu
+
+import ascend_ops
+
+
+def cdiv(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices):
+    if cu_seqlens is not None:
+        seq_idx = chunk_indices[idx * 2]
+        chunk_idx = chunk_indices[idx * 2 + 1]
+        bos = cu_seqlens[seq_idx] + chunk_idx * chunk_size
+        eos = bos + chunk_size
+        if eos > cu_seqlens[seq_idx + 1]:
+            eos = cu_seqlens[seq_idx + 1]
+    else:
+        bos = idx * chunk_size
+        eos = bos + chunk_size
+        if eos > T:
+            eos = T
+    return bos, eos
+
+
+def compute_w_golden(k, v, beta, A, g, cu_seqlens, chunk_indices, B, H, T, D, chunk_size, NT, Hk=0):
+    if Hk == 0:
+        Hk = H
+    hv_per_hk = H // Hk
+    w = torch.zeros(B, H, T, D, dtype=v.dtype, device=v.device)
+    for i_b in range(B):
+        for idx in range(NT):
+            bos, eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
+            for i_h in range(H):
+                hk = i_h // hv_per_hk
+                a_chunk = A[i_b, i_h, bos:eos, : eos - bos]
+                k_chunk = k[i_b, hk, bos:eos, :]
+                beta_chunk = beta[i_b, i_h, bos:eos]
+                g_chunk = g[i_b, i_h, bos:eos]
+                g_exp_chunk = torch.exp(g_chunk.to(torch.float32))
+                beta_g_exp_chunk = beta_chunk.to(torch.float32) * g_exp_chunk
+                kbgexp_chunk = k_chunk * beta_g_exp_chunk[:, None]
+                b_w = torch.matmul(a_chunk.to(torch.float32), kbgexp_chunk.to(torch.float32))
+                w[i_b, i_h, bos:eos, :] = b_w.to(w.dtype)
+    return w
+
+
+def compute_u_golden(v, beta, A, cu_seqlens, chunk_indices, B, Hv, T, chunk_size, NT):
+    u = torch.zeros_like(v)
+    for i_b in range(B):
+        for idx in range(NT):
+            bos, eos = get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices)
+            for i_h in range(Hv):
+                a_chunk = A[i_b, i_h, bos:eos, : eos - bos]
+                v_chunk = v[i_b, i_h, bos:eos, :]
+                beta_chunk = beta[i_b, i_h, bos:eos]
+                vb_chunk = v_chunk.to(torch.float32) * beta_chunk[:, None].to(torch.float32)
+                u_chunk = torch.matmul(a_chunk.to(torch.float32), vb_chunk.to(torch.float32))
+                u[i_b, i_h, bos:eos, :] = u_chunk.to(u.dtype)
+    return u
+
+
+def prepare_cu_seqlens(T: int, L: int = 3, seed: int = 42):
+    random.seed(seed)
+    if L == 2:
+        return [0, T]
+    middle_points = random.sample(range(1, T), L - 2)
+    middle_points.sort()
+    return [0] + middle_points + [T]
+
+
+def prepare_chunk_indices(cu_seqlens, chunk_size: int):
+    indices = []
+    for i in range(len(cu_seqlens) - 1):
+        length = cu_seqlens[i + 1] - cu_seqlens[i]
+        if length <= 0:
+            continue
+        num_chunks = cdiv(length, chunk_size)
+        for chunk_id in range(num_chunks):
+            indices.append(i)
+            indices.append(chunk_id)
+    return indices
+
+
+def run_recompute_wu_fwd(k, v, beta, A, g, chunk_size, cu_seqlens=None, chunk_indices=None):
+    return torch.ops.ascend_ops.recompute_wu_fwd(
+        k.npu(),
+        v.npu(),
+        beta.npu(),
+        A.npu(),
+        chunk_size,
+        g=g.npu(),
+        gk=None,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+
+
+def test_recompute_wu_fwd_interface_exist():
+    assert hasattr(torch.ops.ascend_ops, "recompute_wu_fwd")
+
+
+FIX_TEST_CONFIGS = [
+    (1, 2, 2, 129, 128, 128, 128, torch.float16, torch.float16),
+    (2, 2, 2, 65, 128, 128, 64, torch.float16, torch.float16),
+    (2, 2, 2, 65, 128, 128, 64, torch.bfloat16, torch.bfloat16),
+    (2, 2, 2, 65, 128, 128, 64, torch.float16, torch.float32),
+    (2, 2, 2, 65, 128, 128, 64, torch.bfloat16, torch.float32),
+    (1, 2, 4, 256, 128, 256, 64, torch.float16, torch.float16),
+    (2, 2, 4, 128, 128, 128, 64, torch.float16, torch.float16),
+]
+
+VARIABLE_TEST_CONFIGS = [
+    (1, 2, 4, 128, 128, 128, 64, 3, torch.float16, torch.float16),
+    (1, 2, 4, 128, 128, 128, 64, 3, torch.bfloat16, torch.bfloat16),
+    (1, 2, 4, 256, 128, 256, 64, 2, torch.float16, torch.float16),
+]
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU device not found")
+@pytest.mark.parametrize("B,Hk,Hv,T,K,V,chunk_size,ktype,btype", FIX_TEST_CONFIGS)
+def test_recompute_wu_fwd_fix(B, Hk, Hv, T, K, V, chunk_size, ktype, btype):
+    torch.manual_seed(0)
+    k = torch.randn(B, Hk, T, K, dtype=ktype)
+    v = torch.randn(B, Hv, T, V, dtype=ktype)
+    beta = torch.randn(B, Hv, T, dtype=btype)
+    A = torch.randn(B, Hv, T, chunk_size, dtype=ktype)
+    g = torch.randn(B, Hv, T, dtype=btype)
+    NT = cdiv(T, chunk_size)
+
+    cpu_w = compute_w_golden(k, v, beta, A, g, None, None, B, Hv, T, K, chunk_size, NT, Hk=Hk)
+    cpu_u = compute_u_golden(v, beta, A, None, None, B, Hv, T, chunk_size, NT)
+
+    w, u = run_recompute_wu_fwd(k, v, beta, A, g, chunk_size)
+
+    rtol = 1e-1
+    atol = 1e-1
+    assert torch.allclose(w.cpu().float(), cpu_w.float(), rtol=rtol, atol=atol)
+    assert torch.allclose(u.cpu().float(), cpu_u.float(), rtol=rtol, atol=atol)
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU device not found")
+@pytest.mark.parametrize("B,Hk,Hv,T,K,V,chunk_size,cu_seqlens_len,ktype,btype", VARIABLE_TEST_CONFIGS)
+def test_recompute_wu_fwd_variable(B, Hk, Hv, T, K, V, chunk_size, cu_seqlens_len, ktype, btype):
+    torch.manual_seed(0)
+    k = torch.randn(B, Hk, T, K, dtype=ktype)
+    v = torch.randn(B, Hv, T, V, dtype=ktype)
+    beta = torch.randn(B, Hv, T, dtype=btype)
+    A = torch.randn(B, Hv, T, chunk_size, dtype=ktype)
+    g = torch.randn(B, Hv, T, dtype=btype)
+
+    cu_seqlens = prepare_cu_seqlens(T, cu_seqlens_len)
+    chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = len(chunk_indices) // 2
+
+    cpu_w = compute_w_golden(k, v, beta, A, g, cu_seqlens, chunk_indices, B, Hv, T, K, chunk_size, NT, Hk=Hk)
+    cpu_u = compute_u_golden(v, beta, A, cu_seqlens, chunk_indices, B, Hv, T, chunk_size, NT)
+
+    w, u = run_recompute_wu_fwd(k, v, beta, A, g, chunk_size, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    rtol = 1e-1
+    atol = 1e-1
+    assert torch.allclose(w.cpu().float(), cpu_w.float(), rtol=rtol, atol=atol)
+    assert torch.allclose(u.cpu().float(), cpu_u.float(), rtol=rtol, atol=atol)
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU device not found")
+def test_recompute_wu_fwd_variable_metadata_pair_required():
+    torch.manual_seed(0)
+    B, Hk, Hv, T, K, V, chunk_size = 1, 2, 4, 128, 128, 128, 64
+    k = torch.randn(B, Hk, T, K, dtype=torch.float16)
+    v = torch.randn(B, Hv, T, V, dtype=torch.float16)
+    beta = torch.randn(B, Hv, T, dtype=torch.float16)
+    A = torch.randn(B, Hv, T, chunk_size, dtype=torch.float16)
+    g = torch.randn(B, Hv, T, dtype=torch.float16)
+    cu_seqlens = prepare_cu_seqlens(T, 3)
+
+    with pytest.raises(RuntimeError, match="cu_seqlens and chunk_indices"):
+        run_recompute_wu_fwd(k, v, beta, A, g, chunk_size, cu_seqlens=cu_seqlens, chunk_indices=None)
+
+    with pytest.raises(RuntimeError, match="cu_seqlens and chunk_indices"):
+        run_recompute_wu_fwd(k, v, beta, A, g, chunk_size, cu_seqlens=None, chunk_indices=[0, 0])

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling.cpp
@@ -1,438 +1,100 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
- * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
- * the BSD 3-Clause License (the "License").
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- */
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 /*!
- * \file chunk_bwd_dv_local_tiling.cpp
+ * \file recompute_wu_fwd_tiling.cpp
  * \brief
  */
 
 #include "recompute_wu_fwd_tiling.h"
+#include "recompute_wu_fwd_tiling_processor.h"
 #include <register/op_impl_registry.h>
 #include "tiling_base/data_copy_transpose_tiling.h"
 #include "tiling_base/tiling_templates_registry.h"
 
 namespace optiling {
-static constexpr size_t INPUT_K_IDX = 0;
-static constexpr size_t INPUT_V_IDX = 1;
-static constexpr size_t INPUT_BETA_IDX = 2;
-static constexpr size_t INPUT_A_IDX = 3;
-static constexpr size_t INPUT_G_IDX = 4;
-static constexpr size_t INPUT_SEQLENS_IDX = 6;
-static constexpr size_t INPUT_CHUNK_INDICES_IDX = 7;
 
-static constexpr size_t ATTR_CHUNK_SIZE_IDX = 0;
-
-static constexpr size_t DIM_NUM_3 = 3;
-static constexpr size_t DIM_NUM_4 = 4;
-
-static constexpr size_t DIM_0 = 0;
-static constexpr size_t DIM_1 = 1;
-static constexpr size_t DIM_2 = 2;
-static constexpr size_t DIM_3 = 3;
-
-static constexpr int64_t CHUNK_SIZE_64 = 64;
-static constexpr int64_t CHUNK_SIZE_128 = 128;
-
-static constexpr int64_t VAR_LEN_B_DIM_1 = 1;
-
-static constexpr const char *const INPUT_K_NAME = "k";
-static constexpr const char *const INPUT_V_NAME = "v";
-static constexpr const char *const INPUT_BETA_NAME = "beta";
-static constexpr const char *const INPUT_A_NAME = "A";
-static constexpr const char *const INPUT_DA_NAME = "dA";
-static constexpr const char *const INPUT_DW_NAME = "dw";
-static constexpr const char *const INPUT_DU_NAME = "du";
-static constexpr const char *const INPUT_G_NAME = "g";
-static constexpr const char *const INPUT_CHUNK_INDICES_NAME = "chunk_indices";
-static constexpr const char *const INPUT_SEQLENS_NAME = "cu_seqlens";
-static constexpr uint64_t SIZE_HALF = 2;
-static constexpr uint64_t SIZE_FP32 = 4;
-constexpr uint64_t ONE_BLOCK_32 = 32;
-
-class RecomputeWUFwdTilingProcessor {
-    gert::TilingContext *context_;
-    RecomputeWUFwdTilingData &tiling_;
-    int64_t B = 0;
-    int64_t Hk = 0;
-    int64_t Hv = 0;
-    int64_t hvPerHk = 1;
-    int64_t K = 0;
-    int64_t V = 0;
-    int64_t T = 0;
-    int64_t chunkSize = 0;
-
-public:
-    explicit RecomputeWUFwdTilingProcessor(gert::TilingContext *context, RecomputeWUFwdTilingData &tiling)
-        : context_(context), tiling_(tiling)
-    {
-    }
-
-    ge::graphStatus RequiredInputDimNumCheck(const gert::StorageShape *curShape, size_t validDimNum,
-                                             const char *inputName)
-    {
-        OP_CHECK_IF(curShape == nullptr,
-                    OP_LOGE(context_->GetNodeName(), "Input %s is required, but got nullptr.", inputName),
-                    return ge::GRAPH_FAILED);
-        const gert::Shape storageShape = curShape->GetStorageShape();
-        size_t dimNum = storageShape.GetDimNum();
-        OP_CHECK_IF(dimNum != validDimNum,
-                    OP_LOGE(context_->GetNodeName(),
-                            "Check input %s shape failed, the dim num should be %zu, but get %zu.", inputName,
-                            validDimNum, dimNum),
-                    return ge::GRAPH_FAILED);
-        return ge::GRAPH_SUCCESS;
-    }
-
-    ge::graphStatus PreCheck()
-    {
-        const ge::char_t *nodeName = context_->GetNodeName();
-        OP_CHECK_IF(RequiredInputDimNumCheck(context_->GetRequiredInputShape(INPUT_K_IDX), DIM_NUM_4, INPUT_K_NAME) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(RequiredInputDimNumCheck(context_->GetRequiredInputShape(INPUT_V_IDX), DIM_NUM_4, INPUT_V_NAME) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(RequiredInputDimNumCheck(context_->GetRequiredInputShape(INPUT_BETA_IDX), DIM_NUM_3,
-                                             INPUT_BETA_NAME) != ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(RequiredInputDimNumCheck(context_->GetRequiredInputShape(INPUT_A_IDX), DIM_NUM_4, INPUT_A_NAME) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(RequiredInputDimNumCheck(context_->GetRequiredInputShape(INPUT_G_IDX), DIM_NUM_3, INPUT_G_NAME) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-
-        return ge::GRAPH_SUCCESS;
-    }
-
-    ge::graphStatus CompareShape(const gert::Shape &shape1, const gert::Shape &shape2, const char *inputName1,
-                                 const char *inputName2, size_t compareDimNum)
-    {
-        size_t shapeDim1 = 0;
-        size_t shapeDim2 = 0;
-        for (size_t dimIndex = 0; dimIndex < compareDimNum; dimIndex++) {
-            shapeDim1 = shape1.GetDim(dimIndex);
-            shapeDim2 = shape2.GetDim(dimIndex);
-            OP_CHECK_IF(shapeDim1 != shapeDim2,
-                        OP_LOGE(context_->GetNodeName(),
-                                "Compare input shape of %s and %s failed, the length of dim %zu should be same,but got "
-                                "%zu and %zu.",
-                                inputName1, inputName2, dimIndex, shapeDim1, shapeDim2),
-                        return ge::GRAPH_FAILED);
-        }
-        return ge::GRAPH_SUCCESS;
-    }
-    ge::graphStatus SetKbgExpVecRow(uint64_t ubSize, ge::DataType kType, ge::DataType betaType)
-    {
-        uint64_t rowNum = chunkSize;
-        uint64_t sizeofKType = SIZE_FP32;
-        uint64_t sizeofBetaType = SIZE_FP32;
-        if (kType != ge::DataType::DT_FLOAT) {
-            sizeofKType = SIZE_HALF;
-        }
-        if (betaType != ge::DataType::DT_FLOAT) {
-            sizeofBetaType = SIZE_HALF;
-        }
-        while (rowNum >= 8) {
-            uint64_t useUbSize = 0;
-            useUbSize += 2 * rowNum * K * sizeofKType;
-            useUbSize += 2 * rowNum * sizeofBetaType;
-            useUbSize += 2 * rowNum * sizeofBetaType;
-            useUbSize += 2 * rowNum * K * sizeofKType;
-            useUbSize += rowNum * K * sizeof(float);
-            useUbSize += rowNum * sizeof(float);
-            useUbSize += rowNum * sizeof(float);
-            useUbSize += rowNum * ONE_BLOCK_32;
-            
-            if (useUbSize <= ubSize) {
-                break;
-            }
-            rowNum = rowNum / 2;
-            
-        }
-        tiling_.set_kbgExpVecRow(rowNum);
-        return ge::GRAPH_SUCCESS;
-    }
-
-    ge::graphStatus SetVbVecRow(uint64_t ubSize, ge::DataType kType, ge::DataType betaType)
-    {
-        uint64_t rowNum = chunkSize;
-        uint64_t sizeofKType = SIZE_FP32;
-        uint64_t sizeofBetaType = SIZE_FP32;
-        if (kType != ge::DataType::DT_FLOAT) {
-            sizeofKType = SIZE_HALF;
-        }
-        if (betaType != ge::DataType::DT_FLOAT) {
-            sizeofBetaType = SIZE_HALF;
-        }
-        while (rowNum >= 8) {
-            uint64_t useUbSize = 0;
-            useUbSize += 2 * rowNum * V * sizeofKType;
-            useUbSize += 2 * rowNum * sizeofBetaType;
-            useUbSize += 2 * rowNum * V * sizeofKType;
-            useUbSize += rowNum * V * sizeof(float);
-            useUbSize += rowNum * sizeof(float);
-            useUbSize += rowNum * ONE_BLOCK_32;
-            
-            if (useUbSize <= ubSize) {
-                break;
-            }
-            rowNum = rowNum / 2;
-            
-        }
-        tiling_.set_vbVecRow(rowNum);
-        return ge::GRAPH_SUCCESS;
-    }
-
-    ge::graphStatus CommonTiling()
-    {
-        const gert::Shape kStorageShape = context_->GetRequiredInputShape(INPUT_K_IDX)->GetStorageShape();
-        const gert::Shape vStorageShape = context_->GetRequiredInputShape(INPUT_V_IDX)->GetStorageShape();
-        const gert::Shape betaStorageShape = context_->GetRequiredInputShape(INPUT_BETA_IDX)->GetStorageShape();
-        const gert::Shape AStorageShape = context_->GetRequiredInputShape(INPUT_A_IDX)->GetStorageShape();
-        const gert::Shape gStorageShape = context_->GetRequiredInputShape(INPUT_G_IDX)->GetStorageShape();
-        B = static_cast<int64_t>(vStorageShape.GetDim(DIM_0));
-        Hk = static_cast<int64_t>(kStorageShape.GetDim(DIM_1));
-        Hv = static_cast<int64_t>(vStorageShape.GetDim(DIM_1));
-        OP_CHECK_IF(Hk <= 0 || Hv <= 0,
-                    OP_LOGE(context_->GetNodeName(),
-                            "Invalid head dim: Hk and Hv must be positive, but got Hk=%ld, Hv=%ld.", Hk, Hv),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(Hv % Hk != 0,
-                    OP_LOGE(context_->GetNodeName(),
-                            "GVA check: Hv must be divisible by Hk, but got Hk=%ld, Hv=%ld.", Hk, Hv),
-                    return ge::GRAPH_FAILED);
-        hvPerHk = Hv / Hk;
-        OP_CHECK_IF(vStorageShape.GetDim(DIM_0) != kStorageShape.GetDim(DIM_0),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare B: v B=%ld vs k B=%ld mismatch.",
-                            vStorageShape.GetDim(DIM_0), kStorageShape.GetDim(DIM_0)),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(vStorageShape.GetDim(DIM_2) != kStorageShape.GetDim(DIM_2),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare T: v T=%ld vs k T=%ld mismatch.",
-                            vStorageShape.GetDim(DIM_2), kStorageShape.GetDim(DIM_2)),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(CompareShape(betaStorageShape, gStorageShape, INPUT_BETA_NAME, INPUT_G_NAME, DIM_NUM_3) !=
-                        ge::GRAPH_SUCCESS,
-                    , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(kStorageShape.GetDim(DIM_0) != gStorageShape.GetDim(DIM_0),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare B: k B=%ld vs g B=%ld mismatch.",
-                            kStorageShape.GetDim(DIM_0), gStorageShape.GetDim(DIM_0)),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(kStorageShape.GetDim(DIM_2) != gStorageShape.GetDim(DIM_2),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare T: k T=%ld vs g T=%ld mismatch.",
-                            kStorageShape.GetDim(DIM_2), gStorageShape.GetDim(DIM_2)),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(kStorageShape.GetDim(DIM_0) != AStorageShape.GetDim(DIM_0),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare B: k B=%ld vs A B=%ld mismatch.",
-                            kStorageShape.GetDim(DIM_0), AStorageShape.GetDim(DIM_0)),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(kStorageShape.GetDim(DIM_2) != AStorageShape.GetDim(DIM_2),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare T: k T=%ld vs A T=%ld mismatch.",
-                            kStorageShape.GetDim(DIM_2), AStorageShape.GetDim(DIM_2)),
-                    return ge::GRAPH_FAILED);
-        // A/beta/g 的 head 维必须等于 Hv（kernel 按 for h<Hv 索引这三个输入），否则会越界读
-        OP_CHECK_IF(AStorageShape.GetDim(DIM_1) != Hv,
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare head: A H=%ld must equal Hv=%ld.", AStorageShape.GetDim(DIM_1), Hv),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(betaStorageShape.GetDim(DIM_1) != Hv,
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare head: beta H=%ld must equal Hv=%ld.", betaStorageShape.GetDim(DIM_1), Hv),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(gStorageShape.GetDim(DIM_1) != Hv,
-                    OP_LOGE(context_->GetNodeName(),
-                            "Compare head: g H=%ld must equal Hv=%ld.", gStorageShape.GetDim(DIM_1), Hv),
-                    return ge::GRAPH_FAILED);
-        T = static_cast<int64_t>(vStorageShape.GetDim(DIM_2));
-        K = static_cast<int64_t>(kStorageShape.GetDim(DIM_3));
-        V = static_cast<int64_t>(vStorageShape.GetDim(DIM_3));
-        tiling_.set_B(B);
-        tiling_.set_Hk(Hk);
-        tiling_.set_Hv(Hv);
-        tiling_.set_hvPerHk(hvPerHk);
-        tiling_.set_T(T);
-        tiling_.set_K(K);
-        tiling_.set_V(V);
-        OP_CHECK_IF(V != V_DIM_128 && V != V_DIM_256,
-                    OP_LOGE(context_->GetNodeName(),
-                            "Check value dim V failed: only %ld or %ld is supported, but get %ld.",
-                            V_DIM_128, V_DIM_256, V),
-                    return ge::GRAPH_FAILED);
-        auto attrPtr = context_->GetAttrs();
-        OP_CHECK_NULL_WITH_CONTEXT(context_, attrPtr);
-        chunkSize = static_cast<int64_t>(*(attrPtr->GetAttrPointer<int32_t>(ATTR_CHUNK_SIZE_IDX)));
-        OP_CHECK_IF(chunkSize != CHUNK_SIZE_64 && chunkSize != CHUNK_SIZE_128,
-                    OP_LOGE(context_->GetNodeName(),
-                            "Check attr chunkSize failed, the chunkSize should be 64 or 128, but get %ld.", chunkSize),
-                    return ge::GRAPH_FAILED);
-        tiling_.set_chunkSize(chunkSize);
-        const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context_->GetPlatformInfo());
-        uint64_t ubSize = 0;
-        ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
-
-        auto kDesc = context_->GetDynamicInputDesc(INPUT_K_IDX, 0);
-        OP_CHECK_NULL_WITH_CONTEXT(context_, kDesc); // check xDesc is not null
-        auto kDType = kDesc->GetDataType();
-        auto betaDesc = context_->GetDynamicInputDesc(INPUT_BETA_IDX, 0);
-        OP_CHECK_NULL_WITH_CONTEXT(context_, betaDesc); // check xDesc is not null
-        auto betaDType = kDesc->GetDataType();
-        OP_CHECK_IF(SetVbVecRow(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS, OP_LOGE(context_->GetNodeName(), "SetDvbVecRow Failed."),
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(SetKbgExpVecRow(ubSize, kDType, betaDType) != ge::GRAPH_SUCCESS,
-                    OP_LOGE(context_->GetNodeName(), "SetKBeteVecRow Failed."), return ge::GRAPH_FAILED);
-        return ge::GRAPH_SUCCESS;
-    }
-
-    int64_t CeilDiv(int64_t a, int64_t b)
-    {
-        if (unlikely(b == 0)) {
-            return 0;
-        }
-        return (a + b - 1) / b;
-    }
-
-    ge::graphStatus FixLenTiling()
-    {
-        tiling_.set_chunkNum(tiling_.get_B() * CeilDiv(tiling_.get_T(), tiling_.get_chunkSize()));
-        return ge::GRAPH_SUCCESS;
-    }
-
-    ge::graphStatus VariableLenTiling()
-    {
-        const gert::StorageShape *chunkIndicesShape = context_->GetOptionalInputShape(INPUT_CHUNK_INDICES_IDX);
-        const gert::StorageShape *seqlensShape = context_->GetOptionalInputShape(INPUT_SEQLENS_IDX);
-        auto cuSeqlensTensor = context_->GetOptionalInputTensor(INPUT_SEQLENS_IDX);
-        auto chunkIndicesTensor = context_->GetOptionalInputTensor(INPUT_CHUNK_INDICES_IDX);
-        OP_CHECK_NULL_WITH_CONTEXT(context_, cuSeqlensTensor);
-        OP_CHECK_NULL_WITH_CONTEXT(context_, chunkIndicesShape);
-        OP_CHECK_NULL_WITH_CONTEXT(context_, seqlensShape);
-        OP_CHECK_IF(RequiredInputDimNumCheck(chunkIndicesShape, DIM_1, INPUT_CHUNK_INDICES_NAME) != ge::GRAPH_SUCCESS, ,
-                    return ge::GRAPH_FAILED);
-        OP_CHECK_IF(RequiredInputDimNumCheck(seqlensShape, DIM_1, INPUT_SEQLENS_NAME) != ge::GRAPH_SUCCESS, ,
-                    return ge::GRAPH_FAILED);
-
-        const gert::Shape seqlensStorageShape = seqlensShape->GetStorageShape();
-        int64_t seqlensDim0 = seqlensStorageShape.GetDim(DIM_0);
-        OP_CHECK_IF(seqlensDim0 < 2,
-                    OP_LOGE(context_->GetNodeName(),
-                            "Check seqlens shape failed, the dim 0 of seqlens should be larger than 1, but get %ld.",
-                            seqlensDim0),
-                    return ge::GRAPH_FAILED);
-        const int64_t* cuSeqlens = cuSeqlensTensor->GetData<int64_t>();
-        OP_CHECK_NULL_WITH_CONTEXT(context_, cuSeqlens);
-        if(cuSeqlens[0] != 0){
-            OP_LOGE(context_->GetNodeName(),
-                                "Check seqlens data failed, the seqlens[0] should be 0, but get %ld.",
-                                cuSeqlens[0]);
-            return ge::GRAPH_FAILED;
-        }
-        std::vector<int64_t> expectChunkIndices;
-        for(int64_t i = 1; i < seqlensDim0; i++){
-            int64_t curSeqLen = cuSeqlens[i] - cuSeqlens[i - 1];
-            OP_CHECK_IF(curSeqLen <= 0,
-                        OP_LOGE(context_->GetNodeName(),
-                                "Check seqlens data failed, the seqlens[%ld]:[%ld] should be larger than seqlens[%ld]:[%ld]",
-                                i, cuSeqlens[i], i - 1, cuSeqlens[i - 1]),
-                        return ge::GRAPH_FAILED);
-            for(int64_t j = 0;j < curSeqLen; j += chunkSize){
-                expectChunkIndices.push_back(i - 1);
-                expectChunkIndices.push_back(j / chunkSize);
-            }
-        }
-
-        
-        const gert::Shape chunkIndicesStorageShape = chunkIndicesShape->GetStorageShape();
-        int64_t chunkIndicesDim0 = chunkIndicesStorageShape.GetDim(DIM_0);
-        OP_CHECK_IF(chunkIndicesDim0 != expectChunkIndices.size(),
-                    OP_LOGE(context_->GetNodeName(),
-                            "Check chunk_indices shape failed, the len of chunk_indices should be %ld, but get %ld.",
-                            expectChunkIndices.size(), chunkIndicesDim0),
-                    return ge::GRAPH_FAILED);
-        const int64_t* chunkIndices = chunkIndicesTensor->GetData<int64_t>();
-        OP_CHECK_NULL_WITH_CONTEXT(context_, chunkIndices);
-        for(int64_t i = 0; i < expectChunkIndices.size(); i++){
-            OP_CHECK_IF(expectChunkIndices[i] != chunkIndices[i],
-                        OP_LOGE(context_->GetNodeName(),
-                                "Check chunk_indices data failed, the chunk_indices[%ld] should be %ld, but get %ld.",
-                                i, expectChunkIndices[i], chunkIndices[i]),
-                        return ge::GRAPH_FAILED);
-        }
-        tiling_.set_chunkNum(chunkIndicesStorageShape.GetDim(DIM_0) / 2);
-        return ge::GRAPH_SUCCESS;
-    }
-};
-
-static void RecomputeWUFwdTilingDataPrint(gert::TilingContext *context, RecomputeWUFwdTilingData &tiling)
+static void RecomputeWUFwdTilingDataPrint(gert::TilingContext *context, const RecomputeWUFwdTilingData &tiling)
 {
     auto nodeName = context->GetNodeName();
     OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Start to print RecomputeWUFwd tiling data <<<<<<<<<<<<<<<<");
-    OP_LOGD(nodeName, "=== B: %ld", tiling.get_B());
-    OP_LOGD(nodeName, "=== Hk: %ld", tiling.get_Hk());
-    OP_LOGD(nodeName, "=== Hv: %ld", tiling.get_Hv());
-    OP_LOGD(nodeName, "=== hvPerHk: %ld", tiling.get_hvPerHk());
-    OP_LOGD(nodeName, "=== T: %ld", tiling.get_T());
-    OP_LOGD(nodeName, "=== K: %ld", tiling.get_K());
-    OP_LOGD(nodeName, "=== V: %ld", tiling.get_V());
-    OP_LOGD(nodeName, "=== chunkSize: %ld", tiling.get_chunkSize());
-    OP_LOGD(nodeName, "=== vbVecRow: %ld", tiling.get_vbVecRow());
-    OP_LOGD(nodeName, "=== kbgExpVecRow: %ld", tiling.get_kbgExpVecRow());
+    OP_LOGD(nodeName, "=== B: %ld", tiling.B);
+    OP_LOGD(nodeName, "=== Hk: %ld", tiling.Hk);
+    OP_LOGD(nodeName, "=== Hv: %ld", tiling.Hv);
+    OP_LOGD(nodeName, "=== hvPerHk: %ld", tiling.hvPerHk);
+    OP_LOGD(nodeName, "=== T: %ld", tiling.T);
+    OP_LOGD(nodeName, "=== K: %ld", tiling.K);
+    OP_LOGD(nodeName, "=== V: %ld", tiling.V);
+    OP_LOGD(nodeName, "=== chunkSize: %ld", tiling.chunkSize);
+    OP_LOGD(nodeName, "=== vbVecRow: %ld", tiling.vbVecRow);
+    OP_LOGD(nodeName, "=== kbgExpVecRow: %ld", tiling.kbgExpVecRow);
     OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Print RecomputeWUFwd tiling data end <<<<<<<<<<<<<<<<");
 }
 
 ge::graphStatus Tiling4RecomputeWUFwd(gert::TilingContext *context)
 {
     OP_LOGD(context->GetNodeName(), "Tiling4RecomputeWUFwd start.");
-    RecomputeWUFwdTilingData tiling;
-    RecomputeWUFwdTilingProcessor processor(context, tiling);
+    RecomputeWUFwdTilingData *tiling = context->GetTilingData<RecomputeWUFwdTilingData>();
+    OP_CHECK_NULL_WITH_CONTEXT(context, tiling);
 
-    OP_CHECK_IF(processor.PreCheck() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
-    OP_CHECK_IF(processor.CommonTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+    auto attrPtr = context->GetAttrs();
+    OP_CHECK_NULL_WITH_CONTEXT(context, attrPtr);
 
-    auto cuSeqlensTensor = context->GetOptionalInputTensor(INPUT_SEQLENS_IDX);
-    if (cuSeqlensTensor == nullptr) {
-        OP_CHECK_IF(processor.FixLenTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
-        tiling.set_isVariable(0);
-    } else {
-        OP_CHECK_IF(tiling.get_B() != VAR_LEN_B_DIM_1,
-                    OP_LOGE(context->GetNodeName(),
-                            "If cu_seqlens is not nullptr, the dim 0 of q needs to be 1, but now is %ld.",
-                            tiling.get_B()),
-                    return ge::GRAPH_FAILED);
-        auto chunkIndicesTensor = context->GetOptionalInputTensor(INPUT_CHUNK_INDICES_IDX);
-        OP_CHECK_NULL_WITH_CONTEXT(context, chunkIndicesTensor);
-        OP_CHECK_IF(processor.VariableLenTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
-        tiling.set_isVariable(1);
-    }
-    if (tiling.get_V() == V_DIM_256) {
+    auto kDesc = context->GetDynamicInputDesc(RECOMPUTE_WU_FWD_INPUT_K_IDX, 0);
+    auto betaDesc = context->GetDynamicInputDesc(RECOMPUTE_WU_FWD_INPUT_BETA_IDX, 0);
+    OP_CHECK_NULL_WITH_CONTEXT(context, kDesc);
+    OP_CHECK_NULL_WITH_CONTEXT(context, betaDesc);
+
+    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
+    uint64_t ubSize = 0;
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
+    size_t sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
+
+    auto cuSeqlensTensor = context->GetOptionalInputTensor(RECOMPUTE_WU_FWD_INPUT_SEQLENS_IDX);
+    auto chunkIndicesTensor = context->GetOptionalInputTensor(RECOMPUTE_WU_FWD_INPUT_CHUNK_INDICES_IDX);
+    const int64_t *cuSeqlensData = cuSeqlensTensor != nullptr ? cuSeqlensTensor->GetData<int64_t>() : nullptr;
+    const int64_t *chunkIndicesData =
+        chunkIndicesTensor != nullptr ? chunkIndicesTensor->GetData<int64_t>() : nullptr;
+
+    RecomputeWUFwdTilingContext ctx{
+        context->GetNodeName(),
+        context->GetRequiredInputShape(RECOMPUTE_WU_FWD_INPUT_K_IDX),
+        context->GetRequiredInputShape(RECOMPUTE_WU_FWD_INPUT_V_IDX),
+        context->GetRequiredInputShape(RECOMPUTE_WU_FWD_INPUT_BETA_IDX),
+        context->GetRequiredInputShape(RECOMPUTE_WU_FWD_INPUT_A_IDX),
+        context->GetRequiredInputShape(RECOMPUTE_WU_FWD_INPUT_G_IDX),
+        context->GetOptionalInputShape(RECOMPUTE_WU_FWD_INPUT_SEQLENS_IDX),
+        context->GetOptionalInputShape(RECOMPUTE_WU_FWD_INPUT_CHUNK_INDICES_IDX),
+        cuSeqlensData,
+        chunkIndicesData,
+        *(attrPtr->GetAttrPointer<int32_t>(0)),
+        kDesc->GetDataType(),
+        betaDesc->GetDataType(),
+        ubSize,
+        sysWorkspaceSize,
+    };
+
+    RecomputeWUFwdTilingProcessor processor(ctx, *tiling);
+    OP_CHECK_IF(processor.Process() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+
+    if (tiling->V == RECOMPUTE_WU_FWD_V_DIM_256) {
         context->SetTilingKey(2);
     } else {
         context->SetTilingKey(1);
     }
-    OP_LOGD(context->GetNodeName(), "tilingKey: %d (V=%ld)", context->GetTilingKey(), tiling.get_V());
-    RecomputeWUFwdTilingDataPrint(context, tiling);
+    OP_LOGD(context->GetNodeName(), "tilingKey: %d (V=%ld)", context->GetTilingKey(), tiling->V);
+    RecomputeWUFwdTilingDataPrint(context, *tiling);
 
-    tiling.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
-    context->GetRawTilingData()->SetDataSize(tiling.GetDataSize());
-    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
     context->SetBlockDim(ascendcPlatform.GetCoreNumAic());
-
-    uint32_t sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
-    uint32_t userWorkspaceSize = 2 * tiling.get_B() * tiling.get_Hv() * tiling.get_T() * tiling.get_V();
     size_t *currentWorkspace = context->GetWorkspaceSizes(1);
-    currentWorkspace[0] = userWorkspaceSize + sysWorkspaceSize;
-    context->SetScheduleMode(1); // set as batchmod for template using SyncAll
+    currentWorkspace[0] = processor.GetWorkspaceSize();
+    context->SetScheduleMode(1);
     OP_LOGD(context->GetNodeName(), "Tiling4RecomputeWUFwd end.");
     return ge::GRAPH_SUCCESS;
 }
@@ -442,8 +104,6 @@ ge::graphStatus TilingRecomputeForRecomputeWUFwd(gert::TilingParseContext *conte
     (void)context;
     return ge::GRAPH_SUCCESS;
 }
-
-struct RecomputeWUFwdCompileInfo {};
 
 IMPL_OP_OPTILING(RecomputeWUFwd)
     .Tiling(Tiling4RecomputeWUFwd)

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling.h
@@ -1,46 +1,25 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
- * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
- * the BSD 3-Clause License (the "License").
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- */
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 /*!
  * \file recompute_wu_fwd_tiling.h
- * \brief
+ * \brief Compatibility include for recompute_wu_fwd tiling data.
  */
-#ifndef RECOMPUTE_WU_FWD_TILING_H
-#define RECOMPUTE_WU_FWD_TILING_H
 
-#include <exe_graph/runtime/tiling_context.h>
-#include <graph/utils/type_utils.h>
+#pragma once
 
-#include "register/tilingdata_base.h"
-#include "tiling/tiling_api.h"
+#include "../../op_kernel/recompute_wu_fwd_struct.h"
 
 namespace optiling {
 
-static constexpr int64_t V_DIM_128 = 128;
-static constexpr int64_t V_DIM_256 = 256;
+using GDN::RecomputeWUFwdTilingData;
 
-BEGIN_TILING_DATA_DEF(RecomputeWUFwdTilingData)
-TILING_DATA_FIELD_DEF(int64_t, B);
-TILING_DATA_FIELD_DEF(int64_t, Hk);
-TILING_DATA_FIELD_DEF(int64_t, Hv);
-TILING_DATA_FIELD_DEF(int64_t, hvPerHk);
-TILING_DATA_FIELD_DEF(int64_t, T);
-TILING_DATA_FIELD_DEF(int64_t, K);
-TILING_DATA_FIELD_DEF(int64_t, V);
-TILING_DATA_FIELD_DEF(int64_t, chunkNum);
-TILING_DATA_FIELD_DEF(int64_t, chunkSize);
-TILING_DATA_FIELD_DEF(int64_t, vbVecRow); // kBeta计算流程时vector单次处理的行数
-TILING_DATA_FIELD_DEF(int64_t, kbgExpVecRow);   // dk计算流程时vector单次处理的行数
-TILING_DATA_FIELD_DEF(int64_t, isVariable);
-END_TILING_DATA_DEF;
-REGISTER_TILING_DATA_CLASS(RecomputeWUFwd, RecomputeWUFwdTilingData)
+struct RecomputeWUFwdCompileInfo {};
 
 } // namespace optiling
-
-#endif // RECOMPUTE_WU_FWD_TILING_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling_processor.h
@@ -1,0 +1,426 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file recompute_wu_fwd_tiling_processor.h
+ * \brief Tiling processor shared by aclnn tiling and fast kernel launch.
+ */
+
+#ifndef RECOMPUTE_WU_FWD_TILING_PROCESSOR_H
+#define RECOMPUTE_WU_FWD_TILING_PROCESSOR_H
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+#include "exe_graph/runtime/storage_shape.h"
+#include <register/op_impl_registry.h>
+#include "tiling_base/data_copy_transpose_tiling.h"
+#include "tiling_base/tiling_templates_registry.h"
+#include "../../op_kernel/recompute_wu_fwd_struct.h"
+
+using GDN::RecomputeWUFwdTilingData;
+
+namespace optiling {
+
+static constexpr int64_t RECOMPUTE_WU_FWD_V_DIM_128 = 128;
+static constexpr int64_t RECOMPUTE_WU_FWD_V_DIM_256 = 256;
+
+static constexpr size_t RECOMPUTE_WU_FWD_INPUT_K_IDX = 0;
+static constexpr size_t RECOMPUTE_WU_FWD_INPUT_V_IDX = 1;
+static constexpr size_t RECOMPUTE_WU_FWD_INPUT_BETA_IDX = 2;
+static constexpr size_t RECOMPUTE_WU_FWD_INPUT_A_IDX = 3;
+static constexpr size_t RECOMPUTE_WU_FWD_INPUT_G_IDX = 4;
+static constexpr size_t RECOMPUTE_WU_FWD_INPUT_SEQLENS_IDX = 6;
+static constexpr size_t RECOMPUTE_WU_FWD_INPUT_CHUNK_INDICES_IDX = 7;
+
+static constexpr size_t RECOMPUTE_WU_FWD_DIM_NUM_3 = 3;
+static constexpr size_t RECOMPUTE_WU_FWD_DIM_NUM_4 = 4;
+
+static constexpr size_t RECOMPUTE_WU_FWD_DIM_0 = 0;
+static constexpr size_t RECOMPUTE_WU_FWD_DIM_1 = 1;
+static constexpr size_t RECOMPUTE_WU_FWD_DIM_2 = 2;
+static constexpr size_t RECOMPUTE_WU_FWD_DIM_3 = 3;
+
+static constexpr int64_t RECOMPUTE_WU_FWD_CHUNK_SIZE_64 = 64;
+static constexpr int64_t RECOMPUTE_WU_FWD_CHUNK_SIZE_128 = 128;
+static constexpr int64_t RECOMPUTE_WU_FWD_VAR_LEN_B_DIM_1 = 1;
+
+static constexpr const char *const RECOMPUTE_WU_FWD_INPUT_K_NAME = "k";
+static constexpr const char *const RECOMPUTE_WU_FWD_INPUT_V_NAME = "v";
+static constexpr const char *const RECOMPUTE_WU_FWD_INPUT_BETA_NAME = "beta";
+static constexpr const char *const RECOMPUTE_WU_FWD_INPUT_A_NAME = "A";
+static constexpr const char *const RECOMPUTE_WU_FWD_INPUT_G_NAME = "g";
+static constexpr const char *const RECOMPUTE_WU_FWD_INPUT_CHUNK_INDICES_NAME = "chunk_indices";
+static constexpr const char *const RECOMPUTE_WU_FWD_INPUT_SEQLENS_NAME = "cu_seqlens";
+
+static constexpr uint64_t RECOMPUTE_WU_FWD_SIZE_HALF = 2;
+static constexpr uint64_t RECOMPUTE_WU_FWD_SIZE_FP32 = 4;
+static constexpr uint64_t RECOMPUTE_WU_FWD_ONE_BLOCK_32 = 32;
+
+struct RecomputeWUFwdTilingContext {
+    const char *nodeName;
+    const gert::StorageShape *kShape;
+    const gert::StorageShape *vShape;
+    const gert::StorageShape *betaShape;
+    const gert::StorageShape *aShape;
+    const gert::StorageShape *gShape;
+    const gert::StorageShape *cuSeqlensShape;
+    const gert::StorageShape *chunkIndicesShape;
+    const int64_t *cuSeqlensData;
+    const int64_t *chunkIndicesData;
+    int32_t chunkSize;
+    ge::DataType kDtype;
+    ge::DataType betaDtype;
+    uint64_t ubSize;
+    size_t sysWorkspaceSize;
+};
+
+class RecomputeWUFwdTilingProcessor {
+    RecomputeWUFwdTilingContext &ctx_;
+    RecomputeWUFwdTilingData &tiling_;
+    size_t workspaceSize_ = 0;
+    int64_t B = 0;
+    int64_t Hk = 0;
+    int64_t Hv = 0;
+    int64_t hvPerHk = 1;
+    int64_t K = 0;
+    int64_t V = 0;
+    int64_t T = 0;
+    int64_t chunkSize = 0;
+
+public:
+    explicit RecomputeWUFwdTilingProcessor(RecomputeWUFwdTilingContext &ctx, RecomputeWUFwdTilingData &tiling)
+        : ctx_(ctx), tiling_(tiling)
+    {
+    }
+
+    size_t GetWorkspaceSize() const
+    {
+        return workspaceSize_;
+    }
+
+    bool IsVariableLength() const
+    {
+        return ctx_.cuSeqlensShape != nullptr;
+    }
+
+    ge::graphStatus RequiredInputDimNumCheck(const gert::StorageShape *curShape, size_t validDimNum,
+                                             const char *inputName)
+    {
+        OP_CHECK_IF(curShape == nullptr,
+                    OP_LOGE(ctx_.nodeName, "Input %s is required, but got nullptr.", inputName),
+                    return ge::GRAPH_FAILED);
+        const gert::Shape storageShape = curShape->GetStorageShape();
+        size_t dimNum = storageShape.GetDimNum();
+        OP_CHECK_IF(dimNum != validDimNum,
+                    OP_LOGE(ctx_.nodeName,
+                            "Check input %s shape failed, the dim num should be %zu, but get %zu.", inputName,
+                            validDimNum, dimNum),
+                    return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus PreCheck()
+    {
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.kShape, RECOMPUTE_WU_FWD_DIM_NUM_4, RECOMPUTE_WU_FWD_INPUT_K_NAME) !=
+                        ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.vShape, RECOMPUTE_WU_FWD_DIM_NUM_4, RECOMPUTE_WU_FWD_INPUT_V_NAME) !=
+                        ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.betaShape, RECOMPUTE_WU_FWD_DIM_NUM_3,
+                                             RECOMPUTE_WU_FWD_INPUT_BETA_NAME) != ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.aShape, RECOMPUTE_WU_FWD_DIM_NUM_4, RECOMPUTE_WU_FWD_INPUT_A_NAME) !=
+                        ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.gShape, RECOMPUTE_WU_FWD_DIM_NUM_3, RECOMPUTE_WU_FWD_INPUT_G_NAME) !=
+                        ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus CompareShape(const gert::Shape &shape1, const gert::Shape &shape2, const char *inputName1,
+                                 const char *inputName2, size_t compareDimNum)
+    {
+        size_t shapeDim1 = 0;
+        size_t shapeDim2 = 0;
+        for (size_t dimIndex = 0; dimIndex < compareDimNum; dimIndex++) {
+            shapeDim1 = shape1.GetDim(dimIndex);
+            shapeDim2 = shape2.GetDim(dimIndex);
+            OP_CHECK_IF(shapeDim1 != shapeDim2,
+                        OP_LOGE(ctx_.nodeName,
+                                "Compare input shape of %s and %s failed, the length of dim %zu should be same,but got "
+                                "%zu and %zu.",
+                                inputName1, inputName2, dimIndex, shapeDim1, shapeDim2),
+                        return ge::GRAPH_FAILED);
+        }
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus SetKbgExpVecRow(uint64_t ubSize, ge::DataType kType, ge::DataType betaType)
+    {
+        uint64_t rowNum = static_cast<uint64_t>(chunkSize);
+        uint64_t sizeofKType = RECOMPUTE_WU_FWD_SIZE_FP32;
+        uint64_t sizeofBetaType = RECOMPUTE_WU_FWD_SIZE_FP32;
+        if (kType != ge::DataType::DT_FLOAT) {
+            sizeofKType = RECOMPUTE_WU_FWD_SIZE_HALF;
+        }
+        if (betaType != ge::DataType::DT_FLOAT) {
+            sizeofBetaType = RECOMPUTE_WU_FWD_SIZE_HALF;
+        }
+        while (rowNum >= 8) {
+            uint64_t useUbSize = 0;
+            useUbSize += 2 * rowNum * static_cast<uint64_t>(K) * sizeofKType;
+            useUbSize += 2 * rowNum * sizeofBetaType;
+            useUbSize += 2 * rowNum * sizeofBetaType;
+            useUbSize += 2 * rowNum * static_cast<uint64_t>(K) * sizeofKType;
+            useUbSize += rowNum * static_cast<uint64_t>(K) * sizeof(float);
+            useUbSize += rowNum * sizeof(float);
+            useUbSize += rowNum * sizeof(float);
+            useUbSize += rowNum * RECOMPUTE_WU_FWD_ONE_BLOCK_32;
+
+            if (useUbSize <= ubSize) {
+                break;
+            }
+            rowNum = rowNum / 2;
+        }
+        tiling_.kbgExpVecRow = static_cast<int64_t>(rowNum);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus SetVbVecRow(uint64_t ubSize, ge::DataType kType, ge::DataType betaType)
+    {
+        uint64_t rowNum = static_cast<uint64_t>(chunkSize);
+        uint64_t sizeofKType = RECOMPUTE_WU_FWD_SIZE_FP32;
+        uint64_t sizeofBetaType = RECOMPUTE_WU_FWD_SIZE_FP32;
+        if (kType != ge::DataType::DT_FLOAT) {
+            sizeofKType = RECOMPUTE_WU_FWD_SIZE_HALF;
+        }
+        if (betaType != ge::DataType::DT_FLOAT) {
+            sizeofBetaType = RECOMPUTE_WU_FWD_SIZE_HALF;
+        }
+        while (rowNum >= 8) {
+            uint64_t useUbSize = 0;
+            useUbSize += 2 * rowNum * static_cast<uint64_t>(V) * sizeofKType;
+            useUbSize += 2 * rowNum * sizeofBetaType;
+            useUbSize += 2 * rowNum * static_cast<uint64_t>(V) * sizeofKType;
+            useUbSize += rowNum * static_cast<uint64_t>(V) * sizeof(float);
+            useUbSize += rowNum * sizeof(float);
+            useUbSize += rowNum * RECOMPUTE_WU_FWD_ONE_BLOCK_32;
+
+            if (useUbSize <= ubSize) {
+                break;
+            }
+            rowNum = rowNum / 2;
+        }
+        tiling_.vbVecRow = static_cast<int64_t>(rowNum);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus CommonTiling()
+    {
+        const gert::Shape kStorageShape = ctx_.kShape->GetStorageShape();
+        const gert::Shape vStorageShape = ctx_.vShape->GetStorageShape();
+        const gert::Shape betaStorageShape = ctx_.betaShape->GetStorageShape();
+        const gert::Shape AStorageShape = ctx_.aShape->GetStorageShape();
+        const gert::Shape gStorageShape = ctx_.gShape->GetStorageShape();
+        B = static_cast<int64_t>(vStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_0));
+        Hk = static_cast<int64_t>(kStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_1));
+        Hv = static_cast<int64_t>(vStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_1));
+        OP_CHECK_IF(Hk <= 0 || Hv <= 0,
+                    OP_LOGE(ctx_.nodeName,
+                            "Invalid head dim: Hk and Hv must be positive, but got Hk=%ld, Hv=%ld.", Hk, Hv),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(Hv % Hk != 0,
+                    OP_LOGE(ctx_.nodeName,
+                            "GVA check: Hv must be divisible by Hk, but got Hk=%ld, Hv=%ld.", Hk, Hv),
+                    return ge::GRAPH_FAILED);
+        hvPerHk = Hv / Hk;
+        OP_CHECK_IF(vStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_0) != kStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_0),
+                    OP_LOGE(ctx_.nodeName, "Compare B: v B=%ld vs k B=%ld mismatch.",
+                            vStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_0), kStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_0)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(vStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_2) != kStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_2),
+                    OP_LOGE(ctx_.nodeName, "Compare T: v T=%ld vs k T=%ld mismatch.",
+                            vStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_2), kStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_2)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(CompareShape(betaStorageShape, gStorageShape, RECOMPUTE_WU_FWD_INPUT_BETA_NAME,
+                                 RECOMPUTE_WU_FWD_INPUT_G_NAME, RECOMPUTE_WU_FWD_DIM_NUM_3) != ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(kStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_0) != gStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_0),
+                    OP_LOGE(ctx_.nodeName, "Compare B: k B=%ld vs g B=%ld mismatch.", kStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_0),
+                            gStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_0)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(kStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_2) != gStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_2),
+                    OP_LOGE(ctx_.nodeName, "Compare T: k T=%ld vs g T=%ld mismatch.", kStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_2),
+                            gStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_2)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(kStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_0) != AStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_0),
+                    OP_LOGE(ctx_.nodeName, "Compare B: k B=%ld vs A B=%ld mismatch.", kStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_0),
+                            AStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_0)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(kStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_2) != AStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_2),
+                    OP_LOGE(ctx_.nodeName, "Compare T: k T=%ld vs A T=%ld mismatch.", kStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_2),
+                            AStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_2)),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(AStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_1) != Hv,
+                    OP_LOGE(ctx_.nodeName, "Compare head: A H=%ld must equal Hv=%ld.", AStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_1), Hv),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(betaStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_1) != Hv,
+                    OP_LOGE(ctx_.nodeName, "Compare head: beta H=%ld must equal Hv=%ld.",
+                            betaStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_1), Hv),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(gStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_1) != Hv,
+                    OP_LOGE(ctx_.nodeName, "Compare head: g H=%ld must equal Hv=%ld.", gStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_1), Hv),
+                    return ge::GRAPH_FAILED);
+        T = static_cast<int64_t>(vStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_2));
+        K = static_cast<int64_t>(kStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_3));
+        V = static_cast<int64_t>(vStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_3));
+        tiling_.B = B;
+        tiling_.Hk = Hk;
+        tiling_.Hv = Hv;
+        tiling_.hvPerHk = hvPerHk;
+        tiling_.T = T;
+        tiling_.K = K;
+        tiling_.V = V;
+        OP_CHECK_IF(V != RECOMPUTE_WU_FWD_V_DIM_128 && V != RECOMPUTE_WU_FWD_V_DIM_256,
+                    OP_LOGE(ctx_.nodeName,
+                            "Check value dim V failed: only %ld or %ld is supported, but get %ld.",
+                            RECOMPUTE_WU_FWD_V_DIM_128, RECOMPUTE_WU_FWD_V_DIM_256, V),
+                    return ge::GRAPH_FAILED);
+        chunkSize = static_cast<int64_t>(ctx_.chunkSize);
+        OP_CHECK_IF(chunkSize != RECOMPUTE_WU_FWD_CHUNK_SIZE_64 && chunkSize != RECOMPUTE_WU_FWD_CHUNK_SIZE_128,
+                    OP_LOGE(ctx_.nodeName,
+                            "Check attr chunkSize failed, the chunkSize should be 64 or 128, but get %ld.", chunkSize),
+                    return ge::GRAPH_FAILED);
+        tiling_.chunkSize = chunkSize;
+
+        OP_CHECK_IF(SetVbVecRow(ctx_.ubSize, ctx_.kDtype, ctx_.betaDtype) != ge::GRAPH_SUCCESS,
+                    OP_LOGE(ctx_.nodeName, "SetVbVecRow Failed."), return ge::GRAPH_FAILED);
+        OP_CHECK_IF(SetKbgExpVecRow(ctx_.ubSize, ctx_.kDtype, ctx_.betaDtype) != ge::GRAPH_SUCCESS,
+                    OP_LOGE(ctx_.nodeName, "SetKbgExpVecRow Failed."), return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    static int64_t CeilDiv(int64_t a, int64_t b)
+    {
+        if (unlikely(b == 0)) {
+            return 0;
+        }
+        return (a + b - 1) / b;
+    }
+
+    ge::graphStatus FixLenTiling()
+    {
+        tiling_.chunkNum = tiling_.B * CeilDiv(tiling_.T, tiling_.chunkSize);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus VariableLenTiling()
+    {
+        OP_CHECK_IF(ctx_.cuSeqlensShape == nullptr,
+                    OP_LOGE(ctx_.nodeName, "Input %s is required, but got nullptr.", RECOMPUTE_WU_FWD_INPUT_SEQLENS_NAME),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(ctx_.chunkIndicesShape == nullptr,
+                    OP_LOGE(ctx_.nodeName, "Input %s is required, but got nullptr.",
+                            RECOMPUTE_WU_FWD_INPUT_CHUNK_INDICES_NAME),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.chunkIndicesShape, 1, RECOMPUTE_WU_FWD_INPUT_CHUNK_INDICES_NAME) !=
+                        ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.cuSeqlensShape, 1, RECOMPUTE_WU_FWD_INPUT_SEQLENS_NAME) !=
+                        ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+
+        const gert::Shape seqlensStorageShape = ctx_.cuSeqlensShape->GetStorageShape();
+        int64_t seqlensDim0 = seqlensStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_0);
+        OP_CHECK_IF(seqlensDim0 < 2,
+                    OP_LOGE(ctx_.nodeName,
+                            "Check seqlens shape failed, the dim 0 of seqlens should be larger than 1, but get %ld.",
+                            seqlensDim0),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(ctx_.cuSeqlensData == nullptr,
+                    OP_LOGE(ctx_.nodeName, "Input %s data is required, but got nullptr.", RECOMPUTE_WU_FWD_INPUT_SEQLENS_NAME),
+                    return ge::GRAPH_FAILED);
+        const int64_t *cuSeqlens = ctx_.cuSeqlensData;
+        if (cuSeqlens[0] != 0) {
+            OP_LOGE(ctx_.nodeName, "Check seqlens data failed, the seqlens[0] should be 0, but get %ld.", cuSeqlens[0]);
+            return ge::GRAPH_FAILED;
+        }
+        std::vector<int64_t> expectChunkIndices;
+        for (int64_t i = 1; i < seqlensDim0; i++) {
+            int64_t curSeqLen = cuSeqlens[i] - cuSeqlens[i - 1];
+            OP_CHECK_IF(curSeqLen <= 0,
+                        OP_LOGE(ctx_.nodeName,
+                                "Check seqlens data failed, the seqlens[%ld]:[%ld] should be larger than seqlens[%ld]:[%ld]",
+                                i, cuSeqlens[i], i - 1, cuSeqlens[i - 1]),
+                        return ge::GRAPH_FAILED);
+            for (int64_t j = 0; j < curSeqLen; j += chunkSize) {
+                expectChunkIndices.push_back(i - 1);
+                expectChunkIndices.push_back(j / chunkSize);
+            }
+        }
+
+        const gert::Shape chunkIndicesStorageShape = ctx_.chunkIndicesShape->GetStorageShape();
+        int64_t chunkIndicesDim0 = chunkIndicesStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_0);
+        OP_CHECK_IF(chunkIndicesDim0 != static_cast<int64_t>(expectChunkIndices.size()),
+                    OP_LOGE(ctx_.nodeName,
+                            "Check chunk_indices shape failed, the len of chunk_indices should be %zu, but get %ld.",
+                            expectChunkIndices.size(), chunkIndicesDim0),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(ctx_.chunkIndicesData == nullptr,
+                    OP_LOGE(ctx_.nodeName, "Input %s data is required, but got nullptr.",
+                            RECOMPUTE_WU_FWD_INPUT_CHUNK_INDICES_NAME),
+                    return ge::GRAPH_FAILED);
+        const int64_t *chunkIndices = ctx_.chunkIndicesData;
+        for (size_t i = 0; i < expectChunkIndices.size(); i++) {
+            OP_CHECK_IF(expectChunkIndices[i] != chunkIndices[i],
+                        OP_LOGE(ctx_.nodeName,
+                                "Check chunk_indices data failed, the chunk_indices[%zu] should be %ld, but get %ld.",
+                                i, expectChunkIndices[i], chunkIndices[i]),
+                        return ge::GRAPH_FAILED);
+        }
+        tiling_.chunkNum = chunkIndicesStorageShape.GetDim(RECOMPUTE_WU_FWD_DIM_0) / 2;
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus WorkspaceTiling()
+    {
+        uint64_t userWorkspaceSize =
+            static_cast<uint64_t>(2) * static_cast<uint64_t>(tiling_.B) * static_cast<uint64_t>(tiling_.Hv) *
+            static_cast<uint64_t>(tiling_.T) * static_cast<uint64_t>(tiling_.V);
+        workspaceSize_ = ctx_.sysWorkspaceSize + static_cast<size_t>(userWorkspaceSize);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus Process()
+    {
+        OP_CHECK_IF(PreCheck() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(CommonTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+        if (IsVariableLength()) {
+            OP_CHECK_IF(tiling_.B != RECOMPUTE_WU_FWD_VAR_LEN_B_DIM_1,
+                        OP_LOGE(ctx_.nodeName,
+                                "If cu_seqlens is not nullptr, the dim 0 of q needs to be 1, but now is %ld.",
+                                tiling_.B),
+                        return ge::GRAPH_FAILED);
+            OP_CHECK_IF(VariableLenTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+            tiling_.isVariable = 1;
+        } else {
+            OP_CHECK_IF(FixLenTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+            tiling_.isVariable = 0;
+        }
+        OP_CHECK_IF(WorkspaceTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+};
+
+} // namespace optiling
+
+#endif // RECOMPUTE_WU_FWD_TILING_PROCESSOR_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd.cpp
@@ -1,18 +1,22 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
- * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
- * the BSD 3-Clause License (the "License").
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- */
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 /*!
  * \file recompute_wu_fwd.cpp
  * \brief
  */
+
 #include "kernel_operator.h"
+#ifndef TORCH_MODE
 #include "lib/matmul_intf.h"
+#endif
+#include "recompute_wu_fwd_struct.h"
 #include "recompute_wu_fwd_common.h"
 #include "recompute_wu_fwd_cube.h"
 #include "recompute_wu_fwd_vector.h"
@@ -21,49 +25,80 @@ template <class... Dims>
 using GemmCubeTileShape = tla::Shape<Dims...>;
 using namespace tla;
 
-using namespace AscendC;
-__global__ __aicore__ void recompute_wu_fwd(GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR g, GM_ADDR gk,
-                                             GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR w,
-                                              GM_ADDR u, GM_ADDR workspace, GM_ADDR tiling)
+namespace GDN {
+
+template <typename kType, typename betaType>
+struct RecomputeWUFwdTileShapes128 {
+    using L1TileShape = GemmCubeTileShape<_128, _128, _256>;
+    using L0TileShape = GemmCubeTileShape<_128, _128, _128>;
+};
+
+template <typename kType, typename betaType>
+struct RecomputeWUFwdTileShapes256 {
+    using L1TileShape = GemmCubeTileShape<_128, _256, _256>;
+    using L0TileShape = GemmCubeTileShape<_128, _256, _64>;
+};
+
+template <typename kType, typename betaType, int VDim, typename TileShapes>
+__aicore__ inline void RecomputeWUFwdKernelImplTyped(
+    GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR g, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
+    GM_ADDR w, GM_ADDR u, GM_ADDR workspace, const RecomputeWUFwdTilingData *tilingData)
 {
+    if ASCEND_IS_AIC {
+        RecomputeWUFwdProcess<kType, betaType, typename TileShapes::L1TileShape, typename TileShapes::L0TileShape>
+            recomputeWUFwdProcess(k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
+        recomputeWUFwdProcess.Init(*tilingData);
+        recomputeWUFwdProcess.Process();
+    }
+    if ASCEND_IS_AIV {
+        AscendC::TPipe tPipe;
+        RecomputeWUFwdVectorProcess<kType, betaType> recomputeWUFwdVectorProcess(
+            k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
+        recomputeWUFwdVectorProcess.Init(*tilingData, &tPipe);
+        recomputeWUFwdVectorProcess.Process();
+    }
+}
+
+template <typename kType, typename betaType, int VDim>
+__aicore__ inline void RecomputeWUFwdKernelImpl(
+    GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR g, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
+    GM_ADDR w, GM_ADDR u, GM_ADDR workspace, const RecomputeWUFwdTilingData *tilingData)
+{
+    if constexpr (VDim == 256) {
+        RecomputeWUFwdKernelImplTyped<kType, betaType, VDim, RecomputeWUFwdTileShapes256<kType, betaType>>(
+            k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace, tilingData);
+    } else {
+        RecomputeWUFwdKernelImplTyped<kType, betaType, VDim, RecomputeWUFwdTileShapes128<kType, betaType>>(
+            k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace, tilingData);
+    }
+}
+
+} // namespace GDN
+
+#ifndef TORCH_MODE
+using namespace AscendC;
+
+__global__ __aicore__ void recompute_wu_fwd(GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR g, GM_ADDR gk,
+                                            GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR w, GM_ADDR u,
+                                            GM_ADDR workspace, GM_ADDR tiling)
+{
+    (void)gk;
     AscendC::AscendCUtils::SetOverflow(1);
-    GET_TILING_DATA(tilingData, tiling);
+    GM_ADDR userWS = AscendC::GetUserWorkspace(workspace);
+    if (userWS == nullptr) {
+        return;
+    }
+    REGISTER_TILING_DEFAULT(GDN::RecomputeWUFwdTilingData);
+    GET_TILING_DATA_WITH_STRUCT(GDN::RecomputeWUFwdTilingData, tilingData, tiling);
+
     if (TILING_KEY_IS(1)) {
         KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
-        if ASCEND_IS_AIC {
-            RecomputeWUFwdProcess<DTYPE_K, DTYPE_BETA,
-                                  GemmCubeTileShape<_128, _128, _256>,
-                                  GemmCubeTileShape<_128, _128, _128>>
-                recomputeWUFwdProcess(
-                k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
-           recomputeWUFwdProcess.Init(tilingData);
-           recomputeWUFwdProcess.Process();
-        }
-        if ASCEND_IS_AIV {
-            AscendC::TPipe tPipe;
-            RecomputeWUFwdVectorProcess<DTYPE_K, DTYPE_BETA>recomputeWUFwdVectorProcess(
-                k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
-           recomputeWUFwdVectorProcess.Init(tilingData, &tPipe);
-           recomputeWUFwdVectorProcess.Process();
-        }
+        GDN::RecomputeWUFwdKernelImpl<DTYPE_K, DTYPE_BETA, 128>(
+            k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, userWS, &tilingData);
     } else if (TILING_KEY_IS(2)) {
         KERNEL_TASK_TYPE(2, KERNEL_TYPE_MIX_AIC_1_2);
-        if ASCEND_IS_AIC {
-            RecomputeWUFwdProcess<DTYPE_K, DTYPE_BETA,
-                                  GemmCubeTileShape<_128, _256, _256>,
-                                  GemmCubeTileShape<_128, _256, _64>>
-                recomputeWUFwdProcess(
-                k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
-           recomputeWUFwdProcess.Init(tilingData);
-           recomputeWUFwdProcess.Process();
-        }
-        if ASCEND_IS_AIV {
-            AscendC::TPipe tPipe;
-            RecomputeWUFwdVectorProcess<DTYPE_K, DTYPE_BETA>recomputeWUFwdVectorProcess(
-                k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
-           recomputeWUFwdVectorProcess.Init(tilingData, &tPipe);
-           recomputeWUFwdVectorProcess.Process();
-        }
+        GDN::RecomputeWUFwdKernelImpl<DTYPE_K, DTYPE_BETA, 256>(
+            k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, userWS, &tilingData);
     }
-    return;
 }
+#endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd_cube.h
@@ -15,6 +15,11 @@
 
 #ifndef RECOMPUTE_WU_FWD_CUBE_H
 #define RECOMPUTE_WU_FWD_CUBE_H
+
+#include "recompute_wu_fwd_struct.h"
+
+using GDN::RecomputeWUFwdTilingData;
+
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
 #define CATLASS_ARCH 3510
 #else

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd_struct.h
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file recompute_wu_fwd_struct.h
+ * \brief Shared tiling data for recompute_wu_fwd.
+ */
+
+#ifndef RECOMPUTE_WU_FWD_STRUCT_H
+#define RECOMPUTE_WU_FWD_STRUCT_H
+
+#include <cstdint>
+
+namespace GDN {
+
+struct RecomputeWUFwdTilingData {
+    int64_t B;
+    int64_t Hk;
+    int64_t Hv;
+    int64_t hvPerHk;
+    int64_t T;
+    int64_t K;
+    int64_t V;
+    int64_t chunkNum;
+    int64_t chunkSize;
+    int64_t vbVecRow;
+    int64_t kbgExpVecRow;
+    int64_t isVariable;
+};
+
+} // namespace GDN
+
+#endif // RECOMPUTE_WU_FWD_STRUCT_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd_vector.h
@@ -16,8 +16,11 @@
 #ifndef RECOMPUTE_WU_FWD_VECTOR_H
 #define RECOMPUTE_WU_FWD_VECTOR_H
 
+#include "recompute_wu_fwd_struct.h"
 #include "catlass/arch/cross_core_sync.hpp"
 using namespace AscendC;
+
+using GDN::RecomputeWUFwdTilingData;
 
 template <typename kType, typename betaType>
 class RecomputeWUFwdVectorProcess {


### PR DESCRIPTION
## 修改设计

为 `recompute_wu_fwd` 适配 fast kernel launch（`kernel<<<>>>` 直调）路径，绕过 aclnn 框架、在 PyTorch extension 中直接构造 tiling 并发起 kernel 执行；当前范围仅 `ascend910b`。

### 核心改动
- 抽取共享实现：新增 `recompute_wu_fwd_tiling_processor.h` 与 `recompute_wu_fwd_struct.h`，原 aclnn（GE）路径与 fast launch 路径复用同一套 tiling/kernel 结构体，消除双份维护。
- fast launch csrc：`SetSysWorkspaceForce` + `GetUserWorkspace`；按 V 设置 `KERNEL_TASK_TYPE(1/2)`；`CheckInputs` 校验 rank/device/dtype 及 cu_seqlens/chunk_indices 成对约束。
- 构建：`examples/fast_kernel_launch_example` 增加 `recompute_wu_fwd/ascend910b` 子目标与 CMake 注册。
- 测试：新增 `tests/recompute_wu_fwd/test_recompute_wu_fwd.py`，CPU golden 对比（`rtol=atol=1e-1`，与原 custom op `diff_thd=0.1` 对齐）。

### 涉及文件
- `examples/fast_kernel_launch_example/CMakeLists.txt`
- `examples/fast_kernel_launch_example/csrc/recompute_wu_fwd/ascend910b/CMakeLists.txt`
- `examples/fast_kernel_launch_example/csrc/recompute_wu_fwd/ascend910b/recompute_wu_fwd.cpp`
- `examples/fast_kernel_launch_example/tests/recompute_wu_fwd/test_recompute_wu_fwd.py`
- `fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling.{h,cpp}`
- `fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_host/op_tiling/recompute_wu_fwd_tiling_processor.h`
- `fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel/recompute_wu_fwd.{cpp,cube.h,vector.h,struct.h}`

# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: 无（内部功能增强，无需 Issue）
- 背景与目标: 提供不经过 aclnn 框架的 `kernel<<<>>>` 直调入口，便于框架侧自定义调度与调试；同时通过共享 tiling/kernel 结构体避免两条路径实现漂移。
- 本 PR 解决的问题: recompute_wu_fwd 在 ascend910b 上支持 fast kernel launch：tiling/kernel 结构体抽取、直调 wrapper、pytest 覆盖。

## 变更类型

- [ ] Bug 修复
- [x] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: recompute_wu_fwd
- 涉及目录 / 文件: 见上方「涉及文件」
- 责任人 / 提交人: @Coding-Pangolin
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 与 aclnn 原路径一致：k `[B,Hk,T,K]`、v `[B,Hv,T,V]`、beta/g `[B,Hv,T]`、A `[B,Hv,T,chunkSize]`，输出 w `[B,Hv,T,K]`、u `[B,Hv,T,V]`；支持 GVA（Hv%Hk==0）、V ∈ {128,256}、chunkSize ∈ {64,128}；fast launch 仅 ascend910b，建议调用侧传入 contiguous tensor（wrapper 已做 CheckInputs）。
- 明确不包含的范围: gk 未启用（须 None）；fast launch 不支持 ascend910_93/ascend950；aclnn 路径大 T/大 B 用例未全量执行。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 不涉及

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 8.5.0 | `bash build.sh --pkg --soc=ascend910b --ops=recompute_wu_fwd --vendor_name=fla_npu` | 通过 | custom op 整包编译 OK |
| A2 | `ascend910b` | 8.5.0 | `FAST_KERNEL_OP_NAME=recompute_wu_fwd NPU_ARCH=ascend910b python3 setup.py bdist_wheel` | 通过 | fast kernel whl 编译安装 OK |
| A3/A5 | `ascend910_93 / ascend950` | - | `未执行` | 未执行 | fast launch 仅适配 ascend910b |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | cd torch_custom/fla_npu/test && python3 test_npu_recompute_w_u_fwd.py | 通过 | aclnn 回归 4 case PASS（fixed fp16 T=65、T=129 chunk128、GVA V=256、varlen），约 18.6s |
| A2 | `ascend910b` | cd examples/fast_kernel_launch_example && pytest tests/recompute_wu_fwd/test_recompute_wu_fwd.py -v | 通过 | 12/12 PASS，35.88s；日志 fast_kernel_pytest_20260624.log |

- fast launch 精度判定：`torch.allclose`（CPU golden vs NPU）`rtol=atol=1e-1`，12/12 PASS。
- 覆盖：定长/变长、fp16/bf16、beta/g fp32、GVA（Hk=2,Hv=4）、V=256、chunkSize=128、metadata 成对校验、接口存在性。
- 性能对比：不涉及。
- 边界/异常场景：metadata 必须成对（缺一即报错校验通过）；变长 B=1。
- 未覆盖风险：fast launch 仅 910B；wrapper 未加显式 `aclrtSynchronizeStream`（与 chunk_fwd_o 一致，若遇异步问题再补）。

</details>

<details>
<summary>整体 Example ST 验证</summary>

本 PR 为新增直调入口，未单独执行整体 example ST；依赖仓库 NPU CI 回归确认不破坏 GDN 端到端调用链。

</details>

## 兼容性、风险与回退

- 兼容性说明: 新增 fast launch 入口 `torch.ops.ascend_ops.recompute_wu_fwd`，不改动 aclnn/torch_custom 既有接口。
- 风险点: fast launch 与 aclnn 两条路径共用 tiling/kernel，后续 tiling 改动需双路径同步回归；仅 910B 验证。
- 回退方案: fast launch 相关文件均为新增/独立模块，删除即回退，不影响 aclnn 原路径。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因（内部功能增强，无外部 Issue）
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 可以编译通过
- [ ] 已验证 A3 / A5 编译（fast launch 仅 910B）
- [x] 已验证修改算子的对应 test 在 A2 通过
- [ ] 已验证整体 example ST（未单独执行，依赖 NPU CI）
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用（转测文档已整理，README 随后续文档 PR 同步）
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 转测文档：`recompute_wu_fwd_fast_kernel转测文档.md`（环境、编译、12/12 用例明细、精度/遗留）。
- 入口：`torch.ops.ascend_ops.recompute_wu_fwd` → csrc 直调；原路径 `torch.ops.npu.npu_recompute_w_u_fwd` → aclnn。