### PR TITLE
fwd_o 算子文档补充GVA

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/README.md
@@ -84,13 +84,13 @@ aclnnStatus aclnnChunkFwdO(
 
 | 参数名 | 输入/输出 | 必选/可选 | 描述 | 数据类型 | 数据格式 | 维度（Shape） | 非连续 Tensor |
 |---|---|---|---|---|---|---|---|
-| `q` | 输入 | 必选 | Query 输入张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, K]` | 支持 |
-| `k` | 输入 | 必选 | Key 输入张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, K]` | 支持 |
-| `v` | 输入 | 必选 | Value 输入张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, V]` | 支持 |
-| `h` | 输入 | 必选 | 前向保存的隐藏状态张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, numChunks, K, V]` | 支持 |
-| `g` | 输入 | 必选 | Gate 输入张量 | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, H, T]` | 支持 |
+| `q` | 输入 | 必选 | Query 输入张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HK, T, K]` | 支持 |
+| `k` | 输入 | 必选 | Key 输入张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HK, T, K]` | 支持 |
+| `v` | 输入 | 必选 | Value 输入张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, V]` | 支持 |
+| `h` | 输入 | 必选 | 前向保存的隐藏状态张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, numChunks, K, V]` | 支持 |
+| `g` | 输入 | 必选 | Gate 输入张量 | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, HV, T]` | 支持 |
 | `cuSeqlensOptional` | 输入 | 可选 | 变长序列的累计长度信息 | `INT64` | `ND` | 1 维 | - |
-| `chunkOffsetsOptional` | 输入 | 可选 | 分块索引信息 | `INT64` | `ND` | 2 维 | - |
+| `chunkOffsetsOptional` | 输入 | 可选 | 分块索引信息，按 `[tokenBatchIdx, batchChunkIdx]` 成对扁平化 | `INT64` | `ND` | 1 维，长度需能被 2 整除 | - |
 
 ### 3.2 属性参数（Attributes）
 
@@ -103,20 +103,22 @@ aclnnStatus aclnnChunkFwdO(
 
 | 参数名 | 输入/输出 | 描述 | 数据类型 | 数据格式 | 维度（Shape） | 非连续 Tensor |
 |---|---|---|---|---|---|---|
-| `oOut` | 输出 | 前向注意力输出张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, V]` | 支持 |
+| `oOut` | 输出 | 前向注意力输出张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, V]` | 支持 |
 | `workspaceSize` | 输出 | Device 侧所需 workspace 大小 | `uint64_t` | - | 标量 | - |
 | `executor` | 输出 | 算子执行器，封装了计算流程 | `aclOpExecutor*` | - | - | - |
 
 ### 3.4 形状与约束
 
-- `q`、`k` 的形状必须为 `[B, H, T, K]`。
-- `v`、`oOut` 的形状必须为 `[B, H, T, V]`。
-- `g` 的形状必须为 `[B, H, T]`。
-- `h` 的形状必须为 `[B, H, numChunks, K, V]`。
+- `q`、`k` 的形状必须为 `[B, HK, T, K]`，二者完全同形。
+- `v`、`oOut` 的形状必须为 `[B, HV, T, V]`。
+- `q` 和 `v` 的 `B`、`T` 必须一致，head 数允许不同。
+- `g` 的形状必须为 `[B, HV, T]`，head 维与 `v` 对齐。
+- `h` 的形状必须为 `[B, HV, numChunks, K, V]`，head 维与 `v` 对齐，`K` 维与 `q/k` 对齐，`V` 维与 `v` 对齐。
+- GVA 约束：`HV % HK == 0`，映射关系为 `hk = hv / (HV / HK)`。
 - 当前实现要求 `K = 128`。
 - 当前实现要求 `V = 128` 或 `256`。
 - `chunkSize` 当前仅支持 `64` 或 `128`。
-- 当启用变长模式时，`cuSeqlensOptional` 和 `chunkOffsetsOptional` 用于描述变长分块；同时当前实现仅支持 `B = 1`。
+- 当启用变长模式时，`cuSeqlensOptional` 和 `chunkOffsetsOptional` 用于描述变长分块；二者需要同时提供，且当前实现仅支持 `B = 1`。
 
 ---
 
