### PR TITLE
add ops solve_tril (ascend950) new

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
@@ -805,7 +805,11 @@ namespace Catlass::Gemm::Kernel {
         using LayoutColMajor = layout::ColumnMajor;
 
         // 架构和策略定义
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+        using ArchTag = Arch::Ascend950;
+#else
         using ArchTag = Arch::AtlasA2;
+#endif
         using DispatchPolicy = Gemm::MmadPingpong<ArchTag, true>;
         using L1TileShape = tla::Shape<_128, _128, _256>;
         using L0TileShape = tla::Shape<_128, _128, _128>;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_host/CMakeLists.txt
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_host/CMakeLists.txt
@@ -4,6 +4,9 @@ if(BUILD_OPEN_PROJECT)
     target_sources(op_host_aclnnExc PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/solve_tri_def.cpp
     )
+    target_compile_definitions(op_host_aclnnExc PRIVATE
+        ASCEND_SOC_VERSION="${ASCEND_COMPUTE_UNIT}"
+    )
 endif()
 
 add_modules_sources(OPTYPE solve_tri ACLNNTYPE aclnn_exclude)

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_host/solve_tri_def.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_host/solve_tri_def.cpp
@@ -3,6 +3,7 @@
  * BSD 3-Clause License.
  */
  #include "register/op_def_registry.h"
+ #include <string>
 
  namespace ops {
  class SolveTri : public OpDef {
@@ -49,6 +50,11 @@
  
         this->AICore().AddConfig("ascend910b", aicore_config);
         this->AICore().AddConfig("ascend910_93", aicore_config);
+#ifdef ASCEND_SOC_VERSION
+        if (std::string(ASCEND_SOC_VERSION) == "ascend950") {
+            this->AICore().AddConfig("ascend950", aicore_config);
+        }
+#endif
     }
 };
  OP_ADD(SolveTri);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_host/solve_tri_def.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_host/solve_tri_def.cpp
@@ -50,11 +50,7 @@
  
         this->AICore().AddConfig("ascend910b", aicore_config);
         this->AICore().AddConfig("ascend910_93", aicore_config);
-#ifdef ASCEND_SOC_VERSION
-        if (std::string(ASCEND_SOC_VERSION) == "ascend950") {
-            this->AICore().AddConfig("ascend950", aicore_config);
-        }
-#endif
+        this->AICore().AddConfig("ascend950", aicore_config);
     }
 };
  OP_ADD(SolveTri);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_host/solve_tri_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_host/solve_tri_tiling.cpp
@@ -134,10 +134,9 @@ constexpr uint32_t ATTR_LAYOUT_IDX = 0;
      // Workspace: ascend950 全程片上缓存，仅预留系统 workspace；910b 需 GM 辅助矩阵中转区
      uint32_t sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
      size_t* ws = context->GetWorkspaceSizes(1);
-     bool isAscend950 = (ascendcPlatform.GetSocVersion() == platform_ascendc::SocVersion::ASCEND950);
-     if (isAscend950) {
-         ws[0] = sysWorkspaceSize;
-     } else {
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+     ws[0] = sysWorkspaceSize;
+#else
      size_t sharedSize = 3 * chunkSize * chunkSize * sizeof(uint16_t);  // I + -I + ZERO
      size_t perCoreSize = 2 * chunkSize * chunkSize * sizeof(uint16_t);  // 每核 2 个中转区（X 流 + Y 流双缓冲）
      size_t userWorkspaceSize = sharedSize + usedCoreNum * perCoreSize;
@@ -145,8 +144,7 @@ constexpr uint32_t ATTR_LAYOUT_IDX = 0;
      userWorkspaceSize = ((userWorkspaceSize + 511) / 512) * 512;
      // 总 workspace = 用户 workspace + 系统 workspace
      ws[0] = userWorkspaceSize + sysWorkspaceSize;
-     }
- 
+#endif
      return ge::GRAPH_SUCCESS;
  }
  

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_host/solve_tri_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_host/solve_tri_tiling.cpp
@@ -131,17 +131,21 @@ constexpr uint32_t ATTR_LAYOUT_IDX = 0;
      if (usedCoreNum > coreNum) usedCoreNum = coreNum;
      context->SetBlockDim(usedCoreNum);
  
-     // Workspace: 用于存储辅助矩阵 (-I, ZERO, +I) + 每核中转缓冲区
-     // 需要加上系统 workspace 大小
+     // Workspace: ascend950 全程片上缓存，仅预留系统 workspace；910b 需 GM 辅助矩阵中转区
      uint32_t sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
+     size_t* ws = context->GetWorkspaceSizes(1);
+     bool isAscend950 = (ascendcPlatform.GetSocVersion() == platform_ascendc::SocVersion::ASCEND950);
+     if (isAscend950) {
+         ws[0] = sysWorkspaceSize;
+     } else {
      size_t sharedSize = 3 * chunkSize * chunkSize * sizeof(uint16_t);  // I + -I + ZERO
      size_t perCoreSize = 2 * chunkSize * chunkSize * sizeof(uint16_t);  // 每核 2 个中转区（X 流 + Y 流双缓冲）
      size_t userWorkspaceSize = sharedSize + usedCoreNum * perCoreSize;
      // 对齐到 512 字节
      userWorkspaceSize = ((userWorkspaceSize + 511) / 512) * 512;
      // 总 workspace = 用户 workspace + 系统 workspace
-     size_t* ws = context->GetWorkspaceSizes(1);
      ws[0] = userWorkspaceSize + sysWorkspaceSize;
+     }
  
      return ge::GRAPH_SUCCESS;
  }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/arch35/mem.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/arch35/mem.h
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * Licensed under the BSD 3-Clause License.
+ */
+
+#ifndef MEM_H
+#define MEM_H
+
+struct HardwareInfo {
+    static uint32_t const l1Size = 512 * 1024;
+    static uint32_t const l0ASize = 64 * 1024;
+    static uint32_t const l0BSize = 64 * 1024;
+    static uint32_t const l0CSize = 256 * 1024;
+    static uint32_t const l2Size = 128 * 1024 * 1024;
+    static uint32_t const biasSize = 4 * 1024;
+    static uint32_t const fixBufSize = 6 * 1024;
+    static uint32_t const ubSize = 248 * 1024;
+};
+
+enum class BufferType : uint32_t {
+    ASCEND_UB,
+    ASCEND_CB,
+    ASCEND_L0A,
+    ASCEND_L0B,
+    ASCEND_L0C,
+    ASCEND_MAX
+};
+
+struct OnChipBuffer {
+    template <typename T>
+    using Tensor = AscendC::LocalTensor<T>;
+
+public:
+    __aicore__ inline OnChipBuffer()
+    {
+        constexpr uint32_t bufferSize[(uint32_t)BufferType::ASCEND_MAX] = {
+            HardwareInfo::ubSize, HardwareInfo::l1Size, HardwareInfo::l0ASize,
+            HardwareInfo::l0BSize, HardwareInfo::l0CSize};
+
+        buffer_[(uint32_t)BufferType::ASCEND_UB] =
+            Tensor<uint8_t>(AscendC::TPosition::VECIN, 0, bufferSize[(uint32_t)BufferType::ASCEND_UB]);
+        buffer_[(uint32_t)BufferType::ASCEND_CB] =
+            Tensor<uint8_t>(AscendC::TPosition::A1, 0, bufferSize[(uint32_t)BufferType::ASCEND_CB]);
+        buffer_[(uint32_t)BufferType::ASCEND_L0A] =
+            Tensor<uint8_t>(AscendC::TPosition::A2, 0, bufferSize[(uint32_t)BufferType::ASCEND_L0A]);
+        buffer_[(uint32_t)BufferType::ASCEND_L0B] =
+            Tensor<uint8_t>(AscendC::TPosition::B2, 0, bufferSize[(uint32_t)BufferType::ASCEND_L0B]);
+        buffer_[(uint32_t)BufferType::ASCEND_L0C] =
+            Tensor<uint8_t>(AscendC::TPosition::CO1, 0, bufferSize[(uint32_t)BufferType::ASCEND_L0C]);
+    }
+
+    template <BufferType bufferType, typename Dtype = half>
+    __aicore__ inline Tensor<Dtype> GetBuffer(const uint32_t offset) const
+    {
+        return buffer_[(uint32_t)bufferType][offset].template ReinterpretCast<Dtype>();
+    }
+
+private:
+    AscendC::LocalTensor<uint8_t> buffer_[(uint32_t)BufferType::ASCEND_MAX];
+};
+
+#endif  // MEM_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/arch35/solve_tri_ascend950.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/arch35/solve_tri_ascend950.h
@@ -206,7 +206,9 @@ public:
         loadDataParamsB.ifTranspose = true;
         AscendC::LoadData(l0B, l1B, loadDataParamsB);
 
-        PipeBarrier<PIPE_ALL>();
+        SetFlag<AscendC::HardEvent::MTE1_M>(0);   // LoadData(MTE1, 写 l0A/l0B) -> Mmad(M, 读 l0A/l0B)
+        WaitFlag<AscendC::HardEvent::MTE1_M>(0);
+        // PipeBarrier<PIPE_ALL>();
 
         AscendC::MmadParams mmadParams;
         mmadParams.m = chunkSize;
@@ -288,9 +290,13 @@ public:
         // [尾块辅助矩阵] 仅 chunk 尺寸变化时重建 NZ 单位/全零阵并重拷 l1_I
         if (cur != last_chunk_size) {
             AuxMatrixGen(cur);
-            AscendC::PipeBarrier<PIPE_ALL>();
+            SetFlag<AscendC::HardEvent::V_MTE3>(0);   // AuxMatrixGen(V, 写 ub_I) -> ub_to_l1(MTE3, 读 ub_I)
+            WaitFlag<AscendC::HardEvent::V_MTE3>(0);
+            // AscendC::PipeBarrier<PIPE_ALL>();
             ub_to_l1(l1_I, ub_I, static_cast<uint32_t>(cur));
-            AscendC::PipeBarrier<PIPE_ALL>();
+            SetFlag<AscendC::HardEvent::MTE3_MTE2>(0);   // ub_to_l1(MTE3) -> 下面对角块 gather(MTE2, 写 ub_A)
+            WaitFlag<AscendC::HardEvent::MTE3_MTE2>(0);
+            // AscendC::PipeBarrier<PIPE_ALL>();
             last_chunk_size = cur;
         }
 
@@ -305,19 +311,29 @@ public:
             AscendC::DataCopy(ub_A[dstOffset], gm_a[x_gm_offset + srcOffset],
                               AscendC::DataCopyParams(rows, 1, src_blk_stride, 0));
         }
-        AscendC::PipeBarrier<PIPE_ALL>();
+        SetFlag<AscendC::HardEvent::MTE2_MTE3>(0);   // gather(MTE2, 写 ub_A) -> ub_to_l1(MTE3, 读 ub_A)
+        WaitFlag<AscendC::HardEvent::MTE2_MTE3>(0);
+        // AscendC::PipeBarrier<PIPE_ALL>();
 
         ub_to_l1(l1_Y, ub_A, static_cast<uint32_t>(cur));        // l1_Y = A(块对角)
-        AscendC::PipeBarrier<PIPE_ALL>();
+        SetFlag<AscendC::HardEvent::MTE3_V>(0);   // ub_to_l1(MTE3, 读 ub_A) -> Sub(V, 读 ub_A) [RAR/顺序，保证 gather 已消费]
+        WaitFlag<AscendC::HardEvent::MTE3_V>(0);
+        // AscendC::PipeBarrier<PIPE_ALL>();
         AscendC::Sub(ub_I_A, ub_I, ub_A, (int32_t)(cur * cur));  // I - A
-        AscendC::PipeBarrier<PIPE_ALL>();
+        SetFlag<AscendC::HardEvent::V_MTE3>(0);   // Sub(V, 写 ub_I_A) -> ub_to_l1(MTE3, 读 ub_I_A)
+        WaitFlag<AscendC::HardEvent::V_MTE3>(0);
+        // AscendC::PipeBarrier<PIPE_ALL>();
         ub_to_l1(l1_X, ub_I_A, static_cast<uint32_t>(cur));      // l1_X = I - A
-        AscendC::PipeBarrier<PIPE_ALL>();
+        SetFlag<AscendC::HardEvent::MTE3_V>(0);   // ub_to_l1(MTE3) -> 下面 Duplicate ub_FullA(V) [顺序]
+        WaitFlag<AscendC::HardEvent::MTE3_V>(0);
+        // AscendC::PipeBarrier<PIPE_ALL>();
 
         // MBH 预备（cur>16）：完整 A GM(ND)->ub_FullA(NZ)，尾块只读 actual_size 行（其余清 0），取负 -> l1_MNEG。
         if (cur > 16) {
             Duplicate(ub_FullA, (InDtype)0, (int32_t)(cur * cur));  // 清 padding 行
-            AscendC::PipeBarrier<PIPE_ALL>();
+            SetFlag<AscendC::HardEvent::V_MTE2>(0);   // Duplicate(V, 写 ub_FullA) -> nd2nz DataCopy(MTE2, 写 ub_FullA) [WAW]
+            WaitFlag<AscendC::HardEvent::V_MTE2>(0);
+            // AscendC::PipeBarrier<PIPE_ALL>();
             AscendC::Nd2NzParams p;
             p.ndNum = 1;
             p.nValue = static_cast<uint32_t>(actual_size);
@@ -328,11 +344,15 @@ public:
             p.dstNzC0Stride = static_cast<uint16_t>(cur);
             p.dstNzMatrixStride = 0;
             AscendC::DataCopy(ub_FullA, gm_a[x_gm_offset], p);
-            AscendC::PipeBarrier<PIPE_ALL>();
+            SetFlag<AscendC::HardEvent::MTE2_V>(0);   // nd2nz(MTE2, 写 ub_FullA) -> Muls(V, 读写 ub_FullA)
+            WaitFlag<AscendC::HardEvent::MTE2_V>(0);
+            // AscendC::PipeBarrier<PIPE_ALL>();
             AscendC::Muls(ub_FullA, ub_FullA, (InDtype)(-1.0f), (int32_t)(cur * cur));
-            AscendC::PipeBarrier<PIPE_ALL>();
+            SetFlag<AscendC::HardEvent::V_MTE3>(0);   // Muls(V, 写 ub_FullA) -> ub_to_l1(MTE3, 读 ub_FullA)
+            WaitFlag<AscendC::HardEvent::V_MTE3>(0);
+            // AscendC::PipeBarrier<PIPE_ALL>();
             ub_to_l1(l1_MNEG, ub_FullA, static_cast<uint32_t>(cur));  // l1_MNEG = -A
-            AscendC::PipeBarrier<PIPE_ALL>();
+            // AscendC::PipeBarrier<PIPE_ALL>();   // 冗余：Process 中随后的 CrossCoreSetFlag<PIPE_MTE3> 已 flush MTE3
         }
     }
 
@@ -341,27 +361,37 @@ public:
     __aicore__ inline void AicMchNewton(int64_t cur, int64_t actual_size, int64_t x_gm_offset, int64_t row_stride)
     {
         MatmulToL0C(l1_Y, l1_Y, l0a_Y, l0b_Y, l0c_Y, cur, true);
-        AscendC::PipeBarrier<PIPE_ALL>();
+        SetFlag<AscendC::HardEvent::M_FIX>(0);   // Mmad(M, 写 l0c_Y) -> Fixpipe(FIX, 读 l0c_Y)
+        WaitFlag<AscendC::HardEvent::M_FIX>(0);
+        // AscendC::PipeBarrier<PIPE_ALL>();
         FixpipeL0cToL1(l1_Y, l0c_Y, cur);
-        AscendC::PipeBarrier<PIPE_ALL>();
+        AscendC::PipeBarrier<PIPE_ALL>();   // FIX(写 l1_Y) -> 下个 matmul LoadData(MTE1, 读 l1_Y)：无 FIX_MTE1 事件，暂保留全屏障
 
         MatmulToL0C(l1_I, l1_X, l0a_X, l0b_X, l0c_X, cur, true);
-        AscendC::PipeBarrier<PIPE_ALL>();
+        SetFlag<AscendC::HardEvent::M_FIX>(0);   // Mmad(M, 写 l0c_X) -> Fixpipe(FIX, 读 l0c_X)
+        WaitFlag<AscendC::HardEvent::M_FIX>(0);
+        // AscendC::PipeBarrier<PIPE_ALL>();
         FixpipeL0cToL1(l1_X, l0c_X, cur);
-        AscendC::PipeBarrier<PIPE_ALL>();
+        AscendC::PipeBarrier<PIPE_ALL>();   // FIX(写 l1_X) -> 下个 matmul LoadData(MTE1, 读 l1_X)：无 FIX_MTE1 事件，暂保留全屏障
 
         MatmulToL0C(l1_X, l1_Y, l0a_X, l0b_X, l0c_X, cur, false);
-        AscendC::PipeBarrier<PIPE_ALL>();
+        SetFlag<AscendC::HardEvent::M_FIX>(0);   // Mmad(M, 写 l0c_X) -> Fixpipe(FIX, 读 l0c_X)
+        WaitFlag<AscendC::HardEvent::M_FIX>(0);
+        // AscendC::PipeBarrier<PIPE_ALL>();
         FixpipeL0cToL1(l1_X, l0c_X, cur);
-        AscendC::PipeBarrier<PIPE_ALL>();
+        AscendC::PipeBarrier<PIPE_ALL>();   // FIX(写 l1_X) -> 迭代内 matmul LoadData(MTE1, 读 l1_X)：无 FIX_MTE1 事件，暂保留全屏障
 
         for (uint64_t iter = 0; iter < 2; iter++) {
             MatmulToL0C(l1_Y, l1_Y, l0a_Y, l0b_Y, l0c_Y, cur, true);
-            AscendC::PipeBarrier<PIPE_ALL>();
+            SetFlag<AscendC::HardEvent::M_FIX>(0);   // Mmad(M, 写 l0c_Y) -> Fixpipe(FIX, 读 l0c_Y)
+            WaitFlag<AscendC::HardEvent::M_FIX>(0);
+            // AscendC::PipeBarrier<PIPE_ALL>();
             FixpipeL0cToL1(l1_Y, l0c_Y, cur);
-            AscendC::PipeBarrier<PIPE_ALL>();
+            AscendC::PipeBarrier<PIPE_ALL>();   // FIX(写 l1_Y) -> 下个 matmul LoadData(MTE1, 读 l1_Y)：无 FIX_MTE1 事件，暂保留全屏障
             MatmulToL0C(l1_X, l1_Y, l0a_X, l0b_X, l0c_X, cur, false);
-            AscendC::PipeBarrier<PIPE_ALL>();
+            SetFlag<AscendC::HardEvent::M_FIX>(0);   // Mmad(M, 写 l0c_X) -> Fixpipe(FIX, 读 l0c_X)
+            WaitFlag<AscendC::HardEvent::M_FIX>(0);
+            // AscendC::PipeBarrier<PIPE_ALL>();
             if (iter == 1) {
                 if (cur > 16) {
                     FixpipeL0cToUB(ub_Res, l0c_X, cur);   // -> MBH 消费
@@ -370,10 +400,10 @@ public:
                                    static_cast<uint32_t>(actual_size), static_cast<uint32_t>(cur),
                                    static_cast<uint32_t>(row_stride));
                 }
-                AscendC::PipeBarrier<PIPE_ALL>();
+                // AscendC::PipeBarrier<PIPE_ALL>();   // 冗余：Process 中随后的 CrossCoreSetFlag<PIPE_FIX> 已 flush FIX
             } else {
                 FixpipeL0cToL1(l1_X, l0c_X, cur);
-                AscendC::PipeBarrier<PIPE_ALL>();
+                AscendC::PipeBarrier<PIPE_ALL>();   // FIX(写 l1_X) -> 下轮 matmul LoadData(MTE1, 读 l1_X)：无 FIX_MTE1 事件，暂保留全屏障
             }
         }
     }
