### PR TITLE
fix(dqkwg): correct GVA key-head gradients

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/chunk_bwd_dqkwg_def.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/chunk_bwd_dqkwg_def.cpp
@@ -15,7 +15,8 @@
  * 维度拆分 (GVA): H 拆为 HV 和 HK, HV = n_ratio * HK
  * - q, k: [B, HK, T, K]
  * - v, g, dox, dv, h, dh: [B, HV, T, ...] 或 [B, HV, ...]
- * - 所有输出 (dq/dk/dw/dg): [B, HV, T, ...] 或 [B, HV, ...]
+ * - dq, dk: [B, HK, T, K]
+ * - dw, dg: [B, HV, T, ...]
  */
 
 #include "register/op_def_registry.h"
@@ -112,14 +113,14 @@ public:
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
 
-        // dq: [B, HV, T, K] - gradient of q (HV heads)
+        // dq: [B, HK, T, K] - gradient of q (HK heads)
         this->Output("dq")
             .ParamType(REQUIRED)
             .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
 
-        // dk: [B, HV, T, K] - gradient of k (HV heads)
+        // dk: [B, HK, T, K] - gradient of k (HK heads)
         this->Output("dk")
             .ParamType(REQUIRED)
             .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_api/aclnn_chunk_bwd_dqkwg.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_api/aclnn_chunk_bwd_dqkwg.cpp
@@ -80,6 +80,46 @@ static aclnnStatus CheckFormat(ChunkBwdDqkwgParams params)
 
 static aclnnStatus CheckShape(ChunkBwdDqkwgParams params)
 {
+    const auto qShape = params.q->GetViewShape();
+    const auto kShape = params.k->GetViewShape();
+    const auto vShape = params.v->GetViewShape();
+    const auto gShape = params.g->GetViewShape();
+    const auto dqShape = params.dqOut->GetViewShape();
+    const auto dkShape = params.dkOut->GetViewShape();
+    const auto dwShape = params.dwOut->GetViewShape();
+    const auto dgShape = params.dgOut->GetViewShape();
+
+    CHECK_COND(qShape.GetDimNum() == 4, ACLNN_ERR_PARAM_INVALID, "q must be [B, HK, T, K].");
+    CHECK_COND(kShape.GetDimNum() == 4, ACLNN_ERR_PARAM_INVALID, "k must be [B, HK, T, K].");
+    CHECK_COND(vShape.GetDimNum() == 4, ACLNN_ERR_PARAM_INVALID, "v must be [B, HV, T, V].");
+    CHECK_COND(gShape.GetDimNum() == 3, ACLNN_ERR_PARAM_INVALID, "g must be [B, HV, T].");
+    CHECK_COND(dqShape.GetDimNum() == 4, ACLNN_ERR_PARAM_INVALID, "dqOut must be [B, HK, T, K].");
+    CHECK_COND(dkShape.GetDimNum() == 4, ACLNN_ERR_PARAM_INVALID, "dkOut must be [B, HK, T, K].");
+    CHECK_COND(dwShape.GetDimNum() == 4, ACLNN_ERR_PARAM_INVALID, "dwOut must be [B, HV, T, K].");
+    CHECK_COND(dgShape.GetDimNum() == 3, ACLNN_ERR_PARAM_INVALID, "dgOut must be [B, HV, T].");
+
+    const int64_t B = qShape.GetDim(0);
+    const int64_t HK = qShape.GetDim(1);
+    const int64_t T = qShape.GetDim(2);
+    const int64_t K = qShape.GetDim(3);
+    const int64_t HV = vShape.GetDim(1);
+
+    CHECK_COND(HK > 0 && HV > 0 && HV % HK == 0, ACLNN_ERR_PARAM_INVALID,
+               "GVA requires HV divisible by HK.");
+    CHECK_COND(kShape.GetDim(0) == B && kShape.GetDim(1) == HK && kShape.GetDim(2) == T && kShape.GetDim(3) == K,
+               ACLNN_ERR_PARAM_INVALID, "k must match q shape [B, HK, T, K].");
+    CHECK_COND(vShape.GetDim(0) == B && vShape.GetDim(2) == T, ACLNN_ERR_PARAM_INVALID,
+               "v must match q batch and sequence dimensions.");
+    CHECK_COND(gShape.GetDim(0) == B && gShape.GetDim(1) == HV && gShape.GetDim(2) == T, ACLNN_ERR_PARAM_INVALID,
+               "g must be [B, HV, T].");
+    CHECK_COND(dqShape.GetDim(0) == B && dqShape.GetDim(1) == HK && dqShape.GetDim(2) == T && dqShape.GetDim(3) == K,
+               ACLNN_ERR_PARAM_INVALID, "dqOut must be [B, HK, T, K].");
+    CHECK_COND(dkShape.GetDim(0) == B && dkShape.GetDim(1) == HK && dkShape.GetDim(2) == T && dkShape.GetDim(3) == K,
+               ACLNN_ERR_PARAM_INVALID, "dkOut must be [B, HK, T, K].");
+    CHECK_COND(dwShape.GetDim(0) == B && dwShape.GetDim(1) == HV && dwShape.GetDim(2) == T && dwShape.GetDim(3) == K,
+               ACLNN_ERR_PARAM_INVALID, "dwOut must be [B, HV, T, K].");
+    CHECK_COND(dgShape.GetDim(0) == B && dgShape.GetDim(1) == HV && dgShape.GetDim(2) == T,
+               ACLNN_ERR_PARAM_INVALID, "dgOut must be [B, HV, T].");
     return ACLNN_SUCCESS;
 }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.h
