### PR TITLE
docs: add GVA and Vdim=256 shape notes for recompute, bwd_dhu, fwd_h

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/README.md
@@ -55,15 +55,15 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhu(
 
 | 参数名 | 输入/输出 | 必选/可选 | 描述 | 使用说明 | 数据类型 | 数据格式 | 维度（Shape） | 非连续 Tensor |
 |---|---|---|---|---|---|---|---|---|
-| `q` | 输入 | 必选 | Query 输入张量 | 参与反向递推 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, K]` | 支持 |
-| `k` | 输入 | 必选 | Key 输入张量 | 参与 dv2 计算 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, K]` | 支持 |
-| `w` | 输入 | 必选 | Weight（衰减权重）输入张量 | 参与隐藏状态更新 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, K]` | 支持 |
-| `dO` | 输入 | 必选 | 前向输出 `o` 的梯度张量 | 即上游输出梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, V]` | 支持 |
-| `dv` | 输入 | 必选 | Value 的上游梯度张量 | 将与来自 `dh` 的贡献叠加后输出为 `dv2` | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, V]` | 支持 |
-| `gOptional` | 输入 | 可选 | Gate 张量 | 对隐藏状态递推施加指数门控 `exp(g)` | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, H, T]` | 支持 |
-| `gkOptional` | 输入 | 可选 | Key-wise Gate 张量 | 对每个 Key 维度施加额外门控 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, K]` | 支持 |
-| `h0Optional` | 输入 | 可选 | 初始隐藏状态张量 | 提供时参与递推初始化 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, K, V]` | 支持 |
-| `dhtOptional` | 输入 | 可选 | 末尾隐藏状态的梯度张量 | 反向递推的起始梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, K, V]` | 支持 |
+| `q` | 输入 | 必选 | Query 输入张量 | 参与反向递推 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HK, T, K]` | 支持 |
+| `k` | 输入 | 必选 | Key 输入张量 | 参与 dv2 计算 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HK, T, K]` | 支持 |
+| `w` | 输入 | 必选 | Weight（衰减权重）输入张量 | 参与隐藏状态更新 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, K]` | 支持 |
+| `dO` | 输入 | 必选 | 前向输出 `o` 的梯度张量 | 即上游输出梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, V]` | 支持 |
+| `dv` | 输入 | 必选 | Value 的上游梯度张量 | 将与来自 `dh` 的贡献叠加后输出为 `dv2` | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, V]` | 支持 |
+| `gOptional` | 输入 | 可选 | Gate 张量 | 对隐藏状态递推施加指数门控 `exp(g)` | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, HV, T]` | 支持 |
+| `gkOptional` | 输入 | 可选 | Key-wise Gate 张量 | 对每个 Key 维度施加额外门控 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, K]` | 支持 |
+| `h0Optional` | 输入 | 可选 | 初始隐藏状态张量 | 提供时参与递推初始化 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, K, V]` | 支持 |
+| `dhtOptional` | 输入 | 可选 | 末尾隐藏状态的梯度张量 | 反向递推的起始梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, K, V]` | 支持 |
 | `cuSeqlensOptional` | 输入 | 可选 | 变长序列的累计长度信息 | 变长模式输入，形状为 `[N+1]` | `INT64` | `ND` | 1 维 | - |
 | `chunkIndicesOptional` | 输入 | 可选 | 分块索引信息 | 变长模式输入，扁平化存储 `[seqIdx0, chunkIdx0, ...]`，长度为 `2 * numChunks` | `INT64` | `ND` | 1 维 | - |
 
@@ -78,9 +78,9 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhu(
 
 | 参数名 | 输入/输出 | 描述 | 数据类型 | 数据格式 | 维度（Shape） | 非连续 Tensor |
 |---|---|---|---|---|---|---|
-| `dhOut` | 输出 | 各 chunk 起始时刻的隐藏状态梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, NT, K, V]` | 支持 |
-| `dh0Out` | 输出 | 初始隐藏状态 `h0` 的梯度（仅当 `h0Optional` 非空时有意义）| `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, K, V]` | 支持 |
-| `dv2Out` | 输出 | 融合了隐藏状态贡献后的 Value 梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, V]` | 支持 |
+| `dhOut` | 输出 | 各 chunk 起始时刻的隐藏状态梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, NT, K, V]` | 支持 |
+| `dh0Out` | 输出 | 初始隐藏状态 `h0` 的梯度（仅当 `h0Optional` 非空时有意义）| `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, K, V]` | 支持 |
+| `dv2Out` | 输出 | 融合了隐藏状态贡献后的 Value 梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, V]` | 支持 |
 | `workspaceSize` | 输出 | Device 侧所需 workspace 大小 | `uint64_t` | - | 标量 | - |
 | `executor` | 输出 | 算子执行器，封装了计算流程 | `aclOpExecutor*` | - | - | - |
 