@@ -125,17 +127,18 @@ aclnnStatus aclnnChunkFwdO(
 ### 4.1 可选参数约束
 
 - `cuSeqlensOptional` 和 `chunkOffsetsOptional`：
-  - 同时出现时启用变长模式（varlen）
+  - 二者任意一个出现时进入变长模式，当前实现要求二者同时提供
   - 变长模式仅支持 `B = 1`
 
 ### 4.2 形状约束（强约束）
 
 必须满足以下条件：
 
-- `q, k`: `[B, H, T, K]`
-- `v, oOut`: `[B, H, T, V]`
-- `g`: `[B, H, T]`
-- `h`: `[B, H, numChunks, K, V]`
+- `q, k`: `[B, HK, T, K]`
+- `v, oOut`: `[B, HV, T, V]`
+- `g`: `[B, HV, T]`
+- `h`: `[B, HV, numChunks, K, V]`
+- `HV % HK == 0`
 
 额外限制：
 
@@ -148,8 +151,9 @@ aclnnStatus aclnnChunkFwdO(
 当提供 `cuSeqlensOptional` 时：
 
 - `chunkOffsetsOptional` 必须同时提供
-- `numChunks` 由 `chunkOffsets` 推导
-- 要求 `numChunks` 为偶数
+- `chunkOffsetsOptional` 是扁平化的一维 int64 数组，语义为连续的 `[tokenBatchIdx, batchChunkIdx]` pair
+- `chunkOffsetsOptional` 的长度必须能被 2 整除
+- `numChunks` 由 `chunkOffsetsOptional` 的 pair 数推导
 - 当前实现仅支持 `B = 1`
 
 ### 4.4 数值语义
@@ -185,7 +189,7 @@ import math
 
 def test_chunk_fwd_o_fixed_len():
     # 参数设置
-    B, H, T, K, V = 1, 2, 256, 128, 128
+    B, HK, HV, T, K, V = 1, 2, 4, 256, 128, 128
     chunk_size = 64
     num_chunks = (T + chunk_size - 1) // chunk_size
     scale = 1.0 / math.sqrt(K)
@@ -193,11 +197,11 @@ def test_chunk_fwd_o_fixed_len():
     dtype = torch.bfloat16
 
     # 构造输入
-    q = torch.randn(B, H, T, K, device=device, dtype=dtype)
-    k = torch.randn(B, H, T, K, device=device, dtype=dtype)
-    v = torch.randn(B, H, T, V, device=device, dtype=dtype)
-    h = torch.randn(B, H, num_chunks, K, V, device=device, dtype=dtype)
-    g = torch.randn(B, H, T, device=device, dtype=dtype)
+    q = torch.randn(B, HK, T, K, device=device, dtype=dtype)
+    k = torch.randn(B, HK, T, K, device=device, dtype=dtype)
+    v = torch.randn(B, HV, T, V, device=device, dtype=dtype)
+    h = torch.randn(B, HV, num_chunks, K, V, device=device, dtype=dtype)
+    g = torch.randn(B, HV, T, device=device, dtype=dtype)
 
     # 调用算子（定长：cu_seqlens / chunk_indices 传 None）
     o = torch.ops.npu.npu_chunk_fwd_o(
@@ -229,7 +233,7 @@ import math
 
 def test_chunk_fwd_o_varlen():
     # 参数设置：变长模式仅支持 B = 1
-    B, H, K, V = 1, 2, 128, 128
+    B, HK, HV, K, V = 1, 2, 4, 128, 128
     chunk_size = 64
     scale = 1.0 / math.sqrt(K)
     device = "npu:0"
@@ -252,11 +256,11 @@ def test_chunk_fwd_o_varlen():
     chunk_indices_flat = [x for pair in chunk_indices_pairs for x in pair]
 
     # 构造输入
-    q = torch.randn(B, H, T, K, device=device, dtype=dtype)
-    k = torch.randn(B, H, T, K, device=device, dtype=dtype)
-    v = torch.randn(B, H, T, V, device=device, dtype=dtype)
-    h = torch.randn(B, H, num_chunks, K, V, device=device, dtype=dtype)
-    g = torch.randn(B, H, T, device=device, dtype=dtype)
+    q = torch.randn(B, HK, T, K, device=device, dtype=dtype)
+    k = torch.randn(B, HK, T, K, device=device, dtype=dtype)
+    v = torch.randn(B, HV, T, V, device=device, dtype=dtype)
+    h = torch.randn(B, HV, num_chunks, K, V, device=device, dtype=dtype)
+    g = torch.randn(B, HV, T, device=device, dtype=dtype)
 
     # 调用算子
     o = torch.ops.npu.npu_chunk_fwd_o(
@@ -292,13 +296,17 @@ chunk_fwd_o/
 │   ├── chunk_fwd_o_def.cpp
 │   ├── chunk_fwd_o_tiling.cpp
 │   ├── chunk_fwd_o_tiling.h
+│   ├── chunk_fwd_o_tiling_processor.h
 │   └── op_api/
 │       ├── aclnn_chunk_fwd_o.cpp
 │       ├── aclnn_chunk_fwd_o.h
 │       ├── chunk_fwd_o.cpp
 │       └── chunk_fwd_o.h
 ├── op_kernel/
-│   └── chunk_fwd_o.cpp
+│   ├── chunk_fwd_o.cpp
+│   ├── chunk_fwd_o_struct.h
+│   ├── epilogue/
+│   └── gemm/
 └── tests/
     └── pta/
         ├── data_compare_o.py


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: chunk_fwd_o
- 涉及目录 / 文件: README.md
- 责任人 / 提交人: @Ensley0304
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [x] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [x] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
