### PR TITLE
add gva sum

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/chunk_bwd_dqkwg_def.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/chunk_bwd_dqkwg_def.cpp
@@ -15,7 +15,8 @@
  * 维度拆分: H维度拆分为HV和HK, HV = n * HK
  * - q, k: [B, HK, T, K]
  * - v, g, dox, dv, h, dh: [B, HV, T, ...] 或 [B, HV, ...]
- * - 所有输出: [B, HV, T, ...] 或 [B, HV, ...]
+ * - dq, dk: [B, HK, T, K] (与q/k输入的H维度一致)
+ * - dw, dg: [B, HV, T, ...] 或 [B, HV, ...]
  */
 
 #include "register/op_def_registry.h"
@@ -112,14 +113,14 @@ public:
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
 
-        // dq: [B, HV, T, K] - gradient of q (HV heads)
+        // dq: [B, HK, T, K] - gradient of q (HK heads, same as q input)
         this->Output("dq")
             .ParamType(REQUIRED)
             .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
         
-        // dk: [B, HV, T, K] - gradient of k (HV heads)
+        // dk: [B, HK, T, K] - gradient of k (HK heads, same as k input)
         this->Output("dk")
             .ParamType(REQUIRED)
             .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
@@ -36,6 +36,8 @@ static void ChunkBwdDqkwgTilingDataPrint(gert::TilingContext *context, const Chu
     OP_LOGD(nodeName, "=== scale: %f", tiling.scale);
     OP_LOGD(nodeName, "=== mul0RowNum: %ld", tiling.mul0RowNum);
     OP_LOGD(nodeName, "=== isVarLen: %ld", tiling.isVarLen);
+    OP_LOGD(nodeName, "=== needReduce: %ld", tiling.needReduce);
+    OP_LOGD(nodeName, "=== wsDqkvReduceOffset: %ld", tiling.wsDqkvReduceOffset);
     OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Print ChunkBwdDqkwg tiling data end <<<<<<<<<<<<<<<<");
 }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling_processor.h
@@ -204,6 +204,10 @@ public:
         size_t mm5Size = B * HV * T * K * FP16_SIZE;
         size_t dsTempSize = B * HV * T * BT * FP16_SIZE;
 
+        // When HK != HV, need workspace for intermediate dq/dk results [B, HV, T, K]
+        // before reduction to [B, HK, T, K]
+        size_t dqkvReduceSize = (HK != HV) ? (2 * B * HV * T * K * FP16_SIZE) : 0;
+
         size_t offset = 0;
 
         tiling_.wsDwOffset = 0;
@@ -216,8 +220,12 @@ public:
         tiling_.wsDsTempOffset = static_cast<int64_t>(offset);
         offset += dsTempSize;
 
+        tiling_.wsDqkvReduceOffset = static_cast<int64_t>(offset);
+        offset += dqkvReduceSize;
+
         tiling_.dgLastSize = static_cast<int64_t>(dgLastSize);
         tiling_.totalWorkspaceSize = static_cast<int64_t>(offset);
+        tiling_.needReduce = (HK != HV) ? 1 : 0;
 
         return ge::GRAPH_SUCCESS;
     }
@@ -254,6 +262,9 @@ public:
         size_t mm5Size = tiling_.B * tiling_.HV * tiling_.T * tiling_.K * FP16_SIZE;
         size_t dsTempSize = tiling_.B * tiling_.HV * tiling_.T * tiling_.BT * FP16_SIZE;
 
+        // When HK != HV, need workspace for intermediate dq/dk results [B, HV, T, K]
+        size_t dqkvReduceSize = (tiling_.HK != tiling_.HV) ? (2 * tiling_.B * tiling_.HV * tiling_.T * tiling_.K * FP16_SIZE) : 0;
+
         size_t offset = 0;
 
         tiling_.wsDwOffset = 0;
@@ -266,8 +277,12 @@ public:
         tiling_.wsDsTempOffset = static_cast<int64_t>(offset);
         offset += dsTempSize;
 
+        tiling_.wsDqkvReduceOffset = static_cast<int64_t>(offset);
+        offset += dqkvReduceSize;
+
         tiling_.dgLastSize = static_cast<int64_t>(dgLastSize);
         tiling_.totalWorkspaceSize = static_cast<int64_t>(offset);
+        tiling_.needReduce = (tiling_.HK != tiling_.HV) ? 1 : 0;
 
         return ge::GRAPH_SUCCESS;
     }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_common.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_common.h
@@ -41,6 +41,8 @@ constexpr uint64_t SYNC_PART6_AIC_AIV = 60;
 constexpr uint64_t SYNC_PART6_AIV_AIC = 61;
 constexpr uint64_t SYNC_PART7_AIC_AIV = 70;
 constexpr uint64_t SYNC_PART7_AIV_AIC = 71;
+constexpr uint64_t SYNC_PART8_AIC_AIV = 80;
+constexpr uint64_t SYNC_PART8_AIV_AIC = 81;
 constexpr uint64_t SYNC_AIV_AIC_FLAG_0 = 3;
 constexpr uint64_t SYNC_AIC_AIV_FLAG_0 = 5;
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
@@ -140,6 +140,7 @@ public:
         uint64_t wsDsTempOffset;
         uint64_t wsMm6Offset;
         uint64_t wsMm7Offset;
+        uint64_t wsDqkvReduceOffset;
         
         // 形状参数
         uint64_t B;
@@ -152,6 +153,7 @@ public:
         uint64_t numChunks;
         uint64_t n_ratio;       // HV / HK
         uint64_t isVarLen;
+        uint64_t needReduce;    // 1 if HK != HV
         
         float scale;
         
@@ -165,15 +167,15 @@ public:
             GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
             GM_ADDR workspace,
             uint64_t B, uint64_t HV, uint64_t HK, uint64_t T, uint64_t K, uint64_t V, uint64_t BT, uint64_t numChunks, uint64_t n_ratio,