@@ -433,7 +463,9 @@ public:
         for (int32_t i = 0; i < numFracs; ++i) {
             AscendC::LoadData(l0b_X[i * numFracs * FRAC_LEN], l1B[i * FRAC_LEN], loadParamsB);
         }
-        AscendC::PipeBarrier<PIPE_ALL>();
+        SetFlag<AscendC::HardEvent::MTE1_M>(0);   // LoadData(MTE1, 写 l0a_X/l0b_X) -> Mmad(M, 读 l0a_X/l0b_X)
+        WaitFlag<AscendC::HardEvent::MTE1_M>(0);
+        // AscendC::PipeBarrier<PIPE_ALL>();
 
         AscendC::MmadParams mmadParams;
         mmadParams.m = cur;
@@ -451,9 +483,11 @@ public:
                                            int64_t cur, bool initC)
     {
         MbhMatmulToL0C(l1A, l1B, cur, initC);
-        AscendC::PipeBarrier<PIPE_ALL>();
+        SetFlag<AscendC::HardEvent::M_FIX>(0);   // Mmad(M, 写 l0c_X) -> Fixpipe(FIX, 读 l0c_X)
+        WaitFlag<AscendC::HardEvent::M_FIX>(0);
+        // AscendC::PipeBarrier<PIPE_ALL>();
         FixpipeL0cToL1(l1Dst, l0c_X, cur);
-        AscendC::PipeBarrier<PIPE_ALL>();
+        AscendC::PipeBarrier<PIPE_ALL>();   // FIX(写 l1Dst) -> 调用方下个 matmul LoadData(MTE1, 读 l1Dst)：无 FIX_MTE1 事件，暂保留全屏障
     }
 
     // ---- AIC：MBH 单层 B/C/E/G 四步矩乘 + 层间/末层写出 ----
@@ -462,15 +496,21 @@ public:
     {
         // step B: L0C = I × I（完整单位阵）
         MbhMatmulToL0C(l1_I, l1_I, cur, true);
-        AscendC::PipeBarrier<PIPE_ALL>();
+        SetFlag<AscendC::HardEvent::M_MTE1>(0);   // Mmad(M, 读 l0a_X/l0b_X) -> step C LoadData(MTE1, 覆写 l0a_X/l0b_X) [WAR]
+        WaitFlag<AscendC::HardEvent::M_MTE1>(0);
+        // AscendC::PipeBarrier<PIPE_ALL>();
         // step C: Y = drv(l1_X) × (-A) + I -> l1_Y
         MbhMatmulToSlot(l1_X, l1_MNEG, l1_Y, cur, false);
         // step E: L0C = Y × oth(l1_INPUT)
         MbhMatmulToL0C(l1_Y, l1_INPUT, cur, true);
-        AscendC::PipeBarrier<PIPE_ALL>();
+        SetFlag<AscendC::HardEvent::M_MTE1>(0);   // Mmad(M, 读 l0a_X/l0b_X) -> step G LoadData(MTE1, 覆写 l0a_X/l0b_X) [WAR]
+        WaitFlag<AscendC::HardEvent::M_MTE1>(0);
+        // AscendC::PipeBarrier<PIPE_ALL>();
         // step G: L0C += I × drv(l1_X)
         MbhMatmulToL0C(l1_I, l1_X, cur, false);
-        AscendC::PipeBarrier<PIPE_ALL>();
+        SetFlag<AscendC::HardEvent::M_FIX>(0);   // Mmad(M, 写 l0c_X) -> Fixpipe(FIX, 读 l0c_X)
+        WaitFlag<AscendC::HardEvent::M_FIX>(0);
+        // AscendC::PipeBarrier<PIPE_ALL>();
         if (!lastLevel) {
             FixpipeL0cToUB(ub_Res, l0c_X, cur);   // 层间结果 -> ub_Res，下层提取
         } else {
@@ -478,7 +518,7 @@ public:
                            static_cast<uint32_t>(actual_size), static_cast<uint32_t>(cur),
                            static_cast<uint32_t>(row_stride));
         }
-        AscendC::PipeBarrier<PIPE_ALL>();
+        // AscendC::PipeBarrier<PIPE_ALL>();   // 冗余：Process 中随后的 CrossCoreSetFlag<PIPE_FIX> 已 flush FIX
     }
 
     // ---- Process：CrossCoreFlag + round-robin，MCH 与 MBH 每 tile 逐层握手 ----
@@ -505,10 +545,10 @@ public:
                     for (int32_t blockSize = 16; blockSize < cur; blockSize *= 2) {
                         ClearSlotUB(l1_X, cur);
                         ClearSlotUB(l1_INPUT, cur);
-                        AscendC::PipeBarrier<PIPE_ALL>();
+                        // AscendC::PipeBarrier<PIPE_ALL>();   // 冗余：ClearSlotUB 与 ExtractFromUB 同为 MTE3 流水，天然有序
                         ExtractFromUB(l1_X, cur, blockSize, drvStart);     // drv -> l1_X
                         ExtractFromUB(l1_INPUT, cur, blockSize, othStart); // oth -> l1_INPUT
-                        AscendC::PipeBarrier<PIPE_ALL>();
+                        // AscendC::PipeBarrier<PIPE_ALL>();   // 冗余：随后的 CrossCoreSetFlag<PIPE_MTE3> 已 flush MTE3
                         AscendC::CrossCoreSetFlag<0x4, PIPE_MTE3>(0x2);   // 提取就绪 -> AIC
                         AscendC::CrossCoreWaitFlag<0x4>(0x0);             // 等 AIC：本层矩乘/回写完成
                     }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/arch35/solve_tri_ascend950.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/arch35/solve_tri_ascend950.h
@@ -15,45 +15,35 @@ using namespace AscendC;
 // ============================================================================
 // SolveTri —— 完整下三角逆 (I+A)^{-1} 的 ascend950 实现（MCH + MBH 合一）
 //
-// 两段算法合并在同一 SolveTril 类（source 风格：OnChipBuffer + SyncAll 协同）：
-//   - MCH（块对角逆）：源仓移植。AIV 生成 NZ 辅助矩阵 + gather 对角块，AIC 牛顿迭代
-//     求每个 16×16 对角块逆，结果(NZ)暂存 ub_Res(UB)。
-//   - MBH（递归合并）：基于【本仓已验证 RecursiveMerge(UB-opt) 算法】移植（非源仓）。
-//     X 常驻 ub_Res(UB,NZ)；逐层 blockSize=16->cur：AIV 从 ub_Res 提取 drv/oth 对角块
-//     到 L1，AIC 做 B/C/E/G 四步矩乘合并，层间结果 Fixpipe 回 ub_Res，末层写 gm_out。
+// 两段算法合并在同一 SolveTri 类：
+//   - MCH（块对角逆）：AIV 生成 NZ 辅助矩阵 + gather 对角块，AIC 牛顿迭代求每个
+//     16×16 对角块逆；cur==16 直接写 gm_out，cur>16 结果(NZ)暂存 ub_Res(UB) 供 MBH。
+//   - MBH（递归合并）：X 常驻 ub_Res(UB,NZ)；逐层 blockSize=16->cur：AIV 从 ub_Res
+//     提取 drv/oth 对角块到 L1，AIC 做 B/C/E/G 四步矩乘合并，层间结果 Fixpipe 回
+//     ub_Res，末层写 gm_out。
 //
-// MCH 移植中的接口/“非泛化参数”适配（不改 MCH 整体算法逻辑）：
-//   [接口] kernel 形参收敛为 x / cu_seqlens / chunk_indices / x_out / workspace /
-//          tiling；输出沿用本仓 x_out 命名；索引为 INT64；支持 FP16 + BF16。
-//   [tiling 字段] 沿用本仓字段名、按 MCH 语义读取：
-//          batchSize / seqLen / numHeads / chunkSize / numChunks(=chunkNumInSeq) /
-//          totalChunks(=chunkNumTotal, 主循环上界) / layoutMode(=mode) / isLower。
-//   [尾块辅助矩阵修复] 源实现把单位/全零矩阵按整 chunk_size 在循环外生成一次；尾块
-//          chunk_size_actual 变化时 NZ 单位阵的分形偏移随之改变，会算错。改为仅在
-//          chunk 尺寸“发生变化”时（即 seqlen 尾块）按 chunk_size_actual 重建 I/Zero
-//          并重拷 l1_I；非尾块尺寸不变则复用，避免额外开销。
-//   [GM 偏移泛化] 源 x_gm_offset 仅在“单 chunk / 单 head”下成立。改为与本仓已验证 MBH
-//          的 GetTileGMOffset 对齐的完整公式（[B,T,H,BT] 布局，行跨度 = num_head*chunk_size）。
-//   [搬运步长泛化] 源对角块 gather 的 srcStride 硬编码为 1（仅 BT=32、H=1 成立）。
-//          改为按物理行跨度推导 srcStride = num_head*chunk_size/16 - 1。
+// 【分核 / 同步】（本版：CrossCoreFlag + round-robin，统一 MCH 与 MBH）
+//   - 参照仓1（recurrent_gdn/solve_tril）已验证的 MCH 写法：跨核用 CrossCoreSetFlag/
+//     WaitFlag 每 tile / 每 MBH 层握手，AIC 与其配对 AIV 处理同一 tile（cur 一致 -> 层数
+//     一致 -> 握手计数天然对齐，无需全局屏障 / 固定调度，无死锁）。
+//   - 多核 round-robin，以 num_core 为间隔分核：
+//       AIV(sub0): loop_idx = core_idx/2; loop_idx += num_core
+//       AIC     : loop_idx = core_idx;   loop_idx += num_core
+//   - flag：mode 0x4；0x2 = AIV->AIC(数据/提取就绪)，0x0 = AIC->AIV(计算/回写完成)。
+//     两 flag 严格交替复用于 MCH 与每个 MBH 层。
+//   - 注：原 SyncAll 固定调度版已整体替换为 CrossCoreFlag（MBH 一并切换）。
 //
-// MBH 移植要点（对齐本仓已验证 UB-opt 路径）：
-//   - 跨核同步用 SyncAll<false>（本仓实测：CrossCoreFlag 在 1:2 MIX 上死锁）。多核“固定调度”：
-//     每 (AIC,其2 AIV subcore) 组处理连续 tile 段 [groupIdx*tilesPerCore, +tilesPerCore)，
-//     所有组都走 tilesPerCore 个 slot、每 slot 固定 (2 + 2*maxLevels) 次 SyncAll（maxLevels=
-//     log2(chunk_size/16)，各核一致）—— 真实层做活、其余层空屏障补齐、越界 slot 全空屏障，
-//     故组间 SyncAll 计数恒等，不死锁。单核(usedCoreNum=1)退化为逐 tile 行为。
-//   - -A 由 AIV 备数：完整 A GM(ND)->ub_FullA(NZ) 后 Muls(-1) -> l1_MNEG（替代源 -I 矩乘，
-//     代数等价；省一次 cube 矩乘与 -I 常量）。
-//   - MBH 各步矩乘用本仓已验证 RecursiveMerge 的 V1 约定（MbhMatmulToL0C，对 A 做块转置预交换），
-//     不复用 MCH 的 V2 MatmulToL0C：MBH 的 -A / Y 含非对角分形，两种约定在非对角分形上不等价。
+// 【布局 / 变长 TND】
+//   - GM 偏移按 [B,H,T,BT](bhtd) / [B,T,H,BT](bsnd) / [total_T,H,BT](tnd 变长) 完整公式；
+//     tnd 由 cu_seqlens / chunk_indices（INT64，GetValue）确定每 tile 偏移与序列长度。
+//   - 行跨度 row_stride = (bhtd) chunk_size : num_head*chunk_size。
 //
-// 已知限制 / 假设（待硬件验证）：
-//   * 多核固定调度假设：MIX 1:2 下 GetBlockIdx() 对 AIC 与其配对 AIV 返回同一组索引；若目标
-//     SDK 语义不同（如 AIV 返回 AIV-global 索引），仅需改 Process() 中 groupIdx 推导一行。
-//   * 尾块在 ChunkAlign 上取整后会按对齐尺寸读取 GM，可能越过有效行（源既有行为）。
-//   * MCH 用 V2、MBH 用 V1：MCH 操作数为块对角（非对角分形恒 0），两约定等价，故 MCH 验证
-//     无法覆盖非对角分形；MBH 改用本仓已验证 V1 约定，BT>16 正确性由 V1 自身保证。
+// 【尾块（partial chunk）正确性】
+//   - actual_size = 该 chunk 的有效行数（尾块 < cur）。cur = ChunkAlign(actual_size)。
+//   - 输入 gather 只读 actual_size 行（逐分形 min(16, actual_size-i*16)）；越界分形不读，
+//     由 aux 置 I，使部分对角块逆为 [[valid^-1,0],[0,I]]。
+//   - MBH 的 -A 只读 actual_size 行（其余清 0），保证 padding 参与 MBH 得 I。
+//   - 输出只写 actual_size 行（FixpipeL0cToGM 的 validRows），避免跨序列覆写 / OOB。
 // ============================================================================
 
 constexpr AscendC::FixpipeConfig CFG_NZ_L1 = {AscendC::CO2Layout::NZ, false};
@@ -65,18 +55,18 @@ public:
     __aicore__ inline void Init(GM_ADDR aGm, GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR outGm,
                                 GM_ADDR workspace, const SolveTriTilingData *tilingData)
     {
-        // Tiling（沿用本仓字段名，按 MCH 语义解释）
+        // Tiling
         batch_size = tilingData->batchSize;
-        seq_length = tilingData->seqLen;          // <- seqLength
-        num_head = tilingData->numHeads;          // <- numHead
+        seq_length = tilingData->seqLen;
+        num_head = tilingData->numHeads;
         chunk_size = tilingData->chunkSize;
-        chunk_num_in_seq = tilingData->numChunks; // <- chunkNumInSeq
+        chunk_num_in_seq = tilingData->numChunks;
         chunk_num_total = tilingData->totalTiles; // 主循环上界 = 全部 tile 数
         mode = tilingData->layoutMode;            // 0=bhtd, 1=bsnd, 2=tnd
-        is_lower = tilingData->isLower;           // MBH 驱动块选择（下三角=1）
-        tiles_per_core = tilingData->tilesPerCore;// 每个 (AIC,其AIV) 组处理的 tile 数（多核划分）
+        is_lower = tilingData->isLower;
+        tiles_per_core = tilingData->tilesPerCore;
 
-        // GM
+        // GM（INT64 索引）
         gm_a.SetGlobalBuffer(reinterpret_cast<__gm__ InDtype *>(aGm));
         gm_cu_seqlens.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(cu_seqlens));
         gm_chunk_indices.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(chunk_indices));
@@ -84,17 +74,14 @@ public:
 
         OnChipBuffer buf;
 
-        // UB（每块 chunk_size*chunk_size 个 InDtype）：
-        //   ub_I / ub_Zero / ub_A / ub_I_A / ub_Res 为 MCH 所用；
-        //   ub_FullA 为 MBH 阶段暂存“完整 -A”（GM->UB nd2nz 后取负）。
+        // UB（每块 chunk_size*chunk_size 个 InDtype）
         ub_I = buf.template GetBuffer<BufferType::ASCEND_UB, InDtype>(0);
         ub_Zero = buf.template GetBuffer<BufferType::ASCEND_UB, InDtype>(chunk_size * chunk_size * sizeof(InDtype));
         ub_A = buf.template GetBuffer<BufferType::ASCEND_UB, InDtype>(chunk_size * chunk_size * sizeof(InDtype) * 2);
         ub_I_A = buf.template GetBuffer<BufferType::ASCEND_UB, InDtype>(chunk_size * chunk_size * sizeof(InDtype) * 3);
         ub_Res = buf.template GetBuffer<BufferType::ASCEND_UB, InDtype>(chunk_size * chunk_size * sizeof(InDtype) * 4);
         ub_FullA = buf.template GetBuffer<BufferType::ASCEND_UB, InDtype>(chunk_size * chunk_size * sizeof(InDtype) * 5);
-        // L1（NZ 槽，每槽 chunk_size*chunk_size 个 InDtype）：
-        //   MCH 用 l1_I / l1_X / l1_Y；MBH 复用三者并额外用 l1_MNEG(-A) / l1_INPUT(提取的 oth 块)。
+        // L1（NZ 槽）
         l1_I = buf.template GetBuffer<BufferType::ASCEND_CB, InDtype>(0);
         l1_X = buf.template GetBuffer<BufferType::ASCEND_CB, InDtype>(chunk_size * chunk_size * sizeof(InDtype));
         l1_Y = buf.template GetBuffer<BufferType::ASCEND_CB, InDtype>(chunk_size * chunk_size * sizeof(InDtype) * 2);
@@ -114,7 +101,7 @@ public:
         core_idx = AscendC::GetBlockIdx();
         sub_block_idx = AscendC::GetSubBlockIdx();
 
-        // 辅助矩阵缓存标记：0 为无效初值（chunk_size_actual 恒 >=16），首个 tile 必触发生成。
+        // 辅助矩阵缓存标记：0 为无效初值（cur 恒 >=16），首个 tile 必触发生成
         last_chunk_size = 0;
     }
 