@@ -88,13 +88,18 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhu(
 
 ### 3.4 形状与约束
 
-- `q`、`k`、`w` 的形状必须为 `[B, H, T, K]`。
-- `dO`、`dv` 的形状必须为 `[B, H, T, V]`。
-- `gOptional` 的形状必须为 `[B, H, T]`（若提供）。
-- `gkOptional` 的形状必须为 `[B, H, T, K]`（若提供）。
-- `h0Optional`、`dhtOptional` 的形状必须为 `[B, H, K, V]`（若提供）。
+- `q`、`k` 的形状必须为 `[B, HK, T, K]`，二者完全同形。
+- `w` 的形状必须为 `[B, HV, T, K]`，head 维与 value 侧对齐。
+- `dO`、`dv` 的形状必须为 `[B, HV, T, V]`。
+- `q` 与 `dO`/`dv` 的 `B`、`T` 必须一致，head 数允许不同（GVA）。
+- `gOptional` 的形状必须为 `[B, HV, T]`（若提供）。
+- `gkOptional` 的形状必须为 `[B, HV, T, K]`（若提供）。
+- `h0Optional`、`dhtOptional` 的形状必须为 `[B, HV, K, V]`（若提供）。
+- `dhOut` 的形状必须为 `[B, HV, NT, K, V]`。
+- **GVA 约束**：`HV % HK == 0`；读 `q`/`k` 时使用 `hq = hv / (HV / HK)`，读/写 `w`/`dO`/`dv`/`g`/`dh`/`dv2` 使用 value head 索引 `hv`。
 - 当前实现要求 `K ≤ 128`。
-- 当前实现要求 `V ≤ 256`。
+- 当前实现要求 `V ≤ 256`（Cube tile 原生按 `V` 上限 256 设计，**无**按 V 维切换的 TilingKey）。
+- **TilingKey**：`g` 与 `q` 同 dtype 时为 Key=1，`g` 为 FP32 时为 Key=2（与 V 维无关）。
 - `chunkSize` 当前仅支持 `64` 或 `128`。
 - 当启用变长模式时，`cuSeqlensOptional` 和 `chunkIndicesOptional` 须同时提供，且仅支持 `B = 1`。
 
@@ -119,16 +124,18 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhu(
 
 必须满足以下条件：
 
-- `q, k, w`: `[B, H, T, K]`
-- `dO, dv`: `[B, H, T, V]`
-- `gOptional`: `[B, H, T]`
-- `gkOptional`: `[B, H, T, K]`
-- `h0Optional, dhtOptional`: `[B, H, K, V]`
+- `q, k`: `[B, HK, T, K]`
+- `w`: `[B, HV, T, K]`
+- `dO, dv, dv2Out`: `[B, HV, T, V]`
+- `gOptional`: `[B, HV, T]`
+- `gkOptional`: `[B, HV, T, K]`（若提供）
+- `h0Optional, dhtOptional, dhOut`: head 维为 `HV`
+- `HV % HK == 0`（GVA）
 
 额外限制：
 
 - `K ≤ 128`
-- `V ≤ 256`
+- `V ≤ 256`（支持 `V = 256`）
 - `chunkSize ∈ {64, 128}`
 
 ---
@@ -183,20 +190,20 @@ import torch_npu
 import math
 
 def test_chunk_gated_delta_rule_bwd_dhu_fix():
-    # 参数设置
-    B, H, T, K, V = 2, 8, 256, 128, 128
+    # 参数设置（GVA 示例：HK=2, HV=4, V=256）
+    B, HK, HV, T, K, V = 2, 2, 4, 256, 128, 256
     chunk_size = 64
     scale = 1.0 / math.sqrt(K)
     device = "npu:0"
     dtype = torch.float16
 
     # 构造输入
-    q   = torch.rand(B, H, T, K, dtype=dtype).to(device)
-    k   = torch.rand(B, H, T, K, dtype=dtype).to(device)
-    w   = torch.rand(B, H, T, K, dtype=dtype).to(device)
-    d_o = torch.rand(B, H, T, V, dtype=dtype).to(device)
-    dv  = torch.rand(B, H, T, V, dtype=dtype).to(device)
-    g   = torch.rand(B, H, T,    dtype=dtype).to(device)
+    q   = torch.rand(B, HK, T, K, dtype=dtype).to(device)
+    k   = torch.rand(B, HK, T, K, dtype=dtype).to(device)
+    w   = torch.rand(B, HV, T, K, dtype=dtype).to(device)
+    d_o = torch.rand(B, HV, T, V, dtype=dtype).to(device)
+    dv  = torch.rand(B, HV, T, V, dtype=dtype).to(device)
+    g   = torch.rand(B, HV, T,    dtype=torch.float32).to(device)
 
     # 调用算子（固定长度模式，启用 gate g）
     dh, dh0, dv2 = torch.ops.npu.npu_chunk_gated_delta_rule_bwd_dhu(
@@ -214,10 +221,10 @@ def test_chunk_gated_delta_rule_bwd_dhu_fix():
     )
 
     NT = (T + chunk_size - 1) // chunk_size
-    print("dh   shape:", dh.shape)    # [B, H, NT, K, V]
-    print("dv2  shape:", dv2.shape)   # [B, H, T, V]
-    assert dh.shape  == (B, H, NT, K, V)
-    assert dv2.shape == (B, H, T, V)
+    print("dh   shape:", dh.shape)    # [B, HV, NT, K, V]
+    print("dv2  shape:", dv2.shape)   # [B, HV, T, V]
+    assert dh.shape  == (B, HV, NT, K, V)
+    assert dv2.shape == (B, HV, T, V)
     print("Fix-length Execution Successful!")
 
 if __name__ == "__main__":
@@ -264,7 +271,7 @@ def prepare_chunk_indices(cu_seqlens, chunk_size: int):
 
 def test_chunk_gated_delta_rule_bwd_dhu_varlen():
     # 参数设置（变长模式要求 B = 1）
-    B, H, T, K, V = 1, 8, 512, 128, 128
+    B, HK, HV, T, K, V = 1, 2, 4, 512, 128, 256
     chunk_size = 64
     scale = 1.0 / math.sqrt(K)
     device = "npu:0"
@@ -276,12 +283,12 @@ def test_chunk_gated_delta_rule_bwd_dhu_varlen():
     NT = len(chunk_indices) // 2
 
     # 构造输入
-    q   = torch.rand(B, H, T, K, dtype=dtype).to(device)
-    k   = torch.rand(B, H, T, K, dtype=dtype).to(device)
-    w   = torch.rand(B, H, T, K, dtype=dtype).to(device)
-    d_o = torch.rand(B, H, T, V, dtype=dtype).to(device)
-    dv  = torch.rand(B, H, T, V, dtype=dtype).to(device)
-    g   = torch.rand(B, H, T,    dtype=dtype).to(device)
+    q   = torch.rand(B, HK, T, K, dtype=dtype).to(device)
+    k   = torch.rand(B, HK, T, K, dtype=dtype).to(device)
+    w   = torch.rand(B, HV, T, K, dtype=dtype).to(device)
+    d_o = torch.rand(B, HV, T, V, dtype=dtype).to(device)
+    dv  = torch.rand(B, HV, T, V, dtype=dtype).to(device)
+    g   = torch.rand(B, HV, T,    dtype=torch.float32).to(device)
 
     # 调用算子（变长模式，启用 gate g）
     dh, dh0, dv2 = torch.ops.npu.npu_chunk_gated_delta_rule_bwd_dhu(
@@ -298,10 +305,10 @@ def test_chunk_gated_delta_rule_bwd_dhu_varlen():
         transpose_state_layout=False
     )
 
-    print("dh   shape:", dh.shape)    # [B, H, NT, K, V]
-    print("dv2  shape:", dv2.shape)   # [B, H, T, V]
-    assert dh.shape  == (B, H, NT, K, V)
-    assert dv2.shape == (B, H, T, V)
+    print("dh   shape:", dh.shape)    # [B, HV, NT, K, V]
+    print("dv2  shape:", dv2.shape)   # [B, HV, T, V]
+    assert dh.shape  == (B, HV, NT, K, V)
+    assert dv2.shape == (B, HV, T, V)
     print("Variable-length Execution Successful!")
 
 if __name__ == "__main__":

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/README.md
@@ -7,9 +7,9 @@
 
 在分块序列模型中，计算以下张量：
 
-- **h**：各分块起始处的隐藏状态张量，形状为 `[B, H, numChunks, K, V]`
-- **v_new**：各分块经 WY 分解修正后的 Value 张量，形状与 `u` 相同（`[B, H, T, V]`）
-- **finalState**：最后一个分块结束后的最终隐藏状态，形状为 `[N, H, K, V]`（`N` 为变长子序列数，定长时 `N = B`），仅在 `output_final_state = true` 时返回有效值
+- **h**：各分块起始处的隐藏状态张量，形状为 `[B, HV, numChunks, K, V]`
+- **v_new**：各分块经 WY 分解修正后的 Value 张量，形状与 `u` 相同（`[B, HV, T, V]`）
+- **finalState**：最后一个分块结束后的最终隐藏状态，形状为 `[N, HV, K, V]`（`N` 为变长子序列数，定长时 `N = B`），仅在 `output_final_state = true` 时返回有效值
 
 具体而言，该算子沿分块维度顺序执行递推计算：
 
@@ -109,14 +109,14 @@ aclnnStatus aclnnChunkGatedDeltaRuleFwdH(
 
 | 参数名 | 输入/输出 | 必选/可选 | 描述 | 数据类型 | 数据格式 | 维度（Shape） | 非连续 Tensor |
 |---|---|---|---|---|---|---|---|
-| `k` | 输入 | 必选 | Key 输入张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, K]` | 支持 |
-| `w` | 输入 | 必选 | WY 分解中的 W 矩阵 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, K]` | 支持 |
-| `u` | 输入 | 必选 | 修正后的 Value 张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, V]` | 支持 |
-| `gOptional` | 输入 | 接口为可选；当前实现要求非空 | Gate 输入张量 | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, H, T]` | 支持 |
+| `k` | 输入 | 必选 | Key 输入张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HK, T, K]` | 支持 |
+| `w` | 输入 | 必选 | WY 分解中的 W 矩阵 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, K]` | 支持 |
+| `u` | 输入 | 必选 | 修正后的 Value 张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, V]` | 支持 |
+| `gOptional` | 输入 | 接口为可选；当前实现要求非空 | Gate 输入张量 | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, HV, T]` | 支持 |
 | `gkOptional` | 输入 | 接口为可选；当前实现要求传空 | 预留的逐通道门控张量 | `FLOAT16`、`BFLOAT16` | `ND` | 未启用 | - |