-            uint64_t wsDw, uint64_t wsDgLast, uint64_t wsMm5, uint64_t wsDsTemp, uint64_t wsMm6, uint64_t wsMm7,
-            float s, uint64_t isVarLen
+            uint64_t wsDw, uint64_t wsDgLast, uint64_t wsMm5, uint64_t wsDsTemp, uint64_t wsMm6, uint64_t wsMm7, uint64_t wsDqkvReduce,
+            float s, uint64_t isVarLen, uint64_t needReduce
         ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
             ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLens(cu_seqlen), ptrChunkIndices(chunk_indices),
             ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
             ptrWorkspace(workspace),
             wsDwOffset(wsDw), wsDgLastOffset(wsDgLast),
-            wsMm5Offset(wsMm5), wsDsTempOffset(wsDsTemp), wsMm6Offset(wsMm6), wsMm7Offset(wsMm7),
-            scale(s), B(B), HV(HV), HK(HK), T(T), K(K), V(V), BT(BT), numChunks(numChunks), n_ratio(n_ratio), isVarLen(isVarLen) {}
+            wsMm5Offset(wsMm5), wsDsTempOffset(wsDsTemp), wsMm6Offset(wsMm6), wsMm7Offset(wsMm7), wsDqkvReduceOffset(wsDqkvReduce),
+            scale(s), B(B), HV(HV), HK(HK), T(T), K(K), V(V), BT(BT), numChunks(numChunks), n_ratio(n_ratio), isVarLen(isVarLen), needReduce(needReduce) {}
     };
     
     CATLASS_DEVICE
@@ -419,7 +421,11 @@ public:
                     GlobalTensor<ElementA> gmH;
                     gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
                     GlobalTensor<ElementC> gmDq;
-                    gmDq.SetGlobalBuffer((__gm__ ElementC *)params.ptrDq + dqOffset);
+                    if (params.needReduce) {
+                        gmDq.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDqkvReduceOffset) + dqOffset);
+                    } else {
+                        gmDq.SetGlobalBuffer((__gm__ ElementC *)params.ptrDq + dqOffset);
+                    }
                     
                     auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
                     auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});  // h^T: [V, K]
@@ -477,7 +483,11 @@ public:
                     GlobalTensor<ElementA> gmDh;
                     gmDh.SetGlobalBuffer((__gm__ ElementA *)params.ptrDh + dhOffset);
                     GlobalTensor<ElementC> gmDk;
-                    gmDk.SetGlobalBuffer((__gm__ ElementC *)params.ptrDk + dkOffset);
+                    if (params.needReduce) {
+                        gmDk.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDqkvReduceOffset + params.B * params.HV * params.T * params.K * sizeof(ElementC)) + dkOffset);
+                    } else {
+                        gmDk.SetGlobalBuffer((__gm__ ElementC *)params.ptrDk + dkOffset);
+                    }
                     
                     auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
                     auto tensorDh = tla::MakeTensor(gmDh, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});  // dh: [V, K]
@@ -636,6 +646,9 @@ public:
             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
             AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
         }
+        if (params.needReduce) {
+            AscendC::SyncAll<false>();
+        }
 
     }
 };
@@ -699,6 +712,8 @@ private:
     uint64_t wsDsTempOffset;
     uint64_t wsMm6Offset;
     uint64_t wsMm7Offset;
+    uint64_t wsDqkvReduceOffset;
+    uint64_t needReduce;
 };
 
 template <typename DataType, typename GType>
@@ -734,6 +749,8 @@ __aicore__ inline void ChunkBwdDqkwgCubeProcess<DataType, GType>::Init(const GDN
     wsDsTempOffset = tiling.wsDsTempOffset;
     // wsMm6Offset = tiling.wsMm6Offset;
     // wsMm7Offset = tiling.wsMm7Offset;
+    wsDqkvReduceOffset = tiling.wsDqkvReduceOffset;
+    needReduce = tiling.needReduce;
     isVarLen = tiling.isVarLen;
 // printf("[cube] DTYPE_G %d, float %d\n",sizeof(DTYPE_G),sizeof(float));
 }
@@ -799,8 +816,8 @@ __aicore__ inline void ChunkBwdDqkwgCubeProcess<DataType, GType>::Process() {
         ptrDo, ptrDh, ptrDv, ptrCuSeqLen, ptrChunkIndices,
         ptrDq, ptrDk, ptrDw, ptrDg,
         ptrWorkspace, B, HV, HK, T, K, V, BT, numChunks, n_ratio,
-        wsDwOffset, wsDgLastOffset, wsMm5Offset, wsDsTempOffset, wsMm6Offset, wsMm7Offset,
-        scale, isVarLen
+        wsDwOffset, wsDgLastOffset, wsMm5Offset, wsDsTempOffset, wsMm6Offset, wsMm7Offset, wsDqkvReduceOffset,
+        scale, isVarLen, needReduce
     );
     
     kernel(params);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_struct.h
@@ -152,8 +152,10 @@ struct ChunkBwdDqkwgTilingData {
     int64_t dgLastSize;
     int64_t wsMm5Offset;
     int64_t wsDsTempOffset;
+    int64_t wsDqkvReduceOffset;
     int64_t totalWorkspaceSize;
     int64_t isVarLen;
+    int64_t needReduce;  // 1 if HK != HV, 0 otherwise
 };
 
 } // namespace GDN

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
@@ -41,6 +41,7 @@ private:
     __aicore__ inline void ProcessPart5();  // dk 处理, dg 最终计算
     __aicore__ inline void ProcessPart6();  // dq 累加
     __aicore__ inline void ProcessPart7();  // dk 累加
+    __aicore__ inline void ProcessPart8();  // dq/dk reduce: [B, HV, T, K] -> [B, HK, T, K] when HK != HV
     
     // 辅助函数
     __aicore__ inline void ComputeExpScalar(float input, float &output);
@@ -89,7 +90,9 @@ private:
     uint64_t wsMm6Offset;
     uint64_t wsMm7Offset;
     uint64_t wsMul1Offset;