@@ -126,24 +113,18 @@ public:
     __aicore__ inline void ub_to_l1(AscendC::LocalTensor<InDtype> l1Tensor,
                                     AscendC::LocalTensor<InDtype> ubTensor, uint32_t chunkSize)
     {
-        AscendC::DataCopy(l1Tensor,                               // dst
-                          ubTensor,                               // src
-                          AscendC::DataCopyParams(1,              // nBurst
-                                                  chunkSize * chunkSize / 16,  // lenBurst
-                                                  0,              // srcGap
-                                                  0));            // dstGap
+        AscendC::DataCopy(l1Tensor, ubTensor,
+                          AscendC::DataCopyParams(1, chunkSize * chunkSize / 16, 0, 0));
     }
 
     __aicore__ inline void FixpipeL0cToL1(AscendC::LocalTensor<InDtype> l1Tensor,
-                                          AscendC::LocalTensor<float> l0CTensor,
-                                          uint32_t chunkSize)
+                                          AscendC::LocalTensor<float> l0CTensor, uint32_t chunkSize)
     {
         AscendC::FixpipeParamsArch3510<AscendC::CO2Layout::NZ> fixPipeParams;
         fixPipeParams.nSize = chunkSize;
         fixPipeParams.mSize = chunkSize;
         fixPipeParams.srcStride = chunkSize;
         fixPipeParams.dstStride = chunkSize * 16;
-
         if constexpr (std::is_same_v<InDtype, half>) {
             fixPipeParams.quantPre = QuantMode_t::F322F16;
         } else {
@@ -153,8 +134,7 @@ public:
     }
 
     __aicore__ inline void FixpipeL0cToUB(AscendC::LocalTensor<InDtype> ubTensor,
-                                          AscendC::LocalTensor<float> l0CTensor,
-                                          uint32_t chunkSize)
+                                          AscendC::LocalTensor<float> l0CTensor, uint32_t chunkSize)
     {
         AscendC::FixpipeParamsArch3510<AscendC::CO2Layout::NZ> fixPipeParams;
         fixPipeParams.nSize = chunkSize;
@@ -163,7 +143,6 @@ public:
         fixPipeParams.dstStride = chunkSize * 16;
         fixPipeParams.dualDstCtl = 0;
         fixPipeParams.subBlockId = 0;
-
         if constexpr (std::is_same_v<InDtype, half>) {
             fixPipeParams.quantPre = QuantMode_t::F322F16;
         } else {
@@ -183,13 +162,15 @@ public:
         return 128;
     }
 
-    // 结果写回：L0C(FP32, NZ) -> gm_out(ND, 行优先)。dstStride = GM 物理行跨度。
-    // 用于 cur==16（纯 MCH，无 MBH）及 cur>16 时 MBH 末层的最终结果写出。
+    // 结果写回：L0C(FP32, NZ) -> gm_out(ND, 行优先)。
+    //   validRows = 有效行数（尾块 < curSize），只写 validRows 行避免跨序列覆写。
+    //   curSize   = 对齐后 chunk 尺寸（= L0C/输出的列数与源行跨度）。
+    //   dstStride = GM 物理行跨度。
     __aicore__ inline void FixpipeL0cToGM(AscendC::GlobalTensor<OutDtype> gmTensor,
                                           AscendC::LocalTensor<float> l0CTensor,
-                                          uint32_t curSize, uint32_t dstStride)
+                                          uint32_t validRows, uint32_t curSize, uint32_t dstStride)
     {
-        auto intriParams = AscendC::FixpipeParamsV220(curSize, curSize, curSize, dstStride, false);
+        auto intriParams = AscendC::FixpipeParamsV220(curSize, validRows, curSize, dstStride, false);
         if constexpr (std::is_same_v<OutDtype, half>) {
             intriParams.quantPre = QuantMode_t::F322F16;
         } else {
@@ -198,6 +179,7 @@ public:
         AscendC::Fixpipe<OutDtype, float, AscendC::CFG_ROW_MAJOR>(gmTensor, l0CTensor, intriParams);
     }
 
+    // MCH V2 MatmulToL0C（块对角操作数专用；非对角分形恒 0，V1/V2 等价）
     __aicore__ inline void MatmulToL0C(AscendC::LocalTensor<InDtype> l1A, AscendC::LocalTensor<InDtype> l1B,
                                        AscendC::LocalTensor<InDtype> l0A, AscendC::LocalTensor<InDtype> l0B,
                                        AscendC::LocalTensor<float> l0C, int64_t chunkSize, bool initC)
@@ -239,11 +221,10 @@ public:
     // 按给定 cur_size 生成 NZ 块对角辅助矩阵（尾块安全）：单位阵 I、全零阵 Zero，并清零 ub_A。
     __aicore__ inline void AuxMatrixGen(int64_t cur_size)
     {
-        uint64_t NUM_FRACS = cur_size / 16; // 对角分形个数
-        uint64_t NUM_ITER = NUM_FRACS * 2;  // 8x16 条带数
+        uint64_t NUM_FRACS = cur_size / 16;
+        uint64_t NUM_ITER = NUM_FRACS * 2;
         int32_t chunkElems = static_cast<int32_t>(cur_size * cur_size);
 
-        // 清零 A / 生成单位阵 I（NZ：对角分形落在 (i*NUM_FRACS+i)*256 = i*(cur_size*16+256)）
         Duplicate(ub_A, (InDtype)0, chunkElems);
         Duplicate(ub_I, (InDtype)0, chunkElems);
         for (uint64_t stripIdx = 0; stripIdx < NUM_ITER; stripIdx++) {
@@ -256,13 +237,12 @@ public:
             uint64_t UB_DIAG_I_OFF = fracsIdx * (cur_size + 16) * 16 + oldEvenIdx * 8 * 16;
             Duplicate(ub_I[UB_DIAG_I_OFF], (InDtype)1.0f, diagMask, 1, 1, 1);
         }
-        // 全零矩阵
         Duplicate(ub_Zero, (InDtype)0, chunkElems);
     }
 
-    // 由 loop_idx 计算该 tile 的 GM 偏移与对齐后的实际 chunk 尺寸。
-    // 与本仓已验证 MBH 的 GetTileGMOffset / GetTileValidSize 公式对齐（[B,T,H,BT] 布局）。
-    __aicore__ inline void ComputeTile(int64_t loop_idx, int64_t &x_gm_offset, int64_t &cur_size)
+    // 由 loop_idx 计算该 tile 的 GM 偏移、对齐后 chunk 尺寸 cur_size 与有效行数 actual_size。
+    __aicore__ inline void ComputeTile(int64_t loop_idx, int64_t &x_gm_offset,
+                                       int64_t &cur_size, int64_t &actual_size)
     {
         int64_t seq_idx = 0;
         int64_t chunk_in_seq_idx = 0;
@@ -271,22 +251,21 @@ public:
         int64_t local_seq_length = seq_length;
         int64_t local_chunk_num_in_seq = chunk_num_in_seq;
 
-        if (mode == 0) { // BHTD: [B, H, T, BT]，遍历顺序 B -> H -> chunk
+        if (mode == 0) { // BHTD: [B, H, T, BT]
             seq_idx = loop_idx / (chunk_num_in_seq * num_head);
             head_idx = (loop_idx / chunk_num_in_seq) % num_head;
             chunk_in_seq_idx = loop_idx % chunk_num_in_seq;
             x_gm_offset = seq_idx * num_head * seq_length * chunk_size +
                           head_idx * seq_length * chunk_size +
                           chunk_in_seq_idx * chunk_size * chunk_size;
-        } else if (mode == 1) { // 定长 bsnd
+        } else if (mode == 1) { // BSND: [B, T, H, BT]
             seq_idx = loop_idx / (chunk_num_in_seq * num_head);
             chunk_in_seq_idx = loop_idx % (chunk_num_in_seq * num_head) / num_head;
             head_idx = loop_idx % (chunk_num_in_seq * num_head) % num_head;
-            // [B,T,H,BT]: base = b*T*H*BT + chunk*BT*H*BT + h*BT
             x_gm_offset = seq_idx * seq_length * num_head * chunk_size +
                           chunk_in_seq_idx * chunk_size * num_head * chunk_size +
                           head_idx * chunk_size;
-        } else if (mode == 2) { // 变长 tnd
+        } else { // TND varlen: [total_T, H, BT]; B = 1
             chunk_idx = loop_idx / num_head;
             head_idx = loop_idx % num_head;
             seq_idx = gm_chunk_indices.GetValue(chunk_idx * 2);
@@ -294,20 +273,19 @@ public:
             local_seq_length = gm_cu_seqlens.GetValue(seq_idx + 1) - gm_cu_seqlens.GetValue(seq_idx);
             local_chunk_num_in_seq = CeilDiv(local_seq_length, chunk_size);
             int64_t bos = gm_cu_seqlens.GetValue(seq_idx);
-            // (bos + chunk*BT) * H * BT + h * BT
             x_gm_offset = (bos + chunk_in_seq_idx * chunk_size) * num_head * chunk_size +
                           head_idx * chunk_size;
         }
 
-        cur_size = (chunk_in_seq_idx == (local_chunk_num_in_seq - 1)) ?
-                       ChunkAlign(local_seq_length - chunk_in_seq_idx * chunk_size) :
-                       chunk_size;
+        bool is_last = (chunk_in_seq_idx == (local_chunk_num_in_seq - 1));
+        actual_size = is_last ? (local_seq_length - chunk_in_seq_idx * chunk_size) : chunk_size;
+        cur_size = is_last ? ChunkAlign(actual_size) : chunk_size;
     }
 
     // ---- AIV：MCH 单 tile 备数（含 MBH 所需的完整 -A 暂存）----
-    __aicore__ inline void AivMchPrep(int64_t cur, int64_t x_gm_offset, int64_t row_stride)
+    __aicore__ inline void AivMchPrep(int64_t cur, int64_t actual_size, int64_t x_gm_offset, int64_t row_stride)
     {
-        // [尾块辅助矩阵] 仅 chunk 尺寸变化时重建 NZ 单位/全零阵并重拷 l1_I（避免每 tile 开销）。
+        // [尾块辅助矩阵] 仅 chunk 尺寸变化时重建 NZ 单位/全零阵并重拷 l1_I
         if (cur != last_chunk_size) {
             AuxMatrixGen(cur);
             AscendC::PipeBarrier<PIPE_ALL>();
@@ -316,13 +294,16 @@ public:
             last_chunk_size = cur;
         }
 
-        // 对角 16x16 块 GM(ND) -> ub_A(NZ 块对角)；srcStride 按物理行跨度泛化。
+        // 对角 16x16 块 GM(ND) -> ub_A(NZ 块对角)；尾块只读 actual_size 行（逐分形裁剪）。
         uint16_t src_blk_stride = static_cast<uint16_t>(row_stride / 16 - 1);
-        for (uint64_t i = 0; i < (uint64_t)(cur / 16); i++) {
+        uint64_t num_valid_fracs = static_cast<uint64_t>(CeilDiv(actual_size, 16));
+        for (uint64_t i = 0; i < num_valid_fracs; i++) {
+            int64_t rows64 = actual_size - static_cast<int64_t>(i) * 16;
+            uint16_t rows = static_cast<uint16_t>(rows64 >= 16 ? 16 : rows64);
             uint64_t srcOffset = i * (16 * (uint64_t)row_stride + 16);
             uint64_t dstOffset = i * ((uint64_t)cur * 16 + 16 * 16);
             AscendC::DataCopy(ub_A[dstOffset], gm_a[x_gm_offset + srcOffset],
-                              AscendC::DataCopyParams(16, 1, src_blk_stride, 0));
+                              AscendC::DataCopyParams(rows, 1, src_blk_stride, 0));
         }
         AscendC::PipeBarrier<PIPE_ALL>();
 
@@ -333,11 +314,13 @@ public:
         ub_to_l1(l1_X, ub_I_A, static_cast<uint32_t>(cur));      // l1_X = I - A
         AscendC::PipeBarrier<PIPE_ALL>();
 
-        // MBH 预备（cur>16）：完整 A GM(ND)->ub_FullA(NZ)，取负 -> l1_MNEG(NZ)。
+        // MBH 预备（cur>16）：完整 A GM(ND)->ub_FullA(NZ)，尾块只读 actual_size 行（其余清 0），取负 -> l1_MNEG。
         if (cur > 16) {
+            Duplicate(ub_FullA, (InDtype)0, (int32_t)(cur * cur));  // 清 padding 行
+            AscendC::PipeBarrier<PIPE_ALL>();
             AscendC::Nd2NzParams p;
             p.ndNum = 1;
-            p.nValue = static_cast<uint32_t>(cur);
+            p.nValue = static_cast<uint32_t>(actual_size);
             p.dValue = static_cast<uint32_t>(cur);
             p.srcDValue = static_cast<uint32_t>(row_stride);
             p.srcNdMatrixStride = 0;
@@ -353,9 +336,9 @@ public:
         }
     }
 
-    // ---- AIC：MCH 牛顿迭代，求 16x16 对角块逆（块对角逆）----
-    // cur>16：结果 Fixpipe 暂存 ub_Res(UB,NZ) 供 MBH 消费；cur==16：纯 MCH，直接写 gm_out。
-    __aicore__ inline void AicMchNewton(int64_t cur, int64_t x_gm_offset, int64_t row_stride)
+    // ---- AIC：MCH 牛顿迭代，求 16x16 对角块逆 ----
+    // cur>16：结果 Fixpipe 暂存 ub_Res(UB,NZ) 供 MBH；cur==16：纯 MCH，直接写 gm_out（只写 actual_size 行）。
+    __aicore__ inline void AicMchNewton(int64_t cur, int64_t actual_size, int64_t x_gm_offset, int64_t row_stride)
     {
         MatmulToL0C(l1_Y, l1_Y, l0a_Y, l0b_Y, l0c_Y, cur, true);
         AscendC::PipeBarrier<PIPE_ALL>();
@@ -381,12 +364,11 @@ public:
             AscendC::PipeBarrier<PIPE_ALL>();
             if (iter == 1) {
                 if (cur > 16) {
-                    // MCH 块对角逆 -> ub_Res(UB,NZ)，供 MBH 从 UB 提取消费。
-                    FixpipeL0cToUB(ub_Res, l0c_X, cur);
+                    FixpipeL0cToUB(ub_Res, l0c_X, cur);   // -> MBH 消费
                 } else {
-                    // cur==16：无 MBH，直接写最终结果到 gm_out(ND)。
                     FixpipeL0cToGM(gm_out[x_gm_offset], l0c_X,
-                                   static_cast<uint32_t>(cur), static_cast<uint32_t>(row_stride));
+                                   static_cast<uint32_t>(actual_size), static_cast<uint32_t>(cur),
+                                   static_cast<uint32_t>(row_stride));
                 }
                 AscendC::PipeBarrier<PIPE_ALL>();
             } else {
@@ -396,15 +378,14 @@ public:
         }
     }
 
-    // ---- AIV：清 L1 槽（zeroUB->L1，整槽置零）。zeroUB 复用 ub_Zero（已按 cur 清零）----
+    // ---- AIV：清 L1 槽（zeroUB->L1，整槽置零）----
     __aicore__ inline void ClearSlotUB(AscendC::LocalTensor<InDtype> l1Slot, int64_t cur)
     {
         AscendC::DataCopy(l1Slot, ub_Zero,
                           AscendC::DataCopyParams(1, (uint16_t)(cur * cur / 16), 0, 0));
     }
 
-    // ---- AIV：从 ub_Res(NZ) 按块 raw UB->L1 提取选中对角块到 l1Slot（非选中分形由 ClearSlotUB 置零）----
-    // ub_Res 与 L1 槽 NZ 布局一致：分形 (fr,fc) 偏移 = (fc*NUM_FRACS+fr)*256。
+    // ---- AIV：从 ub_Res(NZ) 按块 raw UB->L1 提取选中对角块到 l1Slot ----
     __aicore__ inline void ExtractFromUB(AscendC::LocalTensor<InDtype> l1Slot,
                                          int64_t cur, int32_t blockSize, int32_t startBlock)
     {
@@ -426,11 +407,7 @@ public:
         }
     }
 
-    // ---- AIC：MBH 矩乘（本仓已验证 RecursiveMerge 的 V1 约定，运行期 cur 参数化）----
-    // 关键：cube 实际算 blockT(OpA)@B，左算子非对角分形会被块转置；故对 A 按 (i,k)<-src(k,i)
-    // 预交换源分形（srcOffsetA = i*numFracs*FRAC_LEN），使 cube 还原出 plain A@B。
-    // 不能复用 MCH 的 V2 MatmulToL0C：MCH 操作数是块对角（非对角分形恒 0），两种约定等价，
-    // 故 MCH 永远无法验证非对角分形行为；而 MBH 的 -A / Y 含非对角分形，必须用本 V1 约定。
+    // ---- AIC：MBH 矩乘（V1 约定，对 A 做块转置预交换，运行期 cur 参数化）----
     __aicore__ inline void MbhMatmulToL0C(AscendC::LocalTensor<InDtype> l1A,
                                           AscendC::LocalTensor<InDtype> l1B,
                                           int64_t cur, bool initC)
@@ -468,7 +445,6 @@ public:
         AscendC::Mmad(l0c_X, l0a_X, l0b_X, mmadParams);
     }
 
-    // ---- AIC：MBH 一层的 matmul + Fixpipe 落 L1 ----
     __aicore__ inline void MbhMatmulToSlot(AscendC::LocalTensor<InDtype> l1A,
                                            AscendC::LocalTensor<InDtype> l1B,
                                            AscendC::LocalTensor<InDtype> l1Dst,
@@ -480,95 +456,85 @@ public:
         AscendC::PipeBarrier<PIPE_ALL>();
     }
 
