### PR TITLE
feat(recurrent_gated_delta_rule): recurrent_gated_delta_rule 支持<<<>>>

### DIFF
--- a/examples/fast_kernel_launch_example/CMakeLists.txt
+++ b/examples/fast_kernel_launch_example/CMakeLists.txt
@@ -42,6 +42,10 @@ set(INCLUDE_DIRECTORIES
     ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel
     ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel
     ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/catlass/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_kernel
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/catlass/include
+    ${ASCEND_DIR}/pkg_inc/op_common/op_host
+    ${ASCEND_DIR}/${SYSTEM_PREFIX}/pkg_inc/op_common/op_host
 )
 
 # link directories

--- a/examples/fast_kernel_launch_example/CMakeLists.txt
+++ b/examples/fast_kernel_launch_example/CMakeLists.txt
@@ -41,7 +41,6 @@ set(INCLUDE_DIRECTORIES
     ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/gdn/chunk_gdn_fwd
     ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel
     ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_wu_fwd/op_kernel
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/catlass/include
     ${CMAKE_CURRENT_SOURCE_DIR}/../../fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_kernel
     ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/catlass/include
     ${ASCEND_DIR}/pkg_inc/op_common/op_host

--- a/examples/fast_kernel_launch_example/csrc/recurrent_gated_delta_rule/ascend910b/CMakeLists.txt
+++ b/examples/fast_kernel_launch_example/csrc/recurrent_gated_delta_rule/ascend910b/CMakeLists.txt
@@ -1,0 +1,10 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2025-2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# ----------------------------------------------------------------------------
+
+add_sources("--npu-arch=dav-2201")

--- a/examples/fast_kernel_launch_example/csrc/recurrent_gated_delta_rule/ascend910b/recurrent_gated_delta_rule.cpp
+++ b/examples/fast_kernel_launch_example/csrc/recurrent_gated_delta_rule/ascend910b/recurrent_gated_delta_rule.cpp
@@ -1,0 +1,314 @@
+/**
+ * Copyright (c) 2025-2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file recurrent_gated_delta_rule.cpp
+ * \brief Recurrent gated delta rule operator with fast kernel launch (<<<>>>).
+ */
+
+#include <vector>
+#include <tuple>
+#include <ATen/Operators.h>
+#include <torch/all.h>
+#include <torch/library.h>
+#include "acl/acl.h"
+#include "torch_npu/csrc/core/npu/NPUStream.h"
+#include "torch_npu/csrc/framework/OpCommand.h"
+#include "kernel_operator.h"
+#include "platform/platform_ascendc.h"
+#include "lib/matmul_intf.h"
+
+#include "fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule_struct.h"
+#include "fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling_processor.h"
+#include "fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule_tiling_data.h"
+#include "fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule.h"
+
+using namespace RecurrentGatedDeltaRule;
+using RecurrentGatedDeltaRuleTilingData = RecurrentGatedDeltaRule::RecurrentGatedDeltaRuleTilingData;
+
+namespace ascend_ops {
+namespace RecurrentGatedDeltaRuleOp {
+
+TORCH_LIBRARY_FRAGMENT(EXTENSION_MODULE_NAME, m)
+{
+    m.def(
+        "recurrent_gated_delta_rule(Tensor query, Tensor key, Tensor value, Tensor(a!) state, *, Tensor? beta=None, "
+        "float? scale=None, Tensor? actual_seq_lengths=None, Tensor? ssm_state_indices=None, "
+        "Tensor? num_accepted_tokens=None, Tensor? g=None, Tensor? gk=None) -> Tensor");
+    m.def(
+        "recurrent_gated_delta_rule_functional(Tensor query, Tensor key, Tensor value, Tensor state, *, "
+        "Tensor? beta=None, float? scale=None, Tensor? actual_seq_lengths=None, Tensor? ssm_state_indices=None, "
+        "Tensor? num_accepted_tokens=None, Tensor? g=None, Tensor? gk=None) -> (Tensor, Tensor)");
+}
+
+at::Tensor recurrent_gated_delta_rule_meta(const at::Tensor &query, const at::Tensor &key, const at::Tensor &value,
+                                            at::Tensor &state, const c10::optional<at::Tensor> &beta,
+                                            const c10::optional<double> &scale,
+                                            const c10::optional<at::Tensor> &actual_seq_lengths,
+                                            const c10::optional<at::Tensor> &ssm_state_indices,
+                                            const c10::optional<at::Tensor> &num_accepted_tokens,
+                                            const c10::optional<at::Tensor> &g, const c10::optional<at::Tensor> &gk)
+{
+    (void)query;
+    (void)key;
+    (void)state;
+    (void)beta;
+    (void)scale;
+    (void)actual_seq_lengths;
+    (void)ssm_state_indices;
+    (void)num_accepted_tokens;
+    (void)g;
+    (void)gk;
+    TORCH_CHECK(value.dim() == 3, "value dim should be 3");
+    c10::SmallVector<int64_t, 3> outShape = {value.size(0), value.size(1), value.size(2)};
+    return at::empty(outShape, value.options().dtype(at::ScalarType::BFloat16));
+}
+
+std::tuple<at::Tensor, at::Tensor> recurrent_gated_delta_rule_functional_meta(
+    const at::Tensor &query, const at::Tensor &key, const at::Tensor &value, const at::Tensor &state,
+    const c10::optional<at::Tensor> &beta, const c10::optional<double> &scale,
+    const c10::optional<at::Tensor> &actual_seq_lengths, const c10::optional<at::Tensor> &ssm_state_indices,
+    const c10::optional<at::Tensor> &num_accepted_tokens, const c10::optional<at::Tensor> &g,
+    const c10::optional<at::Tensor> &gk)
+{
+    (void)query;
+    (void)key;
+    (void)beta;
+    (void)scale;
+    (void)actual_seq_lengths;
+    (void)ssm_state_indices;
+    (void)num_accepted_tokens;
+    (void)g;
+    (void)gk;
+    TORCH_CHECK(value.dim() == 3, "value dim should be 3");
+    TORCH_CHECK(state.dim() == 4, "initial_state dim should be 4");
+    c10::SmallVector<int64_t, 3> outShape = {value.size(0), value.size(1), value.size(2)};
+    at::Tensor out = at::empty(outShape, value.options().dtype(at::ScalarType::BFloat16));
+    at::Tensor stateOut = at::empty_like(state);
+    return std::make_tuple(out, stateOut);
+}
+
+TORCH_LIBRARY_IMPL(EXTENSION_MODULE_NAME, Meta, m)
+{
+    m.impl("recurrent_gated_delta_rule", recurrent_gated_delta_rule_meta);
+    m.impl("recurrent_gated_delta_rule_functional", recurrent_gated_delta_rule_functional_meta);
+}
+
+static ge::DataType ToGeStateDtype(at::ScalarType dtype)
+{
+    if (dtype == at::kFloat) {
+        return ge::DT_FLOAT;
+    }
+    return ge::DT_BF16;
+}
+
+static RecurrentGatedDeltaRuleTilingData CalcTilingParams(const at::Tensor &query, const at::Tensor &key,
+                                                          const at::Tensor &value, const at::Tensor &beta,
+                                                          const at::Tensor &state, const at::Tensor &cuSeqlens,
+                                                          const at::Tensor &ssmStateIndices, float scaleVal,
+                                                          bool hasG, bool hasGk, bool hasAcceptedTokens,
+                                                          uint32_t &blockDim, size_t &workspaceSize)
+{
+    auto qSizes = query.sizes();
+    auto kSizes = key.sizes();
+    auto vSizes = value.sizes();
+    auto bSizes = beta.sizes();
+    auto sSizes = state.sizes();
+    auto cuSizes = cuSeqlens.sizes();
+    auto ssmSizes = ssmStateIndices.sizes();
+
+    gert::Shape qShape({qSizes[0], qSizes[1], qSizes[2]});
+    gert::Shape kShape({kSizes[0], kSizes[1], kSizes[2]});
+    gert::Shape vShape({vSizes[0], vSizes[1], vSizes[2]});
+    gert::Shape betaShape({bSizes[0], bSizes[1]});
+    gert::Shape stateShape({sSizes[0], sSizes[1], sSizes[2], sSizes[3]});
+    gert::Shape cuShape({cuSizes[0]});
+    gert::Shape ssmShape({ssmSizes[0]});
+
+    auto ascendcPlatform = platform_ascendc::PlatformAscendCManager::GetInstance();
+    TORCH_CHECK(ascendcPlatform != nullptr, "PlatformAscendCManager is null.");
+
+    optiling::RecurrentGatedDeltaRuleTilingContext ctx;
+    ctx.nodeName = "recurrent_gated_delta_rule";
+    ctx.queryShape = &qShape;
+    ctx.keyShape = &kShape;
+    ctx.valueShape = &vShape;
+    ctx.betaShape = &betaShape;
+    ctx.stateShape = &stateShape;
+    ctx.cuSeqlensShape = &cuShape;
+    ctx.ssmStateShape = &ssmShape;
+    ctx.scale = scaleVal;
+    ctx.hasGama = hasG ? 1U : 0U;
+    ctx.hasGamaK = hasGk ? 1U : 0U;
+    ctx.hasAcceptedTokens = hasAcceptedTokens ? 1U : 0U;
+    ctx.stateDtype = ToGeStateDtype(state.scalar_type());
+    ctx.aivNum = ascendcPlatform->GetCoreNumAiv();
+    uint64_t ubSize = 0;
+    ascendcPlatform->GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
+    ctx.ubSize = ubSize;
+
+    RecurrentGatedDeltaRuleTilingData tiling{};
+    optiling::RecurrentGatedDeltaRuleTilingProcessor processor(ctx);
+    TORCH_CHECK(processor.Process(tiling, blockDim, workspaceSize) == ge::GRAPH_SUCCESS,
+                "recurrent_gated_delta_rule tiling failed.");
+    return tiling;
+}
+
+template <typename StateT>
+__global__ __aicore__ void recurrent_gated_delta_rule_kernel(
+    GM_ADDR query, GM_ADDR key, GM_ADDR value, GM_ADDR beta, GM_ADDR state, GM_ADDR cuSeqlens, GM_ADDR ssmStateIndices,
+    GM_ADDR g, GM_ADDR gk, GM_ADDR numAcceptedTokens, GM_ADDR out, GM_ADDR stateOut, GM_ADDR workspace,
+    const RecurrentGatedDeltaRuleTilingData tilingData)
+{
+    AscendC::SetSysWorkspaceForce(workspace);
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_AIV_ONLY);
+    TPipe pipe;
+    RGDR<bfloat16_t, bfloat16_t, StateT> op(&tilingData);
+    RGDRInitParams initParams{query, key, value, g, gk, beta, state, cuSeqlens, ssmStateIndices, numAcceptedTokens, out,
+                              stateOut};
+    op.Init(initParams, &pipe);
+    op.Process();
+}
+
+template <typename StateT>
+void LaunchRecurrentGatedDeltaRule(uint32_t blockDim, aclrtStream stream, GM_ADDR query, GM_ADDR key, GM_ADDR value,
+                                   GM_ADDR beta, GM_ADDR state, GM_ADDR cuSeqlens, GM_ADDR ssmStateIndices, GM_ADDR g,
+                                   GM_ADDR gk, GM_ADDR numAcceptedTokens, GM_ADDR out, GM_ADDR stateOut,
+                                   GM_ADDR workspace, const RecurrentGatedDeltaRuleTilingData &tilingData)
+{
+    recurrent_gated_delta_rule_kernel<StateT><<<blockDim, nullptr, stream>>>(
+        query, key, value, beta, state, cuSeqlens, ssmStateIndices, g, gk, numAcceptedTokens, out, stateOut, workspace,
+        tilingData);
+}
+
+static void RunRecurrentGatedDeltaRuleKernel(const at::Tensor &query, const at::Tensor &key, const at::Tensor &value,
+                                             const c10::optional<at::Tensor> &beta, at::Tensor &state,
+                                             const c10::optional<at::Tensor> &actual_seq_lengths,
+                                             const c10::optional<at::Tensor> &ssm_state_indices,
+                                             const c10::optional<at::Tensor> &num_accepted_tokens,
+                                             const c10::optional<at::Tensor> &g, const c10::optional<at::Tensor> &gk,
+                                             float scaleVal, at::Tensor &out, bool functional)
+{
+    TORCH_CHECK(value.dim() == 3, "value dim should be 3");
+    TORCH_CHECK(actual_seq_lengths.has_value(), "actual_seq_lengths is required");
+    TORCH_CHECK(ssm_state_indices.has_value(), "ssm_state_indices is required");
+    TORCH_CHECK(beta.has_value(), "beta is required");
+
+    const c10::OptionalDeviceGuard guard(query.device());
+    auto stream = c10_npu::getCurrentNPUStream().stream(false);
+
+    at::Tensor betaTensor = beta.value();
+    at::Tensor actualSeqLengths = actual_seq_lengths.value();
+    at::Tensor ssmStateIndices = ssm_state_indices.value();
+
+    uint32_t blockDim = 0;
+    size_t workspaceSize = 0;
+    auto tiling = CalcTilingParams(query, key, value, betaTensor, state, actualSeqLengths, ssmStateIndices, scaleVal,
+                                   g.has_value(), gk.has_value(), num_accepted_tokens.has_value(), blockDim,
+                                   workspaceSize);
+
+    GM_ADDR queryPtr = (GM_ADDR)query.data_ptr();
+    GM_ADDR keyPtr = (GM_ADDR)key.data_ptr();
+    GM_ADDR valuePtr = (GM_ADDR)value.data_ptr();
+    GM_ADDR betaPtr = (GM_ADDR)betaTensor.data_ptr();
+    GM_ADDR statePtr = (GM_ADDR)state.data_ptr();
+    GM_ADDR cuSeqlensPtr = (GM_ADDR)actualSeqLengths.data_ptr();
+    GM_ADDR ssmStateIndicesPtr = (GM_ADDR)ssmStateIndices.data_ptr();
+    GM_ADDR outPtr = (GM_ADDR)out.data_ptr();
+    GM_ADDR stateOutPtr = (GM_ADDR)state.data_ptr();
+
+    GM_ADDR gPtr = nullptr;
+    GM_ADDR gkPtr = nullptr;
+    GM_ADDR numAcceptedTokensPtr = nullptr;
+    if (g.has_value()) {
+        gPtr = (GM_ADDR)g.value().data_ptr();
+    }
+    if (gk.has_value()) {
+        gkPtr = (GM_ADDR)gk.value().data_ptr();
+    }
+    if (num_accepted_tokens.has_value()) {
+        numAcceptedTokensPtr = (GM_ADDR)num_accepted_tokens.value().data_ptr();
+    }
+
+    void *workspacePtr = nullptr;
+    if (workspaceSize > 0) {
+        auto ret = aclrtMalloc(&workspacePtr, workspaceSize, ACL_MEM_MALLOC_HUGE_FIRST);
+        TORCH_CHECK(ret == ACL_SUCCESS, "allocate workspace failed. ERROR: ", ret);
+        ret = aclrtMemsetAsync(workspacePtr, workspaceSize, 0, workspaceSize, stream);
+        TORCH_CHECK(ret == ACL_SUCCESS, "memset workspace failed. ERROR: ", ret);
+    }
+    GM_ADDR workspaceGm = (GM_ADDR)workspacePtr;
+
+    auto stateDtype = state.scalar_type();
+    auto aclCall = [=]() -> int {
+        if (stateDtype == at::kBFloat16) {
+            LaunchRecurrentGatedDeltaRule<bfloat16_t>(blockDim, stream, queryPtr, keyPtr, valuePtr, betaPtr, statePtr,
+                                                      cuSeqlensPtr, ssmStateIndicesPtr, gPtr, gkPtr,
+                                                      numAcceptedTokensPtr, outPtr, stateOutPtr, workspaceGm, tiling);
+        } else if (stateDtype == at::kFloat) {
+            LaunchRecurrentGatedDeltaRule<float>(blockDim, stream, queryPtr, keyPtr, valuePtr, betaPtr, statePtr,
+                                               cuSeqlensPtr, ssmStateIndicesPtr, gPtr, gkPtr, numAcceptedTokensPtr,
+                                               outPtr, stateOutPtr, workspaceGm, tiling);
+        } else {
+            TORCH_CHECK(false, "Unsupported state dtype: ", stateDtype);
+        }
+        return 0;
+    };
+
+    at_npu::native::OpCommand::RunOpApi(functional ? "RecurrentGatedDeltaRuleFunctional" : "RecurrentGatedDeltaRule",
+                                        aclCall);
+    c10_npu::getCurrentNPUStream().synchronize();
+
+    if (workspacePtr != nullptr) {
+        aclrtFree(workspacePtr);
+    }
+}
+
+at::Tensor recurrent_gated_delta_rule_npu(const at::Tensor &query, const at::Tensor &key, const at::Tensor &value,
+                                          at::Tensor &state, const c10::optional<at::Tensor> &beta,
+                                          const c10::optional<double> &scale,
+                                          const c10::optional<at::Tensor> &actual_seq_lengths,
+                                          const c10::optional<at::Tensor> &ssm_state_indices,
+                                          const c10::optional<at::Tensor> &num_accepted_tokens,
+                                          const c10::optional<at::Tensor> &g, const c10::optional<at::Tensor> &gk)
+{
+    TORCH_CHECK(scale.has_value(), "scale cannot be empty");
+    auto out = recurrent_gated_delta_rule_meta(query, key, value, state, beta, scale, actual_seq_lengths,
+                                               ssm_state_indices, num_accepted_tokens, g, gk);
+    RunRecurrentGatedDeltaRuleKernel(query, key, value, beta, state, actual_seq_lengths, ssm_state_indices,
+                                     num_accepted_tokens, g, gk, static_cast<float>(scale.value()), out, false);
+    return out;
+}
+
+std::tuple<at::Tensor, at::Tensor> recurrent_gated_delta_rule_functional_npu(
+    const at::Tensor &query, const at::Tensor &key, const at::Tensor &value, const at::Tensor &state,
+    const c10::optional<at::Tensor> &beta, const c10::optional<double> &scale,
+    const c10::optional<at::Tensor> &actual_seq_lengths, const c10::optional<at::Tensor> &ssm_state_indices,
+    const c10::optional<at::Tensor> &num_accepted_tokens, const c10::optional<at::Tensor> &g,
+    const c10::optional<at::Tensor> &gk)
+{
+    TORCH_CHECK(scale.has_value(), "scale cannot be empty");
+    auto outs = recurrent_gated_delta_rule_functional_meta(query, key, value, state, beta, scale, actual_seq_lengths,
+                                                           ssm_state_indices, num_accepted_tokens, g, gk);
+    at::Tensor out = std::get<0>(outs);
+    (void)std::get<1>(outs);
+    at::Tensor stateInplace = state.clone();
+    RunRecurrentGatedDeltaRuleKernel(query, key, value, beta, stateInplace, actual_seq_lengths, ssm_state_indices,
+                                     num_accepted_tokens, g, gk, static_cast<float>(scale.value()), out, true);
+    return std::make_tuple(out, stateInplace);
+}
+
+TORCH_LIBRARY_IMPL(EXTENSION_MODULE_NAME, PrivateUse1, m)
+{
+    m.impl("recurrent_gated_delta_rule", recurrent_gated_delta_rule_npu);
+    m.impl("recurrent_gated_delta_rule_functional", recurrent_gated_delta_rule_functional_npu);
+}
+
+} // namespace RecurrentGatedDeltaRuleOp
+} // namespace ascend_ops