+    uint64_t wsDqkvReduceOffset;
     int BUFFER_NUM = 1;
+    int needReduce = 0;
     
     // Pipeline
     TPipe *pipe = nullptr;
@@ -101,6 +104,7 @@ private:
     GlobalTensor<DataType> gmWorkspace;
     GlobalTensor<float> gmDgLast;
     GlobalTensor<DataType> gmMm5, gmDsTemp, gmMul1, gmMm6, gmMm7;
+    GlobalTensor<DataType> gmDqIntermediate, gmDkIntermediate;
     
     // Queues (用于流水)
     TQue<TPosition::VECIN, 2> inQue1;
@@ -160,6 +164,8 @@ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::Init(const G
     // wsMm6Offset = tiling.wsMm6Offset;
     // wsMm7Offset = tiling.wsMm7Offset;
     // wsMul1Offset = tiling.wsMul1Offset;
+    wsDqkvReduceOffset = tiling.wsDqkvReduceOffset;
+    needReduce = tiling.needReduce;
     uint64_t dgLastSize = tiling.dgLastSize;
     isVarLen = tiling.isVarLen;
     mul0RowNum = tiling.mul0RowNum;
@@ -194,7 +200,19 @@ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::Init(const G
     gmMm6.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm5Offset));
     gmMm7.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm5Offset));
     // gmMul1.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMul1Offset));
-    gmMul1.SetGlobalBuffer((__gm__ DataType *)ptrDq);
+    // When needReduce, ptrDq has [B, HK, T, K] which is too small for mul1 [B, HV, T, BT]
+    // Use dq intermediate workspace instead (it has [B, HV, T, K] space, and BT <= K)
+    if (needReduce) {
+        gmMul1.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsDqkvReduceOffset));
+    } else {
+        gmMul1.SetGlobalBuffer((__gm__ DataType *)ptrDq);
+    }
+
+    // When HK != HV, dq/dk intermediate results go to workspace before reduction
+    if (needReduce) {
+        gmDqIntermediate.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsDqkvReduceOffset));
+        gmDkIntermediate.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsDqkvReduceOffset + B * HV * T * K * sizeof(DataType)));
+    }
 }
 
 // ============== 主处理函数 ==============
@@ -226,6 +244,13 @@ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::Process() {
     AscendC::SyncAll<false>();
     // Part 7: dk 累加
     ProcessPart7();
+    pipe->Reset();
+    
+    // Part 8: dq/dk reduce when HK != HV
+    if (needReduce) {
+        AscendC::SyncAll<false>();
+        ProcessPart8();
+    }
 }
 
 // ============== Part 1: dw 和 dg_last 计算 ==============
@@ -856,7 +881,9 @@ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart4
                 auto tensorGIn = inQue3.AllocTensor<GType>();
                 auto tensorDgIn = inQue4.AllocTensor<GType>();
                 
-                DataCopy(tensorDqIn[dqSize_sub], gmDq[dqOffset + dqSize_sub_offset], dqSize_sub);
+                DataCopy(tensorDqIn[dqSize_sub], (needReduce ? gmDqIntermediate[dqOffset + dqSize_sub_offset] : gmDq[dqOffset + dqSize_sub_offset]), dqSize_sub);
+                // DataCopy(tensorDqIn[0], gmQ[0], 32);
+// DataCopy(tensorDqIn[dqSize_sub], gmDq[0], dqSize_sub);
 
                 DataCopy(tensorQIn[dqSize_sub], gmQ[qkOffset + dqSize_sub_offset], dqSize_sub);
 
@@ -955,7 +982,12 @@ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart4
                 auto tensorDqOut = outQue1.DeQue<DataType>();
                 auto tensorDgOut = outQue2.DeQue<GType>();
 
-                DataCopy(gmDq[dqOffset + dqSize_sub_offset], tensorDqOut, dqSize_sub);
+                if (needReduce) {
+                    DataCopy(gmDqIntermediate[dqOffset + dqSize_sub_offset], tensorDqOut, dqSize_sub);
+                    // DataCopy(gmDqIntermediate[0], tensorDqOut, dqSize_sub);
+                } else {
+                    DataCopy(gmDq[dqOffset + dqSize_sub_offset], tensorDqOut, dqSize_sub);
+                }
 
                 // 累加到 dg (读取现有值, 加上新值, 写回)
                 // 简化: 直接累加 (需要在 Part 5 中处理最终值)
@@ -1052,7 +1084,7 @@ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart5
                 auto tensorGIn = inQue3.AllocTensor<GType>();
                 auto tensorDgIn = inQue4.AllocTensor<GType>();
                 
-                DataCopy(tensorDkIn[dkSize], gmDk[dkOffset], dkSize);
+                DataCopy(tensorDkIn[dkSize], (needReduce ? gmDkIntermediate[dkOffset] : gmDk[dkOffset]), dkSize);
                 DataCopy(tensorKIn[dkSize], gmK[kOffset], dkSize);
 
                 DataCopyParams dataCopyParams;
@@ -1216,7 +1248,11 @@ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart5
                 auto tensorDkOut = outQue1.DeQue<DataType>();
                 auto tensorDgOut = outQue2.DeQue<GType>();
 
-                DataCopy(gmDk[dkOffset], tensorDkOut, dkSize);
+                if (needReduce) {
+                    DataCopy(gmDkIntermediate[dkOffset], tensorDkOut, dkSize);
+                } else {
+                    DataCopy(gmDk[dkOffset], tensorDkOut, dkSize);
+                }
 
                 // dg 需要与之前的累加
                 // 累加到 dg (读取现有值, 加上新值, 写回)
@@ -1286,7 +1322,11 @@ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart6
                 auto tensorDqIn = inQue1.AllocTensor<DataType>();
                 auto tensorMM6In = inQue2.AllocTensor<DataType>();
                 