-| `initalStateOptional` | 输入 | 可选 | 初始隐藏状态张量；不传则默认全零 | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, H, K, V]` | 支持 |
+| `initalStateOptional` | 输入 | 可选 | 初始隐藏状态张量；不传则默认全零 | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, HV, K, V]` | 支持 |
 | `cuSeqlensOptional` | 输入 | 可选 | 变长序列的累计长度信息 | `INT64` | `ND` | 1 维 | - |
-| `chunkIndicesOptional` | 输入 | 可选 | 分块索引信息（`[token_batch_id, chunk_id]` 二元组） | `INT64` | `ND` | 2 维 | - |
+| `chunkIndicesOptional` | 输入 | 可选 | 分块索引信息（`[token_batch_id, chunk_id]` 二元组扁平化） | `INT64` | `ND` | 1 维，长度需能被 2 整除 | - |
 
 ### 3.2 属性参数（Attributes）
 
@@ -132,24 +132,27 @@ aclnnStatus aclnnChunkGatedDeltaRuleFwdH(
 
 | 参数名 | 输入/输出 | 描述 | 数据类型 | 数据格式 | 维度（Shape） | 非连续 Tensor |
 |---|---|---|---|---|---|---|
-| `hOut` | 输出 | 各分块起始隐藏状态张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, numChunks, K, V]` | 支持 |
-| `vNewOut` | 输出 | 经 WY 分解修正的 Value 张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H, T, V]` | 支持 |
-| `finalStateOut` | 输出 | 最终隐藏状态张量；`outputFinalState = false` 时无意义 | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[N, H, K, V]` | 支持 |
+| `hOut` | 输出 | 各分块起始隐藏状态张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, numChunks, K, V]` | 支持 |
+| `vNewOut` | 输出 | 经 WY 分解修正的 Value 张量 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, V]` | 支持 |
+| `finalStateOut` | 输出 | 最终隐藏状态张量；`outputFinalState = false` 时无意义 | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[N, HV, K, V]` | 支持 |
 | `workspaceSize` | 输出 | Device 侧所需 workspace 大小 | `uint64_t` | - | 标量 | - |
 | `executor` | 输出 | 算子执行器，封装了计算流程 | `aclOpExecutor*` | - | - | - |
 
 ### 3.4 形状与约束
 