--- a/examples/fast_kernel_launch_example/tests/recurrent_gated_delta_rule/test_recurrent_gated_delta_rule.py
+++ b/examples/fast_kernel_launch_example/tests/recurrent_gated_delta_rule/test_recurrent_gated_delta_rule.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2025-2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Accuracy test for npu_recurrent_gated_delta_rule.
+
+Compares NPU output against CPU golden reference from PTA.
+"""
+
+import sys
+from pathlib import Path
+
+import ascend_ops
+import pytest
+import torch
+import torch_npu
+
+_PTA_DIR = (
+    Path(__file__).resolve().parents[4]
+    / "fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/tests/pta"
+)
+sys.path.insert(0, str(_PTA_DIR))
+
+from golden import recurrent_gated_delta_rule_golden
+from utils import compare_tensors_by_ratio
+
+
+def make_inputs(
+    bs,
+    mtp,
+    nk,
+    nv,
+    dk,
+    dv,
+    use_g=True,
+    use_gk=False,
+    use_accepted_tokens=False,
+    seed=42,
+):
+    """Generate inputs on CPU, matching the kernel's expected shapes."""
+    torch.manual_seed(seed)
+    star_idx = 1
+    star_idx_tensor = torch.tensor([star_idx], dtype=torch.int32)
+    batch_tensor = torch.ones(bs, dtype=torch.int32) * mtp
+    actual_seq_lengths = torch.cat([star_idx_tensor, batch_tensor])
+    t = int(actual_seq_lengths.sum().item())
+
+    state = torch.rand((t, nv, dv, dk), dtype=torch.float)
+    query = torch.nn.functional.normalize(
+        torch.rand((t, nk, dk), dtype=torch.bfloat16), p=2, dim=-1
+    )
+    key = torch.nn.functional.normalize(
+        torch.rand((t, nk, dk), dtype=torch.bfloat16), p=2, dim=-1
+    )
+    value = torch.rand((t, nv, dv), dtype=torch.bfloat16)
+    beta = torch.rand((t, nv), dtype=torch.bfloat16)
+    scale = dk ** -0.5
+
+    ssm_state_indices = torch.arange(t, dtype=torch.int32)
+
+    g = None
+    if use_g:
+        g = -torch.rand((t, nv), dtype=torch.float32)
+
+    gk = None
+    if use_gk:
+        gk = -torch.rand((t, nv, dk), dtype=torch.float32)
+
+    num_accepted_tokens = None
+    if use_accepted_tokens and mtp > 1:
+        num_accepted_tokens = torch.randint(1, mtp + 1, (bs,), dtype=torch.int32)
+
+    return {
+        "query": query,
+        "key": key,
+        "value": value,
+        "state": state,
+        "beta": beta,
+        "scale": scale,
+        "actual_seq_lengths": actual_seq_lengths,
+        "ssm_state_indices": ssm_state_indices,
+        "num_accepted_tokens": num_accepted_tokens,
+        "g": g,
+        "gk": gk,
+    }
+
+
+def run_golden(inp):
+    """Run CPU golden implementation."""
+    return recurrent_gated_delta_rule_golden(
+        query=inp["query"],
+        key=inp["key"],
+        value=inp["value"],
+        state=inp["state"].clone(),
+        beta=inp["beta"],
+        scale=inp["scale"],
+        actual_seq_lengths=inp["actual_seq_lengths"],
+        ssm_state_indices=inp["ssm_state_indices"],
+        num_accepted_tokens=inp["num_accepted_tokens"],
+        g=inp["g"],
+        gk=inp["gk"],
+    )
+
+
+def run_npu(inp):
+    """Run NPU operator and return CPU tensors."""
+    device = torch.device("npu:7")
+    torch_npu.npu.set_device(device)
+    q_npu = inp["query"].npu()
+    k_npu = inp["key"].npu()
+    v_npu = inp["value"].npu()
+    s_npu = inp["state"].clone().npu()
+    b_npu = inp["beta"].npu()
+    asl_npu = inp["actual_seq_lengths"].npu()
+    ssi_npu = inp["ssm_state_indices"].npu()
+
+    g_npu = inp["g"].npu() if inp["g"] is not None else None
+    gk_npu = inp["gk"].npu() if inp["gk"] is not None else None
+    nat_npu = (
+        inp["num_accepted_tokens"].npu()
+        if inp["num_accepted_tokens"] is not None
+        else None
+    )
+
+    result = torch.ops.ascend_ops.recurrent_gated_delta_rule_functional(
+        q_npu,
+        k_npu,
+        v_npu,
+        s_npu,
+        beta=b_npu,
+        scale=inp["scale"],
+        actual_seq_lengths=asl_npu,
+        ssm_state_indices=ssi_npu,
+        num_accepted_tokens=nat_npu,
+        g=g_npu,
+        gk=gk_npu,
+    )
+    torch_npu.npu.synchronize()
+
+    if isinstance(result, (tuple, list)):
+        attn_out = result[0].cpu()
+        final_state = result[1].cpu()
+    else:
+        attn_out = result.cpu()
+        final_state = s_npu.cpu()
+
+    star_idx = int(inp["actual_seq_lengths"][0].item())
+    attn_out[:star_idx] = 0
+    return attn_out, final_state
+
+
+def assert_compare_tensors_by_ratio(golden, actual, name, rtol=0.01, atol=0.004):
+    passed = compare_tensors_by_ratio(golden, actual, name, rtol=rtol, atol=atol)
+    assert passed, f"{name} comparison failed (rtol={rtol}, atol={atol})"
+
+
+def test_recurrent_gated_delta_rule_interface_exist():
+    assert hasattr(torch.ops.ascend_ops, "recurrent_gated_delta_rule")
+    assert hasattr(torch.ops.ascend_ops, "recurrent_gated_delta_rule_functional")
+
+
+TEST_CONFIGS = [
+    pytest.param(
+        2,
+        2,
+        4,
+        8,
+        128,
+        128,
+        True,
+        False,
+        False,
+        42,
+        0.01,
+        0.004,
+        id="basic_bs2_mtp2",
+    ),
+]
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU device not found")
+@pytest.mark.parametrize(
+    "bs,mtp,nk,nv,dk,dv,use_g,use_gk,use_accepted_tokens,seed,rtol,atol",
+    TEST_CONFIGS,
+)
+def test_recurrent_gated_delta_rule_functional_accuracy(
+    bs,
+    mtp,
+    nk,
+    nv,
+    dk,
+    dv,
+    use_g,
+    use_gk,
+    use_accepted_tokens,
+    seed,
+    rtol,
+    atol,
+):
+    inp = make_inputs(
+        bs,
+        mtp,
+        nk,
+        nv,
+        dk,
+        dv,
+        use_g=use_g,
+        use_gk=use_gk,
+        use_accepted_tokens=use_accepted_tokens,
+        seed=seed,
+    )
+
+    golden_attn, golden_state = run_golden(inp)
+    npu_attn, npu_state = run_npu(inp)
+
+    assert_compare_tensors_by_ratio(golden_attn, npu_attn, "attn_out", rtol=rtol, atol=atol)
+    assert_compare_tensors_by_ratio(golden_state, npu_state, "final_state", rtol=rtol, atol=atol)