-                DataCopy(tensorDqIn[dqSize], gmDq[dqOffset], dqSize);
+                if (needReduce) {
+                    DataCopy(tensorDqIn[dqSize], gmDqIntermediate[dqOffset], dqSize);
+                } else {
+                    DataCopy(tensorDqIn[dqSize], gmDq[dqOffset], dqSize);
+                }
                 DataCopy(tensorMM6In[dqSize], gmMm6[dqOffset], dqSize);
 
                 inQue1.EnQue(tensorDqIn);
@@ -1321,7 +1361,11 @@ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart6
             //CopyOut
             {
                 auto tensorDqOut = outQue1.DeQue<DataType>();
-                DataCopy(gmDq[dqOffset], tensorDqOut, dqSize);
+                if (needReduce) {
+                    DataCopy(gmDqIntermediate[dqOffset], tensorDqOut, dqSize);
+                } else {
+                    DataCopy(gmDq[dqOffset], tensorDqOut, dqSize);
+                }
                 outQue1.FreeTensor(tensorDqOut);
             }
             
@@ -1378,7 +1422,11 @@ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart7
                 auto tensorDkIn = inQue1.AllocTensor<DataType>();
                 auto tensorMm7In = inQue2.AllocTensor<DataType>();
                 
-                DataCopy(tensorDkIn[dkSize], gmDk[dkOffset], dkSize);
+                if (needReduce) {
+                    DataCopy(tensorDkIn[dkSize], gmDkIntermediate[dkOffset], dkSize);
+                } else {
+                    DataCopy(tensorDkIn[dkSize], gmDk[dkOffset], dkSize);
+                }
                 DataCopy(tensorMm7In[dkSize], gmMm7[dkOffset], dkSize);
 
                 inQue1.EnQue(tensorDkIn);
@@ -1411,12 +1459,156 @@ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart7
             //CopyOut
             {
                 auto tensorDkOut = outQue1.DeQue<DataType>();
-                DataCopy(gmDk[dkOffset], tensorDkOut, dkSize);
+                if (needReduce) {
+                    DataCopy(gmDkIntermediate[dkOffset], tensorDkOut, dkSize);
+                } else {
+                    DataCopy(gmDk[dkOffset], tensorDkOut, dkSize);
+                }
 
                 outQue1.FreeTensor(tensorDkOut);
             }
 
             CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+        }
