### PR TITLE
full算子dw KH修改为VH

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/arch35/prepare_wy_repr_bwd_full_tiling_a5.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/arch35/prepare_wy_repr_bwd_full_tiling_a5.cpp
@@ -125,7 +125,7 @@ ge::graphStatus PrepareWyReprBwdFullTilingA5::CommonTiling()
     OP_CHECK_IF(CompareShape(AStorageShape, dAStorageShape, INPUT_A_NAME, INPUT_DA_NAME, DIM_NUM_4) !=
                     ge::GRAPH_SUCCESS,
                 , return ge::GRAPH_FAILED);
-    OP_CHECK_IF(CompareShape(dwStorageShape, kStorageShape, INPUT_DW_NAME, INPUT_K_NAME, DIM_NUM_3) !=
+    OP_CHECK_IF(CompareShape(dwStorageShape, vStorageShape, INPUT_DW_NAME, INPUT_V_NAME, DIM_NUM_3) !=
                     ge::GRAPH_SUCCESS,
                 , return ge::GRAPH_FAILED);
     OP_CHECK_IF(dwStorageShape.GetDim(DIM_3) != kStorageShape.GetDim(DIM_3),

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/prepare_wy_repr_bwd_full_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/prepare_wy_repr_bwd_full_tiling_processor.h
@@ -321,7 +321,7 @@ public:
         OP_CHECK_IF(CompareShape(aStorageShape, dAStorageShape, INPUT_A_NAME, INPUT_DA_NAME, DIM_NUM_4) !=
                         ge::GRAPH_SUCCESS,
                     , return ge::GRAPH_FAILED);
-        OP_CHECK_IF(CompareShape(dwStorageShape, kStorageShape, INPUT_DW_NAME, INPUT_K_NAME, DIM_NUM_3) !=
+        OP_CHECK_IF(CompareShape(dwStorageShape, vStorageShape, INPUT_DW_NAME, INPUT_V_NAME, DIM_NUM_3) !=
                         ge::GRAPH_SUCCESS,
                     , return ge::GRAPH_FAILED);
         OP_CHECK_IF(dwStorageShape.GetDim(DIM_3) != kStorageShape.GetDim(DIM_3),

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/arch35/prepare_wy_repr_bwd_full_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/arch35/prepare_wy_repr_bwd_full_cube.h
@@ -295,18 +295,13 @@ public:
             for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
                                params.chunkSize, loopIdx, bos, eos);
-                kBos = bos;
-                if (params.ptrCuSeqLens == nullptr && params.HV != params.HK) {
-                    GetKBosByVBos(bos, params.T, params.HV, params.HK, kBos);
-                }
                 uint32_t curChunkSize = eos - bos;
                 GemmCoord blockCoord{0, 0, 0};
                 GemmCoord actualBlockShape{curChunkSize, static_cast<uint32_t>(params.K), curChunkSize};
                 for (uint64_t h_v = 0; h_v < params.HV; h_v++) {
-                    uint64_t h_k = h_v / params.groupSize;
                     // Represent the full gm
                     gmAT.SetGlobalBuffer((__gm__ ElementAT *)params.ptrAT + (h_v * params.T + bos) * params.chunkSize);
-                    gmDw.SetGlobalBuffer((__gm__ ElementDw *)params.ptrDw + (h_k * params.T + kBos) * params.K);
+                    gmDw.SetGlobalBuffer((__gm__ ElementDw *)params.ptrDw + (h_v * params.T + bos) * params.K);
 
                     // Represent the full tensors
                     auto tensorAT = tla::MakeTensor(gmAT, params.layoutAT, Arch::PositionGM{});

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full_cube.h
@@ -402,7 +402,7 @@ public:
                 gmAT.SetGlobalBuffer((__gm__ ElementAT *)params.ptrAT + valueBase * params.chunkSize);
                 gmK.SetGlobalBuffer((__gm__ ElementK *)params.ptrK + keyBase * params.K);
                 gmKT.SetGlobalBuffer((__gm__ ElementKT *)params.ptrKT + keyBase * params.K);
-                gmDw.SetGlobalBuffer((__gm__ ElementDw *)params.ptrDw + keyBase * params.K);
+                gmDw.SetGlobalBuffer((__gm__ ElementDw *)params.ptrDw + valueBase * params.K);
                 gmDu.SetGlobalBuffer((__gm__ ElementDu *)params.ptrDu + valueBase * params.V);
 
                 auto tensorDA = tla::MakeTensor(gmDA, params.layoutDA, Arch::PositionGM{});

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/test/test.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/test/test.py
@@ -141,7 +141,7 @@ def compute_dv_golden_high_precision(
 
 def compute_dk_golden(
     A: torch.Tensor,      # [B, T, VH, chunk_size] - 每个chunk的A值
-    dw: torch.Tensor,     # [B, T, KH, D]
+    dw: torch.Tensor,     # [B, T, VH, D]
     g: torch.Tensor,     # [B, VH, T]
     beta: torch.Tensor,   # [B, VH, T] - beta参数
     dA: torch.Tensor,      # [B, T, VH, chunk_size]
@@ -159,7 +159,7 @@ def compute_dk_golden(
     """
     CPU golden implementation for dk computation (变长序列)
     A的形状为 [B, T, VH, chunk_size]
-    k/dw使用KH head, 其余使用VH head
+    k使用KH head, 其余使用VH head
     算法:
     1. 对于每个chunk (由chunk_indices指定)
     2. 获取对应的seq_idx, chunk_indices
@@ -181,7 +181,7 @@ def compute_dk_golden(
                 A_chunk = A[i_b,i_h, bos:eos,: eos - bos]  # [chunk_size, chunk_size]
 
                 # 获取当前chunk的dw
-                dw_chunk = dw[i_b,i_h_k, bos:eos, :]  # [chunk_size, D]
+                dw_chunk = dw[i_b,i_h, bos:eos, :]  # [chunk_size, D]
 
                 # 获取当前chunk的beta,g
                 beta_chunk = beta[i_b,i_h, bos:eos]  # [chunk_size]
@@ -208,7 +208,7 @@ def compute_dk_golden(
 
 def compute_dk_golden_high_precision(
     A: torch.Tensor,      # [B, T, VH, chunk_size] - 每个chunk的A值
-    dw: torch.Tensor,     # [B, T, KH, D]
+    dw: torch.Tensor,     # [B, T, VH, D]
     g: torch.Tensor,     # [B, VH, T]
     beta: torch.Tensor,   # [B, VH, T] - beta参数
     dA: torch.Tensor,      # [B, T, VH, chunk_size]
@@ -226,7 +226,7 @@ def compute_dk_golden_high_precision(
     """
     CPU golden implementation for dk computation (变长序列)
     A的形状为 [B, T, VH, chunk_size]
-    k/dw使用KH head, 其余使用VH head
+    k使用KH head, 其余使用VH head
     算法:
     1. 对于每个chunk (由chunk_indices指定)
     2. 获取对应的seq_idx, chunk_indices
@@ -248,7 +248,7 @@ def compute_dk_golden_high_precision(
                 A_chunk = A[i_b,i_h, bos:eos,: eos - bos]  # [chunk_size, chunk_size]
 
                 # 获取当前chunk的dw
-                dw_chunk = dw[i_b,i_h_k, bos:eos, :]  # [chunk_size, D]
+                dw_chunk = dw[i_b,i_h, bos:eos, :]  # [chunk_size, D]
 
                 # 获取当前chunk的beta,g
                 beta_chunk = beta[i_b,i_h, bos:eos]  # [chunk_size]
@@ -275,7 +275,7 @@ def compute_dk_golden_high_precision(
 
 def compute_dg_golden(
     A: torch.Tensor,      # [B, T, VH, chunk_size] - 每个chunk的A值
-    dw: torch.Tensor,     # [B, T, KH, D]
+    dw: torch.Tensor,     # [B, T, VH, D]
     g: torch.Tensor,     # [B, VH, T]
     beta: torch.Tensor,   # [B, VH, T] - beta参数
     dA: torch.Tensor,      # [B, T, VH, chunk_size]
@@ -293,7 +293,7 @@ def compute_dg_golden(
     """
     CPU golden implementation for dg computation (变长序列)
     A的形状为 [B, T, VH, chunk_size]
-    k/dw使用KH head, 其余使用VH head
+    k使用KH head, 其余使用VH head
     算法:
     1. 对于每个chunk (由chunk_indices指定)
     2. 获取对应的seq_idx, chunk_indices
@@ -316,7 +316,7 @@ def compute_dg_golden(
                 A_chunk = A[i_b,i_h, bos:eos,: eos - bos]  # [chunk_size, chunk_size]
 
                 # 获取当前chunk的dw
-                dw_chunk = dw[i_b,i_h_k, bos:eos, :]  # [chunk_size, D]
+                dw_chunk = dw[i_b,i_h, bos:eos, :]  # [chunk_size, D]
 
                 # 获取当前chunk的beta,g
                 # beta形状: [B, VH, T]
@@ -354,7 +354,7 @@ def compute_dg_golden(
 
 def compute_dg_golden_high_precision(
     A: torch.Tensor,      # [B, T, VH, chunk_size] - 每个chunk的A值
-    dw: torch.Tensor,     # [B, T, KH, D]
+    dw: torch.Tensor,     # [B, T, VH, D]
     g: torch.Tensor,     # [B, VH, T]
     beta: torch.Tensor,   # [B, VH, T] - beta参数
     dA: torch.Tensor,      # [B, T, VH, chunk_size]
@@ -372,7 +372,7 @@ def compute_dg_golden_high_precision(
     """
     CPU golden implementation for dg computation (变长序列)
     A的形状为 [B, T, VH, chunk_size]
-    k/dw使用KH head, 其余使用VH head
+    k使用KH head, 其余使用VH head
     算法:
     1. 对于每个chunk (由chunk_indices指定)
     2. 获取对应的seq_idx, chunk_indices
@@ -395,7 +395,7 @@ def compute_dg_golden_high_precision(
                 A_chunk = A[i_b,i_h, bos:eos,: eos - bos]  # [chunk_size, chunk_size]
 
                 # 获取当前chunk的dw
-                dw_chunk = dw[i_b,i_h_k, bos:eos, :]  # [chunk_size, D]
+                dw_chunk = dw[i_b,i_h, bos:eos, :]  # [chunk_size, D]
 
                 # 获取当前chunk的beta,g
                 # beta形状: [B, VH, T]
@@ -434,7 +434,7 @@ def compute_dg_golden_high_precision(
 
 def compute_dbeta_golden(
     A: torch.Tensor,      # [B, T, VH, chunkSize] - 每个chunk的A值
-    dw: torch.Tensor,     # [B, T, KH, D]
+    dw: torch.Tensor,     # [B, T, VH, D]
     g: torch.Tensor,     # [B, VH, T]
     beta: torch.Tensor,   # [B, VH, T] - beta参数
     dA: torch.Tensor,      # [B, T, VH, chunkSize]
@@ -454,7 +454,7 @@ def compute_dbeta_golden(
     """
     CPU golden implementation for dbeta computation (变长序列)
     A的形状为 [B, T, VH, chunkSize]
-    k/dw使用KH head, 其余使用VH head
+    k使用KH head, 其余使用VH head
     算法:
     1. 对于每个chunk (由chunk_indices指定)
     2. 获取对应的seq_idx, chunk_indices
@@ -477,7 +477,7 @@ def compute_dbeta_golden(
                 v_chunk = v[i_b,i_h, bos:eos,:]  # [chunkSize, V]
 
                 # 获取当前chunk的dw
-                dw_chunk = dw[i_b,i_h_k, bos:eos, :]  # [chunkSize, D]
+                dw_chunk = dw[i_b,i_h, bos:eos, :]  # [chunkSize, D]
                 du_chunk = du[i_b,i_h, bos:eos, :]  # [chunkSize, D]
 
 
@@ -511,7 +511,7 @@ def compute_dbeta_golden(
 
 def compute_dbeta_golden_high_precision(
     A: torch.Tensor,      # [B, T, VH, chunkSize] - 每个chunk的A值
-    dw: torch.Tensor,     # [B, T, KH, D]
+    dw: torch.Tensor,     # [B, T, VH, D]
     g: torch.Tensor,     # [B, VH, T]
     beta: torch.Tensor,   # [B, VH, T] - beta参数
     dA: torch.Tensor,      # [B, T, VH, chunkSize]
@@ -531,7 +531,7 @@ def compute_dbeta_golden_high_precision(
     """
     CPU golden implementation for dbeta computation (变长序列)
     A的形状为 [B, T, VH, chunkSize]
-    k/dw使用KH head, 其余使用VH head
+    k使用KH head, 其余使用VH head
     算法:
     1. 对于每个chunk (由chunk_indices指定)
     2. 获取对应的seq_idx, chunk_indices
@@ -554,7 +554,7 @@ def compute_dbeta_golden_high_precision(
                 v_chunk = v[i_b,i_h, bos:eos,:]  # [chunkSize, V]
 
                 # 获取当前chunk的dw
-                dw_chunk = dw[i_b,i_h_k, bos:eos, :]  # [chunkSize, D]
+                dw_chunk = dw[i_b,i_h, bos:eos, :]  # [chunkSize, D]
                 du_chunk = du[i_b,i_h, bos:eos, :]  # [chunkSize, D]
 
 
@@ -721,7 +721,7 @@ def test_prepare_wy_repr_bwd_full(
     beta = torch.rand(B, VH, T, dtype=btype)
     A = torch.rand(B, VH, T, chunk_size, dtype=ktype)
     dA = torch.rand(B, VH, T, chunk_size, dtype=ktype)
-    dw = torch.rand(B, KH, T, K, dtype=ktype)
+    dw = torch.rand(B, VH, T, K, dtype=ktype)
     du = torch.rand(B, VH, T, V, dtype=ktype)
     g = torch.rand(B, VH, T, dtype=btype)
 


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @maoguolan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
