### PR TITLE
chunk_bwd_dv_local A5 regbase改写

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_host/chunk_bwd_dv_local_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_host/chunk_bwd_dv_local_tiling.cpp
@@ -13,6 +13,7 @@
  */
 
 #include "chunk_bwd_dv_local_tiling_processor.h"
+#include "op_tiling/arch35/chunk_bwd_dv_local_tiling_a5.h"
 #include "../op_kernel/chunk_bwd_dv_local_struct.h"
 
 using namespace GDN;
@@ -42,6 +43,14 @@ static void ChunkBwdDvLocalTilingDataPrint(gert::TilingContext *context, const C
 ge::graphStatus Tiling4ChunkBwdDvLocal(gert::TilingContext *context)
 {
     OP_LOGD(context->GetNodeName(), "Tiling4ChunkBwdDvLocal start.");
+    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
+    if (ascendcPlatform.GetCurNpuArch() == NpuArch::DAV_3510) {
+        ChunkBwdDvLocalTilingA5 chunkBwdDvLocalTilingA5;
+        OP_CHECK_IF(!chunkBwdDvLocalTilingA5.SetTiling(context),
+                    OP_LOGE(context->GetNodeName(), "SetTiling failed."), return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+
     ChunkBwdDvLocalTilingData *tiling = context->GetTilingData<ChunkBwdDvLocalTilingData>();
 
     auto attrPtr = context->GetAttrs();
@@ -83,7 +92,6 @@ ge::graphStatus Tiling4ChunkBwdDvLocal(gert::TilingContext *context)
     OP_LOGD(context->GetNodeName(), "tilingKey: %d", context->GetTilingKey());
     ChunkBwdDvLocalTilingDataPrint(context, *tiling);
 
-    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
     int64_t coreNum = static_cast<int64_t>(ascendcPlatform.GetCoreNumAic());
     int64_t usedCoreNum = std::min(tiling->chunkNumForT * tiling->b, coreNum);
     context->SetBlockDim(usedCoreNum);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_host/op_tiling/arch35/chunk_bwd_dv_local_tiling_a5.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_host/op_tiling/arch35/chunk_bwd_dv_local_tiling_a5.cpp
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "chunk_bwd_dv_local_tiling_a5.h"
+
+using namespace GDN;
+
+namespace optiling {
+
+bool ChunkBwdDvLocalTilingA5::SetTiling(gert::TilingContext *context)
+{
+    ChunkBwdDvLocalTilingData *tiling = context->GetTilingData<ChunkBwdDvLocalTilingData>();
+    OP_CHECK_NULL_WITH_CONTEXT(context, tiling);
+
+    auto attrPtr = context->GetAttrs();
+    OP_CHECK_NULL_WITH_CONTEXT(context, attrPtr);
+    ChunkBwdDvLocalTilingContext ctx{
+        context->GetNodeName(),
+        context->GetOptionalInputShape(CHUNK_BWD_DV_LOCAL_INPUT_Q_IDX),
+        context->GetOptionalInputShape(CHUNK_BWD_DV_LOCAL_INPUT_K_IDX),
+        context->GetOptionalInputShape(CHUNK_BWD_DV_LOCAL_INPUT_DO_IDX),
+        context->GetOptionalInputShape(CHUNK_BWD_DV_LOCAL_INPUT_G_IDX),
+        context->GetOptionalInputShape(CHUNK_BWD_DV_LOCAL_INPUT_SEQLENS_IDX),
+        context->GetOptionalInputShape(CHUNK_BWD_DV_LOCAL_INPUT_CHUNK_INDICES_IDX),
+        *(attrPtr->GetAttrPointer<double>(CHUNK_BWD_DV_LOCAL_ATTR_SCALE_IDX)),
+        *(attrPtr->GetAttrPointer<int32_t>(CHUNK_BWD_DV_LOCAL_ATTR_CHUNK_SIZE_IDX)),
+    };
+
+    ChunkBwdDvLocalTilingProcessor processor(ctx, *tiling);
+    OP_CHECK_IF(processor.Process() != ge::GRAPH_SUCCESS, , return false);
+
+    uint64_t strategyKey =
+        processor.IsVariableLength() ? CHUNK_BWD_DV_LOCAL_STRATEGY_VAR_LEN : CHUNK_BWD_DV_LOCAL_STRATEGY_FIX_LEN;
+
+    auto qInputDesc = context->GetInputDesc(CHUNK_BWD_DV_LOCAL_INPUT_Q_IDX);
+    auto gInputDesc = context->GetInputDesc(CHUNK_BWD_DV_LOCAL_INPUT_G_IDX);
+    OP_CHECK_NULL_WITH_CONTEXT(context, qInputDesc);
+    OP_CHECK_NULL_WITH_CONTEXT(context, gInputDesc);
+    ge::DataType qDtype = qInputDesc->GetDataType();
+    ge::DataType gDtype = gInputDesc->GetDataType();
+
+    int dTQ = (qDtype == ge::DT_BF16) ? CHUNK_BWD_DV_LOCAL_TPL_BF16 : CHUNK_BWD_DV_LOCAL_TPL_FP16;
+    int dTG = (gDtype == ge::DT_FLOAT) ? CHUNK_BWD_DV_LOCAL_TPL_FP32 : dTQ;
+    int v = static_cast<int>(tiling->v);
+    context->SetTilingKey(GET_TPL_TILING_KEY(strategyKey, dTQ, dTG, v));
+    OP_LOGD(context->GetNodeName(), "A5 tilingKey: %d", context->GetTilingKey());
+    PrintTilingData(context, *tiling);
+
+    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
+    int64_t coreNum = static_cast<int64_t>(ascendcPlatform.GetCoreNumAic());
+    int64_t usedCoreNum = std::min(tiling->chunkNumForT * tiling->b, coreNum);
+    context->SetBlockDim(usedCoreNum);
+
+    uint32_t sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
+    uint32_t userWorkspaceSize =
+        QKV_DTYPE_SIZE * usedCoreNum * tiling->headBufNum * tiling->chunkSize * tiling->chunkSize;
+    size_t *currentWorkspace = context->GetWorkspaceSizes(1);
+    currentWorkspace[0] = sysWorkspaceSize + userWorkspaceSize;
+    context->SetScheduleMode(1);
+    OP_LOGD(context->GetNodeName(), "Tiling4ChunkBwdDvLocal A5 end.");
+    return true;
+}
+
+void ChunkBwdDvLocalTilingA5::PrintTilingData(gert::TilingContext *context,
+                                              const ChunkBwdDvLocalTilingData &tiling)
+{
+    auto nodeName = context->GetNodeName();
+    OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Start to print ChunkBwdDvLocal A5 tiling data <<<<<<<<<<<<<<<<");
+    OP_LOGD(nodeName, "=== b: %ld", tiling.b);
+    OP_LOGD(nodeName, "=== hQk: %ld", tiling.hQk);
+    OP_LOGD(nodeName, "=== hDo: %ld", tiling.hDo);
+    OP_LOGD(nodeName, "=== hRatio: %ld", tiling.hRatio);
+    OP_LOGD(nodeName, "=== headBufNum: %ld", tiling.headBufNum);
+    OP_LOGD(nodeName, "=== t: %ld", tiling.t);
+    OP_LOGD(nodeName, "=== k: %ld", tiling.k);
+    OP_LOGD(nodeName, "=== v: %ld", tiling.v);
+    OP_LOGD(nodeName, "=== chunkNumForT: %ld", tiling.chunkNumForT);
+    OP_LOGD(nodeName, "=== chunkSize: %ld", tiling.chunkSize);
+    OP_LOGD(nodeName, "=== scale: %f", tiling.scale);
+    OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Print ChunkBwdDvLocal A5 tiling data end <<<<<<<<<<<<<<<<");
+}
+
+} // namespace optiling

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_host/op_tiling/arch35/chunk_bwd_dv_local_tiling_a5.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_host/op_tiling/arch35/chunk_bwd_dv_local_tiling_a5.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CHUNK_BWD_DV_LOCAL_TILING_A5_H
+#define CHUNK_BWD_DV_LOCAL_TILING_A5_H
+
+#include "../../chunk_bwd_dv_local_tiling_processor.h"
+
+namespace optiling {
+
+class ChunkBwdDvLocalTilingA5 {
+public:
+    bool SetTiling(gert::TilingContext *context);
+
+private:
+    void PrintTilingData(gert::TilingContext *context, const GDN::ChunkBwdDvLocalTilingData &tiling);
+};
+
+} // namespace optiling
+
+#endif // CHUNK_BWD_DV_LOCAL_TILING_A5_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/arch35/chunk_bwd_dv_local_common.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/arch35/chunk_bwd_dv_local_common.h
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CHUNK_BWD_DV_LOCAL_ARCH35_COMMON_H
+#define CHUNK_BWD_DV_LOCAL_ARCH35_COMMON_H
+
+#include "../chunk_bwd_dv_local_common.h"
+
+#endif // CHUNK_BWD_DV_LOCAL_ARCH35_COMMON_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/arch35/chunk_bwd_dv_local_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/arch35/chunk_bwd_dv_local_cube.h
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CHUNK_BWD_DV_LOCAL_ARCH35_CUBE_H
+#define CHUNK_BWD_DV_LOCAL_ARCH35_CUBE_H
+
+#include "../chunk_bwd_dv_local_cube.h"
+
+#endif // CHUNK_BWD_DV_LOCAL_ARCH35_CUBE_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/arch35/chunk_bwd_dv_local_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/arch35/chunk_bwd_dv_local_struct.h
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CHUNK_BWD_DV_LOCAL_ARCH35_STRUCT_H
+#define CHUNK_BWD_DV_LOCAL_ARCH35_STRUCT_H
+
+#include "../chunk_bwd_dv_local_struct.h"
+
+#endif // CHUNK_BWD_DV_LOCAL_ARCH35_STRUCT_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/arch35/chunk_bwd_dv_local_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/arch35/chunk_bwd_dv_local_vector.h
@@ -1,0 +1,354 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_bwd_dv_local_vector.h
+ * \brief A5 regbase vector implementation for chunk_bwd_dv_local.
+ */
+
+#ifndef CHUNK_BWD_DV_LOCAL_ARCH35_VECTOR_H
+#define CHUNK_BWD_DV_LOCAL_ARCH35_VECTOR_H
+
+#include <type_traits>
+#include "chunk_bwd_dv_local_struct.h"
+#include "chunk_bwd_dv_local_common.h"
+#include "kernel_operator.h"
+#include "kernel_utils/vector/regbase.hpp"
+
+using namespace AscendC;
+using namespace AscendC::MicroAPI;
+
+namespace GDN {
+
+template <typename QKVT, typename GT, typename Strategy>
+class ChunkBwdDvLocalVector {
+private:
+    Strategy strategy;
+
+public:
+    __aicore__ inline ChunkBwdDvLocalVector(const Strategy &s) : strategy(s)
+    {
+    }
+
+    __aicore__ inline void Init(GM_ADDR d_o, GM_ADDR g, GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR d_v,
+                                GM_ADDR workspace, const ChunkBwdDvLocalTilingData *__restrict tilingData,
+                                AscendC::TPipe *pipe = nullptr);
+    __aicore__ inline void Process();
+    __aicore__ inline void ProcessChunk(const IndexResult &indexResult);
+    template <uint16_t N_SIZE>
+    __simd_vf__ inline void ProcessGatedKqComputerVF(__ubuf__ QKVT *kqOut, __ubuf__ QKVT *kqIn,
+                                                     __ubuf__ GT *gAllIn, __ubuf__ GT *gRowIn,
+                                                     uint16_t mSize, uint16_t validColSize,
+                                                     uint16_t startRow, float scale);
+
+    AscendC::TPipe *pipe_;
+    AscendC::GlobalTensor<QKVT> dOGm;
+    AscendC::GlobalTensor<GT> gGm;
+    AscendC::GlobalTensor<int64_t> cuSeqlensGm;
+    AscendC::GlobalTensor<int64_t> chunkIndicesGm;
+    AscendC::GlobalTensor<QKVT> dVGm;
+    AscendC::GlobalTensor<QKVT> workspaceGm;
+
+    AscendC::TQue<AscendC::TPosition::VECIN, BUFFER_NUM> gTQueIn;
+    AscendC::TQue<AscendC::TPosition::VECIN, BUFFER_NUM> gHalfTQueIn;
+    AscendC::TQue<AscendC::TPosition::VECIN, BUFFER_NUM> kqTQueIn;
+    AscendC::TQue<AscendC::TPosition::VECOUT, BUFFER_NUM> kqTQueOut;
+
+    int64_t H_qk;
+    int64_t H_do;
+    int64_t hRatio;
+    int64_t headBufNum;
+    int64_t T;
+    int64_t K;
+    int64_t V;
+    int64_t coreLoops;
+    int64_t blockNum;
+    int64_t subBlockNum;
+    int64_t subBlockIdx;
+    int64_t coreIdx;
+    float scale;
+    int64_t vecTaskIdx;
+
+    AscendC::DataCopyExtParams copyParams{1, 0, 0, 0, 0};
+    AscendC::DataCopyPadExtParams<QKVT> qkvPadParams{false, 0, 0, 0};
+    AscendC::DataCopyPadExtParams<GT> gPadParams{false, 0, 0, 0};
+};
+
+template <typename QKVT, typename GT, typename Strategy>
+__aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::Init(
+    GM_ADDR d_o, GM_ADDR g, GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR d_v, GM_ADDR workspace,
+    const ChunkBwdDvLocalTilingData *__restrict tilingData, AscendC::TPipe *pipe)
+{
+    dOGm.SetGlobalBuffer((__gm__ QKVT *)d_o);
+    gGm.SetGlobalBuffer((__gm__ GT *)g);
+    cuSeqlensGm.SetGlobalBuffer((__gm__ int64_t *)cu_seqlens);
+    chunkIndicesGm.SetGlobalBuffer((__gm__ int64_t *)chunk_indices);
+    dVGm.SetGlobalBuffer((__gm__ QKVT *)d_v);
+    workspaceGm.SetGlobalBuffer((__gm__ QKVT *)workspace);
+
+    H_qk = tilingData->hQk;
+    H_do = tilingData->hDo;
+    hRatio = tilingData->hRatio;
+    headBufNum = tilingData->headBufNum;
+    T = tilingData->t;
+    K = tilingData->k;
+    V = tilingData->v;
+    scale = tilingData->scale;
+    coreLoops = tilingData->b * strategy.chunkNumForT;
+    blockNum = static_cast<int64_t>(AscendC::GetBlockNum());
+    subBlockNum = AscendC::GetSubBlockNum();
+    coreIdx = static_cast<int64_t>(AscendC::GetBlockIdx() / subBlockNum);
+    subBlockIdx = static_cast<int64_t>(AscendC::GetSubBlockIdx());
+    vecTaskIdx = 0;
+
+    pipe_ = pipe;
+    pipe_->InitBuffer(gTQueIn, BUFFER_NUM, strategy.chunkSize * sizeof(GT));
+    pipe_->InitBuffer(gHalfTQueIn, BUFFER_NUM, strategy.chunkSize / NUM_2 * sizeof(GT));
+    pipe_->InitBuffer(kqTQueIn, BUFFER_NUM, strategy.chunkSize * strategy.chunkSize * sizeof(QKVT) / NUM_2);
+    pipe_->InitBuffer(kqTQueOut, BUFFER_NUM, strategy.chunkSize * strategy.chunkSize * sizeof(QKVT) / NUM_2);
+}
+
+template <typename QKVT, typename GT, typename Strategy>
+__aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::Process()
+{
+    IndexResult indexResult;
+    for (int64_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += blockNum) {
+        strategy.calculate(loopIdx, indexResult);
+        ProcessChunk(indexResult);
+    }
+}
+
+template <typename QKVT, typename GT, typename Strategy>
+__aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessChunk(const IndexResult &indexResult)
+{
+    int64_t taskSplitLine = indexResult.chunkLen / NUM_2;
+    int64_t taskStartLine = 0;
+    int64_t taskEndLine = 0;
+    int64_t taskLineNum = 0;
+    int64_t taskOffset = 0;
+    int64_t coreBaseOffset = coreIdx * headBufNum * strategy.chunkSize * strategy.chunkSize;
+    int64_t p1SlotNum = headBufNum / (hRatio + 1);
+    if (p1SlotNum <= 0) {
+        p1SlotNum = NUM_2;
+    }
+
+    for (int64_t doHead = 0; doHead < H_do; doHead++) {
+        int64_t qkHead = doHead / hRatio;
+        int64_t doGroup = doHead % hRatio;
+        int64_t p1Slot = qkHead % p1SlotNum;
+        int64_t gatedSlot = p1SlotNum + (qkHead % p1SlotNum) * hRatio + doGroup;
+        int64_t baseReadOffset = coreBaseOffset + p1Slot * strategy.chunkSize * strategy.chunkSize;
+        int64_t baseWriteOffset = coreBaseOffset + gatedSlot * strategy.chunkSize * strategy.chunkSize;
+
+        ++vecTaskIdx;
+        if (vecTaskIdx % subBlockNum != subBlockIdx) {
+            taskStartLine = 0;
+            taskEndLine = taskSplitLine - 1;
+            taskOffset = baseWriteOffset;
+        } else {
+            taskStartLine = taskSplitLine;
+            taskEndLine = indexResult.chunkLen - 1;
+            taskOffset = baseWriteOffset + taskSplitLine * strategy.chunkSize;
+        }
+
+        taskLineNum = taskEndLine - taskStartLine + 1;
+        if (taskLineNum == 0) {
+            if (doHead % hRatio == 0) {
+                AscendC::CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_3);
+            }
+            AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_1);
+            continue;
+        }
+
+        int64_t baseGOffset = indexResult.curBatchId * H_do * T + doHead * T + indexResult.curTokenId;
+        int64_t taskReadOffset = baseReadOffset + taskStartLine * strategy.chunkSize;
+
+        {
+            AscendC::LocalTensor<GT> gLocalTensor = gTQueIn.AllocTensor<GT>();
+            copyParams.blockLen = indexResult.chunkLen * sizeof(GT);
+            AscendC::DataCopyPad(gLocalTensor, gGm[baseGOffset], copyParams, gPadParams);
+            gTQueIn.EnQue(gLocalTensor);
+        }
+        {
+            AscendC::LocalTensor<GT> gHalfLocalTensor = gHalfTQueIn.AllocTensor<GT>();
+            copyParams.blockLen = taskLineNum * sizeof(GT);
+            AscendC::DataCopyPad(gHalfLocalTensor, gGm[baseGOffset + taskStartLine], copyParams, gPadParams);
+            gHalfTQueIn.EnQue(gHalfLocalTensor);
+        }
+
+        if (doHead % hRatio == 0) {
+            AscendC::CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_3);
+        }
+
+        {
+            AscendC::LocalTensor<QKVT> kqLocalTensor = kqTQueIn.AllocTensor<QKVT>();
+            copyParams.blockLen = taskLineNum * strategy.chunkSize * sizeof(QKVT);
+            AscendC::DataCopyPad(kqLocalTensor, workspaceGm[taskReadOffset], copyParams, qkvPadParams);
+            kqTQueIn.EnQue(kqLocalTensor);
+        }
+
+        {
+            AscendC::LocalTensor<GT> gLocalTensor = gTQueIn.DeQue<GT>();
+            AscendC::LocalTensor<GT> gHalfLocalTensor = gHalfTQueIn.DeQue<GT>();
+            AscendC::LocalTensor<QKVT> kqLocalTensor = kqTQueIn.DeQue<QKVT>();
+            AscendC::LocalTensor<QKVT> kqOutLocalTensor = kqTQueOut.AllocTensor<QKVT>();
+
+            auto gAllInAddr = reinterpret_cast<uint64_t>(gLocalTensor.GetPhyAddr());
+            auto gRowInAddr = reinterpret_cast<uint64_t>(gHalfLocalTensor.GetPhyAddr());
+            auto kqInAddr = reinterpret_cast<uint64_t>(kqLocalTensor.GetPhyAddr());
+            auto kqOutAddr = reinterpret_cast<uint64_t>(kqOutLocalTensor.GetPhyAddr());
+
+            if (strategy.chunkSize == 64) {
+                ProcessGatedKqComputerVF<64>((__ubuf__ QKVT *)kqOutAddr, (__ubuf__ QKVT *)kqInAddr,
+                                             (__ubuf__ GT *)gAllInAddr, (__ubuf__ GT *)gRowInAddr,
+                                             static_cast<uint16_t>(taskLineNum),
+                                             static_cast<uint16_t>(indexResult.chunkLen),
+                                             static_cast<uint16_t>(taskStartLine), scale);
+            } else {
+                ProcessGatedKqComputerVF<128>((__ubuf__ QKVT *)kqOutAddr, (__ubuf__ QKVT *)kqInAddr,
+                                              (__ubuf__ GT *)gAllInAddr, (__ubuf__ GT *)gRowInAddr,
+                                              static_cast<uint16_t>(taskLineNum),
+                                              static_cast<uint16_t>(indexResult.chunkLen),
+                                              static_cast<uint16_t>(taskStartLine), scale);
+            }
+
+            gTQueIn.FreeTensor(gLocalTensor);
+            gHalfTQueIn.FreeTensor(gHalfLocalTensor);
+            kqTQueIn.FreeTensor(kqLocalTensor);
+            kqTQueOut.EnQue(kqOutLocalTensor);
+        }
+
+        {
+            AscendC::LocalTensor<QKVT> kqOutLocalTensor = kqTQueOut.DeQue<QKVT>();
+            AscendC::DataCopy(workspaceGm[taskOffset], kqOutLocalTensor, taskLineNum * strategy.chunkSize);
+            kqTQueOut.FreeTensor(kqOutLocalTensor);
+        }
+        AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_1);
+    }
+}
+
+template <typename QKVT, typename GT, typename Strategy>
+template <uint16_t N_SIZE>
+__simd_vf__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessGatedKqComputerVF(
+    __ubuf__ QKVT *kqOut, __ubuf__ QKVT *kqIn, __ubuf__ GT *gAllIn, __ubuf__ GT *gRowIn,
+    uint16_t mSize, uint16_t validColSize, uint16_t startRow, float scale)
+{
+    constexpr uint32_t ONE_ELE_NUM = N_SIZE;
+    uint32_t qkvMaskLen = N_SIZE;
+    uint32_t gMaskLen = N_SIZE;
+    uint32_t storeMaskLen = N_SIZE;
+    RegTensor<GT> gAllReg;
+    RegTensor<GT> gRowReg;
+    RegTensor<QKVT> kqInReg;
+    RegTensor<QKVT> kqOutReg;
+    RegTensor<float> gAllFP32ZeroReg, gAllFP32OneReg;
+    RegTensor<float> gRowFP32Reg;
+    RegTensor<float> gFactorFP32ZeroReg, gFactorFP32OneReg;
+    RegTensor<float> kqFP32ZeroReg, kqFP32OneReg;
+    RegTensor<float> resultFP32ZeroReg, resultFP32OneReg;
+    RegTensor<float> zeroReg, rowIdxReg, scaleReg;
+    RegTensor<float> validColReg;
+    RegTensor<half> colIdxReg;
+    RegTensor<float> colIdxFP32ZeroReg, colIdxFP32OneReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+    MaskReg maskQkv = UpdateMask<QKVT>(qkvMaskLen);
+    MaskReg maskG = UpdateMask<GT>(gMaskLen);
+    MaskReg maskStore = UpdateMask<QKVT>(storeMaskLen);
+    MaskReg maskZeroSelect, maskOneSelect;
+    MaskReg maskInvalidZeroSelect, maskInvalidOneSelect;
+
+    Duplicate(zeroReg, static_cast<float>(0.0), maskFull32);
+    Duplicate(scaleReg, scale, maskFull32);
+    Duplicate(validColReg, static_cast<float>(validColSize), maskFull32);
+    Arange(colIdxReg, 0);
+    CastHalf2Float<half>(colIdxFP32ZeroReg, colIdxFP32OneReg, colIdxReg, maskFull16);
+
+    if constexpr (!std::is_same<GT, float>()) {
+        LoadIn<GT, false>(gAllReg, gAllIn);
+        Cast<float, GT, ctHalf2Fp32Zero>(gAllFP32ZeroReg, gAllReg, maskG);
+        Cast<float, GT, ctHalf2Fp32One>(gAllFP32OneReg, gAllReg, maskG);
+    } else {
+        LoadAlign<GT, LoadDist::DIST_DINTLV_B32>(gAllFP32ZeroReg, gAllFP32OneReg, gAllIn);
+    }
+
+    Duplicate(rowIdxReg, static_cast<float>(startRow));
+    LoadIn<QKVT, false>(kqInReg, kqIn);
+    LoadIn<GT, true>(gRowReg, gRowIn);
+    for (uint16_t rowIdx = 0; rowIdx < mSize - 1; ++rowIdx) {
+        CastHalf2Float<QKVT>(kqFP32ZeroReg, kqFP32OneReg, kqInReg, maskQkv);
+        HalfOrFloat2Float<GT>(gRowFP32Reg, gRowReg, maskFull16, maskFull32);
+
+        SubFloatTwoReg(gFactorFP32ZeroReg, gFactorFP32OneReg, gAllFP32ZeroReg, gAllFP32OneReg,
+                       gRowFP32Reg, gRowFP32Reg, maskFull32);
+        MinsFloatTwoReg(gFactorFP32ZeroReg, gFactorFP32OneReg, gFactorFP32ZeroReg, gFactorFP32OneReg,
+                        static_cast<float>(0.0), maskFull32);
+        ExpFloatTwoReg(gFactorFP32ZeroReg, gFactorFP32OneReg, gFactorFP32ZeroReg, gFactorFP32OneReg, maskFull32);
+        Mul(gFactorFP32ZeroReg, gFactorFP32ZeroReg, scaleReg, maskFull32);
+        Mul(gFactorFP32OneReg, gFactorFP32OneReg, scaleReg, maskFull32);
+
+        CompareTwoReg<float, CMPMODE::LT>(maskZeroSelect, maskOneSelect,
+                                          colIdxFP32ZeroReg, colIdxFP32OneReg,
+                                          rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(gFactorFP32ZeroReg, gFactorFP32OneReg, zeroReg, zeroReg,
+                     gFactorFP32ZeroReg, gFactorFP32OneReg, maskZeroSelect, maskOneSelect);
+        CompareTwoReg<float, CMPMODE::GE>(maskInvalidZeroSelect, maskInvalidOneSelect,
+                                          colIdxFP32ZeroReg, colIdxFP32OneReg,
+                                          validColReg, validColReg, maskFull32);
+        SelectTwoReg(gFactorFP32ZeroReg, gFactorFP32OneReg, zeroReg, zeroReg,
+                     gFactorFP32ZeroReg, gFactorFP32OneReg,
+                     maskInvalidZeroSelect, maskInvalidOneSelect);
+        MulFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, kqFP32ZeroReg, kqFP32OneReg,
+                       gFactorFP32ZeroReg, gFactorFP32OneReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg,
+                     resultFP32ZeroReg, resultFP32OneReg,
+                     maskInvalidZeroSelect, maskInvalidOneSelect);
+        CastFloat2Half<QKVT>(kqOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+        LoadIn<QKVT, false>(kqInReg, kqIn + ONE_ELE_NUM * (rowIdx + 1));
+        LoadIn<GT, true>(gRowReg, gRowIn + rowIdx + 1);
+        StoreAlign((__ubuf__ QKVT *&)kqOut + ONE_ELE_NUM * rowIdx, kqOutReg, maskStore);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+    }
+
+    uint16_t rowIdx = mSize - 1;
+    CastHalf2Float<QKVT>(kqFP32ZeroReg, kqFP32OneReg, kqInReg, maskQkv);
+    HalfOrFloat2Float<GT>(gRowFP32Reg, gRowReg, maskFull16, maskFull32);
+
+    SubFloatTwoReg(gFactorFP32ZeroReg, gFactorFP32OneReg, gAllFP32ZeroReg, gAllFP32OneReg,
+                   gRowFP32Reg, gRowFP32Reg, maskFull32);
+    MinsFloatTwoReg(gFactorFP32ZeroReg, gFactorFP32OneReg, gFactorFP32ZeroReg, gFactorFP32OneReg,
+                    static_cast<float>(0.0), maskFull32);
+    ExpFloatTwoReg(gFactorFP32ZeroReg, gFactorFP32OneReg, gFactorFP32ZeroReg, gFactorFP32OneReg, maskFull32);
+    Mul(gFactorFP32ZeroReg, gFactorFP32ZeroReg, scaleReg, maskFull32);
+    Mul(gFactorFP32OneReg, gFactorFP32OneReg, scaleReg, maskFull32);
+
+    CompareTwoReg<float, CMPMODE::LT>(maskZeroSelect, maskOneSelect,
+                                      colIdxFP32ZeroReg, colIdxFP32OneReg,
+                                      rowIdxReg, rowIdxReg, maskFull32);
+    SelectTwoReg(gFactorFP32ZeroReg, gFactorFP32OneReg, zeroReg, zeroReg,
+                 gFactorFP32ZeroReg, gFactorFP32OneReg, maskZeroSelect, maskOneSelect);
+    CompareTwoReg<float, CMPMODE::GE>(maskInvalidZeroSelect, maskInvalidOneSelect,
+                                      colIdxFP32ZeroReg, colIdxFP32OneReg,
+                                      validColReg, validColReg, maskFull32);
+    SelectTwoReg(gFactorFP32ZeroReg, gFactorFP32OneReg, zeroReg, zeroReg,
+                 gFactorFP32ZeroReg, gFactorFP32OneReg,
+                 maskInvalidZeroSelect, maskInvalidOneSelect);
+    MulFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, kqFP32ZeroReg, kqFP32OneReg,
+                   gFactorFP32ZeroReg, gFactorFP32OneReg, maskFull32);
+    SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg,
+                 resultFP32ZeroReg, resultFP32OneReg,
+                 maskInvalidZeroSelect, maskInvalidOneSelect);
+    CastFloat2Half<QKVT>(kqOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+    StoreAlign((__ubuf__ QKVT *&)kqOut + ONE_ELE_NUM * rowIdx, kqOutReg, maskStore);
+}
+
+} // namespace GDN
+
+#endif // CHUNK_BWD_DV_LOCAL_ARCH35_VECTOR_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local.cpp
@@ -12,9 +12,15 @@
  * \brief
  */
 
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#include "arch35/chunk_bwd_dv_local_struct.h"
+#include "arch35/chunk_bwd_dv_local_cube.h"
+#include "arch35/chunk_bwd_dv_local_vector.h"
+#else
 #include "chunk_bwd_dv_local_struct.h"
 #include "chunk_bwd_dv_local_cube.h"
 #include "chunk_bwd_dv_local_vector.h"
+#endif
 #ifndef TORCH_MODE
 #include "lib/matmul_intf.h"
 #endif


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [x] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @anhao9
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