+    }
+}
+
+// ============== Part 8: dq/dk reduce when HK != HV ==============
+// Equivalent to: dq = dq.view(B, T, HK, HV // HK, K).sum(3)
+//                dk = dk.view(B, T, HK, HV // HK, K).sum(3)
+// Input: gmDqIntermediate/gmDkIntermediate [B, HV, T, K]
+// Output: gmDq/gmDk [B, HK, T, K]
+template <typename DataType, typename GType>
+__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart8() {
+    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+    uint32_t coreNum = GetBlockNum();
+    // Each core processes a subset of (B * HK * T) rows
+    uint32_t totalRows = B * HK * T;
+    
+    // Each row has K elements; we process n_ratio rows at a time (summing them)
+    // Layout of intermediate: [B, HV, T, K] where HV = n_ratio * HK
+    // We need to sum n_ratio consecutive HV heads for each HK head
+    // For a given (b, hk, t), the intermediate rows are at:
+    //   h = hk * n_ratio, hk * n_ratio + 1, ..., hk * n_ratio + n_ratio - 1
+    // offset in intermediate = (h * T + t) * K
+    
+    const uint32_t rowSize = K;  // elements per row
+    const uint32_t rowSizeBytes = rowSize * sizeof(DataType);
+    
+    // UB buffers: need n_ratio input rows + 1 output row (all in fp32 for accumulation)
+    // n_ratio * K * sizeof(float) for inputs + K * sizeof(float) for output
+    uint32_t inputBufSize = n_ratio * rowSize;
+    uint32_t fp32BufSize = inputBufSize * sizeof(float);
+    uint32_t outBufSize = rowSize * sizeof(DataType);
+    
+    pipe->InitBuffer(inQue1, 1, n_ratio * rowSizeBytes);
+    pipe->InitBuffer(outQue1, 1, outBufSize);
+    pipe->InitBuffer(calcBuf1, fp32BufSize);
+    pipe->InitBuffer(calcBuf2, rowSize * sizeof(float));
+    
+    auto tensorAccFp32 = calcBuf1.Get<float>();       // accumulator [n_ratio * K]
+    auto tensorOutFp32 = calcBuf2.Get<float>();       // output row [K]
+    
+    // Process each (b, hk, t) combination
+    for (uint32_t rowIdx = coreIdx; rowIdx < totalRows; rowIdx += coreNum) {
+        uint32_t b = rowIdx / (HK * T);
+        uint32_t remainder = rowIdx % (HK * T);
+        uint32_t hk = remainder / T;
+        uint32_t t = remainder % T;
+        
+        // CopyIn: read n_ratio rows from intermediate dq
+        {
+            auto tensorIn = inQue1.AllocTensor<DataType>();
+            for (uint32_t r = 0; r < n_ratio; r++) {
+                uint32_t h = hk * n_ratio + r;
+                uint64_t offset = ((uint64_t)b * HV + h) * T * K + (uint64_t)t * K;
+                DataCopy(tensorIn[r * rowSize], gmDqIntermediate[offset], rowSize);
+            }
+            inQue1.EnQue(tensorIn);
+        }
+        
+        // Compute: sum n_ratio rows for dq
+        {
+            auto tensorIn = inQue1.DeQue<DataType>();
+            Cast(tensorAccFp32, tensorIn, RoundMode::CAST_NONE, n_ratio * rowSize);
+            PipeBarrier<PIPE_V>();
+            
+            // Sum n_ratio rows: first copy row 0 to output, then add rows 1..n_ratio-1
+            DataCopy(tensorOutFp32, tensorAccFp32, rowSize);
+            PipeBarrier<PIPE_V>();
+            for (uint32_t r = 1; r < n_ratio; r++) {
+                Add(tensorOutFp32, tensorOutFp32, tensorAccFp32[r * rowSize], rowSize);
+                PipeBarrier<PIPE_V>();
+            }
+            
+            auto tensorOut = outQue1.AllocTensor<DataType>();
+            Cast(tensorOut, tensorOutFp32, RoundMode::CAST_RINT, rowSize);
+            inQue1.FreeTensor(tensorIn);
+            outQue1.EnQue(tensorOut);
+        }
+        
+        // CopyOut: write to final dq output [B, HK, T, K]
+        {
+            auto tensorOut = outQue1.DeQue<DataType>();
+            uint64_t dqOutOffset = ((uint64_t)b * HK + hk) * T * K + (uint64_t)t * K;
+            DataCopy(gmDq[dqOutOffset], tensorOut, rowSize);
+            outQue1.FreeTensor(tensorOut);
+        }
+    }
+    
+    pipe->Reset();
+    
+    // Now do the same for dk
+    pipe->InitBuffer(inQue1, 1, n_ratio * rowSizeBytes);
+    pipe->InitBuffer(outQue1, 1, outBufSize);
+    pipe->InitBuffer(calcBuf1, fp32BufSize);
+    pipe->InitBuffer(calcBuf2, rowSize * sizeof(float));
+    
+    auto tensorAccFp32Dk = calcBuf1.Get<float>();
+    auto tensorOutFp32Dk = calcBuf2.Get<float>();
+    
+    for (uint32_t rowIdx = coreIdx; rowIdx < totalRows; rowIdx += coreNum) {
+        uint32_t b = rowIdx / (HK * T);
+        uint32_t remainder = rowIdx % (HK * T);
+        uint32_t hk = remainder / T;
+        uint32_t t = remainder % T;
+        
+        // CopyIn: read n_ratio rows from intermediate dk
+        {
+            auto tensorIn = inQue1.AllocTensor<DataType>();
+            for (uint32_t r = 0; r < n_ratio; r++) {
+                uint32_t h = hk * n_ratio + r;
+                uint64_t offset = ((uint64_t)b * HV + h) * T * K + (uint64_t)t * K;
+                DataCopy(tensorIn[r * rowSize], gmDkIntermediate[offset], rowSize);
+            }
+            inQue1.EnQue(tensorIn);
+        }
+        
+        // Compute: sum n_ratio rows for dk
+        {
+            auto tensorIn = inQue1.DeQue<DataType>();
+            Cast(tensorAccFp32Dk, tensorIn, RoundMode::CAST_NONE, n_ratio * rowSize);
+            PipeBarrier<PIPE_V>();
+            
+            DataCopy(tensorOutFp32Dk, tensorAccFp32Dk, rowSize);
+            PipeBarrier<PIPE_V>();
+            for (uint32_t r = 1; r < n_ratio; r++) {
+                Add(tensorOutFp32Dk, tensorOutFp32Dk, tensorAccFp32Dk[r * rowSize], rowSize);
+                PipeBarrier<PIPE_V>();
+            }
+            
+            auto tensorOut = outQue1.AllocTensor<DataType>();
+            Cast(tensorOut, tensorOutFp32Dk, RoundMode::CAST_RINT, rowSize);
+            inQue1.FreeTensor(tensorIn);
+            outQue1.EnQue(tensorOut);
+        }
+        
+        // CopyOut: write to final dk output [B, HK, T, K]
+        {
+            auto tensorOut = outQue1.DeQue<DataType>();
+            uint64_t dkOutOffset = ((uint64_t)b * HK + hk) * T * K + (uint64_t)t * K;
+            DataCopy(gmDk[dkOutOffset], tensorOut, rowSize);
+            outQue1.FreeTensor(tensorOut);
         }
     }
 }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/cases.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/cases.py