--- a/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.cpp
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.cpp
@@ -1,10 +1,10 @@
 ﻿/**
- * Copyright (c) 2025 Tianjin University, Ltd.
- * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- */
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 /*!
  * \file recurrent_gated_delta_rule_tiling.cpp
@@ -18,8 +18,6 @@
 #include "err/ops_err.h"
 #include "log/log.h"
 #include "tiling/platform/platform_ascendc.h"
-#include "util/math_util.h"
-#include <array>
 
 namespace optiling {
 
@@ -36,20 +34,6 @@ const size_t G_INDEX = 7;
 const size_t GK_INDEX = 8;
 const size_t ACC_TO_INDEX = 9;
 
-const size_t QKV_DIM_NUM = 3;
-const size_t BETA_DIM_NUM = 2;
-const size_t STATE_DIM_NUM = 4;
-const size_t CUSEQLENS_DIM_NUM = 1;
-const size_t SSM_STATE_INDICES_DIM_NUM = 1;
-const size_t G_DIM_NUM = 2;
-
-const size_t DIM_0 = 0;
-const size_t DIM_1 = 1;
-const size_t DIM_2 = 2;
-const size_t DIM_3 = 3;
-
-const size_t MAX_MTP = 8;
-
 void RecurrentGatedDeltaRuleTiling::InitCompileInfo()
 {
     auto platformInfoPtr = context_->GetPlatformInfo();
@@ -65,7 +49,28 @@ void RecurrentGatedDeltaRuleTiling::InitCompileInfo()
         OP_LOGE(context_->GetNodeName(), "aivNum <= 0");
         return;
     }
-    tilingData_.vectorCoreNum = compileInfo_.aivNum;
+    tilingData_.vectorCoreNum = static_cast<uint32_t>(compileInfo_.aivNum);
+}
+
+RecurrentGatedDeltaRuleTilingContext RecurrentGatedDeltaRuleTiling::BuildProcessorContext() const
+{
+    RecurrentGatedDeltaRuleTilingContext ctx;
+    ctx.nodeName = context_->GetNodeName();
+    ctx.queryShape = &context_->GetInputShape(QUERY_INDEX)->GetOriginShape();
+    ctx.keyShape = &context_->GetInputShape(KEY_INDEX)->GetOriginShape();
+    ctx.valueShape = &context_->GetInputShape(VALUE_INDEX)->GetOriginShape();
+    ctx.betaShape = &context_->GetInputShape(BETA_INDEX)->GetOriginShape();
+    ctx.stateShape = &context_->GetInputShape(STATE_INDEX)->GetOriginShape();
+    ctx.cuSeqlensShape = &context_->GetInputShape(CUSEQLENS_INDEX)->GetOriginShape();
+    ctx.ssmStateShape = &context_->GetInputShape(SSM_STATE_INDICES_INDEX)->GetOriginShape();
+    ctx.aivNum = compileInfo_.aivNum;
+    ctx.ubSize = compileInfo_.ubSize;
+    ctx.stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
+    ctx.scale = tilingData_.scale;
+    ctx.hasGama = tilingData_.hasGama;
+    ctx.hasGamaK = tilingData_.hasGamaK;
+    ctx.hasAcceptedTokens = tilingData_.hasAcceptedTokens;
+    return ctx;
 }
 
 ge::graphStatus RecurrentGatedDeltaRuleTiling::GetPlatformInfo()
@@ -118,10 +123,7 @@ uint64_t RecurrentGatedDeltaRuleTiling::GetTilingKey() const
 
 ge::graphStatus RecurrentGatedDeltaRuleTiling::GetWorkspaceSize()
 {
-    // system workspace size is 16 * 1024 * 1024 = 16M;
-    constexpr int64_t sysWorkspaceSize = 16777216;
-    workspaceSize_ = sysWorkspaceSize;
-
+    workspaceSize_ = static_cast<int64_t>(RGDR_SYS_WORKSPACE_SIZE);
     return ge::GRAPH_SUCCESS;
 };
 
@@ -137,7 +139,7 @@ ge::graphStatus RecurrentGatedDeltaRuleTiling::PostTiling()
     }
     context_->GetRawTilingData()->SetDataSize(tilingDataSize);
 
-    size_t *workspaces = context_->GetWorkspaceSizes(1); // set workspace
+    size_t *workspaces = context_->GetWorkspaceSizes(1);
     OP_CHECK_IF(workspaces == nullptr, OPS_REPORT_CUBE_INNER_ERR(context_->GetNodeName(), "workspaces is null"),
                 return ge::GRAPH_FAILED);
     workspaces[0] = workspaceSize_;
@@ -182,8 +184,7 @@ ge::graphStatus RecurrentGatedDeltaRuleTiling::AnalyzeDtype()
 
     auto betaDtype = context_->GetInputDesc(BETA_INDEX)->GetDataType();
     auto stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
-    OP_CHECK_IF(betaDtype != ge::DT_BF16 ,
-                OP_LOGE(context_->GetNodeName(), "beta dtype should be bfloat16"),
+    OP_CHECK_IF(betaDtype != ge::DT_BF16, OP_LOGE(context_->GetNodeName(), "beta dtype should be bfloat16"),
                 return ge::GRAPH_FAILED);
     OP_CHECK_IF(stateDtype != ge::DT_FLOAT && stateDtype != ge::DT_BF16,
                 OP_LOGE(context_->GetNodeName(), "state dtype should be bfloat16 or float32"),
@@ -216,194 +217,11 @@ ge::graphStatus RecurrentGatedDeltaRuleTiling::AnalyzeDtype()
     return ge::GRAPH_SUCCESS;
 }
 
-
-bool RecurrentGatedDeltaRuleTiling::CheckDimEqual(const gert::Shape a, const int64_t dimA, gert::Shape b, const int64_t dimB,
-                                                  const std::string &nameA, const std::string &nameB,
-                                                  const std::string &dimDesc)
-{
-    if (a.GetDim(dimA) != b.GetDim(dimB)) {
-        OP_LOGE(context_->GetNodeName(), "The %s of %s and %s should be the same, but %s is %ld while %s is %ld",
-                dimDesc.c_str(), nameA.c_str(), nameB.c_str(), nameA.c_str(), a.GetDim(dimA), nameB.c_str(),
-                b.GetDim(dimB));
-        return false;
-    }
-    return true;
-}
-
-bool RecurrentGatedDeltaRuleTiling::CheckDim(const gert::Shape shape, const size_t dim, const std::string &dimDesc)
-{
-    if (shape.GetDimNum() != dim) {
-        OP_LOGE(context_->GetNodeName(), "The number of dimensons of %s should be %zu, but it is %zu",
-                dimDesc.c_str(), dim, shape.GetDimNum());
-        return false;
-    }
-    return true;
-}
-
-// Split shape checks/fill/scheduling decisions to improve readability and maintenance.
-ge::graphStatus RecurrentGatedDeltaRuleTiling::CheckShapeDimAndRelation(const gert::Shape &queryShape,
-                                                                         const gert::Shape &keyShape,
-                                                                         const gert::Shape &valueShape,
-                                                                         const gert::Shape &betaShape,
-                                                                         const gert::Shape &stateShape,
-                                                                         const gert::Shape &cuSeqlensShape,
-                                                                         const gert::Shape &ssmStateShape)
-{
-    if (!CheckDim(queryShape, QKV_DIM_NUM, "query") || !CheckDim(keyShape, QKV_DIM_NUM, "key") ||
-        !CheckDim(valueShape, QKV_DIM_NUM, "value") || !CheckDim(betaShape, BETA_DIM_NUM, "beta") ||
-        !CheckDim(stateShape, STATE_DIM_NUM, "state") ||
-        !CheckDim(cuSeqlensShape, CUSEQLENS_DIM_NUM, "actual_seq_lengths") ||
-        !CheckDim(ssmStateShape, SSM_STATE_INDICES_DIM_NUM, "ssm_state_indices")) {
-        return ge::GRAPH_FAILED;
-    }
-
-    if (!CheckDimEqual(queryShape, DIM_0, keyShape, DIM_0, "query", "key", "T dimension") ||
-        !CheckDimEqual(queryShape, DIM_1, keyShape, DIM_1, "query", "key", "Nk dimension") ||
-        !CheckDimEqual(queryShape, DIM_2, keyShape, DIM_2, "query", "key", "Dk dimension") ||
-        !CheckDimEqual(stateShape, DIM_1, valueShape, DIM_1, "state", "value", "Nv dimension") ||
-        !CheckDimEqual(stateShape, DIM_2, valueShape, DIM_2, "state", "value", "Dv dimension") ||
-        !CheckDimEqual(valueShape, DIM_0, queryShape, DIM_0, "value", "query", "T dimension") ||
-        !CheckDimEqual(betaShape, DIM_0, queryShape, DIM_0, "beta", "query", "T dimension") ||
-        !CheckDimEqual(betaShape, DIM_1, valueShape, DIM_1, "beta", "value", "Nv dimension") ||
-        !CheckDimEqual(stateShape, DIM_3, queryShape, DIM_2, "state", "query", "Dk dimension")) {
-        return ge::GRAPH_FAILED;
-    }
-
-    return ge::GRAPH_SUCCESS;
-}
-
-void RecurrentGatedDeltaRuleTiling::FillTilingShapeData(const gert::Shape &queryShape, const gert::Shape &valueShape,
-                                                         const gert::Shape &stateShape,
-                                                         const gert::Shape &cuSeqlensShape)
-{
-    tilingData_.t = queryShape.GetDim(DIM_0);
-    tilingData_.nk = queryShape.GetDim(DIM_1);
-    tilingData_.dk = queryShape.GetDim(DIM_2);
-    tilingData_.nv = valueShape.GetDim(DIM_1);
-    tilingData_.dv = valueShape.GetDim(DIM_2);
-    tilingData_.sBlockNum = stateShape.GetDim(DIM_0);
-    tilingData_.b = cuSeqlensShape.GetDim(DIM_0) - 1;
-}
-
-ge::graphStatus RecurrentGatedDeltaRuleTiling::CheckShapeValueRangeAndRule()
-{
-    OP_CHECK_IF(tilingData_.nk > 256 || tilingData_.nv > 256 || tilingData_.dk > 512 || tilingData_.dv > 512,
-                OP_LOGE(inputParams_.opName,
-                        "nk and nv should no bigger than 256, dk and dv should no bigger than 512, but nk is %u, nv is "
-                        "%u, dk is %u, dv is %u",
-                        tilingData_.nk, tilingData_.nv, tilingData_.dk, tilingData_.dv),
-                return ge::GRAPH_FAILED);
-
-    OP_CHECK_IF(tilingData_.nv % tilingData_.nk != 0,
-                OP_LOGE(inputParams_.opName,
-                        "nv should be an integer multiple of nk, but nv is %u, nk is %u",
-                        tilingData_.nv, tilingData_.nk),
-                return ge::GRAPH_FAILED);
-
-    return ge::GRAPH_SUCCESS;
-}
-
-void RecurrentGatedDeltaRuleTiling::UpdateDynamicBlockDimByTaskUnits()
-{
-    // Dynamic blockDim: do not launch more cores than effective (batch, head) task units.
-    uint64_t taskUnits = static_cast<uint64_t>(tilingData_.b) * static_cast<uint64_t>(tilingData_.nv);
-    if (taskUnits == 0) {
-        taskUnits = 1;
-    }
-    uint64_t maxCoreNum = (compileInfo_.aivNum > 0) ? compileInfo_.aivNum : 1;
-    uint64_t selectedCoreNum = (taskUnits < maxCoreNum) ? taskUnits : maxCoreNum;
-    tilingData_.vectorCoreNum = static_cast<uint32_t>(selectedCoreNum);
-    OP_LOGD(context_->GetNodeName(), "taskUnits: [%llu], selected vectorCoreNum: [%u]",
-            static_cast<unsigned long long>(taskUnits), tilingData_.vectorCoreNum);
-}
-
-ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleCheckShapeDimAndRelation()
-{
-    const auto &queryShape = context_->GetInputShape(QUERY_INDEX)->GetOriginShape();
-    const auto &keyShape = context_->GetInputShape(KEY_INDEX)->GetOriginShape();
-    const auto &valueShape = context_->GetInputShape(VALUE_INDEX)->GetOriginShape();
-    const auto &betaShape = context_->GetInputShape(BETA_INDEX)->GetOriginShape();
-    const auto &stateShape = context_->GetInputShape(STATE_INDEX)->GetOriginShape();
-    const auto &cuSeqlensShape = context_->GetInputShape(CUSEQLENS_INDEX)->GetOriginShape();
-    const auto &ssmStateShape = context_->GetInputShape(SSM_STATE_INDICES_INDEX)->GetOriginShape();
-    return CheckShapeDimAndRelation(queryShape, keyShape, valueShape, betaShape, stateShape, cuSeqlensShape, ssmStateShape);
-}
-
-ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleFillTilingShapeData()
-{
-    const auto &queryShape = context_->GetInputShape(QUERY_INDEX)->GetOriginShape();
-    const auto &valueShape = context_->GetInputShape(VALUE_INDEX)->GetOriginShape();
-    const auto &stateShape = context_->GetInputShape(STATE_INDEX)->GetOriginShape();
-    const auto &cuSeqlensShape = context_->GetInputShape(CUSEQLENS_INDEX)->GetOriginShape();
-    FillTilingShapeData(queryShape, valueShape, stateShape, cuSeqlensShape);
-    return ge::GRAPH_SUCCESS;
-}
-
-ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleCheckShapeValueRangeAndRule()
-{
-    return CheckShapeValueRangeAndRule();
-}
-
-ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleUpdateDynamicBlockDimByTaskUnits()
-{
-    UpdateDynamicBlockDimByTaskUnits();
-    return ge::GRAPH_SUCCESS;
-}
-
-ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleInitUbCalcContext()
-{
-    ubCalcCtx_.ubSize = compileInfo_.ubSize;
-    ubCalcCtx_.aNv = Ops::Base::CeilAlign(tilingData_.nv, static_cast<uint32_t>(16)); // 16 * 2 = 32B
-    ubCalcCtx_.aDv = Ops::Base::CeilAlign(tilingData_.dv, static_cast<uint32_t>(16)); // 16 * 2 = 32B
-    ubCalcCtx_.aDk = Ops::Base::CeilAlign(tilingData_.dk, static_cast<uint32_t>(16)); // 16 * 2 = 32B
-    return ge::GRAPH_SUCCESS;
-}
-
-ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleCalcFixedUbBytes()
-{
-    ubCalcCtx_.fixedUbBytes = CalcFixedUbBytes(ubCalcCtx_.aNv, ubCalcCtx_.aDv, ubCalcCtx_.aDk);
-    tilingData_.ubRestBytes = ubCalcCtx_.ubSize - ubCalcCtx_.fixedUbBytes;
-    return ge::GRAPH_SUCCESS;
-}
-
-ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleCalcWorkingUbBytes()
-{
-    ubCalcCtx_.workingUbBytes = CalcWorkingUbBytes(ubCalcCtx_.aNv, ubCalcCtx_.aDv, ubCalcCtx_.aDk);
-    return ge::GRAPH_SUCCESS;
-}
-
-ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleCalcVStepCoeff()
-{
-    ubCalcCtx_.coeff = CalcVStepCoeff(ubCalcCtx_.aDk, 1, 1);
-    return ge::GRAPH_SUCCESS;
-}
-
-ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleFinalizeVStepFromUb()
-{
-    return FinalizeVStepFromUb(ubCalcCtx_.ubSize, ubCalcCtx_.workingUbBytes, ubCalcCtx_.coeff);
-}
-
-// AnalyzeShapes now executes a deterministic rule-chain, easier to extend/maintain.
 ge::graphStatus RecurrentGatedDeltaRuleTiling::AnalyzeShapes()
 {
-    struct RuleItem {
-        const char *name;
-        HostRuleFn fn;
-    };
-    const std::array<RuleItem, 4> shapeRules = {{
-        {"RuleCheckShapeDimAndRelation", &RecurrentGatedDeltaRuleTiling::RuleCheckShapeDimAndRelation},
-        {"RuleFillTilingShapeData", &RecurrentGatedDeltaRuleTiling::RuleFillTilingShapeData},
-        {"RuleCheckShapeValueRangeAndRule", &RecurrentGatedDeltaRuleTiling::RuleCheckShapeValueRangeAndRule},
-        {"RuleUpdateDynamicBlockDimByTaskUnits", &RecurrentGatedDeltaRuleTiling::RuleUpdateDynamicBlockDimByTaskUnits},
-    }};
-    for (const auto &rule : shapeRules) {
-        OP_CHECK_IF((this->*(rule.fn))() != ge::GRAPH_SUCCESS,
-                    OP_LOGE(inputParams_.opName, "AnalyzeShapes rule failed: %s", rule.name),
-                    return ge::GRAPH_FAILED);
-    }
-    return ge::GRAPH_SUCCESS;
+    RecurrentGatedDeltaRuleTilingProcessor processor(BuildProcessorContext());
+    return processor.ProcessShapes(tilingData_);
 }
-
 
 bool RecurrentGatedDeltaRuleTiling::CheckFormat(ge::Format format, const std::string &Desc)
 {
@@ -495,144 +313,10 @@ void RecurrentGatedDeltaRuleTiling::PrintTilingData()
     OP_LOGD(context_->GetNodeName(), "hasAcceptedTokens: [%u]", tilingData_.hasAcceptedTokens);
 }
 
-int64_t RecurrentGatedDeltaRuleTiling::CalcFixedUbBytes(int64_t aNv, int64_t aDv, int64_t aDk) const
-{
-    int64_t usedUbBytes = MAX_MTP * (4 * aDk + 2 * aDv); // 4 for qInQueue_ & kInQueue_, 2 for vInQueue_
-    usedUbBytes += 128;                                  // reserve 128 Bytes
-    if (tilingData_.hasGamaK) {
-        usedUbBytes += MAX_MTP * 4 * aDk; // 4 for gk gamaInQueue_
-    }
-    if (tilingData_.hasGama) {
-        usedUbBytes += MAX_MTP * 4 * aNv; // 4 for g gamaInQueue_
-    }
-    usedUbBytes += MAX_MTP * 2 * aNv; // 2 for betaInQueue_
-    return usedUbBytes;
-}
-
-int64_t RecurrentGatedDeltaRuleTiling::CalcWorkingUbBytes(int64_t aNv, int64_t aDv, int64_t aDk) const
-{
-    int64_t usedUbBytes = CalcFixedUbBytes(aNv, aDv, aDk);
-    usedUbBytes += MAX_MTP * (8 * aDk + 4 * aDv + 4 * aNv); // 8 for qk in ub, 4 for v in ub, 4 for beta in ub
-    return usedUbBytes;
-}
-
-int64_t RecurrentGatedDeltaRuleTiling::CalcVStepCoeff(int64_t aDk, uint32_t stateOutBufferNum,
-                                                       uint32_t attnOutBufferNum) const
-{
-    auto stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
-    int64_t stateDtypeSize = (stateDtype == ge::DT_FLOAT) ? 4 : 2;
-    int64_t coeff = (stateDtypeSize + static_cast<int64_t>(stateDtypeSize * stateOutBufferNum)) * aDk +
-                    static_cast<int64_t>(4 * attnOutBufferNum); // stateIn/stateOut/attnOut queues
-    coeff += (4 + 4) * aDk + 4 + 4;                             // qInUb/kInUb/vInUb/deltaInUb/attnInUb
-    return coeff;
-}
-
-bool RecurrentGatedDeltaRuleTiling::EvaluateBufferProfile(int64_t ubSize, int64_t usedUbBytes, int64_t aDk,
-                                                           uint32_t stateOutBufferNum, uint32_t attnOutBufferNum,
-                                                           BufferProfile &profile) const
-{
-    int64_t coeff = CalcVStepCoeff(aDk, stateOutBufferNum, attnOutBufferNum);
-    int64_t vStep = (ubSize - usedUbBytes) / coeff / 8 * 8; // 8 * sizeof(float) = 32
-    if (vStep < 8) {
-        return false;
-    }
-    int64_t repeatTime = Ops::Base::CeilDiv(tilingData_.dv, static_cast<uint32_t>(vStep));
-    vStep = Ops::Base::CeilAlign(Ops::Base::CeilDiv(tilingData_.dv, static_cast<uint32_t>(repeatTime)),
-                                 static_cast<uint32_t>(8));
-    if (vStep < 8) {
-        return false;
-    }
-    profile.stateOutBufferNum = stateOutBufferNum;
-    profile.attnOutBufferNum = attnOutBufferNum;
-    profile.vStep = static_cast<uint32_t>(vStep);
-    profile.repeatTime = static_cast<uint32_t>(repeatTime);
-    profile.valid = true;
-    return true;
-}
-
-bool RecurrentGatedDeltaRuleTiling::IsBetterProfile(const BufferProfile &candidate, const BufferProfile &current) const
-{
-    if (!current.valid) {
-        return true;
-    }
-    if (candidate.repeatTime != current.repeatTime) {
-        return candidate.repeatTime < current.repeatTime;
-    }
-    uint32_t candidateDepth = candidate.stateOutBufferNum + candidate.attnOutBufferNum;
-    uint32_t currentDepth = current.stateOutBufferNum + current.attnOutBufferNum;
-    if (candidateDepth != currentDepth) {
-        return candidateDepth > currentDepth;
-    }
-    return candidate.vStep > current.vStep;
-}
-
-ge::graphStatus RecurrentGatedDeltaRuleTiling::FinalizeVStepFromUb(int64_t ubSize, int64_t usedUbBytes, int64_t coeff)
-{
-    (void)coeff;
-    int64_t aDk = Ops::Base::CeilAlign(tilingData_.dk, static_cast<uint32_t>(16)); // 16 * 2 = 32B
-    BufferProfile selected;
-    const std::array<BufferProfile, 3> candidates = {{
-        {1, 1, 0, 0, false},
-        {1, 2, 0, 0, false},
-        {2, 2, 0, 0, false},
-    }};
-    for (const auto &candidate : candidates) {
-        BufferProfile profile;
-        if (!EvaluateBufferProfile(ubSize, usedUbBytes, aDk, candidate.stateOutBufferNum, candidate.attnOutBufferNum,
-                                   profile)) {
-            continue;
-        }
-        if (IsBetterProfile(profile, selected)) {
-            selected = profile;
-        }
-    }
-    
-    OP_LOGD(context_->GetNodeName(), "selected profile: stateOutBufferNum=[%u], attnOutBufferNum=[%u], vStep=[%u], repeatTime=[%u], valid=[%d]",
-            selected.stateOutBufferNum, selected.attnOutBufferNum, selected.vStep, selected.repeatTime, selected.valid);
-
-    if (!selected.valid) {
-        OP_LOGE(context_->GetNodeName(), "vStep should be bigger than 8, shape is too big");
-        return ge::GRAPH_FAILED;
-    }
-    auto stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
-
-    int64_t stateDtypeSize = (stateDtype == ge::DT_FLOAT) ? 4 : 2;
-
-    int64_t queueCoeff = (stateDtypeSize + static_cast<int64_t>(stateDtypeSize * selected.stateOutBufferNum)) * aDk +
-                         static_cast<int64_t>(4 * selected.attnOutBufferNum);
-    int64_t ubRestBytes = ubSize - ubCalcCtx_.fixedUbBytes - queueCoeff * static_cast<int64_t>(selected.vStep);
-    if (ubRestBytes < 0) {
-        OP_LOGE(context_->GetNodeName(), "ubRestBytes should be non-negative, but got %ld", ubRestBytes);
-        return ge::GRAPH_FAILED;
-    }
-    tilingData_.ubCalSize = compileInfo_.ubSize;
-    tilingData_.vStep = selected.vStep;
-    tilingData_.stateOutBufferNum = selected.stateOutBufferNum;
-    tilingData_.attnOutBufferNum = selected.attnOutBufferNum;
-    tilingData_.ubRestBytes = static_cast<uint32_t>(ubRestBytes);
-    return ge::GRAPH_SUCCESS;
-}
-
-// CalUbSize now runs an ordered UB rule-chain with explicit intermediate states.
 ge::graphStatus RecurrentGatedDeltaRuleTiling::CalUbSize()
 {
-    struct RuleItem {
-        const char *name;
-        HostRuleFn fn;
-    };
-    const std::array<RuleItem, 5> ubRules = {{
-        {"RuleInitUbCalcContext", &RecurrentGatedDeltaRuleTiling::RuleInitUbCalcContext},
-        {"RuleCalcFixedUbBytes", &RecurrentGatedDeltaRuleTiling::RuleCalcFixedUbBytes},
-        {"RuleCalcWorkingUbBytes", &RecurrentGatedDeltaRuleTiling::RuleCalcWorkingUbBytes},
-        {"RuleCalcVStepCoeff", &RecurrentGatedDeltaRuleTiling::RuleCalcVStepCoeff},
-        {"RuleFinalizeVStepFromUb", &RecurrentGatedDeltaRuleTiling::RuleFinalizeVStepFromUb},
-    }};
-    for (const auto &rule : ubRules) {
-        OP_CHECK_IF((this->*(rule.fn))() != ge::GRAPH_SUCCESS,
-                    OP_LOGE(inputParams_.opName, "CalUbSize rule failed: %s", rule.name),
-                    return ge::GRAPH_FAILED);
-    }
-    return ge::GRAPH_SUCCESS;
+    RecurrentGatedDeltaRuleTilingProcessor processor(BuildProcessorContext());
+    return processor.ProcessUb(tilingData_);
 }
 
 static ge::graphStatus RecurrentGatedDeltaRuleTilingFunc(gert::TilingContext *context)

--- a/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.h
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.h
@@ -1,10 +1,10 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
- * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- */
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 /*!
  * \file recurrent_gated_delta_rule_tiling.h
@@ -17,6 +17,7 @@
 #include "tiling_base/tiling_base.h"
 #include "err/ops_err.h"
 #include "../op_kernel/recurrent_gated_delta_rule_tiling_data.h"
+#include "recurrent_gated_delta_rule_tiling_processor.h"
 
 namespace optiling {
 using namespace RecurrentGatedDeltaRule;
@@ -45,43 +46,18 @@ protected:
     {
         return true;
     }
-    // 1、获取平台信息比如CoreNum、UB/L1/L0C资源大小
     ge::graphStatus GetPlatformInfo() override;
-    // 2、获取INPUT/OUTPUT/ATTR信息
     ge::graphStatus GetShapeAttrsInfo() override;
-    // 3、计算数据切分TilingData
     ge::graphStatus DoOpTiling() override;
-    // 4、计算高阶API的TilingData
     ge::graphStatus DoLibApiTiling() override;
-    // 5、计算TilingKey
     uint64_t GetTilingKey() const override;
-    // 6、计算Workspace 大小
     ge::graphStatus GetWorkspaceSize() override;
-    // 7、保存Tiling数据
     ge::graphStatus PostTiling() override;
 
 protected:
     void InitCompileInfo();
     void PrintTilingData();
-
-    //Host tiling rule-chain engine: compose shape/UB steps by ordered rules.
-    using HostRuleFn = ge::graphStatus (RecurrentGatedDeltaRuleTiling::*)();
-    struct UbCalcContext {
-        int64_t ubSize = 0;
-        int64_t aNv = 0;
-        int64_t aDv = 0;
-        int64_t aDk = 0;
-        int64_t fixedUbBytes = 0;
-        int64_t workingUbBytes = 0;
-        int64_t coeff = 0;
-    };
-    struct BufferProfile {
-        uint32_t stateOutBufferNum = 1;
-        uint32_t attnOutBufferNum = 1;
-        uint32_t vStep = 0;
-        uint32_t repeatTime = 0;
-        bool valid = false;
-    };
+    RecurrentGatedDeltaRuleTilingContext BuildProcessorContext() const;
 
     ge::graphStatus CheckContext();
     ge::graphStatus AnalyzeDtype();
@@ -90,41 +66,11 @@ protected:
     ge::graphStatus GetScale();
     ge::graphStatus GetOptionalInput();
     ge::graphStatus AnalyzeFormat();
-    //Host tiling refactor helpers: split shape validation/fill and UB calculation.
-    ge::graphStatus CheckShapeDimAndRelation(const gert::Shape &queryShape, const gert::Shape &keyShape,
-                                             const gert::Shape &valueShape, const gert::Shape &betaShape,
-                                             const gert::Shape &stateShape, const gert::Shape &cuSeqlensShape,
-                                             const gert::Shape &ssmStateShape);
-    void FillTilingShapeData(const gert::Shape &queryShape, const gert::Shape &valueShape, const gert::Shape &stateShape,
-                             const gert::Shape &cuSeqlensShape);
-    ge::graphStatus CheckShapeValueRangeAndRule();
-    void UpdateDynamicBlockDimByTaskUnits();
-    int64_t CalcFixedUbBytes(int64_t aNv, int64_t aDv, int64_t aDk) const;
-    int64_t CalcWorkingUbBytes(int64_t aNv, int64_t aDv, int64_t aDk) const;
-    int64_t CalcVStepCoeff(int64_t aDk, uint32_t stateOutBufferNum, uint32_t attnOutBufferNum) const;
-    bool EvaluateBufferProfile(int64_t ubSize, int64_t usedUbBytes, int64_t aDk, uint32_t stateOutBufferNum,
-                               uint32_t attnOutBufferNum, BufferProfile &profile) const;
-    bool IsBetterProfile(const BufferProfile &candidate, const BufferProfile &current) const;
-    ge::graphStatus FinalizeVStepFromUb(int64_t ubSize, int64_t usedUbBytes, int64_t coeff);
-    ge::graphStatus RuleCheckShapeDimAndRelation();
-    ge::graphStatus RuleFillTilingShapeData();
-    ge::graphStatus RuleCheckShapeValueRangeAndRule();
-    ge::graphStatus RuleUpdateDynamicBlockDimByTaskUnits();
-    ge::graphStatus RuleInitUbCalcContext();
-    ge::graphStatus RuleCalcFixedUbBytes();
-    ge::graphStatus RuleCalcWorkingUbBytes();
-    ge::graphStatus RuleCalcVStepCoeff();
-    ge::graphStatus RuleFinalizeVStepFromUb();
-
-    bool CheckDimEqual(const gert::Shape a, const int64_t dimA, gert::Shape b, const int64_t dimB, const std::string &nameA,
-                       const std::string &nameB, const std::string &dimDesc);
-    bool CheckDim(const gert::Shape shape, const size_t dim, const std::string &dimDesc);
     bool CheckFormat(ge::Format format, const std::string &Desc);
 
     RecurrentGatedDeltaRuleCompileInfo compileInfo_;
     RecurrentGatedDeltaRuleTilingData tilingData_;
     RecurrentGatedDeltaRuleInfo inputParams_;
-    UbCalcContext ubCalcCtx_;
 };
 
 } // namespace optiling

--- a/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling_processor.h
@@ -1,0 +1,427 @@
+/**
+ * Copyright (c) 2025-2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file recurrent_gated_delta_rule_tiling_processor.h
+ * \brief Tiling processor shared by aclnn tiling and fast kernel launch.
+ */
+
+#ifndef RECURRENT_GATED_DELTA_RULE_TILING_PROCESSOR_H
+#define RECURRENT_GATED_DELTA_RULE_TILING_PROCESSOR_H
+
+#include "../op_kernel/recurrent_gated_delta_rule_struct.h"
+#include "err/ops_err.h"
+#include "log/log.h"
+#include "register/op_impl_registry.h"
+#include "tiling/tiling_api.h"
+#include "util/math_util.h"
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+using RecurrentGatedDeltaRuleTilingData = RecurrentGatedDeltaRule::RecurrentGatedDeltaRuleTilingData;
+
+namespace optiling {
+
+static constexpr size_t RGDR_QKV_DIM_NUM = 3;
+static constexpr size_t RGDR_BETA_DIM_NUM = 2;
+static constexpr size_t RGDR_STATE_DIM_NUM = 4;
+static constexpr size_t RGDR_CUSEQLENS_DIM_NUM = 1;
+static constexpr size_t RGDR_SSM_STATE_INDICES_DIM_NUM = 1;
+
+static constexpr size_t RGDR_DIM_0 = 0;
+static constexpr size_t RGDR_DIM_1 = 1;
+static constexpr size_t RGDR_DIM_2 = 2;
+static constexpr size_t RGDR_DIM_3 = 3;
+
+static constexpr size_t RGDR_MAX_MTP = 8;
+static constexpr size_t RGDR_SYS_WORKSPACE_SIZE = 16U * 1024U * 1024U;
+
+struct RecurrentGatedDeltaRuleTilingContext {
+    const char *nodeName = "RecurrentGatedDeltaRule";
+    const gert::Shape *queryShape = nullptr;
+    const gert::Shape *keyShape = nullptr;
+    const gert::Shape *valueShape = nullptr;
+    const gert::Shape *betaShape = nullptr;
+    const gert::Shape *stateShape = nullptr;
+    const gert::Shape *cuSeqlensShape = nullptr;
+    const gert::Shape *ssmStateShape = nullptr;
+    float scale = 1.0f;
+    uint32_t hasGama = 0;
+    uint32_t hasGamaK = 0;
+    uint32_t hasAcceptedTokens = 0;
+    ge::DataType stateDtype = ge::DT_BF16;
+    uint64_t aivNum = 0;
+    uint64_t ubSize = 0;
+};
+
+class RecurrentGatedDeltaRuleTilingProcessor {
+public:
+    explicit RecurrentGatedDeltaRuleTilingProcessor(const RecurrentGatedDeltaRuleTilingContext &ctx) : ctx_(ctx) {}
+
+    ge::graphStatus ProcessShapes(RecurrentGatedDeltaRuleTilingData &tiling) const
+    {
+        tiling.vectorCoreNum = static_cast<uint32_t>(ctx_.aivNum);
+
+        struct RuleItem {
+            const char *name;
+            ge::graphStatus (RecurrentGatedDeltaRuleTilingProcessor::*fn)(RecurrentGatedDeltaRuleTilingData &) const;
+        };
+        const std::array<RuleItem, 4> shapeRules = {{
+            {"RuleCheckShapeDimAndRelation", &RecurrentGatedDeltaRuleTilingProcessor::RuleCheckShapeDimAndRelation},
+            {"RuleFillTilingShapeData", &RecurrentGatedDeltaRuleTilingProcessor::RuleFillTilingShapeData},
+            {"RuleCheckShapeValueRangeAndRule", &RecurrentGatedDeltaRuleTilingProcessor::RuleCheckShapeValueRangeAndRule},
+            {"RuleUpdateDynamicBlockDimByTaskUnits", &RecurrentGatedDeltaRuleTilingProcessor::RuleUpdateDynamicBlockDimByTaskUnits},
+        }};
+        for (const auto &rule : shapeRules) {
+            OP_CHECK_IF((this->*(rule.fn))(tiling) != ge::GRAPH_SUCCESS,
+                        OP_LOGE(ctx_.nodeName, "ProcessShapes rule failed: %s", rule.name),
+                        return ge::GRAPH_FAILED);
+        }
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus ProcessUb(RecurrentGatedDeltaRuleTilingData &tiling) const
+    {
+        struct RuleItem {
+            const char *name;
+            ge::graphStatus (RecurrentGatedDeltaRuleTilingProcessor::*fn)(RecurrentGatedDeltaRuleTilingData &,
+                                                                          UbCalcContext &) const;
+        };
+        UbCalcContext ubCalcCtx;
+        const std::array<RuleItem, 5> ubRules = {{
+            {"RuleInitUbCalcContext", &RecurrentGatedDeltaRuleTilingProcessor::RuleInitUbCalcContext},
+            {"RuleCalcFixedUbBytes", &RecurrentGatedDeltaRuleTilingProcessor::RuleCalcFixedUbBytes},
+            {"RuleCalcWorkingUbBytes", &RecurrentGatedDeltaRuleTilingProcessor::RuleCalcWorkingUbBytes},
+            {"RuleCalcVStepCoeff", &RecurrentGatedDeltaRuleTilingProcessor::RuleCalcVStepCoeff},
+            {"RuleFinalizeVStepFromUb", &RecurrentGatedDeltaRuleTilingProcessor::RuleFinalizeVStepFromUb},
+        }};
+        for (const auto &rule : ubRules) {
+            OP_CHECK_IF((this->*(rule.fn))(tiling, ubCalcCtx) != ge::GRAPH_SUCCESS,
+                        OP_LOGE(ctx_.nodeName, "ProcessUb rule failed: %s", rule.name),
+                        return ge::GRAPH_FAILED);
+        }
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus Process(RecurrentGatedDeltaRuleTilingData &tiling, uint32_t &blockDim, size_t &workspaceSize) const
+    {
+        OP_CHECK_IF(ProcessShapes(tiling) != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+
+        tiling.scale = ctx_.scale;
+        tiling.hasGama = ctx_.hasGama;
+        tiling.hasGamaK = ctx_.hasGamaK;
+        tiling.hasAcceptedTokens = ctx_.hasAcceptedTokens;
+
+        OP_CHECK_IF(ProcessUb(tiling) != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+
+        blockDim = tiling.vectorCoreNum;
+        workspaceSize = RGDR_SYS_WORKSPACE_SIZE;
+        return ge::GRAPH_SUCCESS;
+    }
+
+private:
+    struct UbCalcContext {
+        int64_t ubSize = 0;
+        int64_t aNv = 0;
+        int64_t aDv = 0;
+        int64_t aDk = 0;
+        int64_t fixedUbBytes = 0;
+        int64_t workingUbBytes = 0;
+        int64_t coeff = 0;
+    };
+
+    struct BufferProfile {
+        uint32_t stateOutBufferNum = 1;
+        uint32_t attnOutBufferNum = 1;
+        uint32_t vStep = 0;
+        uint32_t repeatTime = 0;
+        bool valid = false;
+    };
+
+    const RecurrentGatedDeltaRuleTilingContext &ctx_;
+
+    bool CheckDimEqual(const gert::Shape a, const int64_t dimA, gert::Shape b, const int64_t dimB,
+                       const std::string &nameA, const std::string &nameB, const std::string &dimDesc) const
+    {
+        if (a.GetDim(dimA) != b.GetDim(dimB)) {
+            OP_LOGE(ctx_.nodeName, "The %s of %s and %s should be the same, but %s is %ld while %s is %ld",
+                    dimDesc.c_str(), nameA.c_str(), nameB.c_str(), nameA.c_str(), a.GetDim(dimA), nameB.c_str(),
+                    b.GetDim(dimB));
+            return false;
+        }
+        return true;
+    }
+
+    bool CheckDim(const gert::Shape shape, const size_t dim, const std::string &dimDesc) const
+    {
+        if (shape.GetDimNum() != dim) {
+            OP_LOGE(ctx_.nodeName, "The number of dimensons of %s should be %zu, but it is %zu", dimDesc.c_str(), dim,
+                    shape.GetDimNum());
+            return false;
+        }
+        return true;
+    }
+
+    ge::graphStatus CheckShapeDimAndRelation(const gert::Shape &queryShape, const gert::Shape &keyShape,
+                                             const gert::Shape &valueShape, const gert::Shape &betaShape,
+                                             const gert::Shape &stateShape, const gert::Shape &cuSeqlensShape,
+                                             const gert::Shape &ssmStateShape) const
+    {
+        if (!CheckDim(queryShape, RGDR_QKV_DIM_NUM, "query") || !CheckDim(keyShape, RGDR_QKV_DIM_NUM, "key") ||
+            !CheckDim(valueShape, RGDR_QKV_DIM_NUM, "value") || !CheckDim(betaShape, RGDR_BETA_DIM_NUM, "beta") ||
+            !CheckDim(stateShape, RGDR_STATE_DIM_NUM, "state") ||
+            !CheckDim(cuSeqlensShape, RGDR_CUSEQLENS_DIM_NUM, "actual_seq_lengths") ||
+            !CheckDim(ssmStateShape, RGDR_SSM_STATE_INDICES_DIM_NUM, "ssm_state_indices")) {
+            return ge::GRAPH_FAILED;
+        }
+
+        if (!CheckDimEqual(queryShape, RGDR_DIM_0, keyShape, RGDR_DIM_0, "query", "key", "T dimension") ||
+            !CheckDimEqual(queryShape, RGDR_DIM_1, keyShape, RGDR_DIM_1, "query", "key", "Nk dimension") ||
+            !CheckDimEqual(queryShape, RGDR_DIM_2, keyShape, RGDR_DIM_2, "query", "key", "Dk dimension") ||
+            !CheckDimEqual(stateShape, RGDR_DIM_1, valueShape, RGDR_DIM_1, "state", "value", "Nv dimension") ||
+            !CheckDimEqual(stateShape, RGDR_DIM_2, valueShape, RGDR_DIM_2, "state", "value", "Dv dimension") ||
+            !CheckDimEqual(valueShape, RGDR_DIM_0, queryShape, RGDR_DIM_0, "value", "query", "T dimension") ||
+            !CheckDimEqual(betaShape, RGDR_DIM_0, queryShape, RGDR_DIM_0, "beta", "query", "T dimension") ||
+            !CheckDimEqual(betaShape, RGDR_DIM_1, valueShape, RGDR_DIM_1, "beta", "value", "Nv dimension") ||
+            !CheckDimEqual(stateShape, RGDR_DIM_3, queryShape, RGDR_DIM_2, "state", "query", "Dk dimension")) {
+            return ge::GRAPH_FAILED;
+        }
+
+        return ge::GRAPH_SUCCESS;
+    }
+
+    void FillTilingShapeData(const gert::Shape &queryShape, const gert::Shape &valueShape, const gert::Shape &stateShape,
+                             const gert::Shape &cuSeqlensShape, RecurrentGatedDeltaRuleTilingData &tiling) const
+    {
+        tiling.t = static_cast<uint32_t>(queryShape.GetDim(RGDR_DIM_0));
+        tiling.nk = static_cast<uint32_t>(queryShape.GetDim(RGDR_DIM_1));
+        tiling.dk = static_cast<uint32_t>(queryShape.GetDim(RGDR_DIM_2));
+        tiling.nv = static_cast<uint32_t>(valueShape.GetDim(RGDR_DIM_1));
+        tiling.dv = static_cast<uint32_t>(valueShape.GetDim(RGDR_DIM_2));
+        tiling.sBlockNum = static_cast<uint32_t>(stateShape.GetDim(RGDR_DIM_0));
+        tiling.b = static_cast<uint32_t>(cuSeqlensShape.GetDim(RGDR_DIM_0) - 1);
+    }
+
+    ge::graphStatus CheckShapeValueRangeAndRule(const RecurrentGatedDeltaRuleTilingData &tiling) const
+    {
+        OP_CHECK_IF(tiling.nk > 256 || tiling.nv > 256 || tiling.dk > 512 || tiling.dv > 512,
+                    OP_LOGE(ctx_.nodeName,
+                            "nk and nv should no bigger than 256, dk and dv should no bigger than 512, but nk is %u, "
+                            "nv is %u, dk is %u, dv is %u",
+                            tiling.nk, tiling.nv, tiling.dk, tiling.dv),
+                    return ge::GRAPH_FAILED);
+
+        OP_CHECK_IF(tiling.nv % tiling.nk != 0,
+                    OP_LOGE(ctx_.nodeName, "nv should be an integer multiple of nk, but nv is %u, nk is %u", tiling.nv,
+                            tiling.nk),
+                    return ge::GRAPH_FAILED);
+
+        return ge::GRAPH_SUCCESS;
+    }
+
+    void UpdateDynamicBlockDimByTaskUnits(RecurrentGatedDeltaRuleTilingData &tiling) const
+    {
+        uint64_t taskUnits = static_cast<uint64_t>(tiling.b) * static_cast<uint64_t>(tiling.nv);
+        if (taskUnits == 0) {
+            taskUnits = 1;
+        }
+        uint64_t maxCoreNum = (ctx_.aivNum > 0) ? ctx_.aivNum : 1;
+        uint64_t selectedCoreNum = (taskUnits < maxCoreNum) ? taskUnits : maxCoreNum;
+        tiling.vectorCoreNum = static_cast<uint32_t>(selectedCoreNum);
+        OP_LOGD(ctx_.nodeName, "taskUnits: [%llu], selected vectorCoreNum: [%u]",
+                static_cast<unsigned long long>(taskUnits), tiling.vectorCoreNum);
+    }
+
+    ge::graphStatus RuleCheckShapeDimAndRelation(RecurrentGatedDeltaRuleTilingData &tiling) const
+    {
+        (void)tiling;
+        OP_CHECK_IF(ctx_.queryShape == nullptr || ctx_.keyShape == nullptr || ctx_.valueShape == nullptr ||
+                        ctx_.betaShape == nullptr || ctx_.stateShape == nullptr || ctx_.cuSeqlensShape == nullptr ||
+                        ctx_.ssmStateShape == nullptr,
+                    OP_LOGE(ctx_.nodeName, "Required shape pointer is null."), return ge::GRAPH_FAILED);
+        return CheckShapeDimAndRelation(*ctx_.queryShape, *ctx_.keyShape, *ctx_.valueShape, *ctx_.betaShape,
+                                        *ctx_.stateShape, *ctx_.cuSeqlensShape, *ctx_.ssmStateShape);
+    }
+
+    ge::graphStatus RuleFillTilingShapeData(RecurrentGatedDeltaRuleTilingData &tiling) const
+    {
+        (void)tiling;
+        FillTilingShapeData(*ctx_.queryShape, *ctx_.valueShape, *ctx_.stateShape, *ctx_.cuSeqlensShape, tiling);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus RuleCheckShapeValueRangeAndRule(RecurrentGatedDeltaRuleTilingData &tiling) const
+    {
+        return CheckShapeValueRangeAndRule(tiling);
+    }
+
+    ge::graphStatus RuleUpdateDynamicBlockDimByTaskUnits(RecurrentGatedDeltaRuleTilingData &tiling) const
+    {
+        UpdateDynamicBlockDimByTaskUnits(tiling);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    int64_t CalcFixedUbBytes(int64_t aNv, int64_t aDv, int64_t aDk, const RecurrentGatedDeltaRuleTilingData &tiling) const
+    {
+        int64_t usedUbBytes = RGDR_MAX_MTP * (4 * aDk + 2 * aDv);
+        usedUbBytes += 128;
+        if (tiling.hasGamaK) {
+            usedUbBytes += RGDR_MAX_MTP * 4 * aDk;
+        }
+        if (tiling.hasGama) {
+            usedUbBytes += RGDR_MAX_MTP * 4 * aNv;
+        }
+        usedUbBytes += RGDR_MAX_MTP * 2 * aNv;
+        return usedUbBytes;
+    }
+
+    int64_t CalcWorkingUbBytes(int64_t aNv, int64_t aDv, int64_t aDk,
+                               const RecurrentGatedDeltaRuleTilingData &tiling) const
+    {
+        int64_t usedUbBytes = CalcFixedUbBytes(aNv, aDv, aDk, tiling);
+        usedUbBytes += RGDR_MAX_MTP * (8 * aDk + 4 * aDv + 4 * aNv);
+        return usedUbBytes;
+    }
+
+    int64_t CalcVStepCoeff(int64_t aDk, uint32_t stateOutBufferNum, uint32_t attnOutBufferNum) const
+    {
+        int64_t stateDtypeSize = (ctx_.stateDtype == ge::DT_FLOAT) ? 4 : 2;
+        int64_t coeff = (stateDtypeSize + static_cast<int64_t>(stateDtypeSize * stateOutBufferNum)) * aDk +
+                        static_cast<int64_t>(4 * attnOutBufferNum);
+        coeff += (4 + 4) * aDk + 4 + 4;
+        return coeff;
+    }
+
+    bool EvaluateBufferProfile(int64_t ubSize, int64_t usedUbBytes, int64_t aDk, uint32_t stateOutBufferNum,
+                               uint32_t attnOutBufferNum, const RecurrentGatedDeltaRuleTilingData &tiling,
+                               BufferProfile &profile) const
+    {
+        int64_t coeff = CalcVStepCoeff(aDk, stateOutBufferNum, attnOutBufferNum);
+        int64_t vStep = (ubSize - usedUbBytes) / coeff / 8 * 8;
+        if (vStep < 8) {
+            return false;
+        }
+        int64_t repeatTime = Ops::Base::CeilDiv(tiling.dv, static_cast<uint32_t>(vStep));
+        vStep = Ops::Base::CeilAlign(Ops::Base::CeilDiv(tiling.dv, static_cast<uint32_t>(repeatTime)),
+                                     static_cast<uint32_t>(8));
+        if (vStep < 8) {
+            return false;
+        }
+        profile.stateOutBufferNum = stateOutBufferNum;
+        profile.attnOutBufferNum = attnOutBufferNum;
+        profile.vStep = static_cast<uint32_t>(vStep);
+        profile.repeatTime = static_cast<uint32_t>(repeatTime);
+        profile.valid = true;
+        return true;
+    }
+
+    bool IsBetterProfile(const BufferProfile &candidate, const BufferProfile &current) const
+    {
+        if (!current.valid) {
+            return true;
+        }
+        if (candidate.repeatTime != current.repeatTime) {
+            return candidate.repeatTime < current.repeatTime;
+        }
+        uint32_t candidateDepth = candidate.stateOutBufferNum + candidate.attnOutBufferNum;
+        uint32_t currentDepth = current.stateOutBufferNum + current.attnOutBufferNum;
+        if (candidateDepth != currentDepth) {
+            return candidateDepth > currentDepth;
+        }
+        return candidate.vStep > current.vStep;
+    }
+
+    ge::graphStatus FinalizeVStepFromUb(int64_t ubSize, int64_t usedUbBytes, int64_t coeff,
+                                        RecurrentGatedDeltaRuleTilingData &tiling, UbCalcContext &ubCalcCtx) const
+    {
+        (void)coeff;
+        int64_t aDk = Ops::Base::CeilAlign(tiling.dk, static_cast<uint32_t>(16));
+        BufferProfile selected;
+        const std::array<BufferProfile, 3> candidates = {{
+            {1, 1, 0, 0, false},
+            {1, 2, 0, 0, false},
+            {2, 2, 0, 0, false},
+        }};
+        for (const auto &candidate : candidates) {
+            BufferProfile profile;
+            if (!EvaluateBufferProfile(ubSize, usedUbBytes, aDk, candidate.stateOutBufferNum, candidate.attnOutBufferNum,
+                                       tiling, profile)) {
+                continue;
+            }
+            if (IsBetterProfile(profile, selected)) {
+                selected = profile;
+            }
+        }
+
+        OP_LOGD(ctx_.nodeName,
+                "selected profile: stateOutBufferNum=[%u], attnOutBufferNum=[%u], vStep=[%u], repeatTime=[%u], "
+                "valid=[%d]",
+                selected.stateOutBufferNum, selected.attnOutBufferNum, selected.vStep, selected.repeatTime,
+                selected.valid);
+
+        if (!selected.valid) {
+            OP_LOGE(ctx_.nodeName, "vStep should be bigger than 8, shape is too big");
+            return ge::GRAPH_FAILED;
+        }
+
+        int64_t stateDtypeSize = (ctx_.stateDtype == ge::DT_FLOAT) ? 4 : 2;
+        int64_t queueCoeff = (stateDtypeSize + static_cast<int64_t>(stateDtypeSize * selected.stateOutBufferNum)) * aDk +
+                             static_cast<int64_t>(4 * selected.attnOutBufferNum);
+        int64_t ubRestBytes = ubSize - ubCalcCtx.fixedUbBytes - queueCoeff * static_cast<int64_t>(selected.vStep);
+        if (ubRestBytes < 0) {
+            OP_LOGE(ctx_.nodeName, "ubRestBytes should be non-negative, but got %ld", ubRestBytes);
+            return ge::GRAPH_FAILED;
+        }
+        tiling.ubCalSize = static_cast<uint32_t>(ctx_.ubSize);
+        tiling.vStep = selected.vStep;
+        tiling.stateOutBufferNum = selected.stateOutBufferNum;
+        tiling.attnOutBufferNum = selected.attnOutBufferNum;
+        tiling.ubRestBytes = static_cast<uint32_t>(ubRestBytes);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus RuleInitUbCalcContext(RecurrentGatedDeltaRuleTilingData &tiling, UbCalcContext &ubCalcCtx) const
+    {
+        ubCalcCtx.ubSize = static_cast<int64_t>(ctx_.ubSize);
+        ubCalcCtx.aNv = Ops::Base::CeilAlign(tiling.nv, static_cast<uint32_t>(16));
+        ubCalcCtx.aDv = Ops::Base::CeilAlign(tiling.dv, static_cast<uint32_t>(16));
+        ubCalcCtx.aDk = Ops::Base::CeilAlign(tiling.dk, static_cast<uint32_t>(16));
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus RuleCalcFixedUbBytes(RecurrentGatedDeltaRuleTilingData &tiling, UbCalcContext &ubCalcCtx) const
+    {
+        ubCalcCtx.fixedUbBytes = CalcFixedUbBytes(ubCalcCtx.aNv, ubCalcCtx.aDv, ubCalcCtx.aDk, tiling);
+        tiling.ubRestBytes = static_cast<uint32_t>(ubCalcCtx.ubSize - ubCalcCtx.fixedUbBytes);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus RuleCalcWorkingUbBytes(RecurrentGatedDeltaRuleTilingData &tiling, UbCalcContext &ubCalcCtx) const
+    {
+        ubCalcCtx.workingUbBytes = CalcWorkingUbBytes(ubCalcCtx.aNv, ubCalcCtx.aDv, ubCalcCtx.aDk, tiling);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus RuleCalcVStepCoeff(RecurrentGatedDeltaRuleTilingData &tiling, UbCalcContext &ubCalcCtx) const
+    {
+        (void)tiling;
+        ubCalcCtx.coeff = CalcVStepCoeff(ubCalcCtx.aDk, 1, 1);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus RuleFinalizeVStepFromUb(RecurrentGatedDeltaRuleTilingData &tiling, UbCalcContext &ubCalcCtx) const
+    {
+        return FinalizeVStepFromUb(ubCalcCtx.ubSize, ubCalcCtx.workingUbBytes, ubCalcCtx.coeff, tiling, ubCalcCtx);
+    }
+};
+
+} // namespace optiling
+
+#endif // RECURRENT_GATED_DELTA_RULE_TILING_PROCESSOR_H

--- a/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule_struct.h
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule_struct.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2025-2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file recurrent_gated_delta_rule_struct.h
+ * \brief Plain tiling struct shared by aclnn tiling and fast kernel launch.
+ */
+
+#ifndef RECURRENT_GATED_DELTA_RULE_STRUCT_H
+#define RECURRENT_GATED_DELTA_RULE_STRUCT_H
+
+#include <cstdint>
+
+namespace RecurrentGatedDeltaRule {
+
+#pragma pack(push, 8)
+struct alignas(8) RecurrentGatedDeltaRuleTilingData {
+    uint32_t vectorCoreNum;
+    uint32_t ubCalSize;
+    uint32_t ubRestBytes;
+    uint32_t t;
+    uint32_t nk;
+    uint32_t dk;
+    uint32_t nv;
+    uint32_t dv;
+    uint32_t sBlockNum;
+    uint32_t b;
+    uint32_t vStep;
+    uint32_t stateOutBufferNum;
+    uint32_t attnOutBufferNum;
+    float scale;
+    uint32_t hasGama;
+    uint32_t hasGamaK;
+    uint32_t hasAcceptedTokens;
+};
+#pragma pack(pop)
+
+} // namespace RecurrentGatedDeltaRule
+
+#endif // RECURRENT_GATED_DELTA_RULE_STRUCT_H

--- a/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule_tiling_data.h
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule_tiling_data.h
@@ -1,42 +1,22 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
- * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- */
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 /*!
- * \file recurrent_gated_delta_rule.cpp
+ * \file recurrent_gated_delta_rule_tiling_data.h
  * \brief
  */
 #ifndef RECURRENT_GATED_DELTA_RULE_TILING_DATA_H
 #define RECURRENT_GATED_DELTA_RULE_TILING_DATA_H
 
-#include "kernel_tiling/kernel_tiling.h"
+#include "recurrent_gated_delta_rule_struct.h"
 
-namespace RecurrentGatedDeltaRule {
-#pragma pack(push, 8)
-struct alignas(8) RecurrentGatedDeltaRuleTilingData { // alignas(8)确保8字节对齐
-    uint32_t vectorCoreNum;
-    uint32_t ubCalSize;
-    uint32_t ubRestBytes;
-    uint32_t t;
-    uint32_t nk;
-    uint32_t dk;
-    uint32_t nv;
-    uint32_t dv;
-    uint32_t sBlockNum;
-    uint32_t b;
-    uint32_t vStep;
-    uint32_t stateOutBufferNum;
-    uint32_t attnOutBufferNum;
-    float scale;
-    uint32_t hasGama;
-    uint32_t hasGamaK;
-    uint32_t hasAcceptedTokens;
-};
-#pragma pack(pop)
-} // RecurrentGatedDeltaRule
+#ifndef TORCH_MODE
+#include "kernel_tiling/kernel_tiling.h"
+#endif
 
 #endif // RECURRENT_GATED_DELTA_RULE_TILING_DATA_H

--- a/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/tests/pta/golden.py
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/tests/pta/golden.py
@@ -1,0 +1,99 @@
+"""
+CPU reference (golden) implementation for recurrent_gated_delta_rule.
+
+Mathematical formula:
+  S_t := alpha_t * S_{t-1} + beta_t * (v_t - alpha_t * S_{t-1} @ k_t) @ k_t^T
+  o_t := S_t @ q_t * scale
+
+Where alpha_t = exp(g_t).
+"""
+import torch
+from typing import Optional, Tuple
+
+
+def recurrent_gated_delta_rule_golden(
+    query: torch.Tensor,             # [T, NK, dk]  bf16
+    key: torch.Tensor,               # [T, NK, dk]  bf16
+    value: torch.Tensor,             # [T, NV, dv]  bf16
+    state: torch.Tensor,             # [T, NV, dv, dk]  bf16
+    beta: torch.Tensor,              # [T, NV]  bf16
+    scale: float,
+    actual_seq_lengths: torch.Tensor, # [B]  int32
+    ssm_state_indices: torch.Tensor,  # [T]  int32
+    num_accepted_tokens: Optional[torch.Tensor] = None,  # [B] int32
+    g: Optional[torch.Tensor] = None,   # [T, NV] fp32
+    gk: Optional[torch.Tensor] = None,  # [T, NK, dk] fp32
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Returns:
+        attn_out:    [T, NV, dv]     bf16
+        final_state: [T, NV, dv, dk] bf16
+    """
+    T, NK, dk = query.shape
+    _, NV, dv = value.shape
+    B = actual_seq_lengths.shape[0]
+
+    # Cast all to float32 for precision
+    q_f = query.float() * scale
+    k_f = key.float()
+    v_f = value.float()
+    beta_f = beta.float()
+    state_f = state.float()
+
+    alpha = torch.exp(g.float()) if g is not None else None
+    alpha_k = torch.exp(gk.float()) if gk is not None else None
+
+    attn_out = torch.zeros(T, NV, dv, dtype=torch.float32)
+    final_state = state_f.clone()
+
+    seq_ptr = int(actual_seq_lengths[0].item())
+    for b in range(1, B):
+        seq_len = int(actual_seq_lengths[b].item())
+        seq0 = seq_ptr
+        seq1 = seq0 + seq_len
+        seq_ptr = seq1
+
+        # Determine which state position to load as initial state
+        state_token_idx = seq0
+        if num_accepted_tokens is not None:
+            accepted = int(num_accepted_tokens[b-1].item())
+            state_token_idx = seq0 + accepted - 1
+
+        state_offset = int(ssm_state_indices[state_token_idx].item())
+
+        for h_v in range(NV):
+            h_k = h_v // (NV // NK)
+
+            # Load initial state for this head: [dv, dk]
+            S = final_state[state_offset, h_v].clone()
+
+            for seq_i in range(seq0, seq1):
+                q_h = q_f[seq_i, h_k]       # [dk]
+                k_h = k_f[seq_i, h_k]       # [dk]
+                v_h = v_f[seq_i, h_v]       # [dv]
+                b_h = beta_f[seq_i, h_v]    # scalar
+
+                # Apply gama decay
+                if alpha is not None:
+                    S = S * alpha[seq_i, h_v]
+
+                # Apply gamaK decay (element-wise along dk dimension)
+                if alpha_k is not None:
+                    S = S * alpha_k[seq_i, h_v].unsqueeze(0)
+
+                # delta = v - S @ k
+                Sk = torch.mv(S, k_h)       # [dv]
+                delta = v_h - Sk
+                delta = delta * b_h
+
+                # Rank-1 update: S += delta * k^T
+                S = S + torch.outer(delta, k_h)
+
+                # Attention output: o = S @ q_scaled
+                attn = torch.mv(S, q_h)     # [dv]
+
+                # Store
+                attn_out[seq_i, h_v] = attn
+                final_state[int(ssm_state_indices[seq_i].item()), h_v] = S
+
+    return attn_out.to(torch.bfloat16), final_state.to(torch.bfloat16)

--- a/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/tests/pta/test_accuracy.py
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/tests/pta/test_accuracy.py
@@ -1,0 +1,182 @@
+"""
+Accuracy test for npu_recurrent_gated_delta_rule.
+
+Compares NPU output against CPU golden reference.
+Tests multiple parameter combinations.
+"""
+import sys
+import torch
+import torch_npu
+
+from golden import recurrent_gated_delta_rule_golden
+from utils import compare_tensors_by_ratio
+
+
+def make_inputs(bs, mtp, nk, nv, dk, dv, use_g=True, use_gk=False,
+                use_accepted_tokens=False, seed=42):
+    """Generate inputs on CPU, matching the kernel's expected shapes."""
+    torch.manual_seed(seed)
+    star_idx = 1
+    star_idx_tensor = torch.tensor([star_idx], dtype=torch.int32)
+    batch_tensor = torch.ones(bs, dtype=torch.int32) * mtp
+    actual_seq_lengths = torch.cat([star_idx_tensor, batch_tensor])
+    t = int(actual_seq_lengths.sum().item())
+
+    state = torch.rand((t, nv, dv, dk), dtype=torch.float)
+    query = torch.nn.functional.normalize(
+        torch.rand((t, nk, dk), dtype=torch.bfloat16), p=2, dim=-1
+    )
+    key = torch.nn.functional.normalize(
+        torch.rand((t, nk, dk), dtype=torch.bfloat16), p=2, dim=-1
+    )
+    value = torch.rand((t, nv, dv), dtype=torch.bfloat16)
+    beta = torch.rand((t, nv), dtype=torch.bfloat16)
+    scale = dk ** -0.5
+
+    ssm_state_indices = torch.arange(t, dtype=torch.int32)
+
+    g = None
+    if use_g:
+        g = -torch.rand((t, nv), dtype=torch.float32)
+
+    gk = None
+    if use_gk:
+        gk = -torch.rand((t, nv, dk), dtype=torch.float32)
+
+    num_accepted_tokens = None
+    if use_accepted_tokens and mtp > 1:
+        num_accepted_tokens = torch.randint(1, mtp + 1, (bs,), dtype=torch.int32)
+
+    return {
+        "query": query,
+        "key": key,
+        "value": value,
+        "state": state,
+        "beta": beta,
+        "scale": scale,
+        "actual_seq_lengths": actual_seq_lengths,
+        "ssm_state_indices": ssm_state_indices,
+        "num_accepted_tokens": num_accepted_tokens,
+        "g": g,
+        "gk": gk,
+    }
+
+
+def run_golden(inp):
+    """Run CPU golden implementation."""
+    return recurrent_gated_delta_rule_golden(
+        query=inp["query"],
+        key=inp["key"],
+        value=inp["value"],
+        state=inp["state"].clone(),
+        beta=inp["beta"],
+        scale=inp["scale"],
+        actual_seq_lengths=inp["actual_seq_lengths"],
+        ssm_state_indices=inp["ssm_state_indices"],
+        num_accepted_tokens=inp["num_accepted_tokens"],
+        g=inp["g"],
+        gk=inp["gk"],
+    )
+
+
+def run_npu(inp, device):
+    """Run NPU operator."""
+    print("start run npu")
+    q_npu = inp["query"].npu()
+    k_npu = inp["key"].npu()
+    v_npu = inp["value"].npu()
+    s_npu = inp["state"].clone().npu()
+    b_npu = inp["beta"].npu()
+    asl_npu = inp["actual_seq_lengths"].npu()
+    ssi_npu = inp["ssm_state_indices"].npu()
+    print("start run npu_recurrent_gated_delta_rule")
+
+    g_npu = inp["g"].to(device) if inp["g"] is not None else None
+    gk_npu = inp["gk"].to(device) if inp["gk"] is not None else None
+    nat_npu = inp["num_accepted_tokens"].to(device) if inp["num_accepted_tokens"] is not None else None
+    
+    print("start run npu_recurrent_gated_delta_rule")
+
+    result = torch_npu.npu_recurrent_gated_delta_rule(
+        q_npu, k_npu, v_npu, s_npu,
+        beta=b_npu,
+        scale=inp["scale"],
+        actual_seq_lengths=asl_npu,
+        ssm_state_indices=ssi_npu,
+        num_accepted_tokens=nat_npu,
+        g=g_npu,
+        gk=gk_npu,
+    )
+    torch_npu.npu.synchronize()
+
+    # result is (attn_out, final_state)
+    if isinstance(result, (tuple, list)):
+        attn_out = result[0].cpu()
+        final_state = result[1].cpu()
+    else:
+        attn_out = result.cpu()
+        final_state = s_npu.cpu()
+    attn_out[:asl_npu[0]] = 0
+    return attn_out, final_state
+
+
+def run_test_case(desc, bs, mtp, nk, nv, dk, dv, device,
+                  use_g=True, use_gk=False, use_accepted_tokens=False,
+                  seed=42, rtol=0.01, atol=0.004):
+    """Run a single test case and report result."""
+    print(f"\n{'='*60}")
+    print(f"TEST: {desc}")
+    print(f"  bs={bs}, mtp={mtp}, nk={nk}, nv={nv}, dk={dk}, dv={dv}")
+    print(f"  use_g={use_g}, use_gk={use_gk}, use_accepted_tokens={use_accepted_tokens}")
+    print(f"  seed={seed}, rtol={rtol}, atol={atol}")
+    print(f"{'='*60}")
+
+    inp = make_inputs(bs, mtp, nk, nv, dk, dv,
+                      use_g=use_g, use_gk=use_gk,
+                      use_accepted_tokens=use_accepted_tokens, seed=seed)
+
+    print("  Running CPU golden ...")
+    golden_attn, golden_state = run_golden(inp)
+
+    print("  Running NPU ...")
+    npu_attn, npu_state = run_npu(inp, device)
+
+    print(f"  NPU attn  shape={npu_attn.shape}  dtype={npu_attn.dtype}")
+    print(f"  NPU state shape={npu_state.shape}  dtype={npu_state.dtype}")
+
+    attn_pass = compare_tensors_by_ratio(golden_attn, npu_attn, "attn_out", rtol=rtol, atol=atol)
+    state_pass = compare_tensors_by_ratio(golden_state, npu_state, "final_state", rtol=rtol, atol=atol)
+
+    overall = attn_pass and state_pass
+    status = "PASS" if overall else "FAIL"
+    print(f"\n  >> {desc}: {status}")
+    return overall
+
+
+def main():
+    device = torch.device("npu:2")
+    torch_npu.npu.set_device(device)
+    results = []
+    print(f"Using device: {device}")
+    results.append(run_test_case(
+        "basic_bs2_mtp2",
+        bs=2, mtp=2, nk=4, nv=8, dk=128, dv=128, device=device,
+        use_g=True, use_accepted_tokens=False,
+    ))
+
+    # --- Summary ---
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    pass_count = sum(results)
+    total = len(results)
+    for i, r in enumerate(results):
+        print(f"  Test {i+1}: {'PASS' if r else 'FAIL'}")
+    print(f"\n  {pass_count}/{total} passed")
+
+    if pass_count < total:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/tests/pta/utils.py
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/tests/pta/utils.py
@@ -1,0 +1,62 @@
+"""
+Utility functions for accuracy testing.
+"""
+import torch
+
+
+def compare_tensors_by_ratio(
+    golden: torch.Tensor,
+    actual: torch.Tensor,
+    name: str = "tensor",
+    rtol: float = 0.01,
+    atol: float = 0.004,
+) -> bool:
+    """
+    Compare two tensors using combined tolerance: pass if |diff| <= atol + rtol * |golden|.
+    Default: rtol=1%, atol=0.004 (roughly 1 ULP for bf16 near zero).
+    Returns True if all points pass.
+    """
+    if golden.shape != actual.shape:
+        print(f"  [{name}] shape mismatch: golden {golden.shape} vs actual {actual.shape}")
+        return False
+
+    golden_f = golden.float()
+    actual_f = actual.float()
+    diff = torch.abs(golden_f - actual_f)
+    threshold = atol + rtol * torch.abs(golden_f)
+    mask = diff > threshold
+    failed_count = int(mask.sum().item())
+    total_count = golden.numel()
+
+    max_abs = diff.max().item()
+    # Relative error only where golden is significant
+    significant = torch.abs(golden_f) > atol
+    if significant.any():
+        rel_on_sig = (diff[significant] / torch.abs(golden_f[significant]))
+        max_rel_sig = rel_on_sig.max().item()
+        mean_rel_sig = rel_on_sig.mean().item()
+    else:
+        max_rel_sig = 0.0
+        mean_rel_sig = 0.0
+
+    if failed_count == 0:
+        print(f"  [{name}] PASS  total={total_count}  "
+              f"max_abs={max_abs:.6f}  "
+              f"max_rel(significant)={max_rel_sig:.6f}  "
+              f"mean_rel(significant)={mean_rel_sig:.6f}")
+        return True
+    else:
+        print(f"  [{name}] FAIL  total={total_count}  "
+              f"failed={failed_count} ({failed_count/total_count*100:.4f}%)  "
+              f"max_abs={max_abs:.6f}  "
+              f"max_rel(significant)={max_rel_sig:.6f}")
+        failed_indices = torch.nonzero(mask, as_tuple=False)
+        for i in range(min(5, failed_count)):
+            idx = tuple(failed_indices[i].tolist())
+            g = golden_f[idx].item()
+            a = actual_f[idx].item()
+            d = diff[idx].item()
+            t = threshold[idx].item()
+            print(f"    pos{idx}: golden={g:.8f}  actual={a:.8f}  "
+                  f"diff={d:.8f}  threshold={t:.8f}")
+        return False


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @1132509010
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [x] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [x] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