@@ -26,7 +26,7 @@ namespace optiling {
 BEGIN_TILING_DATA_DEF(ChunkBwdDqkwgTilingData)
     // 基本形状参数
     TILING_DATA_FIELD_DEF(uint64_t, B);              // batch size
-    TILING_DATA_FIELD_DEF(uint64_t, HV);             // value 侧 head 数 (v/g/h/do/dh/dv 及全部输出)
+    TILING_DATA_FIELD_DEF(uint64_t, HV);             // value 侧 head 数 (v/g/h/do/dh/dv/dw/dg)
     TILING_DATA_FIELD_DEF(uint64_t, HK);             // key/query 侧 head 数 (q/k), HV = n_ratio * HK
     TILING_DATA_FIELD_DEF(uint64_t, T);              // sequence length
     TILING_DATA_FIELD_DEF(uint64_t, K);              // key/query dimension
@@ -44,9 +44,9 @@ BEGIN_TILING_DATA_DEF(ChunkBwdDqkwgTilingData)
     TILING_DATA_FIELD_DEF(uint64_t, wsBtxKSyncSlotsPerHead); // cross-stage group ring depth per core
     TILING_DATA_FIELD_DEF(uint64_t, wsDgLastOffset);     // PartA: b_dg_last 偏移
     TILING_DATA_FIELD_DEF(uint64_t, dgLastSize);         // PartA: b_dg_last 大小, 32B 对齐
-    TILING_DATA_FIELD_DEF(uint64_t, wsMm5Offset);        // PartA: mm5 / 之后 PartD mm7 复用
+    TILING_DATA_FIELD_DEF(uint64_t, wsMm5Offset);        // PartA: mm5 / GVA C: dq_inner / PartD: mm7
     TILING_DATA_FIELD_DEF(uint64_t, wsDsTempOffset);     // PartB: b_ds_temp 偏移
-    TILING_DATA_FIELD_DEF(uint64_t, wsMm6Offset);        // PartC: mm6 复用已释放的 wsDw
+    TILING_DATA_FIELD_DEF(uint64_t, wsMm6Offset);        // PartC: mm6 / GVA D: dk_inner
     TILING_DATA_FIELD_DEF(uint64_t, wsMm7Offset);        // PartD: mm7 复用已释放的 wsMm5
     TILING_DATA_FIELD_DEF(uint64_t, wsMul1Offset);       // independent short BT x BT ring for mul1
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg.cpp
@@ -33,8 +33,8 @@
      GM_ADDR chunk_indices,  // [num_chunks, 2] (optional)
      GM_ADDR w,
      GM_ADDR g_gamma,
-     GM_ADDR dq,             // [B, HV, T, K] - output
-     GM_ADDR dk,             // [B, HV, T, K] - output
+     GM_ADDR dq,             // [B, HK, T, K] - output
+     GM_ADDR dk,             // [B, HK, T, K] - output
      GM_ADDR dw,             // [B, HV, T, K] - output
      GM_ADDR dg,             // [B, HV, T] - output (fp32)
      GM_ADDR workspace,      // workspace buffer

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
@@ -287,8 +287,8 @@ namespace Catlass::Gemm::Kernel {
             GM_ADDR ptrChunkIndices;
 
             // 输出指针
-            GM_ADDR ptrDq;     // [B, HV, T, K]
-            GM_ADDR ptrDk;     // [B, HV, T, K]
+            GM_ADDR ptrDq;     // [B, HK, T, K]
+            GM_ADDR ptrDk;     // [B, HK, T, K]
             GM_ADDR ptrDw;     // [B, HV, T, K]
             GM_ADDR ptrDg;     // [B, HV, T]
 
@@ -306,7 +306,7 @@ namespace Catlass::Gemm::Kernel {
 
             // 形状参数 (GVA: H 拆为 HV/HK, HV = n_ratio * HK)
             uint64_t B;// = CONST_B;
-            uint64_t HV;           // value 侧 head 数 (v/g/h/do/dh/dv 及全部输出), == 原 H
+            uint64_t HV;           // value 侧 head 数 (v/g/h/do/dh/dv/dw/dg), == 原 H
             uint64_t HK;           // key/query 侧 head 数 (q/k), HV = n_ratio * HK
             uint64_t T;// = CONST_T;
             uint64_t K;// = CONST_K;
@@ -536,10 +536,11 @@ namespace Catlass::Gemm::Kernel {
                 uint32_t actual_chunk_len = eos - bos;
                 uint32_t bIdx = loopIdx / params.numChunks;
                 uint32_t chunkIdx = loopIdx % params.numChunks;
+                const bool gvaMode = params.HV != params.HK;
 
                 WaitCredit();
                 for (uint32_t h = 0; h < params.HV; h++) {
-                    // --- Part4: dq_inner = do @ h^T -> ptrDq ---
+                    // --- Part4: dq_inner = do @ h^T ---
                     {
                         GemmCoord actualBlockShape{
                             static_cast<uint32_t>(actual_chunk_len),
@@ -549,13 +550,20 @@ namespace Catlass::Gemm::Kernel {
                         uint64_t doOffset = (h * params.T + bos) * params.V;
                         uint64_t hOffset = ((bIdx * params.HV + h) * params.numChunks + chunkIdx) * params.K * params.V;
                         uint64_t dqOffset = (h * params.T + bos) * params.K;
+                        uint64_t dqTempOffset = DqkwgBtxKRingElemOffset(coreIdx, loopBase, loopIdx, coreNum, h,
+                                                                         params.HV, params.BT, params.K,
+                                                                         (uint32_t)params.wsBtxKSyncSlotsPerHead);
 
                         GlobalTensor<ElementA> gmDo;
                         gmDo.SetGlobalBuffer((__gm__ ElementA *)params.ptrDo + doOffset);
                         GlobalTensor<ElementA> gmH;
                         gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
                         GlobalTensor<ElementC> gmDq;
-                        gmDq.SetGlobalBuffer((__gm__ ElementC *)params.ptrDq + dqOffset);
+                        if (gvaMode) {
+                            gmDq.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm5Offset) + dqTempOffset);
+                        } else {
+                            gmDq.SetGlobalBuffer((__gm__ ElementC *)params.ptrDq + dqOffset);
+                        }
 
                         auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
                         auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});
@@ -623,10 +631,11 @@ namespace Catlass::Gemm::Kernel {
                 uint32_t actual_chunk_len = eos - bos;
                 uint32_t bIdx = loopIdx / params.numChunks;
                 uint32_t chunkIdx = loopIdx % params.numChunks;
+                const bool gvaMode = params.HV != params.HK;
 
                 WaitCredit();
                 for (uint32_t h = 0; h < params.HV; h++) {
-                    // --- Part5: dk_inner = v @ dh -> ptrDk ---
+                    // --- Part5: dk_inner = v @ dh ---
                     {
                         GemmCoord actualBlockShape{
                             static_cast<uint32_t>(actual_chunk_len),
@@ -636,13 +645,20 @@ namespace Catlass::Gemm::Kernel {
                         uint64_t vOffset = (h * params.T + bos) * params.V;
                         uint64_t dhOffset = ((bIdx * params.HV + h) * params.numChunks + chunkIdx) * params.K * params.V;
                         uint64_t dkOffset = (h * params.T + bos) * params.K;
+                        uint64_t dkTempOffset = DqkwgShortBtxKRingElemOffset(
+                            coreIdx, loopIdx, coreNum, h, params.HV, params.BT, params.K,
+                            DqkwgShortRingDepthFromGroup((uint32_t)params.wsBtxKSyncSlotsPerHead));
 
                         GlobalTensor<ElementA> gmV;
                         gmV.SetGlobalBuffer((__gm__ ElementA *)params.ptrV + vOffset);
                         GlobalTensor<ElementA> gmDh;
                         gmDh.SetGlobalBuffer((__gm__ ElementA *)params.ptrDh + dhOffset);
                         GlobalTensor<ElementC> gmDk;
-                        gmDk.SetGlobalBuffer((__gm__ ElementC *)params.ptrDk + dkOffset);
+                        if (gvaMode) {
+                            gmDk.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm6Offset) + dkTempOffset);
+                        } else {
+                            gmDk.SetGlobalBuffer((__gm__ ElementC *)params.ptrDk + dkOffset);
+                        }
 
                         auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
                         auto tensorDh = tla::MakeTensor(gmDh, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
@@ -55,6 +55,7 @@
      __aicore__ inline void ProcessCVector(uint32_t loopBase, uint32_t loopEnd);  // 原 Part4 + Part6 (dq 最终)
      __aicore__ inline void ProcessDVector(uint32_t loopBase, uint32_t loopEnd);  // 原 Part5 + Part7 (dk 最终 + dg 最终)
      __aicore__ inline void ResetStagePipe();
+     __aicore__ inline void FenceGvaAccumReadAfterWrite();
 
      // mul1 一个 row-half 的计算 (= A 的 Part2 per-head 内核, 输出 fp32 到 outFp32[half] )。
      // A (小 case) 调它后 cast+写 GM; B (大 case) 调它两次 (两个 row-half) 后直接乘 ds, 省掉 mul1 GM 往返。
@@ -282,6 +283,13 @@
          AscendC::PipeBarrier<PIPE_MTE3>();
      }
      pipe->Reset();
+ }
+
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::FenceGvaAccumReadAfterWrite() {
+     TEventID eventId = GetTPipePtr()->FetchEventID(HardEvent::MTE3_MTE2);
+     SetFlag<HardEvent::MTE3_MTE2>(eventId);
+     WaitFlag<HardEvent::MTE3_MTE2>(eventId);
  }
 
  template <typename DataType, typename GType>
@@ -934,6 +942,7 @@
 
      uint32_t dqSize = BT * K;
      const uint32_t gSize = BT;
+     const bool gvaMode = HV != HK;
 
      pipe->InitBuffer(inQue1, BUFFER_NUM, dqSize * sizeof(float));    // dq_inner from Cube
      pipe->InitBuffer(inQue2, BUFFER_NUM, dqSize * sizeof(float));    // q / mm6 复用
@@ -960,15 +969,17 @@
          WaitCubeReady();
 
          for (uint32_t h = 0; h < HV; h++) {
-             if (h % subBlockNum != subBlockIdx) {
+             uint32_t hk_idx = h / n_ratio;
+             uint32_t ownerHead = gvaMode ? hk_idx : h;
+             if (ownerHead % subBlockNum != subBlockIdx) {
                  continue;
              }
-             // GVA: q 为 HK 头, dq 为 HV 头
-             uint32_t hk_idx = h / n_ratio;
              uint32_t bIdx = loopIdx / numChunks;
              uint64_t bos_hk = bos - static_cast<uint64_t>(bIdx) * static_cast<uint64_t>(HV - HK) * T;
              uint64_t qkOffset = (hk_idx * T + bos_hk) * K;   // q (HK)
-             uint64_t dqOffset = (h * T + bos) * K;           // dq (HV)
+             uint64_t dqOutOffset = (hk_idx * T + bos_hk) * K; // dq (HK)
+             uint64_t dqTempOffset = DqkwgBtxKRingElemOffset(coreIdx, loopBase, loopIdx, coreNum, h, HV, BT, K,
+                                                             (uint32_t)wsBtxKSyncSlotsPerHead);
              uint64_t gOffset = (h * T + bos);
 
              // CopyIn: dq_inner, q, g, dg
@@ -977,7 +988,11 @@
                  auto tensorQIn = inQue2.AllocTensor<DataType>();
                  auto tensorGIn = inQue3.AllocTensor<GType>();
                  auto tensorDgIn = inQue4.AllocTensor<GType>();
-                 DataCopy(tensorDqIn[dqSize_sub], gmDq[dqOffset], dqSize_sub);
+                 if (gvaMode) {
+                     DataCopy(tensorDqIn[dqSize_sub], gmMm5[dqTempOffset], dqSize_sub);
+                 } else {
+                     DataCopy(tensorDqIn[dqSize_sub], gmDq[dqOutOffset], dqSize_sub);
+                 }
                  DataCopy(tensorQIn[dqSize_sub], gmQ[qkOffset], dqSize_sub);
                  CopyGateWithPad(tensorGIn, gmG, gOffset, actual_chunk_len, gSize);
                  CopyGateWithPad(tensorDgIn, gmDg, gOffset, actual_chunk_len, gSize);
@@ -1070,19 +1085,32 @@
                  {
                      auto tensorMm6InFp16 = inQue2.DeQue<DataType>();
                      auto tensorMm6Fp32 = tensorMm6InFp16.template ReinterpretCast<float>();
-                     auto tensorDqOut = outQue1.AllocTensor<DataType>();
                      Cast(tensorMm6Fp32, tensorMm6InFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
                      PipeBarrier<PIPE_V>();
                      Add(tensorDqInFp32, tensorDqInFp32, tensorMm6Fp32, dqSize_sub);
                      PipeBarrier<PIPE_V>();
+                     inQue2.FreeTensor(tensorMm6InFp16);
+                     if (gvaMode && (h % n_ratio != 0)) {
+                         FenceGvaAccumReadAfterWrite();
+                         auto tensorDqAccumIn = inQue2.AllocTensor<DataType>();
+                         DataCopy(tensorDqAccumIn[dqSize_sub], gmDq[dqOutOffset], dqSize_sub);
+                         inQue2.EnQue(tensorDqAccumIn);
+                         auto tensorDqAccumInFp16 = inQue2.DeQue<DataType>();
+                         auto tensorDqAccumFp32 = tensorDqAccumInFp16.template ReinterpretCast<float>();
+                         Cast(tensorDqAccumFp32, tensorDqAccumInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
+                         PipeBarrier<PIPE_V>();
+                         Add(tensorDqInFp32, tensorDqInFp32, tensorDqAccumFp32, dqSize_sub);
+                         PipeBarrier<PIPE_V>();
+                         inQue2.FreeTensor(tensorDqAccumInFp16);
+                     }
+                     auto tensorDqOut = outQue1.AllocTensor<DataType>();
                      Cast(tensorDqOut, tensorDqInFp32, RoundMode::CAST_RINT, dqSize_sub);
                      inQue1.FreeTensor(tensorDqInFp16);
-                     inQue2.FreeTensor(tensorMm6InFp16);
                      outQue1.EnQue(tensorDqOut);
                  }
                  {
                      auto tensorDqOut = outQue1.DeQue<DataType>();
-                     DataCopy(gmDq[dqOffset], tensorDqOut, dqSize_sub);
+                     DataCopy(gmDq[dqOutOffset], tensorDqOut, dqSize_sub);
                      outQue1.FreeTensor(tensorDqOut);
                  }
              }
@@ -1106,6 +1134,7 @@
 
      uint32_t dkSize = BT * K;
      const uint32_t gSize = BT;
+     const bool gvaMode = HV != HK;
 
      constexpr int32_t part5BufferNum = 1;
      pipe->InitBuffer(inQue1, part5BufferNum, dkSize * sizeof(float));
@@ -1140,14 +1169,17 @@
          WaitCubeReady();
 
          for (uint32_t h = 0; h < HV; h++) {
-             if (h % subBlockNum != subBlockIdx) {
+             uint32_t hk_idx = h / n_ratio;
+             uint32_t ownerHead = gvaMode ? hk_idx : h;
+             if (ownerHead % subBlockNum != subBlockIdx) {
                  continue;
              }
-             // GVA: k 为 HK 头, dk 为 HV 头
-             uint32_t hk_idx = h / n_ratio;
              uint64_t bos_hk = bos - static_cast<uint64_t>(bIdx) * static_cast<uint64_t>(HV - HK) * T;
              uint64_t kOffset = (hk_idx * T + bos_hk) * K;    // k (HK)
-             uint64_t dkOffset = (h * T + bos) * K;           // dk (HV)
+             uint64_t dkOutOffset = (hk_idx * T + bos_hk) * K; // dk (HK)
+             uint64_t dkTempOffset = DqkwgShortBtxKRingElemOffset(
+                 coreIdx, loopIdx, coreNum, h, HV, BT, K,
+                 DqkwgShortRingDepthFromGroup((uint32_t)wsBtxKSyncSlotsPerHead));
              uint64_t gOffset = (h * T + bos);
 
              // CV 融合优化: 读 A_vector 算好的 dg_last = sum(h*dh) (替代本地重算, 省 D 的 h/dh 读 + K*V 归约)。
@@ -1174,7 +1206,11 @@
                  auto tensorKIn = inQue2.AllocTensor<DataType>();
                  auto tensorGIn = inQue3.AllocTensor<GType>();
                  auto tensorDgIn = inQue4.AllocTensor<GType>();
-                 DataCopy(tensorDkIn[dkSize], gmDk[dkOffset], dkSize);
+                 if (gvaMode) {
+                     DataCopy(tensorDkIn[dkSize], gmMm6[dkTempOffset], dkSize);
+                 } else {
+                     DataCopy(tensorDkIn[dkSize], gmDk[dkOutOffset], dkSize);
+                 }
                  DataCopy(tensorKIn[dkSize], gmK[kOffset], dkSize);
                  CopyGateWithPad(tensorGIn, gmG, gOffset, actual_chunk_len, gSize);
                  CopyGateWithPad(tensorDgIn, gmDg, gOffset, actual_chunk_len, gSize);
@@ -1302,19 +1338,32 @@
                  {
                      auto tensorMm7In = inQue2.DeQue<DataType>();
                      auto tensorMm7Fp32 = tensorMm7In.template ReinterpretCast<float>();
-                     auto tensorDkOut = outQue1.AllocTensor<DataType>();
                      Cast(tensorMm7Fp32, tensorMm7In[dkSize], RoundMode::CAST_NONE, dkSize);
                      PipeBarrier<PIPE_V>();
                      Add(tensorDkFp32, tensorDkFp32, tensorMm7Fp32, dkSize);
                      PipeBarrier<PIPE_V>();
+                     inQue2.FreeTensor(tensorMm7In);
+                     if (gvaMode && (h % n_ratio != 0)) {
+                         FenceGvaAccumReadAfterWrite();
+                         auto tensorDkAccumIn = inQue2.AllocTensor<DataType>();
+                         DataCopy(tensorDkAccumIn[dkSize], gmDk[dkOutOffset], dkSize);
+                         inQue2.EnQue(tensorDkAccumIn);
+                         auto tensorDkAccumInFp16 = inQue2.DeQue<DataType>();
+                         auto tensorDkAccumFp32 = tensorDkAccumInFp16.template ReinterpretCast<float>();
+                         Cast(tensorDkAccumFp32, tensorDkAccumInFp16[dkSize], RoundMode::CAST_NONE, dkSize);
+                         PipeBarrier<PIPE_V>();
+                         Add(tensorDkFp32, tensorDkFp32, tensorDkAccumFp32, dkSize);
+                         PipeBarrier<PIPE_V>();
+                         inQue2.FreeTensor(tensorDkAccumInFp16);
+                     }
+                     auto tensorDkOut = outQue1.AllocTensor<DataType>();
                      Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);
                      inQue1.FreeTensor(tensorDkIn);
-                     inQue2.FreeTensor(tensorMm7In);
                      outQue1.EnQue(tensorDkOut);
                  }
                  {
                      auto tensorDkOut = outQue1.DeQue<DataType>();
-                     DataCopy(gmDk[dkOffset], tensorDkOut, dkSize);
+                     DataCopy(gmDk[dkOutOffset], tensorDkOut, dkSize);
                      outQue1.FreeTensor(tensorDkOut);
                  }
              }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/ATK/chunk_bwd_dqkwg_cpu.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/ATK/chunk_bwd_dqkwg_cpu.py
@@ -106,6 +106,8 @@ def chunk_bwd_dqkwg_cpu(
     B, T, HK, K = q.shape
     HV = v.shape[2]
     V = v.shape[-1]
+    if HK <= 0 or HV <= 0 or HV % HK != 0:
+        raise ValueError(f"GVA requires HV divisible by HK, got HV={HV}, HK={HK}")
     n_ratio = HV // HK  # HV = n_ratio * HK
     datatype = q.dtype
     gtype = g.dtype
@@ -114,9 +116,9 @@ def chunk_bwd_dqkwg_cpu(
         gtype = torch.float64
     g_gamma = None
     
-    # 输出使用 HV 维度
-    dq = torch.zeros((B, T, HV, K), dtype=datatype)
-    dk = torch.zeros((B, T, HV, K), dtype=datatype)
+    # Keep per-value-head contributions first, then reduce them into key heads.
+    dq_hv = torch.zeros((B, T, HV, K), dtype=datatype)
+    dk_hv = torch.zeros((B, T, HV, K), dtype=datatype)
     dg = torch.zeros_like(g) if g is not None else None
     dw = torch.zeros((B, T, HV, K), dtype=datatype)
     w = torch.zeros((B, T, HV, K), dtype=datatype)
@@ -355,8 +357,8 @@ def chunk_bwd_dqkwg_cpu(
                     # print(h_idx,i_t,"dk_total",dk_total)
 
 
-                dq[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dq_total
-                dk[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dk_total
+                dq_hv[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dq_total.to(datatype)
+                dk_hv[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dk_total.to(datatype)
 
                 # if RANDOM_DATA == False:
                 #     pass
@@ -407,5 +409,8 @@ def chunk_bwd_dqkwg_cpu(
                 # 但如果发生，通常 cu_seqlens[i] 是第 i 个样本的长度。
                 # 简化起见，我们假设 input 是 packed flat tensor 如果 cu_seqlens 存在。
                 pass 
+
+    dq = dq_hv.view(B, T, HK, n_ratio, K).sum(dim=3).to(datatype)
+    dk = dk_hv.view(B, T, HK, n_ratio, K).sum(dim=3).to(datatype)
 
     return dq, dk, dw, dg

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/chunk_bwd_dqkwg_cpu.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/chunk_bwd_dqkwg_cpu.py
@@ -112,13 +112,15 @@ def chunk_bwd_dqkwg_cpu(
     B, T, HK, K = q.shape
     HV = v.shape[2]
     V = v.shape[-1]
+    if HK <= 0 or HV <= 0 or HV % HK != 0:
+        raise ValueError(f"GVA requires HV divisible by HK, got HV={HV}, HK={HK}")
     n_ratio = HV // HK  # HV = n_ratio * HK
 
     g_gamma = None
     
-    # 输出使用 HV 维度
-    dq = torch.zeros((B, T, HV, K), dtype=datatype)
-    dk = torch.zeros((B, T, HV, K), dtype=datatype)
+    # Keep per-value-head contributions first, then reduce them into key heads.
+    dq_hv = torch.zeros((B, T, HV, K), dtype=datatype)
+    dk_hv = torch.zeros((B, T, HV, K), dtype=datatype)
     dg = torch.zeros_like(g) if g is not None else None
     dw = torch.zeros((B, T, HV, K), dtype=datatype)
     w = torch.zeros((B, T, HV, K), dtype=datatype)
@@ -358,8 +360,8 @@ def chunk_bwd_dqkwg_cpu(
                     # print(h_idx,i_t,"dk_total",dk_total)
 
 
-                dq[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dq_total
-                dk[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dk_total
+                dq_hv[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dq_total.to(datatype)
+                dk_hv[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dk_total.to(datatype)
 
                 # if RANDOM_DATA == False:
                 #     pass
@@ -410,5 +412,8 @@ def chunk_bwd_dqkwg_cpu(
                 # 但如果发生，通常 cu_seqlens[i] 是第 i 个样本的长度。
                 # 简化起见，我们假设 input 是 packed flat tensor 如果 cu_seqlens 存在。
                 pass 
+
+    dq = dq_hv.view(B, T, HK, n_ratio, K).sum(dim=3).to(datatype)
+    dk = dk_hv.view(B, T, HK, n_ratio, K).sum(dim=3).to(datatype)
 
     return dq, dk, dw, dg

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -172,10 +172,17 @@ at::Tensor npu_prepare_wy_repr_bwd_da(const at::Tensor & k, const at::Tensor & v
 
 ::std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor> npu_chunk_bwd_dqkwg(const at::Tensor & q, const at::Tensor & k, const at::Tensor & v, const at::Tensor & g, const at::Tensor & h, const at::Tensor & dox, const at::Tensor & dh, const at::Tensor & dv, int64_t chunk_size, at::OptionalIntArrayRef cu_seqlens, at::OptionalIntArrayRef chunk_indices, const c10::optional<at::Tensor> & w, const c10::optional<at::Tensor> & g_gamma, c10::optional<double> scale, c10::optional<bool> use_exp2, c10::optional<bool> transpose_state_layout)
 {
-    // 获取输入 q 的维度信息
+    const int64_t key_num_heads = q.size(1);
     const int64_t value_num_heads = v.size(1);
-    at::Tensor dq = at::empty({q.size(0), value_num_heads, q.size(2), q.size(3)}, q.options());
-    at::Tensor dk = at::empty({q.size(0), value_num_heads, q.size(2), q.size(3)}, q.options());
+    TORCH_CHECK(
+        key_num_heads > 0 && value_num_heads > 0 && value_num_heads % key_num_heads == 0,
+        "npu_chunk_bwd_dqkwg: GVA requires value heads divisible by key heads; Hk=",
+        key_num_heads,
+        " Hv=",
+        value_num_heads);
+
+    at::Tensor dq = at::empty_like(q);
+    at::Tensor dk = at::empty_like(k);
     at::Tensor dw = at::empty({q.size(0), value_num_heads, q.size(2), q.size(3)}, q.options());
     at::Tensor dg = at::empty_like(g);
 


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见仓库内对应文档。

## 关联 Issue / 背景

- 关联 Issue: 无，当前为 GVA 语义缺陷修复。
- 背景与目标: GVA 场景中 `q` / `k` 使用 key head，`v` / `g` 使用 value head；`dq` / `dk` 是 `q` / `k` 的梯度，语义上应按 key head 返回。
- 本 PR 解决的问题: 修复 GVA 场景下 `dq` / `dk` 误按 value head shape 返回的问题，并同步 CPU golden、aclnn 校验与 torch 适配的新语义。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: `chunk_bwd_dqkwg`
- 涉及目录 / 文件: `chunk_bwd_dqkwg` 算子定义、aclnn 接口、tiling 数据、Ascend C kernel、CPU golden，以及 `torch_custom` 适配。
- 责任人 / 提交人: @ZhangYi2026
- 修改范围:
  - [x] `op_host` / 算子定义
  - [x] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [x] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: `q` / `k` 为 `[B, HK, T, K]`，`v` / `g` 等 value 侧输入为 `[B, HV, T, ...]`，要求 `HV % HK == 0`；GVA 场景下 `dq` / `dk` 返回 `[B, HK, T, K]`，`dw` / `dg` 保持 value head 语义；dtype / format 支持范围不变。
- 明确不包含的范围: 不包含其他算子改动，不包含性能优化策略调整，不包含 `Triton` 实现，不包含整体 Example ST 用例新增。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [x] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: GVA 场景下 `dq` / `dk` 返回 shape 从 value head 语义修正为 key head 语义；这是对梯度语义的缺陷修复，普通 `HV == HK` 场景不变，GVA 调用方需按 key head 语义消费 `dq` / `dk`。

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

记录项:

- CANN 版本: 已确认，不在 PR 描述中披露具体环境信息。
- 产品 / 芯片类型: A3 编译验证已执行；A2 / A5 待 NPU CI 或维护者环境补齐。
- 机器或 CI 链接: 不在 PR 描述中披露内部执行位置。

### 2. 编译验证

通过标准:

- 命令退出码为 0
- 生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未披露 | 待 NPU CI 或维护者环境补齐 | 未执行 | 待补齐公开 CI 结果 |
| A3 | `ascend910_93` | 未披露 | `bash build.sh --pkg --ops=chunk_bwd_dqkwg --soc=ascend910_93` | 通过 | 构建通过，生成 `.run` 包 |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未披露 | 待 NPU CI 或维护者环境补齐 | 未执行 | 待补齐公开 CI 结果 |
| A3 | `ascend910_93` | 未披露 | `bash build.sh --pkg --ops=chunk_bwd_dqkwg --soc=ascend910_93` | 通过 | 构建通过，生成 `.run` 包 |
| A5 | `ascend950` | 未披露 | 待 NPU CI 或维护者环境补齐 | 未执行 | 待补齐公开 CI 结果 |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 待 NPU CI 或维护者环境补齐 | 未执行 | 待补齐公开 CI 结果 |
| A3 | `ascend910_93` | `git diff --check origin/main..HEAD` | 通过 | diff 格式检查通过 |
| A3 | `ascend910_93` | `python -m py_compile fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/ATK/chunk_bwd_dqkwg_cpu.py fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/chunk_bwd_dqkwg_cpu.py` | 通过 | CPU golden 文件语法检查通过 |
| A5 | `ascend950` | 待 NPU CI 或维护者环境补齐 | 未执行 | 待补齐公开 CI 结果 |

- 精度对比: 本 PR 已同步 CPU golden 到 GVA key head 新语义；完整 NPU 精度回归待 NPU CI 或维护者环境补齐。
- 性能对比: 本 PR 不引入额外算子；完整性能回归待 NPU CI 或维护者环境补齐。
- 边界 / 异常场景: 已增加 `HV % HK == 0` 语义校验；`HV == HK` 普通场景保持原有输出语义。
- 未覆盖风险: A2 / A5 编译与完整端到端回归需由公开 CI 或维护者环境补齐。

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐 |

- 端到端场景说明: 本 PR 修改 `chunk_bwd_dqkwg` 的 GVA 反向梯度输出语义，需通过 Example ST 确认 GDN 端到端链路未被破坏。
- 与本 PR 修改算子的关联: Example ST 可覆盖 GDN 链路中对 `chunk_bwd_dqkwg` 输出的消费路径。
- 未覆盖原因及补充计划: PR 创建后触发 NPU CI 补齐公开验证结果。

</details>

## 兼容性、风险与回退

- 兼容性说明: 普通 `HV == HK` 场景保持兼容；GVA 场景的 `dq` / `dk` shape 修正为 key head 语义，调用方需按新语义处理。
- 风险点: GVA 下依赖旧错误 value head shape 的调用方需要同步适配；完整端到端回归需 NPU CI 补齐。
- 回退方案: 如发现阻塞性问题，可整体回退该单独修复 commit。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [x] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [x] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

评审重点建议关注 GVA 下 `dq` / `dk` 从 per-value-head 中间结果累加到 key-head 输出的路径，以及 aclnn / torch wrapper / CPU golden 是否一致采用新语义。