-- `k`、`w` 的形状必须为 `[B, H, T, K]`。
-- `u`、`vNewOut` 的形状必须为 `[B, H, T, V]`。
-- `gOptional` 的形状必须为 `[B, H, T]`。
-- `hOut` 的形状必须为 `[B, H, numChunks, K, V]`；定长时 `numChunks = ceil(T / chunkSize)`，变长时 `numChunks` 由 `chunkIndices` 推导。
-- `initalStateOptional`（若提供）的形状必须为 `[B, H, K, V]`。
-- `finalStateOut` 的形状必须为 `[N, H, K, V]`（`N` 为变长子序列数，定长时 `N = B`）。
+- `k` 的形状必须为 `[B, HK, T, K]`，与 `k` 同形的仅 `k` 自身（无其他 Q/K 张量）。
+- `w` 的形状必须为 `[B, HV, T, K]`，head 维与 value 侧对齐。
+- `u`、`vNewOut` 的形状必须为 `[B, HV, T, V]`。
+- `k` 与 `u` 的 `B`、`T` 必须一致，head 数允许不同（GVA）。
+- `gOptional` 的形状必须为 `[B, HV, T]`，head 维与 `u` 对齐。
+- `hOut` 的形状必须为 `[B, HV, numChunks, K, V]`；定长时 `numChunks = ceil(T / chunkSize)`，变长时 `numChunks` 由 `chunkIndices` 推导。
+- `initalStateOptional`（若提供）的形状必须为 `[B, HV, K, V]`。
+- `finalStateOut` 的形状必须为 `[N, HV, K, V]`（`N` 为变长子序列数，定长时 `N = B`）。
+- **GVA 约束**：`HV % HK == 0`；value head 索引 `hv` 映射到 key head `hk = hv / (HV / HK)`，`k`/`w` 的 key 侧偏移使用 `hk`，其余张量使用 `hv`。
 - 当前实现要求 `K = 128`。
-- 当前实现要求 `V = 128` 或 `256`。
+- 当前实现要求 `V = 128` 或 `256`（`V = 256` 时 kernel 使用对应 Catlass tile 路径）。
 - `chunkSize` 当前仅支持 `64` 或 `128`。
-- 当启用变长模式时，`cuSeqlensOptional` 和 `chunkIndicesOptional` 用于描述变长分块；同时当前实现仅支持 `B = 1`。
+- 当启用变长模式时，`cuSeqlensOptional` 和 `chunkIndicesOptional` 须同时提供，且当前实现仅支持 `B = 1`。
 
 ---
 
