### PR TITLE
feat(chunk_gated_delta_rule_bwd_dhu): 新增 ascend910b fast kernel launch（kernel<<<>>> 直调）支持

### DIFF
--- a/examples/fast_kernel_launch_example/CMakeLists.txt
+++ b/examples/fast_kernel_launch_example/CMakeLists.txt
@@ -36,6 +36,8 @@ set(INCLUDE_DIRECTORIES
     ${CMAKE_CURRENT_SOURCE_DIR}/../..
     ${CMAKE_CURRENT_SOURCE_DIR}/../../common/include
     ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/common
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/gdn/chunk_gdn_bwd
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel
     ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/gdn/chunk_gdn_fwd
     ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel
     ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel

--- a/examples/fast_kernel_launch_example/csrc/chunk_gated_delta_rule_bwd_dhu/ascend910b/CMakeLists.txt
+++ b/examples/fast_kernel_launch_example/csrc/chunk_gated_delta_rule_bwd_dhu/ascend910b/CMakeLists.txt
@@ -1,0 +1,10 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# ----------------------------------------------------------------------------
+
+add_sources("--npu-arch=dav-2201")

--- a/examples/fast_kernel_launch_example/csrc/chunk_gated_delta_rule_bwd_dhu/ascend910b/chunk_gated_delta_rule_bwd_dhu.cpp
+++ b/examples/fast_kernel_launch_example/csrc/chunk_gated_delta_rule_bwd_dhu/ascend910b/chunk_gated_delta_rule_bwd_dhu.cpp
@@ -1,0 +1,367 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_bwd_dhu.cpp
+ * \brief Chunk gated delta rule backward dhu operator with fast kernel launch.
+ */
+
+#include <algorithm>
+#include <tuple>
+#include <vector>
+#include <ATen/Operators.h>
+#include <torch/all.h>
+#include <torch/library.h>
+#include "acl/acl.h"
+#include "torch_npu/csrc/core/npu/NPUStream.h"
+#include "torch_npu/csrc/framework/OpCommand.h"
+#include "kernel_operator.h"
+#include "platform/platform_ascendc.h"
+
+#include "fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h"
+#include "fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu.cpp"
+
+namespace ascend_ops {
+namespace ChunkGatedDeltaRuleBwdDhu {
+
+using TilingData = GDN::ChunkGatedDeltaRuleBwdDhuTilingData;
+
+TORCH_LIBRARY_FRAGMENT(EXTENSION_MODULE_NAME, m)
+{
+    m.def("chunk_gated_delta_rule_bwd_dhu(Tensor q, Tensor k, Tensor w, Tensor d_o, Tensor dv, float scale, int chunk_size, *, Tensor? g=None, Tensor? gK=None, Tensor? h0=None, Tensor? dht=None, int[]? cu_seqlens=None, int[]? chunk_indices=None) -> (Tensor, Tensor, Tensor)");
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_bwd_dhu_meta(
+    const at::Tensor &q, const at::Tensor &k, const at::Tensor &w, const at::Tensor &d_o, const at::Tensor &dv,
+    double scale, int64_t chunk_size, const c10::optional<at::Tensor> &g, const c10::optional<at::Tensor> &gK,
+    const c10::optional<at::Tensor> &h0, const c10::optional<at::Tensor> &dht, at::OptionalIntArrayRef cu_seqlens,
+    at::OptionalIntArrayRef chunk_indices)
+{
+    (void)scale;
+    (void)gK;
+    (void)dht;
+
+    int64_t B = q.size(0);
+    int64_t Hk = q.size(1);
+    int64_t T = q.size(2);
+    int64_t K = q.size(3);
+    int64_t Hv = dv.size(1);
+    int64_t V = dv.size(3);
+    int64_t chunkNum = (T + chunk_size - 1) / chunk_size;
+    if (chunk_indices.has_value()) {
+        chunkNum = static_cast<int64_t>(chunk_indices.value().size()) / 2;
+    }
+
+    at::Tensor dh = at::empty({B, Hv, chunkNum, K, V}, q.options());
+    at::Tensor dv2 = at::empty_like(dv);
+    at::Tensor dh0;
+    if (h0.has_value()) {
+        dh0 = at::empty({B, Hv, chunkNum, K, V}, q.options());
+    } else {
+        dh0 = at::empty({0}, q.options());
+    }
+    return std::make_tuple(dh, dh0, dv2);
+}
+
+TORCH_LIBRARY_IMPL(EXTENSION_MODULE_NAME, Meta, m)
+{
+    m.impl("chunk_gated_delta_rule_bwd_dhu", chunk_gated_delta_rule_bwd_dhu_meta);
+}
+
+struct ChunkGatedDeltaRuleBwdDhuTilingResult {
+    TilingData tiling;
+    uint32_t blockDim;
+    size_t workspaceSize;
+    uint32_t tilingKey;
+};
+
+void CheckInputRank(const at::Tensor &tensor, int64_t rank, const char *name)
+{
+    TORCH_CHECK(tensor.dim() == rank, name, " should be ", rank, "D, but got ", tensor.dim(), "D.");
+}
+
+void CheckSameDevice(const at::Tensor &base, const at::Tensor &tensor, const char *name)
+{
+    TORCH_CHECK(tensor.device() == base.device(), name, " should be on the same device as q.");
+}
+
+void CheckInputs(const at::Tensor &q, const at::Tensor &k, const at::Tensor &w, const at::Tensor &d_o,
+                 const at::Tensor &dv, const at::Tensor &g, at::OptionalIntArrayRef cu_seqlens,
+                 at::OptionalIntArrayRef chunk_indices)
+{
+    CheckInputRank(q, 4, "q");
+    CheckInputRank(k, 4, "k");
+    CheckInputRank(w, 4, "w");
+    CheckInputRank(d_o, 4, "d_o");
+    CheckInputRank(dv, 4, "dv");
+    CheckInputRank(g, 3, "g");
+
+    CheckSameDevice(q, k, "k");
+    CheckSameDevice(q, w, "w");
+    CheckSameDevice(q, d_o, "d_o");
+    CheckSameDevice(q, dv, "dv");
+    CheckSameDevice(q, g, "g");
+
+    int64_t B = q.size(0);
+    int64_t Hk = q.size(1);
+    int64_t T = q.size(2);
+    int64_t K = q.size(3);
+    int64_t Hv = dv.size(1);
+    int64_t V = dv.size(3);
+
+    TORCH_CHECK(k.size(0) == B && k.size(1) == Hk && k.size(2) == T && k.size(3) == K,
+              "k must match q as [B,Hk,T,K]; q=", q.sizes(), " k=", k.sizes());
+    TORCH_CHECK(w.size(0) == B && w.size(1) == Hv && w.size(2) == T && w.size(3) == K,
+              "w must be [B,Hv,T,K]; w=", w.sizes(), " dv=", dv.sizes());
+    TORCH_CHECK(d_o.size(0) == B && d_o.size(1) == Hv && d_o.size(2) == T && d_o.size(3) == V,
+              "d_o must be [B,Hv,T,V]; d_o=", d_o.sizes());
+    TORCH_CHECK(dv.size(0) == B && dv.size(1) == Hv && dv.size(2) == T && dv.size(3) == V,
+              "dv must be [B,Hv,T,V]; dv=", dv.sizes());
+    TORCH_CHECK(Hk > 0 && Hv > 0 && Hv % Hk == 0,
+              "GVA requires Hv divisible by Hk; Hk=", Hk, " Hv=", Hv);
+    TORCH_CHECK(g.size(0) == B && g.size(1) == Hv && g.size(2) == T,
+              "g must be [B,Hv,T]; g=", g.sizes());
+
+    auto qDtype = q.scalar_type();
+    auto gDtype = g.scalar_type();
+    TORCH_CHECK(qDtype == at::kHalf || qDtype == at::kBFloat16,
+              "q/k/w/d_o/dv only support float16 or bfloat16, but got ", qDtype);
+    TORCH_CHECK(k.scalar_type() == qDtype && w.scalar_type() == qDtype && d_o.scalar_type() == qDtype &&
+                    dv.scalar_type() == qDtype,
+              "k/w/d_o/dv should have the same dtype as q.");
+    TORCH_CHECK(gDtype == qDtype || gDtype == at::kFloat,
+              "g should have the same dtype as q or float32, but g is ", gDtype, " and q is ", qDtype);
+    TORCH_CHECK(cu_seqlens.has_value() == chunk_indices.has_value(),
+              "cu_seqlens and chunk_indices should be both provided or both None.");
+}
+
+ge::DataType ToGeDtype(at::ScalarType dtype)
+{
+    if (dtype == at::kBFloat16) {
+        return ge::DT_BF16;
+    }
+    if (dtype == at::kHalf) {
+        return ge::DT_FLOAT16;
+    }
+    if (dtype == at::kFloat) {
+        return ge::DT_FLOAT;
+    }
+    TORCH_CHECK(false, "Unsupported dtype: ", dtype);
+    return ge::DT_FLOAT16;
+}
+
+ChunkGatedDeltaRuleBwdDhuTilingResult CalcTilingParams(
+    const at::Tensor &q, const at::Tensor &k, const at::Tensor &w, const at::Tensor &d_o, const at::Tensor &dv,
+    const at::Tensor &g, double scale, int64_t chunk_size, at::OptionalIntArrayRef cu_seqlens,
+    at::OptionalIntArrayRef chunk_indices)
+{
+    auto qSizes = q.sizes();
+    auto kSizes = k.sizes();
+    auto wSizes = w.sizes();
+    auto doSizes = d_o.sizes();
+    auto dvSizes = dv.sizes();
+    auto gSizes = g.sizes();
+
+    gert::StorageShape qShape({qSizes[0], qSizes[1], qSizes[2], qSizes[3]},
+                              {qSizes[0], qSizes[1], qSizes[2], qSizes[3]});
+    gert::StorageShape kShape({kSizes[0], kSizes[1], kSizes[2], kSizes[3]},
+                              {kSizes[0], kSizes[1], kSizes[2], kSizes[3]});
+    gert::StorageShape wShape({wSizes[0], wSizes[1], wSizes[2], wSizes[3]},
+                              {wSizes[0], wSizes[1], wSizes[2], wSizes[3]});
+    gert::StorageShape doShape({doSizes[0], doSizes[1], doSizes[2], doSizes[3]},
+                               {doSizes[0], doSizes[1], doSizes[2], doSizes[3]});
+    gert::StorageShape dvShape({dvSizes[0], dvSizes[1], dvSizes[2], dvSizes[3]},
+                                {dvSizes[0], dvSizes[1], dvSizes[2], dvSizes[3]});
+    gert::StorageShape gShape({gSizes[0], gSizes[1], gSizes[2]}, {gSizes[0], gSizes[1], gSizes[2]});
+
+    gert::StorageShape *cuSeqlensShapePtr = nullptr;
+    gert::StorageShape *chunkIndicesShapePtr = nullptr;
+    gert::StorageShape cuSeqlensShape;
+    gert::StorageShape chunkIndicesShape;
+
+    if (cu_seqlens.has_value()) {
+        int64_t cuDim0 = static_cast<int64_t>(cu_seqlens.value().size());
+        cuSeqlensShape = gert::StorageShape({cuDim0}, {cuDim0});
+        cuSeqlensShapePtr = &cuSeqlensShape;
+    }
+    if (chunk_indices.has_value()) {
+        int64_t ciDim0 = static_cast<int64_t>(chunk_indices.value().size());
+        chunkIndicesShape = gert::StorageShape({ciDim0}, {ciDim0});
+        chunkIndicesShapePtr = &chunkIndicesShape;
+    }
+
+    auto ascendcPlatform = platform_ascendc::PlatformAscendCManager::GetInstance();
+    TORCH_CHECK(ascendcPlatform != nullptr, "PlatformAscendCManager is null.");
+    uint32_t coreNum = static_cast<uint32_t>(ascendcPlatform->GetCoreNumAic());
+    size_t sysWorkspaceSize = static_cast<size_t>(ascendcPlatform->GetLibApiWorkSpaceSize());
+    uint64_t ubSize = 0;
+    ascendcPlatform->GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
+
+    TilingData tiling{};
+    optiling::ChunkGatedDeltaRuleBwdDhuTilingContext ctx{
+        "chunk_gated_delta_rule_bwd_dhu",
+        &qShape,
+        &kShape,
+        &wShape,
+        &doShape,
+        &dvShape,
+        &gShape,
+        cuSeqlensShapePtr,
+        chunkIndicesShapePtr,
+        ToGeDtype(q.scalar_type()),
+        ToGeDtype(g.scalar_type()),
+        true,
+        true,
+        scale,
+        static_cast<int32_t>(chunk_size),
+        ubSize,
+        coreNum,
+        sysWorkspaceSize,
+    };
+
+    optiling::ChunkGatedDeltaRuleBwdDhuTilingProcessor processor(ctx, tiling);
+    TORCH_CHECK(processor.Process() == ge::GRAPH_SUCCESS, "chunk_gated_delta_rule_bwd_dhu tiling failed.");
+    return ChunkGatedDeltaRuleBwdDhuTilingResult{tiling, processor.GetBlockDim(), processor.GetWorkspaceSize(),
+                                                 processor.GetTilingKey()};
+}
+
+template <typename DT, typename GT>
+__global__ __aicore__ void chunk_gated_delta_rule_bwd_dhu_kernel(
+    GM_ADDR q, GM_ADDR k, GM_ADDR w, GM_ADDR d_o, GM_ADDR dv, GM_ADDR g, GM_ADDR gk, GM_ADDR h0, GM_ADDR dht,
+    GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR dh, GM_ADDR dh0, GM_ADDR dv2, GM_ADDR workspace,
+    const GDN::ChunkGatedDeltaRuleBwdDhuTilingData tilingData)
+{
+    (void)gk;
+    (void)h0;
+    (void)dht;
+    AscendC::SetSysWorkspaceForce(workspace);
+    GM_ADDR userWS = AscendC::GetUserWorkspace(workspace);
+    if (userWS == nullptr) {
+        return;
+    }
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+    GDN::ChunkGatedDeltaRuleBwdDhuKernelImpl<DT, GT>(
+        q, k, w, d_o, dv, g, cu_seqlens, chunk_indices, dh, dh0, dv2, userWS, &tilingData);
+}
+
+template <typename DT, typename GT>
+void LaunchChunkGatedDeltaRuleBwdDhu(uint32_t blockDim, aclrtStream stream, GM_ADDR q, GM_ADDR k, GM_ADDR w, GM_ADDR d_o,
+                                     GM_ADDR dv, GM_ADDR g, GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR dh,
+                                     GM_ADDR dh0, GM_ADDR dv2, GM_ADDR workspace,
+                                     const GDN::ChunkGatedDeltaRuleBwdDhuTilingData &tiling)
+{
+    chunk_gated_delta_rule_bwd_dhu_kernel<DT, GT><<<blockDim, nullptr, stream>>>(
+        q, k, w, d_o, dv, g, nullptr, nullptr, nullptr, cu_seqlens, chunk_indices, dh, dh0, dv2, workspace, tiling);
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_bwd_dhu_npu(
+    const at::Tensor &q, const at::Tensor &k, const at::Tensor &w, const at::Tensor &d_o, const at::Tensor &dv,
+    double scale, int64_t chunk_size, const c10::optional<at::Tensor> &g, const c10::optional<at::Tensor> &gK,
+    const c10::optional<at::Tensor> &h0, const c10::optional<at::Tensor> &dht, at::OptionalIntArrayRef cu_seqlens,
+    at::OptionalIntArrayRef chunk_indices)
+{
+    TORCH_CHECK(g.has_value(), "chunk_gated_delta_rule_bwd_dhu requires g to be provided.");
+    TORCH_CHECK(!gK.has_value(), "gK is not supported and must be None.");
+    TORCH_CHECK(!h0.has_value(), "h0 is not supported in fast kernel launch and must be None.");
+    TORCH_CHECK(!dht.has_value(), "dht is not supported in fast kernel launch and must be None.");
+
+    const c10::OptionalDeviceGuard guard(q.device());
+    const at::Tensor &gTensor = g.value();
+    CheckInputs(q, k, w, d_o, dv, gTensor, cu_seqlens, chunk_indices);
+
+    auto outputs = chunk_gated_delta_rule_bwd_dhu_meta(q, k, w, d_o, dv, scale, chunk_size, g, gK, h0, dht,
+                                                       cu_seqlens, chunk_indices);
+    auto dh = std::get<0>(outputs);
+    auto dh0 = std::get<1>(outputs);
+    auto dv2 = std::get<2>(outputs);
+
+    auto stream = c10_npu::getCurrentNPUStream().stream(false);
+    auto tilingResult = CalcTilingParams(q, k, w, d_o, dv, gTensor, scale, chunk_size, cu_seqlens, chunk_indices);
+
+    GM_ADDR qPtr = (GM_ADDR)q.data_ptr();
+    GM_ADDR kPtr = (GM_ADDR)k.data_ptr();
+    GM_ADDR wPtr = (GM_ADDR)w.data_ptr();
+    GM_ADDR doPtr = (GM_ADDR)d_o.data_ptr();
+    GM_ADDR dvPtr = (GM_ADDR)dv.data_ptr();
+    GM_ADDR gPtr = (GM_ADDR)gTensor.data_ptr();
+    GM_ADDR dhPtr = (GM_ADDR)dh.data_ptr();
+    GM_ADDR dh0Ptr = dh0.numel() > 0 ? (GM_ADDR)dh0.data_ptr() : nullptr;
+    GM_ADDR dv2Ptr = (GM_ADDR)dv2.data_ptr();
+
+    GM_ADDR cuSeqlensPtr = nullptr;
+    GM_ADDR chunkIndicesPtr = nullptr;
+    std::vector<int64_t> cuSeqlensVec;
+    std::vector<int64_t> chunkIndicesVec;
+    at::Tensor cuSeqlensTensor;
+    at::Tensor chunkIndicesTensor;
+
+    if (cu_seqlens.has_value()) {
+        cuSeqlensVec = std::vector<int64_t>(cu_seqlens.value().begin(), cu_seqlens.value().end());
+        cuSeqlensTensor = at::tensor(cuSeqlensVec, at::dtype(at::kLong).device(q.device()));
+        cuSeqlensPtr = (GM_ADDR)cuSeqlensTensor.data_ptr();
+    }
+    if (chunk_indices.has_value()) {
+        chunkIndicesVec = std::vector<int64_t>(chunk_indices.value().begin(), chunk_indices.value().end());
+        chunkIndicesTensor = at::tensor(chunkIndicesVec, at::dtype(at::kLong).device(q.device()));
+        chunkIndicesPtr = (GM_ADDR)chunkIndicesTensor.data_ptr();
+    }
+
+    void *workspacePtr = nullptr;
+    if (tilingResult.workspaceSize > 0) {
+        auto ret = aclrtMalloc(&workspacePtr, tilingResult.workspaceSize, ACL_MEM_MALLOC_HUGE_FIRST);
+        TORCH_CHECK(ret == ACL_SUCCESS, "allocate workspace failed. ERROR: ", ret);
+    }
+    GM_ADDR workspaceGm = (GM_ADDR)workspacePtr;
+
+    auto qDtype = q.scalar_type();
+    auto gDtype = gTensor.scalar_type();
+    auto tiling = tilingResult.tiling;
+    auto blockDim = tilingResult.blockDim;
+
+    auto aclCall = [=]() -> int {
+        if (qDtype == at::kBFloat16 && gDtype == at::kBFloat16) {
+            LaunchChunkGatedDeltaRuleBwdDhu<bfloat16_t, bfloat16_t>(
+                blockDim, stream, qPtr, kPtr, wPtr, doPtr, dvPtr, gPtr, cuSeqlensPtr, chunkIndicesPtr, dhPtr, dh0Ptr,
+                dv2Ptr, workspaceGm, tiling);
+        } else if (qDtype == at::kHalf && gDtype == at::kHalf) {
+            LaunchChunkGatedDeltaRuleBwdDhu<half, half>(
+                blockDim, stream, qPtr, kPtr, wPtr, doPtr, dvPtr, gPtr, cuSeqlensPtr, chunkIndicesPtr, dhPtr, dh0Ptr,
+                dv2Ptr, workspaceGm, tiling);
+        } else if (qDtype == at::kBFloat16 && gDtype == at::kFloat) {
+            LaunchChunkGatedDeltaRuleBwdDhu<bfloat16_t, float>(
+                blockDim, stream, qPtr, kPtr, wPtr, doPtr, dvPtr, gPtr, cuSeqlensPtr, chunkIndicesPtr, dhPtr, dh0Ptr,
+                dv2Ptr, workspaceGm, tiling);
+        } else if (qDtype == at::kHalf && gDtype == at::kFloat) {
+            LaunchChunkGatedDeltaRuleBwdDhu<half, float>(
+                blockDim, stream, qPtr, kPtr, wPtr, doPtr, dvPtr, gPtr, cuSeqlensPtr, chunkIndicesPtr, dhPtr, dh0Ptr,
+                dv2Ptr, workspaceGm, tiling);
+        } else {
+            TORCH_CHECK(false, "Unsupported dtype combination: q=", qDtype, ", g=", gDtype);
+        }
+        return 0;
+    };
+
+    at_npu::native::OpCommand::RunOpApi("ChunkGatedDeltaRuleBwdDhu", aclCall);
+    auto syncRet = aclrtSynchronizeStream(stream);
+    TORCH_CHECK(syncRet == ACL_SUCCESS, "aclrtSynchronizeStream failed. ERROR: ", syncRet);
+
+    if (workspacePtr != nullptr) {
+        aclrtFree(workspacePtr);
+    }
+
+    return std::make_tuple(dh, dh0, dv2);
+}
+
+TORCH_LIBRARY_IMPL(EXTENSION_MODULE_NAME, PrivateUse1, m)
+{
+    m.impl("chunk_gated_delta_rule_bwd_dhu", chunk_gated_delta_rule_bwd_dhu_npu);
+}
+
+} // namespace ChunkGatedDeltaRuleBwdDhu
+} // namespace ascend_ops

--- a/examples/fast_kernel_launch_example/csrc/chunk_gated_delta_rule_bwd_dhu/ascend910b/chunk_gated_delta_rule_bwd_dhu.cpp
+++ b/examples/fast_kernel_launch_example/csrc/chunk_gated_delta_rule_bwd_dhu/ascend910b/chunk_gated_delta_rule_bwd_dhu.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <tuple>
+#include <type_traits>
 #include <vector>
 #include <ATen/Operators.h>
 #include <torch/all.h>
@@ -78,7 +79,6 @@ struct ChunkGatedDeltaRuleBwdDhuTilingResult {
     TilingData tiling;
     uint32_t blockDim;
     size_t workspaceSize;
-    uint32_t tilingKey;
 };
 
 void CheckInputRank(const at::Tensor &tensor, int64_t rank, const char *name)
@@ -227,8 +227,7 @@ ChunkGatedDeltaRuleBwdDhuTilingResult CalcTilingParams(
 
     optiling::ChunkGatedDeltaRuleBwdDhuTilingProcessor processor(ctx, tiling);
     TORCH_CHECK(processor.Process() == ge::GRAPH_SUCCESS, "chunk_gated_delta_rule_bwd_dhu tiling failed.");
-    return ChunkGatedDeltaRuleBwdDhuTilingResult{tiling, processor.GetBlockDim(), processor.GetWorkspaceSize(),
-                                                 processor.GetTilingKey()};
+    return ChunkGatedDeltaRuleBwdDhuTilingResult{tiling, processor.GetBlockDim(), processor.GetWorkspaceSize()};
 }
 
 template <typename DT, typename GT>
@@ -240,12 +239,17 @@ __global__ __aicore__ void chunk_gated_delta_rule_bwd_dhu_kernel(
     (void)gk;
     (void)h0;
     (void)dht;
+    AscendC::AscendCUtils::SetOverflow(1);
     AscendC::SetSysWorkspaceForce(workspace);
     GM_ADDR userWS = AscendC::GetUserWorkspace(workspace);
     if (userWS == nullptr) {
         return;
     }
-    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+    if constexpr (std::is_same_v<GT, float>) {
+        KERNEL_TASK_TYPE(2, KERNEL_TYPE_MIX_AIC_1_2);
+    } else {
+        KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
+    }
     GDN::ChunkGatedDeltaRuleBwdDhuKernelImpl<DT, GT>(
         q, k, w, d_o, dv, g, cu_seqlens, chunk_indices, dh, dh0, dv2, userWS, &tilingData);
 }
@@ -348,8 +352,6 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_bwd_dhu_np
     };
 
     at_npu::native::OpCommand::RunOpApi("ChunkGatedDeltaRuleBwdDhu", aclCall);
-    auto syncRet = aclrtSynchronizeStream(stream);
-    TORCH_CHECK(syncRet == ACL_SUCCESS, "aclrtSynchronizeStream failed. ERROR: ", syncRet);
 
     if (workspacePtr != nullptr) {
         aclrtFree(workspacePtr);

--- a/examples/fast_kernel_launch_example/tests/chunk_gated_delta_rule_bwd_dhu/test_chunk_gated_delta_rule_bwd_dhu.py
+++ b/examples/fast_kernel_launch_example/tests/chunk_gated_delta_rule_bwd_dhu/test_chunk_gated_delta_rule_bwd_dhu.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# the BSD 3-Clause License (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import math
+import random
+from typing import List, Optional, Tuple
+
+import ascend_ops
+import pytest
+import torch
+import torch_npu
+
+_LOW_PRECISION_INPUT_HALF_RANGE_QK = 6.5e-3
+_LOW_PRECISION_INPUT_HALF_RANGE_WO = 6.5e-3
+_LOW_PRECISION_INPUT_HALF_RANGE_DV = 9e-3
+_LOW_PRECISION_SCALE_FACTOR = 0.92
+
+
+def prepare_chunk_indices(cu_seqlens: List[int], chunk_size: int = 64) -> List[int]:
+    chunk_indices = []
+    for seq_idx in range(len(cu_seqlens) - 1):
+        seq_len = cu_seqlens[seq_idx + 1] - cu_seqlens[seq_idx]
+        chunk_num = (seq_len + chunk_size - 1) // chunk_size
+        for chunk_idx in range(chunk_num):
+            chunk_indices.append(seq_idx)
+            chunk_indices.append(chunk_idx)
+    return chunk_indices
+
+
+def create_gate_g(B: int, Hv: int, T: int, gtype, narrow: bool = False):
+    if narrow:
+        lo, hi = -1e-2, -1e-6
+    else:
+        lo, hi = -5e-2, -5e-5
+    span = hi - lo
+    margin = max(span * 1e-7, 1e-12)
+    g_t = torch.linspace(float(hi) - margin, float(lo) + margin, T, dtype=torch.float64)
+    g = g_t.unsqueeze(0).unsqueeze(0).expand(B, Hv, T).contiguous().to(gtype)
+    return g
+
+
+def generate_cu_seqlens(cu_seqlens_len: int, total_length: int, seg_min: int = 64, seg_max: int = 128) -> List[int]:
+    batchsize = cu_seqlens_len - 1
+    if batchsize <= 0:
+        return [0, total_length]
+
+    B = batchsize
+    T = total_length
+    lengths = [(T * (i + 1)) // B - (T * i) // B for i in range(B)]
+    for i in range(B):
+        lengths[i] = max(seg_min, min(seg_max, lengths[i]))
+
+    diff = T - sum(lengths)
+    while diff > 0:
+        cand = [i for i in range(B) if lengths[i] < seg_max]
+        if not cand:
+            break
+        i = min(cand, key=lambda j: lengths[j])
+        lengths[i] += 1
+        diff -= 1
+    while diff < 0:
+        cand = [i for i in range(B) if lengths[i] > seg_min]
+        if not cand:
+            break
+        i = max(cand, key=lambda j: lengths[j])
+        lengths[i] -= 1
+        diff += 1
+
+    sorted_l = sorted(lengths)
+    seq_lengths: List[int] = []
+    i, j = 0, len(sorted_l) - 1
+    while i <= j:
+        if i == j:
+            seq_lengths.append(sorted_l[i])
+        else:
+            seq_lengths.append(sorted_l[i])
+            seq_lengths.append(sorted_l[j])
+        i += 1
+        j -= 1
+
+    cu_seqlens = [0]
+    for seq_len in seq_lengths:
+        cu_seqlens.append(cu_seqlens[-1] + seq_len)
+    return cu_seqlens
+
+
+def rand_symmetric_uniform(shape, dtype: torch.dtype, half_range: float) -> torch.Tensor:
+    x = torch.rand(shape, dtype=torch.float32, device="cpu")
+    x = (x * 2.0 - 1.0) * float(half_range)
+    return x.to(dtype=dtype)
+
+
+def create_bwd_dhu_random_inputs(
+    B: int, Hk: int, Hv: int, T: int, K: int, V: int, ktype: torch.dtype, gtype: torch.dtype
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    low = ktype in (torch.float16, torch.bfloat16)
+    if low:
+        hr_qk = _LOW_PRECISION_INPUT_HALF_RANGE_QK
+        hr_wo = _LOW_PRECISION_INPUT_HALF_RANGE_WO
+        hr_dv = _LOW_PRECISION_INPUT_HALF_RANGE_DV
+        narrow_g = True
+    else:
+        hr_qk = 2e-2
+        hr_wo = 2e-2
+        hr_dv = 3e-2
+        narrow_g = False
+
+    q = rand_symmetric_uniform((B, Hk, T, K), ktype, half_range=hr_qk)
+    k = rand_symmetric_uniform((B, Hk, T, K), ktype, half_range=hr_qk)
+    w = rand_symmetric_uniform((B, Hv, T, K), ktype, half_range=hr_qk)
+    d_o = rand_symmetric_uniform((B, Hv, T, V), ktype, half_range=hr_wo)
+    dv = rand_symmetric_uniform((B, Hv, T, V), ktype, half_range=hr_dv)
+    g = create_gate_g(B, Hv, T, gtype, narrow=narrow_g)
+    return q, k, w, d_o, dv, g
+
+
+def effective_scale(scale: float, K: int) -> float:
+    cap = 1.0 / math.sqrt(float(K))
+    return float(min(scale, cap))
+
+
+def scale_for_compute_dtype(scale: float, ktype: torch.dtype) -> float:
+    if ktype in (torch.float16, torch.bfloat16):
+        return float(scale * _LOW_PRECISION_SCALE_FACTOR)
+    return float(scale)
+
+
+def chunk_gated_delta_rule_bwd_dhu_torch(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    w: torch.Tensor,
+    do: torch.Tensor,
+    dv: torch.Tensor,
+    cu_seqlens: Optional[List[int]] = None,
+    chunk_indices: Optional[List[int]] = None,
+    g: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
+    chunk_size: int = 64,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+    device = q.device
+    B, Hk, T, K = q.shape
+    Hv = do.shape[1]
+    V = do.shape[-1]
+    BT = chunk_size
+    hv_per_hk = Hv // Hk
+
+    if cu_seqlens is not None:
+        NT = len(chunk_indices) // 2
+    else:
+        NT = (T + BT - 1) // BT
+
+    if scale is None:
+        scale = 1.0
+
+    chunk_info = []
+    for i_t in range(NT):
+        if cu_seqlens is not None:
+            i_n = chunk_indices[i_t * 2]
+            block_idx_in_token = chunk_indices[i_t * 2 + 1]
+            bos = cu_seqlens[i_n]
+            token_length = cu_seqlens[i_n + 1] - bos
+        else:
+            i_n = 0
+            block_idx_in_token = i_t
+            bos = 0
+            token_length = T
+
+        start_t = block_idx_in_token * BT
+        end_t = min((block_idx_in_token + 1) * BT, token_length)
+        block_size_t = end_t - start_t
+        global_start_t = bos + start_t
+        global_end_t = bos + end_t
+
+        chunk_info.append({
+            "i_t": i_t,
+            "i_n": i_n,
+            "block_idx_in_token": block_idx_in_token,
+            "bos": bos,
+            "token_length": token_length,
+            "block_size_t": block_size_t,
+            "global_start_t": global_start_t,
+            "global_end_t": global_end_t,
+        })
+
+    dh = torch.zeros(B, Hv, NT, K, V, device=device, dtype=torch.float32)
+    if cu_seqlens is not None:
+        dv2 = dv.clone()
+    else:
+        dv2 = torch.zeros(B, Hv, T, V, device=device, dtype=dv.dtype)
+
+    if cu_seqlens is None:
+        hq = torch.arange(Hv, device=device, dtype=torch.long) // hv_per_hk
+        b_dh = torch.zeros(B, Hv, K, V, device=device, dtype=torch.float32)
+        for i_t in range(NT - 1, -1, -1):
+            info = chunk_info[i_t]
+            global_start_t = info["global_start_t"]
+            global_end_t = info["global_end_t"]
+            block_size_t = info["block_size_t"]
+
+            dh[:, :, i_t, :, :] = b_dh
+
+            last_idx = min((info["block_idx_in_token"] + 1) * BT, info["token_length"]) - 1
+            global_last_idx = info["bos"] + last_idx
+
+            k_blk = k[:, :, global_start_t:global_end_t, :].index_select(1, hq)
+            q_blk = q[:, :, global_start_t:global_end_t, :].index_select(1, hq)
+            w_blk = w[:, :, global_start_t:global_end_t, :]
+            b_do = do[:, :, global_start_t:global_end_t, :]
+            b_dv_existing = dv[:, :, global_start_t:global_end_t, :]
+
+            b_dv = torch.matmul(k_blk.to(torch.float), b_dh.to(torch.float))
+
+            if g is not None:
+                bg_last = g[:, :, global_last_idx]
+                b_g = g[:, :, global_start_t:global_end_t]
+                gate_factor = torch.exp(bg_last.unsqueeze(-1) - b_g).unsqueeze(-1)
+                m_t = torch.arange(block_size_t, device=device, dtype=torch.float32) < float(block_size_t)
+                mask_expanded = m_t.view(1, 1, block_size_t, 1)
+                b_dv = b_dv * gate_factor * mask_expanded
+
+            b_dv = b_dv + b_dv_existing.to(torch.float32)
+            dv2[:, :, global_start_t:global_end_t, :] = b_dv.to(dv2.dtype)
+
+            b_q_t = q_blk.transpose(-1, -2)
+            b_w_t = w_blk.transpose(-1, -2)
+
+            if g is not None:
+                bg_last_exp = torch.exp(bg_last)
+                b_g_exp = torch.exp(b_g)
+                b_dh_for_update = b_dh * bg_last_exp.unsqueeze(-1).unsqueeze(-1)
+                b_q_gated = b_q_t * b_g_exp.unsqueeze(-2)
+            else:
+                b_dh_for_update = b_dh.clone()
+                b_q_gated = b_q_t
+
+            term1 = torch.matmul(b_q_gated.to(torch.float), b_do.to(torch.float)) * scale
+            term2 = torch.matmul(b_w_t.to(torch.float), b_dv.to(torch.float))
+            b_dh = b_dh_for_update + term1 - term2
+    else:
+        for b in range(B):
+            for i_h in range(Hv):
+                hq = i_h // hv_per_hk
+                num_tokens = len(cu_seqlens) - 1
+                b_dh_buffers = {i_n: torch.zeros(K, V, device=device, dtype=torch.float32) for i_n in range(num_tokens)}
+
+                for i_t in range(NT - 1, -1, -1):
+                    info = chunk_info[i_t]
+                    i_n = info["i_n"]
+                    b_dh = b_dh_buffers[i_n]
+                    dh[b, i_h, i_t] = b_dh
+
+                    global_start_t = info["global_start_t"]
+                    global_end_t = info["global_end_t"]
+                    block_size_t = info["block_size_t"]
+                    last_idx = min((info["block_idx_in_token"] + 1) * BT, info["token_length"]) - 1
+                    global_last_idx = info["bos"] + last_idx
+
+                    bg_last = bg_last_exp = b_g = b_g_exp = None
+                    if g is not None:
+                        bg_last = g[b, i_h, global_last_idx]
+                        b_g = g[b, i_h, global_start_t:global_end_t]
+                        bg_last_exp = torch.exp(bg_last)
+                        b_g_exp = torch.exp(b_g)
+
+                    b_do = do[b, i_h, global_start_t:global_end_t, :]
+                    b_dv_existing = dv[b, i_h, global_start_t:global_end_t, :]
+                    b_k = k[b, hq, global_start_t:global_end_t, :]
+                    b_dv = torch.matmul(b_k.to(torch.float), b_dh.to(torch.float))
+
+                    if g is not None:
+                        m_t = torch.arange(block_size_t, device=device) < block_size_t
+                        gate_factor = torch.exp(bg_last - b_g).unsqueeze(-1)
+                        mask_expanded = m_t.unsqueeze(-1).float()
+                        b_dv *= gate_factor * mask_expanded
+
+                    b_dv += b_dv_existing.to(torch.float32)
+                    dv2[b, i_h, global_start_t:global_end_t, :] = b_dv.to(dv2.dtype)
+
+                    b_q = q[b, hq, global_start_t:global_end_t, :]
+                    b_w = w[b, i_h, global_start_t:global_end_t, :]
+                    b_q_t = b_q.transpose(0, 1)
+                    b_w_t = b_w.transpose(0, 1)
+                    b_dh_for_update = b_dh.clone()
+                    if g is not None:
+                        b_dh_for_update = b_dh_for_update * bg_last_exp
+
+                    b_q_gated = b_q_t
+                    if g is not None:
+                        b_q_gated = b_q_t * b_g_exp.unsqueeze(0)
+
+                    term1 = torch.matmul(b_q_gated.to(torch.float), b_do.to(torch.float)) * scale
+                    term2 = torch.matmul(b_w_t.to(torch.float), b_dv.to(torch.float))
+                    b_dh_buffers[i_n] = b_dh_for_update + term1 - term2
+
+    return dh, None, dv2
+
+
+def run_chunk_gated_delta_rule_bwd_dhu(
+    q, k, w, d_o, dv, g, scale, chunk_size, cu_seqlens=None, chunk_indices=None
+):
+    return torch.ops.ascend_ops.chunk_gated_delta_rule_bwd_dhu(
+        q.npu(),
+        k.npu(),
+        w.npu(),
+        d_o.npu(),
+        dv.npu(),
+        scale,
+        chunk_size,
+        g=g.npu(),
+        gK=None,
+        h0=None,
+        dht=None,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+
+
+def test_chunk_gated_delta_rule_bwd_dhu_interface_exist():
+    assert hasattr(torch.ops.ascend_ops, "chunk_gated_delta_rule_bwd_dhu")
+
+
+FIX_TEST_CONFIGS = [
+    (1, 2, 4, 128, 128, 128, 64, 0.088, torch.float16, torch.float16),
+    (1, 2, 4, 128, 128, 128, 64, 0.088, torch.bfloat16, torch.bfloat16),
+    (1, 2, 4, 128, 128, 128, 64, 0.088, torch.bfloat16, torch.float32),
+    (1, 2, 4, 128, 128, 128, 64, 0.088, torch.float16, torch.float32),
+    (1, 4, 4, 128, 128, 128, 64, 0.088, torch.bfloat16, torch.bfloat16),
+]
+
+VARIABLE_TEST_CONFIGS = [
+    (1, 4, 8, 512, 128, 128, 64, 0.011, 4, torch.bfloat16, torch.bfloat16),
+    (1, 4, 8, 512, 128, 128, 64, 0.011, 4, torch.bfloat16, torch.float32),
+]
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU device not found")
+@pytest.mark.parametrize("B,Hk,Hv,T,K,V,chunk_size,scale,ktype,gtype", FIX_TEST_CONFIGS)
+def test_chunk_gated_delta_rule_bwd_dhu_fix(B, Hk, Hv, T, K, V, chunk_size, scale, ktype, gtype):
+    torch.manual_seed(0)
+    scale = scale_for_compute_dtype(effective_scale(scale, K), ktype)
+
+    q, k, w, d_o, dv, g = create_bwd_dhu_random_inputs(B, Hk, Hv, T, K, V, ktype, gtype)
+    dh_golden, _, dv2_golden = chunk_gated_delta_rule_bwd_dhu_torch(
+        q, k, w, d_o, dv, cu_seqlens=None, chunk_indices=None, g=g, scale=scale, chunk_size=chunk_size
+    )
+
+    dh_npu, _, dv2_npu = run_chunk_gated_delta_rule_bwd_dhu(q, k, w, d_o, dv, g, scale, chunk_size)
+
+    rtol = 1e-2
+    atol = 1e-2
+    assert torch.allclose(dh_npu.cpu().float(), dh_golden.float(), rtol=rtol, atol=atol)
+    assert torch.allclose(dv2_npu.cpu().float(), dv2_golden.float(), rtol=rtol, atol=atol)
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU device not found")
+@pytest.mark.parametrize("B,Hk,Hv,T,K,V,chunk_size,scale,cu_seqlens_len,ktype,gtype", VARIABLE_TEST_CONFIGS)
+def test_chunk_gated_delta_rule_bwd_dhu_variable(B, Hk, Hv, T, K, V, chunk_size, scale, cu_seqlens_len, ktype, gtype):
+    torch.manual_seed(0)
+    scale = scale_for_compute_dtype(effective_scale(scale, K), ktype)
+
+    q, k, w, d_o, dv, g = create_bwd_dhu_random_inputs(B, Hk, Hv, T, K, V, ktype, gtype)
+    cu_seqlens = generate_cu_seqlens(cu_seqlens_len, T)
+    chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+
+    dh_golden, _, dv2_golden = chunk_gated_delta_rule_bwd_dhu_torch(
+        q, k, w, d_o, dv, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices, g=g, scale=scale, chunk_size=chunk_size
+    )
+
+    dh_npu, _, dv2_npu = run_chunk_gated_delta_rule_bwd_dhu(
+        q, k, w, d_o, dv, g, scale, chunk_size, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices
+    )
+
+    rtol = 1e-2
+    atol = 1e-2
+    assert torch.allclose(dh_npu.cpu().float(), dh_golden.float(), rtol=rtol, atol=atol)
+    assert torch.allclose(dv2_npu.cpu().float(), dv2_golden.float(), rtol=rtol, atol=atol)
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU device not found")
+def test_chunk_gated_delta_rule_bwd_dhu_metadata_pair():
+    torch.manual_seed(0)
+    B, Hk, Hv, T, K, V = 1, 2, 4, 128, 128, 128
+    chunk_size = 64
+    scale = 0.088
+    ktype = torch.bfloat16
+    gtype = torch.bfloat16
+
+    q, k, w, d_o, dv, g = create_bwd_dhu_random_inputs(B, Hk, Hv, T, K, V, ktype, gtype)
+    cu_seqlens = generate_cu_seqlens(3, T)
+
+    q_npu = q.npu()
+    k_npu = k.npu()
+    w_npu = w.npu()
+    d_o_npu = d_o.npu()
+    dv_npu = dv.npu()
+    g_npu = g.npu()
+
+    with pytest.raises(RuntimeError, match="cu_seqlens and chunk_indices"):
+        torch.ops.ascend_ops.chunk_gated_delta_rule_bwd_dhu(
+            q_npu, k_npu, w_npu, d_o_npu, dv_npu, scale, chunk_size,
+            g=g_npu, gK=None, h0=None, dht=None,
+            cu_seqlens=cu_seqlens, chunk_indices=None,
+        )
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU device not found")
+def test_chunk_gated_delta_rule_bwd_dhu_gva_smoke():
+    torch.manual_seed(0)
+    B, Hk, Hv, T, K, V = 1, 2, 4, 256, 128, 128
+    chunk_size = 64
+    scale = scale_for_compute_dtype(effective_scale(0.088, K), torch.bfloat16)
+    ktype = torch.bfloat16
+    gtype = torch.bfloat16
+
+    q, k, w, d_o, dv, g = create_bwd_dhu_random_inputs(B, Hk, Hv, T, K, V, ktype, gtype)
+    dh_golden, _, dv2_golden = chunk_gated_delta_rule_bwd_dhu_torch(
+        q, k, w, d_o, dv, g=g, scale=scale, chunk_size=chunk_size
+    )
+    dh_npu, _, dv2_npu = run_chunk_gated_delta_rule_bwd_dhu(q, k, w, d_o, dv, g, scale, chunk_size)
+
+    assert dh_npu.shape == dh_golden.shape
+    assert dv2_npu.shape == dv2_golden.shape

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.cpp
@@ -1,309 +1,140 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
- * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
- * the BSD 3-Clause License (the "License").
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- */
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 /*!
- * \file grouped_matmul_tiling.cpp
+ * \file chunk_gated_delta_rule_bwd_dhu_tiling.cpp
  * \brief
  */
-#include "chunk_gated_delta_rule_bwd_dhu_tiling.h"
 
-using namespace Ops::Transformer::OpTiling;
-using namespace ge;
-using namespace AscendC;
+#include "chunk_gated_delta_rule_bwd_dhu_tiling_processor.h"
+#include "chunk_gated_delta_rule_bwd_dhu_tiling.h"
+#include "err/ops_err.h"
+
+using namespace GDN;
 
 namespace optiling {
 namespace {
-  constexpr uint32_t INPUT_Q_IDX = 0;
-  constexpr uint32_t INPUT_K_IDX = 1;
-  constexpr uint32_t INPUT_W_IDX = 2;
-  constexpr uint32_t INPUT_DO_IDX = 3;
-  constexpr uint32_t INPUT_DV_IDX = 4;
-  constexpr uint32_t INPUT_G_IDX = 5;
-  constexpr uint32_t INPUT_GK_IDX = 6;
-  constexpr uint32_t INPUT_H0_IDX = 7;
-  constexpr uint32_t INPUT_DHT_IDX = 8;
-  constexpr uint32_t INPUT_CU_SEQLENS_IDX = 9;
-  constexpr uint32_t INPUT_CHUNK_INDICES_IDX = 10;
+constexpr uint32_t INPUT_Q_IDX = 0;
+constexpr uint32_t INPUT_K_IDX = 1;
+constexpr uint32_t INPUT_W_IDX = 2;
+constexpr uint32_t INPUT_DO_IDX = 3;
+constexpr uint32_t INPUT_DV_IDX = 4;
+constexpr uint32_t INPUT_G_IDX = 5;
+constexpr uint32_t INPUT_CU_SEQLENS_IDX = 9;
+constexpr uint32_t INPUT_CHUNK_INDICES_IDX = 10;
 
-  constexpr uint32_t OUTPUT_DH_IDX = 0;
-  constexpr uint32_t OUTPUT_DH0_IDX = 1;
-  constexpr uint32_t OUTPUT_DV2_IDX = 2;
-  
-  constexpr uint32_t ATTR_SCALE_IDX = 0;
-  constexpr uint32_t ATTR_CHUNK_SIZE_IDX = 1;
+constexpr uint32_t ATTR_SCALE_IDX = 0;
+constexpr uint32_t ATTR_CHUNK_SIZE_IDX = 1;
 
-  constexpr uint32_t DIM_0 = 0;
-  constexpr uint32_t DIM_1 = 1;
-  constexpr uint32_t DIM_2 = 2;
-  constexpr uint32_t DIM_3 = 3;
-  constexpr uint32_t NUM_64 = 64;
-  constexpr uint32_t NUM_128 = 128;
-  constexpr uint32_t NUM_2 = 2;
-  constexpr uint32_t NUM_3 = 3;
-  constexpr uint32_t BLOCK_SIZE = 32;
+static void ChunkGatedDeltaRuleBwdDhuTilingDataPrint(gert::TilingContext *context,
+                                                     const ChunkGatedDeltaRuleBwdDhuTilingData &tiling)
+{
+    auto nodeName = context->GetNodeName();
+    OP_LOGD(nodeName, "End Run ChunkGatedDeltaRuleBwdDhu Tiling");
+    OP_LOGD(nodeName, "B is %lu.", tiling.B);
+    OP_LOGD(nodeName, "Hv is %lu.", tiling.Hv);
+    OP_LOGD(nodeName, "Hk is %lu.", tiling.Hk);
+    OP_LOGD(nodeName, "T is %lu.", tiling.T);
+    OP_LOGD(nodeName, "K is %lu.", tiling.K);
+    OP_LOGD(nodeName, "V is %lu.", tiling.V);
+    OP_LOGD(nodeName, "chunkSize is %lu.", tiling.chunkSize);
+    OP_LOGD(nodeName, "chunkNum is %lu.", tiling.chunkNum);
+    OP_LOGD(nodeName, "seqNum is %lu.", tiling.seqNum);
+    OP_LOGD(nodeName, "gBufSize is %lu.", tiling.gBufSize);
+    OP_LOGD(nodeName, "dvBufSize is %lu.", tiling.dvBufSize);
+    OP_LOGD(nodeName, "qBufSize is %lu.", tiling.qBufSize);
+    OP_LOGD(nodeName, "dhBufSize is %lu.", tiling.dhBufSize);
+    OP_LOGD(nodeName, "totalTbufByte is %lu.", tiling.totalTbufByte);
+    OP_LOGD(nodeName, "bdvWs is %lu.", tiling.bdvWs);
+    OP_LOGD(nodeName, "qWs is %lu.", tiling.qWs);
+    OP_LOGD(nodeName, "wDv2Ws is %lu.", tiling.wDv2Ws);
+    OP_LOGD(nodeName, "qDoWs is %lu.", tiling.qDoWs);
+    OP_LOGD(nodeName, "isVarLen is %lu.", tiling.isVarLen);
+    OP_LOGD(nodeName, "isScale is %lu.", tiling.isScale);
+    OP_LOGD(nodeName, "usedCoreNum is %u.", tiling.usedCoreNum);
+    OP_LOGD(nodeName, "scale is %f.", tiling.scale);
+}
+} // namespace
 
-  constexpr uint32_t HALF_DTYPE_SIZE = 2;
-  constexpr uint32_t FP32_DTYPE_SIZE = 4;
-  constexpr uint32_t INT8_DTYPE_SIZE = 1;
+ASCENDC_EXTERN_C ge::graphStatus Tiling4ChunkGDRBwdDhu(gert::TilingContext *context)
+{
+    OP_LOGD(context->GetNodeName(), "Tiling4ChunkGDRBwdDhu start.");
+    ChunkGatedDeltaRuleBwdDhuTilingData *tiling = context->GetTilingData<ChunkGatedDeltaRuleBwdDhuTilingData>();
 
-  constexpr uint32_t TILING_KEY = 0;
-  constexpr uint32_t TILING_KEY_G_FP32 = 1;
+    auto attrs = context->GetAttrs();
+    OP_CHECK_IF(attrs == nullptr, OP_LOGE(context->GetNodeName(), "attrs is nullptr."), return ge::GRAPH_FAILED);
+    const double *scalePtr = attrs->GetAttrPointer<double>(ATTR_SCALE_IDX);
+    const uint32_t *chunkSizePtr = attrs->GetAttrPointer<uint32_t>(ATTR_CHUNK_SIZE_IDX);
 
-  template <typename T> 
-  static T CeilDiv(T a, T b) {
-    if (b == 0) {
-      return a;
+    auto platformInfoPtr = context->GetPlatformInfo();
+    OP_CHECK_IF(platformInfoPtr == nullptr,
+                OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(), "platformInfoPtr is null!"),
+                return ge::GRAPH_FAILED);
+    auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
+    uint64_t maxUbSize = 0;
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, maxUbSize);
+
+    const auto gInputDesc = context->GetOptionalInputDesc(INPUT_G_IDX);
+    const auto qInputDesc = context->GetInputDesc(INPUT_Q_IDX);
+    OP_CHECK_NULL_WITH_CONTEXT(context, qInputDesc);
+
+    const gert::StorageShape *gShapePtr = nullptr;
+    gert::StorageShape gShape;
+    if (context->GetOptionalInputShape(INPUT_G_IDX) != nullptr) {
+        gShape = *context->GetOptionalInputShape(INPUT_G_IDX);
+        gShapePtr = &gShape;
     }
-    return (a + b - 1) / b;
-  }
+
+    ChunkGatedDeltaRuleBwdDhuTilingContext ctx{
+        context->GetNodeName(),
+        context->GetInputShape(INPUT_Q_IDX),
+        context->GetInputShape(INPUT_K_IDX),
+        context->GetInputShape(INPUT_W_IDX),
+        context->GetInputShape(INPUT_DO_IDX),
+        context->GetInputShape(INPUT_DV_IDX),
+        gShapePtr,
+        context->GetOptionalInputShape(INPUT_CU_SEQLENS_IDX),
+        context->GetOptionalInputShape(INPUT_CHUNK_INDICES_IDX),
+        qInputDesc->GetDataType(),
+        gInputDesc != nullptr ? gInputDesc->GetDataType() : ge::DT_FLOAT,
+        gShapePtr != nullptr,
+        scalePtr != nullptr,
+        scalePtr != nullptr ? *scalePtr : 1.0,
+        chunkSizePtr != nullptr ? static_cast<int32_t>(*chunkSizePtr) : static_cast<int32_t>(64),
+        maxUbSize,
+        static_cast<uint32_t>(ascendcPlatform.GetCoreNumAic()),
+        static_cast<size_t>(ascendcPlatform.GetLibApiWorkSpaceSize()),
+    };
+
+    ChunkGatedDeltaRuleBwdDhuTilingProcessor processor(ctx, *tiling);
+    OP_CHECK_IF(processor.Process() != ge::GRAPH_SUCCESS,
+                OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(), "tiling process failed"),
+                return ge::GRAPH_FAILED);
+
+    context->SetTilingKey(processor.GetTilingKey());
+    context->SetBlockDim(processor.GetBlockDim());
+    size_t *workspace = context->GetWorkspaceSizes(1);
+    workspace[0] = processor.GetWorkspaceSize();
+
+    ChunkGatedDeltaRuleBwdDhuTilingDataPrint(context, *tiling);
+    OP_LOGD(context->GetNodeName(), "Tiling4ChunkGDRBwdDhu end.");
+    return ge::GRAPH_SUCCESS;
 }
 
-bool ChunkGatedDeltaRuleBwdDhuTiling::Init(gert::TilingContext* context) {
-
-  const gert::Shape qShape = context->GetInputShape(INPUT_Q_IDX)->GetStorageShape();
-  const gert::Shape kShape = context->GetInputShape(INPUT_K_IDX)->GetStorageShape();
-  const gert::Shape wShape = context->GetInputShape(INPUT_W_IDX)->GetStorageShape();
-  const gert::Shape doShape = context->GetInputShape(INPUT_DO_IDX)->GetStorageShape();
-  const gert::Shape dvShape = context->GetInputShape(INPUT_DV_IDX)->GetStorageShape();
-  B = qShape.GetDim(DIM_0);
-  Hk = qShape.GetDim(DIM_1);
-  T = qShape.GetDim(DIM_2);
-  K = qShape.GetDim(DIM_3);
-  Hv = doShape.GetDim(DIM_1);
-  V = doShape.GetDim(DIM_3);
-
-  OP_CHECK_IF(
-      kShape.GetDim(DIM_0) != static_cast<int64_t>(B) || kShape.GetDim(DIM_1) != static_cast<int64_t>(Hk) ||
-          kShape.GetDim(DIM_2) != static_cast<int64_t>(T) || kShape.GetDim(DIM_3) != static_cast<int64_t>(K),
-      OP_LOGE(context->GetNodeName(),
-              "k must match q as [B,Hk,T,K]; q [%lu,%lu,%lu,%lu], k [%ld,%ld,%ld,%ld].", B, Hk, T, K,
-              kShape.GetDim(DIM_0), kShape.GetDim(DIM_1), kShape.GetDim(DIM_2), kShape.GetDim(DIM_3)),
-      return false);
-  OP_CHECK_IF(
-      wShape.GetDim(DIM_0) != static_cast<int64_t>(B) || wShape.GetDim(DIM_1) != static_cast<int64_t>(Hv) ||
-          wShape.GetDim(DIM_2) != static_cast<int64_t>(T) || wShape.GetDim(DIM_3) != static_cast<int64_t>(K),
-      OP_LOGE(context->GetNodeName(),
-              "w must be [B,Hv,T,K] with Hv=dO.dim1; expect [%lu,%lu,%lu,%lu], got [%ld,%ld,%ld,%ld].", B, Hv, T, K,
-              wShape.GetDim(DIM_0), wShape.GetDim(DIM_1), wShape.GetDim(DIM_2), wShape.GetDim(DIM_3)),
-      return false);
-  OP_CHECK_IF(doShape.GetDim(DIM_0) != static_cast<int64_t>(B) || doShape.GetDim(DIM_2) != static_cast<int64_t>(T),
-              OP_LOGE(context->GetNodeName(), "dO batch/time must match q."), return false);
-  OP_CHECK_IF(
-      dvShape.GetDim(DIM_0) != static_cast<int64_t>(B) || dvShape.GetDim(DIM_1) != static_cast<int64_t>(Hv) ||
-          dvShape.GetDim(DIM_2) != static_cast<int64_t>(T) || dvShape.GetDim(DIM_3) != static_cast<int64_t>(V),
-      OP_LOGE(context->GetNodeName(), "dv must be [B,Hv,T,V] aligned with dO."), return false);
-  // GVA（Grouped Value Attention）：Hk 为 q/k 头数，Hv 为 value 头数（与 do/dv/w对齐）；须 Hv 是 Hk 的整数倍（见 FLA num_v_heads % num_heads）。
-  OP_CHECK_IF(Hv == 0 || Hk == 0 || (Hv % Hk) != 0,
-              OP_LOGE(context->GetNodeName(),
-                      "GVA: Hv (value heads) must be an integer multiple of Hk (q/k heads); require Hv mod Hk == 0; got Hk=%lu Hv=%lu.",
-                      Hk, Hv),
-              return false);
-  
-  auto attrs = context->GetAttrs();
-  OP_CHECK_IF(attrs == nullptr, OP_LOGE(context->GetNodeName(), "attrs is nullptr."), return false);
-  const double *scalePtr = attrs->GetAttrPointer<double>(ATTR_SCALE_IDX);
-  IS_SCALE = scalePtr == nullptr ? false : true;
-  float scale = IS_SCALE ? *scalePtr : 1.0;
-  const uint32_t *chunkSizePtr = attrs->GetAttrPointer<uint32_t>(ATTR_CHUNK_SIZE_IDX);
-  chunkSize = chunkSizePtr == nullptr ? NUM_64 : *chunkSizePtr;
-  OP_CHECK_IF(!(chunkSize == NUM_64 || chunkSize == NUM_128), 
-              OP_LOGE(context->GetNodeName(), "chunk_size should be 64 or 128, but got %d.", chunkSize), 
-              return false);
-  
-  tilingData.set_B(B);
-  tilingData.set_Hv(Hv);
-  tilingData.set_Hk(Hk);
-  tilingData.set_T(T);
-  tilingData.set_K(K);
-  tilingData.set_V(V);
-  tilingData.set_isScale(IS_SCALE);
-  tilingData.set_scale(scale);
-  tilingData.set_chunkSize(chunkSize);
-  return true;
-}
-
-bool ChunkGatedDeltaRuleBwdDhuTiling::VarLenSetting(gert::TilingContext* context) {
-  const auto cuSeqlens = context->GetOptionalInputTensor(INPUT_CU_SEQLENS_IDX);
-  const auto chunkIndices = context->GetOptionalInputTensor(INPUT_CHUNK_INDICES_IDX);
-  if (cuSeqlens != nullptr && chunkIndices != nullptr) {
-    IS_VARIABLE_LEN = true;
-  } else if (!(cuSeqlens == nullptr && chunkIndices == nullptr)) {
-    OP_LOGE(context->GetNodeName(), 
-    "cu_seqlens and chunkIndices must both be provided or both be omitted.");
-    return false;
-  }
-  tilingData.set_isVarLen(IS_VARIABLE_LEN);
-
-  if (!IS_VARIABLE_LEN) {
-    int64_t chunkNum = static_cast<int64_t>(CeilDiv(T, chunkSize)); 
-    tilingData.set_chunkNum(chunkNum);
-    tilingData.set_seqNum(1);
-  } else {
-    auto seqNum = cuSeqlens->GetShapeSize() - 1;
-    auto chunkNum = chunkIndices->GetShapeSize() / NUM_2;
-    tilingData.set_seqNum(seqNum);
-    tilingData.set_chunkNum(chunkNum);
-  }
-  return true;
-}
-
-
-bool ChunkGatedDeltaRuleBwdDhuTiling::CheckInputShape(gert::TilingContext* context) {
-  OP_CHECK_IF(IS_VARIABLE_LEN && B != 1, 
-              OP_LOGE(context->GetNodeName(), 
-              "B must be 1 when seqence is variable len, but got %u.", B), return false);
-  return true;  
-}
-
-bool ChunkGatedDeltaRuleBwdDhuTiling::CheckInputDtype(gert::TilingContext* context) {
-  const auto gDtype = context->GetOptionalInputDesc(INPUT_G_IDX)->GetDataType();
-  const auto qDtype = context->GetOptionalInputDesc(INPUT_Q_IDX)->GetDataType();
-  if (gDtype != qDtype && gDtype != ge::DT_FLOAT) {
-    OP_LOGE(context->GetNodeName(), "gDtype must be DT_FLOAT or as same as qDtype");
-    return false;
-  }
-  if (gDtype == ge::DT_FLOAT) {
-    tilingKey = TILING_KEY_G_FP32;
-  } else {
-    tilingKey = TILING_KEY;
-  }
-  return true;  
-}
-
-bool ChunkGatedDeltaRuleBwdDhuTiling::CalcUb(gert::TilingContext *context) {
-  // AIC_AIV_1_2, 每个VEC处理BT/2行
-  uint32_t halfBT = CeilDiv(static_cast<uint32_t>(chunkSize), NUM_2);
-  uint32_t halfK = CeilDiv(static_cast<uint32_t>(K), NUM_2);
-  uint32_t gBrcbBufByte = halfBT * BLOCK_SIZE;
-  uint32_t dvBufByte = halfBT * V * HALF_DTYPE_SIZE;
-  uint32_t dvCastBufByte = halfBT * V * FP32_DTYPE_SIZE;
-  uint32_t dqkBufByte = halfBT * K * HALF_DTYPE_SIZE;
-  uint32_t dqkCastBufByte = halfBT * K * FP32_DTYPE_SIZE;
-  uint32_t dhCastBufByte = halfK * V * FP32_DTYPE_SIZE;
-
-  // 与 chunk_gated_delta_rule_bwd_dhu_vec.h InitUB 对齐（同一 vecTbuf 内绝对偏移尖峰）：
-  // - dv2 链：gCast 后 dv2Offset = chunkSize*4，再接 gBrcb、vIn(fp16)、dvCast、bdvCast(fp32)
-  // - gatedQ 链：gCast+gExp 共 2*chunkSize*4，offsetQ 起 qLocal(fp16)+qCast(fp32)+gBCLocal
-  // - UpdateDh：分时复用 [0, 2*dhCastBufByte)，与上两链取 max
-  const uint32_t dvPeak =
-      chunkSize * FP32_DTYPE_SIZE + gBrcbBufByte + dvBufByte + NUM_2 * dvCastBufByte;
-  const uint32_t gatedQPeak =
-      NUM_2 * chunkSize * FP32_DTYPE_SIZE + dqkBufByte + dqkCastBufByte + gBrcbBufByte;
-  const uint32_t dhPeak = NUM_2 * dhCastBufByte;
-  uint32_t tBufByte = std::max(dhPeak, std::max(dvPeak, gatedQPeak));
-  
-  auto platformInfoPtr = context->GetPlatformInfo();
-  auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
-  uint64_t maxUbSize = 0;
-  ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, maxUbSize);
-  OP_CHECK_IF(tBufByte > maxUbSize, OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(),
-              "K/V is too large, K should less than 128 and V should less than 256."), 
-              return false);
-  tilingData.set_gBufSize(halfBT);
-  tilingData.set_dvBufSize(halfBT * V);
-  tilingData.set_qBufSize(halfBT * K);
-  tilingData.set_dhBufSize(halfK * V);
-  tilingData.set_totalTbufByte(tBufByte);
-  return true;
-}
-
-void ChunkGatedDeltaRuleBwdDhuTiling::SetWorkspaceSize(gert::TilingContext* context) {
-  auto platformInfoPtr = context->GetPlatformInfo();
-  auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
-  uint32_t totalCoreNum = ascendcPlatform.GetCoreNumAic();
-  uint32_t taskNum = B * Hk * tilingData.get_seqNum();
-  uint32_t usedCoreNum = taskNum > totalCoreNum ? totalCoreNum : taskNum;  
-  tilingData.set_usedCoreNum(usedCoreNum);
-  context->SetBlockDim(usedCoreNum);
-
-  // GVA 方案 A：粗粒度 task 为 (b,hq,seq)，组内各 value 头 h 串行（见 cube/vec 中 for h 循环）。
-  // Workspace 按物理核 coreIdx / vec 侧 cubeIdx 分片；每片仍对应「单 chunk、单条流水线」的 bdv/gatedQ/dh term，
-  // 完成该 h 的一步后再处理下一 h，同一片复用，故 per-core 步长仍为 chunkSize*V、BT*K、K*V，无需再乘 (Hv/Hk)。
-  // 若将来改为组内多头并行或双缓冲，需同时改 kernel 内偏移与下列 * usedCoreNum 的核算。
-  uint64_t bdvWs = chunkSize * V * usedCoreNum;
-  uint64_t qWs = K * chunkSize * usedCoreNum;
-  uint64_t wDv2Ws = K * V * usedCoreNum;
-  uint64_t qDoWs = K * V * usedCoreNum;
-  size_t usrWsSize = static_cast<size_t>((bdvWs + qWs + wDv2Ws + qDoWs) * HALF_DTYPE_SIZE);
-
-  size_t sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
-  size_t* workspace = context->GetWorkspaceSizes(1);
-  workspace[0] = usrWsSize + sysWorkspaceSize;
-  tilingData.set_bdvWs(bdvWs);
-  tilingData.set_qWs(qWs);
-  tilingData.set_wDv2Ws(wDv2Ws);
-  tilingData.set_qDoWs(qDoWs);
-}
-
-void ChunkGatedDeltaRuleBwdDhuTiling::PrintTilingData(gert::TilingContext *context) {
-  OP_LOGD(context->GetNodeName(), "End Run ChunkGatedDeltaRuleBwdDhu Tiling");
-  OP_LOGD(context->GetNodeName(), "B is %lu.", tilingData.get_B());
-  OP_LOGD(context->GetNodeName(), "Hv is %lu.", tilingData.get_Hv());
-  OP_LOGD(context->GetNodeName(), "Hk is %lu.", tilingData.get_Hk());
-  OP_LOGD(context->GetNodeName(), "T is %lu.", tilingData.get_T());
-  OP_LOGD(context->GetNodeName(), "K is %lu.", tilingData.get_K());
-  OP_LOGD(context->GetNodeName(), "V is %lu.", tilingData.get_V());
-  OP_LOGD(context->GetNodeName(), "chunkSize is %lu.", tilingData.get_chunkSize());
-  OP_LOGD(context->GetNodeName(), "chunkNum is %lu.", tilingData.get_chunkNum());
-  OP_LOGD(context->GetNodeName(), "seqNum is %lu.", tilingData.get_seqNum());
-  OP_LOGD(context->GetNodeName(), "gBufSize is %lu.", tilingData.get_gBufSize());
-  OP_LOGD(context->GetNodeName(), "dvBufSize is %lu.", tilingData.get_dvBufSize());
-  OP_LOGD(context->GetNodeName(), "qBufSize is %lu.", tilingData.get_qBufSize());
-  OP_LOGD(context->GetNodeName(), "dhBufSize is %lu.", tilingData.get_dhBufSize());
-  OP_LOGD(context->GetNodeName(), "totalTbufByte is %lu.", tilingData.get_totalTbufByte());
-  OP_LOGD(context->GetNodeName(), "bdvWs is %lu.", tilingData.get_bdvWs());
-  OP_LOGD(context->GetNodeName(), "qWs is %lu.", tilingData.get_qWs());
-  OP_LOGD(context->GetNodeName(), "wDv2Ws is %lu.", tilingData.get_wDv2Ws());
-  OP_LOGD(context->GetNodeName(), "qDoWs is %lu.", tilingData.get_qDoWs());
-  OP_LOGD(context->GetNodeName(), "isVarLen is %lu.", tilingData.get_isVarLen());
-  OP_LOGD(context->GetNodeName(), "isScale is %lu.", tilingData.get_isScale());
-  OP_LOGD(context->GetNodeName(), "usedCoreNum is %u.", tilingData.get_usedCoreNum());
-  OP_LOGD(context->GetNodeName(), "scale is %f.", tilingData.get_scale());
-}
-
-
-ASCENDC_EXTERN_C ge::graphStatus Tiling4ChunkGDRBwdDhu(gert::TilingContext* context) {
-  ChunkGatedDeltaRuleBwdDhuTiling tiling;
-  OP_CHECK_IF(!tiling.Init(context), 
-              OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(), "tiling init failed"), 
-              return ge::GRAPH_FAILED);
-  
-  OP_CHECK_IF(!tiling.VarLenSetting(context), 
-            OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(), "tiling init failed"), 
-            return ge::GRAPH_FAILED);
-  
-  OP_CHECK_IF(!tiling.CheckInputShape(context), OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(),
-              "CheckInputShape Failed"), return ge::GRAPH_FAILED);
-
-  OP_CHECK_IF(!tiling.CheckInputDtype(context), OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(),
-              "CheckInputDtype Failed"), return ge::GRAPH_FAILED);
-  
-  OP_CHECK_IF(!tiling.CalcUb(context), OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(),
-            "Set Ub Failed"), return ge::GRAPH_FAILED);
-  context->SetTilingKey(tiling.tilingKey);
-  auto platformInfoPtr = context->GetPlatformInfo();
-  OP_CHECK_IF(platformInfoPtr == nullptr,
-              OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(), "platformInfoPtr is null!"),
-              return ge::GRAPH_FAILED);
-  tiling.SetWorkspaceSize(context);
-  tiling.tilingData.SaveToBuffer(
-    context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
-  context->GetRawTilingData()->SetDataSize(tiling.tilingData.GetDataSize());
-  tiling.PrintTilingData(context);
-  return ge::GRAPH_SUCCESS;
-}
-
-ASCENDC_EXTERN_C ge::graphStatus TilingPrepare4ChunkGDRBwdDhu(gert::TilingParseContext* context) {
-  return ge::GRAPH_SUCCESS;
+ASCENDC_EXTERN_C ge::graphStatus TilingPrepare4ChunkGDRBwdDhu(gert::TilingParseContext *context)
+{
+    (void)context;
+    return ge::GRAPH_SUCCESS;
 }
 
 IMPL_OP_OPTILING(ChunkGatedDeltaRuleBwdDhu)
-.Tiling(Tiling4ChunkGDRBwdDhu)
-.TilingParse<ChunkGatedDeltaRuleBwdDhuCompileInfo>(TilingPrepare4ChunkGDRBwdDhu);  // regist into the framework
-}  // namespace optiling
+    .Tiling(Tiling4ChunkGDRBwdDhu)
+    .TilingParse<ChunkGatedDeltaRuleBwdDhuCompileInfo>(TilingPrepare4ChunkGDRBwdDhu);
+
+} // namespace optiling

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.h
@@ -1,79 +1,25 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
- * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
- * the BSD 3-Clause License (the "License").
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- */
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 /*!
- * \file chunk_bwd_dv_local_tiling.h
- * \brief
+ * \file chunk_gated_delta_rule_bwd_dhu_tiling.h
+ * \brief Compatibility include for chunk_gated_delta_rule_bwd_dhu tiling data.
  */
 
 #pragma once
 