+    // ---- AIC：MBH 单层 B/C/E/G 四步矩乘 + 层间/末层写出 ----
+    __aicore__ inline void MbhLevelAic(int64_t cur, int64_t actual_size, int64_t x_gm_offset,
+                                       int64_t row_stride, bool lastLevel)
+    {
+        // step B: L0C = I × I（完整单位阵）
+        MbhMatmulToL0C(l1_I, l1_I, cur, true);
+        AscendC::PipeBarrier<PIPE_ALL>();
+        // step C: Y = drv(l1_X) × (-A) + I -> l1_Y
+        MbhMatmulToSlot(l1_X, l1_MNEG, l1_Y, cur, false);
+        // step E: L0C = Y × oth(l1_INPUT)
+        MbhMatmulToL0C(l1_Y, l1_INPUT, cur, true);
+        AscendC::PipeBarrier<PIPE_ALL>();
+        // step G: L0C += I × drv(l1_X)
+        MbhMatmulToL0C(l1_I, l1_X, cur, false);
+        AscendC::PipeBarrier<PIPE_ALL>();
+        if (!lastLevel) {
+            FixpipeL0cToUB(ub_Res, l0c_X, cur);   // 层间结果 -> ub_Res，下层提取
+        } else {
+            FixpipeL0cToGM(gm_out[x_gm_offset], l0c_X,
+                           static_cast<uint32_t>(actual_size), static_cast<uint32_t>(cur),
+                           static_cast<uint32_t>(row_stride));
+        }
+        AscendC::PipeBarrier<PIPE_ALL>();
+    }
+
+    // ---- Process：CrossCoreFlag + round-robin，MCH 与 MBH 每 tile 逐层握手 ----
     __aicore__ inline void Process()
     {
         int32_t drvStart = is_lower ? 1 : 0;
         int32_t othStart = is_lower ? 0 : 1;
         int64_t row_stride = (mode == 0) ? chunk_size : (num_head * chunk_size);
 
-        // ===== 多核固定调度协同 =====
-        // SyncAll<false> 是全局屏障（要求所有 launched 核调用次数完全一致，否则死锁；
-        // CrossCoreFlag 在本 1:2 MIX 上死锁，故沿用本仓已验证的 SyncAll<false>）。
-        // 为使各 (AIC,其2个AIV subcore) 组的 SyncAll 计数恒等，采用“固定调度”：
-        //   - 每组处理连续 tile 段 [groupIdx*tiles_per_core, +tiles_per_core)；所有组都走
-        //     tiles_per_core 个 slot；每 slot 固定 (2 + 2*maxLevels) 次 SyncAll，与该 tile 的
-        //     实际 cur 无关 —— 真实层做活、其余层用空屏障补齐；越界 slot 全空屏障。
-        //   - maxLevels = log2(chunk_size/16)，由 chunk_size 推导，各核一致。
-        // 这样每核总 SyncAll 次数 = tiles_per_core*(2 + 2*maxLevels)，组间恒等，不死锁。
-        // 单核(usedCoreNum=1)时 tiles_per_core=totalTiles、groupIdx=0，退化为原逐 tile 行为。
-        //
-        // 【关键假设】MIX 1:2 下 GetBlockIdx() 对 AIC 与其配对 AIV 返回同一组索引（core_idx）。
-        //   若目标 SDK 语义不同（如 AIV 返回 AIV-global 索引），仅需改此处 groupIdx 推导一行。
-        int64_t groupIdx = core_idx;
-        int32_t maxLevels = 0;
-        for (int32_t bs = 16; bs < chunk_size; bs *= 2) maxLevels++;
+        if ASCEND_IS_AIV {
+            if (sub_block_idx == 0) {
+                for (int64_t loop_idx = core_idx / 2; loop_idx < chunk_num_total; loop_idx += num_core) {
+                    int64_t x_gm_offset = 0;
+                    int64_t cur = 0;
+                    int64_t actual_size = 0;
+                    ComputeTile(loop_idx, x_gm_offset, cur, actual_size);
 
-        for (int64_t slot = 0; slot < tiles_per_core; slot++) {
-            int64_t loop_idx = groupIdx * tiles_per_core + slot;
-            bool valid = (loop_idx < chunk_num_total);
+                    // ---- MCH 备数 ----
+                    AivMchPrep(cur, actual_size, x_gm_offset, row_stride);
+                    AscendC::CrossCoreSetFlag<0x4, PIPE_MTE3>(0x2);   // 数据就绪 -> AIC
+                    AscendC::CrossCoreWaitFlag<0x4>(0x0);             // 等 AIC：MCH 完成（ub_Res 就绪 / cur==16 已写 GM）
 
-            int64_t x_gm_offset = 0;
-            int64_t cur = 0;
-            if (valid) {
-                ComputeTile(loop_idx, x_gm_offset, cur);
-            }
-
-            // ===== MCH 阶段 =====
-            if ASCEND_IS_AIV {
-                if (valid && sub_block_idx == 0) {
-                    AivMchPrep(cur, x_gm_offset, row_stride);
-                }
-            }
-            AscendC::SyncAll<false>();   // SP_a: AIV 备数完成 -> AIC 可做 MCH 牛顿
-            if ASCEND_IS_AIC {
-                if (valid) {
-                    AicMchNewton(cur, x_gm_offset, row_stride);
-                    AscendC::PipeBarrier<PIPE_ALL>();
-                }
-            }
-            AscendC::SyncAll<false>();   // SP_b: AIC 牛顿完成(ub_Res 就绪 / cur==16 已写 GM)
-
-            // ===== MBH 阶段：固定 maxLevels 层；真实层(blockSize<cur)做活，其余空屏障补齐 =====
-            for (int32_t lvl = 0; lvl < maxLevels; lvl++) {
-                int32_t blockSize = 16 << lvl;                       // 16,32,64,...
-                bool realLevel = valid && (blockSize < cur);
-                bool lastLevel = realLevel && !(blockSize < cur / 2);
-
-                AscendC::SyncAll<false>();   // SP1: ub_Res 就绪 -> AIV 提取
-                if ASCEND_IS_AIV {
-                    if (realLevel && sub_block_idx == 0) {
+                    // ---- MBH 各层：提取 drv/oth -> 握手 ----
+                    for (int32_t blockSize = 16; blockSize < cur; blockSize *= 2) {
                         ClearSlotUB(l1_X, cur);
                         ClearSlotUB(l1_INPUT, cur);
                         AscendC::PipeBarrier<PIPE_ALL>();
                         ExtractFromUB(l1_X, cur, blockSize, drvStart);     // drv -> l1_X
                         ExtractFromUB(l1_INPUT, cur, blockSize, othStart); // oth -> l1_INPUT
                         AscendC::PipeBarrier<PIPE_ALL>();
+                        AscendC::CrossCoreSetFlag<0x4, PIPE_MTE3>(0x2);   // 提取就绪 -> AIC
+                        AscendC::CrossCoreWaitFlag<0x4>(0x0);             // 等 AIC：本层矩乘/回写完成
                     }
                 }
-                AscendC::SyncAll<false>();   // SP2: AIV 提取完成 -> AIC 矩乘
-                if ASCEND_IS_AIC {
-                    if (realLevel) {
-                        // step B: L0C = I × I（完整单位阵）
-                        MbhMatmulToL0C(l1_I, l1_I, cur, true);
-                        AscendC::PipeBarrier<PIPE_ALL>();
-                        // step C: Y = drv(l1_X) × (-A) + I -> l1_Y
-                        MbhMatmulToSlot(l1_X, l1_MNEG, l1_Y, cur, false);
-                        // step E: L0C = Y × oth(l1_INPUT)
-                        MbhMatmulToL0C(l1_Y, l1_INPUT, cur, true);
-                        AscendC::PipeBarrier<PIPE_ALL>();
-                        // step G: L0C += I × drv(l1_X)
-                        MbhMatmulToL0C(l1_I, l1_X, cur, false);
-                        AscendC::PipeBarrier<PIPE_ALL>();
-                        if (!lastLevel) {
-                            FixpipeL0cToUB(ub_Res, l0c_X, cur);   // 层间结果 -> ub_Res，下层提取
-                        } else {
-                            FixpipeL0cToGM(gm_out[x_gm_offset], l0c_X,
-                                        static_cast<uint32_t>(cur), static_cast<uint32_t>(row_stride));
-                        }
-                        AscendC::PipeBarrier<PIPE_ALL>();
-                    }
+            }
+        }
+
+        if ASCEND_IS_AIC {
+            for (int64_t loop_idx = core_idx; loop_idx < chunk_num_total; loop_idx += num_core) {
+                int64_t x_gm_offset = 0;
+                int64_t cur = 0;
+                int64_t actual_size = 0;
+                ComputeTile(loop_idx, x_gm_offset, cur, actual_size);
+
+                // ---- MCH 牛顿 ----
+                AscendC::CrossCoreWaitFlag<0x4, PIPE_MTE1>(0x2);   // 等 AIV：数据就绪
+                AicMchNewton(cur, actual_size, x_gm_offset, row_stride);
+                AscendC::CrossCoreSetFlag<0x4, PIPE_FIX>(0x0);     // MCH 完成 -> AIV
+
+                // ---- MBH 各层：等提取 -> 四步矩乘 -> 写出 -> 握手 ----
+                for (int32_t blockSize = 16; blockSize < cur; blockSize *= 2) {
+                    bool lastLevel = !(blockSize < cur / 2);
+                    AscendC::CrossCoreWaitFlag<0x4, PIPE_MTE1>(0x2);   // 等 AIV：提取就绪
+                    MbhLevelAic(cur, actual_size, x_gm_offset, row_stride, lastLevel);
+                    AscendC::CrossCoreSetFlag<0x4, PIPE_FIX>(0x0);     // 本层完成 -> AIV
                 }
-                
             }
         }
     }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/arch35/solve_tri_ascend950.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/arch35/solve_tri_ascend950.h
@@ -327,6 +327,7 @@ public:
         SetFlag<AscendC::HardEvent::MTE3_V>(0);   // ub_to_l1(MTE3) -> 下面 Duplicate ub_FullA(V) [顺序]
         WaitFlag<AscendC::HardEvent::MTE3_V>(0);
         // AscendC::PipeBarrier<PIPE_ALL>();
+        AscendC::CrossCoreSetFlag<0x4, PIPE_MTE3>(0x2);   // 数据就绪 -> AIC
 
         // MBH 预备（cur>16）：完整 A GM(ND)->ub_FullA(NZ)，尾块只读 actual_size 行（其余清 0），取负 -> l1_MNEG。
         if (cur > 16) {
@@ -538,7 +539,6 @@ public:
 
                     // ---- MCH 备数 ----
                     AivMchPrep(cur, actual_size, x_gm_offset, row_stride);
-                    AscendC::CrossCoreSetFlag<0x4, PIPE_MTE3>(0x2);   // 数据就绪 -> AIC
                     AscendC::CrossCoreWaitFlag<0x4>(0x0);             // 等 AIC：MCH 完成（ub_Res 就绪 / cur==16 已写 GM）
 
                     // ---- MBH 各层：提取 drv/oth -> 握手 ----

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/arch35/solve_tri_ascend950.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/arch35/solve_tri_ascend950.h
@@ -1,0 +1,627 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * Licensed under the BSD 3-Clause License.
+ */
+
+#ifndef SOLVE_TRI_ASCEND950_H
+#define SOLVE_TRI_ASCEND950_H
+
+#include "kernel_operator.h"
+#include "solve_tri_ascend950_common.h"
+#include "mem.h"
+
+using namespace AscendC;
+
+// ============================================================================
+// SolveTri —— 完整下三角逆 (I+A)^{-1} 的 ascend950 实现（MCH + MBH 合一）
+//
+// 两段算法合并在同一 SolveTril 类（source 风格：OnChipBuffer + SyncAll 协同）：
+//   - MCH（块对角逆）：源仓移植。AIV 生成 NZ 辅助矩阵 + gather 对角块，AIC 牛顿迭代
+//     求每个 16×16 对角块逆，结果(NZ)暂存 ub_Res(UB)。
+//   - MBH（递归合并）：基于【本仓已验证 RecursiveMerge(UB-opt) 算法】移植（非源仓）。
+//     X 常驻 ub_Res(UB,NZ)；逐层 blockSize=16->cur：AIV 从 ub_Res 提取 drv/oth 对角块
+//     到 L1，AIC 做 B/C/E/G 四步矩乘合并，层间结果 Fixpipe 回 ub_Res，末层写 gm_out。
+//
+// MCH 移植中的接口/“非泛化参数”适配（不改 MCH 整体算法逻辑）：
+//   [接口] kernel 形参收敛为 x / cu_seqlens / chunk_indices / x_out / workspace /
+//          tiling；输出沿用本仓 x_out 命名；索引为 INT64；支持 FP16 + BF16。
+//   [tiling 字段] 沿用本仓字段名、按 MCH 语义读取：
+//          batchSize / seqLen / numHeads / chunkSize / numChunks(=chunkNumInSeq) /
+//          totalChunks(=chunkNumTotal, 主循环上界) / layoutMode(=mode) / isLower。
+//   [尾块辅助矩阵修复] 源实现把单位/全零矩阵按整 chunk_size 在循环外生成一次；尾块
+//          chunk_size_actual 变化时 NZ 单位阵的分形偏移随之改变，会算错。改为仅在
+//          chunk 尺寸“发生变化”时（即 seqlen 尾块）按 chunk_size_actual 重建 I/Zero
+//          并重拷 l1_I；非尾块尺寸不变则复用，避免额外开销。
+//   [GM 偏移泛化] 源 x_gm_offset 仅在“单 chunk / 单 head”下成立。改为与本仓已验证 MBH
+//          的 GetTileGMOffset 对齐的完整公式（[B,T,H,BT] 布局，行跨度 = num_head*chunk_size）。
+//   [搬运步长泛化] 源对角块 gather 的 srcStride 硬编码为 1（仅 BT=32、H=1 成立）。
+//          改为按物理行跨度推导 srcStride = num_head*chunk_size/16 - 1。
+//
+// MBH 移植要点（对齐本仓已验证 UB-opt 路径）：
+//   - 跨核同步用 SyncAll<false>（本仓实测：CrossCoreFlag 在 1:2 MIX 上死锁）。多核“固定调度”：
+//     每 (AIC,其2 AIV subcore) 组处理连续 tile 段 [groupIdx*tilesPerCore, +tilesPerCore)，
+//     所有组都走 tilesPerCore 个 slot、每 slot 固定 (2 + 2*maxLevels) 次 SyncAll（maxLevels=
+//     log2(chunk_size/16)，各核一致）—— 真实层做活、其余层空屏障补齐、越界 slot 全空屏障，
+//     故组间 SyncAll 计数恒等，不死锁。单核(usedCoreNum=1)退化为逐 tile 行为。
+//   - -A 由 AIV 备数：完整 A GM(ND)->ub_FullA(NZ) 后 Muls(-1) -> l1_MNEG（替代源 -I 矩乘，
+//     代数等价；省一次 cube 矩乘与 -I 常量）。
+//   - MBH 各步矩乘用本仓已验证 RecursiveMerge 的 V1 约定（MbhMatmulToL0C，对 A 做块转置预交换），
+//     不复用 MCH 的 V2 MatmulToL0C：MBH 的 -A / Y 含非对角分形，两种约定在非对角分形上不等价。
+//
+// 已知限制 / 假设（待硬件验证）：
+//   * 多核固定调度假设：MIX 1:2 下 GetBlockIdx() 对 AIC 与其配对 AIV 返回同一组索引；若目标
+//     SDK 语义不同（如 AIV 返回 AIV-global 索引），仅需改 Process() 中 groupIdx 推导一行。
+//   * 尾块在 ChunkAlign 上取整后会按对齐尺寸读取 GM，可能越过有效行（源既有行为）。
+//   * MCH 用 V2、MBH 用 V1：MCH 操作数为块对角（非对角分形恒 0），两约定等价，故 MCH 验证
+//     无法覆盖非对角分形；MBH 改用本仓已验证 V1 约定，BT>16 正确性由 V1 自身保证。
+// ============================================================================
+
+constexpr AscendC::FixpipeConfig CFG_NZ_L1 = {AscendC::CO2Layout::NZ, false};
+constexpr AscendC::FixpipeConfig CFG_NZ_UB = {AscendC::CO2Layout::NZ, true};
+
+template <typename InDtype, typename OutDtype>
+class SolveTri {
+public:
+    __aicore__ inline void Init(GM_ADDR aGm, GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR outGm,
+                                GM_ADDR workspace, const SolveTriTilingData *tilingData)
+    {
+        // Tiling（沿用本仓字段名，按 MCH 语义解释）
+        batch_size = tilingData->batchSize;
+        seq_length = tilingData->seqLen;          // <- seqLength
+        num_head = tilingData->numHeads;          // <- numHead
+        chunk_size = tilingData->chunkSize;
+        chunk_num_in_seq = tilingData->numChunks; // <- chunkNumInSeq
+        chunk_num_total = tilingData->totalTiles; // 主循环上界 = 全部 tile 数
+        mode = tilingData->layoutMode;            // 0=bhtd, 1=bsnd, 2=tnd
+        is_lower = tilingData->isLower;           // MBH 驱动块选择（下三角=1）
+        tiles_per_core = tilingData->tilesPerCore;// 每个 (AIC,其AIV) 组处理的 tile 数（多核划分）
+
+        // GM
+        gm_a.SetGlobalBuffer(reinterpret_cast<__gm__ InDtype *>(aGm));
+        gm_cu_seqlens.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(cu_seqlens));
+        gm_chunk_indices.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(chunk_indices));
+        gm_out.SetGlobalBuffer(reinterpret_cast<__gm__ OutDtype *>(outGm));
+
+        OnChipBuffer buf;
+
+        // UB（每块 chunk_size*chunk_size 个 InDtype）：
+        //   ub_I / ub_Zero / ub_A / ub_I_A / ub_Res 为 MCH 所用；
+        //   ub_FullA 为 MBH 阶段暂存“完整 -A”（GM->UB nd2nz 后取负）。
+        ub_I = buf.template GetBuffer<BufferType::ASCEND_UB, InDtype>(0);
+        ub_Zero = buf.template GetBuffer<BufferType::ASCEND_UB, InDtype>(chunk_size * chunk_size * sizeof(InDtype));
+        ub_A = buf.template GetBuffer<BufferType::ASCEND_UB, InDtype>(chunk_size * chunk_size * sizeof(InDtype) * 2);
+        ub_I_A = buf.template GetBuffer<BufferType::ASCEND_UB, InDtype>(chunk_size * chunk_size * sizeof(InDtype) * 3);
+        ub_Res = buf.template GetBuffer<BufferType::ASCEND_UB, InDtype>(chunk_size * chunk_size * sizeof(InDtype) * 4);
+        ub_FullA = buf.template GetBuffer<BufferType::ASCEND_UB, InDtype>(chunk_size * chunk_size * sizeof(InDtype) * 5);
+        // L1（NZ 槽，每槽 chunk_size*chunk_size 个 InDtype）：
+        //   MCH 用 l1_I / l1_X / l1_Y；MBH 复用三者并额外用 l1_MNEG(-A) / l1_INPUT(提取的 oth 块)。
+        l1_I = buf.template GetBuffer<BufferType::ASCEND_CB, InDtype>(0);
+        l1_X = buf.template GetBuffer<BufferType::ASCEND_CB, InDtype>(chunk_size * chunk_size * sizeof(InDtype));
+        l1_Y = buf.template GetBuffer<BufferType::ASCEND_CB, InDtype>(chunk_size * chunk_size * sizeof(InDtype) * 2);
+        l1_MNEG = buf.template GetBuffer<BufferType::ASCEND_CB, InDtype>(chunk_size * chunk_size * sizeof(InDtype) * 3);
+        l1_INPUT = buf.template GetBuffer<BufferType::ASCEND_CB, InDtype>(chunk_size * chunk_size * sizeof(InDtype) * 4);
+
+        // L0
+        l0a_X = buf.template GetBuffer<BufferType::ASCEND_L0A, InDtype>(0);
+        l0a_Y = buf.template GetBuffer<BufferType::ASCEND_L0A, InDtype>(chunk_size * chunk_size * sizeof(InDtype));
+        l0b_X = buf.template GetBuffer<BufferType::ASCEND_L0B, InDtype>(0);
+        l0b_Y = buf.template GetBuffer<BufferType::ASCEND_L0B, InDtype>(chunk_size * chunk_size * sizeof(InDtype));
+        l0c_X = buf.template GetBuffer<BufferType::ASCEND_L0C, float>(0);
+        l0c_Y = buf.template GetBuffer<BufferType::ASCEND_L0C, float>(chunk_size * chunk_size * sizeof(float));
+
+        // Core
+        num_core = AscendC::GetBlockNum();
+        core_idx = AscendC::GetBlockIdx();
+        sub_block_idx = AscendC::GetSubBlockIdx();
+
+        // 辅助矩阵缓存标记：0 为无效初值（chunk_size_actual 恒 >=16），首个 tile 必触发生成。
+        last_chunk_size = 0;
+    }
+
+    __aicore__ inline int64_t CeilDiv(int64_t a, int64_t b)
+    {
+        return (a + b - 1) / b;
+    }
+
+    __aicore__ inline void ub_to_l1(AscendC::LocalTensor<InDtype> l1Tensor,
+                                    AscendC::LocalTensor<InDtype> ubTensor, uint32_t chunkSize)
+    {
+        AscendC::DataCopy(l1Tensor,                               // dst
+                          ubTensor,                               // src
+                          AscendC::DataCopyParams(1,              // nBurst
+                                                  chunkSize * chunkSize / 16,  // lenBurst
+                                                  0,              // srcGap
+                                                  0));            // dstGap
+    }
+
+    __aicore__ inline void FixpipeL0cToL1(AscendC::LocalTensor<InDtype> l1Tensor,
+                                          AscendC::LocalTensor<float> l0CTensor,
+                                          uint32_t chunkSize)
+    {
+        AscendC::FixpipeParamsArch3510<AscendC::CO2Layout::NZ> fixPipeParams;
+        fixPipeParams.nSize = chunkSize;
+        fixPipeParams.mSize = chunkSize;
+        fixPipeParams.srcStride = chunkSize;
+        fixPipeParams.dstStride = chunkSize * 16;
+
+        if constexpr (std::is_same_v<InDtype, half>) {
+            fixPipeParams.quantPre = QuantMode_t::F322F16;
+        } else {
+            fixPipeParams.quantPre = QuantMode_t::F322BF16;
+        }
+        AscendC::Fixpipe<InDtype, float, CFG_NZ_L1>(l1Tensor, l0CTensor, fixPipeParams);
+    }
+
+    __aicore__ inline void FixpipeL0cToUB(AscendC::LocalTensor<InDtype> ubTensor,
+                                          AscendC::LocalTensor<float> l0CTensor,
+                                          uint32_t chunkSize)
+    {
+        AscendC::FixpipeParamsArch3510<AscendC::CO2Layout::NZ> fixPipeParams;
+        fixPipeParams.nSize = chunkSize;
+        fixPipeParams.mSize = chunkSize;
+        fixPipeParams.srcStride = chunkSize;
+        fixPipeParams.dstStride = chunkSize * 16;
+        fixPipeParams.dualDstCtl = 0;
+        fixPipeParams.subBlockId = 0;
+
+        if constexpr (std::is_same_v<InDtype, half>) {
+            fixPipeParams.quantPre = QuantMode_t::F322F16;
+        } else {
+            fixPipeParams.quantPre = QuantMode_t::F322BF16;
+        }
+        AscendC::Fixpipe<InDtype, float, CFG_NZ_UB>(ubTensor, l0CTensor, fixPipeParams);
+    }
+
+    __aicore__ inline int64_t ChunkAlign(int64_t cur_chunk)
+    {
+        if (cur_chunk <= 16)
+            return 16;
+        if (cur_chunk <= 32)
+            return 32;
+        if (cur_chunk <= 64)
+            return 64;
+        return 128;
+    }
+
+    // 结果写回：L0C(FP32, NZ) -> gm_out(ND, 行优先)。dstStride = GM 物理行跨度。
+    // 用于 cur==16（纯 MCH，无 MBH）及 cur>16 时 MBH 末层的最终结果写出。
+    __aicore__ inline void FixpipeL0cToGM(AscendC::GlobalTensor<OutDtype> gmTensor,
+                                          AscendC::LocalTensor<float> l0CTensor,
+                                          uint32_t curSize, uint32_t dstStride)
+    {
+        auto intriParams = AscendC::FixpipeParamsV220(curSize, curSize, curSize, dstStride, false);
+        if constexpr (std::is_same_v<OutDtype, half>) {
+            intriParams.quantPre = QuantMode_t::F322F16;
+        } else {
+            intriParams.quantPre = QuantMode_t::F322BF16;
+        }
+        AscendC::Fixpipe<OutDtype, float, AscendC::CFG_ROW_MAJOR>(gmTensor, l0CTensor, intriParams);
+    }
+
+    __aicore__ inline void MatmulToL0C(AscendC::LocalTensor<InDtype> l1A, AscendC::LocalTensor<InDtype> l1B,
+                                       AscendC::LocalTensor<InDtype> l0A, AscendC::LocalTensor<InDtype> l0B,
+                                       AscendC::LocalTensor<float> l0C, int64_t chunkSize, bool initC)
+    {
+        int64_t numFracs = chunkSize / 16;
+
+        AscendC::LoadData2DParamsV2 loadDataParamsA;
+        loadDataParamsA.mStartPosition = 0;
+        loadDataParamsA.kStartPosition = 0;
+        loadDataParamsA.mStep = numFracs;
+        loadDataParamsA.kStep = numFracs;
+        loadDataParamsA.srcStride = numFracs;
+        loadDataParamsA.dstStride = numFracs;
+        loadDataParamsA.ifTranspose = false;
+        AscendC::LoadData(l0A, l1A, loadDataParamsA);
+
+        AscendC::LoadData2DParamsV2 loadDataParamsB;
+        loadDataParamsB.mStartPosition = 0;
+        loadDataParamsB.kStartPosition = 0;
+        loadDataParamsB.mStep = numFracs;
+        loadDataParamsB.kStep = numFracs;
+        loadDataParamsB.srcStride = numFracs;
+        loadDataParamsB.dstStride = numFracs;
+        loadDataParamsB.ifTranspose = true;
+        AscendC::LoadData(l0B, l1B, loadDataParamsB);
+
+        PipeBarrier<PIPE_ALL>();
+
+        AscendC::MmadParams mmadParams;
+        mmadParams.m = chunkSize;
+        mmadParams.n = chunkSize;
+        mmadParams.k = chunkSize;
+        mmadParams.cmatrixInitVal = initC;
+        mmadParams.cmatrixSource = false;
+        mmadParams.unitFlag = 0;
+        AscendC::Mmad(l0C, l0A, l0B, mmadParams);
+    }
+
+    // 按给定 cur_size 生成 NZ 块对角辅助矩阵（尾块安全）：单位阵 I、全零阵 Zero，并清零 ub_A。
+    __aicore__ inline void AuxMatrixGen(int64_t cur_size)
+    {
+        uint64_t NUM_FRACS = cur_size / 16; // 对角分形个数
+        uint64_t NUM_ITER = NUM_FRACS * 2;  // 8x16 条带数
+        int32_t chunkElems = static_cast<int32_t>(cur_size * cur_size);
+
+        // 清零 A / 生成单位阵 I（NZ：对角分形落在 (i*NUM_FRACS+i)*256 = i*(cur_size*16+256)）
+        Duplicate(ub_A, (InDtype)0, chunkElems);
+        Duplicate(ub_I, (InDtype)0, chunkElems);
+        for (uint64_t stripIdx = 0; stripIdx < NUM_ITER; stripIdx++) {
+            uint64_t fracsIdx = stripIdx / 2;
+            uint64_t oldEvenIdx = stripIdx % 2;
+            uint64_t diagMask[2] = {
+                DIAG_MASK_8X16[oldEvenIdx ? 0 : 1][0],
+                DIAG_MASK_8X16[oldEvenIdx ? 0 : 1][1]
+            };
+            uint64_t UB_DIAG_I_OFF = fracsIdx * (cur_size + 16) * 16 + oldEvenIdx * 8 * 16;
+            Duplicate(ub_I[UB_DIAG_I_OFF], (InDtype)1.0f, diagMask, 1, 1, 1);
+        }
+        // 全零矩阵
+        Duplicate(ub_Zero, (InDtype)0, chunkElems);
+    }
+
+    // 由 loop_idx 计算该 tile 的 GM 偏移与对齐后的实际 chunk 尺寸。
+    // 与本仓已验证 MBH 的 GetTileGMOffset / GetTileValidSize 公式对齐（[B,T,H,BT] 布局）。
+    __aicore__ inline void ComputeTile(int64_t loop_idx, int64_t &x_gm_offset, int64_t &cur_size)
+    {
+        int64_t seq_idx = 0;
+        int64_t chunk_in_seq_idx = 0;
+        int64_t head_idx = 0;
+        int64_t chunk_idx = 0;
+        int64_t local_seq_length = seq_length;
+        int64_t local_chunk_num_in_seq = chunk_num_in_seq;
+
+        if (mode == 0) { // BHTD: [B, H, T, BT]，遍历顺序 B -> H -> chunk
+            seq_idx = loop_idx / (chunk_num_in_seq * num_head);
+            head_idx = (loop_idx / chunk_num_in_seq) % num_head;
+            chunk_in_seq_idx = loop_idx % chunk_num_in_seq;
+            x_gm_offset = seq_idx * num_head * seq_length * chunk_size +
+                          head_idx * seq_length * chunk_size +
+                          chunk_in_seq_idx * chunk_size * chunk_size;
+        } else if (mode == 1) { // 定长 bsnd
+            seq_idx = loop_idx / (chunk_num_in_seq * num_head);
+            chunk_in_seq_idx = loop_idx % (chunk_num_in_seq * num_head) / num_head;
+            head_idx = loop_idx % (chunk_num_in_seq * num_head) % num_head;
+            // [B,T,H,BT]: base = b*T*H*BT + chunk*BT*H*BT + h*BT
+            x_gm_offset = seq_idx * seq_length * num_head * chunk_size +
+                          chunk_in_seq_idx * chunk_size * num_head * chunk_size +
+                          head_idx * chunk_size;
+        } else if (mode == 2) { // 变长 tnd
+            chunk_idx = loop_idx / num_head;
+            head_idx = loop_idx % num_head;
+            seq_idx = gm_chunk_indices.GetValue(chunk_idx * 2);
+            chunk_in_seq_idx = gm_chunk_indices.GetValue(chunk_idx * 2 + 1);
+            local_seq_length = gm_cu_seqlens.GetValue(seq_idx + 1) - gm_cu_seqlens.GetValue(seq_idx);
+            local_chunk_num_in_seq = CeilDiv(local_seq_length, chunk_size);
+            int64_t bos = gm_cu_seqlens.GetValue(seq_idx);
+            // (bos + chunk*BT) * H * BT + h * BT
+            x_gm_offset = (bos + chunk_in_seq_idx * chunk_size) * num_head * chunk_size +
+                          head_idx * chunk_size;
+        }
+
+        cur_size = (chunk_in_seq_idx == (local_chunk_num_in_seq - 1)) ?
+                       ChunkAlign(local_seq_length - chunk_in_seq_idx * chunk_size) :
+                       chunk_size;
+    }
+
+    // ---- AIV：MCH 单 tile 备数（含 MBH 所需的完整 -A 暂存）----
+    __aicore__ inline void AivMchPrep(int64_t cur, int64_t x_gm_offset, int64_t row_stride)
+    {
+        // [尾块辅助矩阵] 仅 chunk 尺寸变化时重建 NZ 单位/全零阵并重拷 l1_I（避免每 tile 开销）。
+        if (cur != last_chunk_size) {
+            AuxMatrixGen(cur);
+            AscendC::PipeBarrier<PIPE_ALL>();
+            ub_to_l1(l1_I, ub_I, static_cast<uint32_t>(cur));
+            AscendC::PipeBarrier<PIPE_ALL>();
+            last_chunk_size = cur;
+        }
+
+        // 对角 16x16 块 GM(ND) -> ub_A(NZ 块对角)；srcStride 按物理行跨度泛化。
+        uint16_t src_blk_stride = static_cast<uint16_t>(row_stride / 16 - 1);
+        for (uint64_t i = 0; i < (uint64_t)(cur / 16); i++) {
+            uint64_t srcOffset = i * (16 * (uint64_t)row_stride + 16);
+            uint64_t dstOffset = i * ((uint64_t)cur * 16 + 16 * 16);
+            AscendC::DataCopy(ub_A[dstOffset], gm_a[x_gm_offset + srcOffset],
+                              AscendC::DataCopyParams(16, 1, src_blk_stride, 0));
+        }
+        AscendC::PipeBarrier<PIPE_ALL>();
+
+        ub_to_l1(l1_Y, ub_A, static_cast<uint32_t>(cur));        // l1_Y = A(块对角)
+        AscendC::PipeBarrier<PIPE_ALL>();
+        AscendC::Sub(ub_I_A, ub_I, ub_A, (int32_t)(cur * cur));  // I - A
+        AscendC::PipeBarrier<PIPE_ALL>();
+        ub_to_l1(l1_X, ub_I_A, static_cast<uint32_t>(cur));      // l1_X = I - A
+        AscendC::PipeBarrier<PIPE_ALL>();
+
+        // MBH 预备（cur>16）：完整 A GM(ND)->ub_FullA(NZ)，取负 -> l1_MNEG(NZ)。
+        if (cur > 16) {
+            AscendC::Nd2NzParams p;
+            p.ndNum = 1;
+            p.nValue = static_cast<uint32_t>(cur);
+            p.dValue = static_cast<uint32_t>(cur);
+            p.srcDValue = static_cast<uint32_t>(row_stride);
+            p.srcNdMatrixStride = 0;
+            p.dstNzNStride = 1;
+            p.dstNzC0Stride = static_cast<uint16_t>(cur);
+            p.dstNzMatrixStride = 0;
+            AscendC::DataCopy(ub_FullA, gm_a[x_gm_offset], p);
+            AscendC::PipeBarrier<PIPE_ALL>();
+            AscendC::Muls(ub_FullA, ub_FullA, (InDtype)(-1.0f), (int32_t)(cur * cur));
+            AscendC::PipeBarrier<PIPE_ALL>();
+            ub_to_l1(l1_MNEG, ub_FullA, static_cast<uint32_t>(cur));  // l1_MNEG = -A
+            AscendC::PipeBarrier<PIPE_ALL>();
+        }
+    }
+
+    // ---- AIC：MCH 牛顿迭代，求 16x16 对角块逆（块对角逆）----
+    // cur>16：结果 Fixpipe 暂存 ub_Res(UB,NZ) 供 MBH 消费；cur==16：纯 MCH，直接写 gm_out。
+    __aicore__ inline void AicMchNewton(int64_t cur, int64_t x_gm_offset, int64_t row_stride)
+    {
+        MatmulToL0C(l1_Y, l1_Y, l0a_Y, l0b_Y, l0c_Y, cur, true);
+        AscendC::PipeBarrier<PIPE_ALL>();
+        FixpipeL0cToL1(l1_Y, l0c_Y, cur);
+        AscendC::PipeBarrier<PIPE_ALL>();
+
+        MatmulToL0C(l1_I, l1_X, l0a_X, l0b_X, l0c_X, cur, true);
+        AscendC::PipeBarrier<PIPE_ALL>();
+        FixpipeL0cToL1(l1_X, l0c_X, cur);
+        AscendC::PipeBarrier<PIPE_ALL>();
+
+        MatmulToL0C(l1_X, l1_Y, l0a_X, l0b_X, l0c_X, cur, false);
+        AscendC::PipeBarrier<PIPE_ALL>();
+        FixpipeL0cToL1(l1_X, l0c_X, cur);
+        AscendC::PipeBarrier<PIPE_ALL>();
+
+        for (uint64_t iter = 0; iter < 2; iter++) {
+            MatmulToL0C(l1_Y, l1_Y, l0a_Y, l0b_Y, l0c_Y, cur, true);
+            AscendC::PipeBarrier<PIPE_ALL>();
+            FixpipeL0cToL1(l1_Y, l0c_Y, cur);
+            AscendC::PipeBarrier<PIPE_ALL>();
+            MatmulToL0C(l1_X, l1_Y, l0a_X, l0b_X, l0c_X, cur, false);
+            AscendC::PipeBarrier<PIPE_ALL>();
+            if (iter == 1) {
+                if (cur > 16) {
+                    // MCH 块对角逆 -> ub_Res(UB,NZ)，供 MBH 从 UB 提取消费。
+                    FixpipeL0cToUB(ub_Res, l0c_X, cur);
+                } else {
+                    // cur==16：无 MBH，直接写最终结果到 gm_out(ND)。
+                    FixpipeL0cToGM(gm_out[x_gm_offset], l0c_X,
+                                   static_cast<uint32_t>(cur), static_cast<uint32_t>(row_stride));
+                }
+                AscendC::PipeBarrier<PIPE_ALL>();
+            } else {
+                FixpipeL0cToL1(l1_X, l0c_X, cur);
+                AscendC::PipeBarrier<PIPE_ALL>();
+            }
+        }
+    }
+
+    // ---- AIV：清 L1 槽（zeroUB->L1，整槽置零）。zeroUB 复用 ub_Zero（已按 cur 清零）----
+    __aicore__ inline void ClearSlotUB(AscendC::LocalTensor<InDtype> l1Slot, int64_t cur)
+    {
+        AscendC::DataCopy(l1Slot, ub_Zero,
+                          AscendC::DataCopyParams(1, (uint16_t)(cur * cur / 16), 0, 0));
+    }
+
+    // ---- AIV：从 ub_Res(NZ) 按块 raw UB->L1 提取选中对角块到 l1Slot（非选中分形由 ClearSlotUB 置零）----
+    // ub_Res 与 L1 槽 NZ 布局一致：分形 (fr,fc) 偏移 = (fc*NUM_FRACS+fr)*256。
+    __aicore__ inline void ExtractFromUB(AscendC::LocalTensor<InDtype> l1Slot,
+                                         int64_t cur, int32_t blockSize, int32_t startBlock)
+    {
+        int32_t numFracsTotal = static_cast<int32_t>(cur / 16);
+        int32_t numBlocks = static_cast<int32_t>(cur) / blockSize;
+        int32_t fracsPerBlock = blockSize / 16;
+        constexpr int32_t FRAC_LEN = 16 * 16;
+
+        for (int32_t blk = startBlock; blk < numBlocks; blk += 2) {
+            for (int32_t fi = 0; fi < fracsPerBlock; fi++) {
+                for (int32_t fj = 0; fj < fracsPerBlock; fj++) {
+                    int32_t fr = blk * fracsPerBlock + fi;
+                    int32_t fc = blk * fracsPerBlock + fj;
+                    int32_t off = (fc * numFracsTotal + fr) * FRAC_LEN;
+                    AscendC::DataCopy(l1Slot[off], ub_Res[off],
+                                      AscendC::DataCopyParams(1, (uint16_t)(FRAC_LEN / 16), 0, 0));
+                }
+            }
+        }
+    }
+
+    // ---- AIC：MBH 矩乘（本仓已验证 RecursiveMerge 的 V1 约定，运行期 cur 参数化）----
+    // 关键：cube 实际算 blockT(OpA)@B，左算子非对角分形会被块转置；故对 A 按 (i,k)<-src(k,i)
+    // 预交换源分形（srcOffsetA = i*numFracs*FRAC_LEN），使 cube 还原出 plain A@B。
+    // 不能复用 MCH 的 V2 MatmulToL0C：MCH 操作数是块对角（非对角分形恒 0），两种约定等价，
+    // 故 MCH 永远无法验证非对角分形行为；而 MBH 的 -A / Y 含非对角分形，必须用本 V1 约定。
+    __aicore__ inline void MbhMatmulToL0C(AscendC::LocalTensor<InDtype> l1A,
+                                          AscendC::LocalTensor<InDtype> l1B,
+                                          int64_t cur, bool initC)
+    {
+        constexpr int32_t FRAC_LEN = 16 * 16;
+        int32_t numFracs = static_cast<int32_t>(cur / 16);
+
+        AscendC::LoadData2DParams loadParamsA;
+        loadParamsA.startIndex = 0;
+        loadParamsA.repeatTimes = numFracs;
+        loadParamsA.srcStride = 1;
+        loadParamsA.dstGap = 0;
+        loadParamsA.ifTranspose = false;
+        for (int32_t i = 0; i < numFracs; ++i) {
+            AscendC::LoadData(l0a_X[i * numFracs * FRAC_LEN], l1A[i * numFracs * FRAC_LEN], loadParamsA);
+        }
+        AscendC::LoadData2DParams loadParamsB;
+        loadParamsB.startIndex = 0;
+        loadParamsB.repeatTimes = numFracs;
+        loadParamsB.srcStride = numFracs;
+        loadParamsB.dstGap = 0;
+        loadParamsB.ifTranspose = true;
+        for (int32_t i = 0; i < numFracs; ++i) {
+            AscendC::LoadData(l0b_X[i * numFracs * FRAC_LEN], l1B[i * FRAC_LEN], loadParamsB);
+        }
+        AscendC::PipeBarrier<PIPE_ALL>();
+
+        AscendC::MmadParams mmadParams;
+        mmadParams.m = cur;
+        mmadParams.n = cur;
+        mmadParams.k = cur;
+        mmadParams.cmatrixInitVal = initC;
+        mmadParams.cmatrixSource = false;
+        mmadParams.unitFlag = 0;
+        AscendC::Mmad(l0c_X, l0a_X, l0b_X, mmadParams);
+    }
+
+    // ---- AIC：MBH 一层的 matmul + Fixpipe 落 L1 ----
+    __aicore__ inline void MbhMatmulToSlot(AscendC::LocalTensor<InDtype> l1A,
+                                           AscendC::LocalTensor<InDtype> l1B,
+                                           AscendC::LocalTensor<InDtype> l1Dst,
+                                           int64_t cur, bool initC)
+    {
+        MbhMatmulToL0C(l1A, l1B, cur, initC);
+        AscendC::PipeBarrier<PIPE_ALL>();
+        FixpipeL0cToL1(l1Dst, l0c_X, cur);
+        AscendC::PipeBarrier<PIPE_ALL>();
+    }
+
+    __aicore__ inline void Process()
+    {
+        int32_t drvStart = is_lower ? 1 : 0;
+        int32_t othStart = is_lower ? 0 : 1;
+        int64_t row_stride = (mode == 0) ? chunk_size : (num_head * chunk_size);
+
+        // ===== 多核固定调度协同 =====
+        // SyncAll<false> 是全局屏障（要求所有 launched 核调用次数完全一致，否则死锁；
+        // CrossCoreFlag 在本 1:2 MIX 上死锁，故沿用本仓已验证的 SyncAll<false>）。
+        // 为使各 (AIC,其2个AIV subcore) 组的 SyncAll 计数恒等，采用“固定调度”：
+        //   - 每组处理连续 tile 段 [groupIdx*tiles_per_core, +tiles_per_core)；所有组都走
+        //     tiles_per_core 个 slot；每 slot 固定 (2 + 2*maxLevels) 次 SyncAll，与该 tile 的
+        //     实际 cur 无关 —— 真实层做活、其余层用空屏障补齐；越界 slot 全空屏障。
+        //   - maxLevels = log2(chunk_size/16)，由 chunk_size 推导，各核一致。
+        // 这样每核总 SyncAll 次数 = tiles_per_core*(2 + 2*maxLevels)，组间恒等，不死锁。
+        // 单核(usedCoreNum=1)时 tiles_per_core=totalTiles、groupIdx=0，退化为原逐 tile 行为。
+        //
+        // 【关键假设】MIX 1:2 下 GetBlockIdx() 对 AIC 与其配对 AIV 返回同一组索引（core_idx）。
+        //   若目标 SDK 语义不同（如 AIV 返回 AIV-global 索引），仅需改此处 groupIdx 推导一行。
+        int64_t groupIdx = core_idx;
+        int32_t maxLevels = 0;
+        for (int32_t bs = 16; bs < chunk_size; bs *= 2) maxLevels++;
+
+        for (int64_t slot = 0; slot < tiles_per_core; slot++) {
+            int64_t loop_idx = groupIdx * tiles_per_core + slot;
+            bool valid = (loop_idx < chunk_num_total);
+
+            int64_t x_gm_offset = 0;
+            int64_t cur = 0;
+            if (valid) {
+                ComputeTile(loop_idx, x_gm_offset, cur);
+            }
+
+            // ===== MCH 阶段 =====
+            if ASCEND_IS_AIV {
+                if (valid && sub_block_idx == 0) {
+                    AivMchPrep(cur, x_gm_offset, row_stride);
+                }
+            }
+            AscendC::SyncAll<false>();   // SP_a: AIV 备数完成 -> AIC 可做 MCH 牛顿
+            if ASCEND_IS_AIC {
+                if (valid) {
+                    AicMchNewton(cur, x_gm_offset, row_stride);
+                    AscendC::PipeBarrier<PIPE_ALL>();
+                }
+            }
+            AscendC::SyncAll<false>();   // SP_b: AIC 牛顿完成(ub_Res 就绪 / cur==16 已写 GM)
+
+            // ===== MBH 阶段：固定 maxLevels 层；真实层(blockSize<cur)做活，其余空屏障补齐 =====
+            for (int32_t lvl = 0; lvl < maxLevels; lvl++) {
+                int32_t blockSize = 16 << lvl;                       // 16,32,64,...
+                bool realLevel = valid && (blockSize < cur);
+                bool lastLevel = realLevel && !(blockSize < cur / 2);
+
+                AscendC::SyncAll<false>();   // SP1: ub_Res 就绪 -> AIV 提取
+                if ASCEND_IS_AIV {
+                    if (realLevel && sub_block_idx == 0) {
+                        ClearSlotUB(l1_X, cur);
+                        ClearSlotUB(l1_INPUT, cur);
+                        AscendC::PipeBarrier<PIPE_ALL>();
+                        ExtractFromUB(l1_X, cur, blockSize, drvStart);     // drv -> l1_X
+                        ExtractFromUB(l1_INPUT, cur, blockSize, othStart); // oth -> l1_INPUT
+                        AscendC::PipeBarrier<PIPE_ALL>();
+                    }
+                }
+                AscendC::SyncAll<false>();   // SP2: AIV 提取完成 -> AIC 矩乘
+                if ASCEND_IS_AIC {
+                    if (realLevel) {
+                        // step B: L0C = I × I（完整单位阵）
+                        MbhMatmulToL0C(l1_I, l1_I, cur, true);
+                        AscendC::PipeBarrier<PIPE_ALL>();
+                        // step C: Y = drv(l1_X) × (-A) + I -> l1_Y
+                        MbhMatmulToSlot(l1_X, l1_MNEG, l1_Y, cur, false);
+                        // step E: L0C = Y × oth(l1_INPUT)
+                        MbhMatmulToL0C(l1_Y, l1_INPUT, cur, true);
+                        AscendC::PipeBarrier<PIPE_ALL>();
+                        // step G: L0C += I × drv(l1_X)
+                        MbhMatmulToL0C(l1_I, l1_X, cur, false);
+                        AscendC::PipeBarrier<PIPE_ALL>();
+                        if (!lastLevel) {
+                            FixpipeL0cToUB(ub_Res, l0c_X, cur);   // 层间结果 -> ub_Res，下层提取
+                        } else {
+                            FixpipeL0cToGM(gm_out[x_gm_offset], l0c_X,
+                                        static_cast<uint32_t>(cur), static_cast<uint32_t>(row_stride));
+                        }
+                        AscendC::PipeBarrier<PIPE_ALL>();
+                    }
+                }
+                
+            }
+        }
+    }
+
+private:
+    // Gm
+    AscendC::GlobalTensor<InDtype> gm_a;
+    AscendC::GlobalTensor<int64_t> gm_cu_seqlens;
+    AscendC::GlobalTensor<int64_t> gm_chunk_indices;
+    AscendC::GlobalTensor<OutDtype> gm_out;
+
+    // UB
+    AscendC::LocalTensor<InDtype> ub_A;
+    AscendC::LocalTensor<InDtype> ub_I_A;
+    AscendC::LocalTensor<InDtype> ub_I;
+    AscendC::LocalTensor<InDtype> ub_Zero;
+    AscendC::LocalTensor<InDtype> ub_Res;
+    AscendC::LocalTensor<InDtype> ub_FullA;   // MBH: 完整 -A 的 UB 暂存
+
+    // L1
+    AscendC::LocalTensor<InDtype> l1_X;
+    AscendC::LocalTensor<InDtype> l1_Y;
+    AscendC::LocalTensor<InDtype> l1_I;
+    AscendC::LocalTensor<InDtype> l1_MNEG;    // MBH: -A（NZ）
+    AscendC::LocalTensor<InDtype> l1_INPUT;   // MBH: 提取的 oth 对角块（NZ）
+
+    // L0
+    AscendC::LocalTensor<InDtype> l0a_X;
+    AscendC::LocalTensor<InDtype> l0a_Y;
+    AscendC::LocalTensor<InDtype> l0b_X;
+    AscendC::LocalTensor<InDtype> l0b_Y;
+    AscendC::LocalTensor<float> l0c_X;
+    AscendC::LocalTensor<float> l0c_Y;
+
+    // Tiling
+    int64_t batch_size;
+    int64_t seq_length;
+    int64_t num_head;
+    int64_t chunk_size;
+    int64_t chunk_num_in_seq;
+    int64_t chunk_num_total;
+    int64_t mode;
+    int64_t is_lower;
+    int64_t tiles_per_core;
+
+    // Core
+    int64_t num_core;
+    int64_t core_idx;
+    int64_t sub_block_idx;
+
+    // 辅助矩阵当前缓存对应的 chunk 尺寸（仅尺寸变化时重建 I/Zero/l1_I）
+    int64_t last_chunk_size;
+};
+
+
+#endif  // SOLVE_TRI_ASCEND950_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/arch35/solve_tri_ascend950_common.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/arch35/solve_tri_ascend950_common.h
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * BSD 3-Clause License.
+ */
+
+#ifndef SOLVE_TRI_ASCEND950_COMMON_H
+#define SOLVE_TRI_ASCEND950_COMMON_H
+
+#include "kernel_operator.h"
+
+// 8x16 ND 块对角 mask
+// [0] = ODD  (奇数条带, 对角在 col 8..15)
+// [1] = EVEN (偶数条带, 对角在 col 0..7)
+constexpr uint64_t DIAG_MASK_8X16[2][2] = {
+    { 0x0800040002000100ULL, 0x8000400020001000ULL },  // ODD
+    { 0x0008000400020001ULL, 0x0080004000200010ULL }   // EVEN
+};
+
+#endif  // SOLVE_TRI_ASCEND950_COMMON_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/solve_tri.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/solve_tri.cpp
@@ -2,111 +2,130 @@
  * Copyright (c) 2025 Tianjin University, Ltd.
  * BSD 3-Clause License.
  */
- #include "kernel_operator.h"
- #include "lib/matmul_intf.h"
- #include "solve_tri_cube.h"
- #include "solve_tri_vector.h"
- 
- using namespace AscendC;
- 
- extern "C" __global__ __aicore__ void solve_tri(GM_ADDR x, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
-                                                 GM_ADDR x_out, GM_ADDR workspace, GM_ADDR tiling)
- {
-     GET_TILING_DATA(tilingData, tiling);
-     if (TILING_KEY_IS(1)) {
-         // MIX_AIC_1_2 模式：1 个 AIC + 2 个 AIV
-         KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
-         
-         int64_t ms = tilingData.matrixSize;
-         int64_t totalTiles = tilingData.totalTiles;
-         int64_t tilesPerCore = tilingData.tilesPerCore;
-         int64_t dtypeMode = tilingData.dtypeMode;  // 0=fp16, 1=bf16
-         
-         // // AIC 核：执行 CUBE 矩阵乘法
-         if ASCEND_IS_AIC {
-             if (dtypeMode == 0) {
-                 // fp16
-                 if (ms == 16) {
-                     NsSolveTri::SolveTriCube<16, half> op;
-                     op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
-                     op.Process();
-                 } else if (ms == 32) {
-                     NsSolveTri::SolveTriCube<32, half> op;
-                     op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
-                     op.Process();
-                 } else if (ms == 64) {
-                     NsSolveTri::SolveTriCube<64, half> op;
-                     op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
-                     op.Process();
-                 } else if (ms == 128) {
-                     NsSolveTri::SolveTriCube<128, half> op;
-                     op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
-                     op.Process();
-                 }
-             } else {
-                 // bf16
-                 if (ms == 16) {
-                     NsSolveTri::SolveTriCube<16, bfloat16_t> op;
-                     op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
-                     op.Process();
-                 } else if (ms == 32) {
-                     NsSolveTri::SolveTriCube<32, bfloat16_t> op;
-                     op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
-                     op.Process();
-                 } else if (ms == 64) {
-                     NsSolveTri::SolveTriCube<64, bfloat16_t> op;
-                     op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
-                     op.Process();
-                 } else if (ms == 128) {
-                     NsSolveTri::SolveTriCube<128, bfloat16_t> op;
-                     op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
-                     op.Process();
-                 }
-             }
-         }
-         
-         // AIV 核：执行 Vector 操作（生成辅助矩阵）
-         if ASCEND_IS_AIV {
-             if (dtypeMode == 0) {
-                 // fp16
-                 if (ms == 16) {
-                     NsSolveTri::SolveTriVector<16, half> op;
-                     op.Init(workspace, totalTiles, ms);
-                     op.Process();
-                 } else if (ms == 32) {
-                     NsSolveTri::SolveTriVector<32, half> op;
-                     op.Init(workspace, totalTiles, ms);
-                     op.Process();
-                 } else if (ms == 64) {
-                     NsSolveTri::SolveTriVector<64, half> op;
-                     op.Init(workspace, totalTiles, ms);
-                     op.Process();
-                 } else if (ms == 128) {
-                     NsSolveTri::SolveTriVector<128, half> op;
-                     op.Init(workspace, totalTiles, ms);
-                     op.Process();
-                 }
-             } else {
-                 // bf16
-                 if (ms == 16) {
-                     NsSolveTri::SolveTriVector<16, bfloat16_t> op;
-                     op.Init(workspace, totalTiles, ms);
-                     op.Process();
-                 } else if (ms == 32) {
-                     NsSolveTri::SolveTriVector<32, bfloat16_t> op;
-                     op.Init(workspace, totalTiles, ms);
-                     op.Process();
-                 } else if (ms == 64) {
-                     NsSolveTri::SolveTriVector<64, bfloat16_t> op;
-                     op.Init(workspace, totalTiles, ms);
-                     op.Process();
-                 } else if (ms == 128) {
-                     NsSolveTri::SolveTriVector<128, bfloat16_t> op;
-                     op.Init(workspace, totalTiles, ms);
-                     op.Process();
-                 }
-             }
-         }
-     }
- }
- 
+#include "kernel_operator.h"
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#include "arch35/solve_tri_ascend950.h"
+#else
+#include "lib/matmul_intf.h"
+#include "solve_tri_cube.h"
+#include "solve_tri_vector.h"
+#endif
+
+using namespace AscendC;
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+__global__ __aicore__ void solve_tri(GM_ADDR x, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
+                                     GM_ADDR x_out, GM_ADDR workspace, GM_ADDR tiling)
+{
+    if (TILING_KEY_IS(1)) {
+        KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
+        GET_TILING_DATA(tilingData, tiling);
+
+        SolveTri<DTYPE_X, DTYPE_X> op;
+        op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
+        op.Process();
+    }
+}
+#else
+extern "C" __global__ __aicore__ void solve_tri(GM_ADDR x, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
+                                                GM_ADDR x_out, GM_ADDR workspace, GM_ADDR tiling)
+{
+    GET_TILING_DATA(tilingData, tiling);
+    if (TILING_KEY_IS(1)) {
+        // MIX_AIC_1_2 模式：1 个 AIC + 2 个 AIV
+        KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
+        
+        int64_t ms = tilingData.matrixSize;
+        int64_t totalTiles = tilingData.totalTiles;
+        int64_t tilesPerCore = tilingData.tilesPerCore;
+        int64_t dtypeMode = tilingData.dtypeMode;  // 0=fp16, 1=bf16
+        
+        // // AIC 核：执行 CUBE 矩阵乘法
+        if ASCEND_IS_AIC {
+            if (dtypeMode == 0) {
+                // fp16
+                if (ms == 16) {
+                    NsSolveTri::SolveTriCube<16, half> op;
+                    op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
+                    op.Process();
+                } else if (ms == 32) {
+                    NsSolveTri::SolveTriCube<32, half> op;
+                    op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
+                    op.Process();
+                } else if (ms == 64) {
+                    NsSolveTri::SolveTriCube<64, half> op;
+                    op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
+                    op.Process();
+                } else if (ms == 128) {
+                    NsSolveTri::SolveTriCube<128, half> op;
+                    op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
+                    op.Process();
+                }
+            } else {
+                // bf16
+                if (ms == 16) {
+                    NsSolveTri::SolveTriCube<16, bfloat16_t> op;
+                    op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
+                    op.Process();
+                } else if (ms == 32) {
+                    NsSolveTri::SolveTriCube<32, bfloat16_t> op;
+                    op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
+                    op.Process();
+                } else if (ms == 64) {
+                    NsSolveTri::SolveTriCube<64, bfloat16_t> op;
+                    op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
+                    op.Process();
+                } else if (ms == 128) {
+                    NsSolveTri::SolveTriCube<128, bfloat16_t> op;
+                    op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
+                    op.Process();
+                }
+            }
+        }
+        
+        // AIV 核：执行 Vector 操作（生成辅助矩阵）
+        if ASCEND_IS_AIV {
+            if (dtypeMode == 0) {
+                // fp16
+                if (ms == 16) {
+                    NsSolveTri::SolveTriVector<16, half> op;
+                    op.Init(workspace, totalTiles, ms);
+                    op.Process();
+                } else if (ms == 32) {
+                    NsSolveTri::SolveTriVector<32, half> op;
+                    op.Init(workspace, totalTiles, ms);
+                    op.Process();
+                } else if (ms == 64) {
+                    NsSolveTri::SolveTriVector<64, half> op;
+                    op.Init(workspace, totalTiles, ms);
+                    op.Process();
+                } else if (ms == 128) {
+                    NsSolveTri::SolveTriVector<128, half> op;
+                    op.Init(workspace, totalTiles, ms);
+                    op.Process();
+                }
+            } else {
+                // bf16
+                if (ms == 16) {
+                    NsSolveTri::SolveTriVector<16, bfloat16_t> op;
+                    op.Init(workspace, totalTiles, ms);
+                    op.Process();
+                } else if (ms == 32) {
+                    NsSolveTri::SolveTriVector<32, bfloat16_t> op;
+                    op.Init(workspace, totalTiles, ms);
+                    op.Process();
+                } else if (ms == 64) {
+                    NsSolveTri::SolveTriVector<64, bfloat16_t> op;
+                    op.Init(workspace, totalTiles, ms);
+                    op.Process();
+                } else if (ms == 128) {
+                    NsSolveTri::SolveTriVector<128, bfloat16_t> op;
+                    op.Init(workspace, totalTiles, ms);
+                    op.Process();
+                }
+            }
+        }
+    }
+}
+#endif

--- a/torch_custom/fla_npu/test/test_npu_solve_tri_ascend950.py
+++ b/torch_custom/fla_npu/test/test_npu_solve_tri_ascend950.py
@@ -9,6 +9,7 @@ test_npu_solve_tri_ascend950.py - Test SolveTri custom operator on ascend950 via
 用例覆盖：
   - 仓1 原有全部用例（BSND + TND varlen，BT=32）。
   - chunk_size ∈ {16,32,64,128} × 定长(BSND)/变长(TND) × 有尾块/无尾块。
+  - 上述每条用例分别以 fp16 与 bf16 输入各跑一遍（bf16 判据阈值放宽，见 tol_for）。
 """
 import os
 import torch
@@ -22,6 +23,15 @@ torch.npu.utils.set_device(0)
 # 默认 False：每条用例只打印一行 PASS/FAIL 汇总。
 # 打开方式：置为 True，或运行时设环境变量 SOLVE_TRI_VERBOSE=1。
 PRINT_POINT_DETAIL = os.environ.get("SOLVE_TRI_VERBOSE", "0") == "1"
+
+
+def tol_for(dtype):
+    """verify_err 判据阈值：bf16 尾数位(8)少于 fp16(10)，残差更大，放宽容忍度。"""
+    return 2e-2 if dtype == torch.bfloat16 else 1e-3
+
+
+def dtype_name(dtype):
+    return "bf16" if dtype == torch.bfloat16 else "fp16"
 
 
 def solve_tril_golden(A_tensor, chunk_size, layout="bsnd"):
@@ -52,7 +62,7 @@ def solve_tril_golden(A_tensor, chunk_size, layout="bsnd"):
                     result[s:e, h, :actual_size] = M_inv
                 else:
                     result[b, s:e, h, :actual_size] = M_inv
-    return torch.from_numpy(result).half()
+    return torch.from_numpy(result)   # float32 golden（与 dtype 无关，仅用于诊断 max_diff）
 
 
 def generate_lower_tri_input(B, H, T, chunk_size, dtype=torch.float16, seed=42, layout="bsnd"):
@@ -84,6 +94,8 @@ def generate_lower_tri_input(B, H, T, chunk_size, dtype=torch.float16, seed=42, 
 def test_solve_tri(B, H, T, chunk_size, layout="bsnd", dtype=torch.float16):
     """定长用例（BSND / BHTD）。chunk_size = 输入末维 BT。"""
     torch.manual_seed(42)
+    tol = tol_for(dtype)
+    dt = dtype_name(dtype)
     A = generate_lower_tri_input(B, H, T, chunk_size, dtype, layout=layout)
     golden = solve_tril_golden(A, chunk_size, layout=layout)
 
@@ -125,18 +137,20 @@ def test_solve_tri(B, H, T, chunk_size, layout="bsnd", dtype=torch.float16):
                     chunk_diff = np.abs(inv_block - golden_chunk).max()
                     is_partial = (c == num_chunks - 1 and actual_size < chunk_size)
                     partial_tag = f" [partial {actual_size}x{actual_size}]" if is_partial else ""
-                    cst = "OK" if err < 1e-3 else "FAIL"
+                    cst = "OK" if err < tol else "FAIL"
                     print(f"  [{cst}] b={b} h={h} c={c}{partial_tag}: max_diff={chunk_diff:.6f}, verify_err={err:.6f}")
 
-    passed = max_verify_err < 1e-3
+    passed = max_verify_err < tol
     status = "PASS" if passed else "FAIL"
-    print(f"  [{status}] layout={layout} B={B} H={H} T={T} BT={chunk_size}: "
+    print(f"  [{status}] {dt} layout={layout} B={B} H={H} T={T} BT={chunk_size} (tol={tol:g}): "
           f"max_diff={max_diff:.6f}, verify_err={max_verify_err:.6f}")
     return passed
 
 
 def test_solve_tri_varlen(seq_lens, H, chunk_size, dtype=torch.float16):
     """变长 TND 用例 [total_T, H, BT]。chunk_size = 输入末维 BT。"""
+    tol = tol_for(dtype)
+    dt = dtype_name(dtype)
     total_T = sum(seq_lens)
     cu_seqlens = torch.tensor([0] + list(np.cumsum(seq_lens)), dtype=torch.int32)
     lens = cu_seqlens[1:] - cu_seqlens[:-1]
@@ -189,7 +203,7 @@ def test_solve_tri_varlen(seq_lens, H, chunk_size, dtype=torch.float16):
                 M = eye + block
                 M_inv = np.linalg.inv(M)
                 golden[s:e, h, :actual_size] = M_inv
-    golden = torch.from_numpy(golden).half()
+    golden = torch.from_numpy(golden)   # float32 golden（仅用于诊断 max_diff）
 
     A_npu = A.npu()
     cu_seqlens_list = cu_seqlens.tolist()
@@ -229,48 +243,49 @@ def test_solve_tri_varlen(seq_lens, H, chunk_size, dtype=torch.float16):
                     chunk_diff = np.abs(inv_block - golden_chunk).max()
                     is_partial = (actual_size < chunk_size)
                     partial_tag = f" [partial {actual_size}x{actual_size}]" if is_partial else ""
-                    cst = "OK" if err < 1e-3 else "FAIL"
+                    cst = "OK" if err < tol else "FAIL"
                     print(f"  [{cst}] seq={seq_idx} h={h} c={c}{partial_tag}: "
                           f"max_diff={chunk_diff:.6f}, verify_err={err:.6f}")
 
-    passed = max_verify_err < 1e-3
+    passed = max_verify_err < tol
     status = "PASS" if passed else "FAIL"
-    print(f"  [{status}] varlen seqs={seq_lens}, H={H}, BT={chunk_size}: "
+    print(f"  [{status}] {dt} varlen seqs={seq_lens}, H={H}, BT={chunk_size} (tol={tol:g}): "
           f"max_verify_err={max_verify_err:.6f}")
     return passed
 
 
-if __name__ == "__main__":
-    print("=" * 60)
-    print("SolveTri NPU Test (ascend950, torch.ops.npu)")
-    print("=" * 60)
-
+def run_all_cases(dtype):
+    """按给定输入 dtype 跑完整用例集，返回结果布尔列表。"""
     results = []
+    dt = dtype_name(dtype)
+    print(f"\n{'#' * 60}")
+    print(f"##########  INPUT DTYPE = {dt}  ##########")
+    print(f"{'#' * 60}")
 
     # ================================================================
     # Group 1: 仓1 原有全部用例（BT=32）
     # ================================================================
     print("\n########## [Group 1] repo1 original cases (BT=32) ##########")
     print("\n--- BSND layout [B, T, H, BT] ---")
-    results.append(test_solve_tri(1, 2, 40, 32, layout="bsnd"))
-    results.append(test_solve_tri(2, 2, 64, 32, layout="bsnd"))
-    results.append(test_solve_tri(1, 1, 35, 32, layout="bsnd"))
-    results.append(test_solve_tri(2, 2, 100, 32, layout="bsnd"))
+    results.append(test_solve_tri(1, 2, 40, 32, layout="bsnd", dtype=dtype))
+    results.append(test_solve_tri(2, 2, 64, 32, layout="bsnd", dtype=dtype))
+    results.append(test_solve_tri(1, 1, 35, 32, layout="bsnd", dtype=dtype))
+    results.append(test_solve_tri(2, 2, 100, 32, layout="bsnd", dtype=dtype))
     print("\n--- Network Cases layout [B, T, H, BT] ---")
-    results.append(test_solve_tri(1, 4, 32768, 64, layout="bsnd"))
-    results.append(test_solve_tri(1, 4, 32768, 128, layout="bsnd"))
-    results.append(test_solve_tri(8, 8, 4096, 64, layout="bsnd"))
-    results.append(test_solve_tri(8, 8, 4096, 128, layout="bsnd"))
+    results.append(test_solve_tri(1, 4, 32768, 64, layout="bsnd", dtype=dtype))
+    results.append(test_solve_tri(1, 4, 32768, 128, layout="bsnd", dtype=dtype))
+    results.append(test_solve_tri(8, 8, 4096, 64, layout="bsnd", dtype=dtype))
+    results.append(test_solve_tri(8, 8, 4096, 128, layout="bsnd", dtype=dtype))
 
     print("\n--- TND varlen layout [total_T, H, BT] ---")
-    results.append(test_solve_tri_varlen([64], 1, 32))
-    results.append(test_solve_tri_varlen([32, 32, 32], 2, 32))
-    results.append(test_solve_tri_varlen([45], 1, 32))
-    results.append(test_solve_tri_varlen([100, 50, 35], 2, 32))
-    results.append(test_solve_tri_varlen([4, 18], 1, 32))
-    results.append(test_solve_tri_varlen([35], 1, 32))
-    results.append(test_solve_tri_varlen([3], 1, 32))
-    results.append(test_solve_tri_varlen([18], 2, 32))
+    results.append(test_solve_tri_varlen([64], 1, 32, dtype=dtype))
+    results.append(test_solve_tri_varlen([32, 32, 32], 2, 32, dtype=dtype))
+    results.append(test_solve_tri_varlen([45], 1, 32, dtype=dtype))
+    results.append(test_solve_tri_varlen([100, 50, 35], 2, 32, dtype=dtype))
+    results.append(test_solve_tri_varlen([4, 18], 1, 32, dtype=dtype))
+    results.append(test_solve_tri_varlen([35], 1, 32, dtype=dtype))
+    results.append(test_solve_tri_varlen([3], 1, 32, dtype=dtype))
+    results.append(test_solve_tri_varlen([18], 2, 32, dtype=dtype))
 
     # ================================================================
     # Group 2: chunk_size ∈ {16,32,64,128} × 定长/变长 × 有尾块/无尾块
@@ -286,15 +301,28 @@ if __name__ == "__main__":
 
         # ---- 定长 BSND ----
         print(f"[BSND fixed, no-tail]  T={2 * cs}")
-        results.append(test_solve_tri(2, 2, 2 * cs, cs, layout="bsnd"))
+        results.append(test_solve_tri(2, 2, 2 * cs, cs, layout="bsnd", dtype=dtype))
         print(f"[BSND fixed, with-tail] T={2 * cs + tb} (tail={tb})")
-        results.append(test_solve_tri(2, 2, 2 * cs + tb, cs, layout="bsnd"))
+        results.append(test_solve_tri(2, 2, 2 * cs + tb, cs, layout="bsnd", dtype=dtype))
 
         # ---- 变长 TND ----
         print(f"[TND varlen, no-tail]  seqs=[{2 * cs},{cs}]")
-        results.append(test_solve_tri_varlen([2 * cs, cs], 2, cs))
+        results.append(test_solve_tri_varlen([2 * cs, cs], 2, cs, dtype=dtype))
         print(f"[TND varlen, with-tail] seqs=[{2 * cs + tb},{cs + ts}] (tails={tb},{ts})")
-        results.append(test_solve_tri_varlen([2 * cs + tb, cs + ts], 2, cs))
+        results.append(test_solve_tri_varlen([2 * cs + tb, cs + ts], 2, cs, dtype=dtype))
+
+    return results
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("SolveTri NPU Test (ascend950, torch.ops.npu) — fp16 + bf16")
+    print("=" * 60)
+
+    results = []
+    # 每条用例分别以 fp16 与 bf16 输入各跑一遍
+    for dtype in (torch.float16, torch.bfloat16):
+        results += run_all_cases(dtype)
 
     print(f"\n{'=' * 60}")
     print(f"Results: {sum(results)}/{len(results)} passed")

--- a/torch_custom/fla_npu/test/test_npu_solve_tri_ascend950.py
+++ b/torch_custom/fla_npu/test/test_npu_solve_tri_ascend950.py
@@ -10,12 +10,18 @@ test_npu_solve_tri_ascend950.py - Test SolveTri custom operator on ascend950 via
   - 仓1 原有全部用例（BSND + TND varlen，BT=32）。
   - chunk_size ∈ {16,32,64,128} × 定长(BSND)/变长(TND) × 有尾块/无尾块。
 """
+import os
 import torch
 import torch_npu
 import numpy as np
 import fla_npu
 
 torch.npu.utils.set_device(0)
+
+# 是否打印每个 (b,h,c)/(seq,h,c) 点位的 OK/FAIL 明细及用例头。
+# 默认 False：每条用例只打印一行 PASS/FAIL 汇总。
+# 打开方式：置为 True，或运行时设环境变量 SOLVE_TRI_VERBOSE=1。
+PRINT_POINT_DETAIL = os.environ.get("SOLVE_TRI_VERBOSE", "0") == "1"
 
 
 def solve_tril_golden(A_tensor, chunk_size, layout="bsnd"):
@@ -94,7 +100,8 @@ def test_solve_tri(B, H, T, chunk_size, layout="bsnd", dtype=torch.float16):
     A_np = A.float().numpy()
     R_np = out_cpu.float().numpy()
     max_verify_err = 0.0
-    print(f"\n--- Test (layout={layout}, B={B}, H={H}, T={T}, BT={chunk_size}, numChunks={num_chunks}) ---")
+    if PRINT_POINT_DETAIL:
+        print(f"\n--- Test (layout={layout}, B={B}, H={H}, T={T}, BT={chunk_size}, numChunks={num_chunks}) ---")
     for b in range(B):
         for h in range(H):
             for c in range(num_chunks):
@@ -114,11 +121,12 @@ def test_solve_tri(B, H, T, chunk_size, layout="bsnd", dtype=torch.float16):
                 err = np.abs(product - eye).max()
                 max_verify_err = max(max_verify_err, err)
 
-                chunk_diff = np.abs(inv_block - golden_chunk).max()
-                is_partial = (c == num_chunks - 1 and actual_size < chunk_size)
-                partial_tag = f" [partial {actual_size}x{actual_size}]" if is_partial else ""
-                cst = "OK" if err < 1e-3 else "FAIL"
-                print(f"  [{cst}] b={b} h={h} c={c}{partial_tag}: max_diff={chunk_diff:.6f}, verify_err={err:.6f}")
+                if PRINT_POINT_DETAIL:
+                    chunk_diff = np.abs(inv_block - golden_chunk).max()
+                    is_partial = (c == num_chunks - 1 and actual_size < chunk_size)
+                    partial_tag = f" [partial {actual_size}x{actual_size}]" if is_partial else ""
+                    cst = "OK" if err < 1e-3 else "FAIL"
+                    print(f"  [{cst}] b={b} h={h} c={c}{partial_tag}: max_diff={chunk_diff:.6f}, verify_err={err:.6f}")
 
     passed = max_verify_err < 1e-3
     status = "PASS" if passed else "FAIL"
@@ -195,8 +203,9 @@ def test_solve_tri_varlen(seq_lens, H, chunk_size, dtype=torch.float16):
 
     max_verify_err = 0.0
     total_chunks = chunk_indices.shape[0]
-    print(f"\n--- Varlen test (seqs={seq_lens}, H={H}, BT={chunk_size}, "
-          f"total_T={total_T}, total_chunks={total_chunks}) ---")
+    if PRINT_POINT_DETAIL:
+        print(f"\n--- Varlen test (seqs={seq_lens}, H={H}, BT={chunk_size}, "
+              f"total_T={total_T}, total_chunks={total_chunks}) ---")
 
     for seq_idx in range(num_seqs):
         bos = cu_seqlens[seq_idx].item()
@@ -215,13 +224,14 @@ def test_solve_tri_varlen(seq_lens, H, chunk_size, dtype=torch.float16):
                 err = np.abs(product - eye).max()
                 max_verify_err = max(max_verify_err, err)
 
-                golden_chunk = golden[s:e, h, :actual_size].float().numpy()
-                chunk_diff = np.abs(inv_block - golden_chunk).max()
-                is_partial = (actual_size < chunk_size)
-                partial_tag = f" [partial {actual_size}x{actual_size}]" if is_partial else ""
-                cst = "OK" if err < 1e-3 else "FAIL"
-                print(f"  [{cst}] seq={seq_idx} h={h} c={c}{partial_tag}: "
-                      f"max_diff={chunk_diff:.6f}, verify_err={err:.6f}")
+                if PRINT_POINT_DETAIL:
+                    golden_chunk = golden[s:e, h, :actual_size].float().numpy()
+                    chunk_diff = np.abs(inv_block - golden_chunk).max()
+                    is_partial = (actual_size < chunk_size)
+                    partial_tag = f" [partial {actual_size}x{actual_size}]" if is_partial else ""
+                    cst = "OK" if err < 1e-3 else "FAIL"
+                    print(f"  [{cst}] seq={seq_idx} h={h} c={c}{partial_tag}: "
+                          f"max_diff={chunk_diff:.6f}, verify_err={err:.6f}")
 
     passed = max_verify_err < 1e-3
     status = "PASS" if passed else "FAIL"

--- a/torch_custom/fla_npu/test/test_npu_solve_tri_ascend950.py
+++ b/torch_custom/fla_npu/test/test_npu_solve_tri_ascend950.py
@@ -1,11 +1,14 @@
 """
 test_npu_solve_tri_ascend950.py - Test SolveTri custom operator on ascend950 via torch.ops.npu
 
-整算子测试（MCH + MBH）：
-    solve_tri 接口为 (x, cu_seqlens, chunk_indices, layout)，chunk_size 由 x 末维隐式确定。
-    算子对严格下三角 A 计算完整的 (I + A)^{-1}（与 triton 参考约定一致）。
+由仓1 test_npu_solve_tril.py 适配而来。仓2 算子接口：
+    npu_solve_tri(x, *, cu_seqlens=None, chunk_indices=None, layout="bsnd")
+  —— 无 chunk_size 入参，chunk_size 由 x 末维 BT 隐式确定；每个 chunk 块为 BT×BT。
+支持 BSND [B,T,H,BT] 与 TND [total_T,H,BT]（变长）两种布局。
 
-    算法分两段：MCH 求 16×16 对角块逆（块对角逆），MBH 递归合并非对角块得到完整下三角逆。
+用例覆盖：
+  - 仓1 原有全部用例（BSND + TND varlen，BT=32）。
+  - chunk_size ∈ {16,32,64,128} × 定长(BSND)/变长(TND) × 有尾块/无尾块。
 """
 import torch
 import torch_npu
@@ -14,98 +17,276 @@ import fla_npu
 
 torch.npu.utils.set_device(0)
 
-FRAC = 16  # 叶子块大小（MCH 对角块）
 
-
-def solve_tri_golden(block):
-    """完整下三角逆 golden：(I + A)^{-1}，A 为 BT×BT 严格下三角 (float32 numpy)。"""
-    bt = block.shape[0]
-    eye = np.eye(bt, dtype=np.float32)
-    return np.linalg.inv(eye + block)
-
-
-def generate_lower_tri_block(bt, dtype=torch.float16, seed=42):
-    """生成单个 BT×BT 的严格下三角矩阵。"""
-    torch.manual_seed(seed)
-    m = torch.randn(bt, bt, dtype=dtype) * 0.1
-    for i in range(bt):
-        for j in range(i, bt):
-            m[i, j] = 0.0
-    return m
-
-
-def test_solve_tri(BT, layout="bhtd", dtype=torch.float16, seed=42):
-    """整算子单 tile 测试：B=H=1, T=BT，单个 chunk。"""
-    B, H, T = 1, 1, BT
-
-    block = generate_lower_tri_block(BT, dtype, seed)
-    block_np = block.float().numpy()
-    golden_np = solve_tri_golden(block_np)
-
-    if layout == "bhtd":
-        A = block.reshape(B, H, T, BT)
+def solve_tril_golden(A_tensor, chunk_size, layout="bsnd"):
+    """CPU golden: 逐 chunk 计算 (I + A)^{-1}，支持非对齐 T（尾块）。"""
+    A = A_tensor.float().numpy()
+    if layout == "tnd":
+        T, H, BT = A.shape
+        B = 1
     else:
-        A = block.reshape(B, T, H, BT)
+        B, T, H, BT = A.shape
+    num_chunks = (T + chunk_size - 1) // chunk_size
+    result = np.zeros_like(A)
+
+    for b in range(B):
+        for h in range(H):
+            for c in range(num_chunks):
+                s = c * chunk_size
+                e = min(s + chunk_size, T)
+                actual_size = e - s
+                if layout == "tnd":
+                    block = A[s:e, h, :actual_size]
+                else:
+                    block = A[b, s:e, h, :actual_size]
+                eye = np.eye(actual_size, dtype=np.float32)
+                M = eye + block
+                M_inv = np.linalg.inv(M)
+                if layout == "tnd":
+                    result[s:e, h, :actual_size] = M_inv
+                else:
+                    result[b, s:e, h, :actual_size] = M_inv
+    return torch.from_numpy(result).half()
+
+
+def generate_lower_tri_input(B, H, T, chunk_size, dtype=torch.float16, seed=42, layout="bsnd"):
+    """生成随机严格下三角输入（每 chunk 块严格下三角，尾块只填 actual_size×actual_size）。"""
+    torch.manual_seed(seed)
+    if layout == "tnd":
+        A = torch.zeros(T, H, chunk_size, dtype=dtype)
+    else:
+        A = torch.zeros(B, T, H, chunk_size, dtype=dtype)
+    num_chunks = (T + chunk_size - 1) // chunk_size
+
+    for b in range(B):
+        for h in range(H):
+            for c in range(num_chunks):
+                s = c * chunk_size
+                e = min(s + chunk_size, T)
+                actual_size = e - s
+                one_chunk = torch.randn(actual_size, actual_size, dtype=dtype) * 0.1
+                for i in range(actual_size):
+                    for j in range(i, actual_size):
+                        one_chunk[i, j] = 0.0
+                if layout == "tnd":
+                    A[s:e, h, :actual_size] = one_chunk
+                else:
+                    A[b, s:e, h, :actual_size] = one_chunk
+    return A
+
+
+def test_solve_tri(B, H, T, chunk_size, layout="bsnd", dtype=torch.float16):
+    """定长用例（BSND / BHTD）。chunk_size = 输入末维 BT。"""
+    torch.manual_seed(42)
+    A = generate_lower_tri_input(B, H, T, chunk_size, dtype, layout=layout)
+    golden = solve_tril_golden(A, chunk_size, layout=layout)
 
     A_npu = A.npu()
-
-    out_npu = torch.ops.npu.npu_solve_tri(
-        A_npu,
-        cu_seqlens=None,
-        chunk_indices=None,
-        layout=layout,
-    )
+    # 仓2 接口：chunk_size 由 x 末维隐式确定，定长无需 cu_seqlens / chunk_indices
+    out_npu = torch.ops.npu.npu_solve_tri(A_npu, cu_seqlens=None, chunk_indices=None, layout=layout)
     out_cpu = out_npu.cpu()
 
-    if layout == "bhtd":
-        inv_block = out_cpu[0, 0].float().numpy()
-    else:
-        inv_block = out_cpu[0, :, 0].float().numpy()
+    num_chunks = (T + chunk_size - 1) // chunk_size
 
-    max_diff = np.abs(inv_block - golden_np).max()
-    eye = np.eye(BT, dtype=np.float32)
-    product = (eye + block_np) @ inv_block
-    verify_err = np.abs(product - eye).max()
+    diff = (out_cpu.float() - golden.float()).abs()
+    max_diff = diff.max().item()
 
-    passed = verify_err < 1e-3
+    A_np = A.float().numpy()
+    R_np = out_cpu.float().numpy()
+    max_verify_err = 0.0
+    print(f"\n--- Test (layout={layout}, B={B}, H={H}, T={T}, BT={chunk_size}, numChunks={num_chunks}) ---")
+    for b in range(B):
+        for h in range(H):
+            for c in range(num_chunks):
+                s = c * chunk_size
+                e = min(s + chunk_size, T)
+                actual_size = e - s
+                if layout == "tnd":
+                    block = A_np[s:e, h, :actual_size]
+                    inv_block = R_np[s:e, h, :actual_size]
+                    golden_chunk = golden[s:e, h, :actual_size].float().numpy()
+                else:
+                    block = A_np[b, s:e, h, :actual_size]
+                    inv_block = R_np[b, s:e, h, :actual_size]
+                    golden_chunk = golden[b, s:e, h, :actual_size].float().numpy()
+                eye = np.eye(actual_size, dtype=np.float32)
+                product = (eye + block) @ inv_block
+                err = np.abs(product - eye).max()
+                max_verify_err = max(max_verify_err, err)
+
+                chunk_diff = np.abs(inv_block - golden_chunk).max()
+                is_partial = (c == num_chunks - 1 and actual_size < chunk_size)
+                partial_tag = f" [partial {actual_size}x{actual_size}]" if is_partial else ""
+                cst = "OK" if err < 1e-3 else "FAIL"
+                print(f"  [{cst}] b={b} h={h} c={c}{partial_tag}: max_diff={chunk_diff:.6f}, verify_err={err:.6f}")
+
+    passed = max_verify_err < 1e-3
     status = "PASS" if passed else "FAIL"
-    print(f"  [{status}] layout={layout} BT={BT}: "
-          f"max_diff={max_diff:.6f}, verify_err={verify_err:.6f}")
+    print(f"  [{status}] layout={layout} B={B} H={H} T={T} BT={chunk_size}: "
+          f"max_diff={max_diff:.6f}, verify_err={max_verify_err:.6f}")
+    return passed
 
-    if (not passed) and BT <= 64:
-        nf = BT // FRAC
-        print(f"      --- block-wise diagnosis (BT={BT}, {nf}x{nf} blocks of 16) ---")
-        for bi in range(nf):
-            row_err = []
-            for bj in range(nf):
-                o = inv_block[bi*FRAC:(bi+1)*FRAC, bj*FRAC:(bj+1)*FRAC]
-                g = golden_np[bi*FRAC:(bi+1)*FRAC, bj*FRAC:(bj+1)*FRAC]
-                tag = "diag" if bi == bj else ("low " if bi > bj else "up  ")
-                row_err.append(f"({bi},{bj}){tag} err={np.abs(o-g).max():.4f}")
-            print("        " + " | ".join(row_err))
+
+def test_solve_tri_varlen(seq_lens, H, chunk_size, dtype=torch.float16):
+    """变长 TND 用例 [total_T, H, BT]。chunk_size = 输入末维 BT。"""
+    total_T = sum(seq_lens)
+    cu_seqlens = torch.tensor([0] + list(np.cumsum(seq_lens)), dtype=torch.int32)
+    lens = cu_seqlens[1:] - cu_seqlens[:-1]
+    num_chunks_per_seq = (lens + chunk_size - 1) // chunk_size
+
+    all_seq_ids = []
+    all_chunk_ids = []
+    for seq_idx, n_chunks in enumerate(num_chunks_per_seq):
+        n = n_chunks.item()
+        all_seq_ids.extend([seq_idx] * n)
+        all_chunk_ids.extend(range(n))
+    chunk_indices = torch.stack([
+        torch.tensor(all_seq_ids, dtype=torch.int32),
+        torch.tensor(all_chunk_ids, dtype=torch.int32)
+    ], dim=1)
+
+    torch.manual_seed(42)
+    A = torch.zeros(total_T, H, chunk_size, dtype=dtype)
+    num_seqs = len(seq_lens)
+    for seq_idx in range(num_seqs):
+        bos = cu_seqlens[seq_idx].item()
+        eos = cu_seqlens[seq_idx + 1].item()
+        seq_len = eos - bos
+        num_chunks = (seq_len + chunk_size - 1) // chunk_size
+        for h in range(H):
+            for c in range(num_chunks):
+                s = bos + c * chunk_size
+                e = min(s + chunk_size, eos)
+                actual_size = e - s
+                one_chunk = torch.randn(actual_size, actual_size, dtype=dtype) * 0.1
+                for i in range(actual_size):
+                    for j in range(i, actual_size):
+                        one_chunk[i, j] = 0.0
+                A[s:e, h, :actual_size] = one_chunk
+
+    A_np = A.float().numpy()
+    golden = np.zeros_like(A_np)
+    for seq_idx in range(num_seqs):
+        bos = cu_seqlens[seq_idx].item()
+        eos = cu_seqlens[seq_idx + 1].item()
+        seq_len = eos - bos
+        num_chunks = (seq_len + chunk_size - 1) // chunk_size
+        for h in range(H):
+            for c in range(num_chunks):
+                s = bos + c * chunk_size
+                e = min(s + chunk_size, eos)
+                actual_size = e - s
+                block = A_np[s:e, h, :actual_size]
+                eye = np.eye(actual_size, dtype=np.float32)
+                M = eye + block
+                M_inv = np.linalg.inv(M)
+                golden[s:e, h, :actual_size] = M_inv
+    golden = torch.from_numpy(golden).half()
+
+    A_npu = A.npu()
+    cu_seqlens_list = cu_seqlens.tolist()
+    chunk_indices_flat = chunk_indices.flatten().tolist()
+
+    out_npu = torch.ops.npu.npu_solve_tri(A_npu,
+                                          cu_seqlens=cu_seqlens_list,
+                                          chunk_indices=chunk_indices_flat,
+                                          layout="tnd")
+    out_cpu = out_npu.cpu()
+
+    max_verify_err = 0.0
+    total_chunks = chunk_indices.shape[0]
+    print(f"\n--- Varlen test (seqs={seq_lens}, H={H}, BT={chunk_size}, "
+          f"total_T={total_T}, total_chunks={total_chunks}) ---")
+
+    for seq_idx in range(num_seqs):
+        bos = cu_seqlens[seq_idx].item()
+        eos = cu_seqlens[seq_idx + 1].item()
+        seq_len = eos - bos
+        num_chunks = (seq_len + chunk_size - 1) // chunk_size
+        for h in range(H):
+            for c in range(num_chunks):
+                s = bos + c * chunk_size
+                e = min(s + chunk_size, eos)
+                actual_size = e - s
+                block = A_np[s:e, h, :actual_size]
+                inv_block = out_cpu[s:e, h, :actual_size].float().numpy()
+                eye = np.eye(actual_size, dtype=np.float32)
+                product = (eye + block) @ inv_block
+                err = np.abs(product - eye).max()
+                max_verify_err = max(max_verify_err, err)
+
+                golden_chunk = golden[s:e, h, :actual_size].float().numpy()
+                chunk_diff = np.abs(inv_block - golden_chunk).max()
+                is_partial = (actual_size < chunk_size)
+                partial_tag = f" [partial {actual_size}x{actual_size}]" if is_partial else ""
+                cst = "OK" if err < 1e-3 else "FAIL"
+                print(f"  [{cst}] seq={seq_idx} h={h} c={c}{partial_tag}: "
+                      f"max_diff={chunk_diff:.6f}, verify_err={err:.6f}")
+
+    passed = max_verify_err < 1e-3
+    status = "PASS" if passed else "FAIL"
+    print(f"  [{status}] varlen seqs={seq_lens}, H={H}, BT={chunk_size}: "
+          f"max_verify_err={max_verify_err:.6f}")
     return passed
 
 
 if __name__ == "__main__":
     print("=" * 60)
-    print("SolveTri NPU Test (ascend950) - whole operator (torch.ops.npu)")
+    print("SolveTri NPU Test (ascend950, torch.ops.npu)")
     print("=" * 60)
 
     results = []
 
-    print("\n--- BHTD layout [B=1, H=1, T=BT, BT] ---")
-    for bt in (16, 32, 64, 128):
-        results.append(test_solve_tri(bt, layout="bhtd"))
+    # ================================================================
+    # Group 1: 仓1 原有全部用例（BT=32）
+    # ================================================================
+    print("\n########## [Group 1] repo1 original cases (BT=32) ##########")
+    print("\n--- BSND layout [B, T, H, BT] ---")
+    results.append(test_solve_tri(1, 2, 40, 32, layout="bsnd"))
+    results.append(test_solve_tri(2, 2, 64, 32, layout="bsnd"))
+    results.append(test_solve_tri(1, 1, 35, 32, layout="bsnd"))
+    results.append(test_solve_tri(2, 2, 100, 32, layout="bsnd"))
+    print("\n--- Network Cases layout [B, T, H, BT] ---")
+    results.append(test_solve_tri(1, 4, 32768, 64, layout="bsnd"))
+    results.append(test_solve_tri(1, 4, 32768, 128, layout="bsnd"))
+    results.append(test_solve_tri(8, 8, 4096, 64, layout="bsnd"))
+    results.append(test_solve_tri(8, 8, 4096, 128, layout="bsnd"))
 
-    print("\n--- BSND layout [B=1, T=BT, H=1, BT] ---")
-    for bt in (16, 32, 64, 128):
-        results.append(test_solve_tri(bt, layout="bsnd"))
+    print("\n--- TND varlen layout [total_T, H, BT] ---")
+    results.append(test_solve_tri_varlen([64], 1, 32))
+    results.append(test_solve_tri_varlen([32, 32, 32], 2, 32))
+    results.append(test_solve_tri_varlen([45], 1, 32))
+    results.append(test_solve_tri_varlen([100, 50, 35], 2, 32))
+    results.append(test_solve_tri_varlen([4, 18], 1, 32))
+    results.append(test_solve_tri_varlen([35], 1, 32))
+    results.append(test_solve_tri_varlen([3], 1, 32))
+    results.append(test_solve_tri_varlen([18], 2, 32))
 
-    print("\n--- BT=128, multiple seeds ---")
-    for sd in (1, 7, 123):
-        results.append(test_solve_tri(128, layout="bhtd", seed=sd))
+    # ================================================================
+    # Group 2: chunk_size ∈ {16,32,64,128} × 定长/变长 × 有尾块/无尾块
+    #   - tb = 大尾块（cs>16 时 ChunkAlign→cs，触发 MBH 尾块路径），恒 < cs
+    #   - ts = 小尾块（ChunkAlign→16，触发 MCH-only 尾块 + cur<cs 写回路径）
+    # ================================================================
+    print("\n########## [Group 2] chunk_size sweep x fixed/varlen x tail/no-tail ##########")
+    for cs in (16, 32, 64, 128):
+        tb = (cs // 2 + 8) if cs > 16 else 8   # 大尾块（< cs）
+        ts = 8                                  # 小尾块（→ cur=16）
 
-    print(f"\n{'='*60}")
+        print(f"\n=== chunk_size (BT) = {cs} ===")
+
+        # ---- 定长 BSND ----
+        print(f"[BSND fixed, no-tail]  T={2 * cs}")
+        results.append(test_solve_tri(2, 2, 2 * cs, cs, layout="bsnd"))
+        print(f"[BSND fixed, with-tail] T={2 * cs + tb} (tail={tb})")
+        results.append(test_solve_tri(2, 2, 2 * cs + tb, cs, layout="bsnd"))
+
+        # ---- 变长 TND ----
+        print(f"[TND varlen, no-tail]  seqs=[{2 * cs},{cs}]")
+        results.append(test_solve_tri_varlen([2 * cs, cs], 2, cs))
+        print(f"[TND varlen, with-tail] seqs=[{2 * cs + tb},{cs + ts}] (tails={tb},{ts})")
+        results.append(test_solve_tri_varlen([2 * cs + tb, cs + ts], 2, cs))
+
+    print(f"\n{'=' * 60}")
     print(f"Results: {sum(results)}/{len(results)} passed")
     if all(results):
         print("All tests PASSED!")

--- a/torch_custom/fla_npu/test/test_npu_solve_tri_ascend950.py
+++ b/torch_custom/fla_npu/test/test_npu_solve_tri_ascend950.py
@@ -1,0 +1,115 @@
+"""
+test_npu_solve_tri_ascend950.py - Test SolveTri custom operator on ascend950 via torch.ops.npu
+
+整算子测试（MCH + MBH）：
+    solve_tri 接口为 (x, cu_seqlens, chunk_indices, layout)，chunk_size 由 x 末维隐式确定。
+    算子对严格下三角 A 计算完整的 (I + A)^{-1}（与 triton 参考约定一致）。
+
+    算法分两段：MCH 求 16×16 对角块逆（块对角逆），MBH 递归合并非对角块得到完整下三角逆。
+"""
+import torch
+import torch_npu
+import numpy as np
+import fla_npu
+
+torch.npu.utils.set_device(0)
+
+FRAC = 16  # 叶子块大小（MCH 对角块）
+
+
+def solve_tri_golden(block):
+    """完整下三角逆 golden：(I + A)^{-1}，A 为 BT×BT 严格下三角 (float32 numpy)。"""
+    bt = block.shape[0]
+    eye = np.eye(bt, dtype=np.float32)
+    return np.linalg.inv(eye + block)
+
+
+def generate_lower_tri_block(bt, dtype=torch.float16, seed=42):
+    """生成单个 BT×BT 的严格下三角矩阵。"""
+    torch.manual_seed(seed)
+    m = torch.randn(bt, bt, dtype=dtype) * 0.1
+    for i in range(bt):
+        for j in range(i, bt):
+            m[i, j] = 0.0
+    return m
+
+
+def test_solve_tri(BT, layout="bhtd", dtype=torch.float16, seed=42):
+    """整算子单 tile 测试：B=H=1, T=BT，单个 chunk。"""
+    B, H, T = 1, 1, BT
+
+    block = generate_lower_tri_block(BT, dtype, seed)
+    block_np = block.float().numpy()
+    golden_np = solve_tri_golden(block_np)
+
+    if layout == "bhtd":
+        A = block.reshape(B, H, T, BT)
+    else:
+        A = block.reshape(B, T, H, BT)
+
+    A_npu = A.npu()
+
+    out_npu = torch.ops.npu.npu_solve_tri(
+        A_npu,
+        cu_seqlens=None,
+        chunk_indices=None,
+        layout=layout,
+    )
+    out_cpu = out_npu.cpu()
+
+    if layout == "bhtd":
+        inv_block = out_cpu[0, 0].float().numpy()
+    else:
+        inv_block = out_cpu[0, :, 0].float().numpy()
+
+    max_diff = np.abs(inv_block - golden_np).max()
+    eye = np.eye(BT, dtype=np.float32)
+    product = (eye + block_np) @ inv_block
+    verify_err = np.abs(product - eye).max()
+
+    passed = verify_err < 1e-3
+    status = "PASS" if passed else "FAIL"
+    print(f"  [{status}] layout={layout} BT={BT}: "
+          f"max_diff={max_diff:.6f}, verify_err={verify_err:.6f}")
+
+    if (not passed) and BT <= 64:
+        nf = BT // FRAC
+        print(f"      --- block-wise diagnosis (BT={BT}, {nf}x{nf} blocks of 16) ---")
+        for bi in range(nf):
+            row_err = []
+            for bj in range(nf):
+                o = inv_block[bi*FRAC:(bi+1)*FRAC, bj*FRAC:(bj+1)*FRAC]
+                g = golden_np[bi*FRAC:(bi+1)*FRAC, bj*FRAC:(bj+1)*FRAC]
+                tag = "diag" if bi == bj else ("low " if bi > bj else "up  ")
+                row_err.append(f"({bi},{bj}){tag} err={np.abs(o-g).max():.4f}")
+            print("        " + " | ".join(row_err))
+    return passed
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("SolveTri NPU Test (ascend950) - whole operator (torch.ops.npu)")
+    print("=" * 60)
+
+    results = []
+
+    print("\n--- BHTD layout [B=1, H=1, T=BT, BT] ---")
+    for bt in (16, 32, 64, 128):
+        results.append(test_solve_tri(bt, layout="bhtd"))
+
+    print("\n--- BSND layout [B=1, T=BT, H=1, BT] ---")
+    for bt in (16, 32, 64, 128):
+        results.append(test_solve_tri(bt, layout="bsnd"))
+
+    print("\n--- BT=128, multiple seeds ---")
+    for sd in (1, 7, 123):
+        results.append(test_solve_tri(128, layout="bhtd", seed=sd))
+
+    print(f"\n{'='*60}")
+    print(f"Results: {sum(results)}/{len(results)} passed")
+    if all(results):
+        print("All tests PASSED!")
+        exit(0)
+    else:
+        print("Some tests FAILED!")
+        exit(1)


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @Oscillated
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