@@ -163,9 +166,9 @@ aclnnStatus aclnnChunkGatedDeltaRuleFwdH(
   - 接口层为可选；**当前实现要求传空指针，否则执行失败**
 - `initalStateOptional`：
   - 若不提供（传空指针），则默认初始状态为全零矩阵
-  - 形状必须为 `[B, H, K, V]`
+  - 形状必须为 `[B, HV, K, V]`
 - `cuSeqlensOptional` 和 `chunkIndicesOptional`：
-  - 同时出现时启用变长模式（varlen）
+  - 二者须同时提供或同时省略；同时提供时启用变长模式（varlen）
   - 变长模式仅支持 `B = 1`
 - `saveNewValue` / `useExp2` / `transposeStateLayout`：
   - 当前实现下分别只允许 `true` / `false` / `false`
@@ -174,12 +177,14 @@ aclnnStatus aclnnChunkGatedDeltaRuleFwdH(
 
 必须满足以下条件：
 
-- `k, w`: `[B, H, T, K]`
-- `u, vNewOut`: `[B, H, T, V]`
-- `gOptional`: `[B, H, T]`
-- `hOut`: `[B, H, numChunks, K, V]`
-- `initalStateOptional`: `[B, H, K, V]`（若提供）
-- `finalStateOut`: `[N, H, K, V]`
+- `k`: `[B, HK, T, K]`
+- `w`: `[B, HV, T, K]`
+- `u, vNewOut`: `[B, HV, T, V]`
+- `gOptional`: `[B, HV, T]`
+- `hOut`: `[B, HV, numChunks, K, V]`
+- `initalStateOptional`: `[B, HV, K, V]`（若提供）
+- `finalStateOut`: `[N, HV, K, V]`
+- `HV % HK == 0`（GVA）
 
 额外限制：
 
@@ -252,19 +257,19 @@ import torch_npu
 import math
 
 def test_chunk_gated_delta_rule_fwd_h_fixed_len():
-    # 参数设置
-    B, H, T, K, V = 1, 2, 256, 128, 128
+    # 参数设置（GVA 示例：HK=2, HV=4）
+    B, HK, HV, T, K, V = 1, 2, 4, 256, 128, 128
     chunk_size = 64
     num_chunks = (T + chunk_size - 1) // chunk_size
     device = "npu:0"
     dtype = torch.bfloat16
 
     # 构造输入
-    k = torch.randn(B, H, T, K, device=device, dtype=dtype)
-    w = torch.randn(B, H, T, K, device=device, dtype=dtype)
-    u = torch.randn(B, H, T, V, device=device, dtype=dtype)
-    g = torch.randn(B, H, T, device=device, dtype=torch.float32)
-    initial_state = torch.zeros(B, H, K, V, device=device, dtype=dtype)
+    k = torch.randn(B, HK, T, K, device=device, dtype=dtype)
+    w = torch.randn(B, HV, T, K, device=device, dtype=dtype)
+    u = torch.randn(B, HV, T, V, device=device, dtype=dtype)
+    g = torch.randn(B, HV, T, device=device, dtype=torch.float32)
+    initial_state = torch.zeros(B, HV, K, V, device=device, dtype=dtype)
 
     # 调用算子（定长：cu_seqlens / chunk_indices 传 None）
     h, v_new, final_state = torch.ops.npu.npu_chunk_gated_delta_rule_fwd_h(
@@ -284,9 +289,9 @@ def test_chunk_gated_delta_rule_fwd_h_fixed_len():
     print("h shape:", h.shape)
     print("v_new shape:", v_new.shape)
     print("final_state shape:", final_state.shape)
-    assert h.shape == (B, H, num_chunks, K, V)
-    assert v_new.shape == (B, H, T, V)
-    assert final_state.shape == (B, H, K, V)
+    assert h.shape == (B, HV, num_chunks, K, V)
+    assert v_new.shape == (B, HV, T, V)
+    assert final_state.shape == (B, HV, K, V)
     print("Execution Successful!")
 
 if __name__ == "__main__":
@@ -303,8 +308,8 @@ import torch_npu
 import math
 
 def test_chunk_gated_delta_rule_fwd_h_varlen():
-    # 参数设置：变长模式仅支持 B = 1
-    B, H, K, V = 1, 2, 128, 128
+    # 参数设置：变长模式仅支持 B = 1（GVA：HK=2, HV=4）
+    B, HK, HV, K, V = 1, 2, 4, 128, 128
     chunk_size = 64
     device = "npu:0"
     dtype = torch.bfloat16
@@ -326,10 +331,10 @@ def test_chunk_gated_delta_rule_fwd_h_varlen():
     chunk_indices_flat = [x for pair in chunk_indices_pairs for x in pair]
 
     # 构造输入
-    k = torch.randn(B, H, T, K, device=device, dtype=dtype)
-    w = torch.randn(B, H, T, K, device=device, dtype=dtype)
-    u = torch.randn(B, H, T, V, device=device, dtype=dtype)
-    g = torch.randn(B, H, T, device=device, dtype=torch.float32)
+    k = torch.randn(B, HK, T, K, device=device, dtype=dtype)
+    w = torch.randn(B, HV, T, K, device=device, dtype=dtype)
+    u = torch.randn(B, HV, T, V, device=device, dtype=dtype)
+    g = torch.randn(B, HV, T, device=device, dtype=torch.float32)
 
     # 调用算子（变长模式：传入 cu_seqlens 与 chunk_indices；本例不带 initial_state）
     h, v_new, final_state = torch.ops.npu.npu_chunk_gated_delta_rule_fwd_h(
@@ -350,9 +355,9 @@ def test_chunk_gated_delta_rule_fwd_h_varlen():
     print("h shape:", h.shape)
     print("v_new shape:", v_new.shape)
     print("final_state shape:", final_state.shape)
-    assert h.shape == (B, H, num_chunks, K, V)
-    assert v_new.shape == (B, H, T, V)
-    assert final_state.shape == (N, H, K, V)
+    assert h.shape == (B, HV, num_chunks, K, V)
+    assert v_new.shape == (B, HV, T, V)
+    assert final_state.shape == (N, HV, K, V)
     print("Execution Successful!")
 
 if __name__ == "__main__":

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/README.md
@@ -23,7 +23,7 @@ w = A @ kbg_exp
 
 其中：
 
-- `A` 为 chunk 内局部矩阵，形状为 `[B, H, T, chunkSize]`
+- `A` 为 chunk 内局部矩阵，形状为 `[B, HV, T, chunkSize]`
 - `vb` 的局部形状为 `[curChunkSize, V]`
 - `kbg_exp` 的局部形状为 `[curChunkSize, K]`
 - `u` 的局部输出形状为 `[curChunkSize, V]`
@@ -82,11 +82,11 @@ aclnnStatus aclnnRecomputeWUFwd(
 
 | 参数名                 | 输入/输出 | 必选/可选                    | 描述                         | 使用说明                                                                 | 数据类型                       | 数据格式 | 维度（Shape）          | 非连续 Tensor |
 | ---------------------- | --------- | ---------------------------- | ---------------------------- | ------------------------------------------------------------------------ | ------------------------------ | -------- | ---------------------- | ------------- |
-| `k`                    | 输入      | 必选                         | Key 输入张量                 | 参与 `w` 的重计算；ACLNN 接口执行前会先转为连续内存                       | `FLOAT16`、`BFLOAT16`          | `ND`     | `[B, H, T, K]`         | 支持          |
-| `v`                    | 输入      | 必选                         | Value 输入张量               | 参与 `u` 的重计算；ACLNN 接口执行前会先转为连续内存                       | `FLOAT16`、`BFLOAT16`          | `ND`     | `[B, H, T, V]`         | 支持          |
-| `beta`                 | 输入      | 必选                         | beta 权重张量                | 用于缩放 `v` 和 `k`；ACLNN 接口执行前会先转为连续内存                     | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND`     | `[B, H, T]`            | 支持          |
-| `a` / `A`              | 输入      | 必选                         | chunk 内局部矩阵             | 每个 chunk 内参与 `A @ vb` 和 `A @ kbg_exp`；ACLNN 接口执行前会先转为连续内存 | `FLOAT16`、`BFLOAT16`          | `ND`     | `[B, H, T, chunkSize]` | 支持          |
-| `g`                    | 输入      | ACLNN 当前实现要求必传       | Gate / log-decay 输入张量     | 当前实现中用于计算 `exp(g)`；ACLNN 接口执行前会先转为连续内存             | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND`     | `[B, H, T]`            | 支持          |
+| `k`                    | 输入      | 必选                         | Key 输入张量                 | 参与 `w` 的重计算；ACLNN 接口执行前会先转为连续内存                       | `FLOAT16`、`BFLOAT16`          | `ND`     | `[B, HK, T, K]`         | 支持          |
+| `v`                    | 输入      | 必选                         | Value 输入张量               | 参与 `u` 的重计算；ACLNN 接口执行前会先转为连续内存                       | `FLOAT16`、`BFLOAT16`          | `ND`     | `[B, HV, T, V]`         | 支持          |
+| `beta`                 | 输入      | 必选                         | beta 权重张量                | 用于缩放 `v` 和 `k`；ACLNN 接口执行前会先转为连续内存                     | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND`     | `[B, HV, T]`            | 支持          |
+| `a` / `A`              | 输入      | 必选                         | chunk 内局部矩阵             | 每个 chunk 内参与 `A @ vb` 和 `A @ kbg_exp`；ACLNN 接口执行前会先转为连续内存 | `FLOAT16`、`BFLOAT16`          | `ND`     | `[B, HV, T, chunkSize]` | 支持          |
+| `g`                    | 输入      | ACLNN 当前实现要求必传       | Gate / log-decay 输入张量     | 当前实现中用于计算 `exp(g)`；ACLNN 接口执行前会先转为连续内存             | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND`     | `[B, HV, T]`            | 支持          |
 | `gk`                   | 输入      | 接口存在；当前实现要求传空   | 预留输入                     | 当前 ACLNN 封装要求 `gk == nullptr`，否则参数检查失败                    | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND`     | 未启用                 | -             |
 | `cuSeqlensOptional`    | 输入      | 可选                         | 变长序列累计长度信息         | 变长模式输入；表示每条序列的起止位置，形状为 `[N + 1]`                   | `INT64`                        | `ND`     | 1 维                   | -             |
 | `chunkIndicesOptional` | 输入      | 可选                         | 变长模式 chunk 索引信息      | 逻辑上表示为 `[numChunks, 2]`，实际按一维数组 `[numChunks * 2]` 传入       | `INT64`                        | `ND`     | 1 维                   | -             |
@@ -105,8 +105,8 @@ aclnnStatus aclnnRecomputeWUFwd(
 
 | 参数名          | 输入/输出 | 描述                         | 数据类型              | 数据格式 | 维度（Shape）  | 非连续 Tensor |
 | --------------- | --------- | ---------------------------- | --------------------- | -------- | -------------- | ------------- |
-| `wOut` / `w`    | 输出      | 重计算得到的 `w` 张量         | `FLOAT16`、`BFLOAT16` | `ND`     | `[B, H, T, K]` | 支持          |
-| `uOut` / `u`    | 输出      | 重计算得到的 `u` 张量         | `FLOAT16`、`BFLOAT16` | `ND`     | `[B, H, T, V]` | 支持          |
+| `wOut` / `w`    | 输出      | 重计算得到的 `w` 张量         | `FLOAT16`、`BFLOAT16` | `ND`     | `[B, HV, T, K]` | 支持          |
+| `uOut` / `u`    | 输出      | 重计算得到的 `u` 张量         | `FLOAT16`、`BFLOAT16` | `ND`     | `[B, HV, T, V]` | 支持          |
 | `workspaceSize` | 输出      | Device 侧所需 workspace 大小 | `uint64_t`            | -        | 标量           | -             |
 | `executor`      | 输出      | 算子执行器                   | `aclOpExecutor*`      | -        | -              | -             |
 
@@ -116,25 +116,23 @@ aclnnStatus aclnnRecomputeWUFwd(
 
 当前实现显式检查以下维度要求：
 
-- `k` 必须为 4 维：`[B, H, T, K]`
-- `v` 必须为 4 维：`[B, H, T, V]`
-- `beta` 必须为 3 维：`[B, H, T]`
-- `A` 必须为 4 维：`[B, H, T, chunkSize]`
-- `g` 必须为 3 维：`[B, H, T]`
-
-并要求以下输入的前三维一致：
-
-- `v` 与 `k` 的 `[B, H, T]` 一致
-- `beta` 与 `g` 的 `[B, H, T]` 一致
-- `k` 与 `g` 的 `[B, H, T]` 一致
-- `k` 与 `A` 的 `[B, H, T]` 一致
+- `k` 必须为 4 维：`[B, HK, T, K]`
+- `v` 必须为 4 维：`[B, HV, T, V]`
+- `beta` 必须为 3 维：`[B, HV, T]`
+- `A` 必须为 4 维：`[B, HV, T, chunkSize]`
+- `g` 必须为 3 维：`[B, HV, T]`
+- `k` 与 `v` 的 `B`、`T` 必须一致；`K` 维与 `k` 对齐，`V` 维与 `v` 对齐
+- `beta`、`g`、`A` 的 head 维须与 `v` 对齐（`HV`）
+- **GVA 约束**：`HV % HK == 0`；读 `k` 时使用 `hk = hv / (HV / HK)`，写 `w`/`u` 及 `v`/`beta`/`g`/`A` 使用 value head 索引 `hv`
+- `w` 输出形状为 `[B, HV, T, K]`（**非** `empty_like(k)` 的 `[B, HK, T, K]`）
 
 额外限制：
 
 - `chunkSize` 当前仅支持 `64` 或 `128`
 - 变长模式下要求 `B = 1`
 - `gk` 当前实现未启用，必须传 `nullptr`
-- 当前 kernel 设计和测试场景主要面向 `K = 128`，`V = 128` 或 `256`；若使用其他 `K/V`，需结合 kernel tiling 和 workspace 重新验证
+- 当前 kernel 主要面向 `K = 128`，`V ∈ {128, 256}`
+- **TilingKey**：`V = 128` 时 Key=1，`V = 256` 时 Key=2（Cube Catlass tile 分支不同）
 
 ---
 
@@ -285,16 +283,17 @@ w_chunk       : [curChunkSize, K]
 
 `RecomputeWUFwd` 根据 `k`、`v`、`beta`、`A` 和 `g` 重计算并输出 `w`、`u`：
 
-- `w`: `[B, H, T, K]`
-- `u`: `[B, H, T, V]`
+- `w`: `[B, HV, T, K]`
+- `u`: `[B, HV, T, V]`
 
 其中：
 
-- `k`: `[B, H, T, K]`
-- `v`: `[B, H, T, V]`
-- `beta`: `[B, H, T]`
-- `A`: `[B, H, T, chunk_size]`
-- `g`: `[B, H, T]`
+- `k`: `[B, HK, T, K]`
+- `v`: `[B, HV, T, V]`
+- `beta`: `[B, HV, T]`
+- `A`: `[B, HV, T, chunk_size]`
+- `g`: `[B, HV, T]`
+- GVA：`HV % HK == 0`
 
 当前实现中：
 
@@ -315,26 +314,22 @@ import torch_npu
 # 设备
 device = "npu:0"
 
-# 基本参数
-B, H, T, K, V = 1, 8, 1024, 128, 128
+# 基本参数（GVA 示例：HK=2, HV=4；MHA 时令 HK=HV）
+B, HK, HV, T, K, V = 1, 2, 4, 1024, 128, 128
 chunk_size = 64
 
 # 构造输入
-k = torch.randn(B, H, T, K, device=device, dtype=torch.float16)
-v = torch.randn(B, H, T, V, device=device, dtype=torch.float16)
+k = torch.randn(B, HK, T, K, device=device, dtype=torch.float16)
+v = torch.randn(B, HV, T, V, device=device, dtype=torch.float16)
 
-# beta shape: [B, H, T]
-# 当前算子支持 beta 为 float16 / bfloat16 / float32；
-# 测试中建议使用 float32，便于覆盖 beta/g 的 FP32 路径。
-beta = torch.randn(B, H, T, device=device, dtype=torch.float32)
+# beta shape: [B, HV, T]
+beta = torch.randn(B, HV, T, device=device, dtype=torch.float32)
 
-# A shape: [B, H, T, chunk_size]
-# 每个 chunk 内实际参与矩阵乘的局部形状为 [cur_chunk_size, cur_chunk_size]。
-A = torch.randn(B, H, T, chunk_size, device=device, dtype=torch.float16)
+# A shape: [B, HV, T, chunk_size]
+A = torch.randn(B, HV, T, chunk_size, device=device, dtype=torch.float16)
 
-# g shape: [B, H, T]
-# 当前实现中会计算 exp(g)，g 必须传入，不能为 None。
-g = torch.randn(B, H, T, device=device, dtype=torch.float32)
+# g shape: [B, HV, T]
+g = torch.randn(B, HV, T, device=device, dtype=torch.float32)
 
 # 定长场景下 cu_seqlens 和 chunk_indices 均为 None。
 # gk 当前未启用，必须为 None。
@@ -352,7 +347,7 @@ w, u = torch.ops.npu.npu_recompute_wu_fwd(
 
 print(w.shape, u.shape)
 # 期望输出:
-# torch.Size([B, H, T, K]) torch.Size([B, H, T, V])
+# torch.Size([B, HV, T, K]) torch.Size([B, HV, T, V])
 ```
 
 ---
@@ -366,7 +361,7 @@ import torch_npu
 device = "npu:0"
 
 # 变长场景当前仅支持 B = 1
-B, H, K, V = 1, 8, 128, 128
+B, HK, HV, K, V = 1, 2, 4, 128, 128
 chunk_size = 64
 
 # 3 条变长序列
@@ -410,18 +405,17 @@ chunk_indices = torch.tensor(chunk_indices_list, device=device, dtype=torch.int6
 # 变长场景下 T 使用 total_len
 T = total_len
 
-k = torch.randn(B, H, T, K, device=device, dtype=torch.float16)
-v = torch.randn(B, H, T, V, device=device, dtype=torch.float16)
+k = torch.randn(B, HK, T, K, device=device, dtype=torch.float16)
+v = torch.randn(B, HV, T, V, device=device, dtype=torch.float16)
 
-# beta shape: [B, H, T]
-beta = torch.randn(B, H, T, device=device, dtype=torch.float32)
+# beta shape: [B, HV, T]
+beta = torch.randn(B, HV, T, device=device, dtype=torch.float32)
 
-# A shape: [B, H, T, chunk_size]
-A = torch.randn(B, H, T, chunk_size, device=device, dtype=torch.float16)
+# A shape: [B, HV, T, chunk_size]
+A = torch.randn(B, HV, T, chunk_size, device=device, dtype=torch.float16)
 
-# g shape: [B, H, T]
-# 当前实现中会计算 exp(g)，g 必须传入。
-g = torch.randn(B, H, T, device=device, dtype=torch.float32)
+# g shape: [B, HV, T]
+g = torch.randn(B, HV, T, device=device, dtype=torch.float32)
 
 w, u = torch.ops.npu.npu_recompute_wu_fwd(
     k,
@@ -437,7 +431,7 @@ w, u = torch.ops.npu.npu_recompute_wu_fwd(
 
 print(w.shape, u.shape)
 # 期望输出:
-# torch.Size([1, H, total_len, K]) torch.Size([1, H, total_len, V])
+# torch.Size([1, HV, total_len, K]) torch.Size([1, HV, total_len, V])
 ```
 
 ---
@@ -462,8 +456,8 @@ print(w.shape, u.shape)
   - `chunk_size` 仅支持 `64` 或 `128`
 
 - 输出：
-  - `w`: `[B, H, T, K]`
-  - `u`: `[B, H, T, V]`
+  - `w`: `[B, HV, T, K]`
+  - `u`: `[B, HV, T, V]`
 
 ---
 


### PR DESCRIPTION
Align operator READMEs with the HK/HV head split and V=128/256 support documented in chunk_fwd_o (PR #88). Clarify GVA mapping, output shapes, TilingKey semantics, and update Torch examples to use decoupled heads.

# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @Coding-Pangolin
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