@@ -19,7 +19,8 @@ def generate_increasing_sequence(start, end, count):
 
 
 cases = {   #B,HV,HK,T,chunk_size,dtype,Gtype,scale,cu_seqlens, K,V
-        "case_fast": [2,8,4,512,128,torch.bfloat16,torch.float32,0.088,None,128,256],
+        "case_fast": [1,4,2,512,128,torch.bfloat16,torch.float32,0.088,[0,130,500,512],128,256],
+        "case_fast_128": [1,2,2,200,128,torch.bfloat16,torch.bfloat16,0.088,None,128,128],
         "case_01": [64,8,8,1024,64,torch.float16,torch.float16,0.088,None,128,128],
         "case_02": [32,16,16,2048,64,torch.bfloat16,torch.bfloat16,0.0625,None,128,128],
         "case_03": [16,32,32,4096,64,torch.float16,torch.float16,0.0442,None,128,128],
@@ -31,32 +32,32 @@ cases = {   #B,HV,HK,T,chunk_size,dtype,Gtype,scale,cu_seqlens, K,V
         "case_09": [64,8,8,2048,128,torch.float16,torch.float16,0.0625,None,128,128],
         "case_10": [32,16,16,4096,128,torch.bfloat16,torch.bfloat16,0.0442,None,128,128],
         "case_11": [16,32,32,8192,128,torch.float16,torch.float16,0.03125,None,128,128],
-        "case_12": [8,32,32,8192,128,torch.bfloat16,torch.bfloat16,0.0221,None,128,128],  #C12
+        "case_12": [8,32,32,16384,128,torch.bfloat16,torch.bfloat16,0.0221,None,128,128],  #C12
         "case_13": [1,4,4,1024,64,torch.float16,torch.float16,0.088,None,128,128],
         "case_14": [48,8,8,2048,64,torch.bfloat16,torch.bfloat16,0.0625,None,128,128],
         "case_15": [24,16,16,4096,64,torch.float16,torch.float16,0.0442,None,128,128],
         "case_16": [12,32,32,8192,64,torch.bfloat16,torch.bfloat16,0.03125,None,128,128],
-        "case_17": [1,16,16,32768,64,torch.float16,torch.float32,0.0625,[0,16,20000,30000,32768],128,128],      # V1
-        "case_18": [1,8,8,65536,64,torch.bfloat16,torch.bfloat16,0.0625,[0,16,20000,65536],128,128],
-        "case_19": [1,32,32,65536,64,torch.float16,torch.float32,0.0442,[0,16,20000,50000,65536],128,128],
-        "case_20": [1,32,32,262144,64,torch.bfloat16,torch.bfloat16,0.03125,[0,16,20000,50000,65536,210000,262144],128,128],
+        "case_17": [1,16,16,32768,64,torch.float16,torch.float32,0.0625,generate_increasing_sequence(0, 32768, 32),128,128],      # V1
+        "case_18": [1,8,8,65536,64,torch.bfloat16,torch.bfloat16,0.0625,generate_increasing_sequence(0, 65536, 64),128,128],
+        "case_19": [1,32,32,65536,64,torch.float16,torch.float32,0.0442,generate_increasing_sequence(0, 65536, 16),128,128],
+        "case_20": [1,32,32,16384,64,torch.bfloat16,torch.bfloat16,0.03125,generate_increasing_sequence(0, 16384, 8),128,128],
         "case_21": [21,32,32,195,64,torch.float16,torch.float16,0.03125,None,128,128],
         "case_22": [1,32,32,7909,64,torch.bfloat16,torch.bfloat16,0.03125,[0,1024,2168,3087,4096,7909],128,128],
         "case_23": [1,32,32,65536,64,torch.bfloat16,torch.bfloat16,0.32,case_extra_info.pj_cu_seqlens,128,128],
         "case_24": [1,32,32,65536,128,torch.bfloat16,torch.bfloat16,0.32,case_extra_info.pj_cu_seqlens,128,128],
         "case_25": [1,16,8,1024,64,torch.bfloat16,torch.float32,0.088, [0, 57, 143, 187, 197, 227],128,256],
-        "case_step2_01": [1,32,16,16384,64,torch.float16,torch.float32,0.03125, generate_increasing_sequence(0, 16384, 128),128,256],
-        "case_step2_02": [1,63,21,16384,64,torch.bfloat16,torch.float32,0.03125, [0, 1066, 2048, 5000, 9000, 10000, 12000, 14000, 16384],128,256],
+        "case_step2_01": [1,32,16,16384,64,torch.bfloat16,torch.float32,0.03125, generate_increasing_sequence(0, 16384, 128),128,256],
+        "case_step2_02": [1,63,21,16384,64,torch.bfloat16,torch.float32,0.03125, [0, 16384],128,256],
         "case_step2_03": [1,32,8,65536,128,torch.float16,torch.float32,0.03125, generate_increasing_sequence(0, 65536, 172),128,256],
-        "case_step2_04": [1,32,16,65536,64,torch.bfloat16,torch.float32,0.03125, generate_increasing_sequence(0, 65536, 668),128,128],
-        "case_step2_05": [1,32,4,65536,64,torch.float16,torch.float32,0.03125, generate_increasing_sequence(0, 65536, 17),128,128],
-        "case_step2_06": [1,64,2,65519,64,torch.bfloat16,torch.float32,0.03125, generate_increasing_sequence(0, 65519, 30),128,256],
+        "case_step2_04": [1,32,16,36621,64,torch.bfloat16,torch.float32,0.03125, generate_increasing_sequence(0, 36621, 172),128,128],
+        "case_step2_05": [1,32,4,7178,64,torch.float16,torch.float32,0.03125, generate_increasing_sequence(0, 7178, 17),128,128],
+        "case_step2_06": [1,64,2,11202,64,torch.bfloat16,torch.float32,0.03125, generate_increasing_sequence(0, 11202, 668),128,256],
         "case_step2_07": [1,32,16,4096,64,torch.float16,torch.float32,0.03125, None,128,256],
         "case_step2_08": [16,63,21,2048,64,torch.bfloat16,torch.float32,0.03125, None,128,256],
         "case_step2_09": [711,32,4,196,128,torch.float16,torch.float32,0.03125, None,128,128],
         "case_step2_10": [176,64,2,24,64,torch.bfloat16,torch.float32,0.03125, None,128,256],
-        "case_step2_11": [1,48,16,65536,64,torch.float16,torch.float32,0.03125, generate_increasing_sequence(0, 65536, 667),128,256],
-        "case_step2_12": [1,48,16,65536,128,torch.bfloat16,torch.float32,0.03125, generate_increasing_sequence(0, 65536, 13),128,256],
+        "case_step2_11": [1,48,16,16387,64,torch.float16,torch.float32,0.03125, generate_increasing_sequence(0, 16387, 667),128,256],
+        "case_step2_12": [1,48,16,8999,128,torch.bfloat16,torch.float32,0.03125, generate_increasing_sequence(0, 8999, 13),128,256],
 }
 def error_exit(msg):
     print(f"[error_exit] {msg}")

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/chunk_bwd_dqkwg_cpu.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/chunk_bwd_dqkwg_cpu.py
@@ -85,12 +85,12 @@ def chunk_bwd_dqkwg_cpu(
     scale: float,
     cu_seqlens: torch.LongTensor,
     chunk_size: int = 64,
-    benchmark = False
+    run_fp64 = False
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     CPU Equivalent of chunk_bwd_kernel_dqkwg.
     """
-    if benchmark:
+    if run_fp64:
         calc_type = torch.float64
         datatype = torch.float64
         gtype = torch.float64
@@ -410,5 +410,7 @@ def chunk_bwd_dqkwg_cpu(
                 # 但如果发生，通常 cu_seqlens[i] 是第 i 个样本的长度。
                 # 简化起见，我们假设 input 是 packed flat tensor 如果 cu_seqlens 存在。
                 pass 
-
+    if HK != HV:
+        dq = dq.view(B, T, HK, HV // HK, K).sum(3)
+        dk = dk.view(B, T, HK, HV // HK, K).sum(3)
     return dq, dk, dw, dg

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/pta.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/pta.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     chunk_size = 128
     from cases import get_case_info
     case = get_case_info(case_name)
-    device_id = 6
+    device_id = 5
     
 
     dtype = torch.float16
@@ -68,6 +68,7 @@ if __name__ == "__main__":
         B = 1  ##变长只支持B=1
         T = cu_seqlens_torch[-1]
         chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+        chunk_indices_torch = torch.tensor(chunk_indices)
         num_chunks = len(chunk_indices) // 2
         # print("chunk_indices",chunk_indices)
     else:
@@ -78,7 +79,7 @@ if __name__ == "__main__":
     RANDOM_DATA = True
     RUN_CPU = True
     SAVE_FILES = True
-    BENCHMARK = True
+    FP64 = True
 
     if SAVE_FILES:
         os.makedirs(f'{data_path}/{case_name}/in/', exist_ok=True)
@@ -108,6 +109,9 @@ if __name__ == "__main__":
             torch.save(w, f"{data_path}/{case_name}/in/w_cpu.pt")
             torch.save(h, f"{data_path}/{case_name}/in/h_cpu.pt")
             torch.save(dh, f"{data_path}/{case_name}/in/dh_cpu.pt")
+            if cu_seqlens is not None:
+                torch.save(cu_seqlens_torch, f"{data_path}/{case_name}/in/cu_seqlen_cpu.pt")
+                torch.save(chunk_indices_torch, f"{data_path}/{case_name}/in/chunk_indices_cpu.pt")
     else:
         # q=torch.load("/home/huangjunzhe/GDN/data/model/after_cpu/q_cpu.pt", weights_only=False)
         # k=torch.load("/home/huangjunzhe/GDN/data/model/after_cpu/k_cpu.pt", weights_only=False)
@@ -127,6 +131,11 @@ if __name__ == "__main__":
         dv=torch.load(f"{data_path}/{case_name}/in/dv_cpu.pt", weights_only=False)
         do=torch.load(f"{data_path}/{case_name}/in/do_cpu.pt", weights_only=False)
         dh=torch.load(f"{data_path}/{case_name}/in/dh_cpu.pt", weights_only=False)
+        if cu_seqlens is not None:
+            cu_seqlens_torch=torch.load(f"{data_path}/{case_name}/in/cu_seqlen_cpu.pt", weights_only=False)
+            chunk_indices_torch=torch.load(f"{data_path}/{case_name}/in/chunk_indices_cpu.pt", weights_only=False)
+            cu_seqlens = cu_seqlens_torch.tolist()
+            chunk_indices = chunk_indices_torch.tolist()
 
     q = q.to(dtype).to(calc_type)
     k = k.to(dtype).to(calc_type)
@@ -171,6 +180,7 @@ if __name__ == "__main__":
     # cu_seqlens_npu = cu_seqlens if cu_seqlens is not None else None
     chunk_indices_npu = chunk_indices if cu_seqlens is not None else None
     down_tri = q_npu
+    print("start torch.ops.npu.npu_chunk_bwd_dqkwg")
     dq_npu, dk_npu, dw_npu, dg_npu = torch.ops.npu.npu_chunk_bwd_dqkwg(
         q_npu, k_npu, v_npu, g_npu, h_npu, do_npu, dh_npu, dv_npu, chunk_size, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices_npu, w=None, g_gamma=None, scale=scale, transpose_state_layout=None
        #q_npu, k_npu, v_npu, g_npu, h_npu, do_npu, dh_npu, dv_npu, chunk_size, cu_seqlens=cu_seqlens, w=None, g_gamma=None, chunk_indices=chunk_indices_npu, scale=scale, transpose_state_layout=None
@@ -203,15 +213,15 @@ if __name__ == "__main__":
         dq, dk, dw, dg = chunk_bwd_dqkwg_cpu(
             q, k, v, do, h, dh, w, g, dv, scale, cu_seqlens_torch, chunk_size
         )
-        if BENCHMARK:
-            print("=====start cpu benchmark=========")
-            dq_benchmark, dk_benchmark, dw_benchmark, dg_benchmark = chunk_bwd_dqkwg_cpu(
-                q, k, v, do, h, dh, w, g, dv, scale, cu_seqlens_torch, chunk_size, benchmark = True
+        if FP64:
+            print("=====start cpu run_fp64=========")
+            dq_fp64, dk_fp64, dw_fp64, dg_fp64 = chunk_bwd_dqkwg_cpu(
+                q, k, v, do, h, dh, w, g, dv, scale, cu_seqlens_torch, chunk_size, run_fp64 = True
             )
-            dq_benchmark = torch.transpose(dq_benchmark, 1, 2).cpu()
-            dk_benchmark = torch.transpose(dk_benchmark, 1, 2).cpu()
-            dw_benchmark = torch.transpose(dw_benchmark, 1, 2).cpu()
-            dg_benchmark = torch.transpose(dg_benchmark, 1, 2).cpu()
+            dq_fp64 = torch.transpose(dq_fp64, 1, 2).cpu()
+            dk_fp64 = torch.transpose(dk_fp64, 1, 2).cpu()
+            dw_fp64 = torch.transpose(dw_fp64, 1, 2).cpu()
+            dg_fp64 = torch.transpose(dg_fp64, 1, 2).cpu()
         # dq = dq.to(dtype)
         # dk = dk.to(dtype)
         # dw = dw.to(dtype)
@@ -239,12 +249,12 @@ if __name__ == "__main__":
                 torch.save(dw.detach(),f"{data_path}/{case_name}/out/dw_cpu.pt")
                 torch.save(dg.detach(),f"{data_path}/{case_name}/out/dg_cpu.pt")
                 print(f"cpu files saved to {data_path}/{case_name}/out/ .")
-                if BENCHMARK:
-                    torch.save(dq_benchmark.detach(),f"{data_path}/{case_name}/out/dq_cpu_benchmark.pt")
-                    torch.save(dk_benchmark.detach(),f"{data_path}/{case_name}/out/dk_cpu_benchmark.pt")
-                    torch.save(dw_benchmark.detach(),f"{data_path}/{case_name}/out/dw_cpu_benchmark.pt")
-                    torch.save(dg_benchmark.detach(),f"{data_path}/{case_name}/out/dg_cpu_benchmark.pt")
-                    print(f"cpu benchmark files saved to {data_path}/{case_name}/out/ .")
+                if FP64:
+                    torch.save(dq_fp64.detach(),f"{data_path}/{case_name}/out/dq_cpu_fp64.pt")
+                    torch.save(dk_fp64.detach(),f"{data_path}/{case_name}/out/dk_cpu_fp64.pt")
+                    torch.save(dw_fp64.detach(),f"{data_path}/{case_name}/out/dw_cpu_fp64.pt")
+                    torch.save(dg_fp64.detach(),f"{data_path}/{case_name}/out/dg_cpu_fp64.pt")
+                    print(f"cpu run_fp64 files saved to {data_path}/{case_name}/out/ .")
                 
     if SAVE_FILES:
         torch.save(dq_npu.detach(),f"{data_path}/{case_name}/out/dq_npu.pt")

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/run.sh
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/run.sh
@@ -75,19 +75,20 @@ fi
 # ct viz ${data_path}/${caseid}/out/dq_npu.pt ${data_path}/${caseid}/out/dq_cpu.pt --out_dir ${data_path}/${caseid} --name dq -wl 1
 # ct viz ${data_path}/${caseid}/out/dk_npu.pt ${data_path}/${caseid}/out/dk_cpu.pt --out_dir ${data_path}/${caseid} --name dk -wl 1
 
-# ct dual ${data_path}/${caseid}/out/dg_npu.pt ${data_path}/${caseid}/out/dg_cpu.pt ${data_path}/${caseid}/out/dg_cpu_benchmark.pt --out_dir ${data_path}/${caseid}
-# ct dual ${data_path}/${caseid}/out/dw_npu.pt ${data_path}/${caseid}/out/dw_cpu.pt ${data_path}/${caseid}/out/dw_cpu_benchmark.pt --out_dir ${data_path}/${caseid}
-# ct dual ${data_path}/${caseid}/out/dq_npu.pt ${data_path}/${caseid}/out/dq_cpu.pt ${data_path}/${caseid}/out/dq_cpu_benchmark.pt --out_dir ${data_path}/${caseid}
-# ct dual ${data_path}/${caseid}/out/dk_npu.pt ${data_path}/${caseid}/out/dk_cpu.pt ${data_path}/${caseid}/out/dk_cpu_benchmark.pt --out_dir ${data_path}/${caseid}
+# ct dual ${data_path}/${caseid}/out/dg_npu.pt ${data_path}/${caseid}/out/dg_cpu.pt ${data_path}/${caseid}/out/dg_cpu_fp64.pt --out_dir ${data_path}/${caseid}
+# ct dual ${data_path}/${caseid}/out/dw_npu.pt ${data_path}/${caseid}/out/dw_cpu.pt ${data_path}/${caseid}/out/dw_cpu_fp64.pt --out_dir ${data_path}/${caseid}
+# ct dual ${data_path}/${caseid}/out/dq_npu.pt ${data_path}/${caseid}/out/dq_cpu.pt ${data_path}/${caseid}/out/dq_cpu_fp64.pt --out_dir ${data_path}/${caseid}
+# ct dual ${data_path}/${caseid}/out/dk_npu.pt ${data_path}/${caseid}/out/dk_cpu.pt ${data_path}/${caseid}/out/dk_cpu_fp64.pt --out_dir ${data_path}/${caseid}
 
 names=(dw dg dq dk)
+# names=(dq)
 
 for name in "${names[@]}"; do
     (
         echo "Processing dual $name..."
         ct dual ${data_path}/${caseid}/out/${name}_npu.pt \
+                ${data_path}/${caseid}/out/${name}_cpu_fp64.pt \
                 ${data_path}/${caseid}/out/${name}_cpu.pt \
-                ${data_path}/${caseid}/out/${name}_cpu_benchmark.pt \
                 --out_dir ${data_path}/${caseid} \
                 > ${data_path}/${caseid}/${name}.txt 2>&1
     ) &
@@ -100,4 +101,4 @@ for name in "${names[@]}"; do
 done
 wait
 
-md5sum ${data_path}/${caseid}/out/*.pt
+# md5sum ${data_path}/${caseid}/out/*.pt

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -176,14 +176,15 @@ at::Tensor npu_prepare_wy_repr_bwd_da(const at::Tensor & k, const at::Tensor & v
     auto q_sizes = q.sizes();
     auto v_sizes = v.sizes();
     int64_t batch_size = q_sizes[0];
-    int64_t num_heads = v_sizes[1];
+    int64_t k_num_heads = q_sizes[1];
+    int64_t v_num_heads = v_sizes[1];
     int64_t seq_len = q_sizes[2];
     int64_t head_dim = q_sizes[3];
     
     // 使用具体 shape 创建，但保持相同的 dtype/device
-    at::Tensor dq = at::empty({batch_size, num_heads, seq_len, head_dim}, q.options());
-    at::Tensor dk = at::empty({batch_size, num_heads, seq_len, head_dim}, q.options());
-    at::Tensor dw = at::empty({batch_size, num_heads, seq_len, head_dim}, q.options());
+    at::Tensor dq = at::empty({batch_size, k_num_heads, seq_len, head_dim}, q.options());
+    at::Tensor dk = at::empty({batch_size, k_num_heads, seq_len, head_dim}, q.options());
+    at::Tensor dw = at::empty({batch_size, v_num_heads, seq_len, head_dim}, q.options());
     at::Tensor dg = at::empty_like(g);
 
     // scale处理


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @alvazu
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
