### PR TITLE
feat: add forward KDA AscendC operator

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_def.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_def.cpp
@@ -42,7 +42,14 @@ public:
             .AutoContiguous();
 
         this->Input("g")
-            .ParamType(REQUIRED)
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+
+        this->Input("gk")
+            .ParamType(OPTIONAL)
             .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.cpp
@@ -16,28 +16,16 @@
 #include <register/op_impl_registry.h>
 #include "tiling_base/data_copy_transpose_tiling.h"
 #include "tiling_base/tiling_templates_registry.h"
-#include "chunk_gated_delta_rule_fwd_h_tiling_processor.h"
 
 namespace optiling {
-
-// Maps a ge::DataType to the {fp16:0, bf16:1, fp32:2} convention shared with the kernel.
-static int64_t GdnFwdHDtypeToEnum(ge::DataType dtype)
-{
-    if (dtype == ge::DT_BF16) {
-        return GDN_FWD_H_DTYPE_BF16;
-    }
-    if (dtype == ge::DT_FLOAT16) {
-        return GDN_FWD_H_DTYPE_FP16;
-    }
-    return GDN_FWD_H_DTYPE_FP32;
-}
 static constexpr size_t INPUT_K_IDX = 0;
 static constexpr size_t INPUT_W_IDX = 1;
 static constexpr size_t INPUT_U_IDX = 2;
 static constexpr size_t INPUT_G_IDX = 3;
-static constexpr size_t INPUT_INITIAL_STATE_IDX = 4;
-static constexpr size_t INPUT_SEQLENS_IDX = 5;
-static constexpr size_t INPUT_CHUNK_INDICES_IDX = 6;
+static constexpr size_t INPUT_GK_IDX = 4;
+static constexpr size_t INPUT_INITIAL_STATE_IDX = 5;
+static constexpr size_t INPUT_SEQLENS_IDX = 6;
+static constexpr size_t INPUT_CHUNK_INDICES_IDX = 7;
 
 static constexpr size_t ATTR_STORE_FINAL_STATE_IDX = 0;
 static constexpr size_t ATTR_CHUNK_SIZE_IDX = 1;
@@ -62,6 +50,7 @@ static void ChunkGatedDeltaRuleFwdHTilingDataPrint(gert::TilingContext *context,
     OP_LOGD(nodeName, "=== useInitialState: %ld", tiling.get_useInitialState());
     OP_LOGD(nodeName, "=== storeFinalState: %ld", tiling.get_storeFinalState());
     OP_LOGD(nodeName, "=== dataType: %ld", tiling.get_dataType());
+    OP_LOGD(nodeName, "=== hasGk: %ld", tiling.get_hasGk());
     OP_LOGD(nodeName, "=== isVariedLen: %ld", tiling.get_isVariedLen());
     OP_LOGD(nodeName, "=== shapeBatch: %ld", tiling.get_shapeBatch());
     OP_LOGD(nodeName, "=== tokenBatch: %f", tiling.get_tokenBatch());
@@ -76,66 +65,106 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdH(gert::TilingContext *context)
     gert::Shape kStorageShape = context->GetOptionalInputShape(INPUT_K_IDX)->GetStorageShape();
     gert::Shape uStorageShape = context->GetOptionalInputShape(INPUT_U_IDX)->GetStorageShape();
 
+    int64_t seqlen = kStorageShape.GetDim(DIM_SEQLEN);
+    int64_t kNumHead = kStorageShape.GetDim(DIM_HEAD_NUM);
+    int64_t vNumHead = uStorageShape.GetDim(DIM_HEAD_NUM);
+    int64_t kHeadDim = kStorageShape.GetDim(DIM_HEAD_DIM);
+    int64_t vHeadDim = uStorageShape.GetDim(DIM_HEAD_DIM);
+    int64_t batch, isVariedLen, shapeBatch, tokenBatch;
+
     auto cuSeqlensTensor = context->GetOptionalInputTensor(INPUT_SEQLENS_IDX);
+    if (cuSeqlensTensor == nullptr) {
+        isVariedLen = false;
+        shapeBatch = kStorageShape.GetDim(DIM_BATCH);
+        tokenBatch = 1;
+        batch = shapeBatch;
+    } else {
+        isVariedLen = true;
+        shapeBatch = 1;
+        tokenBatch = cuSeqlensTensor->GetStorageShape().GetDim(DIM_BATCH) - 1;
+        batch = tokenBatch;
+    }
+
     auto initialStateTensor = context->GetOptionalInputTensor(INPUT_INITIAL_STATE_IDX);
     bool useInitialState = initialStateTensor != nullptr;
+    int64_t stateDataType = 2;
+    if (useInitialState) {
+        auto stateDType = initialStateTensor->GetDataType();
+        if (stateDType == ge::DT_BF16) {
+            stateDataType = 1;
+        } else if (stateDType == ge::DT_FLOAT16) {
+            stateDataType = 0;
+        }
+    }
+
+    auto gTensor = context->GetOptionalInputTensor(INPUT_G_IDX);
+    auto gkTensor = context->GetOptionalInputTensor(INPUT_GK_IDX);
+    bool hasGk = gkTensor != nullptr;
+    OP_CHECK_IF(gTensor == nullptr && gkTensor == nullptr,
+                OP_LOGE(context->GetNodeName(), "Either g or gk must be provided."),
+                return ge::GRAPH_FAILED);
+    auto gateTensor = gTensor != nullptr ? gTensor : gkTensor;
+    auto gDType = gateTensor->GetDataType();
+    int64_t gDataType = 2;
+    if (gDType == ge::DT_BF16) {
+        gDataType = 1;
+    } else if (gDType == ge::DT_FLOAT16) {
+        gDataType = 0;
+    }
 
     auto attrPtr = context->GetAttrs();
     bool storeFinalState = *(attrPtr->GetAttrPointer<bool>(ATTR_STORE_FINAL_STATE_IDX));
     int64_t chunkSize = *(attrPtr->GetAttrPointer<int64_t>(ATTR_CHUNK_SIZE_IDX));
 
+    auto dtype = context->GetInputTensor(0)->GetDataType();
+    uint64_t dataType =  dtype == ge::DT_BF16 ? 1 : 0;
+
     const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
+    uint32_t aicCoreNum = ascendcPlatform.GetCoreNumAic();
+    context->SetBlockDim(aicCoreNum);
 
-    ChunkGatedDeltaRuleFwdHTilingContext tilingCtx{};
-    tilingCtx.seqlen = kStorageShape.GetDim(DIM_SEQLEN);
-    tilingCtx.kNumHead = kStorageShape.GetDim(DIM_HEAD_NUM);
-    tilingCtx.kHeadDim = kStorageShape.GetDim(DIM_HEAD_DIM);
-    tilingCtx.vNumHead = uStorageShape.GetDim(DIM_HEAD_NUM);
-    tilingCtx.vHeadDim = uStorageShape.GetDim(DIM_HEAD_DIM);
-    tilingCtx.shapeBatchDim = kStorageShape.GetDim(DIM_BATCH);
-    tilingCtx.hasCuSeqlens = cuSeqlensTensor != nullptr;
-    tilingCtx.cuSeqlensDim0 =
-        cuSeqlensTensor != nullptr ? cuSeqlensTensor->GetStorageShape().GetDim(DIM_BATCH) : 0;
-    tilingCtx.dataType = GdnFwdHDtypeToEnum(context->GetInputTensor(0)->GetDataType());
-    tilingCtx.gDataType = GdnFwdHDtypeToEnum(context->GetOptionalInputTensor(INPUT_G_IDX)->GetDataType());
-    tilingCtx.useInitialState = useInitialState;
-    tilingCtx.stateDataType =
-        useInitialState ? GdnFwdHDtypeToEnum(initialStateTensor->GetDataType()) : GDN_FWD_H_DTYPE_FP32;
-    tilingCtx.storeFinalState = storeFinalState;
-    tilingCtx.chunkSize = chunkSize;
-    tilingCtx.aicCoreNum = ascendcPlatform.GetCoreNumAic();
-    tilingCtx.libApiWorkSpaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
+    constexpr size_t WORKSPACE_RSV_BYTE = 16 * 1024 * 1024;
+    constexpr size_t GM_ALIGN = 512;
+    constexpr int64_t PING_PONG_STAGES = 2;
 
-    ::ChunkGatedDeltaRuleFwdHTilingData plainTiling{};
-    uint32_t blockDim = 0;
-    size_t workspaceSize = 0;
-    ChunkGatedDeltaRuleFwdHTilingProcessor processor(tilingCtx);
-    processor.Process(plainTiling, blockDim, workspaceSize);
+    size_t workspaceOffset = ascendcPlatform.GetLibApiWorkSpaceSize();
+    workspaceOffset += WORKSPACE_RSV_BYTE;
 
-    context->SetBlockDim(blockDim);
+    tiling.set_vWorkspaceOffset(workspaceOffset);
+    workspaceOffset += (aicCoreNum * chunkSize * vHeadDim * sizeof(float) * PING_PONG_STAGES + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
+
+    tiling.set_vUpdateWorkspaceOffset(workspaceOffset);
+    workspaceOffset += (aicCoreNum * chunkSize * vHeadDim * sizeof(float) * PING_PONG_STAGES + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
+
+    tiling.set_hWorkspaceOffset(workspaceOffset);
+    workspaceOffset += (aicCoreNum * kHeadDim * vHeadDim * sizeof(float) * PING_PONG_STAGES + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
+
+    tiling.set_numSeqWorkspaceOffset(workspaceOffset);
+    workspaceOffset += ((tokenBatch + 1) * sizeof(int64_t) + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
+
+    tiling.set_numChunksWorkspaceOffset(workspaceOffset);
+    workspaceOffset += ((tokenBatch + 1) * sizeof(int64_t) + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
+
+    workspaceOffset += WORKSPACE_RSV_BYTE;
     size_t *currentWorkspace = context->GetWorkspaceSizes(1);
-    currentWorkspace[0] = workspaceSize;
+    currentWorkspace[0] = (workspaceOffset - 0);
 
-    tiling.set_batch(plainTiling.batch);
-    tiling.set_seqlen(plainTiling.seqlen);
-    tiling.set_kNumHead(plainTiling.kNumHead);
-    tiling.set_vNumHead(plainTiling.vNumHead);
-    tiling.set_kHeadDim(plainTiling.kHeadDim);
-    tiling.set_vHeadDim(plainTiling.vHeadDim);
-    tiling.set_chunkSize(plainTiling.chunkSize);
-    tiling.set_useInitialState(plainTiling.useInitialState);
-    tiling.set_storeFinalState(plainTiling.storeFinalState);
-    tiling.set_dataType(plainTiling.dataType);
-    tiling.set_stateDataType(plainTiling.stateDataType);
-    tiling.set_gDataType(plainTiling.gDataType);
-    tiling.set_isVariedLen(plainTiling.isVariedLen);
-    tiling.set_shapeBatch(plainTiling.shapeBatch);
-    tiling.set_tokenBatch(plainTiling.tokenBatch);
-    tiling.set_vWorkspaceOffset(plainTiling.vWorkspaceOffset);
-    tiling.set_vUpdateWorkspaceOffset(plainTiling.vUpdateWorkspaceOffset);
-    tiling.set_hWorkspaceOffset(plainTiling.hWorkspaceOffset);
-    tiling.set_numSeqWorkspaceOffset(plainTiling.numSeqWorkspaceOffset);
-    tiling.set_numChunksWorkspaceOffset(plainTiling.numChunksWorkspaceOffset);
+    tiling.set_batch(batch);
+    tiling.set_seqlen(seqlen);
+    tiling.set_kNumHead(kNumHead);
+    tiling.set_vNumHead(vNumHead);
+    tiling.set_kHeadDim(kHeadDim);
+    tiling.set_vHeadDim(vHeadDim);
+    tiling.set_chunkSize(chunkSize);
+    tiling.set_useInitialState(useInitialState);
+    tiling.set_storeFinalState(storeFinalState);
+    tiling.set_dataType(dataType);
+    tiling.set_stateDataType(stateDataType);
+    tiling.set_gDataType(gDataType);
+    tiling.set_hasGk(hasGk);
+    tiling.set_isVariedLen(isVariedLen);
+    tiling.set_shapeBatch(shapeBatch);
+    tiling.set_tokenBatch(tokenBatch);
 
     tiling.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
     context->GetRawTilingData()->SetDataSize(tiling.GetDataSize());

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.h
@@ -33,6 +33,7 @@ TILING_DATA_FIELD_DEF(bool, storeFinalState);
 TILING_DATA_FIELD_DEF(int64_t, dataType);
 TILING_DATA_FIELD_DEF(int64_t, gDataType);
 TILING_DATA_FIELD_DEF(int64_t, stateDataType);
+TILING_DATA_FIELD_DEF(bool, hasGk);
 TILING_DATA_FIELD_DEF(int64_t, isVariedLen);
 TILING_DATA_FIELD_DEF(int64_t, shapeBatch);
 TILING_DATA_FIELD_DEF(int64_t, tokenBatch);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/op_api/aclnn_chunk_gated_delta_rule_fwd_h.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/op_api/aclnn_chunk_gated_delta_rule_fwd_h.cpp
@@ -94,8 +94,14 @@ static aclnnStatus ParamsDataContiguous(ChunkGatedDeltaRuleFwdHParams &params, a
                "Contiguous w failed.");
     CHECK_COND(DataContiguous(params.u, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
                "Contiguous u failed.");
-    CHECK_COND(DataContiguous(params.gOptional, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
-               "Contiguous gOptional failed.");
+    if (params.gOptional != nullptr) {
+        CHECK_COND(DataContiguous(params.gOptional, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+                   "Contiguous gOptional failed.");
+    }
+    if (params.gkOptional != nullptr) {
+        CHECK_COND(DataContiguous(params.gkOptional, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+                   "Contiguous gkOptional failed.");
+    }
     if (params.initalStateOptional != nullptr) {
         CHECK_COND(DataContiguous(params.initalStateOptional, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
                    "Contiguous initalStateOptional failed.");
@@ -104,17 +110,15 @@ static aclnnStatus ParamsDataContiguous(ChunkGatedDeltaRuleFwdHParams &params, a
     return ACLNN_SUCCESS;
 }
 
-static aclnnStatus CheckGOptionalNonNull(const ChunkGatedDeltaRuleFwdHParams &params)
+static aclnnStatus CheckGateOptionalNonNull(const ChunkGatedDeltaRuleFwdHParams &params)
 {
-    CHECK_COND(params.gOptional != nullptr, ACLNN_ERR_PARAM_INVALID,
-               "g is an optional-parameter slot in the API but only a non-null aclTensor is supported; nullptr is not allowed until g=None is implemented.");
+    CHECK_COND(params.gOptional != nullptr || params.gkOptional != nullptr, ACLNN_ERR_PARAM_INVALID,
+               "either gOptional or gkOptional must be non-null.");
     return ACLNN_SUCCESS;
 }
 
 static aclnnStatus CheckReservedOptions(const ChunkGatedDeltaRuleFwdHParams &params)
 {
-    CHECK_COND(params.gkOptional == nullptr, ACLNN_ERR_PARAM_INVALID,
-               "gk is reserved for ChunkGatedDeltaRuleFwdH and must be nullptr.");
     CHECK_COND(params.saveNewValue, ACLNN_ERR_PARAM_INVALID,
                "save_new_value is reserved and only true is supported.");
     CHECK_COND(!params.useExp2, ACLNN_ERR_PARAM_INVALID,
@@ -127,7 +131,7 @@ static aclnnStatus CheckReservedOptions(const ChunkGatedDeltaRuleFwdHParams &par
 static aclnnStatus CheckParams(ChunkGatedDeltaRuleFwdHParams params)
 {
     CHECK_RET(CheckNotNull(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
-    CHECK_RET(CheckGOptionalNonNull(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(CheckGateOptionalNonNull(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
     CHECK_RET(CheckReservedOptions(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
     CHECK_RET(CheckFormat(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
     CHECK_RET(CheckShape(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
@@ -182,18 +186,8 @@ aclnnStatus aclnnChunkGatedDeltaRuleFwdHGetWorkspaceSize(
     CHECK_RET(ret == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
     CHECK_COND(ParamsDataContiguous(params, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
                "ParamsDataContiguous failed.");
-    auto result = l0op::ChunkGatedDeltaRuleFwdH(params.k, params.w, params.u, params.gOptional, params.initalStateOptional, params.cuSeqlensOptional, params.chunkIndicesOptional, params.outputFinalState, params.chunkSize, params.hOut, params.vNewOut, params.finalStateOut, executorPtr);
+    auto result = l0op::ChunkGatedDeltaRuleFwdH(params.k, params.w, params.u, params.gOptional, params.gkOptional, params.initalStateOptional, params.cuSeqlensOptional, params.chunkIndicesOptional, params.outputFinalState, params.chunkSize, params.hOut, params.vNewOut, params.finalStateOut, executorPtr);
     CHECK_RET(result[0] != nullptr, ACLNN_ERR_PARAM_NULLPTR);
-
-    // If the output tensor is non-contiguous, convert the calculated contiguous tensor to non-contiguous.
-    auto viewCopyResult0 = l0op::ViewCopy(result[0], params.hOut, executorPtr);
-    CHECK_RET(viewCopyResult0 != nullptr, ACLNN_ERR_INNER_NULLPTR);
-    auto viewCopyResult1 = l0op::ViewCopy(result[1], params.vNewOut, executorPtr);
-    CHECK_RET(viewCopyResult1 != nullptr, ACLNN_ERR_INNER_NULLPTR);
-    if (outputFinalState && params.finalStateOut != nullptr) {
-        auto viewCopyResult2 = l0op::ViewCopy(result[2], params.finalStateOut, executorPtr);
-        CHECK_RET(viewCopyResult2 != nullptr, ACLNN_ERR_INNER_NULLPTR);
-    }
 
     // Standard syntax, get the size of workspace needed during computation.
     *workspaceSize = uniqueExecutor->GetWorkspaceSize();

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/op_api/aclnn_chunk_gated_delta_rule_fwd_h.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/op_api/aclnn_chunk_gated_delta_rule_fwd_h.h
@@ -19,8 +19,8 @@ extern "C" {
  * k : required
  * w : required
  * u : required
- * gOptional : optional, only non-null aclTensor is supported
- * gkOptional : optional, reserved (must be nullptr)
+ * gOptional : optional, scalar gate tensor; either gOptional or gkOptional must be non-null
+ * gkOptional : optional, K-dim gate tensor; either gOptional or gkOptional must be non-null
  * initalStateOptional : optional
  * outputFinalState : required
  * chunkSize : required

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/op_api/chunk_gated_delta_rule_fwd_h.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/op_api/chunk_gated_delta_rule_fwd_h.cpp
@@ -22,6 +22,7 @@ const std::array<const aclTensor *, 3> ChunkGatedDeltaRuleFwdH(
     const aclTensor *w,
     const aclTensor *u,
     const aclTensor *g,
+    const aclTensor *gkOptional,
     const aclTensor *initalStateOptional,
     const aclIntArray *cuSeqlensOptional,
     const aclIntArray *chunkIndicesOptional,
@@ -32,7 +33,7 @@ const std::array<const aclTensor *, 3> ChunkGatedDeltaRuleFwdH(
     const aclTensor *finalStateOut,
     aclOpExecutor *executor)
 {
-    L0_DFX(ChunkGatedDeltaRuleFwdH, k, w, u, g, initalStateOptional, cuSeqlensOptional, chunkIndicesOptional, outputFinalState, chunkSize, hOut, vNewOut, finalStateOut);
+    L0_DFX(ChunkGatedDeltaRuleFwdH, k, w, u, g, gkOptional, initalStateOptional, cuSeqlensOptional, chunkIndicesOptional, outputFinalState, chunkSize, hOut, vNewOut, finalStateOut);
 
     const aclTensor *actualCuSeqlens = nullptr;
     if (cuSeqlensOptional) {
@@ -55,7 +56,7 @@ const std::array<const aclTensor *, 3> ChunkGatedDeltaRuleFwdH(
     }
 
     auto ret = ADD_TO_LAUNCHER_LIST_AICORE(ChunkGatedDeltaRuleFwdH,
-        OP_INPUT(k, w, u, g, initalStateOptional, actualCuSeqlens, actualChunkIndices),
+        OP_INPUT(k, w, u, g, gkOptional, initalStateOptional, actualCuSeqlens, actualChunkIndices),
         OP_OUTPUT(hOut, vNewOut, finalStateOut),
         OP_ATTR(outputFinalState, chunkSize));
     if (ret != ACLNN_SUCCESS) {

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
@@ -71,10 +71,12 @@ public:
         hUpdateUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_BUF_0_OFFSET);
         hUbTensor_ping = resource.ubBuf.template GetBufferByByte<HElementOutput>(PING_BUF_3_OFFSET);
         glastUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_G_INPUT_BUF_OFFSET);
+        gkInputUbTensor_ping = resource.ubBuf.template GetBufferByByte<GElementInput>(PING_G_SUB_BUF_OFFSET);
 
         hUpdateUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_BUF_0_OFFSET);
         hUbTensor_pong = resource.ubBuf.template GetBufferByByte<HElementOutput>(PONG_BUF_3_OFFSET);
         glastUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_G_INPUT_BUF_OFFSET);
+        gkInputUbTensor_pong = resource.ubBuf.template GetBufferByByte<GElementInput>(PONG_G_SUB_BUF_OFFSET);
 
     }
 
@@ -86,6 +88,7 @@ public:
         AscendC::GlobalTensor<HElementOutput> hOutput,
         AscendC::GlobalTensor<FinalStateElement> finalState,
         AscendC::GlobalTensor<GElementInput> gInput,
+        AscendC::GlobalTensor<GElementInput> gkInput,
         AscendC::GlobalTensor<HElementInput> hInput,
         AscendC::GlobalTensor<float> hUpdateInput,
         uint32_t chunkSize,
@@ -95,6 +98,7 @@ public:
         bool isInitialState,
         bool isFinalState,
         bool storeFinalState,
+        bool hasGk,
         bool isPing
     )
     {
@@ -115,11 +119,13 @@ public:
         AscendC::GlobalTensor<HElementInput> hInputThisSubBlock = hInput[offsetH];
         AscendC::GlobalTensor<float> hUpdateInputThisSubBlock = hUpdateInput[offsetH];
         AscendC::GlobalTensor<FinalStateElement> finalStateThisSubBlock = finalState[offsetH];
+        AscendC::GlobalTensor<GElementInput> gkInputThisSubBlock = gkInput[(chunkSize - 1) * kHeadDim + mOffset];
 
         uint32_t pingpongFlag = isPing ? 0 : pongBaseEvent;
         AscendC::LocalTensor<float> hUpdateUbTensor = isPing ? hUpdateUbTensor_ping : hUpdateUbTensor_pong;
         AscendC::LocalTensor<HElementOutput> hUbTensor = isPing ? hUbTensor_ping : hUbTensor_pong;
         AscendC::LocalTensor<float> glastUbTensor = isPing ? glastUbTensor_ping : glastUbTensor_pong;
+        AscendC::LocalTensor<GElementInput> gkInputUbTensor = isPing ? gkInputUbTensor_ping : gkInputUbTensor_pong;
 
         if (storeFinalState && isInitialState && std::is_same<FinalStateElement, float>::value) {
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
@@ -136,27 +142,61 @@ public:
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
         }
 
-        GElementInput gLastVal = gInputThisSubBlock.GetValue(chunkSize-1);
-        float gLastFloat = 0.0f;
-        if constexpr(std::is_same<GElementInput, float>::value) {
-            gLastFloat = gLastVal;
-        } else if constexpr(std::is_same<GElementInput, half>::value) {
-            gLastFloat = (float)gLastVal;
-        } else if constexpr(std::is_same<GElementInput, bfloat16_t>::value) {
-            gLastFloat = AscendC::ToFloat(gLastVal);
-        }
-        glastUbTensor.SetValue(0, gLastFloat);
+        if (hasGk) {
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
+            if constexpr(std::is_same<GElementInput, float>::value) {
+                AscendC::DataCopyParams gkParams{1, (uint16_t)(mActualThisSubBlock * sizeof(float)), 0, 0};
+                AscendC::DataCopyPadParams gkPadParams{false, 0, 0, 0};
+                AscendC::DataCopyPad(glastUbTensor, gkInputThisSubBlock, gkParams, gkPadParams);
+            } else {
+                AscendC::DataCopyParams gkParams{1, (uint16_t)(mActualThisSubBlock * sizeof(GElementInput)), 0, 0};
+                AscendC::DataCopyPadParams gkPadParams{false, 0, 0, 0};
+                AscendC::DataCopyPad(gkInputUbTensor, gkInputThisSubBlock, gkParams, gkPadParams);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3 + pingpongFlag);
+            if constexpr(!std::is_same<GElementInput, float>::value) {
+                AscendC::Cast(glastUbTensor, gkInputUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock);
+            }
+            AscendC::Muls(glastUbTensor, glastUbTensor, 0.6931471805599453f, mActualThisSubBlock);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Exp(glastUbTensor, glastUbTensor, mActualThisSubBlock);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+            for (uint32_t row = 0; row < mActualThisSubBlock; ++row) {
+                float muls = glastUbTensor.GetValue(row);
+                AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+                AscendC::Muls(calcUbTensor[row * nActual], calcUbTensor[row * nActual], muls, nActual);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
+        } else {
+            GElementInput gLastVal = gInputThisSubBlock.GetValue(chunkSize-1);
+            float gLastFloat = 0.0f;
+            if constexpr(std::is_same<GElementInput, float>::value) {
+                gLastFloat = gLastVal;
+            } else if constexpr(std::is_same<GElementInput, half>::value) {
+                gLastFloat = (float)gLastVal;
+            } else if constexpr(std::is_same<GElementInput, bfloat16_t>::value) {
+                gLastFloat = AscendC::ToFloat(gLastVal);
+            }
+            glastUbTensor.SetValue(0, gLastFloat);
 
-        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
-        AscendC::Exp(glastUbTensor, glastUbTensor, 1);
-        AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
-        float muls = glastUbTensor.GetValue(0);
-        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
-        AscendC::Muls(calcUbTensor, calcUbTensor, muls, mActualThisSubBlock * nActual);
-        AscendC::PipeBarrier<PIPE_V>();
+            AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::Exp(glastUbTensor, glastUbTensor, 1);
+            AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+            float muls = glastUbTensor.GetValue(0);
+            AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::Muls(calcUbTensor, calcUbTensor, muls, mActualThisSubBlock * nActual);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
 
         Arch::CrossCoreWaitFlag(cube2Done);
 
@@ -200,10 +240,12 @@ private:
     AscendC::LocalTensor<float> hUpdateUbTensor_ping;
     AscendC::LocalTensor<HElementOutput> hUbTensor_ping;
     AscendC::LocalTensor<float> glastUbTensor_ping;
+    AscendC::LocalTensor<GElementInput> gkInputUbTensor_ping;
 
     AscendC::LocalTensor<float> hUpdateUbTensor_pong;
     AscendC::LocalTensor<HElementOutput> hUbTensor_pong;
     AscendC::LocalTensor<float> glastUbTensor_pong;
+    AscendC::LocalTensor<GElementInput> gkInputUbTensor_pong;
 
 };
 }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
@@ -112,6 +112,7 @@ public:
         bool isInitialState,
         bool isFinalState,
         bool storeFinalState,
+        bool hasGk,
         bool isPing
     )
     {
@@ -176,37 +177,42 @@ public:
         AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag); // wait u
         AscendC::Cast(calcUbTensor, uUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nvActual); // cast u
 
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag); // wait last g
-        if constexpr(std::is_same<GElementInput, float>::value) {
-            AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(float)), 0, 0};
-            AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
-            AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams); // copy g
+        if (!hasGk) {
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag); // wait last g
+            if constexpr(std::is_same<GElementInput, float>::value) {
+                AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(float)), 0, 0};
+                AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
+                AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams); // copy g
+            } else {
+                AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(half)), 0, 0};
+                AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
+                AscendC::DataCopyPad(gInputUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3 + pingpongFlag);
+            if constexpr(!std::is_same<GElementInput, float>::value) {
+                AscendC::Cast(gUbTensor, gInputUbTensor, AscendC::RoundMode::CAST_NONE, mActual);
+            }
+
+            AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+            float inputVal = gUbTensor.GetValue(mActual-1);
+            AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Duplicate<float>(gLastUbTensor, inputVal, mActual);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            AscendC::Sub<float>(gUbTensor, gLastUbTensor, gUbTensor, mActual);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            AscendC::Exp(gUbTensor, gUbTensor, mActual);
+            AscendC::PipeBarrier<PIPE_V>();
         } else {
-            AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(half)), 0, 0};
-            AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
-            AscendC::DataCopyPad(gInputUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
         }
-        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3 + pingpongFlag);
-        if constexpr(!std::is_same<GElementInput, float>::value) {
-            AscendC::Cast(gUbTensor, gInputUbTensor, AscendC::RoundMode::CAST_NONE, mActual);
-        }
-
-        AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
-        float inputVal = gUbTensor.GetValue(mActual-1);
-        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
-
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Duplicate<float>(gLastUbTensor, inputVal, mActual);
-        AscendC::PipeBarrier<PIPE_V>();
-
-        AscendC::Sub<float>(gUbTensor, gLastUbTensor, gUbTensor, mActual);
-        AscendC::PipeBarrier<PIPE_V>();
-
-        AscendC::Exp(gUbTensor, gUbTensor, mActual);
-        AscendC::PipeBarrier<PIPE_V>();
 
         Arch::CrossCoreWaitFlag(cube1Done);
 
@@ -216,18 +222,26 @@ public:
         AscendC::Sub<float>(wsUbTensor, calcUbTensor, wsUbTensor, mActualThisSubBlock * nvActual);
         AscendC::PipeBarrier<PIPE_V>();
 
-        AscendC::Broadcast<float, 2, 1>(calcUbTensor, gUbTensor[gbrcRealStart], dstShape_, srcShape_, shareBuffer_);
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
-
-        AscendC::Mul(calcUbTensor[gbrcEffStart*nvActual], wsUbTensor, calcUbTensor[gbrcEffStart*nvActual], mActualThisSubBlock * nvActual);
-        AscendC::PipeBarrier<PIPE_V>();
-
         uint32_t nvLoops = vHeadDim / FLOAT_NUM_PER_REPEAT;
-        for (uint32_t nLoop = 0; nLoop < nvLoops; nLoop++) {
-            uint32_t castSrcOffset = gbrcEffStart * nvActual + nLoop * FLOAT_NUM_PER_REPEAT;
-            uint32_t castDstOffset = nLoop * mActualThisSubBlock * FLOAT_NUM_PER_REPEAT;
-            AscendC::Cast(vNewDecayUbTensor[castDstOffset], calcUbTensor[castSrcOffset], AscendC::RoundMode::CAST_RINT, FLOAT_NUM_PER_REPEAT, mActualThisSubBlock, {(uint16_t)mActualThisSubBlock, 1, 1, (uint8_t)(nvLoops * 8)});
+        if (hasGk) {
+            for (uint32_t nLoop = 0; nLoop < nvLoops; nLoop++) {
+                uint32_t castSrcOffset = nLoop * FLOAT_NUM_PER_REPEAT;
+                uint32_t castDstOffset = nLoop * mActualThisSubBlock * FLOAT_NUM_PER_REPEAT;
+                AscendC::Cast(vNewDecayUbTensor[castDstOffset], wsUbTensor[castSrcOffset], AscendC::RoundMode::CAST_RINT, FLOAT_NUM_PER_REPEAT, mActualThisSubBlock, {(uint16_t)mActualThisSubBlock, 1, 1, (uint8_t)(nvLoops * 8)});
+            }
+        } else {
+            AscendC::Broadcast<float, 2, 1>(calcUbTensor, gUbTensor[gbrcRealStart], dstShape_, srcShape_, shareBuffer_);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
+
+            AscendC::Mul(calcUbTensor[gbrcEffStart*nvActual], wsUbTensor, calcUbTensor[gbrcEffStart*nvActual], mActualThisSubBlock * nvActual);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            for (uint32_t nLoop = 0; nLoop < nvLoops; nLoop++) {
+                uint32_t castSrcOffset = gbrcEffStart * nvActual + nLoop * FLOAT_NUM_PER_REPEAT;
+                uint32_t castDstOffset = nLoop * mActualThisSubBlock * FLOAT_NUM_PER_REPEAT;
+                AscendC::Cast(vNewDecayUbTensor[castDstOffset], calcUbTensor[castSrcOffset], AscendC::RoundMode::CAST_RINT, FLOAT_NUM_PER_REPEAT, mActualThisSubBlock, {(uint16_t)mActualThisSubBlock, 1, 1, (uint8_t)(nvLoops * 8)});
+            }
         }
 
         AscendC::PipeBarrier<PIPE_V>();
@@ -244,6 +258,7 @@ public:
         uint32_t l1Addr = mOffset * SIZE_16_NUM_PER_C0;
         AscendC::DataCopy(l1VUpdate[l1Addr], vNewDecayUbTensor, intriParams);
 
+        Arch::CrossCoreBarrier<0x1, PIPE_MTE3>();
         Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vec1Done);
 
         AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1 + pingpongFlag);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/block/block_scheduler_gdn_fwd_h.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/block/block_scheduler_gdn_fwd_h.hpp
@@ -53,6 +53,7 @@ struct GDNFwdHOffsets {
     bool isInitialState;
     bool isFinalState;
     uint32_t blockTokens;
+    uint32_t streamId;
     // for debug
     uint32_t batchIdx;
     uint32_t headIdx;
@@ -122,10 +123,10 @@ struct BlockSchedulerGdnFwdH {
     AscendC::GlobalTensor<int64_t> gmNumSeq;
     AscendC::GlobalTensor<int64_t> gmNumChunks;
 
-    Arch::CrossCoreFlag cube1Done{0};
-    Arch::CrossCoreFlag vec1Done{1};
-    Arch::CrossCoreFlag cube2Done{2};
-    Arch::CrossCoreFlag vec2Done[PING_PONG_STAGES] = {3, 4};
+    Arch::CrossCoreFlag cube1Done[PING_PONG_STAGES] = {0, 1};
+    Arch::CrossCoreFlag vec1Done[PING_PONG_STAGES] = {2, 3};
+    Arch::CrossCoreFlag cube2Done[PING_PONG_STAGES] = {4, 5};
+    Arch::CrossCoreFlag vec2Done[PING_PONG_STAGES] = {6, 7};
 
     CATLASS_DEVICE
     BlockSchedulerGdnFwdH() {}
@@ -238,6 +239,7 @@ struct BlockSchedulerGdnFwdH {
         offset.hWorkOffset = (cubeCoreIdx * PING_PONG_STAGES + streamId) * kHeadDim * vHeadDim;
         offset.vWorkOffset = (cubeCoreIdx * PING_PONG_STAGES + streamId) * chunkSize * vHeadDim;
         offset.blockTokens = offset.isFinalState ? (stream.batchTokens - stream.chunkIdx * chunkSize) : chunkSize;
+        offset.streamId = streamId;
         offset.batchIdx = stream.batchIdx;
         offset.headIdx = stream.vHeadIdx;
         offset.chunkIdx = stream.chunkIdx;
@@ -336,7 +338,10 @@ struct BlockSchedulerGdnFwdHVec : public BlockSchedulerGdnFwdH {
 
     CATLASS_DEVICE
     void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR tiling, GM_ADDR user) {
-        BlockSchedulerGdnFwdH::Init(cu_seqlens, chunk_indices, tiling, user, AscendC::GetBlockIdx() / AscendC::GetSubBlockNum(), AscendC::GetBlockNum());
+        BlockSchedulerGdnFwdH::Init(
+            cu_seqlens, chunk_indices, tiling, user,
+            AscendC::GetBlockIdx() / AscendC::GetSubBlockNum(),
+            AscendC::GetBlockNum());
     }
 
 };

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -132,6 +132,7 @@ public:
     uint32_t chunkSize;
     bool useInitialState;
     bool storeFinalState;
+    bool hasGk;
     uint32_t isVariedLen;
     uint32_t shapeBatch;
     uint32_t tokenBatch;
@@ -145,6 +146,7 @@ public:
     AscendC::GlobalTensor<ElementW> gmW;
     AscendC::GlobalTensor<ElementU> gmU;
     AscendC::GlobalTensor<ElementG> gmG;
+    AscendC::GlobalTensor<ElementG> gmGk;
     AscendC::GlobalTensor<ElementInitialState> gmInitialState;
     AscendC::GlobalTensor<ElementH> gmH;
     AscendC::GlobalTensor<ElementV> gmV;
@@ -173,7 +175,7 @@ public:
 
     __aicore__ inline GDNFwdHKernel() {}
 
-    __aicore__ inline void Init(GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g, GM_ADDR inital_state, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
+    __aicore__ inline void Init(GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g, GM_ADDR gk, GM_ADDR inital_state, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
         GM_ADDR h, GM_ADDR v_new, GM_ADDR final_state, GM_ADDR tiling, GM_ADDR user) {
 
         __gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict>(tiling);
@@ -187,6 +189,7 @@ public:
         chunkSize = gdnFwdHTilingData->chunkSize;
         useInitialState = gdnFwdHTilingData->useInitialState;
         storeFinalState = gdnFwdHTilingData->storeFinalState;
+        hasGk = gdnFwdHTilingData->hasGk;
         isVariedLen = gdnFwdHTilingData->isVariedLen;
         shapeBatch = gdnFwdHTilingData->shapeBatch;
         tokenBatch = gdnFwdHTilingData->tokenBatch;
@@ -200,6 +203,7 @@ public:
         gmW.SetGlobalBuffer((__gm__ ElementW *)w);
         gmU.SetGlobalBuffer((__gm__ ElementU *)u);
         gmG.SetGlobalBuffer((__gm__ ElementG *)g);
+        gmGk.SetGlobalBuffer((__gm__ ElementG *)gk);
         gmInitialState.SetGlobalBuffer((__gm__ ElementInitialState *)inital_state);
         gmH.SetGlobalBuffer((__gm__ ElementH *)h);
         gmV.SetGlobalBuffer((__gm__ ElementV *)v_new);
@@ -257,7 +261,8 @@ public:
                         }
 
                         const GDNFwdHOffsets& cube1Offsets = cubeBlockScheduler.GetCurTaskOffsets(stream);
-                        Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[i]);
+                        uint32_t streamId = cube1Offsets.streamId;
+                        Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[streamId]);
                         auto vLayout = tla::MakeLayout<ElementVWork, LayoutV>(cube1Offsets.blockTokens, vHeadDim);
                         int64_t cube1OffsetW = cube1Offsets.wOffset;
                         int64_t cube1OffsetH = cube1Offsets.hSrcOffset;
@@ -273,7 +278,7 @@ public:
                         blockMmadWH.preSetFlags();
                         blockMmadWH(tensorBlockW, tensorBlockH, tensorV, cube1Shape);
                         blockMmadWH.finalWaitFlags();
-                        Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done);
+                        Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done[streamId]);
                     }
                 } else {
                     /* C2: h[i+1] = k.T @ v_work */
@@ -283,7 +288,8 @@ public:
                             continue;
                         }
                         const GDNFwdHOffsets& cube2Offsets = cubeBlockScheduler.GetCurTaskOffsets(stream);
-                        Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done);
+                        uint32_t streamId = cube2Offsets.streamId;
+                        Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done[streamId]);
 
                         if (cubeBlockScheduler.NeedProcessStage2(stream)) {
                             // step 3: h[i+1] = k.T @ v_work
@@ -303,7 +309,7 @@ public:
                             blockMmadKV(tensorBlockK, tensorVwork, tensorHwork, cube2Shape);
                             blockMmadKV.finalWaitFlags();
                         }
-                        Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube2Done);
+                        Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube2Done[streamId]);
                     }
                 }
                 currStage ^= 0x01;
@@ -418,8 +424,9 @@ public:
                             gmV[vec1Offsets.uvOffset], gmVUpdateWorkspace[vec1Offsets.vWorkOffset], l1VUpdate,
                             gmG[vec1Offsets.gOffset], gmU[vec1Offsets.uvOffset], gmVWorkspace[vec1Offsets.vWorkOffset],
                             vec1Offsets.blockTokens, kHeadDim, vHeadDim,
-                            vecBlockScheduler.cube1Done, vecBlockScheduler.vec1Done,
-                            vec1Offsets.isInitialState, vec1Offsets.isFinalState, storeFinalState, (i == 0)
+                            vecBlockScheduler.cube1Done[vec1Offsets.streamId],
+                            vecBlockScheduler.vec1Done[vec1Offsets.streamId],
+                            vec1Offsets.isInitialState, vec1Offsets.isFinalState, storeFinalState, hasGk, (i == 0)
                         );
                     }
                 } else {
@@ -435,16 +442,18 @@ public:
                             // step 4:  h[i+1] += h_work if i < num_chunks - 1 else None
                             epilogueGDNFwdHUpdate(
                                 gmH[vec2Offsets.hDstOffset], gmFinalState[vec2Offsets.finalStateOffset],
-                                gmG[vec2Offsets.gOffset],
+                                gmG[vec2Offsets.gOffset], gmGk[vec2Offsets.gOffset * kHeadDim],
                                 gmH[vec2Offsets.hSrcOffset],
                                 gmHWorkspace[vec2Offsets.hWorkOffset],
-                                vec2Offsets.blockTokens, kHeadDim, vHeadDim, vecBlockScheduler.cube2Done,
-                                vec2Offsets.isInitialState, vec2Offsets.isFinalState, storeFinalState, (i == 0)
+                                vec2Offsets.blockTokens, kHeadDim, vHeadDim,
+                                vecBlockScheduler.cube2Done[vec2Offsets.streamId],
+                                vec2Offsets.isInitialState, vec2Offsets.isFinalState, storeFinalState, hasGk, (i == 0)
                             );
                         } else {
-                            Arch::CrossCoreWaitFlag(vecBlockScheduler.cube2Done);
+                            Arch::CrossCoreWaitFlag(vecBlockScheduler.cube2Done[vec2Offsets.streamId]);
                         }
-                        Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done[i]);
+                        Arch::CrossCoreBarrier<0x1, PIPE_MTE3>();
+                        Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done[vec2Offsets.streamId]);
                     }
                 }
                 currStage ^= 0x01;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h.cpp
@@ -23,7 +23,7 @@
 using namespace Catlass;
 
 extern "C" __global__ __aicore__ void chunk_gated_delta_rule_fwd_h(GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g,
-                                                         GM_ADDR inital_state, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
+                                                         GM_ADDR gk, GM_ADDR inital_state, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
                                                          GM_ADDR h, GM_ADDR v_new, GM_ADDR final_state,
                                                          GM_ADDR workspace, GM_ADDR tiling)
 {
@@ -39,24 +39,24 @@ extern "C" __global__ __aicore__ void chunk_gated_delta_rule_fwd_h(GM_ADDR k, GM
             if (gdnFwdHTilingData->gDataType == 2) {
                 using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<bfloat16_t, float, float, workspaceType>;
                 GDNFwdHKernel gdnFwdH;
-                gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+                gdnFwdH.Init(k, w, u, g, gk, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
                 gdnFwdH.Process();
             } else {
                 using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<bfloat16_t, bfloat16_t, float, workspaceType>;
                 GDNFwdHKernel gdnFwdH;
-                gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+                gdnFwdH.Init(k, w, u, g, gk, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
                 gdnFwdH.Process();
             }
         } else {
             if (gdnFwdHTilingData->gDataType == 2) {
                 using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<bfloat16_t, float, bfloat16_t, workspaceType>;
                 GDNFwdHKernel gdnFwdH;
-                gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+                gdnFwdH.Init(k, w, u, g, gk, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
                 gdnFwdH.Process();
             } else {
                 using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<bfloat16_t, bfloat16_t, bfloat16_t, workspaceType>;
                 GDNFwdHKernel gdnFwdH;
-                gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+                gdnFwdH.Init(k, w, u, g, gk, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
                 gdnFwdH.Process();
             }
         }
@@ -65,24 +65,24 @@ extern "C" __global__ __aicore__ void chunk_gated_delta_rule_fwd_h(GM_ADDR k, GM
             if (gdnFwdHTilingData->gDataType == 2) {
                 using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<half, float, float, workspaceType>;
                 GDNFwdHKernel gdnFwdH;
-                gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+                gdnFwdH.Init(k, w, u, g, gk, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
                 gdnFwdH.Process();
             } else {
                 using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<half, half, float, workspaceType>;
                 GDNFwdHKernel gdnFwdH;
-                gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+                gdnFwdH.Init(k, w, u, g, gk, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
                 gdnFwdH.Process();
             }
         } else {
             if (gdnFwdHTilingData->gDataType == 2) {
                 using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<half, float, half, workspaceType>;
                 GDNFwdHKernel gdnFwdH;
-                gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+                gdnFwdH.Init(k, w, u, g, gk, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
                 gdnFwdH.Process();
             } else {
                 using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<half, half, half, workspaceType>;
                 GDNFwdHKernel gdnFwdH;
-                gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+                gdnFwdH.Init(k, w, u, g, gk, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
                 gdnFwdH.Process();
             }
         }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
@@ -71,10 +71,13 @@ public:
         hUpdateUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_BUF_0_OFFSET);
         hUbTensor_ping = resource.ubBuf.template GetBufferByByte<HElementOutput>(PING_BUF_3_OFFSET);
         glastUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_G_INPUT_BUF_OFFSET);
+        gkInputUbTensor_ping = resource.ubBuf.template GetBufferByByte<GElementInput>(PING_G_SUB_BUF_OFFSET);
 
         hUpdateUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_BUF_0_OFFSET);
         hUbTensor_pong = resource.ubBuf.template GetBufferByByte<HElementOutput>(PONG_BUF_3_OFFSET);
         glastUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_G_INPUT_BUF_OFFSET);
+        gkInputUbTensor_pong = resource.ubBuf.template GetBufferByByte<GElementInput>(PONG_G_SUB_BUF_OFFSET);
+        shareBuffer_ = resource.ubBuf.template GetBufferByByte<uint8_t>(SHARE_BUF_OFFSET);
 
     }
 
@@ -86,6 +89,7 @@ public:
         AscendC::GlobalTensor<HElementOutput> hOutput,
         AscendC::GlobalTensor<FinalStateElement> finalState,
         AscendC::GlobalTensor<GElementInput> gInput,
+        AscendC::GlobalTensor<GElementInput> gkInput,
         AscendC::GlobalTensor<HElementInput> hInput,
         AscendC::GlobalTensor<float> hUpdateInput,
         uint32_t chunkSize,
@@ -95,6 +99,7 @@ public:
         bool isInitialState,
         bool isFinalState,
         bool storeFinalState,
+        bool hasGk,
         bool isPing
     )
     {
@@ -115,11 +120,13 @@ public:
         AscendC::GlobalTensor<HElementInput> hInputThisSubBlock = hInput[offsetH];
         AscendC::GlobalTensor<float> hUpdateInputThisSubBlock = hUpdateInput[offsetH];
         AscendC::GlobalTensor<FinalStateElement> finalStateThisSubBlock = finalState[offsetH];
+        AscendC::GlobalTensor<GElementInput> gkInputThisSubBlock = gkInput[(chunkSize - 1) * kHeadDim + mOffset];
 
         uint32_t pingpongFlag = isPing ? 0 : pongBaseEvent;
         AscendC::LocalTensor<float> hUpdateUbTensor = isPing ? hUpdateUbTensor_ping : hUpdateUbTensor_pong;
         AscendC::LocalTensor<HElementOutput> hUbTensor = isPing ? hUbTensor_ping : hUbTensor_pong;
         AscendC::LocalTensor<float> glastUbTensor = isPing ? glastUbTensor_ping : glastUbTensor_pong;
+        AscendC::LocalTensor<GElementInput> gkInputUbTensor = isPing ? gkInputUbTensor_ping : gkInputUbTensor_pong;
 
         if (storeFinalState && isInitialState && std::is_same<FinalStateElement, float>::value) {
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
@@ -136,27 +143,58 @@ public:
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
         }
 
-        GElementInput gLastVal = gInputThisSubBlock.GetValue(chunkSize-1);
-        float gLastFloat = 0.0f;
-        if constexpr(std::is_same<GElementInput, float>::value) {
-            gLastFloat = gLastVal;
-        } else if constexpr(std::is_same<GElementInput, half>::value) {
-            gLastFloat = (float)gLastVal;
-        } else if constexpr(std::is_same<GElementInput, bfloat16_t>::value) {
-            gLastFloat = AscendC::ToFloat(gLastVal);
-        }
-        glastUbTensor.SetValue(0, gLastFloat);
+        if (hasGk) {
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
+            if constexpr(std::is_same<GElementInput, float>::value) {
+                AscendC::DataCopyParams gkParams{1, (uint16_t)(mActualThisSubBlock * sizeof(float)), 0, 0};
+                AscendC::DataCopyPadParams gkPadParams{false, 0, 0, 0};
+                AscendC::DataCopyPad(glastUbTensor, gkInputThisSubBlock, gkParams, gkPadParams);
+            } else {
+                AscendC::DataCopyParams gkParams{1, (uint16_t)(mActualThisSubBlock * sizeof(GElementInput)), 0, 0};
+                AscendC::DataCopyPadParams gkPadParams{false, 0, 0, 0};
+                AscendC::DataCopyPad(gkInputUbTensor, gkInputThisSubBlock, gkParams, gkPadParams);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3 + pingpongFlag);
+            if constexpr(!std::is_same<GElementInput, float>::value) {
+                AscendC::Cast(glastUbTensor, gkInputUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock);
+            }
+            AscendC::Muls(glastUbTensor, glastUbTensor, 0.6931471805599453f, mActualThisSubBlock);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Exp(glastUbTensor, glastUbTensor, mActualThisSubBlock);
+            AscendC::PipeBarrier<PIPE_V>();
+            uint32_t dstShape[2] = {mActualThisSubBlock, nActual};
+            uint32_t srcShape[2] = {mActualThisSubBlock, 1};
+            AscendC::Broadcast<float, 2, 1>(hUpdateUbTensor, glastUbTensor, dstShape, srcShape, shareBuffer_);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Mul(calcUbTensor, calcUbTensor, hUpdateUbTensor, mActualThisSubBlock * nActual);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
+        } else {
+            GElementInput gLastVal = gInputThisSubBlock.GetValue(chunkSize-1);
+            float gLastFloat = 0.0f;
+            if constexpr(std::is_same<GElementInput, float>::value) {
+                gLastFloat = gLastVal;
+            } else if constexpr(std::is_same<GElementInput, half>::value) {
+                gLastFloat = (float)gLastVal;
+            } else if constexpr(std::is_same<GElementInput, bfloat16_t>::value) {
+                gLastFloat = AscendC::ToFloat(gLastVal);
+            }
+            glastUbTensor.SetValue(0, gLastFloat);
 
-        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
-        AscendC::Exp(glastUbTensor, glastUbTensor, 1);
-        AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
-        float muls = glastUbTensor.GetValue(0);
-        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
-        AscendC::Muls(calcUbTensor, calcUbTensor, muls, mActualThisSubBlock * nActual);
-        AscendC::PipeBarrier<PIPE_V>();
+            AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::Exp(glastUbTensor, glastUbTensor, 1);
+            AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+            float muls = glastUbTensor.GetValue(0);
+            AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::Muls(calcUbTensor, calcUbTensor, muls, mActualThisSubBlock * nActual);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
 
         Arch::CrossCoreWaitFlag(cube2Done);
 
@@ -206,10 +244,13 @@ private:
     AscendC::LocalTensor<float> hUpdateUbTensor_ping;
     AscendC::LocalTensor<HElementOutput> hUbTensor_ping;
     AscendC::LocalTensor<float> glastUbTensor_ping;
+    AscendC::LocalTensor<GElementInput> gkInputUbTensor_ping;
 
     AscendC::LocalTensor<float> hUpdateUbTensor_pong;
     AscendC::LocalTensor<HElementOutput> hUbTensor_pong;
     AscendC::LocalTensor<float> glastUbTensor_pong;
+    AscendC::LocalTensor<GElementInput> gkInputUbTensor_pong;
+    AscendC::LocalTensor<uint8_t> shareBuffer_;
 
 };
 }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
@@ -107,6 +107,7 @@ public:
         bool isInitialState,
         bool isFinalState,
         bool storeFinalState,
+        bool hasGk,
         bool isPing
     )
     {
@@ -171,37 +172,39 @@ public:
         AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag); // wait u
         AscendC::Cast(calcUbTensor, uUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nvActual); // cast u
 
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag); // wait last g
-        if constexpr(std::is_same<GElementInput, float>::value) {
-            AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(float)), 0, 0};
-            AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
-            AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams); // copy g
-        } else {
-            AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(half)), 0, 0};
-            AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
-            AscendC::DataCopyPad(gInputUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams);
+        if (!hasGk) {
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag); // wait last g
+            if constexpr(std::is_same<GElementInput, float>::value) {
+                AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(float)), 0, 0};
+                AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
+                AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams); // copy g
+            } else {
+                AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(half)), 0, 0};
+                AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
+                AscendC::DataCopyPad(gInputUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3 + pingpongFlag);
+            if constexpr(!std::is_same<GElementInput, float>::value) {
+                AscendC::Cast(gUbTensor, gInputUbTensor, AscendC::RoundMode::CAST_NONE, mActual);
+            }
+
+            AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+            float inputVal = gUbTensor.GetValue(mActual-1);
+            AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Duplicate<float>(gLastUbTensor, inputVal, mActual);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            AscendC::Sub<float>(gUbTensor, gLastUbTensor, gUbTensor, mActual);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            AscendC::Exp(gUbTensor, gUbTensor, mActual);
+            AscendC::PipeBarrier<PIPE_V>();
         }
-        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3 + pingpongFlag);
-        if constexpr(!std::is_same<GElementInput, float>::value) {
-            AscendC::Cast(gUbTensor, gInputUbTensor, AscendC::RoundMode::CAST_NONE, mActual);
-        }
-
-        AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
-        float inputVal = gUbTensor.GetValue(mActual-1);
-        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
-
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Duplicate<float>(gLastUbTensor, inputVal, mActual);
-        AscendC::PipeBarrier<PIPE_V>();
-
-        AscendC::Sub<float>(gUbTensor, gLastUbTensor, gUbTensor, mActual);
-        AscendC::PipeBarrier<PIPE_V>();
-
-        AscendC::Exp(gUbTensor, gUbTensor, mActual);
-        AscendC::PipeBarrier<PIPE_V>();
 
         Arch::CrossCoreWaitFlag(cube1Done);
 
@@ -217,19 +220,26 @@ public:
         AscendC::Sub<float>(wsUbTensor, calcUbTensor, wsUbTensor, mActualThisSubBlock * nvActual);
         AscendC::PipeBarrier<PIPE_V>();
 
-        AscendC::Broadcast<float, 2, 1>(calcUbTensor, gUbTensor[gbrcRealStart], dstShape_, srcShape_, shareBuffer_);
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
+        if (hasGk) {
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
+            AscendC::Cast(vNewDecayUbTensor, wsUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nvActual);
+        } else {
+            AscendC::Broadcast<float, 2, 1>(calcUbTensor, gUbTensor[gbrcRealStart], dstShape_, srcShape_, shareBuffer_);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
 
-        AscendC::Mul(calcUbTensor[gbrcEffStart*nvActual], wsUbTensor, calcUbTensor[gbrcEffStart*nvActual], mActualThisSubBlock * nvActual);
-        AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Mul(calcUbTensor[gbrcEffStart*nvActual], wsUbTensor, calcUbTensor[gbrcEffStart*nvActual], mActualThisSubBlock * nvActual);
+            AscendC::PipeBarrier<PIPE_V>();
 
-        AscendC::Cast(vNewDecayUbTensor, calcUbTensor[gbrcEffStart*nvActual], AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nvActual);
+            AscendC::Cast(vNewDecayUbTensor, calcUbTensor[gbrcEffStart*nvActual], AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nvActual);
+        }
         AscendC::PipeBarrier<PIPE_V>();
 
         AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
         AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
         AscendC::DataCopy(vnewdecayOutputThisSubBlock, vNewDecayUbTensor, mActualThisSubBlock * nvActual);
+        Arch::CrossCoreBarrier<0x1, PIPE_MTE3>();
         Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vec1Done);
 
         AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1 + pingpongFlag);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
@@ -53,6 +53,7 @@ struct GDNFwdHOffsets {
     bool isInitialState;
     bool isFinalState;
     uint32_t blockTokens;
+    uint32_t streamId;
     // for debug
     uint32_t batchIdx;
     uint32_t headIdx;
@@ -122,10 +123,10 @@ struct BlockSchedulerGdnFwdH {
     AscendC::GlobalTensor<int64_t> gmNumSeq;
     AscendC::GlobalTensor<int64_t> gmNumChunks;
 
-    Arch::CrossCoreFlag cube1Done{0};
-    Arch::CrossCoreFlag vec1Done{1};
-    Arch::CrossCoreFlag cube2Done{2};
-    Arch::CrossCoreFlag vec2Done[PING_PONG_STAGES] = {3, 4};
+    Arch::CrossCoreFlag cube1Done[PING_PONG_STAGES] = {0, 1};
+    Arch::CrossCoreFlag vec1Done[PING_PONG_STAGES] = {2, 3};
+    Arch::CrossCoreFlag cube2Done[PING_PONG_STAGES] = {4, 5};
+    Arch::CrossCoreFlag vec2Done[PING_PONG_STAGES] = {6, 7};
 
     CATLASS_DEVICE
     BlockSchedulerGdnFwdH() {}
@@ -238,6 +239,7 @@ struct BlockSchedulerGdnFwdH {
         offset.hWorkOffset = (cubeCoreIdx * PING_PONG_STAGES + streamId) * kHeadDim * vHeadDim;
         offset.vWorkOffset = (cubeCoreIdx * PING_PONG_STAGES + streamId) * chunkSize * vHeadDim;
         offset.blockTokens = offset.isFinalState ? (stream.batchTokens - stream.chunkIdx * chunkSize) : chunkSize;
+        offset.streamId = streamId;
         offset.batchIdx = stream.batchIdx;
         offset.headIdx = stream.vHeadIdx;
         offset.chunkIdx = stream.chunkIdx;
@@ -336,7 +338,10 @@ struct BlockSchedulerGdnFwdHVec : public BlockSchedulerGdnFwdH {
 
     CATLASS_DEVICE
     void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR tiling, GM_ADDR user) {
-        BlockSchedulerGdnFwdH::Init(cu_seqlens, chunk_indices, tiling, user, AscendC::GetBlockIdx() / AscendC::GetSubBlockNum(), AscendC::GetBlockNum());
+        BlockSchedulerGdnFwdH::Init(
+            cu_seqlens, chunk_indices, tiling, user,
+            AscendC::GetBlockIdx() / AscendC::GetSubBlockNum(),
+            AscendC::GetBlockNum());
     }
 
 };

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -108,6 +108,7 @@ public:
     uint32_t chunkSize;
     bool useInitialState;
     bool storeFinalState;
+    bool hasGk;
     uint32_t isVariedLen;
     uint32_t shapeBatch;
     uint32_t tokenBatch;
@@ -121,6 +122,7 @@ public:
     AscendC::GlobalTensor<ElementW> gmW;
     AscendC::GlobalTensor<ElementU> gmU;
     AscendC::GlobalTensor<ElementG> gmG;
+    AscendC::GlobalTensor<ElementG> gmGk;
     AscendC::GlobalTensor<ElementInitialState> gmInitialState;
     AscendC::GlobalTensor<ElementH> gmH;
     AscendC::GlobalTensor<ElementV> gmV;
@@ -141,7 +143,7 @@ public:
 
     __aicore__ inline GDNFwdHKernel() {}
 
-    __aicore__ inline void Init(GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g, GM_ADDR inital_state, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
+    __aicore__ inline void Init(GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g, GM_ADDR gk, GM_ADDR inital_state, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
         GM_ADDR h, GM_ADDR v_new, GM_ADDR final_state, GM_ADDR tiling, GM_ADDR user) {
 
         __gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict>(tiling);
@@ -155,6 +157,7 @@ public:
         chunkSize = gdnFwdHTilingData->chunkSize;
         useInitialState = gdnFwdHTilingData->useInitialState;
         storeFinalState = gdnFwdHTilingData->storeFinalState;
+        hasGk = gdnFwdHTilingData->hasGk;
         isVariedLen = gdnFwdHTilingData->isVariedLen;
         shapeBatch = gdnFwdHTilingData->shapeBatch;
         tokenBatch = gdnFwdHTilingData->tokenBatch;
@@ -168,6 +171,7 @@ public:
         gmW.SetGlobalBuffer((__gm__ ElementW *)w);
         gmU.SetGlobalBuffer((__gm__ ElementU *)u);
         gmG.SetGlobalBuffer((__gm__ ElementG *)g);
+        gmGk.SetGlobalBuffer((__gm__ ElementG *)gk);
         gmInitialState.SetGlobalBuffer((__gm__ ElementInitialState *)inital_state);
         gmH.SetGlobalBuffer((__gm__ ElementH *)h);
         gmV.SetGlobalBuffer((__gm__ ElementV *)v_new);
@@ -187,6 +191,60 @@ public:
         if ASCEND_IS_AIV {
             vecBlockScheduler.Init(cu_seqlens, chunk_indices, tiling, user);
         }
+    }
+
+    __aicore__ inline void CopyInitialStatesBySchedulerTask(uint32_t subBlockIdx, uint32_t subBlockNum) {
+        if (!useInitialState) {
+            return;
+        }
+        uint32_t mPerSubBlock = (kHeadDim + subBlockNum - 1) / subBlockNum;
+        uint32_t mOffset = subBlockIdx * mPerSubBlock;
+        if (mOffset >= kHeadDim) {
+            return;
+        }
+        uint32_t mThisSubBlock = kHeadDim - mOffset;
+        if (mThisSubBlock > mPerSubBlock) {
+            mThisSubBlock = mPerSubBlock;
+        }
+        uint32_t copyCount = mThisSubBlock * vHeadDim;
+        AscendC::LocalTensor<ElementInitialState> stateUbTensor =
+            resource.ubBuf.template GetBufferByByte<ElementInitialState>(0);
+        AscendC::LocalTensor<ElementH> hUbTensor =
+            resource.ubBuf.template GetBufferByByte<ElementH>(64 * 1024);
+
+        VecScheduler initScheduler = vecBlockScheduler;
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+        while (initScheduler.isRunning) {
+            initScheduler.InitTasks();
+            for (uint32_t i = 0; i < PING_PONG_STAGES; ++i) {
+                const auto& stream = initScheduler.GetStream(i);
+                if (initScheduler.StreamIsDone(stream)) {
+                    continue;
+                }
+                const GDNFwdHOffsets& offsets = initScheduler.GetCurTaskOffsets(stream);
+                if (!offsets.isInitialState) {
+                    continue;
+                }
+                uint32_t stateOffset = offsets.initialStateOffset + mOffset * vHeadDim;
+                uint32_t hOffset = offsets.hSrcOffset + mOffset * vHeadDim;
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+                AscendC::DataCopy(stateUbTensor, gmInitialState[stateOffset], copyCount);
+                if constexpr(!std::is_same<ElementInitialState, ElementH>::value) {
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+                    AscendC::Cast(hUbTensor, stateUbTensor, AscendC::RoundMode::CAST_RINT, copyCount);
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+                    AscendC::DataCopy(gmH[hOffset], hUbTensor, copyCount);
+                } else {
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(EVENT_ID0);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(EVENT_ID0);
+                    AscendC::DataCopy(gmH[hOffset], stateUbTensor, copyCount);
+                }
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            }
+        }
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
     }
 
     __aicore__ inline void Process() {
@@ -218,7 +276,8 @@ public:
                         }
 
                         const GDNFwdHOffsets& cube1Offsets = cubeBlockScheduler.GetCurTaskOffsets(stream);
-                        Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[i]);
+                        uint32_t streamId = cube1Offsets.streamId;
+                        Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[streamId]);
                         int64_t cube1OffsetW = cube1Offsets.wOffset;
                         int64_t cube1OffsetH = cube1Offsets.hSrcOffset;
                         int64_t cube1OffsetVwork = cube1Offsets.vWorkOffset;
@@ -232,7 +291,7 @@ public:
                         blockMmadWH.preSetFlags();
                         blockMmadWH(tensorBlockW, tensorBlockH, tensorBlockV, cube1Shape);
                         blockMmadWH.finalWaitFlags();
-                        Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done);
+                        Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done[streamId]);
                     }
                 } else {
                     /* C2: h[i+1] = k.T @ v_work */
@@ -242,7 +301,8 @@ public:
                             continue;
                         }
                         const GDNFwdHOffsets& cube2Offsets = cubeBlockScheduler.GetCurTaskOffsets(stream);
-                        Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done);
+                        uint32_t streamId = cube2Offsets.streamId;
+                        Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done[streamId]);
 
                         if (cubeBlockScheduler.NeedProcessStage2(stream)) {
                             // step 3: h[i+1] = k.T @ v_work
@@ -260,7 +320,7 @@ public:
                             blockMmadKV(tensorBlockK, tensorBlockVwork, tensorBlockHwork, cube2Shape);
                             blockMmadKV.finalWaitFlags();
                         }
-                        Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube2Done);
+                        Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube2Done[streamId]);
                     }
                 }
                 currStage ^= 0x01;
@@ -276,58 +336,7 @@ public:
             uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
             uint32_t subBlockNum = AscendC::GetSubBlockNum();
 
-            if (useInitialState) {
-                AscendC::LocalTensor<ElementInitialState> stateUbTensorPing = resource.ubBuf.template GetBufferByByte<ElementInitialState>(0);
-                AscendC::LocalTensor<ElementInitialState> stateUbTensorPong = resource.ubBuf.template GetBufferByByte<ElementInitialState>(96 * 1024);
-                AscendC::LocalTensor<ElementH> hUbTensorPing = resource.ubBuf.template GetBufferByByte<ElementH>(64 * 1024);
-                AscendC::LocalTensor<ElementH> hUbTensorPong = resource.ubBuf.template GetBufferByByte<ElementH>(160 * 1024);
-                uint32_t totalChunks = isVariedLen ? vecBlockScheduler.totalChunks : ((seqlen + chunkSize - 1) / chunkSize);
-                uint32_t transferCount = isVariedLen ? (vecBlockScheduler.tokenBatch * vNumHead / coreNum) : (shapeBatch * vNumHead / coreNum);
-                uint32_t remainderFlag = isVariedLen ? (((vecBlockScheduler.tokenBatch * vNumHead) % coreNum) != 0): (((shapeBatch * vNumHead) % coreNum) != 0);
-                uint32_t step = transferCount + remainderFlag;
-                uint32_t stateBlockSize = kHeadDim * vHeadDim;
-                uint32_t pingpongFlag = 1;
-                uint32_t start = coreIdx * step;
-                uint32_t end = start + step;
-                uint32_t maxLimit = isVariedLen ? vecBlockScheduler.tokenBatch * vNumHead : shapeBatch * vNumHead;
-                uint32_t realEnd = min(end, maxLimit);
-                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
-                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
-                for(uint32_t initialStateBlockOffset = start ;initialStateBlockOffset >= start && initialStateBlockOffset < realEnd;initialStateBlockOffset++)
-                {
-                    uint32_t batchIdx = initialStateBlockOffset / vNumHead;
-                    uint32_t vHeadIdx = initialStateBlockOffset % vNumHead;
-                    uint32_t chunkOffset = isVariedLen ? gmNumChunks.GetValue(batchIdx) : 0;
-                    uint32_t initialStateOffset = initialStateBlockOffset * stateBlockSize;
-                    uint32_t shapeBatchIdx = isVariedLen ? 0 : batchIdx;
-                    uint32_t hOffset = (shapeBatchIdx * vNumHead * totalChunks + vHeadIdx * totalChunks + chunkOffset) * stateBlockSize;
-                    AscendC::LocalTensor<ElementInitialState> stateUbTensor = pingpongFlag ? stateUbTensorPing : stateUbTensorPong;
-                    AscendC::LocalTensor<ElementH> hUbTensor = pingpongFlag ? hUbTensorPing : hUbTensorPong;
-                    auto event_id = pingpongFlag ? EVENT_ID1 : EVENT_ID0;
-                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
-                    if constexpr(!std::is_same<ElementInitialState, ElementH>::value) {
-                        AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateOffset], stateBlockSize);
-                        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(event_id);
-                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(event_id);
-                        AscendC::Cast(hUbTensor, stateUbTensor, AscendC::RoundMode::CAST_RINT, stateBlockSize);
-                        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(event_id);
-                        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(event_id);
-                        AscendC::DataCopy(gmH[hOffset], hUbTensor, stateBlockSize);
-                    } else {
-                        AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateOffset], stateBlockSize);
-                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
-                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
-                        AscendC::DataCopy(gmH[hOffset], stateUbTensor, stateBlockSize);
-                    }
-                    AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
-                    pingpongFlag = 1 - pingpongFlag;
-
-                }
-
-                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
-                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
-
-            }
+            CopyInitialStatesBySchedulerTask(subBlockIdx, subBlockNum);
 
             AscendC::SyncAll<false>();
 
@@ -374,8 +383,9 @@ public:
                             gmV[vec1Offsets.uvOffset], gmVUpdateWorkspace[vec1Offsets.vWorkOffset],
                             gmG[vec1Offsets.gOffset], gmU[vec1Offsets.uvOffset], gmVWorkspace[vec1Offsets.vWorkOffset],
                             vec1Offsets.blockTokens, kHeadDim, vHeadDim,
-                            vecBlockScheduler.cube1Done, vecBlockScheduler.vec1Done,
-                            vec1Offsets.isInitialState, vec1Offsets.isFinalState, storeFinalState, (i == 0)
+                            vecBlockScheduler.cube1Done[vec1Offsets.streamId],
+                            vecBlockScheduler.vec1Done[vec1Offsets.streamId],
+                            vec1Offsets.isInitialState, vec1Offsets.isFinalState, storeFinalState, hasGk, (i == 0)
                         );
                     }
                 } else {
@@ -391,16 +401,18 @@ public:
                             // step 4:  h[i+1] += h_work if i < num_chunks - 1 else None
                             epilogueGDNFwdHUpdate(
                                 gmH[vec2Offsets.hDstOffset], gmFinalState[vec2Offsets.finalStateOffset],
-                                gmG[vec2Offsets.gOffset],
+                                gmG[vec2Offsets.gOffset], gmGk[vec2Offsets.gOffset * kHeadDim],
                                 gmH[vec2Offsets.hSrcOffset],
                                 gmHWorkspace[vec2Offsets.hWorkOffset],
-                                vec2Offsets.blockTokens, kHeadDim, vHeadDim, vecBlockScheduler.cube2Done,
-                                vec2Offsets.isInitialState, vec2Offsets.isFinalState, storeFinalState, (i == 0)
+                                vec2Offsets.blockTokens, kHeadDim, vHeadDim,
+                                vecBlockScheduler.cube2Done[vec2Offsets.streamId],
+                                vec2Offsets.isInitialState, vec2Offsets.isFinalState, storeFinalState, hasGk, (i == 0)
                             );
                         } else {
-                            Arch::CrossCoreWaitFlag(vecBlockScheduler.cube2Done);
+                            Arch::CrossCoreWaitFlag(vecBlockScheduler.cube2Done[vec2Offsets.streamId]);
                         }
-                        Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done[i]);
+                        Arch::CrossCoreBarrier<0x1, PIPE_MTE3>();
+                        Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done[vec2Offsets.streamId]);
                     }
                 }
                 currStage ^= 0x01;

--- a/fla/ops/ascendc/kda/KDA_FORWARD_DESIGN.md
+++ b/fla/ops/ascendc/kda/KDA_FORWARD_DESIGN.md
@@ -109,6 +109,42 @@ stage 2: 计算 output cube 主路径和最终 o 行
 stage 3: 启用 post-WU cube 时后处理 w/kg/u
 ```
 
+目标 split forward 路径中，L2 对 L0 接口的拼接关系如下。小 shape 或 `fp32` fallback 路径不拆 stage，直接调用 `ChunkKdaFwd(stage=0)` 一次性产出同一组输出。
+
+```mermaid
+flowchart LR
+    In["输入: q/k/v/gk/beta<br/>initial_state/cu_seqlens/chunk_indices"] --> Prep["L2: contiguous + layout 推导"]
+    Prep -->|BSND/TND| SwapIn["L0: KdaLayoutSwap12<br/>转 BNSD 内部布局"]
+    Prep -->|BNSD/NTD| ViewIn["L2: Reshape/View<br/>直通 BNSD 内部布局"]
+    SwapIn --> CastGate["L0: Cast<br/>gk/beta -> fp32"]
+    ViewIn --> CastGate
+
+    CastGate --> S1["L0: ChunkKdaFwd(stage=1)<br/>产出 Aqk/Akk/w/u/qg/kg"]
+    S1 --> AqkScale["L0: Muls<br/>Aqk * scale"]
+    S1 --> S3["L0: ChunkKdaFwd(stage=3)<br/>post-WU 后处理"]
+    S3 --> CastW["L0: Cast<br/>w -> fwd_h dtype"]
+    S1 --> FwdH["L0: ChunkGatedDeltaRuleFwdH<br/>消费 kg/w/u/gk"]
+    CastW --> FwdH
+    FwdH --> S2["L0: ChunkKdaFwd(stage=2)<br/>消费 qg/Aqk/v_new/h"]
+    S1 --> S2
+
+    S2 --> OScale["L0: Muls<br/>o * scale"]
+    OScale --> WriteO["L0: ViewCopy 或 KdaLayoutSwap12<br/>按公开 layout 回写"]
+    WriteO --> OutO["输出: o"]
+    AqkScale --> WriteAqk["L0: ViewCopy 或 KdaLayoutSwap12"]
+    WriteAqk --> OutAqk["输出: Aqk"]
+    S1 --> WriteAkk["L0: ViewCopy 或 KdaLayoutSwap12"]
+    WriteAkk --> OutAkk["输出: Akk"]
+    S3 --> WriteWu["L0: ViewCopy 或 KdaLayoutSwap12"]
+    WriteWu --> OutWu["输出: w/u/qg/kg"]
+    FwdH --> WriteState["L0: ViewCopy 或 KdaLayoutSwap12"]
+    WriteState --> OutState["输出: h/v_new"]
+    FwdH --> OutFinal["输出: final_state"]
+
+    Prep -->|fallback| S0["L0: ChunkKdaFwd(stage=0)<br/>monolithic path"]
+    S0 --> OutAll["输出: o/final_state/Aqk/Akk/w/u/qg/kg/v_new/h"]
+```
+
 `ChunkGatedDeltaRuleFwdH` 扩展为可接收可选 `gk`。这是 KDA 复用状态传播的最小依赖；除该正向状态传播复用点外，不扩大修改 GDN 算子族。
 
 BNSD/NTD split forward 中，未做最终后处理（raw）的 `o/Aqk/Akk/w/u/qg/kg/v_new/h` 存放在 executor 管理的临时张量里。L2 最后一步使用同 layout 的 `ViewCopy` 写入用户输出。这样可以避免把用户输出张量作为 custom L0 和逐元素 L0 算子（elementwise L0, elewise L0）之间的生产者-消费者中间张量，否则可能触发非法 tiling 或 workspace 推导。

--- a/fla/ops/ascendc/kda/KDA_FORWARD_DESIGN.md
+++ b/fla/ops/ascendc/kda/KDA_FORWARD_DESIGN.md
@@ -95,9 +95,9 @@ BNSD 和 NTD 是性能布局，适用于上游 causal conv 已经完成数据排
 3. 对 BNSD/NTD，NTD reshape 为 `[1, HV, T, D]` view 后直接进入 kernel，不触发布局转换。
 4. 对 BSND/TND，TND reshape 为 `[1, T, H, D]` 后通过 `KdaLayoutSwap12` 转成 BNSD。
 5. 如有需要，将 `gk/beta` cast 到 `fp32`。
-6. 根据场景选择 dispatch：
-   - 大 shape half/bfloat16 且 `chunk_size=64` 时走 split forward 路径；
-   - 小 shape 或 `fp32` 场景走 monolithic `ChunkKdaFwd` 路径。
+6. 根据 `useSplitForward` 选择 dispatch：
+   - `useSplitForward=true` 表示走 split forward 路径，当前触发条件为 `q` dtype 不是 `fp32`、`chunk_size == 64` 且 `K * V >= 8192`。该路径把一次 KDA 正向拆成多个 L0 调用，以便复用 cube/向量主路径、GDN 状态传播和独立后处理。
+   - `useSplitForward=false` 表示走 monolithic `ChunkKdaFwd(stage=0)` 路径，用于小 shape 或 `fp32` 场景。
 7. 对 BNSD/NTD，split 路径的临时输出 copy 回相同 layout 的用户输出。对 BSND/TND，将 BNSD 中间结果转回公开输出 layout。
 
 split 路径包含三个 `ChunkKdaFwd` 阶段以及一次 GDN 状态传播：
@@ -109,7 +109,7 @@ stage 2: 计算 output cube 主路径和最终 o 行
 stage 3: 启用 post-WU cube 时后处理 w/kg/u
 ```
 
-目标 split forward 路径中，L2 对 L0 接口的拼接关系如下。小 shape 或 `fp32` fallback 路径不拆 stage，直接调用 `ChunkKdaFwd(stage=0)` 一次性产出同一组输出。
+目标 split forward 路径中，L2 对 L0 接口的拼接关系如下。小 shape 或 `fp32` fallback 路径在完成 layout/cast 后不拆 stage，直接调用 `ChunkKdaFwd(stage=0)` 一次性产出同一组输出。
 
 ```mermaid
 flowchart LR
@@ -119,7 +119,7 @@ flowchart LR
     SwapIn --> CastGate["L0: Cast<br/>gk/beta -> fp32"]
     ViewIn --> CastGate
 
-    CastGate --> S1["L0: ChunkKdaFwd(stage=1)<br/>产出 Aqk/Akk/w/u/qg/kg"]
+    CastGate -->|useSplitForward=true| S1["L0: ChunkKdaFwd(stage=1)<br/>产出 Aqk/Akk/w/u/qg/kg"]
     S1 --> AqkScale["L0: Muls<br/>Aqk * scale"]
     S1 --> S3["L0: ChunkKdaFwd(stage=3)<br/>post-WU 后处理"]
     S3 --> CastW["L0: Cast<br/>w -> fwd_h dtype"]
@@ -141,7 +141,7 @@ flowchart LR
     WriteState --> OutState["输出: h/v_new"]
     FwdH --> OutFinal["输出: final_state"]
 
-    Prep -->|fallback| S0["L0: ChunkKdaFwd(stage=0)<br/>monolithic path"]
+    CastGate -->|useSplitForward=false| S0["L0: ChunkKdaFwd(stage=0)<br/>monolithic path"]
     S0 --> OutAll["输出: o/final_state/Aqk/Akk/w/u/qg/kg/v_new/h"]
 ```
 

--- a/fla/ops/ascendc/kda/KDA_FORWARD_DESIGN.md
+++ b/fla/ops/ascendc/kda/KDA_FORWARD_DESIGN.md
@@ -97,6 +97,7 @@ BNSD 和 NTD 是性能布局，适用于上游 causal conv 已经完成数据排
 5. 如有需要，将 `gk/beta` cast 到 `fp32`。
 6. 根据 `useSplitForward` 选择 dispatch：
    - `useSplitForward=true` 表示走 split forward 路径，当前触发条件为 `q` dtype 不是 `fp32`、`chunk_size == 64` 且 `K * V >= 8192`。该路径把一次 KDA 正向拆成多个 L0 调用，以便复用 cube/向量主路径、GDN 状态传播和独立后处理。
+     典型主流模型场景 `bf16, K=128, V=128, chunk_size=64` 满足该条件，因为 `bf16 != fp32` 且 `128 * 128 = 16384 >= 8192`。
    - `useSplitForward=false` 表示走 monolithic `ChunkKdaFwd(stage=0)` 路径，用于小 shape 或 `fp32` 场景。
 7. 对 BNSD/NTD，split 路径的临时输出 copy 回相同 layout 的用户输出。对 BSND/TND，将 BNSD 中间结果转回公开输出 layout。
 

--- a/fla/ops/ascendc/kda/KDA_FORWARD_DESIGN.md
+++ b/fla/ops/ascendc/kda/KDA_FORWARD_DESIGN.md
@@ -1,0 +1,194 @@
+# KDA Forward AscendC Operator Design
+
+## 1. Scope
+
+This document describes the forward-only KDA implementation in this PR. The goal is to provide an AscendC operator stack that can execute KDA forward with `gk` while reusing existing GDN forward-h logic where it is semantically identical.
+
+Current PR scope:
+
+- Add `ChunkKdaFwd` AscendC L0/L2 operator for KDA forward.
+- Add helper operators `KdaLayoutSwap12` and `KdaGateCumsum`.
+- Extend `ChunkGatedDeltaRuleFwdH` with optional `gk`, because KDA reuses GDN state propagation.
+- Add PyTorch custom API `npu_chunk_kda_fwd` and reference tests.
+- Validate dense BSND/TND compatibility inputs and BNSD/NTD direct inputs for `K=128, V=128, chunk_size=64`.
+
+Out of this PR:
+
+- Backward KDA.
+- `V=256` performance template. `V=256` should use a separate template because the UB/L1 budget and cube tiling differ from `V=128`.
+- High-throughput non-aligned varlen partial chunks. The public API keeps `cu_seqlens` and `chunk_indices`, but non-chunk-aligned high `K/V` varlen requires a dedicated partial-chunk synchronization path before it should be advertised as optimized.
+
+## 2. Reference Semantics
+
+The implementation follows the KDA forward decomposition used by fla-org:
+
+```text
+Aqk[i, j] = tril(q_i * k_j * exp2(g_i - g_j)) * scale
+Akk       = inv(I + tril(k_i * k_j * exp2(g_i - g_j) * beta_i, -1))
+w         = Akk @ (k * beta * exp2(g))
+u         = Akk @ (v * beta)
+v_new     = u - w @ h_prev
+h_next    = exp2(g_last) * h_prev + kg @ v_new
+o         = qg @ h_prev * scale + Aqk @ v_new
+```
+
+Where:
+
+- `gk` is the cumulative key gate in log2 space.
+- `exp2(x)` is implemented as `exp(x * ln2)` on AscendC vector pipes.
+- `final_state` follows fla-org/GDN semantics and is `float32`, even when `q/k/v/o` are `fp16` or `bf16`.
+
+## 3. Public Interface
+
+PyTorch API:
+
+```python
+torch.ops.npu.npu_chunk_kda_fwd(
+    q,
+    k,
+    v,
+    gk,
+    beta,
+    scale,
+    chunk_size,
+    *,
+    initial_state=None,
+    output_final_state=False,
+    cu_seqlens=None,
+    chunk_indices=None,
+    return_intermediate=False,
+    safe_gate=False,
+    transpose_state_layout=False,
+)
+```
+
+Supported layout intent:
+
+- BSND: `q/k: [B, T, H, K]`, `v: [B, T, HV, V]`, `gk: [B, T, HV, K]`, `beta: [B, T, HV]`.
+- BNSD: `q/k: [B, H, T, K]`, `v: [B, HV, T, V]`, `gk: [B, HV, T, K]`, `beta: [B, HV, T]`.
+- TND: `q/k: [T, H, K]`, `v: [T, HV, V]`, `gk: [T, HV, K]`, `beta: [T, HV]`.
+- NTD: `q/k: [H, T, K]`, `v: [HV, T, V]`, `gk: [HV, T, K]`, `beta: [HV, T]`.
+
+BNSD and NTD are the performance layouts for a pipeline where causal conv has already converted the data. BSND and TND remain compatibility layouts and are converted by `KdaLayoutSwap12` before entering the kernel.
+
+Supported dtype intent:
+
+- `q/k/v/o/Aqk/Akk/w/u/qg/kg/v_new/h`: same dtype as `q` or `v` depending on the tensor role, with `fp16`, `bf16`, and `fp32` operator registrations.
+- `gk/beta`: accepted by the PyTorch layer as `fp32` or `bf16`; internally cast to `fp32` before `ChunkKdaFwd`.
+- `initial_state/final_state`: `fp32`.
+
+Reserved or rejected:
+
+- `safe_gate=True` is rejected in the PyTorch wrapper for this PR.
+- `transpose_state_layout=True` is rejected in the PyTorch wrapper for this PR.
+
+## 4. L2 Composition
+
+The L2 implementation in `aclnn_chunk_kda_fwd.cpp` performs:
+
+1. Make all inputs contiguous.
+2. Infer BSND/BNSD/TND/NTD from rank and shape consistency. Ambiguous cases prefer the layout whose head dimension is the shorter dimension.
+3. For BNSD/NTD, reshape NTD to a `[1, HV, T, D]` view and enter the kernel directly. No layout swap is issued.
+4. For BSND/TND, reshape TND to `[1, T, H, D]` and convert to BNSD through `KdaLayoutSwap12`.
+5. Cast `gk/beta` to `fp32` if needed.
+6. Dispatch either:
+   - split forward path for large half/bfloat16 `chunk_size=64` cases, or
+   - monolithic `ChunkKdaFwd` path for smaller or `fp32` cases.
+7. For BNSD/NTD, copy split-path temporary outputs back to the same layout. For BSND/TND, convert BNSD intermediates back to the public output layout.
+
+The split path has three `ChunkKdaFwd` stages plus GDN state propagation:
+
+```text
+stage 1: prepare qg/kg/w/u/Aqk/Akk inputs and solve intra-chunk terms
+GDN fwd_h: update h/v_new/final_state using kg, w, u, gk
+stage 2: compute output cube path and final o rows
+stage 3: postprocess w/kg/u when post-WU cube is enabled
+```
+
+`ChunkGatedDeltaRuleFwdH` is extended to accept optional `gk`. This is a minimal dependency for KDA; the broader GDN operator family is not changed unless required by this forward-h reuse.
+
+For BNSD/NTD split forward, raw `o/Aqk/Akk/w/u/qg/kg/v_new/h` are stored in executor-owned temporary tensors. The final L2 step uses same-layout `ViewCopy` to user outputs. This avoids passing user output tensors as producer-consumer intermediates between custom L0 and elewise L0 ops, which can trigger invalid tiling/workspace inference.
+
+## 5. L0 Kernel Design
+
+`ChunkKdaFwd` contains AIV and AIC work that are paired through cross-core flags.
+
+Important paths:
+
+- Gate product preparation:
+  - AIV loads rows of `q/k/gk`.
+  - AIV computes `qg = q * exp2(g)`, `w seed = k * exp2(g)`, `kg = k * exp2(-g)`.
+  - Double-buffered queues are used for row input/output.
+- `Aqk/Akk` raw score:
+  - Target `K>=16` path uses Catlass cube GEMM.
+  - Scalar fallback exists only as a correctness fallback for non-target shapes and must not be treated as the target performance path.
+- `Akk` inverse:
+  - Full `BT=64` uses blocked cube-assisted matrix-chain iteration.
+  - The solve scratch is stored in `h` workspace slots before state propagation consumes `h`.
+- `w/u` post computation:
+  - Full `BT=64`, aligned `K/V` uses cube GEMM for `Akk @ w` and `Akk @ v_new`.
+  - AIV prepares beta-scaled inputs and finalizes vector postprocess.
+- Output:
+  - AIC computes `qg @ h` and `Aqk @ v_new`.
+  - AIV combines state contribution and local contribution into `o`.
+
+For half/bfloat16 and `K>=16`, tiling launches full AICore block count so every AIC producer has a paired AIV consumer and vice versa. This is required for cross-core flag balance.
+
+## 6. Memory And Layout
+
+The L2 layer uses BNSD internally because it gives contiguous reads/writes on the head and token dimensions used by the kernel:
+
+```text
+BSND/TND public input  -> KdaLayoutSwap12 -> BNSD internal tensors
+BNSD/NTD direct input  -> reshape/view     -> BNSD internal tensors
+```
+
+State layout:
+
+```text
+h:           [B, HV, NT, K, V] in the kernel
+final_state: [seq_num, HV, K, V], fp32
+```
+
+UB principles:
+
+- Use `DataCopy` or `DataCopyPad` for GM/UB transfer.
+- Avoid `GetValue` and `SetValue` in target paths.
+- Reuse a large UB arena for matrix/vector staging.
+- Keep `V=128` and `V=256` templates separate because their UB residency and tile reuse plans are different.
+
+## 7. Validation
+
+Build validation:
+
+- Custom package build for `chunk_kda_fwd`, `chunk_gated_delta_rule_fwd_h`, `kda_layout_swap12`, and `kda_gate_cumsum` passed.
+
+Precision validation:
+
+- Small BSND/TND/BNSD/NTD unit tests passed against `tests/reference/chunk_kda_reference.py`.
+- Target sampled BNSD `B=1, H_K=1, H_V=2, T=16384, K=128, V=128, chunk_size=64` passed:
+  - `o`: `max_abs=4.26e-4`, `mean_abs=3.78e-5`.
+  - `final_state`: `max_abs=1.09e-3`, `mean_abs=1.45e-5`.
+- Target sampled BNSD `B=1, H_K=32, H_V=64, T=4096, K=128, V=128, chunk_size=64` passed:
+  - `o`: `max_abs=4.63e-4`, `mean_abs=4.01e-5`.
+  - `final_state`: `max_abs=1.21e-4`, `mean_abs=9.68e-6`.
+- Target sampled NTD `B=1, H_K=1, H_V=2, T=16384, K=128, V=128, chunk_size=64` passed.
+
+Performance validation with `msopprof --aic-metrics=BasicInfo`:
+
+- BNSD `B=1, H_K=1, H_V=2, T=16384, K=128, V=128, chunk_size=64`: relevant KDA+GDN average `3.05 ms`; `KdaLayoutSwap12` count `0`.
+- BNSD `B=1, H_K=32, H_V=64, T=4096, K=128, V=128, chunk_size=64`: relevant KDA+GDN average `13.60 ms`; `KdaLayoutSwap12` count `0`.
+
+Known validation boundary:
+
+- Non-chunk-aligned `cu_seqlens` with high `K/V` can hit a kernel timeout in the current prototype. Do not claim optimized varlen high `K/V` support until a dedicated partial-chunk path is implemented and validated.
+- `V=256` is intentionally not validated in this PR.
+
+## 8. Extension Plan
+
+Recommended next steps:
+
+1. Add a dedicated partial-chunk varlen path where AIC/AIV flag counts are balanced for each participating subblock, and where cube paths never consume dirty rows outside the valid chunk.
+2. Add a `V=256` template with an explicit UB/L1 residency plan instead of stretching the `V=128` template.
+3. Add backward KDA as a separate PR, using the same `gk` and state dtype conventions.
+4. Add sanitizer runs for race, memory, init, and sync checks once the varlen partial path is stable.

--- a/fla/ops/ascendc/kda/KDA_FORWARD_DESIGN.md
+++ b/fla/ops/ascendc/kda/KDA_FORWARD_DESIGN.md
@@ -28,13 +28,15 @@ Akk       = inv(I + tril(k_i * k_j * exp2(g_i - g_j) * beta_i, -1))
 w         = Akk @ (k * beta * exp2(g))
 u         = Akk @ (v * beta)
 v_new     = u - w @ h_prev
-h_next    = exp2(g_last) * h_prev + kg @ v_new
+h_next    = exp2(g_last) * h_prev + kg_state @ v_new
 o         = qg @ h_prev * scale + Aqk @ v_new
 ```
 
 其中：
 
 - `gk` 是 log2 空间下 key gate 的累积值。
+- `qg` 是 `q * exp2(gk)` 的中间张量。
+- `kg` 不是 `gk` 的笔误，而是 key-gated k 中间张量。kernel 中保存的 `kg = k * exp2(-gk)`；状态更新时结合当前 chunk 的 `g_last` 后，数学上等价于 `kg_state = k * exp2(g_last - gk)`。
 - AscendC vector pipe 中使用 `exp(x * ln2)` 实现 `exp2(x)`。
 - `final_state` 遵循三方对标实现和 GDN 语义，固定为 `float32`，即使 `q/k/v/o` 是 `fp16` 或 `bf16`。
 
@@ -73,7 +75,7 @@ BNSD 和 NTD 是性能布局，适用于上游 causal conv 已经完成数据排
 
 支持的 dtype 语义：
 
-- `q/k/v/o/Aqk/Akk/w/u/qg/kg/v_new/h`：根据张量角色跟随 `q` 或 `v` 的 dtype，算子注册覆盖 `fp16`、`bf16` 和 `fp32`。
+- `q/k/v/o/Aqk/Akk/w/u/qg/kg/v_new/h`：根据张量角色跟随 `q` 或 `v` 的 dtype，算子注册覆盖 `fp16`、`bf16` 和 `fp32`；其中 `kg` 表示 key-gated k 中间张量，不是 `gk` 输入。
 - `gk/beta`：PyTorch 层接受 `fp32` 或 `bf16`，进入 `ChunkKdaFwd` 前统一 cast 到 `fp32`。
 - `initial_state/final_state`：固定为 `fp32`。
 
@@ -100,7 +102,7 @@ split 路径包含三个 `ChunkKdaFwd` 阶段以及一次 GDN 状态传播：
 
 ```text
 stage 1: 准备 qg/kg/w/u/Aqk/Akk 输入并求解 chunk 内部项
-GDN fwd_h: 使用 kg、w、u、gk 更新 h/v_new/final_state
+GDN fwd_h: 使用 kg（key-gated k）、w、u、gk 更新 h/v_new/final_state
 stage 2: 计算 output cube 主路径和最终 o 行
 stage 3: 启用 post-WU cube 时后处理 w/kg/u
 ```
@@ -117,7 +119,7 @@ BNSD/NTD split forward 中，raw `o/Aqk/Akk/w/u/qg/kg/v_new/h` 存放在 executo
 
 - Gate 乘积准备：
   - AIV 加载 `q/k/gk` 行。
-  - AIV 计算 `qg = q * exp2(g)`、`w seed = k * exp2(g)`、`kg = k * exp2(-g)`。
+  - AIV 计算 `qg = q * exp2(gk)`、`w seed = k * exp2(gk)`、`kg = k * exp2(-gk)`。
   - 行输入和输出使用 double-buffer 队列。
 - `Aqk/Akk` raw score：
   - 目标 `K>=16` 路径使用 Catlass cube GEMM。

--- a/fla/ops/ascendc/kda/KDA_FORWARD_DESIGN.md
+++ b/fla/ops/ascendc/kda/KDA_FORWARD_DESIGN.md
@@ -1,26 +1,26 @@
-# KDA Forward AscendC Operator Design
+# KDA 正向 AscendC 算子设计
 
-## 1. Scope
+## 1. 范围
 
-This document describes the forward-only KDA implementation in this PR. The goal is to provide an AscendC operator stack that can execute KDA forward with `gk` while reusing existing GDN forward-h logic where it is semantically identical.
+本文档说明本 PR 中 KDA 正向算子的实现设计。目标是提供一套支持 `gk` 的 AscendC 算子栈，并在语义完全一致的地方复用已有 GDN 正向状态传播逻辑。
 
-Current PR scope:
+当前 PR 范围：
 
-- Add `ChunkKdaFwd` AscendC L0/L2 operator for KDA forward.
-- Add helper operators `KdaLayoutSwap12` and `KdaGateCumsum`.
-- Extend `ChunkGatedDeltaRuleFwdH` with optional `gk`, because KDA reuses GDN state propagation.
-- Add PyTorch custom API `npu_chunk_kda_fwd` and reference tests.
-- Validate dense BSND/TND compatibility inputs and BNSD/NTD direct inputs for `K=128, V=128, chunk_size=64`.
+- 新增 KDA 正向 `ChunkKdaFwd` AscendC L0/L2 算子。
+- 新增辅助算子 `KdaLayoutSwap12` 和 `KdaGateCumsum`。
+- 为 `ChunkGatedDeltaRuleFwdH` 增加可选 `gk` 入参，因为 KDA 复用 GDN 的状态传播。
+- 新增 PyTorch 自定义接口 `npu_chunk_kda_fwd` 和参考测试。
+- 验证 `K=128, V=128, chunk_size=64` 下 dense BSND/TND 兼容输入，以及 BNSD/NTD 直通性能布局。
 
-Out of this PR:
+不在当前 PR 范围：
 
-- Backward KDA.
-- `V=256` performance template. `V=256` should use a separate template because the UB/L1 budget and cube tiling differ from `V=128`.
-- High-throughput non-aligned varlen partial chunks. The public API keeps `cu_seqlens` and `chunk_indices`, but non-chunk-aligned high `K/V` varlen requires a dedicated partial-chunk synchronization path before it should be advertised as optimized.
+- KDA 反向算子。
+- `V=256` 性能模板。`V=256` 应使用独立模板，因为 UB/L1 预算和 cube tiling 与 `V=128` 不同。
+- 高吞吐的非 chunk 对齐 varlen partial chunk 路径。公开 API 保留 `cu_seqlens` 和 `chunk_indices`，但高 `K/V` 非 chunk 对齐 varlen 需要专门的 partial chunk 同步路径，验证完成前不应宣称已优化。
 
-## 2. Reference Semantics
+## 2. 对标语义
 
-The implementation follows the KDA forward decomposition used by fla-org:
+实现对齐三方对标实现 fla-org 的 KDA 正向分解：
 
 ```text
 Aqk[i, j] = tril(q_i * k_j * exp2(g_i - g_j)) * scale
@@ -32,15 +32,15 @@ h_next    = exp2(g_last) * h_prev + kg @ v_new
 o         = qg @ h_prev * scale + Aqk @ v_new
 ```
 
-Where:
+其中：
 
-- `gk` is the cumulative key gate in log2 space.
-- `exp2(x)` is implemented as `exp(x * ln2)` on AscendC vector pipes.
-- `final_state` follows fla-org/GDN semantics and is `float32`, even when `q/k/v/o` are `fp16` or `bf16`.
+- `gk` 是 log2 空间下 key gate 的累积值。
+- AscendC vector pipe 中使用 `exp(x * ln2)` 实现 `exp2(x)`。
+- `final_state` 遵循三方对标实现和 GDN 语义，固定为 `float32`，即使 `q/k/v/o` 是 `fp16` 或 `bf16`。
 
-## 3. Public Interface
+## 3. 对外接口
 
-PyTorch API:
+PyTorch API：
 
 ```python
 torch.ops.npu.npu_chunk_kda_fwd(
@@ -62,133 +62,133 @@ torch.ops.npu.npu_chunk_kda_fwd(
 )
 ```
 
-Supported layout intent:
+支持的 layout 语义：
 
-- BSND: `q/k: [B, T, H, K]`, `v: [B, T, HV, V]`, `gk: [B, T, HV, K]`, `beta: [B, T, HV]`.
-- BNSD: `q/k: [B, H, T, K]`, `v: [B, HV, T, V]`, `gk: [B, HV, T, K]`, `beta: [B, HV, T]`.
-- TND: `q/k: [T, H, K]`, `v: [T, HV, V]`, `gk: [T, HV, K]`, `beta: [T, HV]`.
-- NTD: `q/k: [H, T, K]`, `v: [HV, T, V]`, `gk: [HV, T, K]`, `beta: [HV, T]`.
+- BSND：`q/k: [B, T, H, K]`，`v: [B, T, HV, V]`，`gk: [B, T, HV, K]`，`beta: [B, T, HV]`。
+- BNSD：`q/k: [B, H, T, K]`，`v: [B, HV, T, V]`，`gk: [B, HV, T, K]`，`beta: [B, HV, T]`。
+- TND：`q/k: [T, H, K]`，`v: [T, HV, V]`，`gk: [T, HV, K]`，`beta: [T, HV]`。
+- NTD：`q/k: [H, T, K]`，`v: [HV, T, V]`，`gk: [HV, T, K]`，`beta: [HV, T]`。
 
-BNSD and NTD are the performance layouts for a pipeline where causal conv has already converted the data. BSND and TND remain compatibility layouts and are converted by `KdaLayoutSwap12` before entering the kernel.
+BNSD 和 NTD 是性能布局，适用于上游 causal conv 已经完成数据排布转换的流水线。BSND 和 TND 是兼容布局，进入 kernel 前通过 `KdaLayoutSwap12` 转成内部布局。
 
-Supported dtype intent:
+支持的 dtype 语义：
 
-- `q/k/v/o/Aqk/Akk/w/u/qg/kg/v_new/h`: same dtype as `q` or `v` depending on the tensor role, with `fp16`, `bf16`, and `fp32` operator registrations.
-- `gk/beta`: accepted by the PyTorch layer as `fp32` or `bf16`; internally cast to `fp32` before `ChunkKdaFwd`.
-- `initial_state/final_state`: `fp32`.
+- `q/k/v/o/Aqk/Akk/w/u/qg/kg/v_new/h`：根据张量角色跟随 `q` 或 `v` 的 dtype，算子注册覆盖 `fp16`、`bf16` 和 `fp32`。
+- `gk/beta`：PyTorch 层接受 `fp32` 或 `bf16`，进入 `ChunkKdaFwd` 前统一 cast 到 `fp32`。
+- `initial_state/final_state`：固定为 `fp32`。
 
-Reserved or rejected:
+预留或拦截：
 
-- `safe_gate=True` is rejected in the PyTorch wrapper for this PR.
-- `transpose_state_layout=True` is rejected in the PyTorch wrapper for this PR.
+- 当前 PR 中 PyTorch wrapper 拦截 `safe_gate=True`。
+- 当前 PR 中 PyTorch wrapper 拦截 `transpose_state_layout=True`。
 
-## 4. L2 Composition
+## 4. L2 组合设计
 
-The L2 implementation in `aclnn_chunk_kda_fwd.cpp` performs:
+`aclnn_chunk_kda_fwd.cpp` 中的 L2 实现流程：
 
-1. Make all inputs contiguous.
-2. Infer BSND/BNSD/TND/NTD from rank and shape consistency. Ambiguous cases prefer the layout whose head dimension is the shorter dimension.
-3. For BNSD/NTD, reshape NTD to a `[1, HV, T, D]` view and enter the kernel directly. No layout swap is issued.
-4. For BSND/TND, reshape TND to `[1, T, H, D]` and convert to BNSD through `KdaLayoutSwap12`.
-5. Cast `gk/beta` to `fp32` if needed.
-6. Dispatch either:
-   - split forward path for large half/bfloat16 `chunk_size=64` cases, or
-   - monolithic `ChunkKdaFwd` path for smaller or `fp32` cases.
-7. For BNSD/NTD, copy split-path temporary outputs back to the same layout. For BSND/TND, convert BNSD intermediates back to the public output layout.
+1. 将所有输入处理为 contiguous。
+2. 根据 rank 和 shape 一致性推导 BSND/BNSD/TND/NTD。歧义场景优先选择 head 维更短的 layout。
+3. 对 BNSD/NTD，NTD reshape 为 `[1, HV, T, D]` view 后直接进入 kernel，不触发布局转换。
+4. 对 BSND/TND，TND reshape 为 `[1, T, H, D]` 后通过 `KdaLayoutSwap12` 转成 BNSD。
+5. 如有需要，将 `gk/beta` cast 到 `fp32`。
+6. 根据场景选择 dispatch：
+   - 大 shape half/bfloat16 且 `chunk_size=64` 时走 split forward 路径；
+   - 小 shape 或 `fp32` 场景走 monolithic `ChunkKdaFwd` 路径。
+7. 对 BNSD/NTD，split 路径的临时输出 copy 回相同 layout 的用户输出。对 BSND/TND，将 BNSD 中间结果转回公开输出 layout。
 
-The split path has three `ChunkKdaFwd` stages plus GDN state propagation:
-
-```text
-stage 1: prepare qg/kg/w/u/Aqk/Akk inputs and solve intra-chunk terms
-GDN fwd_h: update h/v_new/final_state using kg, w, u, gk
-stage 2: compute output cube path and final o rows
-stage 3: postprocess w/kg/u when post-WU cube is enabled
-```
-
-`ChunkGatedDeltaRuleFwdH` is extended to accept optional `gk`. This is a minimal dependency for KDA; the broader GDN operator family is not changed unless required by this forward-h reuse.
-
-For BNSD/NTD split forward, raw `o/Aqk/Akk/w/u/qg/kg/v_new/h` are stored in executor-owned temporary tensors. The final L2 step uses same-layout `ViewCopy` to user outputs. This avoids passing user output tensors as producer-consumer intermediates between custom L0 and elewise L0 ops, which can trigger invalid tiling/workspace inference.
-
-## 5. L0 Kernel Design
-
-`ChunkKdaFwd` contains AIV and AIC work that are paired through cross-core flags.
-
-Important paths:
-
-- Gate product preparation:
-  - AIV loads rows of `q/k/gk`.
-  - AIV computes `qg = q * exp2(g)`, `w seed = k * exp2(g)`, `kg = k * exp2(-g)`.
-  - Double-buffered queues are used for row input/output.
-- `Aqk/Akk` raw score:
-  - Target `K>=16` path uses Catlass cube GEMM.
-  - Scalar fallback exists only as a correctness fallback for non-target shapes and must not be treated as the target performance path.
-- `Akk` inverse:
-  - Full `BT=64` uses blocked cube-assisted matrix-chain iteration.
-  - The solve scratch is stored in `h` workspace slots before state propagation consumes `h`.
-- `w/u` post computation:
-  - Full `BT=64`, aligned `K/V` uses cube GEMM for `Akk @ w` and `Akk @ v_new`.
-  - AIV prepares beta-scaled inputs and finalizes vector postprocess.
-- Output:
-  - AIC computes `qg @ h` and `Aqk @ v_new`.
-  - AIV combines state contribution and local contribution into `o`.
-
-For half/bfloat16 and `K>=16`, tiling launches full AICore block count so every AIC producer has a paired AIV consumer and vice versa. This is required for cross-core flag balance.
-
-## 6. Memory And Layout
-
-The L2 layer uses BNSD internally because it gives contiguous reads/writes on the head and token dimensions used by the kernel:
+split 路径包含三个 `ChunkKdaFwd` 阶段以及一次 GDN 状态传播：
 
 ```text
-BSND/TND public input  -> KdaLayoutSwap12 -> BNSD internal tensors
-BNSD/NTD direct input  -> reshape/view     -> BNSD internal tensors
+stage 1: 准备 qg/kg/w/u/Aqk/Akk 输入并求解 chunk 内部项
+GDN fwd_h: 使用 kg、w、u、gk 更新 h/v_new/final_state
+stage 2: 计算 output cube 主路径和最终 o 行
+stage 3: 启用 post-WU cube 时后处理 w/kg/u
 ```
 
-State layout:
+`ChunkGatedDeltaRuleFwdH` 扩展为可接收可选 `gk`。这是 KDA 复用状态传播的最小依赖；除该正向状态传播复用点外，不扩大修改 GDN 算子族。
+
+BNSD/NTD split forward 中，raw `o/Aqk/Akk/w/u/qg/kg/v_new/h` 存放在 executor 管理的临时张量里。L2 最后一步使用同 layout 的 `ViewCopy` 写入用户输出。这样可以避免把用户输出张量作为 custom L0 和 elewise L0 之间的生产者-消费者中间张量，否则可能触发非法 tiling 或 workspace 推导。
+
+## 5. L0 Kernel 设计
+
+`ChunkKdaFwd` 内部包含 AIV 和 AIC 两类工作，通过跨核 flag 成对协作。
+
+关键路径：
+
+- Gate 乘积准备：
+  - AIV 加载 `q/k/gk` 行。
+  - AIV 计算 `qg = q * exp2(g)`、`w seed = k * exp2(g)`、`kg = k * exp2(-g)`。
+  - 行输入和输出使用 double-buffer 队列。
+- `Aqk/Akk` raw score：
+  - 目标 `K>=16` 路径使用 Catlass cube GEMM。
+  - scalar fallback 仅作为非目标 shape 的 correctness fallback，不能作为目标性能路径。
+- `Akk` 求逆：
+  - 完整 `BT=64` 使用 cube 辅助的 blocked matrix-chain iteration。
+  - solve scratch 在状态传播消费 `h` 之前暂存在 `h` workspace slot 中。
+- `w/u` 后处理：
+  - 完整 `BT=64` 且 `K/V` 对齐时，使用 cube GEMM 计算 `Akk @ w` 和 `Akk @ v_new`。
+  - AIV 准备 beta 缩放输入并完成 vector 后处理。
+- Output：
+  - AIC 计算 `qg @ h` 和 `Aqk @ v_new`。
+  - AIV 合并 state contribution 和 local contribution，得到 `o`。
+
+对于 half/bfloat16 且 `K>=16` 的目标路径，tiling 使用完整 AICore block 数启动，确保每个 AIC producer 都有成对的 AIV consumer，反之亦然。这是 cross-core flag 计数保持平衡的必要条件。
+
+## 6. 内存与 Layout
+
+L2 内部使用 BNSD，因为该 layout 在 kernel 使用的 head 和 token 维度上读写更连续：
 
 ```text
-h:           [B, HV, NT, K, V] in the kernel
-final_state: [seq_num, HV, K, V], fp32
+BSND/TND 公开输入 -> KdaLayoutSwap12 -> BNSD 内部张量
+BNSD/NTD 直通输入 -> reshape/view     -> BNSD 内部张量
 ```
 
-UB principles:
+状态 layout：
 
-- Use `DataCopy` or `DataCopyPad` for GM/UB transfer.
-- Avoid `GetValue` and `SetValue` in target paths.
-- Reuse a large UB arena for matrix/vector staging.
-- Keep `V=128` and `V=256` templates separate because their UB residency and tile reuse plans are different.
+```text
+h:           kernel 内为 [B, HV, NT, K, V]
+final_state: [seq_num, HV, K, V]，fp32
+```
 
-## 7. Validation
+UB 使用原则：
 
-Build validation:
+- GM/UB 搬运使用 `DataCopy` 或 `DataCopyPad`。
+- 目标路径避免使用 `GetValue` 和 `SetValue`。
+- 复用大块 UB arena 做矩阵和向量 staging。
+- `V=128` 和 `V=256` 模板保持独立，因为二者的 UB 驻留和 tile 复用计划不同。
 
-- Custom package build for `chunk_kda_fwd`, `chunk_gated_delta_rule_fwd_h`, `kda_layout_swap12`, and `kda_gate_cumsum` passed.
+## 7. 验证结果
 
-Precision validation:
+构建验证：
 
-- Small BSND/TND/BNSD/NTD unit tests passed against `tests/reference/chunk_kda_reference.py`.
-- Target sampled BNSD `B=1, H_K=1, H_V=2, T=16384, K=128, V=128, chunk_size=64` passed:
-  - `o`: `max_abs=4.26e-4`, `mean_abs=3.78e-5`.
-  - `final_state`: `max_abs=1.09e-3`, `mean_abs=1.45e-5`.
-- Target sampled BNSD `B=1, H_K=32, H_V=64, T=4096, K=128, V=128, chunk_size=64` passed:
-  - `o`: `max_abs=4.63e-4`, `mean_abs=4.01e-5`.
-  - `final_state`: `max_abs=1.21e-4`, `mean_abs=9.68e-6`.
-- Target sampled NTD `B=1, H_K=1, H_V=2, T=16384, K=128, V=128, chunk_size=64` passed.
+- `chunk_kda_fwd`、`chunk_gated_delta_rule_fwd_h`、`kda_layout_swap12` 和 `kda_gate_cumsum` custom package 构建通过。
 
-Performance validation with `msopprof --aic-metrics=BasicInfo`:
+精度验证：
 
-- BNSD `B=1, H_K=1, H_V=2, T=16384, K=128, V=128, chunk_size=64`: relevant KDA+GDN average `3.05 ms`; `KdaLayoutSwap12` count `0`.
-- BNSD `B=1, H_K=32, H_V=64, T=4096, K=128, V=128, chunk_size=64`: relevant KDA+GDN average `13.60 ms`; `KdaLayoutSwap12` count `0`.
+- 小 shape BSND/TND/BNSD/NTD 单测对齐 `tests/reference/chunk_kda_reference.py` 并通过。
+- 目标 sampled BNSD `B=1, H_K=1, H_V=2, T=16384, K=128, V=128, chunk_size=64` 通过：
+  - `o`：`max_abs=4.26e-4`，`mean_abs=3.78e-5`。
+  - `final_state`：`max_abs=1.09e-3`，`mean_abs=1.45e-5`。
+- 目标 sampled BNSD `B=1, H_K=32, H_V=64, T=4096, K=128, V=128, chunk_size=64` 通过：
+  - `o`：`max_abs=4.63e-4`，`mean_abs=4.01e-5`。
+  - `final_state`：`max_abs=1.21e-4`，`mean_abs=9.68e-6`。
+- 目标 sampled NTD `B=1, H_K=1, H_V=2, T=16384, K=128, V=128, chunk_size=64` 通过。
 
-Known validation boundary:
+性能验证使用 `msopprof --aic-metrics=BasicInfo`：
 
-- Non-chunk-aligned `cu_seqlens` with high `K/V` can hit a kernel timeout in the current prototype. Do not claim optimized varlen high `K/V` support until a dedicated partial-chunk path is implemented and validated.
-- `V=256` is intentionally not validated in this PR.
+- BNSD `B=1, H_K=1, H_V=2, T=16384, K=128, V=128, chunk_size=64`：相关 KDA+GDN 平均耗时 `3.05 ms`；`KdaLayoutSwap12` 次数为 `0`。
+- BNSD `B=1, H_K=32, H_V=64, T=4096, K=128, V=128, chunk_size=64`：相关 KDA+GDN 平均耗时 `13.60 ms`；`KdaLayoutSwap12` 次数为 `0`。
 
-## 8. Extension Plan
+已知验证边界：
 
-Recommended next steps:
+- 高 `K/V` 的非 chunk 对齐 `cu_seqlens` 在当前 prototype 中可能触发 kernel timeout。在 dedicated partial-chunk 路径实现并验证前，不宣称已优化 varlen high `K/V` 支持。
+- 当前 PR 有意不验证 `V=256`。
 
-1. Add a dedicated partial-chunk varlen path where AIC/AIV flag counts are balanced for each participating subblock, and where cube paths never consume dirty rows outside the valid chunk.
-2. Add a `V=256` template with an explicit UB/L1 residency plan instead of stretching the `V=128` template.
-3. Add backward KDA as a separate PR, using the same `gk` and state dtype conventions.
-4. Add sanitizer runs for race, memory, init, and sync checks once the varlen partial path is stable.
+## 8. 后续扩展计划
+
+建议后续工作：
+
+1. 增加 dedicated partial-chunk varlen 路径，保证每个参与 subblock 的 AIC/AIV flag 计数平衡，并确保 cube 路径不会消费有效 chunk 外的脏行。
+2. 增加 `V=256` 模板，明确 UB/L1 驻留计划，而不是拉伸 `V=128` 模板。
+3. 将 KDA 反向算子放到独立 PR 中实现，并复用相同的 `gk` 和 state dtype 约定。
+4. varlen partial 路径稳定后，补充 race、memory、init 和 sync sanitizer 验证。

--- a/fla/ops/ascendc/kda/KDA_FORWARD_DESIGN.md
+++ b/fla/ops/ascendc/kda/KDA_FORWARD_DESIGN.md
@@ -1,22 +1,22 @@
-# KDA 正向 AscendC 算子设计
+# Kimi Delta Attention（KDA）正向 AscendC 算子设计
 
 ## 1. 范围
 
-本文档说明本 PR 中 KDA 正向算子的实现设计。目标是提供一套支持 `gk` 的 AscendC 算子栈，并在语义完全一致的地方复用已有 GDN 正向状态传播逻辑。
+本文档说明本代码合入请求（Pull Request, PR）中 KDA 正向算子的实现设计。目标是提供一套支持 `gk` 的 AscendC 算子栈，并在语义完全一致的地方复用已有 Gated DeltaNet（GDN）正向状态传播逻辑。
 
 当前 PR 范围：
 
-- 新增 KDA 正向 `ChunkKdaFwd` AscendC L0/L2 算子。
+- 新增 KDA 正向 `ChunkKdaFwd` AscendC 算子内核/算子接口层（L0/L2）算子。
 - 新增辅助算子 `KdaLayoutSwap12` 和 `KdaGateCumsum`。
 - 为 `ChunkGatedDeltaRuleFwdH` 增加可选 `gk` 入参，因为 KDA 复用 GDN 的状态传播。
 - 新增 PyTorch 自定义接口 `npu_chunk_kda_fwd` 和参考测试。
-- 验证 `K=128, V=128, chunk_size=64` 下 dense BSND/TND 兼容输入，以及 BNSD/NTD 直通性能布局。
+- 验证 `K=128, V=128, chunk_size=64` 下 dense batch-sequence-head-dim/token-head-dim（BSND/TND）兼容输入，以及 batch-head-sequence-dim/head-token-dim（BNSD/NTD）直通性能布局。
 
 不在当前 PR 范围：
 
 - KDA 反向算子。
-- `V=256` 性能模板。`V=256` 应使用独立模板，因为 UB/L1 预算和 cube tiling 与 `V=128` 不同。
-- 高吞吐的非 chunk 对齐 varlen partial chunk 路径。公开 API 保留 `cu_seqlens` 和 `chunk_indices`，但高 `K/V` 非 chunk 对齐 varlen 需要专门的 partial chunk 同步路径，验证完成前不应宣称已优化。
+- `V=256` 性能模板。`V=256` 应使用独立模板，因为统一缓冲/一级缓存（UB/L1）预算和 cube tiling 与 `V=128` 不同。
+- 高吞吐的非 chunk 对齐变长序列（varlen）非完整 chunk（partial chunk）路径。公开对外接口（Application Programming Interface, API）保留 `cu_seqlens` 和 `chunk_indices`，但高 `K/V` 非 chunk 对齐 varlen 需要专门的 partial chunk 同步路径，验证完成前不应宣称已优化。
 
 ## 2. 对标语义
 
@@ -37,8 +37,8 @@ o         = qg @ h_prev * scale + Aqk @ v_new
 - `gk` 是 log2 空间下 key gate 的累积值。
 - `qg` 是 `q * exp2(gk)` 的中间张量。
 - `kg` 不是 `gk` 的笔误，而是 key-gated k 中间张量。kernel 中保存的 `kg = k * exp2(-gk)`；状态更新时结合当前 chunk 的 `g_last` 后，数学上等价于 `kg_state = k * exp2(g_last - gk)`。
-- AscendC vector pipe 中使用 `exp(x * ln2)` 实现 `exp2(x)`。
-- `final_state` 遵循三方对标实现和 GDN 语义，固定为 `float32`，即使 `q/k/v/o` 是 `fp16` 或 `bf16`。
+- AscendC 向量流水（vector pipe）中使用 `exp(x * ln2)` 实现 `exp2(x)`。
+- `final_state` 遵循三方对标实现和 GDN 语义，固定为 `float32`，即使 `q/k/v/o` 是 16 位浮点（fp16）或 Brain Floating Point 16（bf16）。
 
 ## 3. 对外接口
 
@@ -64,18 +64,20 @@ torch.ops.npu.npu_chunk_kda_fwd(
 )
 ```
 
-支持的 layout 语义：
+支持的内存排布（layout）语义：
 
 - BSND：`q/k: [B, T, H, K]`，`v: [B, T, HV, V]`，`gk: [B, T, HV, K]`，`beta: [B, T, HV]`。
 - BNSD：`q/k: [B, H, T, K]`，`v: [B, HV, T, V]`，`gk: [B, HV, T, K]`，`beta: [B, HV, T]`。
 - TND：`q/k: [T, H, K]`，`v: [T, HV, V]`，`gk: [T, HV, K]`，`beta: [T, HV]`。
 - NTD：`q/k: [H, T, K]`，`v: [HV, T, V]`，`gk: [HV, T, K]`，`beta: [HV, T]`。
 
+其中 `B/T/H/HV/K/V` 分别表示 batch、token 序列长度、query/key head 数、value head 数、key 维度和 value 维度。
+
 BNSD 和 NTD 是性能布局，适用于上游 causal conv 已经完成数据排布转换的流水线。BSND 和 TND 是兼容布局，进入 kernel 前通过 `KdaLayoutSwap12` 转成内部布局。
 
-支持的 dtype 语义：
+支持的数据类型（dtype）语义：
 
-- `q/k/v/o/Aqk/Akk/w/u/qg/kg/v_new/h`：根据张量角色跟随 `q` 或 `v` 的 dtype，算子注册覆盖 `fp16`、`bf16` 和 `fp32`；其中 `kg` 表示 key-gated k 中间张量，不是 `gk` 输入。
+- `q/k/v/o/Aqk/Akk/w/u/qg/kg/v_new/h`：根据张量角色跟随 `q` 或 `v` 的 dtype，算子注册覆盖 `fp16`、`bf16` 和 32 位浮点（fp32）；其中 `kg` 表示 key-gated k 中间张量，不是 `gk` 输入。
 - `gk/beta`：PyTorch 层接受 `fp32` 或 `bf16`，进入 `ChunkKdaFwd` 前统一 cast 到 `fp32`。
 - `initial_state/final_state`：固定为 `fp32`。
 
@@ -109,11 +111,11 @@ stage 3: 启用 post-WU cube 时后处理 w/kg/u
 
 `ChunkGatedDeltaRuleFwdH` 扩展为可接收可选 `gk`。这是 KDA 复用状态传播的最小依赖；除该正向状态传播复用点外，不扩大修改 GDN 算子族。
 
-BNSD/NTD split forward 中，raw `o/Aqk/Akk/w/u/qg/kg/v_new/h` 存放在 executor 管理的临时张量里。L2 最后一步使用同 layout 的 `ViewCopy` 写入用户输出。这样可以避免把用户输出张量作为 custom L0 和 elewise L0 之间的生产者-消费者中间张量，否则可能触发非法 tiling 或 workspace 推导。
+BNSD/NTD split forward 中，未做最终后处理（raw）的 `o/Aqk/Akk/w/u/qg/kg/v_new/h` 存放在 executor 管理的临时张量里。L2 最后一步使用同 layout 的 `ViewCopy` 写入用户输出。这样可以避免把用户输出张量作为 custom L0 和逐元素 L0 算子（elementwise L0, elewise L0）之间的生产者-消费者中间张量，否则可能触发非法 tiling 或 workspace 推导。
 
 ## 5. L0 Kernel 设计
 
-`ChunkKdaFwd` 内部包含 AIV 和 AIC 两类工作，通过跨核 flag 成对协作。
+`ChunkKdaFwd` 内部包含向量侧（AI Vector, AIV）和矩阵侧（AI Core/Cube, AIC）两类工作，通过跨核 flag 成对协作。
 
 关键路径：
 
@@ -122,10 +124,10 @@ BNSD/NTD split forward 中，raw `o/Aqk/Akk/w/u/qg/kg/v_new/h` 存放在 executo
   - AIV 计算 `qg = q * exp2(gk)`、`w seed = k * exp2(gk)`、`kg = k * exp2(-gk)`。
   - 行输入和输出使用 double-buffer 队列。
 - `Aqk/Akk` raw score：
-  - 目标 `K>=16` 路径使用 Catlass cube GEMM。
+  - 目标 `K>=16` 路径使用 Catlass cube 通用矩阵乘（General Matrix Multiplication, GEMM）。
   - scalar fallback 仅作为非目标 shape 的 correctness fallback，不能作为目标性能路径。
 - `Akk` 求逆：
-  - 完整 `BT=64` 使用 cube 辅助的 blocked matrix-chain iteration。
+  - 完整 block token 长度（BT）为 64 时，使用 cube 辅助的 blocked matrix-chain iteration。
   - solve scratch 在状态传播消费 `h` 之前暂存在 `h` workspace slot 中。
 - `w/u` 后处理：
   - 完整 `BT=64` 且 `K/V` 对齐时，使用 cube GEMM 计算 `Akk @ w` 和 `Akk @ v_new`。
@@ -154,7 +156,7 @@ final_state: [seq_num, HV, K, V]，fp32
 
 UB 使用原则：
 
-- GM/UB 搬运使用 `DataCopy` 或 `DataCopyPad`。
+- 全局内存/统一缓冲（GM/UB）搬运使用 `DataCopy` 或 `DataCopyPad`。
 - 目标路径避免使用 `GetValue` 和 `SetValue`。
 - 复用大块 UB arena 做矩阵和向量 staging。
 - `V=128` 和 `V=256` 模板保持独立，因为二者的 UB 驻留和 tile 复用计划不同。
@@ -166,6 +168,8 @@ UB 使用原则：
 - `chunk_kda_fwd`、`chunk_gated_delta_rule_fwd_h`、`kda_layout_swap12` 和 `kda_gate_cumsum` custom package 构建通过。
 
 精度验证：
+
+以下验证 shape 中，`H_K/H_V` 表示 key/value head 数。
 
 - 小 shape BSND/TND/BNSD/NTD 单测对齐 `tests/reference/chunk_kda_reference.py` 并通过。
 - 目标 sampled BNSD `B=1, H_K=1, H_V=2, T=16384, K=128, V=128, chunk_size=64` 通过：
@@ -193,4 +197,4 @@ UB 使用原则：
 1. 增加 dedicated partial-chunk varlen 路径，保证每个参与 subblock 的 AIC/AIV flag 计数平衡，并确保 cube 路径不会消费有效 chunk 外的脏行。
 2. 增加 `V=256` 模板，明确 UB/L1 驻留计划，而不是拉伸 `V=128` 模板。
 3. 将 KDA 反向算子放到独立 PR 中实现，并复用相同的 `gk` 和 state dtype 约定。
-4. varlen partial 路径稳定后，补充 race、memory、init 和 sync sanitizer 验证。
+4. varlen partial 路径稳定后，补充 race、memory、init 和 sync 内存/同步检查工具（sanitizer）验证。

--- a/fla/ops/ascendc/kda/KDA_FORWARD_DESIGN.md
+++ b/fla/ops/ascendc/kda/KDA_FORWARD_DESIGN.md
@@ -110,6 +110,12 @@ stage 2: 计算 output cube 主路径和最终 o 行
 stage 3: 启用 post-WU cube 时后处理 w/kg/u
 ```
 
+这样设计的原因：
+
+- KDA 正向天然分成“chunk 内矩阵项”和“chunk 间状态传播”两类依赖。`Aqk/Akk/w/u/qg/kg` 可以按 chunk 并行准备；`h/v_new/final_state` 依赖前一 chunk 状态，需要复用 GDN 的 `ChunkGatedDeltaRuleFwdH` 串起状态传播；最终 `o` 又依赖已经产出的 `h` 和 `v_new`。
+- 如果把全部逻辑塞进一个大 kernel，需要在 `ChunkKdaFwd` 内重新实现 GDN 状态传播和输出后处理，既会重复已有可靠实现，也会把 cube 主路径、向量后处理、跨 chunk 依赖揉在一起，后续维护和定位都更困难。
+- 对主流 `bf16, K=128, V=128, chunk_size=64` 场景，矩阵计算量足够大，拆分带来的 L0 调用和临时张量开销可以被 cube/向量主路径收益覆盖；而小 shape 或 `fp32` 场景收益不足，所以保留 `stage=0` 单 L0 路径作为简单通用路径。
+
 目标 split forward 路径中，L2 对 L0 接口的拼接关系如下。小 shape 或 `fp32` fallback 路径在完成 layout/cast 后不拆 stage，直接调用 `ChunkKdaFwd(stage=0)` 一次性产出同一组输出。
 
 ```mermaid

--- a/fla/ops/ascendc/kda/KDA_FORWARD_LESSONS.md
+++ b/fla/ops/ascendc/kda/KDA_FORWARD_LESSONS.md
@@ -1,0 +1,350 @@
+# KDA Forward Development Lessons
+
+This document is intentionally written as a handoff note for a future engineer or AI agent. Read it before changing KDA forward. It records the design traps already encountered so the same mistakes are not repeated.
+
+## 1. Start Here
+
+If you enter this project from a fresh conversation, assume the current KDA forward PR has these constraints:
+
+- Focus on forward only.
+- `K=128, V=128, chunk_size=64` dense BSND and TND have been validated.
+- BNSD/NTD are the direct performance layouts when upstream causal conv has already converted memory order. Do not route these layouts back through `KdaLayoutSwap12`.
+- `V=256` is not the same template. Do not "just increase V" in the `V=128` path.
+- High `K/V` non-chunk-aligned varlen still needs a real partial-chunk design.
+- `final_state` is `float32`, not the dtype of `q`.
+- Target matrix work must use Catlass cube. Do not reintroduce scalar dot-product loops for target shapes.
+
+## 2. Do Not Repeat These Mistakes
+
+### Mistake 1: Treating `exp2` as a scalar helper
+
+Bad pattern:
+
+```cpp
+for (...) {
+    float gate = Exp2Scalar(x);
+}
+```
+
+Why it is wrong:
+
+- It turns a vector operation into scalar pipe work.
+- It blocks the intended AIV SIMD style.
+- It hides performance problems until large shapes are tested.
+
+Correct direction:
+
+- Use vector `Exp` on `x * ln2`.
+- Keep `gk` rows in UB as vector tensors.
+- Use `DataCopy`/`DataCopyPad` to move rows, then apply vector math.
+
+### Mistake 2: Computing `q @ k^T` with per-element loops
+
+Bad pattern:
+
+```cpp
+for i:
+  for j:
+    for d:
+      acc += q[i, d] * k[j, d] * gate[i, j, d]
+```
+
+Why it is wrong:
+
+- Cube is much faster than vector/scalar for matrix products.
+- The whole point of the KDA forward split is to put `Aqk/Akk`, post-WU, and output matmuls on cube.
+
+Correct direction:
+
+- Prepare `qg`, `kg`, and `w` rows on AIV.
+- Use Catlass cube GEMM for full target chunks.
+- Keep scalar fallback only for non-target correctness paths, never for target performance.
+
+### Mistake 3: Using `GetValue` and `SetValue`
+
+Do not use `GetValue`/`SetValue` for hot paths. They produce scalarized code and usually indicate the kernel has fallen out of the AscendC SIMD programming model.
+
+Correct direction:
+
+- Move full rows or tiles with `DataCopy`/`DataCopyPad`.
+- Process vector chunks with `Mul`, `Muls`, `Add`, `Sub`, `Cast`, `Duplicate`, `Brcb`, `Exp`.
+- Use row-level helper functions that still compile to vector operations.
+
+### Mistake 4: Forgetting `final_state` dtype
+
+fla-org and GDN forward-h semantics keep state in `float32`. KDA must follow this:
+
+```text
+initial_state: optional float32
+final_state:  float32
+h:            q dtype
+```
+
+Symptoms when this is wrong:
+
+- PyTorch reference comparison fails only on dtype.
+- L0 op registration can reject the call with executor/nullptr because `final_state` was registered as q dtype.
+
+Correct files to check:
+
+- `chunk_kda_fwd_def.cpp`: `initial_state` and `final_state` must be `DT_FLOAT`.
+- `FLANpuOpApi.cpp`: allocate `final_state_work` as `at::kFloat`.
+- `chunk_kda_fwd.cpp`: `initialState_` and `finalState_` should be `GlobalTensor<float>`.
+
+### Mistake 5: Assuming op_def dtype lists are harmless
+
+The op_def dtype list is not documentation only. It participates in graph/operator matching.
+
+If the kernel writes `float32 final_state` but op_def says `final_state` follows `q` dtype, the call can fail before useful kernel diagnostics.
+
+Checklist:
+
+- Every required output dtype in op_def must match the actual tensor allocated by L2.
+- Optional inputs with fixed semantics, such as `initial_state`, should not reuse broad `q/k/v` dtype lists.
+- If L2 casts `gk/beta` before L0, L0 op_def only needs to match the post-cast dtype.
+
+### Mistake 6: Pairing AIC/AIV through task count instead of core count
+
+Cross-core flag protocols require both sides to participate with matching counts. Launching only `taskNum` blocks for half/bfloat16 `K>=16` can leave some AIC/AIV pairs unmatched.
+
+Symptom:
+
+- Small dense shapes may pass.
+- Varlen or partial chunk shapes timeout in `torch.npu.synchronize`.
+
+Correct direction:
+
+- For half/bfloat16 target cube paths, launch full AICore count.
+- Derive logical `coreIdx` from `GetBlockIdx() / GetSubBlockNum()` on AIV.
+- Make every `CrossCoreSetFlagWithReverse` have a matching wait on the paired side.
+
+### Mistake 7: Treating partial chunks like full chunks
+
+This is the biggest current trap.
+
+Full `BT=64` paths can use cube solve and fixed scratch slots. A partial chunk, for example a sequence segment of length 40, has different requirements:
+
+- Some AIV subblocks may have no valid rows.
+- AIC may still expect a ready flag for a chunk that AIV skipped.
+- Catlass tiles may read dirty rows if full tile cleanup is not designed.
+- `chunkIdx` is a scratch slot index, while `start` is a token offset. Do not mix the two.
+
+Do not claim high `K/V` varlen support until this is fixed.
+
+Correct direction for a future fix:
+
+1. Separate full chunk and partial chunk scheduling.
+2. For partial chunks, either:
+   - use a vector-only correctness path with no cube handshake, or
+   - pad/clean UB/GM scratch to full `BT` and still balance all AIC/AIV flags.
+3. Make `ResolveFlatChunk` return both:
+   - `globalTokenStart` for q/k/v/gk/beta/o reads and writes.
+   - `chunkSlot` for h/scratch/final state slots.
+4. Add timeout tests for `cu_seqlens` where at least one segment length is not divisible by `chunk_size`.
+
+### Mistake 8: Retrofitting `V=256` into the `V=128` template
+
+`V=256` doubles the row payload and changes whether `w/u/o/h_next` can stay in UB. A template that is acceptable for `V=128` can become scalar-bound, MTE-bound, or simply exceed practical UB staging when stretched.
+
+Correct direction:
+
+- Build a separate `V=256` template.
+- Recompute UB arena partitioning.
+- Decide which rows are resident and which are streamed.
+- Recheck Catlass tile shapes and post-WU/output cube paths.
+
+### Mistake 9: Overusing `SyncAll`
+
+`SyncAll` may hide lifecycle bugs while destroying performance. It is not a substitute for a clear producer-consumer protocol.
+
+Correct direction:
+
+- Prefer independent output regions.
+- For AIC/AIV cooperation, use named cross-core flags with reverse/credit behavior.
+- Keep flag ids centralized and avoid magic-number reuse.
+- Use kernel-stage separation when a dependency is naturally stage-wide.
+
+### Mistake 10: Misreading `ct viz` slowness
+
+`ct viz` can be slow for large tensors, so use sampling:
+
+```bash
+ct viz real.npy expect.npy --out_dir out --name name --diff_thd 0.03 --spatial -sc 4096
+```
+
+But if the program hangs before `.npy` files are produced, the problem is not `ct viz`. It is usually:
+
+- kernel timeout,
+- deadlocked cross-core flags,
+- out-of-bounds/invalid memory access,
+- or an op launch/runtime error.
+
+Always distinguish:
+
+```text
+Python produced .npy, ct viz is slow  -> use --sc
+torch.npu.synchronize times out      -> debug kernel
+```
+
+### Mistake 11: Reusing a UB tile without closing the VEC-to-MTE2 lifecycle
+
+This caused a real fixed-input, non-bitwise-stable bug in the `hasGk` path.
+
+Bad pattern:
+
+```cpp
+// hUpdateUbTensor is used as a temporary broadcast buffer.
+Broadcast(hUpdateUbTensor, gkScale, ...);
+Mul(calcUbTensor, calcUbTensor, hUpdateUbTensor, ...);
+
+// Later the same hUpdateUbTensor is reused as the MTE2 destination.
+WaitFlag<V_MTE2>(oldEvent);
+DataCopy(hUpdateUbTensor, hUpdateInput, ...);
+Add(hUpdateUbTensor, calcUbTensor, hUpdateUbTensor, ...);
+```
+
+Why it is wrong:
+
+- The old event only says the previous owner released the tile.
+- It does not say the current VEC writes to `hUpdateUbTensor` are finished before MTE2 overwrites it.
+- With fixed inputs, outputs can change between runs because `Add` may see the stale broadcast value instead of the copied `hUpdateInput`.
+
+Correct direction:
+
+1. Before using the tile as a VEC temporary, consume the free event for that tile.
+2. After the VEC temporary use finishes, set the matching `V_MTE2` event.
+3. Only then let the later MTE2 `DataCopy` wait on that event and overwrite the tile.
+
+For `chunk_gated_delta_rule_fwd_h`, the `hasGk` HUpdate path must keep:
+
+```cpp
+WaitFlag<V_MTE2>(EVENT_ID0 + pingpongFlag);
+...
+Mul(calcUbTensor, calcUbTensor, hUpdateUbTensor, ...);
+PipeBarrier<PIPE_V>();
+SetFlag<V_MTE2>(EVENT_ID0 + pingpongFlag);
+...
+WaitFlag<V_MTE2>(EVENT_ID0 + pingpongFlag);
+DataCopy(hUpdateUbTensor, hUpdateInputThisSubBlock, ...);
+```
+
+### Mistake 12: Running layout swap after upstream conv already converted layout
+
+KDA's kernel layout is BNSD. If upstream causal conv already produces BNSD/NTD-contiguous tensors, adding `KdaLayoutSwap12` inside KDA is pure overhead.
+
+Symptoms:
+
+- `msopprof` shows `KdaLayoutSwap12` dominating the target cases.
+- The short-head long-sequence case spends more time moving layout than computing KDA.
+
+Correct direction:
+
+- Treat BSND/TND as compatibility layouts.
+- Treat BNSD/NTD as the hot path.
+- For NTD, reshape to `[1, H, T, D]`/`[1, HV, T, D]` views in L2 and call the BNSD kernel directly.
+- `npu_kda_gate_cumsum` must preserve the input layout too; BNSD input returns BNSD `gk`, NTD input returns NTD `gk`.
+
+### Mistake 13: Using user outputs as split-path raw intermediates
+
+The split KDA forward path computes raw `o` and raw `Aqk`, then applies scale with elewise L0 ops. It also feeds `w/u/kg/h/v_new` between custom L0 ops.
+
+Bad pattern:
+
+```cpp
+// For BNSD direct input, oBnsd/aqkBnst point to user outputs.
+ChunkKdaFwd(..., oBnsd, aqkBnst, wBnsd, uBnsd, ...);
+auto aqkScaled = Muls(aqkBnst, scale, executor);
+auto hResult = ChunkGatedDeltaRuleFwdH(kgBnsd, wBnsd, uBnsd, ...);
+```
+
+Why it is wrong:
+
+- Executor-owned temporaries and user outputs do not behave the same in producer-consumer L0 chains.
+- Using user output tensors as raw intermediate inputs can trigger elewise tiling shape errors or invalid workspace inference, including impossible allocations.
+
+Correct direction:
+
+- In split forward, allocate executor-owned BNSD temporaries for `o/Aqk/Akk/w/u/qg/kg/v_new/h`.
+- Feed these temporaries through `ChunkKdaFwd`, elewise scale, and `ChunkGatedDeltaRuleFwdH`.
+- At the end, `ViewCopy` the temporary tensors to user outputs in the same BNSD/NTD layout. This is not a layout swap.
+- Keep `KdaLayoutSwap12` only for BSND/TND compatibility paths.
+
+## 3. KDA Forward Debug Checklist
+
+Before running long shapes:
+
+1. Build only the necessary operators:
+   - `chunk_kda_fwd`
+   - `chunk_gated_delta_rule_fwd_h`
+   - `kda_layout_swap12`
+   - `kda_gate_cumsum`
+2. Source the custom package environment.
+3. Confirm Python imports the installed `fla_npu` extension, not the source package without a compiled `.so`.
+4. Start with dense `T=64` and `T=128`.
+5. Compare `o` and `final_state` against `tests/reference/chunk_kda_reference.py`.
+6. Run `ct viz --sc` after outputs exist.
+7. Only then move to TND, varlen, and long sequence performance.
+
+## 4. Shape Ladder
+
+Use this progression to avoid wasting time:
+
+```text
+1. Dense BNSD, fp16, K=128, V=128, T=64
+2. Dense BNSD, fp16, K=128, V=128, T=128
+3. Dense NTD,  fp16, K=128, V=128, T=128
+4. Dense BNSD, fp16, K=128, V=128, T=512
+5. Varlen aligned cu_seqlens, all segment lengths divisible by chunk_size
+6. Varlen non-aligned cu_seqlens
+7. Long sequence performance
+8. V=256 only after a separate template exists
+```
+
+If step 6 times out, do not keep trying larger varlen shapes. Fix partial chunk scheduling first.
+
+## 5. What A Future Partial-Chunk Fix Must Prove
+
+A correct high `K/V` varlen implementation must prove:
+
+- Every AIC wait has a corresponding AIV set.
+- Every AIV wait has a corresponding AIC set.
+- Subblocks with no valid rows still participate in the flag protocol if their paired AIC expects them.
+- Dirty rows outside `curT` are either never read or explicitly padded to neutral values.
+- `Aqk/Akk` rows outside `curT` do not affect solve/output.
+- Scratch slots are indexed by compact chunk slot, not by absolute token start.
+- `h` output remains semantically ordered as `[chunk, HV, K, V]` for TND and `[B, chunk, HV, K, V]` for BSND public outputs.
+
+## 6. Public Reporting Rules
+
+When writing PR descriptions or test reports:
+
+- Do not include server names, IPs, usernames, absolute paths, temporary directories, package install directories, or log paths.
+- Report only what was tested and whether it passed.
+- Say "`ct viz --sc 4096` found no sampled point over threshold" instead of publishing artifact paths.
+- If a scenario times out, say the scenario and failure type, not where it was run.
+
+## 7. Minimal Known-Good Claims
+
+At the time this note was written, these claims were validated:
+
+- Custom package build passed for KDA forward and required helper/GDN operators.
+- Dense BSND `K=128, V=128, chunk_size=64` passed reference comparison.
+- Dense TND `K=128, V=128, chunk_size=64` passed reference comparison.
+- Dense BNSD and NTD direct layouts passed reference comparison.
+- Sampled `ct viz` with `-sc 4096` showed no points over `0.03` threshold for `o` and `final_state`.
+- Fixed-input repeated runs are bitwise stable for:
+  - standalone `chunk_gated_delta_rule_fwd_h` `hasGk`,
+  - KDA special-value dense case,
+  - KDA random dense case with `H_V=32`.
+- Sampled long-shape reference checks passed for:
+  - BNSD `B=1, H_K=1, H_V=2, T=16384, K=128, V=128, chunk_size=64`,
+  - BNSD `B=1, H_K=32, H_V=64, T=4096, K=128, V=128, chunk_size=64`,
+  - NTD `B=1, H_K=1, H_V=2, T=16384, K=128, V=128, chunk_size=64`.
+- `msopprof` BasicInfo measured no `KdaLayoutSwap12` on the BNSD target path.
+
+These claims must not be made without more work:
+
+- `V=256` template support.
+- Optimized high `K/V` non-aligned varlen support.
+- Backward KDA support.
+- Sanitizer-clean memory/race/sync result for the new high `K/V` varlen path.

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/CMakeLists.txt
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/CMakeLists.txt
@@ -1,0 +1,16 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# -----------------------------------------------------------------------------------------------------------
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+if(NOT ENABLE_TEST AND NOT BENCHMARK)
+    list(REMOVE_ITEM CURRENT_DIRS tests)
+endif()
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/CMakeLists.txt
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/CMakeLists.txt
@@ -1,0 +1,20 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# -----------------------------------------------------------------------------------------------------------
+add_op_to_compiled_list()
+if (BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnnExc PRIVATE
+        chunk_kda_fwd_def.cpp
+    )
+endif()
+
+add_modules_sources(OPTYPE chunk_kda_fwd ACLNNTYPE aclnn_exclude)
+add_ops_compile_options(
+    OP_NAME ChunkKdaFwd
+    OPTIONS --cce-auto-sync=off
+            -Wno-deprecated-declarations
+)

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/chunk_kda_fwd_def.cpp
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/chunk_kda_fwd_def.cpp
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "register/op_def_registry.h"
+
+namespace ops {
+class ChunkKdaFwd : public OpDef {
+public:
+    explicit ChunkKdaFwd(const char *name) : OpDef(name)
+    {
+        const std::initializer_list<ge::DataType> dataTypes = {
+            ge::DT_FLOAT, ge::DT_FLOAT16, ge::DT_BF16
+        };
+        const std::initializer_list<ge::DataType> stateTypes = {
+            ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT
+        };
+        const std::initializer_list<ge::Format> formats = {
+            ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND
+        };
+
+        this->Input("q").ParamType(REQUIRED).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Input("k").ParamType(REQUIRED).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Input("v").ParamType(REQUIRED).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Input("gk").ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format(formats).UnknownShapeFormat(formats);
+        this->Input("beta").ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format(formats).UnknownShapeFormat(formats);
+        this->Input("initial_state").ParamType(OPTIONAL).DataType(stateTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Input("cu_seqlens").ParamType(OPTIONAL).ValueDepend(OPTIONAL)
+            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
+            .Format(formats).UnknownShapeFormat(formats);
+        this->Input("chunk_indices").ParamType(OPTIONAL).ValueDepend(OPTIONAL)
+            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
+            .Format(formats).UnknownShapeFormat(formats);
+
+        this->Output("o").ParamType(REQUIRED).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Output("final_state").ParamType(REQUIRED).DataType(stateTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Output("Aqk").ParamType(REQUIRED).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Output("Akk").ParamType(REQUIRED).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Output("w").ParamType(REQUIRED).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Output("u").ParamType(REQUIRED).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Output("qg").ParamType(REQUIRED).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Output("kg").ParamType(REQUIRED).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Output("v_new").ParamType(REQUIRED).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Output("h").ParamType(REQUIRED).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+
+        this->Attr("scale").AttrType(REQUIRED).Float(1.0);
+        this->Attr("chunk_size").AttrType(REQUIRED).Int(64);
+        this->Attr("output_final_state").AttrType(REQUIRED).Bool(false);
+        this->Attr("total_chunks").AttrType(REQUIRED).Int(1);
+        this->Attr("stage").AttrType(OPTIONAL).Int(0);
+
+        OpAICoreConfig aicoreConfig;
+        aicoreConfig.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .PrecisionReduceFlag(true)
+            .ExtendCfgInfo("prebuildPattern.value", "Opaque")
+            .ExtendCfgInfo("coreType.value", "AiCore")
+            .ExtendCfgInfo("aclnnSupport.value", "support_aclnn");
+
+        this->AICore().AddConfig("ascend910b", aicoreConfig);
+        this->AICore().AddConfig("ascend910_93", aicoreConfig);
+        this->AICore().AddConfig("ascend950", aicoreConfig);
+    }
+};
+
+OP_ADD(ChunkKdaFwd);
+} // namespace ops

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/chunk_kda_fwd_tiling.cpp
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/chunk_kda_fwd_tiling.cpp
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "chunk_kda_fwd_tiling.h"
+#include <algorithm>
+#include <register/op_impl_registry.h>
+#include "tiling/platform/platform_ascendc.h"
+
+namespace optiling {
+namespace {
+constexpr size_t INPUT_Q_IDX = 0;
+constexpr size_t INPUT_V_IDX = 2;
+constexpr size_t INPUT_GK_IDX = 3;
+constexpr size_t INPUT_INITIAL_IDX = 5;
+constexpr size_t INPUT_CU_SEQLENS_IDX = 6;
+constexpr size_t ATTR_SCALE_IDX = 0;
+constexpr size_t ATTR_CHUNK_SIZE_IDX = 1;
+constexpr size_t ATTR_OUTPUT_FINAL_STATE_IDX = 2;
+constexpr size_t ATTR_TOTAL_CHUNKS_IDX = 3;
+constexpr size_t ATTR_STAGE_IDX = 4;
+
+constexpr size_t DIM_B = 0;
+constexpr size_t DIM_H = 1;
+constexpr size_t DIM_T = 2;
+constexpr size_t DIM_D = 3;
+
+int64_t DTypeCode(ge::DataType dtype)
+{
+    if (dtype == ge::DT_BF16) {
+        return 1;
+    }
+    if (dtype == ge::DT_FLOAT) {
+        return 2;
+    }
+    return 0;
+}
+} // namespace
+
+ge::graphStatus Tiling4ChunkKdaFwd(gert::TilingContext *context)
+{
+    ChunkKdaFwdTilingData tiling;
+
+    auto qShape = context->GetOptionalInputShape(INPUT_Q_IDX)->GetStorageShape();
+    auto vShape = context->GetOptionalInputShape(INPUT_V_IDX)->GetStorageShape();
+    auto qDesc = context->GetInputDesc(INPUT_Q_IDX);
+    auto gDesc = context->GetInputDesc(INPUT_GK_IDX);
+    if (qDesc == nullptr || gDesc == nullptr) {
+        return ge::GRAPH_FAILED;
+    }
+
+    auto attrPtr = context->GetAttrs();
+    if (attrPtr == nullptr) {
+        return ge::GRAPH_FAILED;
+    }
+    float scale = static_cast<float>(*(attrPtr->GetAttrPointer<double>(ATTR_SCALE_IDX)));
+    int64_t chunkSize = *(attrPtr->GetAttrPointer<int64_t>(ATTR_CHUNK_SIZE_IDX));
+    bool outputFinalState = *(attrPtr->GetAttrPointer<bool>(ATTR_OUTPUT_FINAL_STATE_IDX));
+    int64_t totalChunks = *(attrPtr->GetAttrPointer<int64_t>(ATTR_TOTAL_CHUNKS_IDX));
+    int64_t stage = 0;
+    const int64_t *stagePtr = attrPtr->GetAttrPointer<int64_t>(ATTR_STAGE_IDX);
+    if (stagePtr != nullptr) {
+        stage = *stagePtr;
+    }
+
+    bool isVarLen = context->GetOptionalInputTensor(INPUT_CU_SEQLENS_IDX) != nullptr;
+    int64_t batch = qShape.GetDim(DIM_B);
+    int64_t seqNum = batch;
+    if (isVarLen) {
+        auto cuTensor = context->GetOptionalInputTensor(INPUT_CU_SEQLENS_IDX);
+        seqNum = cuTensor->GetStorageShape().GetDim(0) - 1;
+    }
+
+    bool hasInitialState = context->GetOptionalInputTensor(INPUT_INITIAL_IDX) != nullptr;
+
+    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
+    uint32_t coreNum = ascendcPlatform.GetCoreNumAic();
+    int64_t taskNum = seqNum * vShape.GetDim(DIM_H);
+    if (stage == 1 || stage == 2 || stage == 3) {
+        taskNum = (isVarLen ? totalChunks : batch * totalChunks) * vShape.GetDim(DIM_H);
+    }
+    uint32_t blockDim = static_cast<uint32_t>(std::min<int64_t>(taskNum, coreNum));
+    if (stage == 1 || stage == 2 || stage == 3 ||
+        (qDesc->GetDataType() != ge::DT_FLOAT && qShape.GetDim(DIM_D) >= 16)) {
+        blockDim = coreNum;
+    }
+    context->SetBlockDim(blockDim == 0 ? 1 : blockDim);
+    size_t *workspace = context->GetWorkspaceSizes(1);
+    workspace[0] = ascendcPlatform.GetLibApiWorkSpaceSize();
+
+    tiling.set_batch(batch);
+    tiling.set_seqNum(seqNum);
+    tiling.set_qHeadNum(qShape.GetDim(DIM_H));
+    tiling.set_vHeadNum(vShape.GetDim(DIM_H));
+    tiling.set_seqlen(qShape.GetDim(DIM_T));
+    tiling.set_kHeadDim(qShape.GetDim(DIM_D));
+    tiling.set_vHeadDim(vShape.GetDim(DIM_D));
+    tiling.set_chunkSize(chunkSize);
+    tiling.set_totalChunks(totalChunks);
+    tiling.set_scale(scale);
+    tiling.set_hasInitialState(hasInitialState);
+    tiling.set_outputFinalState(outputFinalState);
+    tiling.set_isVarLen(isVarLen);
+    tiling.set_dataType(DTypeCode(qDesc->GetDataType()));
+    tiling.set_gateDataType(DTypeCode(gDesc->GetDataType()));
+    tiling.set_usedCoreNum(blockDim == 0 ? 1 : blockDim);
+    tiling.set_stage(stage);
+
+    if (qDesc->GetDataType() == ge::DT_FLOAT) {
+        context->SetTilingKey(0);
+    } else if (qShape.GetDim(DIM_D) < 16) {
+        context->SetTilingKey(2);
+    } else {
+        context->SetTilingKey(1);
+    }
+    tiling.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
+    context->GetRawTilingData()->SetDataSize(tiling.GetDataSize());
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus TilingPrepare4ChunkKdaFwd(gert::TilingParseContext *context)
+{
+    (void)context;
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(ChunkKdaFwd)
+    .Tiling(Tiling4ChunkKdaFwd)
+    .TilingParse<ChunkKdaFwdCompileInfo>(TilingPrepare4ChunkKdaFwd);
+
+} // namespace optiling

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/chunk_kda_fwd_tiling.h
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/chunk_kda_fwd_tiling.h
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <register/tilingdata_base.h>
+#include <tiling/tiling_api.h>
+
+namespace optiling {
+
+BEGIN_TILING_DATA_DEF(ChunkKdaFwdTilingData)
+TILING_DATA_FIELD_DEF(int64_t, batch);
+TILING_DATA_FIELD_DEF(int64_t, seqNum);
+TILING_DATA_FIELD_DEF(int64_t, qHeadNum);
+TILING_DATA_FIELD_DEF(int64_t, vHeadNum);
+TILING_DATA_FIELD_DEF(int64_t, seqlen);
+TILING_DATA_FIELD_DEF(int64_t, kHeadDim);
+TILING_DATA_FIELD_DEF(int64_t, vHeadDim);
+TILING_DATA_FIELD_DEF(int64_t, chunkSize);
+TILING_DATA_FIELD_DEF(int64_t, totalChunks);
+TILING_DATA_FIELD_DEF(float, scale);
+TILING_DATA_FIELD_DEF(bool, hasInitialState);
+TILING_DATA_FIELD_DEF(bool, outputFinalState);
+TILING_DATA_FIELD_DEF(bool, isVarLen);
+TILING_DATA_FIELD_DEF(int64_t, dataType);
+TILING_DATA_FIELD_DEF(int64_t, gateDataType);
+TILING_DATA_FIELD_DEF(int64_t, usedCoreNum);
+TILING_DATA_FIELD_DEF(int64_t, stage);
+END_TILING_DATA_DEF;
+
+REGISTER_TILING_DATA_CLASS(ChunkKdaFwd, ChunkKdaFwdTilingData)
+
+struct ChunkKdaFwdCompileInfo {};
+} // namespace optiling

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/aclnn_chunk_kda_fwd.cpp
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/aclnn_chunk_kda_fwd.cpp
@@ -1,0 +1,548 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "aclnn_chunk_kda_fwd.h"
+#include "chunk_kda_fwd.h"
+#include "../../../kda_layout_swap12/op_host/op_api/kda_layout_swap12.h"
+#include "../../../../gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/op_api/chunk_gated_delta_rule_fwd_h.h"
+
+#include "acl/acl.h"
+#include "aclnn/aclnn_base.h"
+#include "aclnn_kernels/cast.h"
+#include "aclnn_kernels/common/op_error_check.h"
+#include "aclnn_kernels/contiguous.h"
+#include "aclnn_kernels/reshape.h"
+#include "opdev/make_op_executor.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_executor.h"
+#include "opdev/op_log.h"
+#include "opdev/tensor_view_utils.h"
+
+using namespace op;
+
+namespace l0op {
+const aclTensor *Muls(const aclTensor *self, float alpha, aclOpExecutor *executor);
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+namespace {
+constexpr int64_t MAX_KDA_K_DIM = 256;
+
+struct ChunkKdaFwdParams {
+    const aclTensor *q = nullptr;
+    const aclTensor *k = nullptr;
+    const aclTensor *v = nullptr;
+    const aclTensor *gk = nullptr;
+    const aclTensor *beta = nullptr;
+    const aclTensor *initialStateOptional = nullptr;
+    const aclIntArray *cuSeqlensOptional = nullptr;
+    const aclIntArray *chunkIndicesOptional = nullptr;
+    double scale = 1.0;
+    int64_t chunkSize = 64;
+    bool outputFinalState = false;
+    int64_t totalChunks = 1;
+    const aclTensor *oOut = nullptr;
+    const aclTensor *finalStateOut = nullptr;
+    const aclTensor *aqkOut = nullptr;
+    const aclTensor *akkOut = nullptr;
+    const aclTensor *wOut = nullptr;
+    const aclTensor *uOut = nullptr;
+    const aclTensor *qgOut = nullptr;
+    const aclTensor *kgOut = nullptr;
+    const aclTensor *vNewOut = nullptr;
+    const aclTensor *hOut = nullptr;
+};
+
+aclnnStatus KdaFwdDataContiguous(const aclTensor *&tensor, aclOpExecutor *executor)
+{
+    if (tensor == nullptr) {
+        return ACLNN_SUCCESS;
+    }
+    tensor = l0op::Contiguous(tensor, executor);
+    CHECK_RET(tensor != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    return ACLNN_SUCCESS;
+}
+
+op::Shape KdaFwdMakeShape(std::initializer_list<int64_t> dims)
+{
+    op::Shape shape;
+    for (int64_t dim : dims) {
+        shape.AppendDim(dim);
+    }
+    return shape;
+}
+
+int64_t KdaFwdDim(const aclTensor *tensor, size_t idx)
+{
+    return tensor->GetViewShape().GetDim(idx);
+}
+
+size_t KdaFwdRank(const aclTensor *tensor)
+{
+    return tensor->GetViewShape().GetDimNum();
+}
+
+enum class KdaFwdLayout {
+    BSND,
+    BNSD,
+    TND,
+    NTD,
+};
+
+KdaFwdLayout InferKdaFwdLayout(const ChunkKdaFwdParams &params)
+{
+    size_t rank = KdaFwdRank(params.q);
+    if (rank == 3) {
+        bool isTnd = KdaFwdDim(params.v, 0) == KdaFwdDim(params.q, 0) &&
+                     KdaFwdDim(params.gk, 0) == KdaFwdDim(params.q, 0) &&
+                     KdaFwdDim(params.beta, 0) == KdaFwdDim(params.q, 0) &&
+                     KdaFwdDim(params.gk, 1) == KdaFwdDim(params.v, 1) &&
+                     KdaFwdDim(params.beta, 1) == KdaFwdDim(params.v, 1) &&
+                     KdaFwdDim(params.gk, 2) == KdaFwdDim(params.q, 2);
+        bool isNtd = KdaFwdDim(params.v, 1) == KdaFwdDim(params.q, 1) &&
+                     KdaFwdDim(params.gk, 0) == KdaFwdDim(params.v, 0) &&
+                     KdaFwdDim(params.beta, 0) == KdaFwdDim(params.v, 0) &&
+                     KdaFwdDim(params.gk, 1) == KdaFwdDim(params.q, 1) &&
+                     KdaFwdDim(params.beta, 1) == KdaFwdDim(params.q, 1) &&
+                     KdaFwdDim(params.gk, 2) == KdaFwdDim(params.q, 2);
+        if (isTnd && isNtd) {
+            return KdaFwdDim(params.q, 0) <= KdaFwdDim(params.q, 1) ? KdaFwdLayout::NTD : KdaFwdLayout::TND;
+        }
+        return isNtd ? KdaFwdLayout::NTD : KdaFwdLayout::TND;
+    }
+
+    bool isBsnd = KdaFwdDim(params.v, 0) == KdaFwdDim(params.q, 0) &&
+                  KdaFwdDim(params.v, 1) == KdaFwdDim(params.q, 1) &&
+                  KdaFwdDim(params.gk, 0) == KdaFwdDim(params.q, 0) &&
+                  KdaFwdDim(params.gk, 1) == KdaFwdDim(params.q, 1) &&
+                  KdaFwdDim(params.beta, 0) == KdaFwdDim(params.q, 0) &&
+                  KdaFwdDim(params.beta, 1) == KdaFwdDim(params.q, 1) &&
+                  KdaFwdDim(params.gk, 2) == KdaFwdDim(params.v, 2) &&
+                  KdaFwdDim(params.beta, 2) == KdaFwdDim(params.v, 2) &&
+                  KdaFwdDim(params.gk, 3) == KdaFwdDim(params.q, 3);
+    bool isBnsd = KdaFwdDim(params.v, 0) == KdaFwdDim(params.q, 0) &&
+                  KdaFwdDim(params.v, 2) == KdaFwdDim(params.q, 2) &&
+                  KdaFwdDim(params.gk, 0) == KdaFwdDim(params.q, 0) &&
+                  KdaFwdDim(params.gk, 1) == KdaFwdDim(params.v, 1) &&
+                  KdaFwdDim(params.beta, 0) == KdaFwdDim(params.q, 0) &&
+                  KdaFwdDim(params.beta, 1) == KdaFwdDim(params.v, 1) &&
+                  KdaFwdDim(params.gk, 2) == KdaFwdDim(params.q, 2) &&
+                  KdaFwdDim(params.beta, 2) == KdaFwdDim(params.q, 2) &&
+                  KdaFwdDim(params.gk, 3) == KdaFwdDim(params.q, 3);
+    if (isBsnd && isBnsd) {
+        return KdaFwdDim(params.q, 1) <= KdaFwdDim(params.q, 2) ? KdaFwdLayout::BNSD : KdaFwdLayout::BSND;
+    }
+    return isBnsd ? KdaFwdLayout::BNSD : KdaFwdLayout::BSND;
+}
+
+aclnnStatus KdaFwdCheckParams(const ChunkKdaFwdParams &params)
+{
+    CHECK_COND(params.q != nullptr, ACLNN_ERR_PARAM_NULLPTR, "q must not be nullptr.");
+    CHECK_COND(params.k != nullptr, ACLNN_ERR_PARAM_NULLPTR, "k must not be nullptr.");
+    CHECK_COND(params.v != nullptr, ACLNN_ERR_PARAM_NULLPTR, "v must not be nullptr.");
+    CHECK_COND(params.gk != nullptr, ACLNN_ERR_PARAM_NULLPTR, "gk must not be nullptr.");
+    CHECK_COND(params.beta != nullptr, ACLNN_ERR_PARAM_NULLPTR, "beta must not be nullptr.");
+    CHECK_COND(params.oOut != nullptr && params.finalStateOut != nullptr && params.aqkOut != nullptr &&
+                   params.akkOut != nullptr && params.wOut != nullptr && params.uOut != nullptr &&
+                   params.qgOut != nullptr && params.kgOut != nullptr && params.vNewOut != nullptr &&
+                   params.hOut != nullptr,
+               ACLNN_ERR_PARAM_NULLPTR, "ChunkKdaFwd outputs must not be nullptr.");
+    CHECK_COND(params.chunkSize > 0, ACLNN_ERR_PARAM_INVALID, "chunkSize must be positive.");
+    CHECK_COND(params.totalChunks > 0, ACLNN_ERR_PARAM_INVALID, "totalChunks must be positive.");
+    size_t qRank = KdaFwdRank(params.q);
+    size_t betaRank = KdaFwdRank(params.beta);
+    CHECK_COND((qRank == 4 && betaRank == 3) || (qRank == 3 && betaRank == 2), ACLNN_ERR_PARAM_INVALID,
+               "q/k/v/gk must be BSND/BNSD rank4 with beta rank3, or TND/NTD rank3 with beta rank2.");
+    size_t kDimIdx = (qRank == 4) ? 3 : 2;
+    CHECK_COND(params.q->GetViewShape().GetDim(kDimIdx) <= MAX_KDA_K_DIM, ACLNN_ERR_PARAM_INVALID,
+               "k head dimension must be less than or equal to 256.");
+    return ACLNN_SUCCESS;
+}
+
+aclnnStatus KdaFwdParamsDataContiguous(ChunkKdaFwdParams &params, aclOpExecutor *executor)
+{
+    CHECK_RET(KdaFwdDataContiguous(params.q, executor) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(KdaFwdDataContiguous(params.k, executor) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(KdaFwdDataContiguous(params.v, executor) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(KdaFwdDataContiguous(params.gk, executor) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(KdaFwdDataContiguous(params.beta, executor) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(KdaFwdDataContiguous(params.initialStateOptional, executor) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    return ACLNN_SUCCESS;
+}
+} // namespace
+
+aclnnStatus aclnnChunkKdaFwdGetWorkspaceSize(
+    const aclTensor *q,
+    const aclTensor *k,
+    const aclTensor *v,
+    const aclTensor *gk,
+    const aclTensor *beta,
+    const aclTensor *initialStateOptional,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    double scale,
+    int64_t chunkSize,
+    bool outputFinalState,
+    int64_t totalChunks,
+    const aclTensor *oOut,
+    const aclTensor *finalStateOut,
+    const aclTensor *aqkOut,
+    const aclTensor *akkOut,
+    const aclTensor *wOut,
+    const aclTensor *uOut,
+    const aclTensor *qgOut,
+    const aclTensor *kgOut,
+    const aclTensor *vNewOut,
+    const aclTensor *hOut,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor)
+{
+    ChunkKdaFwdParams params{q, k, v, gk, beta, initialStateOptional, cuSeqlensOptional, chunkIndicesOptional,
+                             scale, chunkSize, outputFinalState, totalChunks, oOut, finalStateOut, aqkOut,
+                             akkOut, wOut, uOut, qgOut, kgOut, vNewOut, hOut};
+    L2_DFX_PHASE_1(aclnnChunkKdaFwd,
+                   DFX_IN(q, k, v, gk, beta, initialStateOptional, cuSeqlensOptional, chunkIndicesOptional),
+                   DFX_OUT(oOut, finalStateOut, aqkOut, akkOut, wOut, uOut, qgOut, kgOut, vNewOut, hOut));
+    auto uniqueExecutor = CREATE_EXECUTOR();
+    CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);
+    auto executorPtr = uniqueExecutor.get();
+    CHECK_RET(KdaFwdCheckParams(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(KdaFwdParamsDataContiguous(params, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+
+    KdaFwdLayout layout = InferKdaFwdLayout(params);
+    bool isTnd = layout == KdaFwdLayout::TND || layout == KdaFwdLayout::NTD;
+    bool isInternalLayout = layout == KdaFwdLayout::BNSD || layout == KdaFwdLayout::NTD;
+    int64_t batch = isTnd ? 1 : KdaFwdDim(params.q, 0);
+    int64_t seqlen = layout == KdaFwdLayout::TND ? KdaFwdDim(params.q, 0) :
+                     (layout == KdaFwdLayout::NTD ? KdaFwdDim(params.q, 1) :
+                     (layout == KdaFwdLayout::BNSD ? KdaFwdDim(params.q, 2) : KdaFwdDim(params.q, 1)));
+    int64_t hNum = layout == KdaFwdLayout::TND ? KdaFwdDim(params.q, 1) :
+                   (layout == KdaFwdLayout::NTD ? KdaFwdDim(params.q, 0) :
+                   (layout == KdaFwdLayout::BNSD ? KdaFwdDim(params.q, 1) : KdaFwdDim(params.q, 2)));
+    int64_t kDim = isTnd ? KdaFwdDim(params.q, 2) : KdaFwdDim(params.q, 3);
+    int64_t hvNum = layout == KdaFwdLayout::TND ? KdaFwdDim(params.v, 1) :
+                    (layout == KdaFwdLayout::NTD ? KdaFwdDim(params.v, 0) :
+                    (layout == KdaFwdLayout::BNSD ? KdaFwdDim(params.v, 1) : KdaFwdDim(params.v, 2)));
+    int64_t vDim = isTnd ? KdaFwdDim(params.v, 2) : KdaFwdDim(params.v, 3);
+
+    const aclTensor *qBsnd = params.q;
+    const aclTensor *kBsnd = params.k;
+    const aclTensor *vBsnd = params.v;
+    const aclTensor *gkBsnd = params.gk;
+    const aclTensor *betaBsn = params.beta;
+    if (layout == KdaFwdLayout::TND) {
+        qBsnd = l0op::Reshape(params.q, KdaFwdMakeShape({1, seqlen, hNum, kDim}), executorPtr);
+        kBsnd = l0op::Reshape(params.k, KdaFwdMakeShape({1, seqlen, hNum, kDim}), executorPtr);
+        vBsnd = l0op::Reshape(params.v, KdaFwdMakeShape({1, seqlen, hvNum, vDim}), executorPtr);
+        gkBsnd = l0op::Reshape(params.gk, KdaFwdMakeShape({1, seqlen, hvNum, kDim}), executorPtr);
+        betaBsn = l0op::Reshape(params.beta, KdaFwdMakeShape({1, seqlen, hvNum}), executorPtr);
+        CHECK_RET(qBsnd != nullptr && kBsnd != nullptr && vBsnd != nullptr && gkBsnd != nullptr && betaBsn != nullptr,
+                  ACLNN_ERR_INNER_NULLPTR);
+    } else if (layout == KdaFwdLayout::NTD) {
+        qBsnd = l0op::Reshape(params.q, KdaFwdMakeShape({1, hNum, seqlen, kDim}), executorPtr);
+        kBsnd = l0op::Reshape(params.k, KdaFwdMakeShape({1, hNum, seqlen, kDim}), executorPtr);
+        vBsnd = l0op::Reshape(params.v, KdaFwdMakeShape({1, hvNum, seqlen, vDim}), executorPtr);
+        gkBsnd = l0op::Reshape(params.gk, KdaFwdMakeShape({1, hvNum, seqlen, kDim}), executorPtr);
+        betaBsn = l0op::Reshape(params.beta, KdaFwdMakeShape({1, hvNum, seqlen}), executorPtr);
+        CHECK_RET(qBsnd != nullptr && kBsnd != nullptr && vBsnd != nullptr && gkBsnd != nullptr && betaBsn != nullptr,
+                  ACLNN_ERR_INNER_NULLPTR);
+    }
+
+    const aclTensor *qBnsd = isInternalLayout ? qBsnd :
+        executorPtr->AllocTensor(KdaFwdMakeShape({batch, hNum, seqlen, kDim}),
+                                 params.q->GetDataType(), Format::FORMAT_ND);
+    const aclTensor *kBnsd = isInternalLayout ? kBsnd :
+        executorPtr->AllocTensor(KdaFwdMakeShape({batch, hNum, seqlen, kDim}),
+                                 params.k->GetDataType(), Format::FORMAT_ND);
+    const aclTensor *vBnsd = isInternalLayout ? vBsnd :
+        executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, vDim}),
+                                 params.v->GetDataType(), Format::FORMAT_ND);
+    const aclTensor *gkBnsdRaw = isInternalLayout ? gkBsnd :
+        executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, kDim}),
+                                 params.gk->GetDataType(), Format::FORMAT_ND);
+    const aclTensor *betaBnsRaw = isInternalLayout ? betaBsn :
+        executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen}),
+                                 params.beta->GetDataType(), Format::FORMAT_ND);
+    const aclTensor *oBnsd = nullptr;
+    const aclTensor *aqkBnst = nullptr;
+    const aclTensor *akkBnst = nullptr;
+    const aclTensor *wBnsd = nullptr;
+    const aclTensor *uBnsd = nullptr;
+    const aclTensor *qgBnsd = nullptr;
+    const aclTensor *kgBnsd = nullptr;
+    const aclTensor *vNewBnsd = nullptr;
+    const aclTensor *hBnst = nullptr;
+    if (isInternalLayout) {
+        if (layout == KdaFwdLayout::NTD) {
+            oBnsd = l0op::Reshape(params.oOut, KdaFwdMakeShape({1, hvNum, seqlen, vDim}), executorPtr);
+            aqkBnst = l0op::Reshape(params.aqkOut, KdaFwdMakeShape({1, hvNum, seqlen, params.chunkSize}),
+                                    executorPtr);
+            akkBnst = l0op::Reshape(params.akkOut, KdaFwdMakeShape({1, hvNum, seqlen, params.chunkSize}),
+                                    executorPtr);
+            wBnsd = l0op::Reshape(params.wOut, KdaFwdMakeShape({1, hvNum, seqlen, kDim}), executorPtr);
+            uBnsd = l0op::Reshape(params.uOut, KdaFwdMakeShape({1, hvNum, seqlen, vDim}), executorPtr);
+            qgBnsd = l0op::Reshape(params.qgOut, KdaFwdMakeShape({1, hvNum, seqlen, kDim}), executorPtr);
+            kgBnsd = l0op::Reshape(params.kgOut, KdaFwdMakeShape({1, hvNum, seqlen, kDim}), executorPtr);
+            vNewBnsd = l0op::Reshape(params.vNewOut, KdaFwdMakeShape({1, hvNum, seqlen, vDim}), executorPtr);
+            hBnst = l0op::Reshape(params.hOut, KdaFwdMakeShape({1, hvNum, params.totalChunks, kDim, vDim}),
+                                  executorPtr);
+        } else {
+            oBnsd = params.oOut;
+            aqkBnst = params.aqkOut;
+            akkBnst = params.akkOut;
+            wBnsd = params.wOut;
+            uBnsd = params.uOut;
+            qgBnsd = params.qgOut;
+            kgBnsd = params.kgOut;
+            vNewBnsd = params.vNewOut;
+            hBnst = params.hOut;
+        }
+    } else {
+        oBnsd = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, vDim}),
+                                         params.oOut->GetDataType(), Format::FORMAT_ND);
+        aqkBnst = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, params.chunkSize}),
+                                           params.aqkOut->GetDataType(), Format::FORMAT_ND);
+        akkBnst = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, params.chunkSize}),
+                                           params.akkOut->GetDataType(), Format::FORMAT_ND);
+        wBnsd = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, kDim}),
+                                         params.wOut->GetDataType(), Format::FORMAT_ND);
+        uBnsd = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, vDim}),
+                                         params.uOut->GetDataType(), Format::FORMAT_ND);
+        qgBnsd = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, kDim}),
+                                          params.qgOut->GetDataType(), Format::FORMAT_ND);
+        kgBnsd = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, kDim}),
+                                          params.kgOut->GetDataType(), Format::FORMAT_ND);
+        vNewBnsd = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, vDim}),
+                                            params.vNewOut->GetDataType(), Format::FORMAT_ND);
+        hBnst = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, params.totalChunks, kDim, vDim}),
+                                         params.hOut->GetDataType(), Format::FORMAT_ND);
+    }
+    CHECK_RET(qBnsd != nullptr && kBnsd != nullptr && vBnsd != nullptr && gkBnsdRaw != nullptr &&
+                  betaBnsRaw != nullptr && oBnsd != nullptr && aqkBnst != nullptr && akkBnst != nullptr &&
+                  wBnsd != nullptr && uBnsd != nullptr && qgBnsd != nullptr && kgBnsd != nullptr &&
+                  vNewBnsd != nullptr && hBnst != nullptr,
+              ACLNN_ERR_INNER_NULLPTR);
+
+    if (!isInternalLayout) {
+        CHECK_RET(l0op::KdaLayoutSwap12(qBsnd, qBnsd, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(kBsnd, kBnsd, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(vBsnd, vBnsd, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(gkBsnd, gkBnsdRaw, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(betaBsn, betaBnsRaw, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    }
+
+    const aclTensor *gkBnsd = gkBnsdRaw;
+    const aclTensor *betaBns = betaBnsRaw;
+    if (gkBnsd->GetDataType() != DataType::DT_FLOAT) {
+        gkBnsd = l0op::Cast(gkBnsd, DataType::DT_FLOAT, executorPtr);
+        CHECK_RET(gkBnsd != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    }
+    if (betaBns->GetDataType() != DataType::DT_FLOAT) {
+        betaBns = l0op::Cast(betaBns, DataType::DT_FLOAT, executorPtr);
+        CHECK_RET(betaBns != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    }
+
+    std::array<const aclTensor *, 10> result;
+    bool useSplitForward = params.q->GetDataType() != DataType::DT_FLOAT && params.chunkSize == 64 &&
+                           kDim * vDim >= 8192;
+    const aclTensor *oComputeBnsd = oBnsd;
+    const aclTensor *aqkComputeBnst = aqkBnst;
+    const aclTensor *akkComputeBnst = akkBnst;
+    const aclTensor *wComputeBnsd = wBnsd;
+    const aclTensor *uComputeBnsd = uBnsd;
+    const aclTensor *qgComputeBnsd = qgBnsd;
+    const aclTensor *kgComputeBnsd = kgBnsd;
+    const aclTensor *vNewComputeBnsd = vNewBnsd;
+    const aclTensor *hComputeBnst = hBnst;
+    if (useSplitForward && isInternalLayout) {
+        oComputeBnsd = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, vDim}),
+                                                params.oOut->GetDataType(), Format::FORMAT_ND);
+        aqkComputeBnst = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, params.chunkSize}),
+                                                  params.aqkOut->GetDataType(), Format::FORMAT_ND);
+        akkComputeBnst = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, params.chunkSize}),
+                                                  params.akkOut->GetDataType(), Format::FORMAT_ND);
+        wComputeBnsd = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, kDim}),
+                                                params.wOut->GetDataType(), Format::FORMAT_ND);
+        uComputeBnsd = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, vDim}),
+                                                params.uOut->GetDataType(), Format::FORMAT_ND);
+        qgComputeBnsd = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, kDim}),
+                                                 params.qgOut->GetDataType(), Format::FORMAT_ND);
+        kgComputeBnsd = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, kDim}),
+                                                 params.kgOut->GetDataType(), Format::FORMAT_ND);
+        vNewComputeBnsd = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, vDim}),
+                                                   params.vNewOut->GetDataType(), Format::FORMAT_ND);
+        hComputeBnst = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, params.totalChunks, kDim, vDim}),
+                                                params.hOut->GetDataType(), Format::FORMAT_ND);
+        CHECK_RET(oComputeBnsd != nullptr && aqkComputeBnst != nullptr && akkComputeBnst != nullptr &&
+                      wComputeBnsd != nullptr && uComputeBnsd != nullptr && qgComputeBnsd != nullptr &&
+                      kgComputeBnsd != nullptr && vNewComputeBnsd != nullptr && hComputeBnst != nullptr,
+                  ACLNN_ERR_INNER_NULLPTR);
+    }
+    if (useSplitForward) {
+        auto prepResult = l0op::ChunkKdaFwd(qBnsd, kBnsd, vBnsd, gkBnsd, betaBns, params.initialStateOptional,
+                                            params.cuSeqlensOptional, params.chunkIndicesOptional, params.scale,
+                                            params.chunkSize, params.outputFinalState, params.totalChunks, 1,
+                                            oComputeBnsd, params.finalStateOut, aqkComputeBnst, akkComputeBnst,
+                                            wComputeBnsd, uComputeBnsd, qgComputeBnsd, kgComputeBnsd,
+                                            vNewComputeBnsd, hComputeBnst, executorPtr);
+        for (auto tensor : prepResult) {
+            CHECK_RET(tensor != nullptr, ACLNN_ERR_PARAM_NULLPTR);
+        }
+        const aclTensor *aqkScaledBnst = l0op::Muls(aqkComputeBnst, static_cast<float>(params.scale), executorPtr);
+        CHECK_RET(aqkScaledBnst != nullptr, ACLNN_ERR_INNER_NULLPTR);
+
+        auto wScratchBntd = executorPtr->AllocTensor(
+            KdaFwdMakeShape({batch, hvNum, params.totalChunks, params.chunkSize, kDim}),
+            params.wOut->GetDataType(), Format::FORMAT_ND);
+        CHECK_RET(wScratchBntd != nullptr, ACLNN_ERR_INNER_NULLPTR);
+
+        auto postResult = l0op::ChunkKdaFwd(qBnsd, kBnsd, vBnsd, gkBnsd, betaBns, params.initialStateOptional,
+                                            params.cuSeqlensOptional, params.chunkIndicesOptional, params.scale,
+                                            params.chunkSize, params.outputFinalState, params.totalChunks, 3,
+                                            oComputeBnsd, params.finalStateOut, aqkComputeBnst, akkComputeBnst,
+                                            wComputeBnsd, uComputeBnsd, qgComputeBnsd, kgComputeBnsd,
+                                            vNewComputeBnsd, wScratchBntd, executorPtr);
+        for (auto tensor : postResult) {
+            CHECK_RET(tensor != nullptr, ACLNN_ERR_PARAM_NULLPTR);
+        }
+
+        const aclTensor *wForHFp32 = l0op::Cast(wComputeBnsd, DataType::DT_FLOAT, executorPtr);
+        CHECK_RET(wForHFp32 != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        const aclTensor *wForH = l0op::Cast(wForHFp32, params.wOut->GetDataType(), executorPtr);
+        CHECK_RET(wForH != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        auto hResult = l0op::ChunkGatedDeltaRuleFwdH(kgComputeBnsd, wForH, uComputeBnsd, nullptr, gkBnsd,
+                                                     params.initialStateOptional, params.cuSeqlensOptional,
+                                                     params.chunkIndicesOptional, params.outputFinalState,
+                                                     params.chunkSize, hComputeBnst, vNewComputeBnsd, params.finalStateOut,
+                                                     executorPtr);
+        for (auto tensor : hResult) {
+            CHECK_RET(tensor != nullptr, ACLNN_ERR_PARAM_NULLPTR);
+        }
+
+        auto oLocalBnsd = executorPtr->AllocTensor(KdaFwdMakeShape({batch, hvNum, seqlen, vDim}),
+                                                   params.uOut->GetDataType(), Format::FORMAT_ND);
+        CHECK_RET(oLocalBnsd != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        auto outResult = l0op::ChunkKdaFwd(qBnsd, kBnsd, vBnsd, gkBnsd, betaBns, params.initialStateOptional,
+                                           params.cuSeqlensOptional, params.chunkIndicesOptional, params.scale,
+                                           params.chunkSize, params.outputFinalState, params.totalChunks, 2,
+                                           oComputeBnsd, params.finalStateOut, aqkComputeBnst, akkComputeBnst,
+                                           wComputeBnsd, oLocalBnsd, qgComputeBnsd, kgComputeBnsd,
+                                           vNewComputeBnsd, hComputeBnst, executorPtr);
+        for (auto tensor : outResult) {
+            CHECK_RET(tensor != nullptr, ACLNN_ERR_PARAM_NULLPTR);
+        }
+        const aclTensor *oScaledBnsd = l0op::Muls(oComputeBnsd, static_cast<float>(params.scale), executorPtr);
+        CHECK_RET(oScaledBnsd != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        result = {oScaledBnsd, params.finalStateOut, aqkScaledBnst, akkComputeBnst, wComputeBnsd, uComputeBnsd,
+                  qgComputeBnsd, kgComputeBnsd, vNewComputeBnsd, hComputeBnst};
+    } else {
+        result = l0op::ChunkKdaFwd(qBnsd, kBnsd, vBnsd, gkBnsd, betaBns, params.initialStateOptional,
+                                   params.cuSeqlensOptional, params.chunkIndicesOptional, params.scale,
+                                   params.chunkSize, params.outputFinalState, params.totalChunks, 0, oBnsd,
+                                   params.finalStateOut, aqkBnst, akkBnst, wBnsd, uBnsd, qgBnsd, kgBnsd,
+                                   vNewBnsd, hBnst, executorPtr);
+    }
+    for (auto tensor : result) {
+        CHECK_RET(tensor != nullptr, ACLNN_ERR_PARAM_NULLPTR);
+    }
+    if (isInternalLayout) {
+        if (useSplitForward) {
+            CHECK_RET(l0op::ViewCopy(result[0], oBnsd, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+            CHECK_RET(l0op::ViewCopy(result[2], aqkBnst, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+            CHECK_RET(l0op::ViewCopy(result[3], akkBnst, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+            CHECK_RET(l0op::ViewCopy(result[4], wBnsd, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+            CHECK_RET(l0op::ViewCopy(result[5], uBnsd, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+            CHECK_RET(l0op::ViewCopy(result[6], qgBnsd, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+            CHECK_RET(l0op::ViewCopy(result[7], kgBnsd, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+            CHECK_RET(l0op::ViewCopy(result[8], vNewBnsd, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+            CHECK_RET(l0op::ViewCopy(result[9], hBnst, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        }
+    } else if (isTnd) {
+        auto oBsnd = executorPtr->AllocTensor(KdaFwdMakeShape({1, seqlen, hvNum, vDim}),
+                                              params.oOut->GetDataType(), Format::FORMAT_ND);
+        auto aqkBsnt = executorPtr->AllocTensor(KdaFwdMakeShape({1, seqlen, hvNum, params.chunkSize}),
+                                                params.aqkOut->GetDataType(), Format::FORMAT_ND);
+        auto akkBsnt = executorPtr->AllocTensor(KdaFwdMakeShape({1, seqlen, hvNum, params.chunkSize}),
+                                                params.akkOut->GetDataType(), Format::FORMAT_ND);
+        auto wBsnd = executorPtr->AllocTensor(KdaFwdMakeShape({1, seqlen, hvNum, kDim}),
+                                              params.wOut->GetDataType(), Format::FORMAT_ND);
+        auto uBsnd = executorPtr->AllocTensor(KdaFwdMakeShape({1, seqlen, hvNum, vDim}),
+                                              params.uOut->GetDataType(), Format::FORMAT_ND);
+        auto qgBsnd = executorPtr->AllocTensor(KdaFwdMakeShape({1, seqlen, hvNum, kDim}),
+                                               params.qgOut->GetDataType(), Format::FORMAT_ND);
+        auto kgBsnd = executorPtr->AllocTensor(KdaFwdMakeShape({1, seqlen, hvNum, kDim}),
+                                               params.kgOut->GetDataType(), Format::FORMAT_ND);
+        auto vNewBsnd = executorPtr->AllocTensor(KdaFwdMakeShape({1, seqlen, hvNum, vDim}),
+                                                 params.vNewOut->GetDataType(), Format::FORMAT_ND);
+        auto hBsnt = executorPtr->AllocTensor(KdaFwdMakeShape({1, params.totalChunks, hvNum, kDim, vDim}),
+                                              params.hOut->GetDataType(), Format::FORMAT_ND);
+        CHECK_RET(oBsnd != nullptr && aqkBsnt != nullptr && akkBsnt != nullptr && wBsnd != nullptr &&
+                      uBsnd != nullptr && qgBsnd != nullptr && kgBsnd != nullptr && vNewBsnd != nullptr &&
+                      hBsnt != nullptr,
+                  ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[0], oBsnd, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[2], aqkBsnt, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[3], akkBsnt, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[4], wBsnd, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[5], uBsnd, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[6], qgBsnd, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[7], kgBsnd, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[8], vNewBsnd, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[9], hBsnt, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::ViewCopy(l0op::Reshape(oBsnd, KdaFwdMakeShape({seqlen, hvNum, vDim}), executorPtr),
+                                 params.oOut, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::ViewCopy(l0op::Reshape(aqkBsnt, KdaFwdMakeShape({seqlen, hvNum, params.chunkSize}),
+                                                executorPtr),
+                                 params.aqkOut, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::ViewCopy(l0op::Reshape(akkBsnt, KdaFwdMakeShape({seqlen, hvNum, params.chunkSize}),
+                                                executorPtr),
+                                 params.akkOut, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::ViewCopy(l0op::Reshape(wBsnd, KdaFwdMakeShape({seqlen, hvNum, kDim}), executorPtr),
+                                 params.wOut, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::ViewCopy(l0op::Reshape(uBsnd, KdaFwdMakeShape({seqlen, hvNum, vDim}), executorPtr),
+                                 params.uOut, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::ViewCopy(l0op::Reshape(qgBsnd, KdaFwdMakeShape({seqlen, hvNum, kDim}), executorPtr),
+                                 params.qgOut, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::ViewCopy(l0op::Reshape(kgBsnd, KdaFwdMakeShape({seqlen, hvNum, kDim}), executorPtr),
+                                 params.kgOut, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::ViewCopy(l0op::Reshape(vNewBsnd, KdaFwdMakeShape({seqlen, hvNum, vDim}), executorPtr),
+                                 params.vNewOut, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::ViewCopy(l0op::Reshape(hBsnt, KdaFwdMakeShape({params.totalChunks, hvNum, kDim, vDim}),
+                                                executorPtr),
+                                 params.hOut, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    } else {
+        CHECK_RET(l0op::KdaLayoutSwap12(result[0], params.oOut, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[2], params.aqkOut, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[3], params.akkOut, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[4], params.wOut, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[5], params.uOut, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[6], params.qgOut, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[7], params.kgOut, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[8], params.vNewOut, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        CHECK_RET(l0op::KdaLayoutSwap12(result[9], params.hOut, executorPtr)[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    }
+    *workspaceSize = uniqueExecutor->GetWorkspaceSize();
+    uniqueExecutor.ReleaseTo(executor);
+    return ACLNN_SUCCESS;
+}
+
+aclnnStatus aclnnChunkKdaFwd(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor, aclrtStream stream)
+{
+    L2_DFX_PHASE_2(aclnnChunkKdaFwd);
+    CHECK_COND(CommonOpExecutorRun(workspace, workspaceSize, executor, stream) == ACLNN_SUCCESS, ACLNN_ERR_INNER,
+               "ChunkKdaFwd launch failed.");
+    return ACLNN_SUCCESS;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/aclnn_chunk_kda_fwd.h
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/aclnn_chunk_kda_fwd.h
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+#ifndef OP_API_INC_ACLNN_CHUNK_KDA_FWD_H
+#define OP_API_INC_ACLNN_CHUNK_KDA_FWD_H
+
+#include "aclnn/aclnn_base.h"
+#include "aclnn_util.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+aclnnStatus aclnnChunkKdaFwdGetWorkspaceSize(
+    const aclTensor *q,
+    const aclTensor *k,
+    const aclTensor *v,
+    const aclTensor *gk,
+    const aclTensor *beta,
+    const aclTensor *initialStateOptional,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    double scale,
+    int64_t chunkSize,
+    bool outputFinalState,
+    int64_t totalChunks,
+    const aclTensor *oOut,
+    const aclTensor *finalStateOut,
+    const aclTensor *aqkOut,
+    const aclTensor *akkOut,
+    const aclTensor *wOut,
+    const aclTensor *uOut,
+    const aclTensor *qgOut,
+    const aclTensor *kgOut,
+    const aclTensor *vNewOut,
+    const aclTensor *hOut,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor);
+
+aclnnStatus aclnnChunkKdaFwd(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor, aclrtStream stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/chunk_kda_fwd.cpp
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/chunk_kda_fwd.cpp
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "chunk_kda_fwd.h"
+
+#include "opdev/make_op_executor.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_log.h"
+
+using namespace op;
+
+namespace l0op {
+OP_TYPE_REGISTER(ChunkKdaFwd);
+
+const std::array<const aclTensor *, 10> ChunkKdaFwd(
+    const aclTensor *q,
+    const aclTensor *k,
+    const aclTensor *v,
+    const aclTensor *gk,
+    const aclTensor *beta,
+    const aclTensor *initialStateOptional,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    double scale,
+    int64_t chunkSize,
+    bool outputFinalState,
+    int64_t totalChunks,
+    int64_t stage,
+    const aclTensor *oOut,
+    const aclTensor *finalStateOut,
+    const aclTensor *aqkOut,
+    const aclTensor *akkOut,
+    const aclTensor *wOut,
+    const aclTensor *uOut,
+    const aclTensor *qgOut,
+    const aclTensor *kgOut,
+    const aclTensor *vNewOut,
+    const aclTensor *hOut,
+    aclOpExecutor *executor)
+{
+    L0_DFX(ChunkKdaFwd, q, k, v, gk, beta, initialStateOptional, cuSeqlensOptional, chunkIndicesOptional,
+           scale, chunkSize, outputFinalState, totalChunks, stage, oOut, finalStateOut, aqkOut, akkOut, wOut, uOut,
+           qgOut, kgOut, vNewOut, hOut);
+
+    const aclTensor *actualCuSeqlens = nullptr;
+    if (cuSeqlensOptional != nullptr) {
+        actualCuSeqlens = executor->ConvertToTensor(cuSeqlensOptional, DataType::DT_INT64);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetStorageFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetViewFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetOriginalFormat(Format::FORMAT_ND);
+    }
+
+    const aclTensor *actualChunkIndices = nullptr;
+    if (chunkIndicesOptional != nullptr) {
+        actualChunkIndices = executor->ConvertToTensor(chunkIndicesOptional, DataType::DT_INT64);
+        const_cast<aclTensor *>(actualChunkIndices)->SetStorageFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualChunkIndices)->SetViewFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualChunkIndices)->SetOriginalFormat(Format::FORMAT_ND);
+    }
+
+    auto ret = ADD_TO_LAUNCHER_LIST_AICORE(
+        ChunkKdaFwd,
+        OP_INPUT(q, k, v, gk, beta, initialStateOptional, actualCuSeqlens, actualChunkIndices),
+        OP_OUTPUT(oOut, finalStateOut, aqkOut, akkOut, wOut, uOut, qgOut, kgOut, vNewOut, hOut),
+        OP_ATTR(scale, chunkSize, outputFinalState, totalChunks, stage));
+    if (ret != ACLNN_SUCCESS) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "ADD_TO_LAUNCHER_LIST_AICORE ChunkKdaFwd failed.");
+        return {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+    }
+    return {oOut, finalStateOut, aqkOut, akkOut, wOut, uOut, qgOut, kgOut, vNewOut, hOut};
+}
+
+} // namespace l0op

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/chunk_kda_fwd.h
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/chunk_kda_fwd.h
@@ -1,31 +1,42 @@
 /**
  * Copyright (c) 2026 Tianjin University, Ltd.
  * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
  * Please refer to the License for details. You may not use this file except in compliance with the License.
  * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
  * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- * See LICENSE in the root of the software repository for the full text of the License.
  */
-#ifndef OP_API_INC_LEVEL0_OP_CHUNK_GATED_DELTA_RULE_FWD_H_H
-#define OP_API_INC_LEVEL0_OP_CHUNK_GATED_DELTA_RULE_FWD_H_H
+#ifndef OP_API_INC_LEVEL0_OP_CHUNK_KDA_FWD_OP_H
+#define OP_API_INC_LEVEL0_OP_CHUNK_KDA_FWD_OP_H
 
+#include <array>
 #include "opdev/op_executor.h"
 
 namespace l0op {
-const std::array<const aclTensor *, 3> ChunkGatedDeltaRuleFwdH(
+const std::array<const aclTensor *, 10> ChunkKdaFwd(
+    const aclTensor *q,
     const aclTensor *k,
-    const aclTensor *w,
-    const aclTensor *u,
-    const aclTensor *g,
-    const aclTensor *gkOptional,
-    const aclTensor *initalStateOptional,
+    const aclTensor *v,
+    const aclTensor *gk,
+    const aclTensor *beta,
+    const aclTensor *initialStateOptional,
     const aclIntArray *cuSeqlensOptional,
     const aclIntArray *chunkIndicesOptional,
-    bool outputFinalState,
+    double scale,
     int64_t chunkSize,
-    const aclTensor *hOut,
-    const aclTensor *vNewOut,
+    bool outputFinalState,
+    int64_t totalChunks,
+    int64_t stage,
+    const aclTensor *oOut,
     const aclTensor *finalStateOut,
+    const aclTensor *aqkOut,
+    const aclTensor *akkOut,
+    const aclTensor *wOut,
+    const aclTensor *uOut,
+    const aclTensor *qgOut,
+    const aclTensor *kgOut,
+    const aclTensor *vNewOut,
+    const aclTensor *hOut,
     aclOpExecutor *executor);
 }
 

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/chunk_kda_fwd.cpp
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/chunk_kda_fwd.cpp
@@ -1,0 +1,2174 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "kernel_operator.h"
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#define CATLASS_ARCH 3510
+#include "catlass/arch/arch.hpp"
+#include "catlass/catlass.hpp"
+#include "catlass/gemm/block/block_mmad.hpp"
+#include "catlass/gemm/dispatch_policy.hpp"
+#include "catlass/gemm/gemm_type.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/layout/layout.hpp"
+#include "catlass/arch/cross_core_sync.hpp"
+#include "tla/layout.hpp"
+#include "tla/tensor.hpp"
+using _128 = tla::Int<128>;
+#else
+#define CATLASS_ARCH 2201
+#include "catlass/arch/arch.hpp"
+#include "catlass/catlass.hpp"
+#include "catlass/gemm/block/block_mmad.hpp"
+#include "catlass/gemm/dispatch_policy.hpp"
+#include "catlass/gemm/gemm_type.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/layout/layout.hpp"
+#include "catlass/arch/cross_core_sync.hpp"
+#include "tla/layout.hpp"
+#include "tla/tensor.hpp"
+#endif
+
+#ifndef TORCH_MODE
+#include "lib/matmul_intf.h"
+#endif
+
+using namespace AscendC;
+
+namespace {
+constexpr float LN2 = 0.69314718055994530942f;
+constexpr uint32_t EXP2_UB_ELEMENTS = 256;
+constexpr uint32_t EXP2_EVENT_ID = 0;
+constexpr uint32_t KDA_MTE2_V_EVENT_ID = 1;
+constexpr uint32_t KDA_SCALAR_MTE2_V_EVENT_ID = 2;
+constexpr uint32_t KDA_SCALAR_V_S_EVENT_ID = 3;
+constexpr uint32_t KDA_SCALAR_V_MTE3_EVENT_ID = 4;
+constexpr uint32_t KDA_SCALAR_MTE3_V_EVENT_ID = 5;
+constexpr uint32_t KDA_MTE2_MTE3_EVENT_ID = 6;
+constexpr uint32_t KDA_MTE3_MTE2_EVENT_ID = 7;
+constexpr uint32_t KDA_VEC_BUFFER_NUM = 2;
+constexpr uint32_t KDA_SOLVE_BT = 64;
+constexpr uint32_t KDA_SOLVE_MATRIX_ELEMENTS = KDA_SOLVE_BT * KDA_SOLVE_BT;
+constexpr uint32_t KDA_SOLVE_SCRATCH_X = 0;
+constexpr uint32_t KDA_SOLVE_SCRATCH_Y0 = 1;
+constexpr uint32_t KDA_SOLVE_SCRATCH_TMP = 2;
+constexpr uint32_t KDA_SOLVE_SCRATCH_Y1 = 3;
+constexpr uint32_t KDA_SOLVE_SCRATCH_SLOTS = 4;
+constexpr uint32_t KDA_SOLVE_MCH_ITERS = 5;
+constexpr uint32_t KDA_VEC_ARENA_ELEMENTS = 32768;
+constexpr uint8_t KDA_SCORE_DONE_FLAG0 = 2;
+constexpr uint8_t KDA_SCORE_DONE_FLAG1 = 3;
+constexpr uint8_t KDA_SCORE_READY_FLAG0 = 4;
+constexpr uint8_t KDA_SCORE_READY_FLAG1 = 5;
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+using KdaArchTag = Catlass::Arch::Ascend950;
+#else
+using KdaArchTag = Catlass::Arch::AtlasA2;
+#endif
+using KdaDispatchPolicy = Catlass::Gemm::MmadPingpong<KdaArchTag, true, false>;
+using KdaL1TileShape = tla::Shape<_128, _128, _128>;
+using KdaL0TileShape = KdaL1TileShape;
+
+__aicore__ inline uint32_t FloatToBits(float value)
+{
+    union Bits {
+        __aicore__ Bits() {}
+        float f;
+        uint32_t u;
+    } bits;
+    bits.f = value;
+    return bits.u;
+}
+
+__aicore__ inline float BitsToFloat(uint32_t value)
+{
+    union Bits {
+        __aicore__ Bits() {}
+        uint32_t u;
+        float f;
+    } bits;
+    bits.u = value;
+    return bits.f;
+}
+
+__aicore__ inline uint16_t Bf16ToBits(bfloat16_t value)
+{
+    union Bits {
+        __aicore__ Bits() {}
+        bfloat16_t f;
+        uint16_t u;
+    } bits;
+    bits.f = value;
+    return bits.u;
+}
+
+__aicore__ inline bfloat16_t BitsToBf16(uint16_t value)
+{
+    union Bits {
+        __aicore__ Bits() {}
+        uint16_t u;
+        bfloat16_t f;
+    } bits;
+    bits.u = value;
+    return bits.f;
+}
+
+template <typename T>
+__aicore__ inline T FloatToType(float value)
+{
+    if constexpr (IsSameType<T, bfloat16_t>::value) {
+        uint32_t bits = FloatToBits(value);
+        uint32_t bias = 0x7FFFu + ((bits >> 16) & 1u);
+        return BitsToBf16(static_cast<uint16_t>((bits + bias) >> 16));
+    }
+    return static_cast<T>(value);
+}
+
+template <typename T>
+class ChunkKdaFwdKernel {
+public:
+    __aicore__ inline void Init(GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR gk, GM_ADDR beta, GM_ADDR initialState,
+                                GM_ADDR cuSeqlens, GM_ADDR chunkIndices, GM_ADDR o, GM_ADDR finalState,
+                                GM_ADDR aqk, GM_ADDR akk, GM_ADDR w, GM_ADDR u, GM_ADDR qg, GM_ADDR kg,
+                                GM_ADDR vNew, GM_ADDR h, const ChunkKdaFwdTilingData &tiling, TPipe *pipe,
+                                bool initVecBuffers = true)
+    {
+        pipe_ = pipe;
+        q_.SetGlobalBuffer((__gm__ T *)q);
+        k_.SetGlobalBuffer((__gm__ T *)k);
+        v_.SetGlobalBuffer((__gm__ T *)v);
+        gk_.SetGlobalBuffer((__gm__ float *)gk);
+        beta_.SetGlobalBuffer((__gm__ float *)beta);
+        if (initialState != nullptr) {
+            initialState_.SetGlobalBuffer((__gm__ float *)initialState);
+        }
+        if (cuSeqlens != nullptr) {
+            cuSeqlens_.SetGlobalBuffer((__gm__ int64_t *)cuSeqlens);
+        }
+        if (chunkIndices != nullptr) {
+            chunkIndices_.SetGlobalBuffer((__gm__ int64_t *)chunkIndices);
+        }
+        o_.SetGlobalBuffer((__gm__ T *)o);
+        finalState_.SetGlobalBuffer((__gm__ float *)finalState);
+        aqk_.SetGlobalBuffer((__gm__ T *)aqk);
+        akk_.SetGlobalBuffer((__gm__ T *)akk);
+        w_.SetGlobalBuffer((__gm__ T *)w);
+        u_.SetGlobalBuffer((__gm__ T *)u);
+        qg_.SetGlobalBuffer((__gm__ T *)qg);
+        kg_.SetGlobalBuffer((__gm__ T *)kg);
+        vNew_.SetGlobalBuffer((__gm__ T *)vNew);
+        h_.SetGlobalBuffer((__gm__ T *)h);
+
+        B_ = tiling.batch;
+        N_ = tiling.seqNum;
+        H_ = tiling.qHeadNum;
+        HV_ = tiling.vHeadNum;
+        T_ = tiling.seqlen;
+        K_ = tiling.kHeadDim;
+        V_ = tiling.vHeadDim;
+        BT_ = tiling.chunkSize;
+        NT_ = tiling.totalChunks;
+        scale_ = tiling.scale;
+        hasInitial_ = tiling.hasInitialState;
+        isVarLen_ = tiling.isVarLen;
+        usedCoreNum_ = tiling.usedCoreNum;
+        stage_ = tiling.stage;
+
+        if (pipe_ != nullptr) {
+            pipe_->InitBuffer(scalarInBuf_, 32);
+            pipe_->InitBuffer(scalarFp32Buf_, 32);
+            pipe_->InitBuffer(scalarOutBuf_, 32);
+            pipe_->InitBuffer(scalarI64Buf_, 32);
+        }
+        if (pipe_ != nullptr && initVecBuffers) {
+            pipe_->InitBuffer(exp2Buf_, EXP2_UB_ELEMENTS * sizeof(float));
+            pipe_->InitBuffer(vecBuf_, KDA_VEC_ARENA_ELEMENTS * sizeof(float));
+            pipe_->InitBuffer(qInQue_, KDA_VEC_BUFFER_NUM, EXP2_UB_ELEMENTS * sizeof(T));
+            pipe_->InitBuffer(kInQue_, KDA_VEC_BUFFER_NUM, EXP2_UB_ELEMENTS * sizeof(T));
+            pipe_->InitBuffer(gInQue_, KDA_VEC_BUFFER_NUM, EXP2_UB_ELEMENTS * sizeof(float));
+            pipe_->InitBuffer(qgOutQue_, KDA_VEC_BUFFER_NUM, EXP2_UB_ELEMENTS * sizeof(T));
+            pipe_->InitBuffer(wOutQue_, KDA_VEC_BUFFER_NUM, EXP2_UB_ELEMENTS * sizeof(T));
+            pipe_->InitBuffer(kgOutQue_, KDA_VEC_BUFFER_NUM, EXP2_UB_ELEMENTS * sizeof(T));
+        }
+    }
+
+    __aicore__ inline void ProcessAivOnly()
+    {
+        if (stage_ == 1) {
+            isAivOnly_ = true;
+            ProcessPreAiv();
+            return;
+        }
+        if (stage_ == 2) {
+            isAivOnly_ = true;
+            ProcessOutAiv();
+            return;
+        }
+        if (stage_ == 3) {
+            isAivOnly_ = true;
+            ProcessPostAiv();
+            return;
+        }
+        isAivOnly_ = true;
+        uint64_t taskNum = static_cast<uint64_t>(N_ * HV_);
+        uint64_t blockNum = static_cast<uint64_t>(GetBlockNum());
+        for (uint64_t task = GetBlockIdx(); task < taskNum; task += blockNum) {
+            uint64_t seq = task / HV_;
+            uint64_t hv = task % HV_;
+            ProcessSeqHeadAiv(seq, hv);
+        }
+    }
+
+    __aicore__ inline void ProcessAiv()
+    {
+        if (stage_ == 1) {
+            ProcessPreAiv();
+            return;
+        }
+        if (stage_ == 2) {
+            ProcessOutAiv();
+            return;
+        }
+        if (stage_ == 3) {
+            ProcessPostAiv();
+            return;
+        }
+        if constexpr (IsSameType<T, float>::value) {
+            ProcessAivOnly();
+        } else {
+            isAivOnly_ = false;
+            uint64_t subBlockNum = static_cast<uint64_t>(GetSubBlockNum());
+            if (subBlockNum == 0) {
+                return;
+            }
+            uint64_t taskNum = static_cast<uint64_t>(N_ * HV_);
+            uint64_t coreNum = usedCoreNum_ == 0 ? 1 : usedCoreNum_;
+            uint64_t coreIdx = static_cast<uint64_t>(GetBlockIdx()) / subBlockNum;
+            for (uint64_t task = coreIdx; task < taskNum; task += coreNum) {
+                uint64_t seq = task / HV_;
+                uint64_t hv = task % HV_;
+                ProcessSeqHeadAiv(seq, hv);
+            }
+        }
+    }
+
+    __aicore__ inline void ProcessAic()
+    {
+        if (stage_ == 1) {
+            ProcessPreAic();
+            return;
+        }
+        if (stage_ == 2) {
+            ProcessOutAic();
+            return;
+        }
+        if (stage_ == 3) {
+            ProcessPostAic();
+            return;
+        }
+        if constexpr (IsSameType<T, float>::value) {
+            return;
+        } else {
+            uint64_t taskNum = static_cast<uint64_t>(N_ * HV_);
+            uint64_t coreNum = usedCoreNum_ == 0 ? 1 : usedCoreNum_;
+            for (uint64_t task = GetBlockIdx(); task < taskNum; task += coreNum) {
+                uint64_t seq = task / HV_;
+                uint64_t hv = task % HV_;
+                ProcessSeqHeadAic(seq, hv);
+            }
+        }
+    }
+
+private:
+    __aicore__ inline uint64_t QOffset(uint64_t b, uint64_t h, uint64_t t, uint64_t d) const
+    {
+        return ((b * H_ + h) * T_ + t) * K_ + d;
+    }
+
+    __aicore__ inline uint64_t KVOffset(uint64_t b, uint64_t hv, uint64_t t, uint64_t d, uint64_t dim) const
+    {
+        return ((b * HV_ + hv) * T_ + t) * dim + d;
+    }
+
+    __aicore__ inline uint64_t BetaOffset(uint64_t b, uint64_t hv, uint64_t t) const
+    {
+        return (b * HV_ + hv) * T_ + t;
+    }
+
+    __aicore__ inline uint64_t AOffset(uint64_t b, uint64_t hv, uint64_t t, uint64_t j) const
+    {
+        return ((b * HV_ + hv) * T_ + t) * BT_ + j;
+    }
+
+    __aicore__ inline uint64_t HOffset(uint64_t b, uint64_t hv, uint64_t chunkIdx, uint64_t d, uint64_t r) const
+    {
+        return (((b * HV_ + hv) * NT_ + chunkIdx) * K_ + d) * V_ + r;
+    }
+
+    __aicore__ inline uint64_t WScratchOffset(uint64_t b, uint64_t hv, uint64_t chunkIdx, uint64_t t, uint64_t d) const
+    {
+        return (((b * HV_ + hv) * NT_ + chunkIdx) * BT_ + t) * K_ + d;
+    }
+
+    __aicore__ inline uint64_t SolveScratchOffset(uint64_t b, uint64_t hv, uint64_t chunkIdx,
+                                                  uint64_t slot) const
+    {
+        return HOffset(b, hv, chunkIdx, 0, 0) + slot * KDA_SOLVE_MATRIX_ELEMENTS;
+    }
+
+    __aicore__ inline uint64_t StateOffset(uint64_t seq, uint64_t hv, uint64_t d, uint64_t r) const
+    {
+        return ((seq * HV_ + hv) * K_ + d) * V_ + r;
+    }
+
+    __aicore__ inline uint64_t ChunkCountBefore(uint64_t seq)
+    {
+        if (!isVarLen_) {
+            return 0;
+        }
+        uint64_t count = 0;
+        for (uint64_t s = 0; s < seq; ++s) {
+            uint64_t start = static_cast<uint64_t>(ReadInt64(cuSeqlens_, s));
+            uint64_t end = static_cast<uint64_t>(ReadInt64(cuSeqlens_, s + 1));
+            count += (end - start + BT_ - 1) / BT_;
+        }
+        return count;
+    }
+
+    __aicore__ inline void RunExp2(LocalTensor<float> &tensor, uint32_t count)
+    {
+        SetFlag<HardEvent::S_V>(EXP2_EVENT_ID);
+        WaitFlag<HardEvent::S_V>(EXP2_EVENT_ID);
+        Exp(tensor, tensor, count);
+        PipeBarrier<PIPE_V>();
+        SetFlag<HardEvent::V_S>(EXP2_EVENT_ID);
+        WaitFlag<HardEvent::V_S>(EXP2_EVENT_ID);
+    }
+
+    template <typename CopyT>
+    __aicore__ inline void CopyVectorIn(LocalTensor<CopyT> &dst, GlobalTensor<CopyT> &src, uint64_t offset,
+                                        uint64_t count)
+    {
+        uint64_t rowBytes = count * static_cast<uint64_t>(sizeof(CopyT));
+        if (rowBytes >= 32 && rowBytes % 32 == 0) {
+            DataCopy(dst, src[offset], static_cast<uint32_t>(count));
+            return;
+        }
+        DataCopyParams params{1, static_cast<uint16_t>(rowBytes), 0, 0};
+        DataCopyPadParams padParams{false, 0, 0, 0};
+        DataCopyPad(dst, src[offset], params, padParams);
+    }
+
+    template <typename CopyT>
+    __aicore__ inline void CopyVectorOut(GlobalTensor<CopyT> &dst, uint64_t offset, LocalTensor<CopyT> &src,
+                                         uint64_t count)
+    {
+        uint64_t rowBytes = count * static_cast<uint64_t>(sizeof(CopyT));
+        if (rowBytes >= 32 && rowBytes % 32 == 0) {
+            DataCopy(dst[offset], src, static_cast<uint32_t>(count));
+            return;
+        }
+        DataCopyParams params{1, static_cast<uint16_t>(rowBytes), 0, 0};
+        DataCopyPad(dst[offset], src, params);
+    }
+
+    template <typename CopyT>
+    __aicore__ inline void CopyRowIn(LocalTensor<CopyT> &dst, GlobalTensor<CopyT> &src, uint64_t offset)
+    {
+        CopyVectorIn(dst, src, offset, K_);
+    }
+
+    template <typename CopyT>
+    __aicore__ inline void CopyRowOut(GlobalTensor<CopyT> &dst, uint64_t offset, LocalTensor<CopyT> &src)
+    {
+        CopyVectorOut(dst, offset, src, K_);
+    }
+
+    template <typename DstT, typename SrcT>
+    __aicore__ inline void CopyTensorRow(GlobalTensor<DstT> &dst, uint64_t dstOffset, GlobalTensor<SrcT> &src,
+                                         uint64_t srcOffset, uint64_t count)
+    {
+        LocalTensor<float> rowFp32 = vecBuf_.Get<float>();
+        LoadAsFloatRow(src, srcOffset, rowFp32, count);
+        StoreFloatRow(dst, dstOffset, rowFp32, count);
+    }
+
+    template <typename CopyT>
+    __aicore__ inline void ZeroTensorRow(GlobalTensor<CopyT> &dst, uint64_t dstOffset, uint64_t count)
+    {
+        LocalTensor<float> rowFp32 = vecBuf_.Get<float>();
+        Duplicate(rowFp32, 0.0f, static_cast<uint32_t>(count));
+        PipeBarrier<PIPE_V>();
+        StoreFloatRow(dst, dstOffset, rowFp32, count);
+    }
+
+    template <typename CopyT>
+    __aicore__ inline float ReadAsFloat(GlobalTensor<CopyT> &tensor, uint64_t offset)
+    {
+        LocalTensor<CopyT> scalarIn = scalarInBuf_.Get<CopyT>();
+        DataCopyParams params{1, static_cast<uint16_t>(sizeof(CopyT)), 0, 0};
+        DataCopyPadParams padParams{false, 0, 0, 0};
+        DataCopyPad(scalarIn, tensor[offset], params, padParams);
+        SetFlag<HardEvent::MTE2_V>(KDA_SCALAR_MTE2_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE2_V>(KDA_SCALAR_MTE2_V_EVENT_ID);
+
+        LocalTensor<float> scalarFp32 = scalarFp32Buf_.Get<float>();
+        if constexpr (IsSameType<CopyT, float>::value) {
+            Adds(scalarFp32, scalarIn, 0.0f, 1);
+        } else {
+            Cast(scalarFp32, scalarIn, RoundMode::CAST_NONE, 1);
+        }
+        PipeBarrier<PIPE_V>();
+        SetFlag<HardEvent::V_S>(KDA_SCALAR_V_S_EVENT_ID);
+        WaitFlag<HardEvent::V_S>(KDA_SCALAR_V_S_EVENT_ID);
+        __ubuf__ float *ptr = (__ubuf__ float *)scalarFp32.GetPhyAddr();
+        return ptr[0];
+    }
+
+    __aicore__ inline int64_t ReadInt64(GlobalTensor<int64_t> &tensor, uint64_t offset)
+    {
+        LocalTensor<int64_t> scalarI64 = scalarI64Buf_.Get<int64_t>();
+        DataCopyParams params{1, static_cast<uint16_t>(sizeof(int64_t)), 0, 0};
+        DataCopyPadParams padParams{false, 0, 0, 0};
+        DataCopyPad(scalarI64, tensor[offset], params, padParams);
+        SetFlag<HardEvent::MTE2_V>(KDA_SCALAR_MTE2_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE2_V>(KDA_SCALAR_MTE2_V_EVENT_ID);
+        SetFlag<HardEvent::V_S>(KDA_SCALAR_V_S_EVENT_ID);
+        WaitFlag<HardEvent::V_S>(KDA_SCALAR_V_S_EVENT_ID);
+        __ubuf__ int64_t *ptr = (__ubuf__ int64_t *)scalarI64.GetPhyAddr();
+        return ptr[0];
+    }
+
+    template <typename CopyT>
+    __aicore__ inline void WriteFromFloat(GlobalTensor<CopyT> &tensor, uint64_t offset, float value)
+    {
+        LocalTensor<float> scalarFp32 = scalarFp32Buf_.Get<float>();
+        Duplicate(scalarFp32, value, 1);
+        PipeBarrier<PIPE_V>();
+        DataCopyParams params{1, static_cast<uint16_t>(sizeof(CopyT)), 0, 0};
+        if constexpr (IsSameType<CopyT, float>::value) {
+            SetFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            DataCopyPad(tensor[offset], scalarFp32, params);
+        } else {
+            LocalTensor<CopyT> scalarOut = scalarOutBuf_.Get<CopyT>();
+            Cast(scalarOut, scalarFp32, RoundMode::CAST_RINT, 1);
+            PipeBarrier<PIPE_V>();
+            SetFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            DataCopyPad(tensor[offset], scalarOut, params);
+        }
+        SetFlag<HardEvent::MTE3_V>(KDA_SCALAR_MTE3_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_V>(KDA_SCALAR_MTE3_V_EVENT_ID);
+    }
+
+    __aicore__ inline float ReadFloat(GlobalTensor<float> &tensor, uint64_t offset)
+    {
+        return ReadAsFloat(tensor, offset);
+    }
+
+    __aicore__ inline void WriteFloat(GlobalTensor<float> &tensor, uint64_t offset, float value)
+    {
+        WriteFromFloat(tensor, offset, value);
+    }
+
+    __aicore__ inline __ubuf__ float *UbPtr(LocalTensor<float> &tensor)
+    {
+        return (__ubuf__ float *)tensor.GetPhyAddr();
+    }
+
+    __aicore__ inline LocalTensor<float> VecScratch(uint64_t slot)
+    {
+        return vecBuf_.Get<float>()[slot * EXP2_UB_ELEMENTS];
+    }
+
+    template <typename CopyT>
+    __aicore__ inline void LoadAsFloatRow(GlobalTensor<CopyT> &src, uint64_t srcOffset, LocalTensor<float> &dst,
+                                          uint64_t count)
+    {
+        if constexpr (IsSameType<CopyT, float>::value) {
+            CopyVectorIn(dst, src, srcOffset, count);
+            SetFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            WaitFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            Adds(dst, dst, 0.0f, static_cast<uint32_t>(count));
+            PipeBarrier<PIPE_V>();
+            SetFlag<HardEvent::V_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        } else {
+            LocalTensor<CopyT> rowLocal = exp2Buf_.Get<CopyT>();
+            CopyVectorIn(rowLocal, src, srcOffset, count);
+            SetFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            WaitFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            Cast(dst, rowLocal, RoundMode::CAST_NONE, static_cast<uint32_t>(count));
+            PipeBarrier<PIPE_V>();
+            SetFlag<HardEvent::V_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        }
+        PipeBarrier<PIPE_V>();
+    }
+
+    template <typename CopyT>
+    __aicore__ inline void StoreFloatRow(GlobalTensor<CopyT> &dst, uint64_t dstOffset, LocalTensor<float> &src,
+                                         uint64_t count)
+    {
+        if constexpr (IsSameType<CopyT, float>::value) {
+            SetFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            CopyVectorOut(dst, dstOffset, src, count);
+        } else {
+            LocalTensor<CopyT> rowLocal = exp2Buf_.Get<CopyT>();
+            Cast(rowLocal, src, RoundMode::CAST_RINT, static_cast<uint32_t>(count));
+            PipeBarrier<PIPE_V>();
+            SetFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            CopyVectorOut(dst, dstOffset, rowLocal, count);
+        }
+        SetFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        SetFlag<HardEvent::MTE3_V>(KDA_SCALAR_MTE3_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_V>(KDA_SCALAR_MTE3_V_EVENT_ID);
+    }
+
+    __aicore__ inline void LoadExp2GTo(LocalTensor<float> &dst, uint64_t b, uint64_t hv, uint64_t t)
+    {
+        CopyRowIn(dst, gk_, KVOffset(b, hv, t, 0, K_));
+        SetFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+        Muls(dst, dst, LN2, static_cast<uint32_t>(K_));
+        PipeBarrier<PIPE_V>();
+        RunExp2(dst, static_cast<uint32_t>(K_));
+    }
+
+    template <typename CopyT>
+    __aicore__ inline void CopyStackFloatRowOut(GlobalTensor<CopyT> &dst, uint64_t dstOffset, float *values,
+                                                uint64_t count, uint64_t slot = 0)
+    {
+        LocalTensor<float> rowFp32 = vecBuf_.Get<float>()[slot * EXP2_UB_ELEMENTS];
+        __ubuf__ float *rowPtr = UbPtr(rowFp32);
+        for (uint64_t idx = 0; idx < count; ++idx) {
+            rowPtr[idx] = values[idx];
+        }
+        SetFlag<HardEvent::S_V>(EXP2_EVENT_ID);
+        WaitFlag<HardEvent::S_V>(EXP2_EVENT_ID);
+        Adds(rowFp32, rowFp32, 0.0f, static_cast<uint32_t>(count));
+        PipeBarrier<PIPE_V>();
+        if constexpr (IsSameType<CopyT, float>::value) {
+            SetFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            CopyVectorOut(dst, dstOffset, rowFp32, count);
+        } else {
+            LocalTensor<CopyT> rowLocal = exp2Buf_.Get<CopyT>();
+            Cast(rowLocal, rowFp32, RoundMode::CAST_RINT, static_cast<uint32_t>(count));
+            PipeBarrier<PIPE_V>();
+            SetFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            CopyVectorOut(dst, dstOffset, rowLocal, count);
+        }
+        SetFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        SetFlag<HardEvent::MTE3_V>(KDA_SCALAR_MTE3_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_V>(KDA_SCALAR_MTE3_V_EVENT_ID);
+        SetFlag<HardEvent::MTE3_S>(KDA_SCALAR_MTE3_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_S>(KDA_SCALAR_MTE3_V_EVENT_ID);
+    }
+
+    template <typename CopyT>
+    __aicore__ inline void LoadStackFloatRow(GlobalTensor<CopyT> &src, uint64_t srcOffset, float *values,
+                                             uint64_t count, uint64_t slot = 0)
+    {
+        LocalTensor<float> rowFp32 = vecBuf_.Get<float>()[slot * EXP2_UB_ELEMENTS];
+        if constexpr (IsSameType<CopyT, float>::value) {
+            CopyVectorIn(rowFp32, src, srcOffset, count);
+            SetFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            WaitFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            Adds(rowFp32, rowFp32, 0.0f, static_cast<uint32_t>(count));
+            PipeBarrier<PIPE_V>();
+            SetFlag<HardEvent::V_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        } else {
+            LocalTensor<CopyT> rowLocal = exp2Buf_.Get<CopyT>();
+            CopyVectorIn(rowLocal, src, srcOffset, count);
+            SetFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            WaitFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            Cast(rowFp32, rowLocal, RoundMode::CAST_NONE, static_cast<uint32_t>(count));
+            PipeBarrier<PIPE_V>();
+            SetFlag<HardEvent::V_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        }
+        PipeBarrier<PIPE_V>();
+        SetFlag<HardEvent::V_S>(KDA_SCALAR_V_S_EVENT_ID);
+        WaitFlag<HardEvent::V_S>(KDA_SCALAR_V_S_EVENT_ID);
+        __ubuf__ float *rowPtr = UbPtr(rowFp32);
+        for (uint64_t idx = 0; idx < count; ++idx) {
+            values[idx] = rowPtr[idx];
+        }
+    }
+
+    __aicore__ inline LocalTensor<float> Exp2G(uint64_t b, uint64_t hv, uint64_t t)
+    {
+        LocalTensor<float> exp2Local = exp2Buf_.Get<float>();
+        CopyRowIn(exp2Local, gk_, KVOffset(b, hv, t, 0, K_));
+        SetFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+        Muls(exp2Local, exp2Local, LN2, static_cast<uint32_t>(K_));
+        PipeBarrier<PIPE_V>();
+        RunExp2(exp2Local, static_cast<uint32_t>(K_));
+        return exp2Local;
+    }
+
+    __aicore__ inline LocalTensor<float> Exp2NegG(uint64_t b, uint64_t hv, uint64_t t)
+    {
+        LocalTensor<float> exp2Local = exp2Buf_.Get<float>();
+        CopyRowIn(exp2Local, gk_, KVOffset(b, hv, t, 0, K_));
+        SetFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+        Muls(exp2Local, exp2Local, -LN2, static_cast<uint32_t>(K_));
+        PipeBarrier<PIPE_V>();
+        RunExp2(exp2Local, static_cast<uint32_t>(K_));
+        return exp2Local;
+    }
+
+    __aicore__ inline LocalTensor<float> Exp2GDiff(uint64_t b, uint64_t hv, uint64_t lhs, uint64_t rhs)
+    {
+        LocalTensor<float> exp2Local = exp2Buf_.Get<float>();
+        LocalTensor<float> rhsLocal = vecBuf_.Get<float>();
+        CopyRowIn(exp2Local, gk_, KVOffset(b, hv, lhs, 0, K_));
+        CopyRowIn(rhsLocal, gk_, KVOffset(b, hv, rhs, 0, K_));
+        SetFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+        Sub(exp2Local, exp2Local, rhsLocal, static_cast<uint32_t>(K_));
+        PipeBarrier<PIPE_V>();
+        Muls(exp2Local, exp2Local, LN2, static_cast<uint32_t>(K_));
+        PipeBarrier<PIPE_V>();
+        RunExp2(exp2Local, static_cast<uint32_t>(K_));
+        return exp2Local;
+    }
+
+    __aicore__ inline uint64_t GateProductToken(uint64_t start, uint64_t logicalIdx, uint64_t subBlockIdx,
+                                                uint64_t subBlockNum) const
+    {
+        return start + subBlockIdx + logicalIdx * subBlockNum;
+    }
+
+    __aicore__ inline void LoadGateProductRow(uint64_t b, uint64_t h, uint64_t hv, uint64_t ti)
+    {
+        LocalTensor<T> qLocal = qInQue_.AllocTensor<T>();
+        LocalTensor<T> kLocal = kInQue_.AllocTensor<T>();
+        LocalTensor<float> gLocal = gInQue_.AllocTensor<float>();
+        CopyRowIn(qLocal, q_, QOffset(b, h, ti, 0));
+        CopyRowIn(kLocal, k_, QOffset(b, h, ti, 0));
+        CopyRowIn(gLocal, gk_, KVOffset(b, hv, ti, 0, K_));
+        qInQue_.EnQue(qLocal);
+        kInQue_.EnQue(kLocal);
+        gInQue_.EnQue(gLocal);
+    }
+
+    __aicore__ inline void StoreGateProductRow(uint64_t b, uint64_t hv, uint64_t ti)
+    {
+        LocalTensor<T> qPosLocal = qgOutQue_.DeQue<T>();
+        LocalTensor<T> kPosLocal = wOutQue_.DeQue<T>();
+        LocalTensor<T> kNegLocal = kgOutQue_.DeQue<T>();
+        SetFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+        WaitFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+        CopyRowOut(qg_, KVOffset(b, hv, ti, 0, K_), qPosLocal);
+        CopyRowOut(w_, KVOffset(b, hv, ti, 0, K_), kPosLocal);
+        CopyRowOut(kg_, KVOffset(b, hv, ti, 0, K_), kNegLocal);
+        SetFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        SetFlag<HardEvent::MTE3_V>(KDA_SCALAR_MTE3_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_V>(KDA_SCALAR_MTE3_V_EVENT_ID);
+        qgOutQue_.FreeTensor(qPosLocal);
+        wOutQue_.FreeTensor(kPosLocal);
+        kgOutQue_.FreeTensor(kNegLocal);
+    }
+
+    __aicore__ inline void ComputeGateProductRow(LocalTensor<float> &qFp32, LocalTensor<float> &kFp32,
+                                                 LocalTensor<float> &gFp32, LocalTensor<float> &expFp32,
+                                                 LocalTensor<float> &outFp32)
+    {
+        LocalTensor<T> qPosLocal = qgOutQue_.AllocTensor<T>();
+        LocalTensor<T> kPosLocal = wOutQue_.AllocTensor<T>();
+        LocalTensor<T> kNegLocal = kgOutQue_.AllocTensor<T>();
+
+        Muls(expFp32, gFp32, LN2, static_cast<uint32_t>(K_));
+        PipeBarrier<PIPE_V>();
+        Exp(expFp32, expFp32, static_cast<uint32_t>(K_));
+        PipeBarrier<PIPE_V>();
+
+        Mul(outFp32, qFp32, expFp32, static_cast<uint32_t>(K_));
+        PipeBarrier<PIPE_V>();
+        if constexpr (IsSameType<T, float>::value) {
+            DataCopy(qPosLocal, outFp32, static_cast<uint32_t>(K_));
+        } else {
+            Cast(qPosLocal, outFp32, RoundMode::CAST_RINT, static_cast<uint32_t>(K_));
+        }
+        PipeBarrier<PIPE_V>();
+
+        Mul(outFp32, kFp32, expFp32, static_cast<uint32_t>(K_));
+        PipeBarrier<PIPE_V>();
+        if constexpr (IsSameType<T, float>::value) {
+            DataCopy(kPosLocal, outFp32, static_cast<uint32_t>(K_));
+        } else {
+            Cast(kPosLocal, outFp32, RoundMode::CAST_RINT, static_cast<uint32_t>(K_));
+        }
+        PipeBarrier<PIPE_V>();
+
+        Muls(expFp32, gFp32, -LN2, static_cast<uint32_t>(K_));
+        PipeBarrier<PIPE_V>();
+        Exp(expFp32, expFp32, static_cast<uint32_t>(K_));
+        PipeBarrier<PIPE_V>();
+        Mul(outFp32, kFp32, expFp32, static_cast<uint32_t>(K_));
+        PipeBarrier<PIPE_V>();
+        if constexpr (IsSameType<T, float>::value) {
+            DataCopy(kNegLocal, outFp32, static_cast<uint32_t>(K_));
+        } else {
+            Cast(kNegLocal, outFp32, RoundMode::CAST_RINT, static_cast<uint32_t>(K_));
+        }
+
+        qgOutQue_.EnQue(qPosLocal);
+        wOutQue_.EnQue(kPosLocal);
+        kgOutQue_.EnQue(kNegLocal);
+    }
+
+    __aicore__ inline void PrepareGateProducts(uint64_t b, uint64_t h, uint64_t hv, uint64_t start, uint64_t curT,
+                                               uint64_t subBlockIdx, uint64_t subBlockNum)
+    {
+        if (subBlockIdx >= curT || subBlockNum == 0) {
+            return;
+        }
+
+        LocalTensor<float> vecLocal = vecBuf_.Get<float>();
+        LocalTensor<float> qFp32 = vecLocal;
+        LocalTensor<float> kFp32 = vecLocal[EXP2_UB_ELEMENTS];
+        LocalTensor<float> gFp32 = vecLocal[2 * EXP2_UB_ELEMENTS];
+        LocalTensor<float> expFp32 = vecLocal[3 * EXP2_UB_ELEMENTS];
+        LocalTensor<float> outFp32 = vecLocal[4 * EXP2_UB_ELEMENTS];
+
+        uint64_t rowCount = 0;
+        for (uint64_t i = subBlockIdx; i < curT; i += subBlockNum) {
+            ++rowCount;
+        }
+
+        LoadGateProductRow(b, h, hv, GateProductToken(start, 0, subBlockIdx, subBlockNum));
+        for (uint64_t logicalIdx = 0; logicalIdx < rowCount; ++logicalIdx) {
+            uint64_t ti = GateProductToken(start, logicalIdx, subBlockIdx, subBlockNum);
+            LocalTensor<T> qLocal = qInQue_.DeQue<T>();
+            LocalTensor<T> kLocal = kInQue_.DeQue<T>();
+            LocalTensor<float> gLocal = gInQue_.DeQue<float>();
+
+            if (logicalIdx + 1 < rowCount) {
+                LoadGateProductRow(b, h, hv, GateProductToken(start, logicalIdx + 1, subBlockIdx, subBlockNum));
+            }
+
+            if constexpr (IsSameType<T, float>::value) {
+                DataCopy(qFp32, qLocal, static_cast<uint32_t>(K_));
+                DataCopy(kFp32, kLocal, static_cast<uint32_t>(K_));
+            } else {
+                Cast(qFp32, qLocal, RoundMode::CAST_NONE, static_cast<uint32_t>(K_));
+                Cast(kFp32, kLocal, RoundMode::CAST_NONE, static_cast<uint32_t>(K_));
+            }
+            DataCopy(gFp32, gLocal, static_cast<uint32_t>(K_));
+            qInQue_.FreeTensor(qLocal);
+            kInQue_.FreeTensor(kLocal);
+            gInQue_.FreeTensor(gLocal);
+            PipeBarrier<PIPE_V>();
+
+            if (logicalIdx > 0) {
+                StoreGateProductRow(b, hv, GateProductToken(start, logicalIdx - 1, subBlockIdx, subBlockNum));
+            }
+            ComputeGateProductRow(qFp32, kFp32, gFp32, expFp32, outFp32);
+        }
+        StoreGateProductRow(b, hv, GateProductToken(start, rowCount - 1, subBlockIdx, subBlockNum));
+        SetFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+    }
+
+    __aicore__ inline void ComputeRawAqkAkkScalar(uint64_t b, uint64_t h, uint64_t hv, uint64_t start, uint64_t curT)
+    {
+        for (uint64_t i = 0; i < curT; ++i) {
+            uint64_t ti = start + i;
+            float aqkRow[EXP2_UB_ELEMENTS];
+            float akkRow[EXP2_UB_ELEMENTS];
+            for (uint64_t j = 0; j < BT_; ++j) {
+                aqkRow[j] = 0.0f;
+                akkRow[j] = 0.0f;
+            }
+            for (uint64_t j = 0; j < curT; ++j) {
+                uint64_t tj = start + j;
+                float aqkRaw = 0.0f;
+                float akkRaw = 0.0f;
+                LocalTensor<float> gateLocal = Exp2GDiff(b, hv, ti, tj);
+                __ubuf__ float *gatePtr = UbPtr(gateLocal);
+                for (uint64_t d = 0; d < K_; ++d) {
+                    float qi = ReadAsFloat(q_, QOffset(b, h, ti, d));
+                    float ki = ReadAsFloat(k_, QOffset(b, h, ti, d));
+                    float kj = ReadAsFloat(k_, QOffset(b, h, tj, d));
+                    aqkRaw += qi * kj * gatePtr[d];
+                    akkRaw += ki * kj * gatePtr[d];
+                }
+                aqkRow[j] = aqkRaw;
+                akkRow[j] = akkRaw;
+            }
+            CopyStackFloatRowOut(aqk_, AOffset(b, hv, ti, 0), aqkRow, BT_, 0);
+            CopyStackFloatRowOut(akk_, AOffset(b, hv, ti, 0), akkRow, BT_, 1);
+        }
+        SetFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+    }
+
+    __aicore__ inline void ComputeRawAqkAkkCube(uint64_t b, uint64_t hv, uint64_t start, uint64_t curT)
+    {
+        using ElementA = T;
+        using ElementB = T;
+        using ElementC = T;
+        using LayoutTagA = Catlass::layout::RowMajor;
+        using LayoutTagB = Catlass::layout::ColumnMajor;
+        using LayoutTagC = Catlass::layout::RowMajor;
+        using TileCopy = Catlass::Gemm::Tile::PackedTileCopyTla<KdaArchTag, ElementA, LayoutTagA, ElementB,
+                                                                LayoutTagB, ElementC, LayoutTagC>;
+        using BlockMmad = Catlass::Gemm::Block::BlockMmadTla<KdaDispatchPolicy, KdaL1TileShape, KdaL0TileShape,
+                                                              ElementA, ElementB, ElementC, void, TileCopy>;
+
+        Catlass::Arch::Resource<KdaArchTag> resource;
+        BlockMmad blockMmad(resource);
+        auto layoutA = tla::MakeLayout<ElementA, LayoutTagA>(BT_, K_);
+        auto layoutB = tla::MakeLayout<ElementB, LayoutTagB>(K_, BT_);
+        auto layoutC = tla::MakeLayout<ElementC, LayoutTagC>(BT_, BT_);
+        Catlass::GemmCoord shape{static_cast<uint32_t>(curT), static_cast<uint32_t>(curT),
+                                 static_cast<uint32_t>(K_)};
+
+        auto tensorQPos = tla::MakeTensor(qg_[KVOffset(b, hv, start, 0, K_)], layoutA,
+                                          Catlass::Arch::PositionGM{});
+        auto tensorKPos = tla::MakeTensor(w_[KVOffset(b, hv, start, 0, K_)], layoutA,
+                                          Catlass::Arch::PositionGM{});
+        auto tensorKNeg = tla::MakeTensor(kg_[KVOffset(b, hv, start, 0, K_)], layoutB,
+                                          Catlass::Arch::PositionGM{});
+        auto tensorAqk = tla::MakeTensor(aqk_[AOffset(b, hv, start, 0)], layoutC,
+                                         Catlass::Arch::PositionGM{});
+        auto tensorAkk = tla::MakeTensor(akk_[AOffset(b, hv, start, 0)], layoutC,
+                                         Catlass::Arch::PositionGM{});
+
+        auto blockQPos = GetTile(tensorQPos, tla::MakeCoord(0, 0), tla::MakeShape(shape.m(), shape.k()));
+        auto blockKPos = GetTile(tensorKPos, tla::MakeCoord(0, 0), tla::MakeShape(shape.m(), shape.k()));
+        auto blockKNeg = GetTile(tensorKNeg, tla::MakeCoord(0, 0), tla::MakeShape(shape.k(), shape.n()));
+        auto blockAqk = GetTile(tensorAqk, tla::MakeCoord(0, 0), tla::MakeShape(shape.m(), shape.n()));
+        auto blockAkk = GetTile(tensorAkk, tla::MakeCoord(0, 0), tla::MakeShape(shape.m(), shape.n()));
+
+        blockMmad(blockQPos, blockKNeg, blockAqk, shape);
+        PipeBarrier<PIPE_ALL>();
+        blockMmad(blockKPos, blockKNeg, blockAkk, shape);
+        PipeBarrier<PIPE_ALL>();
+    }
+
+    __aicore__ inline bool UseAkkCubeSolve(uint64_t curT) const
+    {
+        return curT == KDA_SOLVE_BT && K_ >= 16 && V_ >= 16 && V_ <= 128 && K_ % 16 == 0 && V_ % 16 == 0 &&
+               K_ * V_ >= KDA_SOLVE_SCRATCH_SLOTS * KDA_SOLVE_MATRIX_ELEMENTS &&
+               K_ * V_ >= curT * (K_ + V_);
+    }
+
+    __aicore__ inline bool UsePostWuCube(uint64_t curT) const
+    {
+        return curT == KDA_SOLVE_BT && K_ >= 16 && V_ >= 16 && V_ <= 128 && K_ % 16 == 0 && V_ % 16 == 0 &&
+               K_ * V_ >= curT * (K_ + V_);
+    }
+
+    __aicore__ inline void CopyLocalFloat(LocalTensor<float> dst, LocalTensor<float> src, uint64_t count)
+    {
+        if (count == 0) {
+            return;
+        }
+        Adds(dst, src, 0.0f, static_cast<uint32_t>(count));
+        PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void FillLocalFloat(LocalTensor<float> dst, float value, uint64_t count)
+    {
+        if (count == 0) {
+            return;
+        }
+        Duplicate(dst, value, static_cast<uint32_t>(count));
+        PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void BuildPrefixMask(LocalTensor<float> dst, uint64_t prefix, uint64_t count)
+    {
+        FillLocalFloat(dst, 0.0f, count);
+        if (prefix > count) {
+            prefix = count;
+        }
+        FillLocalFloat(dst, 1.0f, prefix);
+    }
+
+    __aicore__ inline void PrepareAqkAkkSolveInput64(uint64_t b, uint64_t hv, uint64_t chunkIdx, uint64_t start)
+    {
+        LocalTensor<float> arena = vecBuf_.Get<float>();
+        LocalTensor<float> aqkMat = arena;
+        LocalTensor<float> akkMat = arena[KDA_SOLVE_MATRIX_ELEMENTS];
+        LocalTensor<float> xMat = arena[2 * KDA_SOLVE_MATRIX_ELEMENTS];
+        LocalTensor<float> betaLocal = arena[3 * KDA_SOLVE_MATRIX_ELEMENTS];
+        LocalTensor<float> betaBrcb = arena[3 * KDA_SOLVE_MATRIX_ELEMENTS + KDA_SOLVE_BT];
+        LocalTensor<float> maskLocal = arena[3 * KDA_SOLVE_MATRIX_ELEMENTS + KDA_SOLVE_BT + 512];
+        LocalTensor<float> oneHotLocal = arena[3 * KDA_SOLVE_MATRIX_ELEMENTS + KDA_SOLVE_BT + 512 + KDA_SOLVE_BT];
+
+        constexpr uint64_t typedOffsetFloats = 20480;
+        constexpr uint64_t typedOffset = typedOffsetFloats * sizeof(float) / sizeof(T);
+
+        LoadAsFloatRow(beta_, BetaOffset(b, hv, start), betaLocal, KDA_SOLVE_BT);
+        Brcb(betaBrcb, betaLocal, 8, {1, 8});
+        PipeBarrier<PIPE_V>();
+
+        if constexpr (IsSameType<T, float>::value) {
+            DataCopy(aqkMat, aqk_[AOffset(b, hv, start, 0)], KDA_SOLVE_MATRIX_ELEMENTS);
+            DataCopy(akkMat, akk_[AOffset(b, hv, start, 0)], KDA_SOLVE_MATRIX_ELEMENTS);
+            SetFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            WaitFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+        } else {
+            LocalTensor<T> typedAqk = vecBuf_.Get<T>()[typedOffset];
+            LocalTensor<T> typedAkk = typedAqk[KDA_SOLVE_MATRIX_ELEMENTS];
+            DataCopy(typedAqk, aqk_[AOffset(b, hv, start, 0)], KDA_SOLVE_MATRIX_ELEMENTS);
+            DataCopy(typedAkk, akk_[AOffset(b, hv, start, 0)], KDA_SOLVE_MATRIX_ELEMENTS);
+            SetFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            WaitFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            Cast(aqkMat, typedAqk, RoundMode::CAST_NONE, KDA_SOLVE_MATRIX_ELEMENTS);
+            Cast(akkMat, typedAkk, RoundMode::CAST_NONE, KDA_SOLVE_MATRIX_ELEMENTS);
+            PipeBarrier<PIPE_V>();
+        }
+
+        for (uint64_t col = 0; col < KDA_SOLVE_BT; col += 8) {
+            Mul(akkMat[col], akkMat[col], betaBrcb, 8, KDA_SOLVE_BT, {1, 1, 1, 8, 8, 1});
+            PipeBarrier<PIPE_V>();
+        }
+        for (uint64_t row = 0; row < KDA_SOLVE_BT; ++row) {
+            BuildPrefixMask(maskLocal, row + 1, KDA_SOLVE_BT);
+            Mul(aqkMat[row * KDA_SOLVE_BT], aqkMat[row * KDA_SOLVE_BT], maskLocal, KDA_SOLVE_BT);
+            PipeBarrier<PIPE_V>();
+
+            BuildPrefixMask(maskLocal, row, KDA_SOLVE_BT);
+            Mul(akkMat[row * KDA_SOLVE_BT], akkMat[row * KDA_SOLVE_BT], maskLocal, KDA_SOLVE_BT);
+            PipeBarrier<PIPE_V>();
+        }
+
+        Muls(xMat, akkMat, -1.0f, KDA_SOLVE_MATRIX_ELEMENTS);
+        PipeBarrier<PIPE_V>();
+        for (uint64_t row = 0; row < KDA_SOLVE_BT; ++row) {
+            BuildPrefixMask(maskLocal, row + 1, KDA_SOLVE_BT);
+            BuildPrefixMask(oneHotLocal, row, KDA_SOLVE_BT);
+            Sub(maskLocal, maskLocal, oneHotLocal, KDA_SOLVE_BT);
+            PipeBarrier<PIPE_V>();
+            Add(xMat[row * KDA_SOLVE_BT], xMat[row * KDA_SOLVE_BT], maskLocal, KDA_SOLVE_BT);
+            PipeBarrier<PIPE_V>();
+        }
+
+        if constexpr (IsSameType<T, float>::value) {
+            SetFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            DataCopy(aqk_[AOffset(b, hv, start, 0)], aqkMat, KDA_SOLVE_MATRIX_ELEMENTS);
+            DataCopy(akk_[AOffset(b, hv, start, 0)], akkMat, KDA_SOLVE_MATRIX_ELEMENTS);
+            DataCopy(h_[SolveScratchOffset(b, hv, chunkIdx, KDA_SOLVE_SCRATCH_X)], xMat,
+                     KDA_SOLVE_MATRIX_ELEMENTS);
+        } else {
+            LocalTensor<T> typedAqk = vecBuf_.Get<T>()[typedOffset];
+            LocalTensor<T> typedAkk = typedAqk[KDA_SOLVE_MATRIX_ELEMENTS];
+            LocalTensor<T> typedX = typedAkk[KDA_SOLVE_MATRIX_ELEMENTS];
+            Cast(typedAqk, aqkMat, RoundMode::CAST_RINT, KDA_SOLVE_MATRIX_ELEMENTS);
+            Cast(typedAkk, akkMat, RoundMode::CAST_RINT, KDA_SOLVE_MATRIX_ELEMENTS);
+            Cast(typedX, xMat, RoundMode::CAST_RINT, KDA_SOLVE_MATRIX_ELEMENTS);
+            PipeBarrier<PIPE_V>();
+            SetFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            DataCopy(aqk_[AOffset(b, hv, start, 0)], typedAqk, KDA_SOLVE_MATRIX_ELEMENTS);
+            DataCopy(akk_[AOffset(b, hv, start, 0)], typedAkk, KDA_SOLVE_MATRIX_ELEMENTS);
+            DataCopy(h_[SolveScratchOffset(b, hv, chunkIdx, KDA_SOLVE_SCRATCH_X)], typedX,
+                     KDA_SOLVE_MATRIX_ELEMENTS);
+        }
+        SetFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        SetFlag<HardEvent::MTE3_V>(KDA_SCALAR_MTE3_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_V>(KDA_SCALAR_MTE3_V_EVENT_ID);
+    }
+
+    __aicore__ inline void CubeGemmSolveSub(GlobalTensor<T> &tensorA, uint64_t baseA, uint64_t rowA, uint64_t colA,
+                                            GlobalTensor<T> &tensorB, uint64_t baseB, uint64_t rowB, uint64_t colB,
+                                            GlobalTensor<T> &tensorC, uint64_t baseC, uint64_t rowC, uint64_t colC,
+                                            uint32_t m, uint32_t n, uint32_t k)
+    {
+        using ElementA = T;
+        using ElementB = T;
+        using ElementC = T;
+        using LayoutTagA = Catlass::layout::RowMajor;
+        using LayoutTagB = Catlass::layout::RowMajor;
+        using LayoutTagC = Catlass::layout::RowMajor;
+        using TileCopy = Catlass::Gemm::Tile::PackedTileCopyTla<KdaArchTag, ElementA, LayoutTagA, ElementB,
+                                                                LayoutTagB, ElementC, LayoutTagC>;
+        using PostL1TileShape = tla::Shape<_128, _128, _256>;
+        using PostL0TileShape = tla::Shape<_128, _128, _128>;
+        using BlockMmad = Catlass::Gemm::Block::BlockMmadTla<KdaDispatchPolicy, PostL1TileShape, PostL0TileShape,
+                                                              ElementA, ElementB, ElementC, void, TileCopy>;
+
+        Catlass::Arch::Resource<KdaArchTag> resource;
+        BlockMmad blockMmad(resource);
+        auto layoutA = tla::MakeLayout<ElementA, LayoutTagA>(KDA_SOLVE_BT, KDA_SOLVE_BT);
+        auto layoutB = tla::MakeLayout<ElementB, LayoutTagB>(KDA_SOLVE_BT, KDA_SOLVE_BT);
+        auto layoutC = tla::MakeLayout<ElementC, LayoutTagC>(KDA_SOLVE_BT, KDA_SOLVE_BT);
+        auto tensorLayoutA = tla::MakeTensor(tensorA[baseA], layoutA, Catlass::Arch::PositionGM{});
+        auto tensorLayoutB = tla::MakeTensor(tensorB[baseB], layoutB, Catlass::Arch::PositionGM{});
+        auto tensorLayoutC = tla::MakeTensor(tensorC[baseC], layoutC, Catlass::Arch::PositionGM{});
+        Catlass::GemmCoord shape{m, n, k};
+        auto blockA = GetTile(tensorLayoutA, tla::MakeCoord(rowA, colA), tla::MakeShape(shape.m(), shape.k()));
+        auto blockB = GetTile(tensorLayoutB, tla::MakeCoord(rowB, colB), tla::MakeShape(shape.k(), shape.n()));
+        auto blockC = GetTile(tensorLayoutC, tla::MakeCoord(rowC, colC), tla::MakeShape(shape.m(), shape.n()));
+        blockMmad(blockA, blockB, blockC, shape);
+        PipeBarrier<PIPE_ALL>();
+    }
+
+    __aicore__ inline void AddSolveTmpToX(uint64_t b, uint64_t hv, uint64_t chunkIdx, uint64_t start,
+                                          bool storeAkk)
+    {
+        LocalTensor<float> arena = vecBuf_.Get<float>();
+        LocalTensor<float> xLocal = arena;
+        LocalTensor<float> tmpLocal = arena[KDA_SOLVE_MATRIX_ELEMENTS];
+        constexpr uint64_t typedOffsetFloats = 20480;
+        constexpr uint64_t typedOffset = typedOffsetFloats * sizeof(float) / sizeof(T);
+        uint64_t xBase = SolveScratchOffset(b, hv, chunkIdx, KDA_SOLVE_SCRATCH_X);
+        uint64_t tmpBase = SolveScratchOffset(b, hv, chunkIdx, KDA_SOLVE_SCRATCH_TMP);
+
+        if constexpr (IsSameType<T, float>::value) {
+            DataCopy(xLocal, h_[xBase], KDA_SOLVE_MATRIX_ELEMENTS);
+            DataCopy(tmpLocal, h_[tmpBase], KDA_SOLVE_MATRIX_ELEMENTS);
+            SetFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            WaitFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+        } else {
+            LocalTensor<T> typedX = vecBuf_.Get<T>()[typedOffset];
+            LocalTensor<T> typedTmp = typedX[KDA_SOLVE_MATRIX_ELEMENTS];
+            DataCopy(typedX, h_[xBase], KDA_SOLVE_MATRIX_ELEMENTS);
+            DataCopy(typedTmp, h_[tmpBase], KDA_SOLVE_MATRIX_ELEMENTS);
+            SetFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            WaitFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            Cast(xLocal, typedX, RoundMode::CAST_NONE, KDA_SOLVE_MATRIX_ELEMENTS);
+            Cast(tmpLocal, typedTmp, RoundMode::CAST_NONE, KDA_SOLVE_MATRIX_ELEMENTS);
+            PipeBarrier<PIPE_V>();
+        }
+
+        Add(xLocal, xLocal, tmpLocal, KDA_SOLVE_MATRIX_ELEMENTS);
+        PipeBarrier<PIPE_V>();
+
+        if constexpr (IsSameType<T, float>::value) {
+            SetFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            DataCopy(h_[xBase], xLocal, KDA_SOLVE_MATRIX_ELEMENTS);
+            if (storeAkk) {
+                DataCopy(akk_[AOffset(b, hv, start, 0)], xLocal, KDA_SOLVE_MATRIX_ELEMENTS);
+            }
+        } else {
+            LocalTensor<T> typedX = vecBuf_.Get<T>()[typedOffset];
+            Cast(typedX, xLocal, RoundMode::CAST_RINT, KDA_SOLVE_MATRIX_ELEMENTS);
+            PipeBarrier<PIPE_V>();
+            SetFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            DataCopy(h_[xBase], typedX, KDA_SOLVE_MATRIX_ELEMENTS);
+            if (storeAkk) {
+                DataCopy(akk_[AOffset(b, hv, start, 0)], typedX, KDA_SOLVE_MATRIX_ELEMENTS);
+            }
+        }
+        SetFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        SetFlag<HardEvent::MTE3_V>(KDA_SCALAR_MTE3_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_V>(KDA_SCALAR_MTE3_V_EVENT_ID);
+    }
+
+    __aicore__ inline void ComputeAkkInverseMch64(uint64_t b, uint64_t hv, uint64_t chunkIdx, uint64_t start)
+    {
+        uint64_t aBase = AOffset(b, hv, start, 0);
+        uint64_t xBase = SolveScratchOffset(b, hv, chunkIdx, KDA_SOLVE_SCRATCH_X);
+        uint64_t yBase = SolveScratchOffset(b, hv, chunkIdx, KDA_SOLVE_SCRATCH_Y0);
+        uint64_t yNextBase = SolveScratchOffset(b, hv, chunkIdx, KDA_SOLVE_SCRATCH_Y1);
+        uint64_t tmpBase = SolveScratchOffset(b, hv, chunkIdx, KDA_SOLVE_SCRATCH_TMP);
+
+        CubeGemmSolveSub(akk_, aBase, 0, 0, akk_, aBase, 0, 0, h_, yBase, 0, 0, KDA_SOLVE_BT,
+                         KDA_SOLVE_BT, KDA_SOLVE_BT);
+        for (uint32_t iter = 0; iter < KDA_SOLVE_MCH_ITERS; ++iter) {
+            CubeGemmSolveSub(h_, xBase, 0, 0, h_, yBase, 0, 0, h_, tmpBase, 0, 0, KDA_SOLVE_BT,
+                             KDA_SOLVE_BT, KDA_SOLVE_BT);
+            Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(scoreDoneFlag_);
+            if (iter + 1 < KDA_SOLVE_MCH_ITERS) {
+                CubeGemmSolveSub(h_, yBase, 0, 0, h_, yBase, 0, 0, h_, yNextBase, 0, 0, KDA_SOLVE_BT,
+                                 KDA_SOLVE_BT, KDA_SOLVE_BT);
+            }
+            Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_FIX>(scoreReadyFlag_);
+            if (iter + 1 < KDA_SOLVE_MCH_ITERS) {
+                uint64_t oldYBase = yBase;
+                yBase = yNextBase;
+                yNextBase = oldYBase;
+            }
+        }
+    }
+
+    __aicore__ inline void ComputeAkkMerge64Cube(uint64_t b, uint64_t hv, uint64_t chunkIdx, uint64_t start)
+    {
+        uint64_t aiBase = AOffset(b, hv, start, 0);
+        uint64_t negABase = HOffset(b, hv, chunkIdx, 0, 0);
+        uint64_t tmpBase = negABase + KDA_SOLVE_MATRIX_ELEMENTS;
+
+        CubeGemmSolveSub(akk_, aiBase, 16, 16, h_, negABase, 16, 0, h_, tmpBase, 0, 0, 16, 16, 16);
+        CubeGemmSolveSub(h_, tmpBase, 0, 0, akk_, aiBase, 0, 0, akk_, aiBase, 16, 0, 16, 16, 16);
+
+        CubeGemmSolveSub(akk_, aiBase, 48, 48, h_, negABase, 48, 32, h_, tmpBase, 0, 0, 16, 16, 16);
+        CubeGemmSolveSub(h_, tmpBase, 0, 0, akk_, aiBase, 32, 32, akk_, aiBase, 48, 32, 16, 16, 16);
+
+        CubeGemmSolveSub(akk_, aiBase, 32, 32, h_, negABase, 32, 0, h_, tmpBase, 0, 0, 32, 32, 32);
+        CubeGemmSolveSub(h_, tmpBase, 0, 0, akk_, aiBase, 0, 0, akk_, aiBase, 32, 0, 32, 32, 32);
+    }
+
+    __aicore__ inline void FinalizeAqkAkk(uint64_t b, uint64_t hv, uint64_t start, uint64_t curT)
+    {
+        for (uint64_t i = 0; i < curT; ++i) {
+            uint64_t ti = start + i;
+            float aqkRow[EXP2_UB_ELEMENTS];
+            float akkRow[EXP2_UB_ELEMENTS];
+            for (uint64_t j = 0; j < BT_; ++j) {
+                float aqkValue = 0.0f;
+                float akkValue = 0.0f;
+                if (j < curT && j <= i) {
+                    aqkValue = ReadAsFloat(aqk_, AOffset(b, hv, ti, j)) * (stage_ == 1 ? 1.0f : scale_);
+                    if (j < i) {
+                        akkValue = ReadAsFloat(akk_, AOffset(b, hv, ti, j)) *
+                                   ReadFloat(beta_, BetaOffset(b, hv, ti));
+                    }
+                }
+                aqkRow[j] = aqkValue;
+                akkRow[j] = akkValue;
+            }
+
+            for (uint64_t j = 0; j < i; ++j) {
+                float sum = 0.0f;
+                for (uint64_t m = j; m < i; ++m) {
+                    float lim = akkRow[m];
+                    float ymj = ReadAsFloat(akk_, AOffset(b, hv, start + m, j));
+                    sum += lim * ymj;
+                }
+                akkRow[j] = -sum;
+            }
+            akkRow[i] = 1.0f;
+            CopyStackFloatRowOut(aqk_, AOffset(b, hv, ti, 0), aqkRow, BT_, 0);
+            CopyStackFloatRowOut(akk_, AOffset(b, hv, ti, 0), akkRow, BT_, 1);
+        }
+    }
+
+    __aicore__ inline void ComputePostKgWUVec(uint64_t b, uint64_t h, uint64_t hv, uint64_t chunkIdx,
+                                              uint64_t start, uint64_t curT)
+    {
+        uint64_t last = start + curT - 1;
+        uint64_t wScratchBase = HOffset(b, hv, chunkIdx, 0, 0);
+        LocalTensor<float> rowLocal = VecScratch(0);
+        LocalTensor<float> accLocal = VecScratch(1);
+        LocalTensor<float> tmpLocal = VecScratch(2);
+        LocalTensor<float> gateLast = VecScratch(4);
+        LoadExp2GTo(gateLast, b, hv, last);
+
+        for (uint64_t i = 0; i < curT; ++i) {
+            uint64_t ti = start + i;
+            LoadAsFloatRow(kg_, KVOffset(b, hv, ti, 0, K_), rowLocal, K_);
+            Mul(tmpLocal, rowLocal, gateLast, static_cast<uint32_t>(K_));
+            PipeBarrier<PIPE_V>();
+            StoreFloatRow(kg_, KVOffset(b, hv, ti, 0, K_), tmpLocal, K_);
+        }
+
+        LocalTensor<float> gateLocal = VecScratch(5);
+
+        for (uint64_t i = 0; i < curT; ++i) {
+            uint64_t ti = start + i;
+
+            Duplicate(accLocal, 0.0f, static_cast<uint32_t>(K_));
+            PipeBarrier<PIPE_V>();
+            for (uint64_t j = 0; j < curT; ++j) {
+                uint64_t tj = start + j;
+                float coeff = ReadAsFloat(akk_, AOffset(b, hv, ti, j)) * ReadFloat(beta_, BetaOffset(b, hv, tj));
+                LoadAsFloatRow(k_, QOffset(b, h, tj, 0), rowLocal, K_);
+                LoadExp2GTo(gateLocal, b, hv, tj);
+                Mul(rowLocal, rowLocal, gateLocal, static_cast<uint32_t>(K_));
+                PipeBarrier<PIPE_V>();
+                Muls(tmpLocal, rowLocal, coeff, static_cast<uint32_t>(K_));
+                PipeBarrier<PIPE_V>();
+                Add(accLocal, accLocal, tmpLocal, static_cast<uint32_t>(K_));
+                PipeBarrier<PIPE_V>();
+            }
+            StoreFloatRow(h_, wScratchBase + i * K_, accLocal, K_);
+
+            Duplicate(accLocal, 0.0f, static_cast<uint32_t>(V_));
+            PipeBarrier<PIPE_V>();
+            for (uint64_t j = 0; j < curT; ++j) {
+                uint64_t tj = start + j;
+                float coeff = ReadAsFloat(akk_, AOffset(b, hv, ti, j)) * ReadFloat(beta_, BetaOffset(b, hv, tj));
+                LoadAsFloatRow(v_, KVOffset(b, hv, tj, 0, V_), rowLocal, V_);
+                Muls(tmpLocal, rowLocal, coeff, static_cast<uint32_t>(V_));
+                PipeBarrier<PIPE_V>();
+                Add(accLocal, accLocal, tmpLocal, static_cast<uint32_t>(V_));
+                PipeBarrier<PIPE_V>();
+            }
+            StoreFloatRow(u_, KVOffset(b, hv, ti, 0, V_), accLocal, V_);
+        }
+        for (uint64_t i = 0; i < curT; ++i) {
+            CopyTensorRow(w_, KVOffset(b, hv, start + i, 0, K_), h_, wScratchBase + i * K_, K_);
+        }
+    }
+
+    __aicore__ inline void ScaleRowsByBeta(GlobalTensor<T> &src, GlobalTensor<T> &dst, uint64_t b, uint64_t hv,
+                                           uint64_t start, uint64_t rowBegin, uint64_t rowCount, uint64_t dim,
+                                           LocalTensor<float> &betaBrcb, LocalTensor<float> &matrixLocal)
+    {
+        constexpr uint64_t vecElemsPerRepeat = 64;
+        constexpr uint64_t typedOffsetFloats = 20480;
+        constexpr uint64_t typedOffset = typedOffsetFloats * sizeof(float) / sizeof(T);
+        uint64_t elemCount = rowCount * dim;
+        uint64_t baseOffset = KVOffset(b, hv, start + rowBegin, 0, dim);
+
+        if constexpr (IsSameType<T, float>::value) {
+            DataCopy(matrixLocal, src[baseOffset], static_cast<uint32_t>(elemCount));
+            SetFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            WaitFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+        } else {
+            LocalTensor<T> matrixTyped = vecBuf_.Get<T>()[typedOffset];
+            DataCopy(matrixTyped, src[baseOffset], static_cast<uint32_t>(elemCount));
+            SetFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            WaitFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            Cast(matrixLocal, matrixTyped, RoundMode::CAST_NONE, static_cast<uint32_t>(elemCount));
+            PipeBarrier<PIPE_V>();
+        }
+
+        uint8_t repeatStride = static_cast<uint8_t>(dim * sizeof(float) / 32);
+        for (uint64_t col = 0; col < dim; col += vecElemsPerRepeat) {
+            uint64_t mask = dim - col;
+            if (mask > vecElemsPerRepeat) {
+                mask = vecElemsPerRepeat;
+            }
+            Mul(matrixLocal[col], matrixLocal[col], betaBrcb, mask, static_cast<uint8_t>(rowCount),
+                {1, 1, 0, repeatStride, repeatStride, 1});
+            PipeBarrier<PIPE_V>();
+        }
+
+        if constexpr (IsSameType<T, float>::value) {
+            SetFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            DataCopy(dst[baseOffset], matrixLocal, static_cast<uint32_t>(elemCount));
+        } else {
+            LocalTensor<T> matrixTyped = vecBuf_.Get<T>()[typedOffset];
+            Cast(matrixTyped, matrixLocal, RoundMode::CAST_RINT, static_cast<uint32_t>(elemCount));
+            PipeBarrier<PIPE_V>();
+            SetFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            DataCopy(dst[baseOffset], matrixTyped, static_cast<uint32_t>(elemCount));
+        }
+        SetFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        SetFlag<HardEvent::MTE3_V>(KDA_SCALAR_MTE3_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_V>(KDA_SCALAR_MTE3_V_EVENT_ID);
+    }
+
+    __aicore__ inline void PrepareWuCubeInputs(uint64_t b, uint64_t hv, uint64_t start, uint64_t curT,
+                                               uint64_t subBlockIdx, uint64_t subBlockNum)
+    {
+        uint64_t rowsPerSubBlock = (curT + subBlockNum - 1) / subBlockNum;
+        uint64_t rowBegin = subBlockIdx * rowsPerSubBlock;
+        if (rowBegin >= curT) {
+            return;
+        }
+        uint64_t rowCount = curT - rowBegin;
+        if (rowCount > rowsPerSubBlock) {
+            rowCount = rowsPerSubBlock;
+        }
+        LocalTensor<float> arena = vecBuf_.Get<float>();
+        LocalTensor<float> betaLocal = arena;
+        LocalTensor<float> betaBrcb = arena[KDA_SOLVE_BT];
+        LocalTensor<float> matrixLocal = arena[KDA_SOLVE_BT + 512];
+        LoadAsFloatRow(beta_, BetaOffset(b, hv, start + rowBegin), betaLocal, rowCount);
+        Brcb(betaBrcb, betaLocal, static_cast<uint8_t>((rowCount + 7) / 8), {1, 8});
+        PipeBarrier<PIPE_V>();
+        ScaleRowsByBeta(w_, w_, b, hv, start, rowBegin, rowCount, K_, betaBrcb, matrixLocal);
+        ScaleRowsByBeta(v_, vNew_, b, hv, start, rowBegin, rowCount, V_, betaBrcb, matrixLocal);
+    }
+
+    __aicore__ inline void ComputePostWuCube(uint64_t b, uint64_t hv, uint64_t chunkIdx, uint64_t start,
+                                             uint64_t curT)
+    {
+        using ElementA = T;
+        using ElementB = T;
+        using ElementC = T;
+        using LayoutTagA = Catlass::layout::RowMajor;
+        using LayoutTagB = Catlass::layout::RowMajor;
+        using LayoutTagC = Catlass::layout::RowMajor;
+        using TileCopy = Catlass::Gemm::Tile::PackedTileCopyTla<KdaArchTag, ElementA, LayoutTagA, ElementB,
+                                                                LayoutTagB, ElementC, LayoutTagC>;
+        using PostL1TileShape = tla::Shape<_128, _128, _256>;
+        using PostL0TileShape = tla::Shape<_128, _128, _128>;
+        using BlockMmad = Catlass::Gemm::Block::BlockMmadTla<KdaDispatchPolicy, PostL1TileShape, PostL0TileShape,
+                                                              ElementA, ElementB, ElementC, void, TileCopy>;
+
+        Catlass::Arch::Resource<KdaArchTag> resource;
+        BlockMmad blockMmad(resource);
+        LayoutTagA tagA = LayoutTagA::template MakeLayout<ElementA>(BT_, BT_);
+        auto layoutA = tla::MakeLayoutFromTag(tagA);
+        auto tensorA = tla::MakeTensor(akk_[AOffset(b, hv, start, 0)], layoutA, Catlass::Arch::PositionGM{});
+
+        {
+            LayoutTagB tagB = LayoutTagB::template MakeLayout<ElementB>(BT_, K_);
+            LayoutTagC tagC = LayoutTagC::template MakeLayout<ElementC>(BT_, K_);
+            auto layoutB = tla::MakeLayoutFromTag(tagB);
+            auto layoutC = tla::MakeLayoutFromTag(tagC);
+            Catlass::GemmCoord shape{static_cast<uint32_t>(curT), static_cast<uint32_t>(K_),
+                                     static_cast<uint32_t>(curT)};
+            auto tensorB = tla::MakeTensor(w_[KVOffset(b, hv, start, 0, K_)], layoutB,
+                                           Catlass::Arch::PositionGM{});
+            auto tensorC = tla::MakeTensor(h_[WScratchOffset(b, hv, chunkIdx, 0, 0)], layoutC,
+                                            Catlass::Arch::PositionGM{});
+            auto blockA = GetTile(tensorA, tla::MakeCoord(0, 0), tla::MakeShape(shape.m(), shape.k()));
+            auto blockB = GetTile(tensorB, tla::MakeCoord(0, 0), tla::MakeShape(shape.k(), shape.n()));
+            auto blockC = GetTile(tensorC, tla::MakeCoord(0, 0), tla::MakeShape(shape.m(), shape.n()));
+            blockMmad(blockA, blockB, blockC, shape);
+            PipeBarrier<PIPE_ALL>();
+        }
+
+        {
+            LayoutTagB tagB = LayoutTagB::template MakeLayout<ElementB>(BT_, V_);
+            LayoutTagC tagC = LayoutTagC::template MakeLayout<ElementC>(BT_, V_);
+            auto layoutB = tla::MakeLayoutFromTag(tagB);
+            auto layoutC = tla::MakeLayoutFromTag(tagC);
+            Catlass::GemmCoord shape{static_cast<uint32_t>(curT), static_cast<uint32_t>(V_),
+                                     static_cast<uint32_t>(curT)};
+            auto tensorB = tla::MakeTensor(vNew_[KVOffset(b, hv, start, 0, V_)], layoutB,
+                                           Catlass::Arch::PositionGM{});
+            auto tensorC = tla::MakeTensor(u_[KVOffset(b, hv, start, 0, V_)], layoutC,
+                                           Catlass::Arch::PositionGM{});
+            auto blockA = GetTile(tensorA, tla::MakeCoord(0, 0), tla::MakeShape(shape.m(), shape.k()));
+            auto blockB = GetTile(tensorB, tla::MakeCoord(0, 0), tla::MakeShape(shape.k(), shape.n()));
+            auto blockC = GetTile(tensorC, tla::MakeCoord(0, 0), tla::MakeShape(shape.m(), shape.n()));
+            blockMmad(blockA, blockB, blockC, shape);
+            PipeBarrier<PIPE_ALL>();
+        }
+
+    }
+
+    __aicore__ inline void CopyScratchWAndFinalizeKg(uint64_t b, uint64_t h, uint64_t hv, uint64_t chunkIdx,
+                                                     uint64_t start, uint64_t curT)
+    {
+        (void)h;
+        constexpr uint64_t vecElemsPerRepeat = 64;
+        constexpr uint64_t matrixOffset = 1024;
+        constexpr uint64_t typedOffsetFloats = 20480;
+        constexpr uint64_t typedOffset = typedOffsetFloats * sizeof(float) / sizeof(T);
+        uint64_t last = start + curT - 1;
+        uint64_t elemCount = curT * K_;
+        uint64_t repeatStride = K_ * sizeof(float) / 32;
+        LocalTensor<float> arena = vecBuf_.Get<float>();
+        LocalTensor<float> gateLast = arena;
+        LocalTensor<float> matrixLocal = arena[matrixOffset];
+        uint64_t scratchBase = WScratchOffset(b, hv, chunkIdx, 0, 0);
+
+        if constexpr (IsSameType<T, float>::value) {
+            DataCopy(matrixLocal, h_[scratchBase], static_cast<uint32_t>(elemCount));
+            SetFlag<HardEvent::MTE2_MTE3>(KDA_MTE2_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::MTE2_MTE3>(KDA_MTE2_MTE3_EVENT_ID);
+            DataCopy(w_[KVOffset(b, hv, start, 0, K_)], matrixLocal, static_cast<uint32_t>(elemCount));
+        } else {
+            LocalTensor<T> matrixTyped = vecBuf_.Get<T>()[typedOffset];
+            DataCopy(matrixTyped, h_[scratchBase], static_cast<uint32_t>(elemCount));
+            SetFlag<HardEvent::MTE2_MTE3>(KDA_MTE2_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::MTE2_MTE3>(KDA_MTE2_MTE3_EVENT_ID);
+            DataCopy(w_[KVOffset(b, hv, start, 0, K_)], matrixTyped, static_cast<uint32_t>(elemCount));
+        }
+        SetFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+
+        LoadExp2GTo(gateLast, b, hv, last);
+
+        if constexpr (IsSameType<T, float>::value) {
+            DataCopy(matrixLocal, kg_[KVOffset(b, hv, start, 0, K_)], static_cast<uint32_t>(elemCount));
+            SetFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            WaitFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+        } else {
+            LocalTensor<T> matrixTyped = vecBuf_.Get<T>()[typedOffset];
+            DataCopy(matrixTyped, kg_[KVOffset(b, hv, start, 0, K_)], static_cast<uint32_t>(elemCount));
+            SetFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            WaitFlag<HardEvent::MTE2_V>(KDA_MTE2_V_EVENT_ID);
+            Cast(matrixLocal, matrixTyped, RoundMode::CAST_NONE, static_cast<uint32_t>(elemCount));
+            PipeBarrier<PIPE_V>();
+        }
+
+        for (uint64_t col = 0; col < K_; col += vecElemsPerRepeat) {
+            uint64_t mask = K_ - col;
+            if (mask > vecElemsPerRepeat) {
+                mask = vecElemsPerRepeat;
+            }
+            Mul(matrixLocal[col], matrixLocal[col], gateLast[col], mask, static_cast<uint8_t>(curT),
+                {1, 1, 1, static_cast<uint8_t>(repeatStride), static_cast<uint8_t>(repeatStride), 0});
+            PipeBarrier<PIPE_V>();
+        }
+
+        if constexpr (IsSameType<T, float>::value) {
+            SetFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            DataCopy(kg_[KVOffset(b, hv, start, 0, K_)], matrixLocal, static_cast<uint32_t>(elemCount));
+        } else {
+            LocalTensor<T> matrixTyped = vecBuf_.Get<T>()[typedOffset];
+            Cast(matrixTyped, matrixLocal, RoundMode::CAST_RINT, static_cast<uint32_t>(elemCount));
+            PipeBarrier<PIPE_V>();
+            SetFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE3>(KDA_SCALAR_V_MTE3_EVENT_ID);
+            DataCopy(kg_[KVOffset(b, hv, start, 0, K_)], matrixTyped, static_cast<uint32_t>(elemCount));
+        }
+        SetFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_MTE2>(KDA_MTE3_MTE2_EVENT_ID);
+        SetFlag<HardEvent::MTE3_V>(KDA_SCALAR_MTE3_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_V>(KDA_SCALAR_MTE3_V_EVENT_ID);
+    }
+
+    __aicore__ inline void InitState(uint64_t seq, uint64_t hv)
+    {
+        for (uint64_t d = 0; d < K_; ++d) {
+            uint64_t stateOffset = StateOffset(seq, hv, d, 0);
+            if (hasInitial_) {
+                CopyTensorRow(finalState_, stateOffset, initialState_, stateOffset, V_);
+            } else {
+                ZeroTensorRow(finalState_, stateOffset, V_);
+            }
+        }
+    }
+
+    __aicore__ inline void StoreCurrentState(uint64_t b, uint64_t hv, uint64_t seq, uint64_t chunkIdx)
+    {
+        for (uint64_t d = 0; d < K_; ++d) {
+            CopyTensorRow(h_, HOffset(b, hv, chunkIdx, d, 0), finalState_, StateOffset(seq, hv, d, 0), V_);
+        }
+    }
+
+    __aicore__ inline void ProcessChunkAiv(uint64_t b, uint64_t seq, uint64_t h, uint64_t hv, uint64_t chunkIdx,
+                                           uint64_t start, uint64_t end)
+    {
+        uint64_t curT = end - start;
+        if (curT == 0) {
+            return;
+        }
+
+        if constexpr (IsSameType<T, float>::value) {
+            PrepareGateProducts(b, h, hv, start, curT, 0, 1);
+            ComputeRawAqkAkkScalar(b, h, hv, start, curT);
+        } else {
+            uint64_t subBlockIdx = isAivOnly_ ? 0 : static_cast<uint64_t>(GetSubBlockIdx());
+            if (K_ < 16) {
+                if (!isAivOnly_ && subBlockIdx != 0) {
+                    return;
+                }
+                PrepareGateProducts(b, h, hv, start, curT, 0, 1);
+                ComputeRawAqkAkkScalar(b, h, hv, start, curT);
+            } else {
+                if (subBlockIdx == 0) {
+                    PrepareGateProducts(b, h, hv, start, curT, 0, 1);
+                    PipeBarrier<PIPE_ALL>();
+                }
+                Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(scoreReadyFlag_);
+                Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(scoreReadyFlag_);
+                Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(scoreDoneFlag_);
+                Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(scoreDoneFlag_);
+                if (subBlockIdx != 0) {
+                    return;
+                }
+            }
+        }
+        FinalizeAqkAkk(b, hv, start, curT);
+
+        uint64_t last = end - 1;
+        for (uint64_t i = 0; i < curT; ++i) {
+            uint64_t ti = start + i;
+            LocalTensor<float> expLastMinusG = Exp2GDiff(b, hv, last, ti);
+            __ubuf__ float *expLastMinusGPtr = UbPtr(expLastMinusG);
+            float kgRow[EXP2_UB_ELEMENTS];
+            for (uint64_t d = 0; d < K_; ++d) {
+                float kv = ReadAsFloat(k_, QOffset(b, h, ti, d));
+                kgRow[d] = kv * expLastMinusGPtr[d];
+            }
+            CopyStackFloatRowOut(kg_, KVOffset(b, hv, ti, 0, K_), kgRow, K_, 2);
+
+            float wSum[EXP2_UB_ELEMENTS];
+            for (uint64_t d = 0; d < K_; ++d) {
+                wSum[d] = 0.0f;
+            }
+            for (uint64_t j = 0; j < curT; ++j) {
+                uint64_t tj = start + j;
+                LocalTensor<float> expGj = Exp2G(b, hv, tj);
+                __ubuf__ float *expGjPtr = UbPtr(expGj);
+                float betaJ = ReadFloat(beta_, BetaOffset(b, hv, tj));
+                float a = ReadAsFloat(akk_, AOffset(b, hv, ti, j));
+                for (uint64_t d = 0; d < K_; ++d) {
+                    float kj = ReadAsFloat(k_, QOffset(b, h, tj, d));
+                    wSum[d] += a * kj * betaJ * expGjPtr[d];
+                }
+            }
+            CopyStackFloatRowOut(w_, KVOffset(b, hv, ti, 0, K_), wSum, K_, 3);
+
+            float uRow[EXP2_UB_ELEMENTS];
+            for (uint64_t r = 0; r < V_; ++r) {
+                uRow[r] = 0.0f;
+            }
+            for (uint64_t j = 0; j < curT; ++j) {
+                uint64_t tj = start + j;
+                float vRow[EXP2_UB_ELEMENTS];
+                LoadStackFloatRow(v_, KVOffset(b, hv, tj, 0, V_), vRow, V_, 0);
+                float a = ReadAsFloat(akk_, AOffset(b, hv, ti, j));
+                float betaJ = ReadFloat(beta_, BetaOffset(b, hv, tj));
+                for (uint64_t r = 0; r < V_; ++r) {
+                    uRow[r] += a * vRow[r] * betaJ;
+                }
+            }
+            CopyStackFloatRowOut(u_, KVOffset(b, hv, ti, 0, V_), uRow, V_, 4);
+
+            float vNewRow[EXP2_UB_ELEMENTS];
+            for (uint64_t r = 0; r < V_; ++r) {
+                vNewRow[r] = uRow[r];
+            }
+            for (uint64_t d = 0; d < K_; ++d) {
+                float hRow[EXP2_UB_ELEMENTS];
+                LoadStackFloatRow(finalState_, StateOffset(seq, hv, d, 0), hRow, V_, 1);
+                float wi = wSum[d];
+                for (uint64_t r = 0; r < V_; ++r) {
+                    vNewRow[r] -= wi * hRow[r];
+                }
+            }
+            CopyStackFloatRowOut(vNew_, KVOffset(b, hv, ti, 0, V_), vNewRow, V_, 2);
+        }
+
+        StoreCurrentState(b, hv, seq, chunkIdx);
+
+        for (uint64_t i = 0; i < curT; ++i) {
+            uint64_t ti = start + i;
+            float oRow[EXP2_UB_ELEMENTS];
+            for (uint64_t r = 0; r < V_; ++r) {
+                oRow[r] = 0.0f;
+            }
+            float qgRow[EXP2_UB_ELEMENTS];
+            LoadStackFloatRow(qg_, KVOffset(b, hv, ti, 0, K_), qgRow, K_, 0);
+            for (uint64_t d = 0; d < K_; ++d) {
+                float hRow[EXP2_UB_ELEMENTS];
+                LoadStackFloatRow(finalState_, StateOffset(seq, hv, d, 0), hRow, V_, 1);
+                float qgValue = qgRow[d] * scale_;
+                for (uint64_t r = 0; r < V_; ++r) {
+                    oRow[r] += qgValue * hRow[r];
+                }
+            }
+            for (uint64_t j = 0; j < curT; ++j) {
+                uint64_t tj = start + j;
+                float vNewRow[EXP2_UB_ELEMENTS];
+                LoadStackFloatRow(vNew_, KVOffset(b, hv, tj, 0, V_), vNewRow, V_, 2);
+                float a = ReadAsFloat(aqk_, AOffset(b, hv, ti, j));
+                for (uint64_t r = 0; r < V_; ++r) {
+                    oRow[r] += a * vNewRow[r];
+                }
+            }
+            CopyStackFloatRowOut(o_, KVOffset(b, hv, ti, 0, V_), oRow, V_, 3);
+        }
+
+        LocalTensor<float> decayGate = Exp2G(b, hv, last);
+        __ubuf__ float *decayGatePtr = UbPtr(decayGate);
+        float decayValues[EXP2_UB_ELEMENTS];
+        for (uint64_t d = 0; d < K_; ++d) {
+            decayValues[d] = decayGatePtr[d];
+        }
+        for (uint64_t d = 0; d < K_; ++d) {
+            float decay = decayValues[d];
+            float stateRow[EXP2_UB_ELEMENTS];
+            LoadStackFloatRow(finalState_, StateOffset(seq, hv, d, 0), stateRow, V_, 0);
+            for (uint64_t r = 0; r < V_; ++r) {
+                stateRow[r] *= decay;
+            }
+            for (uint64_t i = 0; i < curT; ++i) {
+                uint64_t ti = start + i;
+                float kgRow[EXP2_UB_ELEMENTS];
+                float vNewRow[EXP2_UB_ELEMENTS];
+                LoadStackFloatRow(kg_, KVOffset(b, hv, ti, 0, K_), kgRow, K_, 1);
+                LoadStackFloatRow(vNew_, KVOffset(b, hv, ti, 0, V_), vNewRow, V_, 2);
+                float kgValue = kgRow[d];
+                for (uint64_t r = 0; r < V_; ++r) {
+                    stateRow[r] += kgValue * vNewRow[r];
+                }
+            }
+            CopyStackFloatRowOut(finalState_, StateOffset(seq, hv, d, 0), stateRow, V_, 4);
+        }
+    }
+
+    __aicore__ inline void ProcessChunkAic(uint64_t b, uint64_t hv, uint64_t start, uint64_t end)
+    {
+        uint64_t curT = end - start;
+        if (curT == 0 || K_ < 16) {
+            return;
+        }
+        Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_FIX>(scoreReadyFlag_);
+        Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_FIX>(scoreReadyFlag_);
+        ComputeRawAqkAkkCube(b, hv, start, curT);
+        Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(scoreDoneFlag_);
+        Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(scoreDoneFlag_);
+    }
+
+    __aicore__ inline void ComputeOutputCube(uint64_t b, uint64_t hv, uint64_t chunkIdx, uint64_t start,
+                                             uint64_t curT)
+    {
+        using ElementA = T;
+        using ElementB = T;
+        using ElementC = T;
+        using LayoutTagA = Catlass::layout::RowMajor;
+        using LayoutTagB = Catlass::layout::RowMajor;
+        using LayoutTagC = Catlass::layout::RowMajor;
+        using TileCopy = Catlass::Gemm::Tile::PackedTileCopyTla<KdaArchTag, ElementA, LayoutTagA, ElementB,
+                                                                LayoutTagB, ElementC, LayoutTagC>;
+        using BlockMmad = Catlass::Gemm::Block::BlockMmadTla<KdaDispatchPolicy, KdaL1TileShape, KdaL0TileShape,
+                                                              ElementA, ElementB, ElementC, void, TileCopy>;
+
+        Catlass::Arch::Resource<KdaArchTag> resource;
+        BlockMmad blockMmad(resource);
+
+        auto layoutQ = tla::MakeLayout<ElementA, LayoutTagA>(BT_, K_);
+        auto layoutH = tla::MakeLayout<ElementB, LayoutTagB>(K_, V_);
+        auto layoutO = tla::MakeLayout<ElementC, LayoutTagC>(BT_, V_);
+        Catlass::GemmCoord shapeQH{static_cast<uint32_t>(curT), static_cast<uint32_t>(V_),
+                                   static_cast<uint32_t>(K_)};
+        auto tensorQ = tla::MakeTensor(qg_[KVOffset(b, hv, start, 0, K_)], layoutQ,
+                                       Catlass::Arch::PositionGM{});
+        auto tensorH = tla::MakeTensor(h_[HOffset(b, hv, chunkIdx, 0, 0)], layoutH,
+                                       Catlass::Arch::PositionGM{});
+        auto tensorO = tla::MakeTensor(o_[KVOffset(b, hv, start, 0, V_)], layoutO,
+                                       Catlass::Arch::PositionGM{});
+        auto blockQ = GetTile(tensorQ, tla::MakeCoord(0, 0), tla::MakeShape(shapeQH.m(), shapeQH.k()));
+        auto blockH = GetTile(tensorH, tla::MakeCoord(0, 0), tla::MakeShape(shapeQH.k(), shapeQH.n()));
+        auto blockO = GetTile(tensorO, tla::MakeCoord(0, 0), tla::MakeShape(shapeQH.m(), shapeQH.n()));
+        blockMmad(blockQ, blockH, blockO, shapeQH);
+        PipeBarrier<PIPE_ALL>();
+
+        auto layoutAqk = tla::MakeLayout<ElementA, LayoutTagA>(BT_, BT_);
+        auto layoutV = tla::MakeLayout<ElementB, LayoutTagB>(BT_, V_);
+        Catlass::GemmCoord shapeAV{static_cast<uint32_t>(curT), static_cast<uint32_t>(V_),
+                                   static_cast<uint32_t>(curT)};
+        auto tensorAqk = tla::MakeTensor(aqk_[AOffset(b, hv, start, 0)], layoutAqk,
+                                         Catlass::Arch::PositionGM{});
+        auto tensorVNew = tla::MakeTensor(vNew_[KVOffset(b, hv, start, 0, V_)], layoutV,
+                                          Catlass::Arch::PositionGM{});
+        auto tensorLocal = tla::MakeTensor(u_[KVOffset(b, hv, start, 0, V_)], layoutO,
+                                           Catlass::Arch::PositionGM{});
+        auto blockAqk = GetTile(tensorAqk, tla::MakeCoord(0, 0), tla::MakeShape(shapeAV.m(), shapeAV.k()));
+        auto blockVNew = GetTile(tensorVNew, tla::MakeCoord(0, 0), tla::MakeShape(shapeAV.k(), shapeAV.n()));
+        auto blockLocal = GetTile(tensorLocal, tla::MakeCoord(0, 0), tla::MakeShape(shapeAV.m(), shapeAV.n()));
+        blockMmad(blockAqk, blockVNew, blockLocal, shapeAV);
+        PipeBarrier<PIPE_ALL>();
+    }
+
+    __aicore__ inline void FinalizeOutputRows(uint64_t b, uint64_t hv, uint64_t start, uint64_t curT,
+                                              uint64_t subBlockIdx, uint64_t subBlockNum)
+    {
+        LocalTensor<float> stateLocal = VecScratch(0);
+        LocalTensor<float> localLocal = VecScratch(1);
+        LocalTensor<float> outLocal = VecScratch(2);
+        for (uint64_t i = subBlockIdx; i < curT; i += subBlockNum) {
+            uint64_t ti = start + i;
+            LoadAsFloatRow(o_, KVOffset(b, hv, ti, 0, V_), stateLocal, V_);
+            LoadAsFloatRow(u_, KVOffset(b, hv, ti, 0, V_), localLocal, V_);
+            Add(outLocal, stateLocal, localLocal, static_cast<uint32_t>(V_));
+            PipeBarrier<PIPE_V>();
+            StoreFloatRow(o_, KVOffset(b, hv, ti, 0, V_), outLocal, V_);
+        }
+    }
+
+    __aicore__ inline bool ResolveFlatChunk(uint64_t task, uint64_t &seq, uint64_t &b, uint64_t &h, uint64_t &hv,
+                                            uint64_t &chunkIdx, uint64_t &start, uint64_t &end)
+    {
+        hv = task % HV_;
+        uint64_t flatChunk = task / HV_;
+        if (!isVarLen_) {
+            seq = flatChunk / NT_;
+            b = seq;
+            chunkIdx = flatChunk % NT_;
+            start = chunkIdx * BT_;
+            end = start + BT_;
+            if (end > T_) {
+                end = T_;
+            }
+        } else {
+            uint64_t remain = flatChunk;
+            for (uint64_t s = 0; s < N_; ++s) {
+                uint64_t seqStart = static_cast<uint64_t>(ReadInt64(cuSeqlens_, s));
+                uint64_t seqEnd = static_cast<uint64_t>(ReadInt64(cuSeqlens_, s + 1));
+                uint64_t chunks = (seqEnd - seqStart + BT_ - 1) / BT_;
+                if (remain < chunks) {
+                    seq = s;
+                    b = 0;
+                    chunkIdx = flatChunk;
+                    start = seqStart + remain * BT_;
+                    end = start + BT_;
+                    if (end > seqEnd) {
+                        end = seqEnd;
+                    }
+                    h = hv / (HV_ / H_);
+                    return start < end;
+                }
+                remain -= chunks;
+            }
+            return false;
+        }
+        h = hv / (HV_ / H_);
+        return start < end;
+    }
+
+    __aicore__ inline void ProcessChunkPreAiv(uint64_t b, uint64_t h, uint64_t hv, uint64_t chunkIdx,
+                                              uint64_t start, uint64_t end, uint64_t subBlockIdx,
+                                              uint64_t subBlockNum)
+    {
+        uint64_t curT = end - start;
+        if (curT == 0) {
+            return;
+        }
+        if constexpr (IsSameType<T, float>::value) {
+            PrepareGateProducts(b, h, hv, start, curT, 0, 1);
+            ComputeRawAqkAkkScalar(b, h, hv, start, curT);
+            FinalizeAqkAkk(b, hv, start, curT);
+            ComputePostKgWUVec(b, h, hv, chunkIdx, start, curT);
+            return;
+        }
+
+        if (K_ < 16) {
+            if (subBlockIdx != 0) {
+                return;
+            }
+            PrepareGateProducts(b, h, hv, start, curT, 0, 1);
+            ComputeRawAqkAkkScalar(b, h, hv, start, curT);
+            FinalizeAqkAkk(b, hv, start, curT);
+            ComputePostKgWUVec(b, h, hv, chunkIdx, start, curT);
+            return;
+        }
+
+        PrepareGateProducts(b, h, hv, start, curT, subBlockIdx, subBlockNum);
+        Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(scoreReadyFlag_);
+        Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(scoreDoneFlag_);
+        bool usePostWuCube = UsePostWuCube(curT);
+        bool useAkkCubeSolve = UseAkkCubeSolve(curT);
+        if (subBlockIdx == 0) {
+            if (useAkkCubeSolve) {
+                PrepareAqkAkkSolveInput64(b, hv, chunkIdx, start);
+            } else {
+                FinalizeAqkAkk(b, hv, start, curT);
+                if (!usePostWuCube) {
+                    ComputePostKgWUVec(b, h, hv, chunkIdx, start, curT);
+                }
+            }
+        }
+        if (useAkkCubeSolve) {
+            Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(scoreReadyFlag_);
+            for (uint32_t iter = 0; iter < KDA_SOLVE_MCH_ITERS; ++iter) {
+                Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(scoreDoneFlag_);
+                if (subBlockIdx == 0) {
+                    AddSolveTmpToX(b, hv, chunkIdx, start, iter + 1 == KDA_SOLVE_MCH_ITERS);
+                }
+                Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(scoreReadyFlag_);
+            }
+        }
+        if (!useAkkCubeSolve && !usePostWuCube) {
+            return;
+        }
+        PrepareWuCubeInputs(b, hv, start, curT, subBlockIdx, subBlockNum);
+    }
+
+    __aicore__ inline void ProcessChunkPreAic(uint64_t b, uint64_t hv, uint64_t chunkIdx, uint64_t start,
+                                              uint64_t end)
+    {
+        uint64_t curT = end - start;
+        if (curT == 0 || K_ < 16) {
+            return;
+        }
+        Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_FIX>(scoreReadyFlag_);
+        ComputeRawAqkAkkCube(b, hv, start, curT);
+        Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(scoreDoneFlag_);
+        bool usePostWuCube = UsePostWuCube(curT);
+        bool useAkkCubeSolve = UseAkkCubeSolve(curT);
+        if (useAkkCubeSolve) {
+            Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_FIX>(scoreReadyFlag_);
+            ComputeAkkInverseMch64(b, hv, chunkIdx, start);
+        }
+        if (!useAkkCubeSolve && !usePostWuCube) {
+            return;
+        }
+        (void)chunkIdx;
+    }
+
+    __aicore__ inline void ProcessChunkPostAiv(uint64_t b, uint64_t h, uint64_t hv, uint64_t chunkIdx,
+                                               uint64_t start, uint64_t end, uint64_t subBlockIdx)
+    {
+        uint64_t curT = end - start;
+        if (curT == 0 || !UsePostWuCube(curT)) {
+            return;
+        }
+        Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(scoreDoneFlag_);
+        if (subBlockIdx == 0) {
+            CopyScratchWAndFinalizeKg(b, h, hv, chunkIdx, start, curT);
+        }
+    }
+
+    __aicore__ inline void ProcessChunkPostAic(uint64_t b, uint64_t hv, uint64_t chunkIdx, uint64_t start,
+                                               uint64_t end)
+    {
+        uint64_t curT = end - start;
+        if (curT == 0 || !UsePostWuCube(curT)) {
+            return;
+        }
+        ComputePostWuCube(b, hv, chunkIdx, start, curT);
+        Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(scoreDoneFlag_);
+    }
+
+    __aicore__ inline void ProcessChunkOutAiv(uint64_t b, uint64_t hv, uint64_t start, uint64_t end,
+                                              uint64_t subBlockIdx, uint64_t subBlockNum)
+    {
+        uint64_t curT = end - start;
+        if (curT == 0) {
+            return;
+        }
+        if constexpr (IsSameType<T, float>::value) {
+            return;
+        }
+        Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(scoreDoneFlag_);
+        FinalizeOutputRows(b, hv, start, curT, subBlockIdx, subBlockNum);
+    }
+
+    __aicore__ inline void ProcessChunkOutAic(uint64_t b, uint64_t hv, uint64_t chunkIdx, uint64_t start,
+                                             uint64_t end)
+    {
+        uint64_t curT = end - start;
+        if (curT == 0) {
+            return;
+        }
+        ComputeOutputCube(b, hv, chunkIdx, start, curT);
+        Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(scoreDoneFlag_);
+    }
+
+    __aicore__ inline void ProcessPreAiv()
+    {
+        if constexpr (IsSameType<T, float>::value) {
+            isAivOnly_ = true;
+        }
+        uint64_t subBlockNum = isAivOnly_ ? 1 : static_cast<uint64_t>(GetSubBlockNum());
+        if (subBlockNum == 0) {
+            return;
+        }
+        uint64_t subBlockIdx = isAivOnly_ ? 0 : static_cast<uint64_t>(GetSubBlockIdx());
+        uint64_t coreNum = isAivOnly_ ? static_cast<uint64_t>(GetBlockNum()) : usedCoreNum_;
+        uint64_t coreIdx = isAivOnly_ ? static_cast<uint64_t>(GetBlockIdx()) :
+                                        static_cast<uint64_t>(GetBlockIdx()) / subBlockNum;
+        uint64_t taskNum = static_cast<uint64_t>((isVarLen_ ? NT_ : B_ * NT_) * HV_);
+        for (uint64_t task = coreIdx; task < taskNum; task += coreNum) {
+            uint64_t seq = 0;
+            uint64_t b = 0;
+            uint64_t h = 0;
+            uint64_t hv = 0;
+            uint64_t chunkIdx = 0;
+            uint64_t start = 0;
+            uint64_t end = 0;
+            if (ResolveFlatChunk(task, seq, b, h, hv, chunkIdx, start, end)) {
+                (void)seq;
+                ProcessChunkPreAiv(b, h, hv, chunkIdx, start, end, subBlockIdx, subBlockNum);
+            }
+        }
+    }
+
+    __aicore__ inline void ProcessPreAic()
+    {
+        if constexpr (IsSameType<T, float>::value) {
+            return;
+        }
+        uint64_t taskNum = static_cast<uint64_t>((isVarLen_ ? NT_ : B_ * NT_) * HV_);
+        uint64_t coreNum = usedCoreNum_ == 0 ? 1 : usedCoreNum_;
+        for (uint64_t task = GetBlockIdx(); task < taskNum; task += coreNum) {
+            uint64_t seq = 0;
+            uint64_t b = 0;
+            uint64_t h = 0;
+            uint64_t hv = 0;
+            uint64_t chunkIdx = 0;
+            uint64_t start = 0;
+            uint64_t end = 0;
+            if (ResolveFlatChunk(task, seq, b, h, hv, chunkIdx, start, end)) {
+                (void)seq;
+                (void)h;
+                ProcessChunkPreAic(b, hv, chunkIdx, start, end);
+            }
+        }
+    }
+
+    __aicore__ inline void ProcessPostAiv()
+    {
+        if constexpr (IsSameType<T, float>::value) {
+            return;
+        }
+        uint64_t subBlockNum = static_cast<uint64_t>(GetSubBlockNum());
+        if (subBlockNum == 0) {
+            return;
+        }
+        uint64_t subBlockIdx = static_cast<uint64_t>(GetSubBlockIdx());
+        uint64_t coreNum = usedCoreNum_ == 0 ? 1 : usedCoreNum_;
+        uint64_t coreIdx = static_cast<uint64_t>(GetBlockIdx()) / subBlockNum;
+        uint64_t taskNum = static_cast<uint64_t>((isVarLen_ ? NT_ : B_ * NT_) * HV_);
+        for (uint64_t task = coreIdx; task < taskNum; task += coreNum) {
+            uint64_t seq = 0;
+            uint64_t b = 0;
+            uint64_t h = 0;
+            uint64_t hv = 0;
+            uint64_t chunkIdx = 0;
+            uint64_t start = 0;
+            uint64_t end = 0;
+            if (ResolveFlatChunk(task, seq, b, h, hv, chunkIdx, start, end)) {
+                (void)seq;
+                ProcessChunkPostAiv(b, h, hv, chunkIdx, start, end, subBlockIdx);
+            }
+        }
+    }
+
+    __aicore__ inline void ProcessPostAic()
+    {
+        if constexpr (IsSameType<T, float>::value) {
+            return;
+        }
+        uint64_t taskNum = static_cast<uint64_t>((isVarLen_ ? NT_ : B_ * NT_) * HV_);
+        uint64_t coreNum = usedCoreNum_ == 0 ? 1 : usedCoreNum_;
+        for (uint64_t task = GetBlockIdx(); task < taskNum; task += coreNum) {
+            uint64_t seq = 0;
+            uint64_t b = 0;
+            uint64_t h = 0;
+            uint64_t hv = 0;
+            uint64_t chunkIdx = 0;
+            uint64_t start = 0;
+            uint64_t end = 0;
+            if (ResolveFlatChunk(task, seq, b, h, hv, chunkIdx, start, end)) {
+                (void)seq;
+                (void)h;
+                ProcessChunkPostAic(b, hv, chunkIdx, start, end);
+            }
+        }
+    }
+
+    __aicore__ inline void ProcessOutAiv()
+    {
+        if constexpr (IsSameType<T, float>::value) {
+            return;
+        }
+        uint64_t subBlockNum = static_cast<uint64_t>(GetSubBlockNum());
+        if (subBlockNum == 0) {
+            return;
+        }
+        uint64_t subBlockIdx = static_cast<uint64_t>(GetSubBlockIdx());
+        uint64_t coreNum = usedCoreNum_ == 0 ? 1 : usedCoreNum_;
+        uint64_t coreIdx = static_cast<uint64_t>(GetBlockIdx()) / subBlockNum;
+        uint64_t taskNum = static_cast<uint64_t>((isVarLen_ ? NT_ : B_ * NT_) * HV_);
+        for (uint64_t task = coreIdx; task < taskNum; task += coreNum) {
+            uint64_t seq = 0;
+            uint64_t b = 0;
+            uint64_t h = 0;
+            uint64_t hv = 0;
+            uint64_t chunkIdx = 0;
+            uint64_t start = 0;
+            uint64_t end = 0;
+            if (ResolveFlatChunk(task, seq, b, h, hv, chunkIdx, start, end)) {
+                (void)seq;
+                (void)h;
+                (void)chunkIdx;
+                ProcessChunkOutAiv(b, hv, start, end, subBlockIdx, subBlockNum);
+            }
+        }
+    }
+
+    __aicore__ inline void ProcessOutAic()
+    {
+        if constexpr (IsSameType<T, float>::value) {
+            return;
+        }
+        uint64_t taskNum = static_cast<uint64_t>((isVarLen_ ? NT_ : B_ * NT_) * HV_);
+        uint64_t coreNum = usedCoreNum_ == 0 ? 1 : usedCoreNum_;
+        for (uint64_t task = GetBlockIdx(); task < taskNum; task += coreNum) {
+            uint64_t seq = 0;
+            uint64_t b = 0;
+            uint64_t h = 0;
+            uint64_t hv = 0;
+            uint64_t chunkIdx = 0;
+            uint64_t start = 0;
+            uint64_t end = 0;
+            if (ResolveFlatChunk(task, seq, b, h, hv, chunkIdx, start, end)) {
+                (void)seq;
+                (void)h;
+                ProcessChunkOutAic(b, hv, chunkIdx, start, end);
+            }
+        }
+    }
+
+    __aicore__ inline void ResolveSeq(uint64_t seq, uint64_t &b, uint64_t &seqStart, uint64_t &seqEnd,
+                                      uint64_t &chunkBase)
+    {
+        b = isVarLen_ ? 0 : seq;
+        seqStart = 0;
+        seqEnd = T_;
+        if (isVarLen_) {
+            seqStart = static_cast<uint64_t>(ReadInt64(cuSeqlens_, seq));
+            seqEnd = static_cast<uint64_t>(ReadInt64(cuSeqlens_, seq + 1));
+        }
+        chunkBase = isVarLen_ ? ChunkCountBefore(seq) : 0;
+    }
+
+    __aicore__ inline void ProcessSeqHeadAiv(uint64_t seq, uint64_t hv)
+    {
+        uint64_t b = 0;
+        uint64_t seqStart = 0;
+        uint64_t seqEnd = 0;
+        uint64_t chunkBase = 0;
+        ResolveSeq(seq, b, seqStart, seqEnd, chunkBase);
+        uint64_t h = hv / (HV_ / H_);
+        InitState(seq, hv);
+        uint64_t localChunk = 0;
+        for (uint64_t start = seqStart; start < seqEnd; start += BT_) {
+            uint64_t end = start + BT_;
+            if (end > seqEnd) {
+                end = seqEnd;
+            }
+            ProcessChunkAiv(b, seq, h, hv, chunkBase + localChunk, start, end);
+            ++localChunk;
+        }
+    }
+
+    __aicore__ inline void ProcessSeqHeadAic(uint64_t seq, uint64_t hv)
+    {
+        uint64_t b = 0;
+        uint64_t seqStart = 0;
+        uint64_t seqEnd = 0;
+        uint64_t chunkBase = 0;
+        ResolveSeq(seq, b, seqStart, seqEnd, chunkBase);
+        uint64_t localChunk = 0;
+        for (uint64_t start = seqStart; start < seqEnd; start += BT_) {
+            uint64_t end = start + BT_;
+            if (end > seqEnd) {
+                end = seqEnd;
+            }
+            ProcessChunkAic(b, hv, start, end);
+            ++localChunk;
+        }
+    }
+
+private:
+    GlobalTensor<T> q_;
+    GlobalTensor<T> k_;
+    GlobalTensor<T> v_;
+    GlobalTensor<float> gk_;
+    GlobalTensor<float> beta_;
+    GlobalTensor<float> initialState_;
+    GlobalTensor<int64_t> cuSeqlens_;
+    GlobalTensor<int64_t> chunkIndices_;
+    GlobalTensor<T> o_;
+    GlobalTensor<float> finalState_;
+    GlobalTensor<T> aqk_;
+    GlobalTensor<T> akk_;
+    GlobalTensor<T> w_;
+    GlobalTensor<T> u_;
+    GlobalTensor<T> qg_;
+    GlobalTensor<T> kg_;
+    GlobalTensor<T> vNew_;
+    GlobalTensor<T> h_;
+    TPipe *pipe_ = nullptr;
+    TBuf<TPosition::VECCALC> scalarInBuf_;
+    TBuf<TPosition::VECCALC> scalarFp32Buf_;
+    TBuf<TPosition::VECCALC> scalarOutBuf_;
+    TBuf<TPosition::VECCALC> scalarI64Buf_;
+    TBuf<TPosition::VECCALC> exp2Buf_;
+    TBuf<TPosition::VECCALC> vecBuf_;
+    TQue<TPosition::VECIN, KDA_VEC_BUFFER_NUM> qInQue_;
+    TQue<TPosition::VECIN, KDA_VEC_BUFFER_NUM> kInQue_;
+    TQue<TPosition::VECIN, KDA_VEC_BUFFER_NUM> gInQue_;
+    TQue<TPosition::VECOUT, KDA_VEC_BUFFER_NUM> qgOutQue_;
+    TQue<TPosition::VECOUT, KDA_VEC_BUFFER_NUM> wOutQue_;
+    TQue<TPosition::VECOUT, KDA_VEC_BUFFER_NUM> kgOutQue_;
+    Catlass::Arch::CrossCoreFlagWithReverse<> scoreReadyFlag_{KDA_SCORE_READY_FLAG0, KDA_SCORE_READY_FLAG1};
+    Catlass::Arch::CrossCoreFlagWithReverse<> scoreDoneFlag_{KDA_SCORE_DONE_FLAG0, KDA_SCORE_DONE_FLAG1};
+
+    uint64_t B_ = 0;
+    uint64_t N_ = 0;
+    uint64_t H_ = 0;
+    uint64_t HV_ = 0;
+    uint64_t T_ = 0;
+    uint64_t K_ = 0;
+    uint64_t V_ = 0;
+    uint64_t BT_ = 0;
+    uint64_t NT_ = 0;
+    float scale_ = 1.0f;
+    bool hasInitial_ = false;
+    bool isVarLen_ = false;
+    bool isAivOnly_ = false;
+    uint64_t usedCoreNum_ = 1;
+    int64_t stage_ = 0;
+};
+} // namespace
+
+extern "C" __global__ __aicore__ void chunk_kda_fwd(GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR gk, GM_ADDR beta,
+                                                      GM_ADDR initial_state, GM_ADDR cu_seqlens,
+                                                      GM_ADDR chunk_indices, GM_ADDR o, GM_ADDR final_state,
+                                                      GM_ADDR aqk, GM_ADDR akk, GM_ADDR w, GM_ADDR u, GM_ADDR qg,
+                                                      GM_ADDR kg, GM_ADDR v_new, GM_ADDR h, GM_ADDR workspace,
+                                                      GM_ADDR tiling)
+{
+    GM_ADDR userWS = AscendC::GetUserWorkspace(workspace);
+    (void)userWS;
+    GET_TILING_DATA(tilingData, tiling);
+    TPipe pipe;
+    if (TILING_KEY_IS(0)) {
+        KERNEL_TASK_TYPE(0, KERNEL_TYPE_AIV_ONLY);
+        ChunkKdaFwdKernel<float> op;
+        op.Init(q, k, v, gk, beta, initial_state, cu_seqlens, chunk_indices, o, final_state, aqk, akk, w, u, qg, kg,
+                v_new, h, tilingData, &pipe);
+        op.ProcessAivOnly();
+    } else if (TILING_KEY_IS(1)) {
+        KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
+        if (tilingData.dataType == 1) {
+            if ASCEND_IS_AIC {
+                ChunkKdaFwdKernel<bfloat16_t> op;
+                op.Init(q, k, v, gk, beta, initial_state, cu_seqlens, chunk_indices, o, final_state, aqk, akk, w, u,
+                        qg, kg, v_new, h, tilingData, &pipe, false);
+                op.ProcessAic();
+            }
+            if ASCEND_IS_AIV {
+                ChunkKdaFwdKernel<bfloat16_t> op;
+                op.Init(q, k, v, gk, beta, initial_state, cu_seqlens, chunk_indices, o, final_state, aqk, akk, w, u,
+                        qg, kg, v_new, h, tilingData, &pipe);
+                op.ProcessAiv();
+            }
+        } else {
+            if ASCEND_IS_AIC {
+                ChunkKdaFwdKernel<half> op;
+                op.Init(q, k, v, gk, beta, initial_state, cu_seqlens, chunk_indices, o, final_state, aqk, akk, w, u,
+                        qg, kg, v_new, h, tilingData, &pipe, false);
+                op.ProcessAic();
+            }
+            if ASCEND_IS_AIV {
+                ChunkKdaFwdKernel<half> op;
+                op.Init(q, k, v, gk, beta, initial_state, cu_seqlens, chunk_indices, o, final_state, aqk, akk, w, u,
+                        qg, kg, v_new, h, tilingData, &pipe);
+                op.ProcessAiv();
+            }
+        }
+    } else if (TILING_KEY_IS(2)) {
+        KERNEL_TASK_TYPE(2, KERNEL_TYPE_AIV_ONLY);
+        if (tilingData.dataType == 1) {
+            ChunkKdaFwdKernel<bfloat16_t> op;
+            op.Init(q, k, v, gk, beta, initial_state, cu_seqlens, chunk_indices, o, final_state, aqk, akk, w, u, qg,
+                    kg, v_new, h, tilingData, &pipe);
+            op.ProcessAivOnly();
+        } else {
+            ChunkKdaFwdKernel<half> op;
+            op.Init(q, k, v, gk, beta, initial_state, cu_seqlens, chunk_indices, o, final_state, aqk, akk, w, u, qg,
+                    kg, v_new, h, tilingData, &pipe);
+            op.ProcessAivOnly();
+        }
+    }
+}

--- a/fla/ops/ascendc/kda/kda_gate_cumsum/CMakeLists.txt
+++ b/fla/ops/ascendc/kda/kda_gate_cumsum/CMakeLists.txt
@@ -1,0 +1,12 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# the BSD 3-Clause License (the "License"). Please refer to the License for details.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+# -----------------------------------------------------------------------------------------------------------
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/fla/ops/ascendc/kda/kda_gate_cumsum/op_host/CMakeLists.txt
+++ b/fla/ops/ascendc/kda/kda_gate_cumsum/op_host/CMakeLists.txt
@@ -1,0 +1,19 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# the BSD 3-Clause License (the "License"). Please refer to the License for details.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+# -----------------------------------------------------------------------------------------------------------
+add_op_to_compiled_list()
+if (BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnnExc PRIVATE
+        kda_gate_cumsum_def.cpp
+    )
+endif()
+
+add_modules_sources(OPTYPE kda_gate_cumsum ACLNNTYPE aclnn_exclude)
+add_ops_compile_options(
+    OP_NAME KdaGateCumsum
+    OPTIONS --cce-auto-sync=off
+            -Wno-deprecated-declarations
+)

--- a/fla/ops/ascendc/kda/kda_gate_cumsum/op_host/kda_gate_cumsum_def.cpp
+++ b/fla/ops/ascendc/kda/kda_gate_cumsum/op_host/kda_gate_cumsum_def.cpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License"). Please refer to the License for details.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+ */
+
+#include "register/op_def_registry.h"
+
+namespace ops {
+class KdaGateCumsum : public OpDef {
+public:
+    explicit KdaGateCumsum(const char *name) : OpDef(name)
+    {
+        const std::initializer_list<ge::DataType> gateTypes = {
+            ge::DT_FLOAT, ge::DT_FLOAT16, ge::DT_BF16
+        };
+        const std::initializer_list<ge::DataType> floatTypes = {
+            ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT
+        };
+        const std::initializer_list<ge::DataType> intTypes = {
+            ge::DT_INT64, ge::DT_INT64, ge::DT_INT64
+        };
+        const std::initializer_list<ge::Format> formats = {
+            ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND
+        };
+
+        this->Input("g").ParamType(REQUIRED).DataType(gateTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Input("a_log").ParamType(OPTIONAL).DataType(floatTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Input("dt_bias").ParamType(OPTIONAL).DataType(floatTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Input("cu_seqlens").ParamType(OPTIONAL).ValueDepend(OPTIONAL)
+            .DataType(intTypes).Format(formats).UnknownShapeFormat(formats);
+
+        this->Output("gk").ParamType(REQUIRED).DataType(floatTypes).Format(formats).UnknownShapeFormat(formats);
+
+        this->Attr("chunk_size").AttrType(REQUIRED).Int(64);
+        this->Attr("use_gate_in_kernel").AttrType(REQUIRED).Bool(false);
+        this->Attr("safe_gate").AttrType(REQUIRED).Bool(false);
+        this->Attr("lower_bound").AttrType(REQUIRED).Float(-5.0);
+
+        OpAICoreConfig aicoreConfig;
+        aicoreConfig.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .PrecisionReduceFlag(true)
+            .ExtendCfgInfo("prebuildPattern.value", "Opaque")
+            .ExtendCfgInfo("coreType.value", "AiCore")
+            .ExtendCfgInfo("aclnnSupport.value", "support_aclnn");
+
+        this->AICore().AddConfig("ascend910b", aicoreConfig);
+        this->AICore().AddConfig("ascend910_93", aicoreConfig);
+        this->AICore().AddConfig("ascend950", aicoreConfig);
+    }
+};
+
+OP_ADD(KdaGateCumsum);
+} // namespace ops

--- a/fla/ops/ascendc/kda/kda_gate_cumsum/op_host/kda_gate_cumsum_tiling.cpp
+++ b/fla/ops/ascendc/kda/kda_gate_cumsum/op_host/kda_gate_cumsum_tiling.cpp
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License"). Please refer to the License for details.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+ */
+
+#include "kda_gate_cumsum_tiling.h"
+#include <algorithm>
+#include <register/op_impl_registry.h>
+#include "tiling/platform/platform_ascendc.h"
+
+namespace optiling {
+namespace {
+constexpr size_t INPUT_G_IDX = 0;
+constexpr size_t INPUT_A_LOG_IDX = 1;
+constexpr size_t INPUT_DT_BIAS_IDX = 2;
+constexpr size_t INPUT_CU_SEQLENS_IDX = 3;
+constexpr size_t ATTR_CHUNK_SIZE_IDX = 0;
+constexpr size_t ATTR_USE_GATE_IDX = 1;
+constexpr size_t ATTR_SAFE_GATE_IDX = 2;
+constexpr size_t ATTR_LOWER_BOUND_IDX = 3;
+constexpr int64_t MAX_K_DIM = 256;
+
+enum class KdaGateLayout : int64_t {
+    BSND = 0,
+    BNSD = 1,
+    TND = 2,
+    NTD = 3,
+};
+} // namespace
+
+ge::graphStatus Tiling4KdaGateCumsum(gert::TilingContext *context)
+{
+    KdaGateCumsumTilingData tiling;
+    auto gShape = context->GetOptionalInputShape(INPUT_G_IDX)->GetStorageShape();
+    auto gDesc = context->GetInputDesc(INPUT_G_IDX);
+    if (gDesc == nullptr || (gShape.GetDimNum() != 3 && gShape.GetDimNum() != 4)) {
+        return ge::GRAPH_FAILED;
+    }
+
+    int64_t rank = static_cast<int64_t>(gShape.GetDimNum());
+    KdaGateLayout layout;
+    if (rank == 4) {
+        layout = gShape.GetDim(1) <= gShape.GetDim(2) ? KdaGateLayout::BNSD : KdaGateLayout::BSND;
+    } else {
+        layout = gShape.GetDim(0) <= gShape.GetDim(1) ? KdaGateLayout::NTD : KdaGateLayout::TND;
+    }
+    int64_t batch = (rank == 4) ? gShape.GetDim(0) : 1;
+    int64_t t = (layout == KdaGateLayout::BNSD) ? gShape.GetDim(2) :
+                ((layout == KdaGateLayout::NTD) ? gShape.GetDim(1) :
+                 ((rank == 4) ? gShape.GetDim(1) : gShape.GetDim(0)));
+    int64_t hv = (layout == KdaGateLayout::BNSD) ? gShape.GetDim(1) :
+                 ((layout == KdaGateLayout::NTD) ? gShape.GetDim(0) :
+                  ((rank == 4) ? gShape.GetDim(2) : gShape.GetDim(1)));
+    int64_t k = (rank == 4) ? gShape.GetDim(3) : gShape.GetDim(2);
+    if (k > MAX_K_DIM) {
+        return ge::GRAPH_FAILED;
+    }
+
+    int64_t chunkSize = *context->GetAttrs()->GetAttrPointer<int64_t>(ATTR_CHUNK_SIZE_IDX);
+    bool useGate = *context->GetAttrs()->GetAttrPointer<bool>(ATTR_USE_GATE_IDX);
+    bool safeGate = *context->GetAttrs()->GetAttrPointer<bool>(ATTR_SAFE_GATE_IDX);
+    float lowerBound = *context->GetAttrs()->GetAttrPointer<float>(ATTR_LOWER_BOUND_IDX);
+
+    const auto cuShape = context->GetOptionalInputShape(INPUT_CU_SEQLENS_IDX);
+    int64_t hasCuSeqlens = (cuShape != nullptr) ? 1 : 0;
+    int64_t seqNum = hasCuSeqlens ? (cuShape->GetStorageShape().GetDim(0) - 1) : batch;
+    int64_t maxChunks = (t + chunkSize - 1) / chunkSize;
+    int64_t taskCount = seqNum * hv * maxChunks;
+
+    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
+    uint32_t coreNum = ascendcPlatform.GetCoreNumAiv();
+    uint32_t blockDim = static_cast<uint32_t>(std::min<int64_t>(taskCount, coreNum));
+    context->SetBlockDim(blockDim == 0 ? 1 : blockDim);
+
+    size_t *workspace = context->GetWorkspaceSizes(1);
+    workspace[0] = ascendcPlatform.GetLibApiWorkSpaceSize();
+
+    tiling.set_batch(batch);
+    tiling.set_t(t);
+    tiling.set_hv(hv);
+    tiling.set_k(k);
+    tiling.set_rank(rank);
+    tiling.set_layout(static_cast<int64_t>(layout));
+    tiling.set_chunkSize(chunkSize);
+    tiling.set_seqNum(seqNum);
+    tiling.set_hasCuSeqlens(hasCuSeqlens);
+    tiling.set_hasALog(context->GetOptionalInputDesc(INPUT_A_LOG_IDX) != nullptr ? 1 : 0);
+    tiling.set_hasDtBias(context->GetOptionalInputDesc(INPUT_DT_BIAS_IDX) != nullptr ? 1 : 0);
+    tiling.set_useGateInKernel(useGate ? 1 : 0);
+    tiling.set_safeGate(safeGate ? 1 : 0);
+    tiling.set_lowerBound(lowerBound);
+    tiling.set_usedCoreNum(blockDim == 0 ? 1 : blockDim);
+
+    if (gDesc->GetDataType() == ge::DT_FLOAT) {
+        context->SetTilingKey(0);
+    } else if (gDesc->GetDataType() == ge::DT_BF16) {
+        context->SetTilingKey(1);
+    } else {
+        context->SetTilingKey(2);
+    }
+    tiling.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
+    context->GetRawTilingData()->SetDataSize(tiling.GetDataSize());
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus TilingPrepare4KdaGateCumsum(gert::TilingParseContext *context)
+{
+    (void)context;
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(KdaGateCumsum)
+    .Tiling(Tiling4KdaGateCumsum)
+    .TilingParse<KdaGateCumsumCompileInfo>(TilingPrepare4KdaGateCumsum);
+
+} // namespace optiling

--- a/fla/ops/ascendc/kda/kda_gate_cumsum/op_host/kda_gate_cumsum_tiling.h
+++ b/fla/ops/ascendc/kda/kda_gate_cumsum/op_host/kda_gate_cumsum_tiling.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License"). Please refer to the License for details.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <register/tilingdata_base.h>
+
+namespace optiling {
+
+BEGIN_TILING_DATA_DEF(KdaGateCumsumTilingData)
+TILING_DATA_FIELD_DEF(int64_t, batch);
+TILING_DATA_FIELD_DEF(int64_t, t);
+TILING_DATA_FIELD_DEF(int64_t, hv);
+TILING_DATA_FIELD_DEF(int64_t, k);
+TILING_DATA_FIELD_DEF(int64_t, rank);
+TILING_DATA_FIELD_DEF(int64_t, layout);
+TILING_DATA_FIELD_DEF(int64_t, chunkSize);
+TILING_DATA_FIELD_DEF(int64_t, seqNum);
+TILING_DATA_FIELD_DEF(int64_t, hasCuSeqlens);
+TILING_DATA_FIELD_DEF(int64_t, hasALog);
+TILING_DATA_FIELD_DEF(int64_t, hasDtBias);
+TILING_DATA_FIELD_DEF(int64_t, useGateInKernel);
+TILING_DATA_FIELD_DEF(int64_t, safeGate);
+TILING_DATA_FIELD_DEF(float, lowerBound);
+TILING_DATA_FIELD_DEF(int64_t, usedCoreNum);
+END_TILING_DATA_DEF;
+
+REGISTER_TILING_DATA_CLASS(KdaGateCumsum, KdaGateCumsumTilingData)
+
+struct KdaGateCumsumCompileInfo {};
+} // namespace optiling

--- a/fla/ops/ascendc/kda/kda_gate_cumsum/op_host/op_api/aclnn_kda_gate_cumsum.cpp
+++ b/fla/ops/ascendc/kda/kda_gate_cumsum/op_host/op_api/aclnn_kda_gate_cumsum.cpp
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License"). Please refer to the License for details.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+ */
+
+#include "aclnn_kda_gate_cumsum.h"
+#include "kda_gate_cumsum.h"
+
+#include "acl/acl.h"
+#include "aclnn/aclnn_base.h"
+#include "aclnn_kernels/common/op_error_check.h"
+#include "aclnn_kernels/contiguous.h"
+#include "opdev/make_op_executor.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_executor.h"
+#include "opdev/op_log.h"
+#include "opdev/tensor_view_utils.h"
+
+using namespace op;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+namespace {
+constexpr int64_t MAX_KDA_K_DIM = 256;
+
+enum class KdaGateLayout : int64_t {
+    BSND = 0,
+    BNSD = 1,
+    TND = 2,
+    NTD = 3,
+};
+
+aclnnStatus KdaGateDataContiguous(const aclTensor *&tensor, aclOpExecutor *executor)
+{
+    if (tensor == nullptr) {
+        return ACLNN_SUCCESS;
+    }
+    tensor = l0op::Contiguous(tensor, executor);
+    CHECK_RET(tensor != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    return ACLNN_SUCCESS;
+}
+
+int64_t KdaGateDim(const aclTensor *tensor, size_t idx)
+{
+    return tensor->GetViewShape().GetDim(idx);
+}
+
+size_t KdaGateRank(const aclTensor *tensor)
+{
+    return tensor->GetViewShape().GetDimNum();
+}
+
+bool KdaGateSameShape(const aclTensor *lhs, const aclTensor *rhs)
+{
+    size_t rank = KdaGateRank(lhs);
+    if (rank != KdaGateRank(rhs)) {
+        return false;
+    }
+    for (size_t idx = 0; idx < rank; ++idx) {
+        if (KdaGateDim(lhs, idx) != KdaGateDim(rhs, idx)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+KdaGateLayout InferKdaGateLayout(const aclTensor *g)
+{
+    size_t rank = KdaGateRank(g);
+    if (rank == 4) {
+        return KdaGateDim(g, 1) <= KdaGateDim(g, 2) ? KdaGateLayout::BNSD : KdaGateLayout::BSND;
+    }
+    return KdaGateDim(g, 0) <= KdaGateDim(g, 1) ? KdaGateLayout::NTD : KdaGateLayout::TND;
+}
+
+aclnnStatus KdaGateCheckParams(
+    const aclTensor *g,
+    const aclTensor *aLogOptional,
+    const aclTensor *dtBiasOptional,
+    const aclIntArray *cuSeqlensOptional,
+    int64_t chunkSize,
+    bool useGateInKernel,
+    bool safeGate,
+    double lowerBound,
+    const aclTensor *gkOut)
+{
+    CHECK_COND(g != nullptr, ACLNN_ERR_PARAM_NULLPTR, "g must not be nullptr.");
+    CHECK_COND(gkOut != nullptr, ACLNN_ERR_PARAM_NULLPTR, "gkOut must not be nullptr.");
+    CHECK_COND(chunkSize == 32 || chunkSize == 64 || chunkSize == 128, ACLNN_ERR_PARAM_INVALID,
+               "chunkSize must be 32, 64 or 128.");
+    size_t rank = KdaGateRank(g);
+    CHECK_COND(rank == 3 || rank == 4, ACLNN_ERR_PARAM_INVALID,
+               "g must be BSND/BNSD rank4 or TND/NTD rank3.");
+    size_t kDimIdx = rank == 4 ? 3 : 2;
+    CHECK_COND(KdaGateDim(g, kDimIdx) <= MAX_KDA_K_DIM, ACLNN_ERR_PARAM_INVALID,
+               "K must be less than or equal to 256.");
+    CHECK_COND(gkOut->GetDataType() == DataType::DT_FLOAT, ACLNN_ERR_PARAM_INVALID,
+               "gkOut must be float32.");
+    CHECK_COND(KdaGateSameShape(gkOut, g), ACLNN_ERR_PARAM_INVALID, "gkOut shape must match g shape.");
+    KdaGateLayout layout = InferKdaGateLayout(g);
+    int64_t hv = (layout == KdaGateLayout::BNSD) ? KdaGateDim(g, 1) :
+                 ((layout == KdaGateLayout::NTD) ? KdaGateDim(g, 0) :
+                  ((rank == 4) ? KdaGateDim(g, 2) : KdaGateDim(g, 1)));
+    if (useGateInKernel) {
+        CHECK_COND(aLogOptional != nullptr, ACLNN_ERR_PARAM_NULLPTR,
+                   "aLogOptional must be provided when useGateInKernel is true.");
+        CHECK_COND(safeGate, ACLNN_ERR_PARAM_INVALID,
+                   "Only safe_gate raw-gate path is supported; set safeGate=true with lowerBound.");
+        CHECK_COND(lowerBound >= -5.0 && lowerBound < 0.0, ACLNN_ERR_PARAM_INVALID,
+                   "lowerBound must be in [-5, 0).");
+        int64_t k = KdaGateDim(g, kDimIdx);
+        CHECK_COND(KdaGateRank(aLogOptional) == 1 && KdaGateDim(aLogOptional, 0) == hv,
+                   ACLNN_ERR_PARAM_INVALID, "aLogOptional shape must be [HV].");
+        if (dtBiasOptional != nullptr) {
+            size_t biasRank = KdaGateRank(dtBiasOptional);
+            bool validBias = (biasRank == 1 && KdaGateDim(dtBiasOptional, 0) == hv * k) ||
+                             (biasRank == 2 && KdaGateDim(dtBiasOptional, 0) == hv &&
+                              KdaGateDim(dtBiasOptional, 1) == k);
+            CHECK_COND(validBias, ACLNN_ERR_PARAM_INVALID, "dtBiasOptional shape must be [HV*K] or [HV, K].");
+        }
+    } else {
+        CHECK_COND(!safeGate, ACLNN_ERR_PARAM_INVALID,
+                   "safeGate only takes effect when useGateInKernel is true.");
+    }
+    (void)cuSeqlensOptional;
+    return ACLNN_SUCCESS;
+}
+} // namespace
+
+aclnnStatus aclnnKdaGateCumsumGetWorkspaceSize(
+    const aclTensor *g,
+    const aclTensor *aLogOptional,
+    const aclTensor *dtBiasOptional,
+    const aclIntArray *cuSeqlensOptional,
+    int64_t chunkSize,
+    bool useGateInKernel,
+    bool safeGate,
+    double lowerBound,
+    const aclTensor *gkOut,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor)
+{
+    L2_DFX_PHASE_1(aclnnKdaGateCumsum, DFX_IN(g, aLogOptional, dtBiasOptional, cuSeqlensOptional), DFX_OUT(gkOut));
+    auto uniqueExecutor = CREATE_EXECUTOR();
+    CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);
+    auto executorPtr = uniqueExecutor.get();
+    CHECK_RET(KdaGateCheckParams(g, aLogOptional, dtBiasOptional, cuSeqlensOptional, chunkSize, useGateInKernel,
+                                 safeGate, lowerBound, gkOut) == ACLNN_SUCCESS,
+              ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(KdaGateDataContiguous(g, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(KdaGateDataContiguous(aLogOptional, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(KdaGateDataContiguous(dtBiasOptional, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+
+    auto result = l0op::KdaGateCumsum(g, aLogOptional, dtBiasOptional, cuSeqlensOptional, chunkSize,
+                                      useGateInKernel, safeGate, lowerBound, gkOut, executorPtr);
+    CHECK_RET(result[0] != nullptr, ACLNN_ERR_INNER_NULLPTR);
+
+    *workspaceSize = uniqueExecutor->GetWorkspaceSize();
+    uniqueExecutor.ReleaseTo(executor);
+    return ACLNN_SUCCESS;
+}
+
+aclnnStatus aclnnKdaGateCumsum(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor, aclrtStream stream)
+{
+    L2_DFX_PHASE_2(aclnnKdaGateCumsum);
+    return CommonOpExecutorRun(workspace, workspaceSize, executor, stream);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/fla/ops/ascendc/kda/kda_gate_cumsum/op_host/op_api/aclnn_kda_gate_cumsum.h
+++ b/fla/ops/ascendc/kda/kda_gate_cumsum/op_host/op_api/aclnn_kda_gate_cumsum.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License"). Please refer to the License for details.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+ */
+
+#ifndef OP_API_INC_ACLNN_KDA_GATE_CUMSUM_H
+#define OP_API_INC_ACLNN_KDA_GATE_CUMSUM_H
+
+#include "aclnn/aclnn_base.h"
+#include "aclnn_util.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+aclnnStatus aclnnKdaGateCumsumGetWorkspaceSize(
+    const aclTensor *g,
+    const aclTensor *aLogOptional,
+    const aclTensor *dtBiasOptional,
+    const aclIntArray *cuSeqlensOptional,
+    int64_t chunkSize,
+    bool useGateInKernel,
+    bool safeGate,
+    double lowerBound,
+    const aclTensor *gkOut,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor);
+
+aclnnStatus aclnnKdaGateCumsum(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor, aclrtStream stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/fla/ops/ascendc/kda/kda_gate_cumsum/op_host/op_api/kda_gate_cumsum.cpp
+++ b/fla/ops/ascendc/kda/kda_gate_cumsum/op_host/op_api/kda_gate_cumsum.cpp
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License"). Please refer to the License for details.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+ */
+
+#include "kda_gate_cumsum.h"
+
+#include "opdev/make_op_executor.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_log.h"
+
+using namespace op;
+
+namespace l0op {
+OP_TYPE_REGISTER(KdaGateCumsum);
+
+const std::array<const aclTensor *, 1> KdaGateCumsum(
+    const aclTensor *g,
+    const aclTensor *aLogOptional,
+    const aclTensor *dtBiasOptional,
+    const aclIntArray *cuSeqlensOptional,
+    int64_t chunkSize,
+    bool useGateInKernel,
+    bool safeGate,
+    double lowerBound,
+    const aclTensor *gkOut,
+    aclOpExecutor *executor)
+{
+    L0_DFX(KdaGateCumsum, g, aLogOptional, dtBiasOptional, cuSeqlensOptional, chunkSize, useGateInKernel,
+           safeGate, lowerBound, gkOut);
+
+    const aclTensor *actualCuSeqlens = nullptr;
+    if (cuSeqlensOptional != nullptr) {
+        actualCuSeqlens = executor->ConvertToTensor(cuSeqlensOptional, DataType::DT_INT64);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetStorageFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetViewFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetOriginalFormat(Format::FORMAT_ND);
+    }
+
+    auto ret = ADD_TO_LAUNCHER_LIST_AICORE(
+        KdaGateCumsum,
+        OP_INPUT(g, aLogOptional, dtBiasOptional, actualCuSeqlens),
+        OP_OUTPUT(gkOut),
+        OP_ATTR(chunkSize, useGateInKernel, safeGate, static_cast<float>(lowerBound)));
+    if (ret != ACLNN_SUCCESS) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "ADD_TO_LAUNCHER_LIST_AICORE KdaGateCumsum failed.");
+        return {nullptr};
+    }
+    return {gkOut};
+}
+} // namespace l0op

--- a/fla/ops/ascendc/kda/kda_gate_cumsum/op_host/op_api/kda_gate_cumsum.h
+++ b/fla/ops/ascendc/kda/kda_gate_cumsum/op_host/op_api/kda_gate_cumsum.h
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License"). Please refer to the License for details.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+ */
+
+#pragma once
+
+#include "aclnn/aclnn_base.h"
+#include <array>
+
+namespace l0op {
+const std::array<const aclTensor *, 1> KdaGateCumsum(
+    const aclTensor *g,
+    const aclTensor *aLogOptional,
+    const aclTensor *dtBiasOptional,
+    const aclIntArray *cuSeqlensOptional,
+    int64_t chunkSize,
+    bool useGateInKernel,
+    bool safeGate,
+    double lowerBound,
+    const aclTensor *gkOut,
+    aclOpExecutor *executor);
+} // namespace l0op

--- a/fla/ops/ascendc/kda/kda_gate_cumsum/op_kernel/kda_gate_cumsum.cpp
+++ b/fla/ops/ascendc/kda/kda_gate_cumsum/op_kernel/kda_gate_cumsum.cpp
@@ -1,0 +1,308 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License"). Please refer to the License for details.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+ */
+
+#include "kernel_operator.h"
+
+using namespace AscendC;
+
+namespace {
+constexpr float RCP_LN2 = 1.4426950408889634f;
+constexpr uint32_t GATE_MTE2_V_EVENT_ID = 0;
+constexpr uint32_t GATE_V_MTE3_EVENT_ID = 1;
+constexpr uint32_t GATE_MTE3_MTE2_EVENT_ID = 2;
+constexpr uint32_t GATE_SCALAR_MTE2_V_EVENT_ID = 3;
+constexpr uint32_t GATE_SCALAR_V_S_EVENT_ID = 4;
+constexpr uint32_t GATE_ROW_ELEMENTS = 256;
+
+template <typename T>
+class KdaGateCumsumKernel {
+public:
+    __aicore__ inline void Init(GM_ADDR g, GM_ADDR aLog, GM_ADDR dtBias, GM_ADDR cuSeqlens, GM_ADDR gk,
+                                const KdaGateCumsumTilingData &tiling, TPipe *pipe)
+    {
+        g_.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(g));
+        aLog_.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(aLog));
+        dtBias_.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(dtBias));
+        cuSeqlens_.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(cuSeqlens));
+        gk_.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(gk));
+        pipe_ = pipe;
+        batch_ = static_cast<uint64_t>(tiling.batch);
+        t_ = static_cast<uint64_t>(tiling.t);
+        hv_ = static_cast<uint64_t>(tiling.hv);
+        k_ = static_cast<uint64_t>(tiling.k);
+        rank_ = static_cast<uint64_t>(tiling.rank);
+        layout_ = static_cast<uint64_t>(tiling.layout);
+        chunkSize_ = static_cast<uint64_t>(tiling.chunkSize);
+        seqNum_ = static_cast<uint64_t>(tiling.seqNum);
+        hasCuSeqlens_ = tiling.hasCuSeqlens != 0;
+        hasALog_ = tiling.hasALog != 0;
+        hasDtBias_ = tiling.hasDtBias != 0;
+        useGateInKernel_ = tiling.useGateInKernel != 0;
+        safeGate_ = tiling.safeGate != 0;
+        lowerBound_ = tiling.lowerBound;
+        usedCoreNum_ = static_cast<uint64_t>(tiling.usedCoreNum);
+        maxChunks_ = (t_ + chunkSize_ - 1) / chunkSize_;
+        pipe_->InitBuffer(rowBuf_, GATE_ROW_ELEMENTS * sizeof(float));
+        pipe_->InitBuffer(accBuf_, GATE_ROW_ELEMENTS * sizeof(float));
+        pipe_->InitBuffer(tmpBuf_, GATE_ROW_ELEMENTS * sizeof(float));
+        pipe_->InitBuffer(oneBuf_, GATE_ROW_ELEMENTS * sizeof(float));
+        pipe_->InitBuffer(inBuf_, GATE_ROW_ELEMENTS * sizeof(T));
+        pipe_->InitBuffer(scalarBuf_, 32);
+        pipe_->InitBuffer(scalarI64Buf_, 32);
+    }
+
+    __aicore__ inline void Process()
+    {
+        uint64_t taskCount = seqNum_ * hv_ * maxChunks_;
+        uint64_t coreIdx = static_cast<uint64_t>(GetBlockIdx());
+        for (uint64_t task = coreIdx; task < taskCount; task += usedCoreNum_) {
+            ProcessTask(task);
+        }
+    }
+
+private:
+    __aicore__ inline uint64_t Offset(uint64_t b, uint64_t t, uint64_t hv, uint64_t k) const
+    {
+        if (layout_ == 1) {
+            return ((b * hv_ + hv) * t_ + t) * k_ + k;
+        }
+        if (layout_ == 3) {
+            return (hv * t_ + t) * k_ + k;
+        }
+        if (rank_ == 4) {
+            return ((b * t_ + t) * hv_ + hv) * k_ + k;
+        }
+        return (t * hv_ + hv) * k_ + k;
+    }
+
+    __aicore__ inline void CopyVectorIn(LocalTensor<T> &dst, GlobalTensor<T> &src, uint64_t offset, uint64_t count)
+    {
+        uint64_t rowBytes = count * static_cast<uint64_t>(sizeof(T));
+        if (rowBytes >= 32 && rowBytes % 32 == 0) {
+            DataCopy(dst, src[offset], static_cast<uint32_t>(count));
+        } else {
+            DataCopyParams params{1, static_cast<uint16_t>(rowBytes), 0, 0};
+            DataCopyPadParams padParams{false, 0, 0, 0};
+            DataCopyPad(dst, src[offset], params, padParams);
+        }
+    }
+
+    __aicore__ inline void CopyFloatVectorIn(LocalTensor<float> &dst, GlobalTensor<float> &src, uint64_t offset,
+                                             uint64_t count)
+    {
+        uint64_t rowBytes = count * sizeof(float);
+        if (rowBytes >= 32 && rowBytes % 32 == 0) {
+            DataCopy(dst, src[offset], static_cast<uint32_t>(count));
+        } else {
+            DataCopyParams params{1, static_cast<uint16_t>(rowBytes), 0, 0};
+            DataCopyPadParams padParams{false, 0, 0, 0};
+            DataCopyPad(dst, src[offset], params, padParams);
+        }
+    }
+
+    __aicore__ inline void CopyFloatVectorOut(GlobalTensor<float> &dst, uint64_t offset, LocalTensor<float> &src,
+                                              uint64_t count)
+    {
+        uint64_t rowBytes = count * sizeof(float);
+        if (rowBytes >= 32 && rowBytes % 32 == 0) {
+            DataCopy(dst[offset], src, static_cast<uint32_t>(count));
+        } else {
+            DataCopyParams params{1, static_cast<uint16_t>(rowBytes), 0, 0};
+            DataCopyPad(dst[offset], src, params);
+        }
+    }
+
+    __aicore__ inline void LoadGateRow(uint64_t offset, LocalTensor<float> &row)
+    {
+        if constexpr (IsSameType<T, float>::value) {
+            CopyVectorIn(row, g_, offset, k_);
+        } else {
+            LocalTensor<T> inLocal = inBuf_.Get<T>();
+            CopyVectorIn(inLocal, g_, offset, k_);
+            SetFlag<HardEvent::MTE2_V>(GATE_MTE2_V_EVENT_ID);
+            WaitFlag<HardEvent::MTE2_V>(GATE_MTE2_V_EVENT_ID);
+            Cast(row, inLocal, RoundMode::CAST_NONE, static_cast<uint32_t>(k_));
+            PipeBarrier<PIPE_V>();
+            return;
+        }
+        SetFlag<HardEvent::MTE2_V>(GATE_MTE2_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE2_V>(GATE_MTE2_V_EVENT_ID);
+        Adds(row, row, 0.0f, static_cast<uint32_t>(k_));
+        PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline float ReadFloat(GlobalTensor<float> &tensor, uint64_t offset)
+    {
+        LocalTensor<float> scalar = scalarBuf_.Get<float>();
+        DataCopyParams params{1, static_cast<uint16_t>(sizeof(float)), 0, 0};
+        DataCopyPadParams padParams{false, 0, 0, 0};
+        DataCopyPad(scalar, tensor[offset], params, padParams);
+        SetFlag<HardEvent::MTE2_V>(GATE_SCALAR_MTE2_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE2_V>(GATE_SCALAR_MTE2_V_EVENT_ID);
+        Adds(scalar, scalar, 0.0f, 1);
+        PipeBarrier<PIPE_V>();
+        SetFlag<HardEvent::V_S>(GATE_SCALAR_V_S_EVENT_ID);
+        WaitFlag<HardEvent::V_S>(GATE_SCALAR_V_S_EVENT_ID);
+        __ubuf__ float *ptr = (__ubuf__ float *)scalar.GetPhyAddr();
+        return ptr[0];
+    }
+
+    __aicore__ inline int64_t ReadInt64(GlobalTensor<int64_t> &tensor, uint64_t offset)
+    {
+        LocalTensor<int64_t> scalar = scalarI64Buf_.Get<int64_t>();
+        DataCopyParams params{1, static_cast<uint16_t>(sizeof(int64_t)), 0, 0};
+        DataCopyPadParams padParams{false, 0, 0, 0};
+        DataCopyPad(scalar, tensor[offset], params, padParams);
+        SetFlag<HardEvent::MTE2_V>(GATE_SCALAR_MTE2_V_EVENT_ID);
+        WaitFlag<HardEvent::MTE2_V>(GATE_SCALAR_MTE2_V_EVENT_ID);
+        SetFlag<HardEvent::V_S>(GATE_SCALAR_V_S_EVENT_ID);
+        WaitFlag<HardEvent::V_S>(GATE_SCALAR_V_S_EVENT_ID);
+        __ubuf__ int64_t *ptr = (__ubuf__ int64_t *)scalar.GetPhyAddr();
+        return ptr[0];
+    }
+
+    __aicore__ inline float ExpScalar(float x)
+    {
+        LocalTensor<float> scalar = scalarBuf_.Get<float>();
+        Duplicate(scalar, x, 1);
+        PipeBarrier<PIPE_V>();
+        Exp(scalar, scalar, 1);
+        PipeBarrier<PIPE_V>();
+        SetFlag<HardEvent::V_S>(GATE_SCALAR_V_S_EVENT_ID);
+        WaitFlag<HardEvent::V_S>(GATE_SCALAR_V_S_EVENT_ID);
+        __ubuf__ float *ptr = (__ubuf__ float *)scalar.GetPhyAddr();
+        return ptr[0];
+    }
+
+    __aicore__ inline void ApplySafeGate(uint64_t hv, LocalTensor<float> &row)
+    {
+        if (!useGateInKernel_) {
+            return;
+        }
+        if (hasDtBias_) {
+            LocalTensor<float> tmp = tmpBuf_.Get<float>();
+            CopyFloatVectorIn(tmp, dtBias_, hv * k_, k_);
+            SetFlag<HardEvent::MTE2_V>(GATE_MTE2_V_EVENT_ID);
+            WaitFlag<HardEvent::MTE2_V>(GATE_MTE2_V_EVENT_ID);
+            Add(row, row, tmp, static_cast<uint32_t>(k_));
+            PipeBarrier<PIPE_V>();
+        }
+
+        float expA = hasALog_ ? ExpScalar(ReadFloat(aLog_, hv)) : 1.0f;
+        Muls(row, row, expA, static_cast<uint32_t>(k_));
+        PipeBarrier<PIPE_V>();
+
+        LocalTensor<float> tmp = tmpBuf_.Get<float>();
+        Muls(tmp, row, -1.0f, static_cast<uint32_t>(k_));
+        PipeBarrier<PIPE_V>();
+        Exp(tmp, tmp, static_cast<uint32_t>(k_));
+        PipeBarrier<PIPE_V>();
+        Adds(tmp, tmp, 1.0f, static_cast<uint32_t>(k_));
+        PipeBarrier<PIPE_V>();
+
+        LocalTensor<float> one = oneBuf_.Get<float>();
+        Duplicate(one, 1.0f, static_cast<uint32_t>(k_));
+        PipeBarrier<PIPE_V>();
+        Div(row, one, tmp, static_cast<uint32_t>(k_));
+        PipeBarrier<PIPE_V>();
+        Muls(row, row, lowerBound_, static_cast<uint32_t>(k_));
+        PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void ProcessTask(uint64_t task)
+    {
+        uint64_t chunkSlot = task % maxChunks_;
+        uint64_t hv = (task / maxChunks_) % hv_;
+        uint64_t seq = task / (maxChunks_ * hv_);
+        uint64_t b = hasCuSeqlens_ ? 0 : seq;
+        uint64_t seqStart = hasCuSeqlens_ ? static_cast<uint64_t>(ReadInt64(cuSeqlens_, seq)) : 0;
+        uint64_t seqEnd = hasCuSeqlens_ ? static_cast<uint64_t>(ReadInt64(cuSeqlens_, seq + 1)) : t_;
+        uint64_t start = seqStart + chunkSlot * chunkSize_;
+        if (start >= seqEnd) {
+            return;
+        }
+        uint64_t end = start + chunkSize_;
+        if (end > seqEnd) {
+            end = seqEnd;
+        }
+
+        LocalTensor<float> acc = accBuf_.Get<float>();
+        LocalTensor<float> row = rowBuf_.Get<float>();
+        Duplicate(acc, 0.0f, static_cast<uint32_t>(k_));
+        PipeBarrier<PIPE_V>();
+        for (uint64_t t = start; t < end; ++t) {
+            LoadGateRow(Offset(b, t, hv, 0), row);
+            ApplySafeGate(hv, row);
+            Muls(row, row, RCP_LN2, static_cast<uint32_t>(k_));
+            PipeBarrier<PIPE_V>();
+            Add(acc, acc, row, static_cast<uint32_t>(k_));
+            PipeBarrier<PIPE_V>();
+            SetFlag<HardEvent::V_MTE3>(GATE_V_MTE3_EVENT_ID);
+            WaitFlag<HardEvent::V_MTE3>(GATE_V_MTE3_EVENT_ID);
+            CopyFloatVectorOut(gk_, Offset(b, t, hv, 0), acc, k_);
+            SetFlag<HardEvent::MTE3_MTE2>(GATE_MTE3_MTE2_EVENT_ID);
+            WaitFlag<HardEvent::MTE3_MTE2>(GATE_MTE3_MTE2_EVENT_ID);
+        }
+        (void)safeGate_;
+    }
+
+    GlobalTensor<T> g_;
+    GlobalTensor<float> aLog_;
+    GlobalTensor<float> dtBias_;
+    GlobalTensor<int64_t> cuSeqlens_;
+    GlobalTensor<float> gk_;
+    TPipe *pipe_ = nullptr;
+    TBuf<TPosition::VECCALC> rowBuf_;
+    TBuf<TPosition::VECCALC> accBuf_;
+    TBuf<TPosition::VECCALC> tmpBuf_;
+    TBuf<TPosition::VECCALC> oneBuf_;
+    TBuf<TPosition::VECCALC> inBuf_;
+    TBuf<TPosition::VECCALC> scalarBuf_;
+    TBuf<TPosition::VECCALC> scalarI64Buf_;
+    uint64_t batch_ = 0;
+    uint64_t t_ = 0;
+    uint64_t hv_ = 0;
+    uint64_t k_ = 0;
+    uint64_t rank_ = 0;
+    uint64_t layout_ = 0;
+    uint64_t chunkSize_ = 0;
+    uint64_t seqNum_ = 0;
+    uint64_t maxChunks_ = 0;
+    bool hasCuSeqlens_ = false;
+    bool hasALog_ = false;
+    bool hasDtBias_ = false;
+    bool useGateInKernel_ = false;
+    bool safeGate_ = false;
+    float lowerBound_ = -5.0f;
+    uint64_t usedCoreNum_ = 1;
+};
+} // namespace
+
+extern "C" __global__ __aicore__ void kda_gate_cumsum(GM_ADDR g, GM_ADDR aLog, GM_ADDR dtBias,
+                                                       GM_ADDR cuSeqlens, GM_ADDR gk, GM_ADDR workspace,
+                                                       GM_ADDR tiling)
+{
+    (void)workspace;
+    GET_TILING_DATA(tilingData, tiling);
+    TPipe pipe;
+    if (TILING_KEY_IS(0)) {
+        KERNEL_TASK_TYPE(0, KERNEL_TYPE_AIV_ONLY);
+        KdaGateCumsumKernel<float> op;
+        op.Init(g, aLog, dtBias, cuSeqlens, gk, tilingData, &pipe);
+        op.Process();
+    } else if (TILING_KEY_IS(1)) {
+        KERNEL_TASK_TYPE(1, KERNEL_TYPE_AIV_ONLY);
+        KdaGateCumsumKernel<bfloat16_t> op;
+        op.Init(g, aLog, dtBias, cuSeqlens, gk, tilingData, &pipe);
+        op.Process();
+    } else {
+        KERNEL_TASK_TYPE(2, KERNEL_TYPE_AIV_ONLY);
+        KdaGateCumsumKernel<half> op;
+        op.Init(g, aLog, dtBias, cuSeqlens, gk, tilingData, &pipe);
+        op.Process();
+    }
+}

--- a/fla/ops/ascendc/kda/kda_layout_swap12/CMakeLists.txt
+++ b/fla/ops/ascendc/kda/kda_layout_swap12/CMakeLists.txt
@@ -1,0 +1,12 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# the BSD 3-Clause License (the "License"). Please refer to the License for details.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+# -----------------------------------------------------------------------------------------------------------
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/fla/ops/ascendc/kda/kda_layout_swap12/op_host/CMakeLists.txt
+++ b/fla/ops/ascendc/kda/kda_layout_swap12/op_host/CMakeLists.txt
@@ -1,0 +1,19 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# the BSD 3-Clause License (the "License"). Please refer to the License for details.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+# -----------------------------------------------------------------------------------------------------------
+add_op_to_compiled_list()
+if (BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnnExc PRIVATE
+        kda_layout_swap12_def.cpp
+    )
+endif()
+
+add_modules_sources(OPTYPE kda_layout_swap12 ACLNNTYPE aclnn_exclude)
+add_ops_compile_options(
+    OP_NAME KdaLayoutSwap12
+    OPTIONS --cce-auto-sync=off
+            -Wno-deprecated-declarations
+)

--- a/fla/ops/ascendc/kda/kda_layout_swap12/op_host/kda_layout_swap12_def.cpp
+++ b/fla/ops/ascendc/kda/kda_layout_swap12/op_host/kda_layout_swap12_def.cpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License"). Please refer to the License for details.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+ */
+
+#include "register/op_def_registry.h"
+
+namespace ops {
+class KdaLayoutSwap12 : public OpDef {
+public:
+    explicit KdaLayoutSwap12(const char *name) : OpDef(name)
+    {
+        const std::initializer_list<ge::DataType> dataTypes = {
+            ge::DT_FLOAT, ge::DT_FLOAT16, ge::DT_BF16
+        };
+        const std::initializer_list<ge::Format> formats = {
+            ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND
+        };
+
+        this->Input("x").ParamType(REQUIRED).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Output("y").ParamType(REQUIRED).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+
+        OpAICoreConfig aicoreConfig;
+        aicoreConfig.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .PrecisionReduceFlag(true)
+            .ExtendCfgInfo("prebuildPattern.value", "Opaque")
+            .ExtendCfgInfo("coreType.value", "AiCore")
+            .ExtendCfgInfo("aclnnSupport.value", "support_aclnn");
+
+        this->AICore().AddConfig("ascend910b", aicoreConfig);
+        this->AICore().AddConfig("ascend910_93", aicoreConfig);
+        this->AICore().AddConfig("ascend950", aicoreConfig);
+    }
+};
+
+OP_ADD(KdaLayoutSwap12);
+} // namespace ops

--- a/fla/ops/ascendc/kda/kda_layout_swap12/op_host/kda_layout_swap12_tiling.cpp
+++ b/fla/ops/ascendc/kda/kda_layout_swap12/op_host/kda_layout_swap12_tiling.cpp
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License"). Please refer to the License for details.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+ */
+
+#include "kda_layout_swap12_tiling.h"
+#include <algorithm>
+#include <register/op_impl_registry.h>
+#include "tiling/platform/platform_ascendc.h"
+
+namespace optiling {
+namespace {
+constexpr size_t INPUT_X_IDX = 0;
+constexpr size_t OUTPUT_Y_IDX = 0;
+constexpr size_t DIM_B = 0;
+constexpr size_t DIM_FIRST = 1;
+constexpr size_t DIM_SECOND = 2;
+
+int64_t DTypeCode(ge::DataType dtype)
+{
+    if (dtype == ge::DT_BF16) {
+        return 1;
+    }
+    if (dtype == ge::DT_FLOAT) {
+        return 2;
+    }
+    return 0;
+}
+} // namespace
+
+ge::graphStatus Tiling4KdaLayoutSwap12(gert::TilingContext *context)
+{
+    KdaLayoutSwap12TilingData tiling;
+    auto xShape = context->GetOptionalInputShape(INPUT_X_IDX)->GetStorageShape();
+    auto yShape = context->GetOutputShape(OUTPUT_Y_IDX)->GetStorageShape();
+    auto xDesc = context->GetInputDesc(INPUT_X_IDX);
+    if (xDesc == nullptr || xShape.GetDimNum() < 3) {
+        return ge::GRAPH_FAILED;
+    }
+
+    int64_t batch = xShape.GetDim(DIM_B);
+    int64_t firstDim = xShape.GetDim(DIM_FIRST);
+    int64_t secondDim = xShape.GetDim(DIM_SECOND);
+    int64_t tailDim = 1;
+    for (size_t idx = 3; idx < xShape.GetDimNum(); ++idx) {
+        tailDim *= xShape.GetDim(idx);
+    }
+
+    if (xShape.GetDimNum() == 3 && yShape.GetDimNum() == 3 &&
+        yShape.GetDim(0) == xShape.GetDim(1) &&
+        yShape.GetDim(1) == xShape.GetDim(0) &&
+        yShape.GetDim(2) == xShape.GetDim(2)) {
+        batch = 1;
+        firstDim = xShape.GetDim(0);
+        secondDim = xShape.GetDim(1);
+        tailDim = xShape.GetDim(2);
+    }
+
+    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
+    uint32_t coreNum = ascendcPlatform.GetCoreNumAiv();
+    int64_t rowCount = batch * firstDim * secondDim;
+    uint32_t blockDim = static_cast<uint32_t>(std::min<int64_t>(rowCount, coreNum));
+    context->SetBlockDim(blockDim == 0 ? 1 : blockDim);
+
+    size_t *workspace = context->GetWorkspaceSizes(1);
+    workspace[0] = ascendcPlatform.GetLibApiWorkSpaceSize();
+
+    tiling.set_batch(batch);
+    tiling.set_firstDim(firstDim);
+    tiling.set_secondDim(secondDim);
+    tiling.set_tailDim(tailDim);
+    tiling.set_dataType(DTypeCode(xDesc->GetDataType()));
+    tiling.set_usedCoreNum(blockDim == 0 ? 1 : blockDim);
+
+    if (xDesc->GetDataType() == ge::DT_FLOAT) {
+        context->SetTilingKey(0);
+    } else if (xDesc->GetDataType() == ge::DT_BF16) {
+        context->SetTilingKey(1);
+    } else {
+        context->SetTilingKey(2);
+    }
+    tiling.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
+    context->GetRawTilingData()->SetDataSize(tiling.GetDataSize());
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus TilingPrepare4KdaLayoutSwap12(gert::TilingParseContext *context)
+{
+    (void)context;
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(KdaLayoutSwap12)
+    .Tiling(Tiling4KdaLayoutSwap12)
+    .TilingParse<KdaLayoutSwap12CompileInfo>(TilingPrepare4KdaLayoutSwap12);
+
+} // namespace optiling

--- a/fla/ops/ascendc/kda/kda_layout_swap12/op_host/kda_layout_swap12_tiling.h
+++ b/fla/ops/ascendc/kda/kda_layout_swap12/op_host/kda_layout_swap12_tiling.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License"). Please refer to the License for details.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <register/tilingdata_base.h>
+
+namespace optiling {
+
+BEGIN_TILING_DATA_DEF(KdaLayoutSwap12TilingData)
+TILING_DATA_FIELD_DEF(int64_t, batch);
+TILING_DATA_FIELD_DEF(int64_t, firstDim);
+TILING_DATA_FIELD_DEF(int64_t, secondDim);
+TILING_DATA_FIELD_DEF(int64_t, tailDim);
+TILING_DATA_FIELD_DEF(int64_t, dataType);
+TILING_DATA_FIELD_DEF(int64_t, usedCoreNum);
+END_TILING_DATA_DEF;
+
+REGISTER_TILING_DATA_CLASS(KdaLayoutSwap12, KdaLayoutSwap12TilingData)
+
+struct KdaLayoutSwap12CompileInfo {};
+} // namespace optiling

--- a/fla/ops/ascendc/kda/kda_layout_swap12/op_host/op_api/kda_layout_swap12.cpp
+++ b/fla/ops/ascendc/kda/kda_layout_swap12/op_host/op_api/kda_layout_swap12.cpp
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License"). Please refer to the License for details.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+ */
+
+#include "kda_layout_swap12.h"
+
+#include "opdev/make_op_executor.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_log.h"
+
+using namespace op;
+
+namespace l0op {
+OP_TYPE_REGISTER(KdaLayoutSwap12);
+
+const std::array<const aclTensor *, 1> KdaLayoutSwap12(
+    const aclTensor *x,
+    const aclTensor *y,
+    aclOpExecutor *executor)
+{
+    L0_DFX(KdaLayoutSwap12, x, y);
+    auto ret = ADD_TO_LAUNCHER_LIST_AICORE(
+        KdaLayoutSwap12,
+        OP_INPUT(x),
+        OP_OUTPUT(y),
+        OP_ATTR());
+    if (ret != ACLNN_SUCCESS) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "ADD_TO_LAUNCHER_LIST_AICORE KdaLayoutSwap12 failed.");
+        return {nullptr};
+    }
+    (void)executor;
+    return {y};
+}
+} // namespace l0op

--- a/fla/ops/ascendc/kda/kda_layout_swap12/op_host/op_api/kda_layout_swap12.h
+++ b/fla/ops/ascendc/kda/kda_layout_swap12/op_host/op_api/kda_layout_swap12.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License"). Please refer to the License for details.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+ */
+
+#pragma once
+
+#include "aclnn/aclnn_base.h"
+#include <array>
+
+namespace l0op {
+const std::array<const aclTensor *, 1> KdaLayoutSwap12(
+    const aclTensor *x,
+    const aclTensor *y,
+    aclOpExecutor *executor);
+} // namespace l0op

--- a/fla/ops/ascendc/kda/kda_layout_swap12/op_kernel/kda_layout_swap12.cpp
+++ b/fla/ops/ascendc/kda/kda_layout_swap12/op_kernel/kda_layout_swap12.cpp
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License"). Please refer to the License for details.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+ */
+
+#include "kernel_operator.h"
+
+using namespace AscendC;
+
+namespace {
+constexpr uint32_t SWAP12_MTE2_MTE3_EVENT_ID = 0;
+constexpr uint32_t SWAP12_MTE3_MTE2_EVENT_ID = 1;
+constexpr uint32_t SWAP12_UB_ELEMENTS = 8192;
+
+template <typename T>
+class KdaLayoutSwap12Kernel {
+public:
+    __aicore__ inline void Init(GM_ADDR x, GM_ADDR y, const KdaLayoutSwap12TilingData &tiling, TPipe *pipe)
+    {
+        x_.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(x));
+        y_.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(y));
+        pipe_ = pipe;
+        batch_ = static_cast<uint64_t>(tiling.batch);
+        firstDim_ = static_cast<uint64_t>(tiling.firstDim);
+        secondDim_ = static_cast<uint64_t>(tiling.secondDim);
+        tailDim_ = static_cast<uint64_t>(tiling.tailDim);
+        usedCoreNum_ = static_cast<uint64_t>(tiling.usedCoreNum);
+        pipe_->InitBuffer(copyBuf_, SWAP12_UB_ELEMENTS * sizeof(T));
+    }
+
+    __aicore__ inline void Process()
+    {
+        uint64_t rowCount = batch_ * firstDim_ * secondDim_;
+        uint64_t coreIdx = static_cast<uint64_t>(GetBlockIdx());
+        for (uint64_t row = coreIdx; row < rowCount; row += usedCoreNum_) {
+            CopySwappedRow(row);
+        }
+    }
+
+private:
+    __aicore__ inline void CopyTile(uint64_t srcOffset, uint64_t dstOffset, uint64_t elems)
+    {
+        LocalTensor<T> local = copyBuf_.Get<T>();
+        uint64_t rowBytes = elems * static_cast<uint64_t>(sizeof(T));
+        if (rowBytes >= 32 && rowBytes % 32 == 0) {
+            DataCopy(local, x_[srcOffset], static_cast<uint32_t>(elems));
+        } else {
+            DataCopyParams params{1, static_cast<uint16_t>(rowBytes), 0, 0};
+            DataCopyPadParams padParams{false, 0, 0, 0};
+            DataCopyPad(local, x_[srcOffset], params, padParams);
+        }
+        SetFlag<HardEvent::MTE2_MTE3>(SWAP12_MTE2_MTE3_EVENT_ID);
+        WaitFlag<HardEvent::MTE2_MTE3>(SWAP12_MTE2_MTE3_EVENT_ID);
+        if (rowBytes >= 32 && rowBytes % 32 == 0) {
+            DataCopy(y_[dstOffset], local, static_cast<uint32_t>(elems));
+        } else {
+            DataCopyParams params{1, static_cast<uint16_t>(rowBytes), 0, 0};
+            DataCopyPad(y_[dstOffset], local, params);
+        }
+        SetFlag<HardEvent::MTE3_MTE2>(SWAP12_MTE3_MTE2_EVENT_ID);
+        WaitFlag<HardEvent::MTE3_MTE2>(SWAP12_MTE3_MTE2_EVENT_ID);
+    }
+
+    __aicore__ inline void CopySwappedRow(uint64_t row)
+    {
+        uint64_t perBatchRows = firstDim_ * secondDim_;
+        uint64_t b = row / perBatchRows;
+        uint64_t rem = row - b * perBatchRows;
+        uint64_t i = rem / secondDim_;
+        uint64_t j = rem - i * secondDim_;
+
+        uint64_t srcBase = ((b * firstDim_ + i) * secondDim_ + j) * tailDim_;
+        uint64_t dstBase = ((b * secondDim_ + j) * firstDim_ + i) * tailDim_;
+        for (uint64_t off = 0; off < tailDim_; off += SWAP12_UB_ELEMENTS) {
+            uint64_t elems = tailDim_ - off;
+            if (elems > SWAP12_UB_ELEMENTS) {
+                elems = SWAP12_UB_ELEMENTS;
+            }
+            CopyTile(srcBase + off, dstBase + off, elems);
+        }
+    }
+
+    GlobalTensor<T> x_;
+    GlobalTensor<T> y_;
+    TBuf<TPosition::VECCALC> copyBuf_;
+    TPipe *pipe_ = nullptr;
+    uint64_t batch_ = 0;
+    uint64_t firstDim_ = 0;
+    uint64_t secondDim_ = 0;
+    uint64_t tailDim_ = 0;
+    uint64_t usedCoreNum_ = 1;
+};
+} // namespace
+
+extern "C" __global__ __aicore__ void kda_layout_swap12(GM_ADDR x, GM_ADDR y, GM_ADDR workspace, GM_ADDR tiling)
+{
+    (void)workspace;
+    GET_TILING_DATA(tilingData, tiling);
+    TPipe pipe;
+    if (TILING_KEY_IS(0)) {
+        KERNEL_TASK_TYPE(0, KERNEL_TYPE_AIV_ONLY);
+        KdaLayoutSwap12Kernel<float> op;
+        op.Init(x, y, tilingData, &pipe);
+        op.Process();
+    } else if (TILING_KEY_IS(1)) {
+        KERNEL_TASK_TYPE(1, KERNEL_TYPE_AIV_ONLY);
+        KdaLayoutSwap12Kernel<bfloat16_t> op;
+        op.Init(x, y, tilingData, &pipe);
+        op.Process();
+    } else if (TILING_KEY_IS(2)) {
+        KERNEL_TASK_TYPE(2, KERNEL_TYPE_AIV_ONLY);
+        KdaLayoutSwap12Kernel<half> op;
+        op.Init(x, y, tilingData, &pipe);
+        op.Process();
+    }
+}

--- a/tests/reference/chunk_kda_reference.py
+++ b/tests/reference/chunk_kda_reference.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2026 Tianjin University, Ltd.
+#
+# Pure PyTorch reference for chunk KDA forward. This file is intentionally
+# independent from torch_npu and Triton so ATK CPU golden code can reuse it.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+
+@dataclass
+class ChunkKdaForwardResult:
+    o: torch.Tensor
+    final_state: Optional[torch.Tensor]
+    Aqk: torch.Tensor
+    Akk: torch.Tensor
+    w: torch.Tensor
+    u: torch.Tensor
+    qg: torch.Tensor
+    kg: torch.Tensor
+    v_new: torch.Tensor
+    h: torch.Tensor
+
+
+def _chunk_spans(
+    batch: int,
+    total_t: int,
+    chunk_size: int,
+    cu_seqlens: Optional[torch.Tensor],
+) -> list[tuple[int, int, int]]:
+    if cu_seqlens is None:
+        spans: list[tuple[int, int, int]] = []
+        for b in range(batch):
+            for start in range(0, total_t, chunk_size):
+                spans.append((b, start, min(start + chunk_size, total_t)))
+        return spans
+
+    if batch != 1:
+        raise ValueError("varlen reference expects flattened batch B=1.")
+
+    cu = cu_seqlens.detach().cpu().tolist()
+    spans = []
+    for n in range(len(cu) - 1):
+        seq_start, seq_end = int(cu[n]), int(cu[n + 1])
+        for start in range(seq_start, seq_end, chunk_size):
+            spans.append((0, start, min(start + chunk_size, seq_end)))
+    return spans
+
+
+def _lower_inverse(mat: torch.Tensor) -> torch.Tensor:
+    eye = torch.eye(mat.shape[-1], device=mat.device, dtype=torch.float32)
+    lhs = eye + torch.tril(mat.to(torch.float32), diagonal=-1)
+    return torch.linalg.solve_triangular(lhs, eye, upper=False)
+
+
+def chunk_kda_forward_reference(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gk: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    chunk_size: int = 64,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+) -> ChunkKdaForwardResult:
+    """Reference KDA forward for token-first tensors.
+
+    Args:
+        q: [B, T, H, K].
+        k: [B, T, H, K].
+        v: [B, T, HV, V].
+        gk: [B, T, HV, K], cumulative key-wise gate in log2 space.
+        beta: [B, T, HV].
+        scale: attention scale.
+        chunk_size: 64 or 128 in the intended NPU implementation.
+        initial_state: optional [N, HV, K, V] state.
+        output_final_state: whether to return final state.
+        cu_seqlens: optional flattened varlen boundaries.
+    """
+    if q.dim() != 4 or k.dim() != 4 or v.dim() != 4:
+        raise ValueError("q/k/v must be 4-D token-first tensors.")
+    if gk.dim() != 4 or beta.dim() != 3:
+        raise ValueError("gk must be [B, T, HV, K] and beta must be [B, T, HV].")
+    if q.shape != k.shape:
+        raise ValueError("q and k must have identical shape.")
+    bsz, total_t, hq, kdim = q.shape
+    b_v, t_v, hv, vdim = v.shape
+    if (b_v, t_v) != (bsz, total_t):
+        raise ValueError("v shape prefix must match q/k.")
+    if gk.shape != (bsz, total_t, hv, kdim):
+        raise ValueError("gk shape must be [B, T, HV, K].")
+    if beta.shape != (bsz, total_t, hv):
+        raise ValueError("beta shape must be [B, T, HV].")
+    if hv % hq != 0:
+        raise ValueError("HV must be divisible by H.")
+
+    spans = _chunk_spans(bsz, total_t, chunk_size, cu_seqlens)
+    nt = len(spans) if cu_seqlens is not None else (total_t + chunk_size - 1) // chunk_size
+    group = hv // hq
+    num_seq = bsz if cu_seqlens is None else int(cu_seqlens.numel() - 1)
+
+    out_dtype = v.dtype
+    device = q.device
+    o = torch.zeros((bsz, total_t, hv, vdim), device=device, dtype=out_dtype)
+    Aqk = torch.zeros((bsz, total_t, hv, chunk_size), device=device, dtype=q.dtype)
+    Akk = torch.zeros((bsz, total_t, hv, chunk_size), device=device, dtype=q.dtype)
+    w = torch.zeros((bsz, total_t, hv, kdim), device=device, dtype=q.dtype)
+    u = torch.zeros((bsz, total_t, hv, vdim), device=device, dtype=v.dtype)
+    qg = torch.zeros((bsz, total_t, hv, kdim), device=device, dtype=q.dtype)
+    kg = torch.zeros((bsz, total_t, hv, kdim), device=device, dtype=k.dtype)
+    v_new = torch.zeros_like(v)
+    h_out = torch.zeros((bsz, nt, hv, kdim, vdim), device=device, dtype=q.dtype)
+
+    if initial_state is None:
+        state = torch.zeros((num_seq, hv, kdim, vdim), device=device, dtype=torch.float32)
+    else:
+        state = initial_state.to(torch.float32).clone()
+
+    seq_state_index = 0
+    prev_b = None
+    chunk_counter: dict[int, int] = {}
+    if cu_seqlens is not None:
+        cu_cpu = cu_seqlens.detach().cpu().tolist()
+    else:
+        cu_cpu = None
+
+    for span_idx, (b, start, end) in enumerate(spans):
+        if cu_cpu is not None:
+            while seq_state_index + 1 < len(cu_cpu) - 1 and start >= cu_cpu[seq_state_index + 1]:
+                seq_state_index += 1
+            state_b = seq_state_index
+            chunk_idx = span_idx
+        else:
+            if prev_b != b:
+                chunk_counter[b] = 0
+                prev_b = b
+            state_b = b
+            chunk_idx = chunk_counter[b]
+            chunk_counter[b] += 1
+
+        cur_t = end - start
+        local_cols = slice(0, cur_t)
+        for ihv in range(hv):
+            ih = ihv // group
+            q_blk = q[b, start:end, ih].to(torch.float32)
+            k_blk = k[b, start:end, ih].to(torch.float32)
+            v_blk = v[b, start:end, ihv].to(torch.float32)
+            g_blk = gk[b, start:end, ihv].to(torch.float32)
+            beta_blk = beta[b, start:end, ihv].to(torch.float32)
+
+            rel = g_blk[:, None, :] - g_blk[None, :, :]
+            qk = torch.einsum("ik,jk,ijk->ij", q_blk, k_blk, torch.exp2(rel)) * float(scale)
+            kk = torch.einsum("ik,jk,ijk->ij", k_blk, k_blk, torch.exp2(rel))
+            tril_qk = torch.tril(qk, diagonal=0)
+            tril_kk = torch.tril(kk * beta_blk[:, None], diagonal=-1)
+            inv_akk = _lower_inverse(tril_kk)
+
+            k_beta_g = k_blk * beta_blk[:, None] * torch.exp2(g_blk)
+            v_beta = v_blk * beta_blk[:, None]
+            w_blk = inv_akk @ k_beta_g
+            u_blk = inv_akk @ v_beta
+
+            last_g = g_blk[cur_t - 1]
+            qg_blk = q_blk * torch.exp2(g_blk)
+            kg_blk = k_blk * torch.exp2(last_g[None, :] - g_blk)
+
+            h_prev = state[state_b, ihv]
+            h_out[b, chunk_idx, ihv] = h_prev.to(h_out.dtype)
+            v_new_blk = u_blk - w_blk @ h_prev
+            state[state_b, ihv] = torch.exp2(last_g)[:, None] * h_prev + kg_blk.T @ v_new_blk
+
+            o_inter = qg_blk @ h_out[b, chunk_idx, ihv].to(torch.float32) * float(scale)
+            o_local = tril_qk @ v_new_blk
+            o[b, start:end, ihv] = (o_inter + o_local).to(out_dtype)
+
+            Aqk[b, start:end, ihv, local_cols] = tril_qk.to(Aqk.dtype)
+            Akk[b, start:end, ihv, local_cols] = inv_akk.to(Akk.dtype)
+            w[b, start:end, ihv] = w_blk.to(w.dtype)
+            u[b, start:end, ihv] = u_blk.to(u.dtype)
+            qg[b, start:end, ihv] = qg_blk.to(qg.dtype)
+            kg[b, start:end, ihv] = kg_blk.to(kg.dtype)
+            v_new[b, start:end, ihv] = v_new_blk.to(v_new.dtype)
+
+    final_state = state if output_final_state else None
+    return ChunkKdaForwardResult(
+        o=o,
+        final_state=final_state,
+        Aqk=Aqk,
+        Akk=Akk,
+        w=w,
+        u=u,
+        qg=qg,
+        kg=kg,
+        v_new=v_new,
+        h=h_out,
+    )
+
+
+def run_smoke() -> None:
+    torch.manual_seed(0)
+    q = torch.randn(1, 32, 2, 16, dtype=torch.float32)
+    k = torch.randn_like(q)
+    v = torch.randn(1, 32, 2, 32, dtype=torch.float32)
+    gk = torch.randn(1, 32, 2, 16, dtype=torch.float32).cumsum(dim=1) * 0.01
+    beta = torch.sigmoid(torch.randn(1, 32, 2, dtype=torch.float32))
+    res = chunk_kda_forward_reference(q, k, v, gk, beta, scale=16 ** -0.5, chunk_size=16, output_final_state=True)
+    for name, value in vars(res).items():
+        if value is not None and not torch.isfinite(value).all():
+            raise RuntimeError(f"{name} contains NaN or Inf")
+
+
+if __name__ == "__main__":
+    run_smoke()

--- a/torch_custom/fla_npu/fla_npu/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/__init__.py
@@ -14,3 +14,5 @@ def _load_opextension_so():
     torch.ops.load_library(atb_so_path)
 
 _load_opextension_so()
+
+from . import kda  # noqa: F401,E402

--- a/torch_custom/fla_npu/fla_npu/kda.py
+++ b/torch_custom/fla_npu/fla_npu/kda.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Tianjin University, Ltd.
+#
+# KDA operators are registered by the native custom_aclnn_extension_lib through
+# npu_custom.yaml.  This module is intentionally kept as a no-op compatibility
+# import for older fla_npu package entrypoints.
+
+
+def register_kda_ops() -> None:
+    return None

--- a/torch_custom/fla_npu/npu_custom.yaml
+++ b/torch_custom/fla_npu/npu_custom.yaml
@@ -39,6 +39,10 @@ custom:
     op_api: all_version
   - func: npu_solve_tri(Tensor x, *, int[]? cu_seqlens=None, int[]? chunk_indices=None, str layout="bsnd") -> Tensor
     op_api: all_version
+  - func: npu_chunk_kda_fwd(Tensor q, Tensor k, Tensor v, Tensor gk, Tensor beta, float scale, int chunk_size, *, Tensor? initial_state=None, bool? output_final_state=False, int[]? cu_seqlens=None, int[]? chunk_indices=None, bool? return_intermediate=False, bool? safe_gate=False, bool? transpose_state_layout=False) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)
+    op_api: all_version
+  - func: npu_kda_gate_cumsum(Tensor g, int chunk_size, *, Tensor? A_log=None, Tensor? dt_bias=None, int[]? cu_seqlens=None, bool? use_gate_in_kernel=False, bool? safe_gate=False, float? lower_bound=None) -> Tensor
+    op_api: all_version
 
 autograd:
 

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -26,6 +26,41 @@ using npu_preparation = at_npu::native::OpPreparation;
 using namespace op_plugin::utils;
 using namespace op_infer;
 
+namespace {
+int64_t CeilDiv(int64_t x, int64_t y)
+{
+    return (x + y - 1) / y;
+}
+
+int64_t GetKdaSeqNum(int64_t batch, at::OptionalIntArrayRef cu_seqlens)
+{
+    if (!cu_seqlens.has_value()) {
+        return batch;
+    }
+    auto cu = cu_seqlens.value();
+    return static_cast<int64_t>(cu.size()) - 1;
+}
+
+int64_t GetKdaTotalChunks(int64_t batch, int64_t seqlen, int64_t chunk_size,
+                          at::OptionalIntArrayRef cu_seqlens,
+                          at::OptionalIntArrayRef chunk_indices)
+{
+    if (chunk_indices.has_value()) {
+        return static_cast<int64_t>(chunk_indices.value().size()) / 2;
+    }
+    if (!cu_seqlens.has_value()) {
+        return CeilDiv(seqlen, chunk_size);
+    }
+    (void)batch;
+    int64_t total = 0;
+    auto cu = cu_seqlens.value();
+    for (size_t i = 0; i + 1 < cu.size(); ++i) {
+        total += CeilDiv(cu[i + 1] - cu[i], chunk_size);
+    }
+    return total;
+}
+} // namespace
+
 
 ::std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor> npu_prepare_wy_repr_bwd_full(const at::Tensor & k, const at::Tensor & v, const at::Tensor & beta, const at::Tensor & A, const at::Tensor & dA, const at::Tensor & dw, const at::Tensor & du, const at::Tensor & g, int64_t chunk_size, at::OptionalIntArrayRef cu_seqlens, at::OptionalIntArrayRef chunk_indices)
 {
@@ -245,11 +280,8 @@ at::Tensor npu_chunk_fwd_o(
     c10::optional<bool> transpose_state_layout)
 {
     TORCH_CHECK(
-        g.has_value() && g->defined(),
-        "npu_chunk_gated_delta_rule_fwd_h: g cannot be None or undefined; pass a real gate tensor until NPU supports g=None.");
-    TORCH_CHECK(
-        !gk.has_value() || !gk->defined(),
-        "npu_chunk_gated_delta_rule_fwd_h: gk is reserved and only None is supported.");
+        (g.has_value() && g->defined()) || (gk.has_value() && gk->defined()),
+        "npu_chunk_gated_delta_rule_fwd_h: either g or gk must be defined.");
     TORCH_CHECK(
         save_new_value.value_or(true),
         "npu_chunk_gated_delta_rule_fwd_h: save_new_value is reserved and only true is supported.");
@@ -337,6 +369,205 @@ at::Tensor npu_chunk_fwd_o(
     EXEC_NPU_CMD_EXT(aclnnRecomputeWUFwd,
         k, v, beta, A, g_, gK_,cu_seqlens, chunk_indices, chunk_size, w, u);
     return std::tie(w,u);
+}
+::std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor,
+             at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+npu_chunk_kda_fwd(
+    const at::Tensor &q,
+    const at::Tensor &k,
+    const at::Tensor &v,
+    const at::Tensor &gk,
+    const at::Tensor &beta,
+    double scale,
+    int64_t chunk_size,
+    const c10::optional<at::Tensor> &initial_state,
+    c10::optional<bool> output_final_state,
+    at::OptionalIntArrayRef cu_seqlens,
+    at::OptionalIntArrayRef chunk_indices,
+    c10::optional<bool> return_intermediate,
+    c10::optional<bool> safe_gate,
+    c10::optional<bool> transpose_state_layout)
+{
+    TORCH_CHECK(!safe_gate.value_or(false), "npu_chunk_kda_fwd: safe_gate=True is not supported.");
+    TORCH_CHECK(!transpose_state_layout.value_or(false),
+                "npu_chunk_kda_fwd: transpose_state_layout=True is not supported.");
+    TORCH_CHECK(chunk_size == 32 || chunk_size == 64 || chunk_size == 128,
+                "npu_chunk_kda_fwd: chunk_size must be 32, 64 or 128.");
+    bool is_rank3 = q.dim() == 3;
+    TORCH_CHECK((!is_rank3 && q.dim() == 4 && k.dim() == 4 && v.dim() == 4 && gk.dim() == 4 && beta.dim() == 3) ||
+                    (is_rank3 && k.dim() == 3 && v.dim() == 3 && gk.dim() == 3 && beta.dim() == 2),
+                "npu_chunk_kda_fwd: expected q/k/v/gk in BSND/BNSD rank4 with beta rank3, "
+                "or TND/NTD rank3 with beta rank2.");
+    TORCH_CHECK(q.sizes() == k.sizes(), "npu_chunk_kda_fwd: q and k must have identical shape.");
+    auto is_gate_dtype = [](at::ScalarType dtype) {
+        return dtype == at::kFloat || dtype == at::kBFloat16;
+    };
+    TORCH_CHECK(is_gate_dtype(gk.scalar_type()) && is_gate_dtype(beta.scalar_type()),
+                "npu_chunk_kda_fwd: gk and beta must be float32 or bfloat16.");
+
+    auto q_sizes = q.sizes();
+    auto v_sizes = v.sizes();
+    bool is_bsnd = false;
+    bool is_bnsd = false;
+    bool is_tnd = false;
+    bool is_ntd = false;
+    if (is_rank3) {
+        is_tnd = v_sizes[0] == q_sizes[0] && gk.sizes()[0] == q_sizes[0] && beta.sizes()[0] == q_sizes[0] &&
+                 gk.sizes()[1] == v_sizes[1] && beta.sizes()[1] == v_sizes[1] && gk.sizes()[2] == q_sizes[2];
+        is_ntd = v_sizes[1] == q_sizes[1] && gk.sizes()[0] == v_sizes[0] && beta.sizes()[0] == v_sizes[0] &&
+                 gk.sizes()[1] == q_sizes[1] && beta.sizes()[1] == q_sizes[1] && gk.sizes()[2] == q_sizes[2];
+        if (is_tnd && is_ntd) {
+            is_ntd = q_sizes[0] <= q_sizes[1];
+            is_tnd = !is_ntd;
+        }
+    } else {
+        is_bsnd = v_sizes[0] == q_sizes[0] && v_sizes[1] == q_sizes[1] &&
+                  gk.sizes()[0] == q_sizes[0] && gk.sizes()[1] == q_sizes[1] &&
+                  beta.sizes()[0] == q_sizes[0] && beta.sizes()[1] == q_sizes[1] &&
+                  gk.sizes()[2] == v_sizes[2] && beta.sizes()[2] == v_sizes[2] && gk.sizes()[3] == q_sizes[3];
+        is_bnsd = v_sizes[0] == q_sizes[0] && v_sizes[2] == q_sizes[2] &&
+                  gk.sizes()[0] == q_sizes[0] && gk.sizes()[1] == v_sizes[1] &&
+                  beta.sizes()[0] == q_sizes[0] && beta.sizes()[1] == v_sizes[1] &&
+                  gk.sizes()[2] == q_sizes[2] && beta.sizes()[2] == q_sizes[2] && gk.sizes()[3] == q_sizes[3];
+        if (is_bsnd && is_bnsd) {
+            is_bnsd = q_sizes[1] <= q_sizes[2];
+            is_bsnd = !is_bnsd;
+        }
+    }
+    TORCH_CHECK(is_bsnd || is_bnsd || is_tnd || is_ntd,
+                "npu_chunk_kda_fwd: expected BSND [B,T,H,K], BNSD [B,H,T,K], "
+                "TND [T,H,K], or NTD [H,T,K] layout.");
+
+    bool is_internal_layout = is_bnsd || is_ntd;
+    int64_t B = is_rank3 ? 1 : q_sizes[0];
+    int64_t T = is_tnd ? q_sizes[0] : (is_ntd ? q_sizes[1] : (is_bnsd ? q_sizes[2] : q_sizes[1]));
+    int64_t H = is_tnd ? q_sizes[1] : (is_ntd ? q_sizes[0] : (is_bnsd ? q_sizes[1] : q_sizes[2]));
+    int64_t K = is_rank3 ? q_sizes[2] : q_sizes[3];
+    int64_t HV = is_tnd ? v_sizes[1] : (is_ntd ? v_sizes[0] : (is_bnsd ? v_sizes[1] : v_sizes[2]));
+    int64_t V = is_rank3 ? v_sizes[2] : v_sizes[3];
+    TORCH_CHECK((is_tnd && v_sizes[0] == T) || (is_ntd && v_sizes[1] == T) ||
+                    (is_bsnd && v_sizes[0] == B && v_sizes[1] == T) ||
+                    (is_bnsd && v_sizes[0] == B && v_sizes[2] == T),
+                "npu_chunk_kda_fwd: v shape prefix must match q layout.");
+    TORCH_CHECK((is_tnd && gk.sizes()[0] == T && gk.sizes()[1] == HV && gk.sizes()[2] == K) ||
+                    (is_ntd && gk.sizes()[0] == HV && gk.sizes()[1] == T && gk.sizes()[2] == K) ||
+                    (is_bsnd && gk.sizes()[0] == B && gk.sizes()[1] == T && gk.sizes()[2] == HV &&
+                        gk.sizes()[3] == K) ||
+                    (is_bnsd && gk.sizes()[0] == B && gk.sizes()[1] == HV && gk.sizes()[2] == T &&
+                        gk.sizes()[3] == K),
+                "npu_chunk_kda_fwd: gk shape mismatch.");
+    TORCH_CHECK((is_tnd && beta.sizes()[0] == T && beta.sizes()[1] == HV) ||
+                    (is_ntd && beta.sizes()[0] == HV && beta.sizes()[1] == T) ||
+                    (is_bsnd && beta.sizes()[0] == B && beta.sizes()[1] == T && beta.sizes()[2] == HV) ||
+                    (is_bnsd && beta.sizes()[0] == B && beta.sizes()[1] == HV && beta.sizes()[2] == T),
+                "npu_chunk_kda_fwd: beta shape mismatch.");
+    TORCH_CHECK(HV % H == 0, "npu_chunk_kda_fwd: HV must be divisible by H.");
+    if (initial_state.has_value() && initial_state->defined()) {
+        TORCH_CHECK(initial_state->scalar_type() == at::kFloat,
+                    "npu_chunk_kda_fwd: initial_state must be float32 when provided.");
+    }
+
+    int64_t seq_num = GetKdaSeqNum(B, cu_seqlens);
+    int64_t total_chunks = GetKdaTotalChunks(B, T, chunk_size, cu_seqlens, chunk_indices);
+    bool output_final_state_ = output_final_state.value_or(false);
+    bool return_intermediate_ = return_intermediate.value_or(false);
+    double scale_ = scale;
+    int64_t chunk_size_ = chunk_size;
+    bool recompute_output_final_state = true;
+    int64_t total_chunks_ = total_chunks;
+
+    at::Tensor o = at::empty_like(v);
+    at::Tensor final_state_work = at::empty({seq_num, HV, K, V}, q.options().dtype(at::kFloat));
+    at::Tensor aqk = is_rank3 ? (is_internal_layout ? at::empty({HV, T, chunk_size}, q.options()) :
+        at::empty({T, HV, chunk_size}, q.options())) : (is_internal_layout ?
+        at::empty({B, HV, T, chunk_size}, q.options()) : at::empty({B, T, HV, chunk_size}, q.options()));
+    at::Tensor akk = is_rank3 ? (is_internal_layout ? at::empty({HV, T, chunk_size}, q.options()) :
+        at::empty({T, HV, chunk_size}, q.options())) : (is_internal_layout ?
+        at::empty({B, HV, T, chunk_size}, q.options()) : at::empty({B, T, HV, chunk_size}, q.options()));
+    at::Tensor w = is_rank3 ? (is_internal_layout ? at::empty({HV, T, K}, q.options()) :
+        at::empty({T, HV, K}, q.options())) : (is_internal_layout ?
+        at::empty({B, HV, T, K}, q.options()) : at::empty({B, T, HV, K}, q.options()));
+    at::Tensor u = at::empty_like(v);
+    at::Tensor qg = is_rank3 ? (is_internal_layout ? at::empty({HV, T, K}, q.options()) :
+        at::empty({T, HV, K}, q.options())) : (is_internal_layout ?
+        at::empty({B, HV, T, K}, q.options()) : at::empty({B, T, HV, K}, q.options()));
+    at::Tensor kg = is_rank3 ? (is_internal_layout ? at::empty({HV, T, K}, q.options()) :
+        at::empty({T, HV, K}, q.options())) : (is_internal_layout ?
+        at::empty({B, HV, T, K}, q.options()) : at::empty({B, T, HV, K}, q.options()));
+    at::Tensor v_new = at::empty_like(v);
+    at::Tensor h = is_rank3 ? (is_internal_layout ? at::empty({HV, total_chunks, K, V}, q.options()) :
+        at::empty({total_chunks, HV, K, V}, q.options())) : (is_internal_layout ?
+        at::empty({B, HV, total_chunks, K, V}, q.options()) : at::empty({B, total_chunks, HV, K, V}, q.options()));
+    const at::Tensor &initial_state_ = c10::value_or_else(initial_state, [] { return at::Tensor(); });
+
+    EXEC_NPU_CMD_EXT(
+        aclnnChunkKdaFwd,
+        q, k, v, gk, beta, initial_state_,
+        cu_seqlens, chunk_indices,
+        scale_, chunk_size_, recompute_output_final_state, total_chunks_,
+        o, final_state_work, aqk, akk, w, u, qg, kg, v_new, h
+    );
+
+    at::Tensor final_state = output_final_state_ ? final_state_work : at::empty({0}, q.options().dtype(at::kFloat));
+    if (return_intermediate_) {
+        return std::make_tuple(o, final_state, aqk, akk, w, u, qg, kg, v_new, h);
+    }
+    at::Tensor empty = at::empty({0}, q.options());
+    return std::make_tuple(o, final_state, aqk, akk, empty, empty, empty, empty, empty, h);
+}
+
+at::Tensor npu_kda_gate_cumsum(
+    const at::Tensor &g,
+    int64_t chunk_size,
+    const c10::optional<at::Tensor> &A_log,
+    const c10::optional<at::Tensor> &dt_bias,
+    at::OptionalIntArrayRef cu_seqlens,
+    c10::optional<bool> use_gate_in_kernel,
+    c10::optional<bool> safe_gate,
+    c10::optional<double> lower_bound)
+{
+    TORCH_CHECK(g.dim() == 3 || g.dim() == 4,
+                "npu_kda_gate_cumsum: g must be BSND/BNSD rank4 or TND/NTD rank3.");
+    TORCH_CHECK(chunk_size == 32 || chunk_size == 64 || chunk_size == 128,
+                "npu_kda_gate_cumsum: chunk_size must be 32, 64 or 128.");
+    auto gate_dtype = g.scalar_type();
+    TORCH_CHECK(gate_dtype == at::kFloat || gate_dtype == at::kBFloat16 || gate_dtype == at::kHalf,
+                "npu_kda_gate_cumsum: g must be float32, bfloat16 or float16.");
+    bool is_bnsd = g.dim() == 4 && g.sizes()[1] <= g.sizes()[2];
+    bool is_ntd = g.dim() == 3 && g.sizes()[0] <= g.sizes()[1];
+    int64_t K = g.dim() == 4 ? g.sizes()[3] : g.sizes()[2];
+    int64_t HV = is_bnsd ? g.sizes()[1] : (is_ntd ? g.sizes()[0] : (g.dim() == 4 ? g.sizes()[2] : g.sizes()[1]));
+    TORCH_CHECK(K <= 256, "npu_kda_gate_cumsum: K must be <= 256.");
+
+    bool use_gate = use_gate_in_kernel.value_or(false);
+    bool safe = safe_gate.value_or(false);
+    double lower = lower_bound.value_or(-5.0);
+    if (use_gate) {
+        TORCH_CHECK(A_log.has_value() && A_log->defined(),
+                    "npu_kda_gate_cumsum: A_log is required when use_gate_in_kernel=True.");
+        TORCH_CHECK(A_log->scalar_type() == at::kFloat && A_log->dim() == 1 && A_log->sizes()[0] == HV,
+                    "npu_kda_gate_cumsum: A_log must be float32 with shape [HV].");
+        TORCH_CHECK(safe, "npu_kda_gate_cumsum: raw gate path currently requires safe_gate=True.");
+        TORCH_CHECK(lower >= -5.0 && lower < 0.0, "npu_kda_gate_cumsum: lower_bound must be in [-5, 0).");
+        if (dt_bias.has_value() && dt_bias->defined()) {
+            bool valid_bias = dt_bias->scalar_type() == at::kFloat &&
+                ((dt_bias->dim() == 1 && dt_bias->sizes()[0] == HV * K) ||
+                 (dt_bias->dim() == 2 && dt_bias->sizes()[0] == HV && dt_bias->sizes()[1] == K));
+            TORCH_CHECK(valid_bias, "npu_kda_gate_cumsum: dt_bias must be float32 with shape [HV*K] or [HV, K].");
+        }
+    } else {
+        TORCH_CHECK(!safe, "npu_kda_gate_cumsum: safe_gate only applies when use_gate_in_kernel=True.");
+    }
+
+    at::Tensor gk = at::empty(g.sizes(), g.options().dtype(at::kFloat));
+    const at::Tensor &A_log_ = c10::value_or_else(A_log, [] { return at::Tensor(); });
+    const at::Tensor &dt_bias_ = c10::value_or_else(dt_bias, [] { return at::Tensor(); });
+    EXEC_NPU_CMD_EXT(
+        aclnnKdaGateCumsum,
+        g, A_log_, dt_bias_, cu_seqlens,
+        chunk_size, use_gate, safe, lower, gk
+    );
+    return gk;
 }
 
 at::Tensor infer_y_tensor(

--- a/torch_custom/fla_npu/test/test_npu_chunk_kda.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_kda.py
@@ -1,0 +1,510 @@
+# Copyright (c) 2026 Tianjin University, Ltd.
+
+import pathlib
+import sys
+
+import torch
+
+try:
+    import torch_npu  # noqa: F401
+except Exception:  # pragma: no cover - CPU fallback for syntax/smoke only
+    torch_npu = None
+
+import fla_npu  # noqa: F401
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT))
+from tests.reference.chunk_kda_reference import chunk_kda_forward_reference  # noqa: E402
+
+
+def _device():
+    if torch_npu is not None and hasattr(torch, "npu") and torch.npu.is_available():
+        return torch.device("npu:0")
+    return torch.device("cpu")
+
+
+def _make_inputs(device, b=1, h=2, hv=2, t=64, kdim=32, vdim=64, dtype=torch.float32):
+    torch.manual_seed(1234 + b + h + hv + t + kdim + vdim)
+    q = (torch.randn(b, t, h, kdim, device=device, dtype=dtype) * 0.08).requires_grad_(True)
+    k = (torch.randn(b, t, h, kdim, device=device, dtype=dtype) * 0.08).requires_grad_(True)
+    v = (torch.randn(b, t, hv, vdim, device=device, dtype=dtype) * 0.08).requires_grad_(True)
+    gk = (torch.randn(b, t, hv, kdim, device=device, dtype=torch.float32).cumsum(dim=1) * 0.001).requires_grad_(True)
+    beta = torch.sigmoid(torch.randn(b, t, hv, device=device, dtype=torch.float32)).requires_grad_(True)
+    initial_state = (torch.randn(b, hv, kdim, vdim, device=device, dtype=torch.float32) * 0.02).requires_grad_(True)
+    return q, k, v, gk, beta, initial_state
+
+
+def _assert_close(name, actual, expected, rtol=2e-3, atol=2e-3):
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=rtol, atol=atol, msg=name)
+
+
+def _kda_gate_cumsum_reference(g, chunk_size, A_log=None, dt_bias=None, use_gate_in_kernel=False,
+                               safe_gate=False, lower_bound=-5.0):
+    rcp_ln2 = 1.4426950408889634
+    g_float = g.to(torch.float32)
+    if use_gate_in_kernel:
+        if not safe_gate:
+            raise ValueError("test reference only covers safe_gate raw path")
+        x = g_float
+        if dt_bias is not None:
+            bias = dt_bias.reshape(g.shape[-2], g.shape[-1]).to(torch.float32)
+            if g.dim() == 4:
+                x = x + bias[None, None, :, :]
+            else:
+                x = x + bias[None, :, :]
+        a = torch.exp(A_log.to(torch.float32))
+        if g.dim() == 4:
+            x = x * a[None, None, :, None]
+        else:
+            x = x * a[None, :, None]
+        gate = float(lower_bound) * torch.sigmoid(x)
+    else:
+        gate = g_float
+
+    out = torch.empty_like(gate, dtype=torch.float32)
+    if g.dim() == 4:
+        for b in range(g.shape[0]):
+            for start in range(0, g.shape[1], chunk_size):
+                end = min(start + chunk_size, g.shape[1])
+                out[b, start:end] = torch.cumsum(gate[b, start:end] * rcp_ln2, dim=0)
+    else:
+        for start in range(0, g.shape[0], chunk_size):
+            end = min(start + chunk_size, g.shape[0])
+            out[start:end] = torch.cumsum(gate[start:end] * rcp_ln2, dim=0)
+    return out
+
+
+def test_chunk_kda_fwd_matches_reference():
+    device = _device()
+    q, k, v, gk, beta, initial_state = _make_inputs(device, h=1, hv=1, t=8, kdim=8, vdim=8)
+    scale = q.shape[-1] ** -0.5
+
+    got = torch.ops.npu.npu_chunk_kda_fwd(
+        q,
+        k,
+        v,
+        gk,
+        beta,
+        scale,
+        64,
+        initial_state=initial_state,
+        output_final_state=True,
+        return_intermediate=True,
+    )
+    ref = chunk_kda_forward_reference(
+        q.detach().cpu(),
+        k.detach().cpu(),
+        v.detach().cpu(),
+        gk.detach().cpu(),
+        beta.detach().cpu(),
+        scale=scale,
+        chunk_size=64,
+        initial_state=initial_state.detach().cpu(),
+        output_final_state=True,
+    )
+
+    _assert_close("o", got[0], ref.o)
+    _assert_close("final_state", got[1], ref.final_state)
+    _assert_close("Aqk", got[2], ref.Aqk)
+    _assert_close("Akk", got[3], ref.Akk)
+    _assert_close("w", got[4], ref.w)
+    _assert_close("u", got[5], ref.u)
+    _assert_close("qg", got[6], ref.qg)
+    _assert_close("kg", got[7], ref.kg)
+    _assert_close("v_new", got[8], ref.v_new)
+
+
+def test_chunk_kda_fwd_chunk128_v128_gva_varlen():
+    device = _device()
+    q, k, v, gk, beta, _ = _make_inputs(device, h=1, hv=2, t=16, kdim=8, vdim=128)
+    scale = q.shape[-1] ** -0.5
+    cu_seqlens = [0, 6, 16]
+
+    got = torch.ops.npu.npu_chunk_kda_fwd(
+        q,
+        k,
+        v,
+        gk,
+        beta,
+        scale,
+        128,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        return_intermediate=False,
+    )
+    ref = chunk_kda_forward_reference(
+        q.detach().cpu(),
+        k.detach().cpu(),
+        v.detach().cpu(),
+        gk.detach().cpu(),
+        beta.detach().cpu(),
+        scale=scale,
+        chunk_size=128,
+        output_final_state=True,
+        cu_seqlens=torch.tensor(cu_seqlens, dtype=torch.int64),
+    )
+    _assert_close("o chunk128 v128 gva varlen", got[0], ref.o, rtol=3e-3, atol=3e-3)
+    _assert_close("final_state chunk128 v128 gva varlen", got[1], ref.final_state, rtol=3e-3, atol=3e-3)
+
+
+def test_chunk_kda_fwd_bf16_chunk32_matches_reference():
+    device = _device()
+    if device.type == "cpu":
+        return
+    q, k, v, gk, beta, initial_state = _make_inputs(
+        device, h=1, hv=1, t=8, kdim=8, vdim=32, dtype=torch.bfloat16
+    )
+    scale = q.shape[-1] ** -0.5
+
+    got = torch.ops.npu.npu_chunk_kda_fwd(
+        q,
+        k,
+        v,
+        gk,
+        beta,
+        scale,
+        32,
+        initial_state=initial_state,
+        output_final_state=True,
+        return_intermediate=False,
+    )
+    ref = chunk_kda_forward_reference(
+        q.detach().cpu(),
+        k.detach().cpu(),
+        v.detach().cpu(),
+        gk.detach().cpu(),
+        beta.detach().cpu(),
+        scale=scale,
+        chunk_size=32,
+        initial_state=initial_state.detach().cpu(),
+        output_final_state=True,
+    )
+    _assert_close("o bf16 chunk32", got[0], ref.o, rtol=2e-2, atol=2e-2)
+    _assert_close("final_state bf16 chunk32", got[1], ref.final_state, rtol=2e-2, atol=2e-2)
+
+
+def test_chunk_kda_fwd_bf16_gate_matches_reference():
+    device = _device()
+    if device.type == "cpu":
+        return
+    q, k, v, gk, beta, initial_state = _make_inputs(
+        device, h=1, hv=1, t=8, kdim=8, vdim=32, dtype=torch.float16
+    )
+    gk_bf16 = gk.detach().to(torch.bfloat16).requires_grad_(True)
+    beta_bf16 = beta.detach().to(torch.bfloat16).requires_grad_(True)
+    scale = q.shape[-1] ** -0.5
+
+    got = torch.ops.npu.npu_chunk_kda_fwd(
+        q,
+        k,
+        v,
+        gk_bf16,
+        beta_bf16,
+        scale,
+        64,
+        initial_state=initial_state,
+        output_final_state=True,
+        return_intermediate=False,
+    )
+    ref = chunk_kda_forward_reference(
+        q.detach().cpu(),
+        k.detach().cpu(),
+        v.detach().cpu(),
+        gk_bf16.detach().cpu().float(),
+        beta_bf16.detach().cpu().float(),
+        scale=scale,
+        chunk_size=64,
+        initial_state=initial_state.detach().cpu(),
+        output_final_state=True,
+    )
+    _assert_close("o bf16 gate", got[0], ref.o, rtol=2e-2, atol=2e-2)
+    _assert_close("final_state bf16 gate", got[1], ref.final_state, rtol=2e-2, atol=2e-2)
+
+
+def test_chunk_kda_fwd_fp16_matches_reference():
+    device = _device()
+    if device.type == "cpu":
+        return
+    q, k, v, gk, beta, initial_state = _make_inputs(
+        device, h=1, hv=1, t=8, kdim=8, vdim=32, dtype=torch.float16
+    )
+    scale = q.shape[-1] ** -0.5
+
+    got = torch.ops.npu.npu_chunk_kda_fwd(
+        q,
+        k,
+        v,
+        gk,
+        beta,
+        scale,
+        64,
+        initial_state=initial_state,
+        output_final_state=True,
+        return_intermediate=True,
+    )
+    ref = chunk_kda_forward_reference(
+        q.detach().cpu(),
+        k.detach().cpu(),
+        v.detach().cpu(),
+        gk.detach().cpu(),
+        beta.detach().cpu(),
+        scale=scale,
+        chunk_size=64,
+        initial_state=initial_state.detach().cpu(),
+        output_final_state=True,
+    )
+    _assert_close("o fp16", got[0], ref.o, rtol=2e-2, atol=2e-2)
+    _assert_close("final_state fp16", got[1], ref.final_state, rtol=2e-2, atol=2e-2)
+    _assert_close("Aqk fp16", got[2], ref.Aqk, rtol=2e-2, atol=2e-2)
+    _assert_close("Akk fp16", got[3], ref.Akk, rtol=2e-2, atol=2e-2)
+    _assert_close("w fp16", got[4], ref.w, rtol=2e-2, atol=2e-2)
+    _assert_close("u fp16", got[5], ref.u, rtol=2e-2, atol=2e-2)
+    _assert_close("qg fp16", got[6], ref.qg, rtol=2e-2, atol=2e-2)
+    _assert_close("kg fp16", got[7], ref.kg, rtol=2e-2, atol=2e-2)
+    _assert_close("v_new fp16", got[8], ref.v_new, rtol=2e-2, atol=2e-2)
+
+
+def test_chunk_kda_fwd_tnd_matches_reference():
+    device = _device()
+    q, k, v, gk, beta, initial_state = _make_inputs(device, b=1, h=1, hv=2, t=8, kdim=8, vdim=16)
+    scale = q.shape[-1] ** -0.5
+
+    got = torch.ops.npu.npu_chunk_kda_fwd(
+        q.squeeze(0),
+        k.squeeze(0),
+        v.squeeze(0),
+        gk.squeeze(0),
+        beta.squeeze(0),
+        scale,
+        64,
+        initial_state=initial_state,
+        output_final_state=True,
+        return_intermediate=True,
+    )
+    ref = chunk_kda_forward_reference(
+        q.detach().cpu(),
+        k.detach().cpu(),
+        v.detach().cpu(),
+        gk.detach().cpu(),
+        beta.detach().cpu(),
+        scale=scale,
+        chunk_size=64,
+        initial_state=initial_state.detach().cpu(),
+        output_final_state=True,
+    )
+
+    _assert_close("o tnd", got[0], ref.o.squeeze(0))
+    _assert_close("final_state tnd", got[1], ref.final_state)
+    _assert_close("Aqk tnd", got[2], ref.Aqk.squeeze(0))
+    _assert_close("Akk tnd", got[3], ref.Akk.squeeze(0))
+    _assert_close("w tnd", got[4], ref.w.squeeze(0))
+    _assert_close("u tnd", got[5], ref.u.squeeze(0))
+    _assert_close("qg tnd", got[6], ref.qg.squeeze(0))
+    _assert_close("kg tnd", got[7], ref.kg.squeeze(0))
+    _assert_close("v_new tnd", got[8], ref.v_new.squeeze(0))
+    _assert_close("h tnd", got[9], ref.h.squeeze(0))
+
+
+def test_chunk_kda_fwd_bnsd_direct_matches_reference():
+    device = _device()
+    if device.type == "cpu":
+        return
+    q, k, v, gk, beta, initial_state = _make_inputs(device, b=1, h=1, hv=2, t=16, kdim=16, vdim=32,
+                                                    dtype=torch.float16)
+    scale = q.shape[-1] ** -0.5
+    q_bnsd = q.permute(0, 2, 1, 3).contiguous()
+    k_bnsd = k.permute(0, 2, 1, 3).contiguous()
+    v_bnsd = v.permute(0, 2, 1, 3).contiguous()
+    gk_bnsd = gk.permute(0, 2, 1, 3).contiguous()
+    beta_bns = beta.permute(0, 2, 1).contiguous()
+
+    got = torch.ops.npu.npu_chunk_kda_fwd(
+        q_bnsd,
+        k_bnsd,
+        v_bnsd,
+        gk_bnsd,
+        beta_bns,
+        scale,
+        64,
+        initial_state=initial_state,
+        output_final_state=True,
+        return_intermediate=True,
+    )
+    ref = chunk_kda_forward_reference(
+        q.detach().cpu(),
+        k.detach().cpu(),
+        v.detach().cpu(),
+        gk.detach().cpu(),
+        beta.detach().cpu(),
+        scale=scale,
+        chunk_size=64,
+        initial_state=initial_state.detach().cpu(),
+        output_final_state=True,
+    )
+
+    _assert_close("o bnsd", got[0], ref.o.permute(0, 2, 1, 3), rtol=2e-2, atol=2e-2)
+    _assert_close("final_state bnsd", got[1], ref.final_state, rtol=2e-2, atol=2e-2)
+    _assert_close("Aqk bnsd", got[2], ref.Aqk.permute(0, 2, 1, 3), rtol=2e-2, atol=2e-2)
+    _assert_close("Akk bnsd", got[3], ref.Akk.permute(0, 2, 1, 3), rtol=2e-2, atol=2e-2)
+    _assert_close("w bnsd", got[4], ref.w.permute(0, 2, 1, 3), rtol=2e-2, atol=2e-2)
+    _assert_close("u bnsd", got[5], ref.u.permute(0, 2, 1, 3), rtol=2e-2, atol=2e-2)
+    _assert_close("qg bnsd", got[6], ref.qg.permute(0, 2, 1, 3), rtol=2e-2, atol=2e-2)
+    _assert_close("kg bnsd", got[7], ref.kg.permute(0, 2, 1, 3), rtol=2e-2, atol=2e-2)
+    _assert_close("v_new bnsd", got[8], ref.v_new.permute(0, 2, 1, 3), rtol=2e-2, atol=2e-2)
+    _assert_close("h bnsd", got[9], ref.h.permute(0, 2, 1, 3, 4), rtol=2e-2, atol=2e-2)
+
+
+def test_chunk_kda_fwd_ntd_direct_matches_reference():
+    device = _device()
+    if device.type == "cpu":
+        return
+    q, k, v, gk, beta, initial_state = _make_inputs(device, b=1, h=1, hv=2, t=16, kdim=16, vdim=32,
+                                                    dtype=torch.float16)
+    scale = q.shape[-1] ** -0.5
+    q_ntd = q.squeeze(0).permute(1, 0, 2).contiguous()
+    k_ntd = k.squeeze(0).permute(1, 0, 2).contiguous()
+    v_ntd = v.squeeze(0).permute(1, 0, 2).contiguous()
+    gk_ntd = gk.squeeze(0).permute(1, 0, 2).contiguous()
+    beta_nt = beta.squeeze(0).permute(1, 0).contiguous()
+
+    got = torch.ops.npu.npu_chunk_kda_fwd(
+        q_ntd,
+        k_ntd,
+        v_ntd,
+        gk_ntd,
+        beta_nt,
+        scale,
+        64,
+        initial_state=initial_state,
+        output_final_state=True,
+        return_intermediate=True,
+    )
+    ref = chunk_kda_forward_reference(
+        q.detach().cpu(),
+        k.detach().cpu(),
+        v.detach().cpu(),
+        gk.detach().cpu(),
+        beta.detach().cpu(),
+        scale=scale,
+        chunk_size=64,
+        initial_state=initial_state.detach().cpu(),
+        output_final_state=True,
+    )
+
+    _assert_close("o ntd", got[0], ref.o.squeeze(0).permute(1, 0, 2), rtol=2e-2, atol=2e-2)
+    _assert_close("final_state ntd", got[1], ref.final_state, rtol=2e-2, atol=2e-2)
+    _assert_close("Aqk ntd", got[2], ref.Aqk.squeeze(0).permute(1, 0, 2), rtol=2e-2, atol=2e-2)
+    _assert_close("Akk ntd", got[3], ref.Akk.squeeze(0).permute(1, 0, 2), rtol=2e-2, atol=2e-2)
+    _assert_close("w ntd", got[4], ref.w.squeeze(0).permute(1, 0, 2), rtol=2e-2, atol=2e-2)
+    _assert_close("u ntd", got[5], ref.u.squeeze(0).permute(1, 0, 2), rtol=2e-2, atol=2e-2)
+    _assert_close("qg ntd", got[6], ref.qg.squeeze(0).permute(1, 0, 2), rtol=2e-2, atol=2e-2)
+    _assert_close("kg ntd", got[7], ref.kg.squeeze(0).permute(1, 0, 2), rtol=2e-2, atol=2e-2)
+    _assert_close("v_new ntd", got[8], ref.v_new.squeeze(0).permute(1, 0, 2), rtol=2e-2, atol=2e-2)
+    _assert_close("h ntd", got[9], ref.h.squeeze(0).permute(1, 0, 2, 3), rtol=2e-2, atol=2e-2)
+
+
+def test_kda_gate_cumsum_default_and_fwd_integration():
+    device = _device()
+    if device.type == "cpu":
+        return
+    q, k, v, _, beta, initial_state = _make_inputs(
+        device, h=1, hv=2, t=40, kdim=8, vdim=16, dtype=torch.float16
+    )
+    g_step = (torch.randn(1, 40, 2, 8, device=device, dtype=torch.bfloat16) * 0.001)
+    gk = torch.ops.npu.npu_kda_gate_cumsum(g_step, 32)
+    ref_gk = _kda_gate_cumsum_reference(g_step.detach().cpu(), 32)
+    _assert_close("gate cumsum default", gk, ref_gk, rtol=2e-3, atol=2e-3)
+
+    scale = q.shape[-1] ** -0.5
+    got = torch.ops.npu.npu_chunk_kda_fwd(
+        q,
+        k,
+        v,
+        gk,
+        beta,
+        scale,
+        32,
+        initial_state=initial_state,
+        output_final_state=True,
+        return_intermediate=False,
+    )
+    ref = chunk_kda_forward_reference(
+        q.detach().cpu(),
+        k.detach().cpu(),
+        v.detach().cpu(),
+        ref_gk,
+        beta.detach().cpu(),
+        scale=scale,
+        chunk_size=32,
+        initial_state=initial_state.detach().cpu(),
+        output_final_state=True,
+    )
+    _assert_close("gate cumsum fwd o", got[0], ref.o, rtol=2e-2, atol=2e-2)
+    _assert_close("gate cumsum fwd state", got[1], ref.final_state, rtol=2e-2, atol=2e-2)
+
+
+def test_kda_gate_cumsum_bnsd_direct_matches_reference():
+    device = _device()
+    if device.type == "cpu":
+        return
+    torch.manual_seed(6789)
+    g_bsnd = (torch.randn(1, 40, 2, 8, device=device, dtype=torch.bfloat16) * 0.001)
+    g_bnsd = g_bsnd.permute(0, 2, 1, 3).contiguous()
+    got = torch.ops.npu.npu_kda_gate_cumsum(g_bnsd, 32)
+    ref = _kda_gate_cumsum_reference(g_bsnd.detach().cpu(), 32).permute(0, 2, 1, 3)
+    _assert_close("gate cumsum bnsd", got, ref, rtol=2e-3, atol=2e-3)
+
+
+def test_kda_gate_cumsum_ntd_direct_matches_reference():
+    device = _device()
+    if device.type == "cpu":
+        return
+    torch.manual_seed(7890)
+    g_bsnd = (torch.randn(1, 40, 2, 8, device=device, dtype=torch.bfloat16) * 0.001)
+    g_ntd = g_bsnd.squeeze(0).permute(1, 0, 2).contiguous()
+    got = torch.ops.npu.npu_kda_gate_cumsum(g_ntd, 32)
+    ref = _kda_gate_cumsum_reference(g_bsnd.squeeze(0).detach().cpu(), 32).permute(1, 0, 2)
+    _assert_close("gate cumsum ntd", got, ref, rtol=2e-3, atol=2e-3)
+
+
+def test_kda_gate_cumsum_safe_gate_matches_reference():
+    device = _device()
+    if device.type == "cpu":
+        return
+    torch.manual_seed(5678)
+    raw = (torch.randn(1, 40, 2, 8, device=device, dtype=torch.bfloat16) * 0.5)
+    a_log = torch.randn(2, device=device, dtype=torch.float32) * 0.1
+    dt_bias = torch.randn(2, 8, device=device, dtype=torch.float32) * 0.1
+    got = torch.ops.npu.npu_kda_gate_cumsum(
+        raw,
+        32,
+        A_log=a_log,
+        dt_bias=dt_bias,
+        use_gate_in_kernel=True,
+        safe_gate=True,
+        lower_bound=-5.0,
+    )
+    ref = _kda_gate_cumsum_reference(
+        raw.detach().cpu(),
+        32,
+        A_log=a_log.detach().cpu(),
+        dt_bias=dt_bias.detach().cpu(),
+        use_gate_in_kernel=True,
+        safe_gate=True,
+        lower_bound=-5.0,
+    )
+    _assert_close("gate cumsum safe", got, ref, rtol=2e-3, atol=2e-3)
+
+
+if __name__ == "__main__":
+    test_chunk_kda_fwd_matches_reference()
+    test_chunk_kda_fwd_chunk128_v128_gva_varlen()
+    test_chunk_kda_fwd_bf16_chunk32_matches_reference()
+    test_chunk_kda_fwd_bf16_gate_matches_reference()
+    test_chunk_kda_fwd_fp16_matches_reference()
+    test_chunk_kda_fwd_tnd_matches_reference()
+    test_kda_gate_cumsum_default_and_fwd_integration()
+    test_kda_gate_cumsum_bnsd_direct_matches_reference()
+    test_kda_gate_cumsum_ntd_direct_matches_reference()
+    test_kda_gate_cumsum_safe_gate_matches_reference()


### PR DESCRIPTION
## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。

## 关联 Issue / 背景

- 关联 Issue: #113
- 背景与目标: 为 KDA 提供 forward-only AscendC 算子最小闭环，先完成可评审的正向路径，再分阶段扩展 backward、Vdim=256 和 varlen 动态分核。
- 本 PR 解决的问题: 新增 KDA forward-only 算子、aclnn / torch_custom 调用链、辅助 gate/layout 算子、参考实现测试和 forward-only 设计文档。

## 变更类型

- [ ] Bug 修复
- [x] 新功能 / 新算子
- [x] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `ChunkKdaFwd`, `KdaGateCumsum`, `KdaLayoutSwap12`, `ChunkGatedDeltaRuleFwdH`
- 涉及目录 / 文件:
  - `fla/ops/ascendc/kda/`
  - `fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/`
  - `torch_custom/fla_npu/`
  - `tests/reference/chunk_kda_reference.py`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [x] `op_host` / 算子定义
  - [x] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [x] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
  - forward-only KDA 正向路径。
  - 支持 BSND / TND 输入路径，覆盖典型 Kdim=128、Vdim=128 场景。
  - FP16 forward 路径可用；BF16 gate、Vdim=256 专用模板和完整 varlen 动态分核作为后续扩展。
- 明确不包含的范围:
  - backward 算子完整闭环。
  - Vdim=256 专用高性能模板。
  - 更完整的 varlen 动态负载均衡优化。
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [x] 是，请说明影响面、兼容策略和回归范围: 修改 GDN fwd_h 相关接口和实现以支持 KDA forward 复用，保持既有 GDN 调用兼容。
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [x] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 新增 KDA 算子接口，并扩展 GDN fwd_h 相关入参以支持 forward-only KDA 复用。需要重点检视 torch_custom 与 aclnn 调用链的接口匹配。

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 已验证环境 | `bash build.sh --pkg --soc=ascend910b --ops=chunk_kda_fwd,kda_gate_cumsum,kda_layout_swap12 --vendor_name=fla_npu` | 通过 | 已生成 custom 包 |
| A3 | `ascend910_93` | 未执行 | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_kda_fwd,kda_gate_cumsum,kda_layout_swap12 --vendor_name=fla_npu` | 未执行 | 待 CI / 后续补充 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 已验证环境 | `bash build.sh --pkg --soc=ascend910b --ops=chunk_kda_fwd,kda_gate_cumsum,kda_layout_swap12 --vendor_name=fla_npu` | 通过 | 已生成 custom 包 |
| A3 | `ascend910_93` | 未执行 | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_kda_fwd,kda_gate_cumsum,kda_layout_swap12 --vendor_name=fla_npu` | 未执行 | 待 CI / 后续补充 |
| A5 | `ascend950` | 未执行 | `bash build.sh --pkg --soc=ascend950 --ops=chunk_kda_fwd,kda_gate_cumsum,kda_layout_swap12 --vendor_name=fla_npu` | 未执行 | 待 CI / 后续补充 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python -m pytest torch_custom/fla_npu/test/test_npu_chunk_kda.py` | 通过 | forward-only 典型 shape 精度通过 |
| A3 | `ascend910_93` | `python -m pytest torch_custom/fla_npu/test/test_npu_chunk_kda.py` | 未执行 | 待 CI / 后续补充 |
| A5 | `ascend950` | `python -m pytest torch_custom/fla_npu/test/test_npu_chunk_kda.py` | 未执行 | 待 CI / 后续补充 |

- 精度对比: forward-only 典型模型场景与参考实现对齐。
- 性能对比: 已完成 forward-only 典型场景性能采样，后续继续优化 cube/vec 分工和 varlen 动态分核。
- 边界 / 异常场景: 覆盖 BSND / TND 基础路径和典型 head 组合；Vdim=256、完整 backward、复杂 varlen 动态负载均衡不在本 PR 范围。
- 未覆盖风险: A3 / A5 编译与 ST 需要后续 CI 或人工补充。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 本 PR 聚焦 KDA forward-only 单算子闭环，整体 ST 待 CI 补充 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 CI 补充 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 CI 补充 |

- 端到端场景说明: 本 PR 当前不修改默认 GDN example ST 场景。
- 与本 PR 修改算子的关联: KDA forward-only 新算子后续可接入更完整 example/ST。
- 未覆盖原因及补充计划: PR 合入前可按仓库 NPU CI 规则触发 quick/full 验证。

</details>

## 兼容性、风险与回退

- 兼容性说明: 新增 KDA forward-only 算子和 torch_custom 入口；GDN fwd_h 修改需重点确认既有路径兼容。
- 风险点: forward-only 已形成最小闭环，但 backward、Vdim=256 专用模板和复杂 varlen 动态分核尚未纳入本 PR。
- 回退方案: 回退本 PR commit，可恢复到 main 上既有 GDN / torch_custom 实现。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

本 PR 采用 forward-only 独立合入策略，设计和踩坑经验已随代码归档，便于后续继续推进 backward、Vdim=256 和 varlen 动态负载均衡优化。

Closes #113