-#include <cstdint>
-#include <climits>
-#include <register/tilingdata_base.h>
-#include "register/op_impl_registry.h"
-#include "tiling_base/tiling_templates_registry.h"
-#include <tiling/tiling_api.h>
-#include "err/ops_err.h"
+#include "../../op_kernel/chunk_gated_delta_rule_bwd_dhu_struct.h"
 
 namespace optiling {
 
-BEGIN_TILING_DATA_DEF(ChunkGatedDeltaRuleBwdDhuTilingData)
-TILING_DATA_FIELD_DEF(uint64_t, B);
-TILING_DATA_FIELD_DEF(uint64_t, Hv);
-TILING_DATA_FIELD_DEF(uint64_t, Hk);
-TILING_DATA_FIELD_DEF(uint64_t, T);
-TILING_DATA_FIELD_DEF(uint64_t, K);
-TILING_DATA_FIELD_DEF(uint64_t, V);
-TILING_DATA_FIELD_DEF(uint64_t, chunkSize);
-TILING_DATA_FIELD_DEF(uint64_t, chunkNum);
-TILING_DATA_FIELD_DEF(uint64_t, seqNum);
-TILING_DATA_FIELD_DEF(uint64_t, gBufSize);
-TILING_DATA_FIELD_DEF(uint64_t, dvBufSize);
-TILING_DATA_FIELD_DEF(uint64_t, qBufSize);
-TILING_DATA_FIELD_DEF(uint64_t, dhBufSize);
-TILING_DATA_FIELD_DEF(uint64_t, totalTbufByte);
-TILING_DATA_FIELD_DEF(uint64_t, bdvWs);
-TILING_DATA_FIELD_DEF(uint64_t, qWs);
-TILING_DATA_FIELD_DEF(uint64_t, wDv2Ws);
-TILING_DATA_FIELD_DEF(uint64_t, qDoWs);
-TILING_DATA_FIELD_DEF(uint64_t, isVarLen);
-TILING_DATA_FIELD_DEF(uint64_t, isScale);
-TILING_DATA_FIELD_DEF(uint32_t, usedCoreNum);
-TILING_DATA_FIELD_DEF(float, scale);
-END_TILING_DATA_DEF;
-
-REGISTER_TILING_DATA_CLASS(ChunkGatedDeltaRuleBwdDhu, ChunkGatedDeltaRuleBwdDhuTilingData)
+using GDN::ChunkGatedDeltaRuleBwdDhuTilingData;
 
 struct ChunkGatedDeltaRuleBwdDhuCompileInfo {};
-
-class ChunkGatedDeltaRuleBwdDhuTiling {
-public:
-    ChunkGatedDeltaRuleBwdDhuTilingData tilingData;
-    bool Init(gert::TilingContext *context);
-    bool CheckInputShape(gert::TilingContext *context);
-    bool CheckInputDtype(gert::TilingContext *context);
-    bool CalcUb(gert::TilingContext *context);
-    void SetWorkspaceSize(gert::TilingContext *context);
-    bool VarLenSetting(gert::TilingContext *context);
-    void PrintTilingData(gert::TilingContext *context);
-    uint32_t tilingKey = 0;
-private:
-    bool IS_SCALE = false;
-    bool IS_VARIABLE_LEN = false; 
-    uint64_t B = 0;
-    uint64_t Hv = 0;
-    uint64_t Hk = 0;
-    uint64_t T = 0;
-    uint64_t K = 0;
-    uint64_t V = 0;
-    uint64_t chunkSize = 64;
-};
 
 } // namespace optiling

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
@@ -1,0 +1,328 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
+ * \brief Tiling processor decoupled from gert::TilingContext, reusable in both aclnn and kernel launch modes.
+ */
+
+#ifndef CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_PROCESSOR_H
+#define CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_PROCESSOR_H
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include "exe_graph/runtime/storage_shape.h"
+#include <register/op_impl_registry.h>
+#include "tiling_base/data_copy_transpose_tiling.h"
+#include "tiling_base/tiling_templates_registry.h"
+#include "../../op_kernel/chunk_gated_delta_rule_bwd_dhu_struct.h"
+
+using GDN::ChunkGatedDeltaRuleBwdDhuTilingData;
+
+namespace optiling {
+
+static constexpr size_t CHUNK_GDR_BWD_DHU_INPUT_Q_IDX = 0;
+static constexpr size_t CHUNK_GDR_BWD_DHU_INPUT_K_IDX = 1;
+static constexpr size_t CHUNK_GDR_BWD_DHU_INPUT_W_IDX = 2;
+static constexpr size_t CHUNK_GDR_BWD_DHU_INPUT_DO_IDX = 3;
+static constexpr size_t CHUNK_GDR_BWD_DHU_INPUT_DV_IDX = 4;
+static constexpr size_t CHUNK_GDR_BWD_DHU_INPUT_G_IDX = 5;
+
+static constexpr size_t CHUNK_GDR_BWD_DHU_DIM_0 = 0;
+static constexpr size_t CHUNK_GDR_BWD_DHU_DIM_1 = 1;
+static constexpr size_t CHUNK_GDR_BWD_DHU_DIM_2 = 2;
+static constexpr size_t CHUNK_GDR_BWD_DHU_DIM_3 = 3;
+
+static constexpr uint32_t CHUNK_GDR_BWD_DHU_NUM_64 = 64;
+static constexpr uint32_t CHUNK_GDR_BWD_DHU_NUM_128 = 128;
+static constexpr uint32_t CHUNK_GDR_BWD_DHU_NUM_2 = 2;
+static constexpr uint32_t CHUNK_GDR_BWD_DHU_NUM_3 = 3;
+static constexpr uint32_t CHUNK_GDR_BWD_DHU_BLOCK_SIZE = 32;
+
+static constexpr uint32_t CHUNK_GDR_BWD_DHU_HALF_DTYPE_SIZE = 2;
+static constexpr uint32_t CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE = 4;
+
+static constexpr const char *const CHUNK_GDR_BWD_DHU_INPUT_Q_NAME = "q";
+static constexpr const char *const CHUNK_GDR_BWD_DHU_INPUT_K_NAME = "k";
+static constexpr const char *const CHUNK_GDR_BWD_DHU_INPUT_W_NAME = "w";
+static constexpr const char *const CHUNK_GDR_BWD_DHU_INPUT_DO_NAME = "d_o";
+static constexpr const char *const CHUNK_GDR_BWD_DHU_INPUT_DV_NAME = "dv";
+static constexpr const char *const CHUNK_GDR_BWD_DHU_INPUT_G_NAME = "g";
+static constexpr const char *const CHUNK_GDR_BWD_DHU_INPUT_CHUNK_INDICES_NAME = "chunk_indices";
+static constexpr const char *const CHUNK_GDR_BWD_DHU_INPUT_SEQLENS_NAME = "cu_seqlens";
+
+struct ChunkGatedDeltaRuleBwdDhuTilingContext {
+    const char *nodeName;
+    const gert::StorageShape *qShape;
+    const gert::StorageShape *kShape;
+    const gert::StorageShape *wShape;
+    const gert::StorageShape *doShape;
+    const gert::StorageShape *dvShape;
+    const gert::StorageShape *gShape;
+    const gert::StorageShape *cuSeqlensShape;
+    const gert::StorageShape *chunkIndicesShape;
+    ge::DataType qDtype;
+    ge::DataType gDtype;
+    bool hasG;
+    bool hasScaleAttr;
+    double scaleAttr;
+    int32_t chunkSize;
+    uint64_t ubSize;
+    uint32_t totalCoreNum;
+    size_t sysWorkspaceSize;
+};
+
+class ChunkGatedDeltaRuleBwdDhuTilingProcessor {
+    ChunkGatedDeltaRuleBwdDhuTilingContext &ctx_;
+    ChunkGatedDeltaRuleBwdDhuTilingData &tiling_;
+
+    bool isVariableLen_ = false;
+    uint32_t tilingKey_ = GDN::CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_KEY;
+    size_t workspaceSize_ = 0;
+    uint32_t blockDim_ = 0;
+
+    uint64_t B_ = 0;
+    uint64_t Hv_ = 0;
+    uint64_t Hk_ = 0;
+    uint64_t T_ = 0;
+    uint64_t K_ = 0;
+    uint64_t V_ = 0;
+    uint64_t chunkSize_ = CHUNK_GDR_BWD_DHU_NUM_64;
+
+public:
+    explicit ChunkGatedDeltaRuleBwdDhuTilingProcessor(ChunkGatedDeltaRuleBwdDhuTilingContext &ctx,
+                                                        ChunkGatedDeltaRuleBwdDhuTilingData &tiling)
+        : ctx_(ctx), tiling_(tiling)
+    {
+    }
+
+    size_t GetWorkspaceSize() const
+    {
+        return workspaceSize_;
+    }
+
+    uint32_t GetBlockDim() const
+    {
+        return blockDim_;
+    }
+
+    uint32_t GetTilingKey() const
+    {
+        return tilingKey_;
+    }
+
+    bool IsVariableLength() const
+    {
+        return isVariableLen_;
+    }
+
+    template <typename T>
+    static T CeilDiv(T a, T b)
+    {
+        if (b == 0) {
+            return a;
+        }
+        return (a + b - 1) / b;
+    }
+
+    ge::graphStatus Init()
+    {
+        const gert::Shape qShape = ctx_.qShape->GetStorageShape();
+        const gert::Shape kShape = ctx_.kShape->GetStorageShape();
+        const gert::Shape wShape = ctx_.wShape->GetStorageShape();
+        const gert::Shape doShape = ctx_.doShape->GetStorageShape();
+        const gert::Shape dvShape = ctx_.dvShape->GetStorageShape();
+
+        B_ = static_cast<uint64_t>(qShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_0));
+        Hk_ = static_cast<uint64_t>(qShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_1));
+        T_ = static_cast<uint64_t>(qShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_2));
+        K_ = static_cast<uint64_t>(qShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_3));
+        Hv_ = static_cast<uint64_t>(doShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_1));
+        V_ = static_cast<uint64_t>(doShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_3));
+
+        OP_CHECK_IF(
+            kShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_0) != static_cast<int64_t>(B_) ||
+                kShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_1) != static_cast<int64_t>(Hk_) ||
+                kShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_2) != static_cast<int64_t>(T_) ||
+                kShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_3) != static_cast<int64_t>(K_),
+            OP_LOGE(ctx_.nodeName,
+                    "k must match q as [B,Hk,T,K]; q [%lu,%lu,%lu,%lu], k [%ld,%ld,%ld,%ld].", B_, Hk_, T_, K_,
+                    kShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_0), kShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_1),
+                    kShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_2), kShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_3)),
+            return ge::GRAPH_FAILED);
+        OP_CHECK_IF(
+            wShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_0) != static_cast<int64_t>(B_) ||
+                wShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_1) != static_cast<int64_t>(Hv_) ||
+                wShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_2) != static_cast<int64_t>(T_) ||
+                wShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_3) != static_cast<int64_t>(K_),
+            OP_LOGE(ctx_.nodeName,
+                    "w must be [B,Hv,T,K] with Hv=dO.dim1; expect [%lu,%lu,%lu,%lu], got [%ld,%ld,%ld,%ld].", B_, Hv_,
+                    T_, K_, wShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_0), wShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_1),
+                    wShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_2), wShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_3)),
+            return ge::GRAPH_FAILED);
+        OP_CHECK_IF(doShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_0) != static_cast<int64_t>(B_) ||
+                        doShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_2) != static_cast<int64_t>(T_),
+                    OP_LOGE(ctx_.nodeName, "dO batch/time must match q."), return ge::GRAPH_FAILED);
+        OP_CHECK_IF(
+            dvShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_0) != static_cast<int64_t>(B_) ||
+                dvShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_1) != static_cast<int64_t>(Hv_) ||
+                dvShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_2) != static_cast<int64_t>(T_) ||
+                dvShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_3) != static_cast<int64_t>(V_),
+            OP_LOGE(ctx_.nodeName, "dv must be [B,Hv,T,V] aligned with dO."), return ge::GRAPH_FAILED);
+        OP_CHECK_IF(Hv_ == 0 || Hk_ == 0 || (Hv_ % Hk_) != 0,
+                    OP_LOGE(ctx_.nodeName,
+                            "GVA: Hv (value heads) must be an integer multiple of Hk (q/k heads); require Hv mod Hk "
+                            "== 0; got Hk=%lu Hv=%lu.",
+                            Hk_, Hv_),
+                    return ge::GRAPH_FAILED);
+
+        const bool isScale = ctx_.hasScaleAttr;
+        const float scale = isScale ? static_cast<float>(ctx_.scaleAttr) : 1.0f;
+        chunkSize_ = static_cast<uint64_t>(ctx_.chunkSize);
+        OP_CHECK_IF(!(chunkSize_ == CHUNK_GDR_BWD_DHU_NUM_64 || chunkSize_ == CHUNK_GDR_BWD_DHU_NUM_128),
+                    OP_LOGE(ctx_.nodeName, "chunk_size should be 64 or 128, but got %lu.", chunkSize_),
+                    return ge::GRAPH_FAILED);
+
+        tiling_.B = B_;
+        tiling_.Hv = Hv_;
+        tiling_.Hk = Hk_;
+        tiling_.T = T_;
+        tiling_.K = K_;
+        tiling_.V = V_;
+        tiling_.isScale = isScale ? 1 : 0;
+        tiling_.scale = scale;
+        tiling_.chunkSize = chunkSize_;
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus VarLenSetting()
+    {
+        const bool hasCuSeqlens = ctx_.cuSeqlensShape != nullptr;
+        const bool hasChunkIndices = ctx_.chunkIndicesShape != nullptr;
+        if (hasCuSeqlens && hasChunkIndices) {
+            isVariableLen_ = true;
+        } else if (!hasCuSeqlens && !hasChunkIndices) {
+            isVariableLen_ = false;
+        } else {
+            OP_LOGE(ctx_.nodeName, "cu_seqlens and chunk_indices must both be provided or both be omitted.");
+            return ge::GRAPH_FAILED;
+        }
+        tiling_.isVarLen = isVariableLen_ ? 1 : 0;
+
+        if (!isVariableLen_) {
+            tiling_.chunkNum = static_cast<uint64_t>(CeilDiv(T_, chunkSize_));
+            tiling_.seqNum = 1;
+        } else {
+            const gert::Shape cuSeqlensShape = ctx_.cuSeqlensShape->GetStorageShape();
+            const gert::Shape chunkIndicesShape = ctx_.chunkIndicesShape->GetStorageShape();
+            auto seqNum = cuSeqlensShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_0) - 1;
+            auto chunkNum = chunkIndicesShape.GetDim(CHUNK_GDR_BWD_DHU_DIM_0) / CHUNK_GDR_BWD_DHU_NUM_2;
+            tiling_.seqNum = static_cast<uint64_t>(seqNum);
+            tiling_.chunkNum = static_cast<uint64_t>(chunkNum);
+        }
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus CheckInputShape()
+    {
+        OP_CHECK_IF(isVariableLen_ && B_ != 1,
+                    OP_LOGE(ctx_.nodeName, "B must be 1 when sequence is variable len, but got %lu.", B_),
+                    return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus CheckInputDtype()
+    {
+        if (!ctx_.hasG) {
+            OP_LOGE(ctx_.nodeName, "Input g is required for chunk_gated_delta_rule_bwd_dhu kernel.");
+            return ge::GRAPH_FAILED;
+        }
+        const ge::DataType qDtype = ctx_.qDtype;
+        const ge::DataType gDtype = ctx_.gDtype;
+        if (gDtype != qDtype && gDtype != ge::DT_FLOAT) {
+            OP_LOGE(ctx_.nodeName, "gDtype must be DT_FLOAT or as same as qDtype");
+            return ge::GRAPH_FAILED;
+        }
+        if (gDtype == ge::DT_FLOAT) {
+            tilingKey_ = GDN::CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_KEY_G_FP32;
+        } else {
+            tilingKey_ = GDN::CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_KEY;
+        }
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus CalcUb()
+    {
+        const uint32_t halfBT = CeilDiv(static_cast<uint32_t>(chunkSize_), CHUNK_GDR_BWD_DHU_NUM_2);
+        const uint32_t halfK = CeilDiv(static_cast<uint32_t>(K_), CHUNK_GDR_BWD_DHU_NUM_2);
+        const uint32_t gBrcbBufByte = halfBT * CHUNK_GDR_BWD_DHU_BLOCK_SIZE;
+        const uint32_t dvBufByte = halfBT * static_cast<uint32_t>(V_) * CHUNK_GDR_BWD_DHU_HALF_DTYPE_SIZE;
+        const uint32_t dvCastBufByte = halfBT * static_cast<uint32_t>(V_) * CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE;
+        const uint32_t dqkBufByte = halfBT * static_cast<uint32_t>(K_) * CHUNK_GDR_BWD_DHU_HALF_DTYPE_SIZE;
+        const uint32_t dqkCastBufByte = halfBT * static_cast<uint32_t>(K_) * CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE;
+        const uint32_t dhCastBufByte = halfK * static_cast<uint32_t>(V_) * CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE;
+
+        const uint32_t dvPeak =
+            static_cast<uint32_t>(chunkSize_) * CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE + gBrcbBufByte + dvBufByte +
+            CHUNK_GDR_BWD_DHU_NUM_2 * dvCastBufByte;
+        const uint32_t gatedQPeak = CHUNK_GDR_BWD_DHU_NUM_2 * static_cast<uint32_t>(chunkSize_) *
+                                        CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE +
+                                    dqkBufByte + dqkCastBufByte + gBrcbBufByte;
+        const uint32_t dhPeak = CHUNK_GDR_BWD_DHU_NUM_2 * dhCastBufByte;
+        const uint32_t tBufByte = std::max(dhPeak, std::max(dvPeak, gatedQPeak));
+
+        OP_CHECK_IF(tBufByte > ctx_.ubSize,
+                    OP_LOGE(ctx_.nodeName, "K/V is too large, K should less than 128 and V should less than 256."),
+                    return ge::GRAPH_FAILED);
+        tiling_.gBufSize = halfBT;
+        tiling_.dvBufSize = halfBT * static_cast<uint64_t>(V_);
+        tiling_.qBufSize = halfBT * static_cast<uint64_t>(K_);
+        tiling_.dhBufSize = halfK * static_cast<uint64_t>(V_);
+        tiling_.totalTbufByte = tBufByte;
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus SetWorkspaceSize()
+    {
+        const uint32_t taskNum = static_cast<uint32_t>(B_ * Hk_ * tiling_.seqNum);
+        const uint32_t usedCoreNum = taskNum > ctx_.totalCoreNum ? ctx_.totalCoreNum : taskNum;
+        tiling_.usedCoreNum = usedCoreNum;
+        blockDim_ = usedCoreNum;
+
+        const uint64_t bdvWs = chunkSize_ * V_ * usedCoreNum;
+        const uint64_t qWs = K_ * chunkSize_ * usedCoreNum;
+        const uint64_t wDv2Ws = K_ * V_ * usedCoreNum;
+        const uint64_t qDoWs = K_ * V_ * usedCoreNum;
+        const size_t usrWsSize =
+            static_cast<size_t>((bdvWs + qWs + wDv2Ws + qDoWs) * CHUNK_GDR_BWD_DHU_HALF_DTYPE_SIZE);
+
+        workspaceSize_ = usrWsSize + ctx_.sysWorkspaceSize;
+        tiling_.bdvWs = bdvWs;
+        tiling_.qWs = qWs;
+        tiling_.wDv2Ws = wDv2Ws;
+        tiling_.qDoWs = qDoWs;
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus Process()
+    {
+        OP_CHECK_IF(Init() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(VarLenSetting() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(CheckInputShape() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(CheckInputDtype() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(CalcUb() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(SetWorkspaceSize() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+};
+
+} // namespace optiling
+
+#endif // CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_PROCESSOR_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu.cpp
@@ -59,7 +59,6 @@ extern "C" __global__ __aicore__ void chunk_gated_delta_rule_bwd_dhu(
     (void)gk;
     (void)h0;
     (void)dht;
-    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
     GM_ADDR userWS = AscendC::GetUserWorkspace(workspace);
     if (userWS == nullptr) {
         return;
@@ -68,11 +67,12 @@ extern "C" __global__ __aicore__ void chunk_gated_delta_rule_bwd_dhu(
     REGISTER_TILING_DEFAULT(GDN::ChunkGatedDeltaRuleBwdDhuTilingData);
     GET_TILING_DATA_WITH_STRUCT(GDN::ChunkGatedDeltaRuleBwdDhuTilingData, tilingData, tiling);
 
-    if (TILING_KEY_IS(GDN::CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_KEY)) {
+    if (TILING_KEY_IS(1)) {
+        KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
         GDN::ChunkGatedDeltaRuleBwdDhuKernelImpl<DTYPE_Q, DTYPE_Q>(
             q, k, w, d_o, dv, g, cu_seqlens, chunk_indices, dh, dh0, dv2, userWS, &tilingData);
-    }
-    if (TILING_KEY_IS(GDN::CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_KEY_G_FP32)) {
+    } else if (TILING_KEY_IS(2)) {
+        KERNEL_TASK_TYPE(2, KERNEL_TYPE_MIX_AIC_1_2);
         GDN::ChunkGatedDeltaRuleBwdDhuKernelImpl<DTYPE_Q, float>(
             q, k, w, d_o, dv, g, cu_seqlens, chunk_indices, dh, dh0, dv2, userWS, &tilingData);
     }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu.cpp
@@ -1,11 +1,11 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
- * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
- * the BSD 3-Clause License (the "License").
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- */
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 /*!
  * \file chunk_gated_delta_rule_bwd_dhu.cpp
@@ -16,47 +16,65 @@
     #define G_BF16
 #endif
 
+#include "chunk_gated_delta_rule_bwd_dhu_struct.h"
 #include "chunk_gated_delta_rule_bwd_dhu_vec.h"
 #include "chunk_gated_delta_rule_bwd_dhu_cube.h"
 
+#ifndef TORCH_MODE
 #include "kernel_operator.h"
 #include "lib/matmul_intf.h"
+#else
+#include "kernel_operator.h"
+#endif
 
 using namespace AscendC;
+
+namespace GDN {
+
+template <typename DT, typename GT>
+__aicore__ inline void ChunkGatedDeltaRuleBwdDhuKernelImpl(
+    GM_ADDR q, GM_ADDR k, GM_ADDR w, GM_ADDR d_o, GM_ADDR dv, GM_ADDR g, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
+    GM_ADDR dh, GM_ADDR dh0, GM_ADDR dv2, GM_ADDR userWS, const ChunkGatedDeltaRuleBwdDhuTilingData *tilingData)
+{
+    (void)dh0;
+    if ASCEND_IS_AIC {
+        GDRCube<DT, GT> cubeOp(k, w, d_o, dh, dv2, cu_seqlens, chunk_indices, userWS);
+        cubeOp.Init(*tilingData);
+        cubeOp.Process();
+    }
+    if ASCEND_IS_AIV {
+        ChunkGDRBwdDhu::GDRVec<DT, GT> op;
+        op.Init(q, k, w, d_o, dv, g, cu_seqlens, dv2, dh, userWS, *tilingData);
+        op.Process();
+    }
+}
+
+} // namespace GDN
+
+#ifndef TORCH_MODE
 extern "C" __global__ __aicore__ void chunk_gated_delta_rule_bwd_dhu(
-    GM_ADDR q, GM_ADDR k, GM_ADDR w, GM_ADDR d_o, GM_ADDR dv, GM_ADDR g, GM_ADDR gk, GM_ADDR h0, GM_ADDR dht, 
+    GM_ADDR q, GM_ADDR k, GM_ADDR w, GM_ADDR d_o, GM_ADDR dv, GM_ADDR g, GM_ADDR gk, GM_ADDR h0, GM_ADDR dht,
     GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR dh, GM_ADDR dh0, GM_ADDR dv2, GM_ADDR workspace, GM_ADDR tiling)
 {
-    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);  
+    (void)gk;
+    (void)h0;
+    (void)dht;
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
     GM_ADDR userWS = AscendC::GetUserWorkspace(workspace);
     if (userWS == nullptr) {
         return;
     }
 
-    GET_TILING_DATA(tilingData, tiling);
-    
-    if (TILING_KEY_IS(0)) { // g dtype = q dtype
-        if ASCEND_IS_AIC {
-            GDRCube<DTYPE_Q, DTYPE_Q> cubeOp(k, w, d_o, dh, dv2, cu_seqlens, chunk_indices, workspace);
-            cubeOp.Init(tilingData);
-            cubeOp.Process();
-        }
-        if ASCEND_IS_AIV {
-            ChunkGDRBwdDhu::GDRVec<DTYPE_Q, DTYPE_Q> op;
-            op.Init(q, k, w, d_o, dv, g, cu_seqlens, dv2, dh, workspace, tilingData);
-            op.Process();
-        }
+    REGISTER_TILING_DEFAULT(GDN::ChunkGatedDeltaRuleBwdDhuTilingData);
+    GET_TILING_DATA_WITH_STRUCT(GDN::ChunkGatedDeltaRuleBwdDhuTilingData, tilingData, tiling);
+
+    if (TILING_KEY_IS(GDN::CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_KEY)) {
+        GDN::ChunkGatedDeltaRuleBwdDhuKernelImpl<DTYPE_Q, DTYPE_Q>(
+            q, k, w, d_o, dv, g, cu_seqlens, chunk_indices, dh, dh0, dv2, userWS, &tilingData);
     }
-    if (TILING_KEY_IS(1)) { // q dtype = fp16/bf16, while g dtype = fp32
-        if ASCEND_IS_AIC {
-            GDRCube<DTYPE_Q, float> cubeOp(k, w, d_o, dh, dv2, cu_seqlens, chunk_indices, workspace);
-            cubeOp.Init(tilingData);
-            cubeOp.Process();
-        }
-        if ASCEND_IS_AIV {
-            ChunkGDRBwdDhu::GDRVec<DTYPE_Q, float> op;
-            op.Init(q, k, w, d_o, dv, g, cu_seqlens, dv2, dh, workspace, tilingData);
-            op.Process();
-        }
+    if (TILING_KEY_IS(GDN::CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_KEY_G_FP32)) {
+        GDN::ChunkGatedDeltaRuleBwdDhuKernelImpl<DTYPE_Q, float>(
+            q, k, w, d_o, dv, g, cu_seqlens, chunk_indices, dh, dh0, dv2, userWS, &tilingData);
     }
 }
+#endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
@@ -14,8 +14,10 @@
 #ifndef CHUNK_GATED_DELTA_RULE_BWD_DHU_BASE_H
 #define CHUNK_GATED_DELTA_RULE_BWD_DHU_BASE_H
 #include "kernel_operator.h"
+#include "chunk_gated_delta_rule_bwd_dhu_struct.h"
 
 using namespace AscendC;
+using GDN::ChunkGatedDeltaRuleBwdDhuTilingData;
 namespace ChunkGDRBwdDhu {
 constexpr uint64_t SYNC_AIC_AIV_FLAG_0 = 0;
 constexpr uint64_t SYNC_AIC_AIV_FLAG_1 = 1;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_struct.h
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_bwd_dhu_struct.h
+ * \brief Tiling data struct and tiling key declarations for chunk_gated_delta_rule_bwd_dhu operator.
+ */
+
+#ifndef CHUNK_GATED_DELTA_RULE_BWD_DHU_STRUCT_H
+#define CHUNK_GATED_DELTA_RULE_BWD_DHU_STRUCT_H
+
+#include <cstdint>
+
+namespace GDN {
+
+constexpr uint32_t CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_KEY = 0;
+constexpr uint32_t CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_KEY_G_FP32 = 1;
+
+struct ChunkGatedDeltaRuleBwdDhuTilingData {
+    uint64_t B;
+    uint64_t Hv;
+    uint64_t Hk;
+    uint64_t T;
+    uint64_t K;
+    uint64_t V;
+    uint64_t chunkSize;
+    uint64_t chunkNum;
+    uint64_t seqNum;
+    uint64_t gBufSize;
+    uint64_t dvBufSize;
+    uint64_t qBufSize;
+    uint64_t dhBufSize;
+    uint64_t totalTbufByte;
+    uint64_t bdvWs;
+    uint64_t qWs;
+    uint64_t wDv2Ws;
+    uint64_t qDoWs;
+    uint64_t isVarLen;
+    uint64_t isScale;
+    uint32_t usedCoreNum;
+    float scale;
+};
+
+} // namespace GDN
+
+#endif // CHUNK_GATED_DELTA_RULE_BWD_DHU_STRUCT_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_struct.h
@@ -19,8 +19,8 @@
 
 namespace GDN {
 
-constexpr uint32_t CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_KEY = 0;
-constexpr uint32_t CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_KEY_G_FP32 = 1;
+constexpr uint32_t CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_KEY = 1;
+constexpr uint32_t CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_KEY_G_FP32 = 2;
 
 struct ChunkGatedDeltaRuleBwdDhuTilingData {
     uint64_t B;

--- a/torch_custom/fla_npu/test/run_bwd_dhu_gva_cases.sh
+++ b/torch_custom/fla_npu/test/run_bwd_dhu_gva_cases.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# bwd_dhu GVA 双标杆：随机输入直接测，无需 example dump
+#
+# 用法:
+#   TEST_DEVICE_ID=7 bash run_bwd_dhu_gva_cases.sh
+#   BWD_HU_CASE=smoke_varlen_t256_v256 TEST_DEVICE_ID=7 bash run_bwd_dhu_gva_cases.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEVICE="${TEST_DEVICE_ID:-5}"
+
+source /data/miniconda3/etc/profile.d/conda.sh
+conda activate wnc
+source /data/zs/run/8.5/ascend-toolkit/set_env.sh
+# 使用含 GVA kernel 的 vendor；安装后勿混用多层 ASCEND_CUSTOM_OPP_PATH
+export ASCEND_CUSTOM_OPP_PATH=/data/zs/run/8.5/cann-8.5.0/vendors/fla_npu_transformer_transformer
+export LD_LIBRARY_PATH=/data/zs/run/8.5/cann-8.5.0/vendors/fla_npu_transformer_transformer/op_api/lib:${LD_LIBRARY_PATH:-}
+
+export TEST_DEVICE_ID="$DEVICE"
+export BWD_HU_OUT_DIR="${BWD_HU_OUT_DIR:-$SCRIPT_DIR/bwd_dhu_out}"
+export PYTHONUNBUFFERED=1
+
+echo "device=$DEVICE out_dir=$BWD_HU_OUT_DIR"
+cd "$SCRIPT_DIR"
+python3 test_npu_bwd_dhu_gva.py

--- a/torch_custom/fla_npu/test/test_bwd_dhu.py
+++ b/torch_custom/fla_npu/test/test_bwd_dhu.py
@@ -1,0 +1,241 @@
+"""chunk_gated_delta_rule_bwd_dhu CPU 标杆（fp64 / npu / fp32）。"""
+from __future__ import annotations
+
+import importlib.util
+import os
+from typing import List, Optional, Tuple
+
+import torch
+
+_PTA_TEST = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "../../../fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/test/test_chunk_gated_delta_rule_bwd_dhu.py",
+    )
+)
+_spec = importlib.util.spec_from_file_location("pta_bwd_dhu", _PTA_TEST)
+_pta = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_pta)
+
+create_bwd_dhu_random_inputs = _pta.create_bwd_dhu_random_inputs
+create_gate_g = _pta.create_gate_g
+effective_scale = _pta.effective_scale
+generate_cu_seqlens = _pta.generate_cu_seqlens
+prepare_chunk_indices = _pta.prepare_chunk_indices
+scale_for_compute_dtype = _pta.scale_for_compute_dtype
+
+
+def _round_elem(x: torch.Tensor, elem_dtype: torch.dtype) -> torch.Tensor:
+    if elem_dtype == torch.float32:
+        return x.to(torch.float32)
+    return x.to(elem_dtype).to(torch.float32)
+
+
+def _matmul_npu_aligned(a: torch.Tensor, b: torch.Tensor, elem_dtype: torch.dtype) -> torch.Tensor:
+    return _round_elem(a, elem_dtype) @ _round_elem(b, elem_dtype)
+
+
+def chunk_gated_delta_rule_bwd_dhu_cpu(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    w: torch.Tensor,
+    do: torch.Tensor,
+    dv: torch.Tensor,
+    cu_seqlens: Optional[List[int]] = None,
+    chunk_indices: Optional[List[int]] = None,
+    g: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
+    chunk_size: int = 64,
+    golden_mode: str = "fp32",
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+    """GVA 形状 CPU 标杆。golden_mode: fp64 / npu / fp32。"""
+    dtype_ = q.dtype
+    if golden_mode == "fp64":
+        compute_dtype = torch.float64
+        elem_dtype = None
+    elif golden_mode == "npu":
+        compute_dtype = torch.float32
+        elem_dtype = dtype_
+    elif golden_mode == "fp32":
+        compute_dtype = torch.float32
+        elem_dtype = None
+    else:
+        raise ValueError(f"unsupported golden_mode={golden_mode}")
+
+    device = q.device
+    B, Hk, T, K = q.shape
+    Hv = do.shape[1]
+    V = do.shape[-1]
+    BT = chunk_size
+
+    if Hk <= 0 or Hv % Hk != 0:
+        raise ValueError(f"GVA: Hv % Hk == 0 required, Hk={Hk}, Hv={Hv}")
+
+    hv_per_hk = Hv // Hk
+    if cu_seqlens is not None:
+        seq_total = cu_seqlens[-1]
+        if seq_total > T:
+            raise ValueError(f"cu_seqlens[-1]={seq_total} > T={T}")
+        NT = len(chunk_indices) // 2
+    else:
+        NT = (T + BT - 1) // BT
+
+    if scale is None:
+        scale = 1.0
+    scale_f = float(scale)
+
+    if golden_mode == "npu":
+        q = q.to(dtype_)
+        k = k.to(dtype_)
+        w = w.to(dtype_)
+        do = do.to(dtype_)
+        dv = dv.to(dtype_)
+        if g is not None:
+            g = g.float()
+    else:
+        q = q.to(compute_dtype)
+        k = k.to(compute_dtype)
+        w = w.to(compute_dtype)
+        do = do.to(compute_dtype)
+        dv = dv.to(compute_dtype)
+        if g is not None:
+            g = g.to(compute_dtype)
+
+    def _mm(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        if elem_dtype is None:
+            return a @ b
+        return _matmul_npu_aligned(a, b, elem_dtype)
+
+    def _store(x: torch.Tensor) -> torch.Tensor:
+        if elem_dtype is None:
+            return x
+        return _round_elem(x, elem_dtype)
+
+    def _to_compute(x: torch.Tensor) -> torch.Tensor:
+        if elem_dtype is None:
+            return x.to(compute_dtype)
+        return _round_elem(x, elem_dtype)
+
+    chunk_info = []
+    for i_t in range(NT):
+        if cu_seqlens is not None:
+            i_n = chunk_indices[i_t * 2]
+            block_idx_in_token = chunk_indices[i_t * 2 + 1]
+            bos = cu_seqlens[i_n]
+            token_length = cu_seqlens[i_n + 1] - bos
+        else:
+            i_n = 0
+            block_idx_in_token = i_t
+            bos = 0
+            token_length = T
+        start_t = block_idx_in_token * BT
+        end_t = min((block_idx_in_token + 1) * BT, token_length)
+        global_start_t = bos + start_t
+        global_end_t = bos + end_t
+        chunk_info.append({
+            "i_t": i_t,
+            "i_n": i_n,
+            "block_idx_in_token": block_idx_in_token,
+            "bos": bos,
+            "token_length": token_length,
+            "block_size_t": end_t - start_t,
+            "global_start_t": global_start_t,
+            "global_end_t": global_end_t,
+        })
+
+    dh = torch.zeros(B, Hv, NT, K, V, device=device, dtype=compute_dtype)
+    dv2 = dv.clone() if cu_seqlens is not None else torch.zeros(B, Hv, T, V, device=device, dtype=dtype_)
+
+    if cu_seqlens is None:
+        hq = torch.arange(Hv, device=device, dtype=torch.long) // hv_per_hk
+        b_dh = torch.zeros(B, Hv, K, V, device=device, dtype=compute_dtype)
+        for i_t in range(NT - 1, -1, -1):
+            info = chunk_info[i_t]
+            gs, ge = info["global_start_t"], info["global_end_t"]
+            block_size_t = info["block_size_t"]
+            dh[:, :, i_t, :, :] = b_dh
+
+            last_idx = min((info["block_idx_in_token"] + 1) * BT, info["token_length"]) - 1
+            global_last_idx = info["bos"] + last_idx
+
+            k_blk = _to_compute(k[:, :, gs:ge, :].index_select(1, hq))
+            q_blk = _to_compute(q[:, :, gs:ge, :].index_select(1, hq))
+            w_blk = _to_compute(w[:, :, gs:ge, :])
+            b_do = _to_compute(do[:, :, gs:ge, :])
+            b_dv_existing = _to_compute(dv[:, :, gs:ge, :])
+
+            b_dv = _mm(k_blk, b_dh)
+            if g is not None:
+                bg_last = g[:, :, global_last_idx].to(torch.float32)
+                b_g = g[:, :, gs:ge].to(torch.float32)
+                gate_factor = torch.exp(bg_last.unsqueeze(-1) - b_g).unsqueeze(-1)
+                m_t = torch.arange(block_size_t, device=device, dtype=torch.float32) < float(block_size_t)
+                b_dv = b_dv * gate_factor * m_t.view(1, 1, block_size_t, 1)
+
+            b_dv = b_dv + b_dv_existing
+            dv2[:, :, gs:ge, :] = _store(b_dv).to(dtype_)
+
+            b_q_t = q_blk.transpose(-1, -2)
+            b_w_t = w_blk.transpose(-1, -2)
+            if g is not None:
+                bg_last_exp = torch.exp(bg_last)
+                b_g_exp = torch.exp(b_g)
+                b_dh_for_update = b_dh * bg_last_exp.unsqueeze(-1).unsqueeze(-1)
+                b_q_gated = b_q_t * b_g_exp.unsqueeze(-2)
+            else:
+                b_dh_for_update = b_dh.clone()
+                b_q_gated = b_q_t
+
+            term1 = _mm(b_q_gated, b_do) * scale_f
+            term2 = _mm(b_w_t, b_dv)
+            b_dh = _store(b_dh_for_update + term1 - term2)
+    else:
+        for b in range(B):
+            for i_h in range(Hv):
+                hq = i_h // hv_per_hk
+                num_tokens = len(cu_seqlens) - 1
+                b_dh_buffers = {i_n: torch.zeros(K, V, device=device, dtype=compute_dtype) for i_n in range(num_tokens)}
+                for i_t in range(NT - 1, -1, -1):
+                    info = chunk_info[i_t]
+                    i_n = info["i_n"]
+                    b_dh = b_dh_buffers[i_n]
+                    dh[b, i_h, i_t] = b_dh
+                    gs, ge = info["global_start_t"], info["global_end_t"]
+                    block_size_t = info["block_size_t"]
+                    last_idx = min((info["block_idx_in_token"] + 1) * BT, info["token_length"]) - 1
+                    global_last_idx = info["bos"] + last_idx
+
+                    b_do = _to_compute(do[b, i_h, gs:ge, :])
+                    b_dv_existing = _to_compute(dv[b, i_h, gs:ge, :])
+                    b_k = _to_compute(k[b, hq, gs:ge, :])
+                    b_dv = _mm(b_k, b_dh)
+
+                    if g is not None:
+                        bg_last = g[b, i_h, global_last_idx].to(torch.float32)
+                        b_g = g[b, i_h, gs:ge].to(torch.float32)
+                        bg_last_exp = torch.exp(bg_last)
+                        b_g_exp = torch.exp(b_g)
+                        m_t = torch.arange(block_size_t, device=device) < block_size_t
+                        b_dv = b_dv * torch.exp(bg_last - b_g).unsqueeze(-1) * m_t.unsqueeze(-1).float()
+                    else:
+                        bg_last_exp = b_g_exp = None
+
+                    b_dv = b_dv + b_dv_existing
+                    dv2[b, i_h, gs:ge, :] = _store(b_dv).to(dtype_)
+
+                    b_q = _to_compute(q[b, hq, gs:ge, :])
+                    b_w = _to_compute(w[b, i_h, gs:ge, :])
+                    b_q_t = b_q.transpose(0, 1)
+                    b_w_t = b_w.transpose(0, 1)
+                    b_dh_for_update = b_dh.clone()
+                    if g is not None:
+                        b_dh_for_update = b_dh_for_update * bg_last_exp
+                        b_q_gated = b_q_t * b_g_exp.unsqueeze(0)
+                    else:
+                        b_q_gated = b_q_t
+
+                    term1 = _mm(b_q_gated, b_do) * scale_f
+                    term2 = _mm(b_w_t, b_dv)
+                    b_dh_buffers[i_n] = _store(b_dh_for_update + term1 - term2)
+
+    return dh, None, dv2

--- a/torch_custom/fla_npu/test/test_npu_bwd_dhu_gva.py
+++ b/torch_custom/fla_npu/test/test_npu_bwd_dhu_gva.py
@@ -1,0 +1,192 @@
+"""bwd_dhu GVA 双标杆测试：随机输入直接测，无需 example dump。"""
+from __future__ import annotations
+
+import importlib.util
+import math
+import os
+import sys
+from dataclasses import dataclass
+from typing import Optional
+
+import ct
+import fla_npu
+import torch
+import torch_npu
+
+torch.npu.config.allow_internal_format = False
+torch.npu.set_compile_mode(jit_compile=False)
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location("test_bwd_dhu_golden", os.path.join(_SCRIPT_DIR, "test_bwd_dhu.py"))
+_golden_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_golden_mod)
+
+chunk_gated_delta_rule_bwd_dhu_cpu = _golden_mod.chunk_gated_delta_rule_bwd_dhu_cpu
+create_bwd_dhu_random_inputs = _golden_mod.create_bwd_dhu_random_inputs
+effective_scale = _golden_mod.effective_scale
+generate_cu_seqlens = _golden_mod.generate_cu_seqlens
+prepare_chunk_indices = _golden_mod.prepare_chunk_indices
+scale_for_compute_dtype = _golden_mod.scale_for_compute_dtype
+
+DEFAULT_OUT_DIR = os.path.join(_SCRIPT_DIR, "bwd_dhu_out")
+
+
+@dataclass
+class BwdDhuCase:
+    name: str
+    batch: int
+    k_h: int
+    v_h: int
+    tokens: int
+    v_dim: int = 256
+    k_dim: int = 128
+    chunk_size: int = 64
+    varlen: bool = True
+    cu_seqlens_len: Optional[int] = None
+    dtype: str = "bf16"
+    supported: bool = True
+    skip_reason: str = ""
+
+    def ktype(self) -> torch.dtype:
+        return torch.bfloat16 if self.dtype == "bf16" else torch.float16
+
+    def gtype(self) -> torch.dtype:
+        return torch.float32
+
+
+# 与 fwd_h 12 项矩阵对齐，Vdim=256；按规模从小到大排列（去掉与 smoke_fixed 重复的 fixed_t4096）
+CASES = [
+    BwdDhuCase("smoke_varlen_t256_v256", 1, 16, 32, 256, chunk_size=64, cu_seqlens_len=5),
+    BwdDhuCase("fixed_b176_t24_v256", 176, 2, 64, 24, chunk_size=64, varlen=False),
+    BwdDhuCase("fixed_b711_t196_v256", 711, 4, 32, 196, chunk_size=128, varlen=False),
+    BwdDhuCase("fixed_b16_t2048_v256", 16, 21, 63, 2048, chunk_size=64, varlen=False),
+    BwdDhuCase("smoke_fixed_t4096_v256", 1, 16, 32, 4096, chunk_size=64, varlen=False),
+    BwdDhuCase("varlen_t16384_v256_cu2", 1, 21, 63, 16384, chunk_size=64, cu_seqlens_len=2),
+    BwdDhuCase("varlen_t16384_v256_cu128", 1, 16, 32, 16384, chunk_size=64, cu_seqlens_len=128),
+    BwdDhuCase("varlen_t65536_v256_cu17", 1, 4, 32, 65536, chunk_size=128, cu_seqlens_len=17),
+    BwdDhuCase("varlen_t65536_v256_cu172", 1, 8, 32, 65536, chunk_size=128, cu_seqlens_len=172),
+    BwdDhuCase("varlen_t65536_v256_cu668", 1, 16, 32, 65536, chunk_size=64, cu_seqlens_len=668),
+    BwdDhuCase(
+        "varlen_t262144_v256_cu32", 1, 2, 64, 262144, chunk_size=64, cu_seqlens_len=32,
+        supported=False,
+        skip_reason="CPU fp64 golden T=262144 过慢，暂跳过",
+    ),
+]
+
+
+def _dual_check(name: str, npu_out: torch.Tensor, ref_fp64: torch.Tensor, ref_npu: torch.Tensor, level: str = "L1"):
+    print(f"================== {name} (dual: fp64 gt / npu-aligned bench) ==================", flush=True)
+    result = ct.dual(npu_out.cpu().float(), ref_fp64.cpu().float(), ref_npu.cpu().float(), level=level)
+    ok = bool(result.get("success"))
+    ratios = result.get("ratios", {})
+    checks = result.get("checks", {})
+    tag = "PASS" if ok else "FAIL"
+    print(f"[{name}] dual {tag}: checks={checks} ratios={ratios}", flush=True)
+    return ok, ratios, checks
+
+
+def _build_inputs(case: BwdDhuCase, seed: int = 0):
+    ktype = case.ktype()
+    gtype = case.gtype()
+    torch.manual_seed(seed)
+    q, k, w, do, dv, g = create_bwd_dhu_random_inputs(
+        case.batch, case.k_h, case.v_h, case.tokens, case.k_dim, case.v_dim, ktype, gtype,
+    )
+    cu_seqlens = None
+    chunk_indices = None
+    if case.varlen:
+        cu_seqlens = generate_cu_seqlens(case.cu_seqlens_len, case.tokens)
+        chunk_indices = prepare_chunk_indices(cu_seqlens, case.chunk_size)
+    scale = scale_for_compute_dtype(effective_scale(1.0 / math.sqrt(case.k_dim), case.k_dim), ktype)
+    return q, k, w, do, dv, g, cu_seqlens, chunk_indices, scale
+
+
+def run_case(case: BwdDhuCase, device: int, out_root: str, seed: int = 0) -> tuple[str, str]:
+    if not case.supported:
+        return "SKIP", case.skip_reason
+
+    print(f"\n========== {case.name} ==========", flush=True)
+    print(
+        f"B={case.batch} Hk/Hv={case.k_h}/{case.v_h} T={case.tokens} "
+        f"K={case.k_dim} V={case.v_dim} cs={case.chunk_size} varlen={case.varlen}",
+        flush=True,
+    )
+
+    q, k, w, do, dv, g, cu_seqlens, chunk_indices, scale = _build_inputs(case, seed=seed)
+
+    dh_fp64, _, dv2_fp64 = chunk_gated_delta_rule_bwd_dhu_cpu(
+        q, k, w, do, dv, cu_seqlens, chunk_indices, g=g, scale=scale,
+        chunk_size=case.chunk_size, golden_mode="fp64",
+    )
+    dh_npu_bench, _, dv2_npu_bench = chunk_gated_delta_rule_bwd_dhu_cpu(
+        q, k, w, do, dv, cu_seqlens, chunk_indices, g=g, scale=scale,
+        chunk_size=case.chunk_size, golden_mode="npu",
+    )
+
+    dh_npu, _, dv2_npu = torch.ops.npu.npu_chunk_gated_delta_rule_bwd_dhu(
+        q.npu(), k.npu(), w.npu(), do.npu(), dv.npu(),
+        scale=scale,
+        chunk_size=case.chunk_size,
+        g=g.npu(),
+        gK=None,
+        h0=None,
+        dht=None,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+
+    dh_ok, _, _ = _dual_check("dh", dh_npu, dh_fp64, dh_npu_bench)
+    dv2_ok, _, _ = _dual_check("dv2", dv2_npu, dv2_fp64, dv2_npu_bench)
+
+    case_dir = os.path.join(out_root, case.name)
+    if os.environ.get("BWD_HU_SAVE_OUT", "1") == "1":
+        os.makedirs(case_dir, exist_ok=True)
+        torch.save({
+            "case": case.name,
+            "dh_npu": dh_npu.cpu(),
+            "dv2_npu": dv2_npu.cpu(),
+            "dh_fp64": dh_fp64.cpu(),
+            "dh_npu_bench": dh_npu_bench.cpu(),
+            "dv2_fp64": dv2_fp64.cpu(),
+            "dv2_npu_bench": dv2_npu_bench.cpu(),
+        }, os.path.join(case_dir, "outputs.pt"))
+
+    if dh_ok and dv2_ok:
+        return "PASS", f"dh=PASS dv2=PASS | out={case_dir}"
+    return "FAIL", f"dh={'PASS' if dh_ok else 'FAIL'} dv2={'PASS' if dv2_ok else 'FAIL'}"
+
+
+def main():
+    device = int(os.environ.get("TEST_DEVICE_ID", 5))
+    torch.npu.set_device(device)
+    out_root = os.environ.get("BWD_HU_OUT_DIR", DEFAULT_OUT_DIR)
+    only = os.environ.get("BWD_HU_CASE", "").strip()
+
+    cases = CASES
+    if only:
+        cases = [c for c in cases if c.name == only]
+        if not cases:
+            raise SystemExit(f"unknown BWD_HU_CASE={only}")
+
+    print(f"[MODE] random input + dual(fp64 gt / npu-aligned bench), no example dump", flush=True)
+    print(f"device={device} out_root={out_root} cases={len(cases)} Vdim=256", flush=True)
+
+    results = []
+    for case in cases:
+        try:
+            status, detail = run_case(case, device, out_root)
+        except Exception as exc:
+            status, detail = "FAIL", str(exc)
+            print(f"FAIL: {exc}", flush=True)
+        results.append((case.name, status, detail))
+
+    print("\n===== SUMMARY =====", flush=True)
+    for name, status, detail in results:
+        print(f"{name}: {status} ({detail})", flush=True)
+
+    if any(s == "FAIL" for _, s, _ in results):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 修改设计

为 `chunk_gated_delta_rule_bwd_dhu` 适配 fast kernel launch（`kernel<<<>>>` 直调）路径，在 PyTorch extension 中直接构造 tiling 并发起 kernel 执行；当前范围仅 `ascend910b`。

### 核心改动
- 抽取共享实现：新增 `chunk_gated_delta_rule_bwd_dhu_tiling_processor.h` 与 `chunk_gated_delta_rule_bwd_dhu_struct.h`，aclnn（GE）路径与 fast launch 路径复用同一套 tiling/kernel 结构体。
- 双 tiling key 编译对齐：按 g dtype 使用 `KERNEL_TASK_TYPE(1/2)` + 字面量 `TILING_KEY_IS` 分支，保证 aclnn 同时打包两个 kernel entry；fast launch wrapper 按 GT 模板设置匹配的 KERNEL_TASK_TYPE 并移除冗余 tilingKey 字段。
- fast launch csrc：`SetSysWorkspaceForce` + `GetUserWorkspace`；`CheckInputs` 校验 rank/device/dtype/GVA 及 cu_seqlens/chunk_indices 成对约束。
- GVA 双标杆测试工程：`torch_custom/fla_npu/test` 新增 `run_bwd_dhu_gva_cases.sh`、`test_npu_bwd_dhu_gva.py`（随机输入 CPU dual）与 `test_bwd_dhu.py`（fp64/npu 双档 golden），用例按 small-to-large 排序并去除重复 T=4096 用例。
- 测试：新增 `tests/chunk_gated_delta_rule_bwd_dhu/test_chunk_gated_delta_rule_bwd_dhu.py`，CPU golden（`chunk_gated_delta_rule_bwd_dhu_torch`）对比，`rtol=atol=1e-2`。

### 涉及文件
- `examples/fast_kernel_launch_example/CMakeLists.txt`
- `examples/fast_kernel_launch_example/csrc/chunk_gated_delta_rule_bwd_dhu/ascend910b/CMakeLists.txt`
- `examples/fast_kernel_launch_example/csrc/chunk_gated_delta_rule_bwd_dhu/ascend910b/chunk_gated_delta_rule_bwd_dhu.cpp`
- `examples/fast_kernel_launch_example/tests/chunk_gated_delta_rule_bwd_dhu/test_chunk_gated_delta_rule_bwd_dhu.py`
- `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.{h,cpp}`
- `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h`
- `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu.{cpp,base.h,struct.h}`
- `torch_custom/fla_npu/test/run_bwd_dhu_gva_cases.sh`
- `torch_custom/fla_npu/test/test_bwd_dhu.py`
- `torch_custom/fla_npu/test/test_npu_bwd_dhu_gva.py`

# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: 无（内部功能增强，无需 Issue）
- 背景与目标: 提供不经过 aclnn 框架的 `kernel<<<>>>` 直调入口；同时建立 bwd_dhu 的 GVA 双标杆（fp64 + npu）精度测试工程。
- 本 PR 解决的问题: chunk_gated_delta_rule_bwd_dhu 在 ascend910b 上支持 fast kernel launch：tiling/kernel 结构体抽取、双 tiling key 编译对齐、GVA dual 测试工程。

## 变更类型

- [ ] Bug 修复
- [x] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: chunk_gated_delta_rule_bwd_dhu
- 涉及目录 / 文件: 见上方「涉及文件」
- 责任人 / 提交人: @Coding-Pangolin
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 与 aclnn 原路径一致：q/k `[B,Hk,T,K]`、w/d_o/dv `[B,Hv,T,V]`、g `[B,Hv,T]`（fp16/bf16/fp32），输出 dh `[B,Hv,chunkNum,K,V]`、dv2 `[B,Hv,T,V]`（提供 h0 时含 dh0）；支持 GVA、chunkSize ∈ {64,128}；fast launch 仅 ascend910b；K/V 当前面向 K=128、V=128（定长/变长测试覆盖）。
- 明确不包含的范围: gK、h0/dht 在 fast launch 路径不支持（须 None，走 aclnn 原链路）；fast launch 不支持 ascend910_93/ascend950；aclnn 路径 T=32768/65536 大规格用例未在本轮执行。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 不涉及

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 8.5.0 | `bash build.sh --pkg --soc=ascend910b --ops=chunk_gated_delta_rule_bwd_dhu --vendor_name=fla_npu` | 通过 | custom op 整包编译 OK，双 tiling key entry 均打包 |
| A2 | `ascend910b` | 8.5.0 | `FAST_KERNEL_OP_NAME=chunk_gated_delta_rule_bwd_dhu NPU_ARCH=ascend910b python3 setup.py bdist_wheel` | 通过 | fast kernel whl 编译安装 OK |
| A3/A5 | `ascend910_93 / ascend950` | - | `未执行` | 未执行 | fast launch 仅适配 ascend910b |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | cd torch_custom/fla_npu/test && python3 test_npu_chunk_gated_delta_rule_bwd_dhu.py | 通过 | aclnn smoke 3 case PASS（fixed fp16、GVA Hk=2/Hv=4、varlen），约 34s |
| A2 | `ascend910b` | cd examples/fast_kernel_launch_example && pytest tests/chunk_gated_delta_rule_bwd_dhu/test_chunk_gated_delta_rule_bwd_dhu.py -v | 通过 | 10/10 PASS，43.64s；日志 fast_kernel_pytest_20260625.log |
| A2 | `ascend910b` | cd torch_custom/fla_npu/test && TEST_DEVICE_ID=4 bash run_bwd_dhu_gva_cases.sh | 通过 | GVA dual 矩阵（后续全量回归）：GPU dual 30/30 PASS；legacy smoke（chunk_size=128）4/4 PASS |

- fast launch 精度判定：`torch.allclose`（CPU golden vs NPU，dh+dv2）`rtol=atol=1e-2`，10/10 PASS。
- 覆盖：定长/变长、fp16/bf16、g fp32（tiling key 1/2 双路径）、GVA（Hk=2,Hv=4 / Hk=4,Hv=8）、metadata 成对校验、接口存在性。
- GVA dual 精度标准（L1）：MARE_ratio ≤ 5.0、MERE_ratio ≤ 1.5、RMSE_ratio ≤ 1.5、ERR_COUNT_ratio ≤ 2.0，dh+dv2 均须 PASS。
- 性能对比：不涉及。
- 未覆盖风险：fast launch 仅 910B；h0/dht/gK 不支持；CPU-only 批次中 gva_fix_3 的 dv2 精度项待收敛；aclnn 大规格 T=32768/65536 未执行。

</details>

<details>
<summary>整体 Example ST 验证</summary>

本 PR 为新增直调入口与 GVA 测试工程，未单独执行整体 example ST；依赖仓库 NPU CI 回归确认不破坏 GDN 端到端调用链。

</details>

## 兼容性、风险与回退

- 兼容性说明: 新增 fast launch 入口 `torch.ops.ascend_ops.chunk_gated_delta_rule_bwd_dhu`，不改动 aclnn/torch_custom 既有接口；GVA dual 测试为新增脚本。
- 风险点: 双 tiling key 编译依赖 KERNEL_TASK_TYPE/TILING_KEY_IS 字面量对齐，后续 tiling 改动需双路径同步回归；仅 910B 验证。
- 回退方案: fast launch 与测试工程文件均为新增/独立模块，删除即回退，不影响 aclnn 原路径。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因（内部功能增强，无外部 Issue）
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 可以编译通过
- [ ] 已验证 A3 / A5 编译（fast launch 仅 910B）
- [x] 已验证修改算子的对应 test 在 A2 通过
- [ ] 已验证整体 example ST（未单独执行，依赖 NPU CI）
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用（转测文档已整理，README 随后续文档 PR 同步）
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 转测文档：`chunk_gated_delta_rule_bwd_dhu_fast_kernel转测文档.md`（环境、编译、10/10 用例明细、精度/遗留）。
- 入口：`torch.ops.ascend_ops.chunk_gated_delta_rule_bwd_dhu` → csrc 直调；原路径 `torch.ops.npu.npu_chunk_gated_delta_rule_bwd_dhu` → aclnn。
- GVA dual 全量矩阵（cases.json 42 项）在后续 GPU dump dual 工作中完成，harness 为本 PR 新增。