### PR TITLE
0703 26.6.0 dqkwg deep

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/chunk_bwd_dqkwg_def.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/chunk_bwd_dqkwg_def.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
+ * Copyright (c) 2026 Tianjin University, Ltd.
  * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
  * the BSD 3-Clause License (the "License").
  * Please refer to the License for details. You may not use this file except in compliance with the License.
@@ -10,12 +10,12 @@
 /*!
  * \file chunk_bwd_dqkwg_def.cpp
  * \brief ChunkBwdDqkwg 算子定义
- * 
+ *
  * 实现 USE_G=True, USE_DW=True, USE_G_GAMMA=False 的反向传播
- * 维度拆分: H维度拆分为HV和HK, HV = n * HK
+ * 维度拆分 (GVA): H 拆为 HV 和 HK, HV = n_ratio * HK
  * - q, k: [B, HK, T, K]
  * - v, g, dox, dv, h, dh: [B, HV, T, ...] 或 [B, HV, ...]
- * - 所有输出: [B, HV, T, ...] 或 [B, HV, ...]
+ * - 所有输出 (dq/dk/dw/dg): [B, HV, T, ...] 或 [B, HV, ...]
  */
 
 #include "register/op_def_registry.h"
@@ -32,49 +32,49 @@ public:
             .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
-        
+
         // k: [B, HK, T, K] - key tensor (HK heads)
         this->Input("k")
             .ParamType(REQUIRED)
             .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
-        
+
         // v: [B, HV, T, V] - value tensor (HV heads)
         this->Input("v")
             .ParamType(REQUIRED)
             .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
-        
+
         // g: [B, HV, T] - gate tensor (HV heads, 支持 fp16/bf16/fp32)
         this->Input("g")
             .ParamType(REQUIRED)
             .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT, ge::DT_FLOAT})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
-        
+
         // h: [B, HV, num_chunks, K, V] - hidden state tensor (HV heads)
         this->Input("h")
             .ParamType(REQUIRED)
             .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
-        
+
         // do: [B, HV, T, V] - gradient of output (HV heads)
         this->Input("dox")
             .ParamType(REQUIRED)
             .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
-        
+
         // dh: [B, HV, num_chunks, K, V] - gradient of hidden state (HV heads)
         this->Input("dh")
             .ParamType(REQUIRED)
             .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
-        
+
         // dv: [B, HV, T, V] - gradient of v (HV heads, for USE_DW=True, delta rule)
         this->Input("dv")
             .ParamType(REQUIRED)
@@ -118,21 +118,21 @@ public:
             .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
-        
+
         // dk: [B, HV, T, K] - gradient of k (HV heads)
         this->Output("dk")
             .ParamType(REQUIRED)
             .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
-        
+
         // dw: [B, HV, T, K] - gradient of w (HV heads, delta rule)
         this->Output("dw")
             .ParamType(REQUIRED)
             .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
-        
+
         // dg: [B, HV, T] - gradient of g (HV heads, 支持 fp32 输出)
         this->Output("dg")
             .ParamType(REQUIRED)

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/chunk_bwd_dqkwg_def.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/chunk_bwd_dqkwg_def.cpp
@@ -15,7 +15,8 @@
  * 维度拆分 (GVA): H 拆为 HV 和 HK, HV = n_ratio * HK
  * - q, k: [B, HK, T, K]
  * - v, g, dox, dv, h, dh: [B, HV, T, ...] 或 [B, HV, ...]
- * - 所有输出 (dq/dk/dw/dg): [B, HV, T, ...] 或 [B, HV, ...]
+ * - dq, dk: [B, HK, T, K]
+ * - dw, dg: [B, HV, T, ...]
  */
 
 #include "register/op_def_registry.h"
@@ -112,14 +113,14 @@ public:
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
 
-        // dq: [B, HV, T, K] - gradient of q (HV heads)
+        // dq: [B, HK, T, K] - gradient of q (HK heads)
         this->Output("dq")
             .ParamType(REQUIRED)
             .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
 
-        // dk: [B, HV, T, K] - gradient of k (HV heads)
+        // dk: [B, HK, T, K] - gradient of k (HK heads)
         this->Output("dk")
             .ParamType(REQUIRED)
             .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_api/aclnn_chunk_bwd_dqkwg.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_api/aclnn_chunk_bwd_dqkwg.cpp
@@ -80,6 +80,46 @@ static aclnnStatus CheckFormat(ChunkBwdDqkwgParams params)
 
 static aclnnStatus CheckShape(ChunkBwdDqkwgParams params)
 {
+    const auto qShape = params.q->GetViewShape();
+    const auto kShape = params.k->GetViewShape();
+    const auto vShape = params.v->GetViewShape();
+    const auto gShape = params.g->GetViewShape();
+    const auto dqShape = params.dqOut->GetViewShape();
+    const auto dkShape = params.dkOut->GetViewShape();
+    const auto dwShape = params.dwOut->GetViewShape();
+    const auto dgShape = params.dgOut->GetViewShape();
+
+    CHECK_COND(qShape.GetDimNum() == 4, ACLNN_ERR_PARAM_INVALID, "q must be [B, HK, T, K].");
+    CHECK_COND(kShape.GetDimNum() == 4, ACLNN_ERR_PARAM_INVALID, "k must be [B, HK, T, K].");
+    CHECK_COND(vShape.GetDimNum() == 4, ACLNN_ERR_PARAM_INVALID, "v must be [B, HV, T, V].");
+    CHECK_COND(gShape.GetDimNum() == 3, ACLNN_ERR_PARAM_INVALID, "g must be [B, HV, T].");
+    CHECK_COND(dqShape.GetDimNum() == 4, ACLNN_ERR_PARAM_INVALID, "dqOut must be [B, HK, T, K].");
+    CHECK_COND(dkShape.GetDimNum() == 4, ACLNN_ERR_PARAM_INVALID, "dkOut must be [B, HK, T, K].");
+    CHECK_COND(dwShape.GetDimNum() == 4, ACLNN_ERR_PARAM_INVALID, "dwOut must be [B, HV, T, K].");
+    CHECK_COND(dgShape.GetDimNum() == 3, ACLNN_ERR_PARAM_INVALID, "dgOut must be [B, HV, T].");
+
+    const int64_t B = qShape.GetDim(0);
+    const int64_t HK = qShape.GetDim(1);
+    const int64_t T = qShape.GetDim(2);
+    const int64_t K = qShape.GetDim(3);
+    const int64_t HV = vShape.GetDim(1);
+
+    CHECK_COND(HK > 0 && HV > 0 && HV % HK == 0, ACLNN_ERR_PARAM_INVALID,
+               "GVA requires HV divisible by HK.");
+    CHECK_COND(kShape.GetDim(0) == B && kShape.GetDim(1) == HK && kShape.GetDim(2) == T && kShape.GetDim(3) == K,
+               ACLNN_ERR_PARAM_INVALID, "k must match q shape [B, HK, T, K].");
+    CHECK_COND(vShape.GetDim(0) == B && vShape.GetDim(2) == T, ACLNN_ERR_PARAM_INVALID,
+               "v must match q batch and sequence dimensions.");
+    CHECK_COND(gShape.GetDim(0) == B && gShape.GetDim(1) == HV && gShape.GetDim(2) == T, ACLNN_ERR_PARAM_INVALID,
+               "g must be [B, HV, T].");
+    CHECK_COND(dqShape.GetDim(0) == B && dqShape.GetDim(1) == HK && dqShape.GetDim(2) == T && dqShape.GetDim(3) == K,
+               ACLNN_ERR_PARAM_INVALID, "dqOut must be [B, HK, T, K].");
+    CHECK_COND(dkShape.GetDim(0) == B && dkShape.GetDim(1) == HK && dkShape.GetDim(2) == T && dkShape.GetDim(3) == K,
+               ACLNN_ERR_PARAM_INVALID, "dkOut must be [B, HK, T, K].");
+    CHECK_COND(dwShape.GetDim(0) == B && dwShape.GetDim(1) == HV && dwShape.GetDim(2) == T && dwShape.GetDim(3) == K,
+               ACLNN_ERR_PARAM_INVALID, "dwOut must be [B, HV, T, K].");
+    CHECK_COND(dgShape.GetDim(0) == B && dgShape.GetDim(1) == HV && dgShape.GetDim(2) == T,
+               ACLNN_ERR_PARAM_INVALID, "dgOut must be [B, HV, T].");
     return ACLNN_SUCCESS;
 }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
+ * Copyright (c) 2026 Tianjin University, Ltd.
  * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
  * the BSD 3-Clause License (the "License").
  * Please refer to the License for details. You may not use this file except in compliance with the License.
@@ -9,107 +9,299 @@
 
 /*!
  * \file chunk_bwd_dqkwg_tiling.cpp
- * \brief
+ * \brief ChunkBwdDqkwg Tiling 实现
  */
 
-#include "chunk_bwd_dqkwg_tiling_processor.h"
-#include "../../op_kernel/chunk_bwd_dqkwg_struct.h"
-
-using namespace GDN;
+#include "chunk_bwd_dqkwg_tiling.h"
+#include <register/op_impl_registry.h>
+#include "tiling_base/data_copy_transpose_tiling.h"
+#include "tiling_base/tiling_templates_registry.h"
+#include "tiling_base/tiling_type.h"
+#include <cmath>
+#include <algorithm>
 
 namespace optiling {
 
-struct ChunkBwdDqkwgCompileInfo {};
+constexpr int64_t CONST_B = 1;
+constexpr int64_t CONST_HV = 4;
+constexpr int64_t CONST_HK = 4;
+constexpr int64_t CONST_T = 2816;
+constexpr int64_t CONST_K = 128;
+constexpr int64_t CONST_V = 128;
+constexpr int64_t CONST_BT = 64;
 
-static void ChunkBwdDqkwgTilingDataPrint(gert::TilingContext *context, const ChunkBwdDqkwgTilingData &tiling)
+// 数据类型大小
+constexpr size_t FP16_SIZE = 2;
+constexpr size_t FP32_SIZE = 4;
+
+constexpr size_t INPUT_Q_IDX = 0;
+constexpr size_t INPUT_K_IDX = 1;
+constexpr size_t INPUT_V_IDX = 2;
+constexpr size_t INPUT_G_IDX = 3;
+constexpr size_t INPUT_H_IDX = 4;
+constexpr size_t INPUT_DOX_IDX = 5;
+constexpr size_t INPUT_DH_IDX = 6;
+constexpr size_t INPUT_DV_IDX = 7;
+constexpr size_t INPUT_CUSEQLENS_IDX = 8;
+constexpr size_t INPUT_CHUNK_INDICES_IDX = 9;
+constexpr size_t INPUT_W_IDX = 10;
+constexpr size_t INPUT_G_GAMMA_IDX = 11;
+constexpr int ATTR_SCALE_ITEM = 0;
+constexpr int ATTR_CHUNK_SIZE_ITEM = 1;
+
+int64_t CeilDiv(int64_t a, int64_t b)
 {
-    auto nodeName = context->GetNodeName();
-    OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Start to print ChunkBwdDqkwg tiling data <<<<<<<<<<<<<<<<");
-    OP_LOGD(nodeName, "=== B: %ld", tiling.B);
-    OP_LOGD(nodeName, "=== HV: %ld", tiling.HV);
-    OP_LOGD(nodeName, "=== HK: %ld", tiling.HK);
-    OP_LOGD(nodeName, "=== T: %ld", tiling.T);
-    OP_LOGD(nodeName, "=== K: %ld", tiling.K);
-    OP_LOGD(nodeName, "=== V: %ld", tiling.V);
-    OP_LOGD(nodeName, "=== BT: %ld", tiling.BT);
-    OP_LOGD(nodeName, "=== numChunks: %ld", tiling.numChunks);
-    OP_LOGD(nodeName, "=== scale: %f", tiling.scale);
-    OP_LOGD(nodeName, "=== mul0RowNum: %ld", tiling.mul0RowNum);
-    OP_LOGD(nodeName, "=== isVarLen: %ld", tiling.isVarLen);
-    OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Print ChunkBwdDqkwg tiling data end <<<<<<<<<<<<<<<<");
+    if (unlikely(b == 0)) {
+        return 0;
+    }
+    return (a + b - 1) / b;
 }
 
 ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* context) {
-    OP_LOGD(context->GetNodeName(), "TilingChunkBwdDqkwg start.");
-    ChunkBwdDqkwgTilingData *tiling = context->GetTilingData<ChunkBwdDqkwgTilingData>();
+    const gert::Shape qStorageShape = context->GetRequiredInputShape(INPUT_Q_IDX)->GetStorageShape();
+    const gert::Shape kStorageShape = context->GetRequiredInputShape(INPUT_K_IDX)->GetStorageShape();
+    const gert::Shape vStorageShape = context->GetRequiredInputShape(INPUT_V_IDX)->GetStorageShape();
+    const gert::Shape gStorageShape = context->GetRequiredInputShape(INPUT_G_IDX)->GetStorageShape();
+    const gert::Shape hStorageShape = context->GetRequiredInputShape(INPUT_H_IDX)->GetStorageShape();
+    const gert::Shape doxStorageShape = context->GetRequiredInputShape(INPUT_DOX_IDX)->GetStorageShape();
+    const gert::Shape dhStorageShape = context->GetRequiredInputShape(INPUT_DH_IDX)->GetStorageShape();
+    const gert::Shape dvStorageShape = context->GetRequiredInputShape(INPUT_DV_IDX)->GetStorageShape();
 
+    int64_t B = vStorageShape.GetDim(0);
+    int64_t HV = vStorageShape.GetDim(1);   // value 侧 head 数 (v/g/h/do/dh/dv 及全部输出)
+    int64_t T = vStorageShape.GetDim(2);
+    int64_t HK = kStorageShape.GetDim(1);   // key/query 侧 head 数 (q/k)
+    int64_t K = kStorageShape.GetDim(3);
+    int64_t V = vStorageShape.GetDim(3);
+    int64_t BT = CONST_BT;
+    // GVA: HV = n_ratio * HK, n_ratio 由 q/v shape 自动推导
+    if (HK == 0 || HV % HK != 0) {
+        OP_LOGE(context->GetNodeName(), "HV must be a multiple of HK, but HV = %ld, HK = %ld.", HV, HK);
+        return ge::GRAPH_FAILED;
+    }
+    int64_t n_ratio = HV / HK;
+    (void)n_ratio;
     auto attr = context->GetAttrs();
-    OP_CHECK_NULL_WITH_CONTEXT(context, attr);
+    const int32_t* chunkSizePtr = attr->GetAttrPointer<int32_t>(ATTR_CHUNK_SIZE_ITEM);
+    if (chunkSizePtr != nullptr) {
+        BT = *chunkSizePtr;
+        if (BT != 64 && BT != 128) {
+            OP_LOGE(context->GetNodeName(), "BT should be 64 or 128, but got %ld.", BT);
+            return ge::GRAPH_FAILED;
+        }
 
-    const float* scalePtr = attr->GetAttrPointer<float>(CHUNK_BWD_DQKWG_ATTR_SCALE_IDX);
-    OP_CHECK_IF(scalePtr == nullptr,
-                OP_LOGE(context, "scale should not be nullptr."),
-                return ge::GRAPH_FAILED);
+    }
+
+
+    if (context->GetOptionalInputTensor(INPUT_W_IDX) != nullptr ||
+        context->GetOptionalInputTensor(INPUT_G_GAMMA_IDX) != nullptr) {
+        OP_LOGE(context->GetNodeName(), "w and g_gamma should be set at nullptr.");
+        return ge::GRAPH_FAILED;
+    }
+
+    auto cuSeqlensTensor = context->GetOptionalInputTensor(INPUT_CUSEQLENS_IDX);
+    int64_t numChunks = CeilDiv(T, BT);  // = 32
+    int isVarLen = 0;
+    if (cuSeqlensTensor != nullptr) {
+        auto cuChunkIndicesTensor = context->GetOptionalInputTensor(INPUT_CHUNK_INDICES_IDX);
+        OP_CHECK_NULL_WITH_CONTEXT(context, cuChunkIndicesTensor);
+        const gert::StorageShape *chunkIndicesShape = context->GetOptionalInputShape(INPUT_CHUNK_INDICES_IDX);
+        OP_CHECK_NULL_WITH_CONTEXT(context, chunkIndicesShape);
+        const gert::Shape chunkIndicesStorageShape = chunkIndicesShape->GetStorageShape();
+        numChunks = chunkIndicesStorageShape.GetDim(0);
+        if (numChunks % 2 != 0) {
+            OP_LOGE(context->GetNodeName(), "numChunks should be even, but now is %ld.", numChunks);
+            return ge::GRAPH_FAILED;
+        }
+        numChunks /= 2;
+        isVarLen = 1;
+    }
+    if (isVarLen == 1 && B != 1) {
+        OP_LOGE(context->GetNodeName(), "varlen mode only support B = 1, but now B = %ld.", B);
+        return ge::GRAPH_FAILED;
+    }
+    {
+        // 检查输入维度是否符合预期
+        // q, k: [B, HK, T, K]; v, dox, dv: [B, HV, T, V]; g: [B, HV, T]; h, dh: [B, HV, numChunks, K, V]
+        if (qStorageShape.GetDim(0) != B || qStorageShape.GetDim(1) != HK || qStorageShape.GetDim(2) != T || qStorageShape.GetDim(3) != K ||
+            kStorageShape.GetDim(0) != B || kStorageShape.GetDim(1) != HK || kStorageShape.GetDim(2) != T || kStorageShape.GetDim(3) != K ||
+            vStorageShape.GetDim(0) != B || vStorageShape.GetDim(1) != HV || vStorageShape.GetDim(2) != T || vStorageShape.GetDim(3) != V ||
+            gStorageShape.GetDim(0) != B || gStorageShape.GetDim(1) != HV || gStorageShape.GetDim(2) != T ||
+            hStorageShape.GetDim(0) != B || hStorageShape.GetDim(1) != HV || hStorageShape.GetDim(2) != numChunks || hStorageShape.GetDim(3) != K || hStorageShape.GetDim(4) != V ||
+            doxStorageShape.GetDim(0) != B || doxStorageShape.GetDim(1) != HV || doxStorageShape.GetDim(2) != T || doxStorageShape.GetDim(3) != V ||
+            dhStorageShape.GetDim(0) != B || dhStorageShape.GetDim(1) != HV || dhStorageShape.GetDim(2) != numChunks || dhStorageShape.GetDim(3) != K || dhStorageShape.GetDim(4) != V ||
+            dvStorageShape.GetDim(0) != B || dvStorageShape.GetDim(1) != HV || dvStorageShape.GetDim(2) != T || dvStorageShape.GetDim(3) != V) {
+            OP_LOGE(context->GetNodeName(),
+                "Input tensor shapes do not match expected dimensions. Expected: q,k [B,HK,T,K], "
+                "v,dox,dv [B,HV,T,V], g [B,HV,T], h,dh [B,HV,NC,K,V].");
+            return ge::GRAPH_FAILED;
+        }
+        if (K != 128) {
+            OP_LOGE(context->GetNodeName(), "K should be 128, but now K = %ld.", K);
+            return ge::GRAPH_FAILED;
+        }
+        if (V != 128 && V != 256) {
+            OP_LOGE(context->GetNodeName(), "V should be 128 or 256, but now V = %ld.", V);
+            return ge::GRAPH_FAILED;
+        }
+
+    }
+
+
+
+    // 计算 scale = 1.0 / sqrt(K)
+    // float scale = 1.0f / std::sqrt(static_cast<float>(K));
+    const float* scalePtr = attr->GetAttrPointer<float>(ATTR_SCALE_ITEM);
+    if (scalePtr == nullptr) {
+        OP_LOGE(context->GetNodeName(), "scale should not be nullptr.");
+        return ge::GRAPH_FAILED;
+    }
     float scale = *scalePtr;
 
-    const int32_t* chunkSizePtr = attr->GetAttrPointer<int32_t>(CHUNK_BWD_DQKWG_ATTR_CHUNK_SIZE_IDX);
-    int32_t chunkSize = chunkSizePtr != nullptr ? *chunkSizePtr : 64;
+    // 获取平台信息
+    auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
+    auto sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
+    const int64_t physicalAicNum = ascendcPlatform.GetCoreNumAic();
 
-    ChunkBwdDqkwgTilingContext ctx{
-        context->GetNodeName(),
-        context->GetOptionalInputShape(CHUNK_BWD_DQKWG_INPUT_Q_IDX),
-        context->GetOptionalInputShape(CHUNK_BWD_DQKWG_INPUT_K_IDX),
-        context->GetOptionalInputShape(CHUNK_BWD_DQKWG_INPUT_V_IDX),
-        context->GetOptionalInputShape(CHUNK_BWD_DQKWG_INPUT_G_IDX),
-        context->GetOptionalInputShape(CHUNK_BWD_DQKWG_INPUT_H_IDX),
-        context->GetOptionalInputShape(CHUNK_BWD_DQKWG_INPUT_DO_IDX),
-        context->GetOptionalInputShape(CHUNK_BWD_DQKWG_INPUT_DH_IDX),
-        context->GetOptionalInputShape(CHUNK_BWD_DQKWG_INPUT_DV_IDX),
-        context->GetOptionalInputShape(CHUNK_BWD_DQKWG_INPUT_CUSEQLENS_IDX),
-        context->GetOptionalInputShape(CHUNK_BWD_DQKWG_INPUT_CHUNK_INDICES_IDX),
-        scale,
-        chunkSize,
+    // 设置 TilingKey
+    context->SetTilingKey(1);
+
+    auto align32 = [](size_t value) -> size_t {
+        return ((value + 31) / 32) * 32;
     };
 
-    ChunkBwdDqkwgTilingProcessor processor(ctx, *tiling);
+    const int64_t coreLoops = B * numChunks;
+    int64_t aicNum = physicalAicNum;
+    if (aicNum < 1) {
+        aicNum = 1;
+    }
+    int64_t ringCoreSlots = std::min(aicNum, coreLoops);
+    if (ringCoreSlots < 1) {
+        ringCoreSlots = 1;
+    }
 
-    OP_CHECK_IF(processor.Process() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+    const size_t mainDgLastSize = align32(static_cast<size_t>(B) * HV *numChunks * FP32_SIZE);
+    const size_t mainMm5Size = static_cast<size_t>(B) * HV *T * K * FP16_SIZE;
+    const size_t mainDsTempSize = static_cast<size_t>(B) * HV *T * BT * FP16_SIZE;
+    const size_t mainWorkspaceSize = mainDgLastSize + mainMm5Size + mainDsTempSize;
 
-    uint64_t strategyKey = processor.IsVariableLength() ? CHUNK_BWD_DQKWG_STRATEGY_VAR_LEN : CHUNK_BWD_DQKWG_STRATEGY_FIX_LEN;
+    // actualWorkspaceForDepth: 与下面真实分配完全一致 (short 环深自适应 = 2G, mm7 寄生 mm5 group 区, 不再 max)。
+    auto actualWorkspaceForDepth = [&](int64_t g) -> size_t {
+        int64_t shortD = (g / 2 >= 2) ? (g / 2) : 2;                 // 自适应 short = 2G, 地板 2
+        size_t shortBtxK = align32(static_cast<size_t>(ringCoreSlots) * shortD * HV *BT * K * FP16_SIZE);
+        size_t sharedBtxK = align32(static_cast<size_t>(ringCoreSlots) * g * HV *BT * K * FP16_SIZE);  // mm5+mm7 group
+        size_t groupBtb = align32(static_cast<size_t>(ringCoreSlots) * g * HV *BT * BT * FP16_SIZE);
+        size_t shortBtb = align32(static_cast<size_t>(ringCoreSlots) * shortD * HV *BT * BT * FP16_SIZE);
+        size_t dgLast = align32(static_cast<size_t>(ringCoreSlots) * g * HV *FP32_SIZE);
+        return shortBtxK + sharedBtxK + groupBtb + shortBtb + dgLast;
+    };
 
-    auto qInputDesc = context->GetInputDesc(CHUNK_BWD_DQKWG_INPUT_Q_IDX);
-    auto gInputDesc = context->GetInputDesc(CHUNK_BWD_DQKWG_INPUT_G_IDX);
-    OP_CHECK_NULL_WITH_CONTEXT(context, qInputDesc);
-    OP_CHECK_NULL_WITH_CONTEXT(context, gInputDesc);
-    ge::DataType qDtype = qInputDesc->GetDataType();
-    ge::DataType gDtype = gInputDesc->GetDataType();
+    // 选 G: 取 <= min(main, L2 驻留预算) 的最大 G。**memory-bound 关键 (msprof 实锤)**: 大 H/大 BT 的 case
+    // 是 L2 受限 (cube FixPipe 0.997 / MTE2 0.869 被 L2 miss 打满, L2 hit 仅 0.13), group 环 (mm5/ds_temp,
+    // 深度 4G) 装不进 L2 -> 环越大越慢。用 L2 预算把它们压到小 G (group 环减半、贴 L2); 小 case 环本来就小,
+    // 仍能拿到 G=4。L2_RING_BUDGET 按 910B 实测取 (case_03 432MB 不劣 / case_11 604MB 劣之间), 跨设备可调。
+    const size_t L2_RING_BUDGET = static_cast<size_t>(512) * 1024 * 1024;
+    const size_t ringBudget = std::min(mainWorkspaceSize, L2_RING_BUDGET);
+    int64_t groupRingDepth = 4;
+    for (int64_t candidate : {16, 8, 4}) {
+        if (actualWorkspaceForDepth(candidate) <= ringBudget) {
+            groupRingDepth = candidate;
+            break;
+        }
+    }
 
-    int dTQ = (qDtype == ge::DT_BF16) ? CHUNK_BWD_DQKWG_TPL_BF16 : CHUNK_BWD_DQKWG_TPL_FP16;
-    int dTG = (gDtype == ge::DT_FLOAT) ? CHUNK_BWD_DQKWG_TPL_FP32 : dTQ;
+    // ---- 仅针对劣化形状的 overlap 深度修复 (2026-06-28) ----
+    // 判别证据: case_10 (H=16/BT=128, G=2, ring~288MB) 不劣化; case_11/12 (H=32/BT=128) 被 512MB 预算压到
+    // G=1 (ring 也~288MB) 却 +6% 劣化。两者 ring 大小几乎相同 => 差异不在 ring 体积, 而在 overlap 深度:
+    // G=1 => 信用窗口 N=min(G,M)=1 => cube 只能领先 vector 1 个 task (近 lockstep); G=2 => N=2 真正重叠。
+    // (旁证: 历史实测 G=2 = +4.92% < 当前 G=1 = +6.29%。) 故把被压到 depth<8 的形状抬到 depth=8 (G=2), 对齐 case_10。
+    //
+    // **只改坏形状, 好 case 字节不变**: 此 if 仅命中"当前 groupRingDepth<8 且 main 容得下 depth=8"的形状 =>
+    //   - case_10 已是 depth=8 (8<8 false) -> 不变;
+    //   - case_01/03 等在 G=4=depth16 (16<8 false) -> 不变;
+    //   - tiny case footprint(8)>main -> 守卫挡掉 -> 不变;
+    //   - 唯独 case_11/12/24 (H=32/BT=128, 被预算压到 depth=4) 抬到 8。
+    const int64_t MIN_DEPTH_FOR_OVERLAP = 8;  // G=2 => N>=2, 对齐不劣化的 case_10
+    if (groupRingDepth < MIN_DEPTH_FOR_OVERLAP &&
+        actualWorkspaceForDepth(MIN_DEPTH_FOR_OVERLAP) <= mainWorkspaceSize) {
+        groupRingDepth = MIN_DEPTH_FOR_OVERLAP;
+    }
 
-    int v = static_cast<int>(tiling->V);
-    OP_LOGD(context->GetNodeName(), "V value: %d", v);
+    // short 环深自适应 (= 内核 DqkwgShortRingDepthFromGroup 同公式): dw/mm6/mul1 只需 2G-1 个 slot, 固定 8 严重过配。
+    // 大 H/大 BT 的 memory-bound case (G=1~2) 把 short 环砍掉一大半 -> 环贴近 L2 -> 缓解 FixPipe/MTE2 的 L2 miss。
+    const int64_t adaptiveShortDepth = (groupRingDepth / 2 >= 2) ? (groupRingDepth / 2) : 2;  // 2G (G=4→8 复现原值; G<4 收缩), 地板 2
+    const size_t shortBtxKSize = align32(static_cast<size_t>(ringCoreSlots) * adaptiveShortDepth * HV *BT * K * FP16_SIZE);
+    // mm7 改用 group 环 (与 mm5 同槽, 单写, stage B/D 时序错开), 故 mm5/mm7 共享区 = group 深度 (不再 max(group,short))。
+    const size_t sharedBtxKSize = align32(static_cast<size_t>(ringCoreSlots) * groupRingDepth * HV *BT * K * FP16_SIZE);
+    const size_t groupBtbSize = align32(static_cast<size_t>(ringCoreSlots) * groupRingDepth * HV *BT * BT * FP16_SIZE);
+    const size_t shortBtbSize = align32(static_cast<size_t>(ringCoreSlots) * adaptiveShortDepth * HV *BT * BT * FP16_SIZE);
+    size_t dgLastSize = align32(static_cast<size_t>(ringCoreSlots) * groupRingDepth * HV *FP32_SIZE);
 
-    uint64_t tilingKey = GET_TPL_TILING_KEY(strategyKey, dTQ, dTG, v);
-    context->SetTilingKey(tilingKey);
+    size_t offset = 0;
+    size_t wsDwOffset = offset;
+    offset += shortBtxKSize;
 
-    OP_LOGD(context->GetNodeName(), "tilingKey: %d", context->GetTilingKey());
-    ChunkBwdDqkwgTilingDataPrint(context, *tiling);
+    size_t wsMm5Offset = offset;
+    offset += sharedBtxKSize;
 
-    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
-    int64_t coreNum = static_cast<int64_t>(ascendcPlatform.GetCoreNumAic());
-    int64_t usedCoreNum = std::min(tiling->B * tiling->numChunks, coreNum);
-    context->SetBlockDim(usedCoreNum);
+    size_t wsDsTempOffset = offset;
+    offset += groupBtbSize;
 
-    uint32_t sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
-    uint32_t userWorkspaceSize = static_cast<uint32_t>(tiling->totalWorkspaceSize);
-    size_t *currentWorkspace = context->GetWorkspaceSizes(1);
-    currentWorkspace[0] = sysWorkspaceSize + userWorkspaceSize;
-    context->SetScheduleMode(1);
-    OP_LOGD(context->GetNodeName(), "TilingChunkBwdDqkwg end.");
+    size_t wsMul1Offset = offset;
+    offset += shortBtbSize;
+
+    size_t wsDgLastOffset = offset;
+    offset += dgLastSize;
+
+    size_t wsMm6Offset = wsDwOffset;
+    size_t wsMm7Offset = wsMm5Offset;
+    size_t totalUserWorkspace = offset;
+
+    // 设置 workspace 大小
+    size_t* workspaces = context->GetWorkspaceSizes(1);
+    workspaces[0] = static_cast<size_t>(sysWorkspaceSize + totalUserWorkspace);
+
+    // 设置 block 数量
+    context->SetBlockDim(aicNum);
+    context->SetScheduleMode(1); // mixed AIC/AIV schedule
+
+    // 填充 TilingData
+    ChunkBwdDqkwgTilingData tilingData;
+    tilingData.set_B(B);
+    tilingData.set_HV(HV);
+    tilingData.set_HK(HK);
+    tilingData.set_T(T);
+    tilingData.set_K(K);
+    tilingData.set_V(V);
+    tilingData.set_BT(BT);
+    tilingData.set_numChunks(numChunks);
+    tilingData.set_scale(scale);
+    tilingData.set_mul0RowNum(V == 256 ? 16 : 32);
+    tilingData.set_aicCoreNum(static_cast<uint32_t>(aicNum));
+
+    tilingData.set_wsDwOffset(wsDwOffset);
+    tilingData.set_wsBtxKSyncSlotsPerHead(static_cast<uint64_t>(groupRingDepth));
+    tilingData.set_wsDgLastOffset(wsDgLastOffset);
+    tilingData.set_dgLastSize(dgLastSize);
+    tilingData.set_wsMm5Offset(wsMm5Offset);
+    tilingData.set_wsDsTempOffset(wsDsTempOffset);
+    tilingData.set_totalWorkspaceSize(totalUserWorkspace);
+    tilingData.set_wsMm6Offset(wsMm6Offset);
+    tilingData.set_wsMm7Offset(wsMm7Offset);
+    tilingData.set_wsMul1Offset(wsMul1Offset);
+
+    // 检查是否有 cu_seqlens 输入来判断 IS_VARLEN
+    tilingData.set_isVarLen(isVarLen);
+
+    // 保存 tiling data
+    tilingData.SaveToBuffer(context->GetRawTilingData()->GetData(),
+                            context->GetRawTilingData()->GetCapacity());
+    context->GetRawTilingData()->SetDataSize(tilingData.GetDataSize());
+
     return ge::GRAPH_SUCCESS;
 }
 
+struct ChunkBwdDqkwgCompileInfo {};
 ASCENDC_EXTERN_C ge::graphStatus TilingParseChunkBwdDqkwg(gert::TilingParseContext* context) {
     (void)context;
     return ge::GRAPH_SUCCESS;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
+ * Copyright (c) 2026 Tianjin University, Ltd.
  * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
  * the BSD 3-Clause License (the "License").
  * Please refer to the License for details. You may not use this file except in compliance with the License.
@@ -9,14 +9,58 @@
 
 /*!
  * \file chunk_bwd_dqkwg_tiling.h
- * \brief ChunkBwdDqkwg Tiling 数据结构定义 (compatibility wrapper)
+ * \brief ChunkBwdDqkwg Tiling 数据结构定义
  */
 
 #ifndef CHUNK_BWD_DQKWG_TILING_H
 #define CHUNK_BWD_DQKWG_TILING_H
 
-#include "../op_kernel/chunk_bwd_dqkwg_struct.h"
+#include <exe_graph/runtime/tiling_context.h>
+#include <graph/utils/type_utils.h>
 
-using ChunkBwdDqkwgTilingData = GDN::ChunkBwdDqkwgTilingData;
+#include "register/tilingdata_base.h"
+#include "tiling/tiling_api.h"
+
+namespace optiling {
+
+BEGIN_TILING_DATA_DEF(ChunkBwdDqkwgTilingData)
+    // 基本形状参数
+    TILING_DATA_FIELD_DEF(uint64_t, B);              // batch size
+    TILING_DATA_FIELD_DEF(uint64_t, HV);             // value 侧 head 数 (v/g/h/do/dh/dv 及全部输出)
+    TILING_DATA_FIELD_DEF(uint64_t, HK);             // key/query 侧 head 数 (q/k), HV = n_ratio * HK
+    TILING_DATA_FIELD_DEF(uint64_t, T);              // sequence length
+    TILING_DATA_FIELD_DEF(uint64_t, K);              // key/query dimension
+    TILING_DATA_FIELD_DEF(uint64_t, V);              // value dimension
+    TILING_DATA_FIELD_DEF(uint64_t, BT);             // chunk size (tile size in T dimension)
+    TILING_DATA_FIELD_DEF(uint64_t, numChunks);      // T / BT
+
+    // scale 参数
+    TILING_DATA_FIELD_DEF(float, scale);             // 1.0 / sqrt(K)
+    TILING_DATA_FIELD_DEF(uint32_t, mul0RowNum);
+    TILING_DATA_FIELD_DEF(uint32_t, aicCoreNum);     // CV 深融合使用的 AIC blockDim (cube/vector 共用)
+
+    // Workspace 偏移量 (按字节)
+    TILING_DATA_FIELD_DEF(uint64_t, wsDwOffset);         // PartA: b_dw / 之后 PartC mm6 复用
+    TILING_DATA_FIELD_DEF(uint64_t, wsBtxKSyncSlotsPerHead); // cross-stage group ring depth per core
+    TILING_DATA_FIELD_DEF(uint64_t, wsDgLastOffset);     // PartA: b_dg_last 偏移
+    TILING_DATA_FIELD_DEF(uint64_t, dgLastSize);         // PartA: b_dg_last 大小, 32B 对齐
+    TILING_DATA_FIELD_DEF(uint64_t, wsMm5Offset);        // PartA: mm5 / 之后 PartD mm7 复用
+    TILING_DATA_FIELD_DEF(uint64_t, wsDsTempOffset);     // PartB: b_ds_temp 偏移
+    TILING_DATA_FIELD_DEF(uint64_t, wsMm6Offset);        // PartC: mm6 复用已释放的 wsDw
+    TILING_DATA_FIELD_DEF(uint64_t, wsMm7Offset);        // PartD: mm7 复用已释放的 wsMm5
+    TILING_DATA_FIELD_DEF(uint64_t, wsMul1Offset);       // independent short BT x BT ring for mul1
+
+    // 其他偏移
+    TILING_DATA_FIELD_DEF(uint64_t, totalWorkspaceSize); // 总 workspace 大小
+
+    // IS_VARLEN 相关
+    TILING_DATA_FIELD_DEF(uint64_t, isVarLen);           // 是否变长序列
+
+END_TILING_DATA_DEF;
+
+REGISTER_TILING_DATA_CLASS(ChunkBwdDqkwg, ChunkBwdDqkwgTilingData)
+
+
+}  // namespace optiling
 
 #endif  // CHUNK_BWD_DQKWG_TILING_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.h
@@ -26,7 +26,7 @@ namespace optiling {
 BEGIN_TILING_DATA_DEF(ChunkBwdDqkwgTilingData)
     // 基本形状参数
     TILING_DATA_FIELD_DEF(uint64_t, B);              // batch size
-    TILING_DATA_FIELD_DEF(uint64_t, HV);             // value 侧 head 数 (v/g/h/do/dh/dv 及全部输出)
+    TILING_DATA_FIELD_DEF(uint64_t, HV);             // value 侧 head 数 (v/g/h/do/dh/dv/dw/dg)
     TILING_DATA_FIELD_DEF(uint64_t, HK);             // key/query 侧 head 数 (q/k), HV = n_ratio * HK
     TILING_DATA_FIELD_DEF(uint64_t, T);              // sequence length
     TILING_DATA_FIELD_DEF(uint64_t, K);              // key/query dimension
@@ -44,9 +44,9 @@ BEGIN_TILING_DATA_DEF(ChunkBwdDqkwgTilingData)
     TILING_DATA_FIELD_DEF(uint64_t, wsBtxKSyncSlotsPerHead); // cross-stage group ring depth per core
     TILING_DATA_FIELD_DEF(uint64_t, wsDgLastOffset);     // PartA: b_dg_last 偏移
     TILING_DATA_FIELD_DEF(uint64_t, dgLastSize);         // PartA: b_dg_last 大小, 32B 对齐
-    TILING_DATA_FIELD_DEF(uint64_t, wsMm5Offset);        // PartA: mm5 / 之后 PartD mm7 复用
+    TILING_DATA_FIELD_DEF(uint64_t, wsMm5Offset);        // PartA: mm5 / GVA C: dq_inner / PartD: mm7
     TILING_DATA_FIELD_DEF(uint64_t, wsDsTempOffset);     // PartB: b_ds_temp 偏移
-    TILING_DATA_FIELD_DEF(uint64_t, wsMm6Offset);        // PartC: mm6 复用已释放的 wsDw
+    TILING_DATA_FIELD_DEF(uint64_t, wsMm6Offset);        // PartC: mm6 / GVA D: dk_inner
     TILING_DATA_FIELD_DEF(uint64_t, wsMm7Offset);        // PartD: mm7 复用已释放的 wsMm5
     TILING_DATA_FIELD_DEF(uint64_t, wsMul1Offset);       // independent short BT x BT ring for mul1
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
+ * Copyright (c) 2026 Tianjin University, Ltd.
  * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
  * the BSD 3-Clause License (the "License").
  * Please refer to the License for details. You may not use this file except in compliance with the License.
@@ -11,129 +11,77 @@
  * \file chunk_bwd_dqkwg.cpp
  */
 
-#include "chunk_bwd_dqkwg_struct.h"
-#include "chunk_bwd_dqkwg_common.h"
-#include "chunk_bwd_dqkwg_cube.h"
-#include "chunk_bwd_dqkwg_vector.h"
-#ifndef TORCH_MODE
-#include "lib/matmul_intf.h"
-#endif
+ #include "kernel_operator.h"
+ #include "chunk_bwd_dqkwg_common.h"
+ #include "chunk_bwd_dqkwg_cube.h"
+ #include "chunk_bwd_dqkwg_vector.h"
+ #include "lib/matmul_intf.h"
 
-namespace GDN {
+ using namespace AscendC;
 
-template <typename QKVT, typename GT, int V, typename Strategy>
-__aicore__ inline void ChunkBwdDqkwgKernelImpl(
-    GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
-    GM_ADDR do_, GM_ADDR dh, GM_ADDR dv,
-    GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
-    GM_ADDR w, GM_ADDR g_gamma,
-    GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
-    GM_ADDR workspace, const ChunkBwdDqkwgTilingData *tilingData,
-    Strategy strategy)
-{
-    if ASCEND_IS_AIC {
-        ChunkBwdDqkwgCubeProcess<QKVT, GT> cubeProcess(
-            q, k, v, g, h,
-            do_, dh, dv, cu_seqlens, chunk_indices,
-            dq, dk, dw, dg,
-            workspace
-        );
-        cubeProcess.Init(*tilingData);
-        cubeProcess.Process();
-    }
-    if ASCEND_IS_AIV {
-        AscendC::TPipe tPipe;
-        ChunkBwdDqkwgVectorProcess<QKVT, GT> vectorProcess(
-            q, k, v, g, h,
-            do_, dh, dv, cu_seqlens, chunk_indices, nullptr,
-            dq, dk, dw, dg,
-            workspace
-        );
-        vectorProcess.Init(*tilingData, &tPipe);
-        vectorProcess.Process();
-    }
-}
 
-template <int D_T>
-struct DTypeTraitsDqkwg;
+ __global__ __aicore__ void chunk_bwd_dqkwg(
+     GM_ADDR q,              // [B, HK, T, K]
+     GM_ADDR k,              // [B, HK, T, K]
+     GM_ADDR v,              // [B, HV, T, V]
+     GM_ADDR g,              // [B, HV, T]
+     GM_ADDR h,              // [B, HV, num_chunks, K, V]
+     GM_ADDR do_,            // [B, HV, T, V]
+     GM_ADDR dh,             // [B, HV, num_chunks, K, V]
+     GM_ADDR dv,             // [B, HV, T, V]
+     GM_ADDR cu_seqlens,     // [N+1] (optional)
+     GM_ADDR chunk_indices,  // [num_chunks, 2] (optional)
+     GM_ADDR w,
+     GM_ADDR g_gamma,
+     GM_ADDR dq,             // [B, HV, T, K] - output
+     GM_ADDR dk,             // [B, HV, T, K] - output
+     GM_ADDR dw,             // [B, HV, T, K] - output
+     GM_ADDR dg,             // [B, HV, T] - output (fp32)
+     GM_ADDR workspace,      // workspace buffer
+     GM_ADDR tiling          // . data
+ )
+ {
 
-template <>
-struct DTypeTraitsDqkwg<CHUNK_BWD_DQKWG_TPL_BF16> {
-    using type = bfloat16_t;
-};
+     // 设置溢出处理
+     AscendCUtils::SetOverflow(1);
 
-template <>
-struct DTypeTraitsDqkwg<CHUNK_BWD_DQKWG_TPL_FP16> {
-    using type = half;
-};
+     // 根据 TilingKey 选择执行路径
+     if (TILING_KEY_IS(1)) {
 
-template <>
-struct DTypeTraitsDqkwg<CHUNK_BWD_DQKWG_TPL_FP32> {
-    using type = float;
-};
+         // 使用 C-V 融合模式
+         KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
+         GET_TILING_DATA(tilingData, tiling);
+         GM_ADDR userWorkspace = AscendC::GetUserWorkspace(workspace);
+         if (userWorkspace == nullptr) {
+             return;
+         }
+         // AIC (Cube) 端执行
 
-template <uint64_t strategy, int D_T_Q, int D_T_G, int V>
-struct ChunkBwdDqkwgDispatch;
+         if ASCEND_IS_AIC {
+             ChunkBwdDqkwgCubeProcess<DTYPE_Q, DTYPE_G> cubeProcess(
+                 q, k, v, g, h,
+                 do_, dh, dv, cu_seqlens, chunk_indices,
+                 dq, dk, dw, dg,
+                 userWorkspace
+             );
+             cubeProcess.Init(tilingData);
+             cubeProcess.Process();
+         }
 
-template <int D_T_Q, int D_T_G, int V>
-struct ChunkBwdDqkwgDispatch<CHUNK_BWD_DQKWG_STRATEGY_FIX_LEN, D_T_Q, D_T_G, V> {
-    __aicore__ inline static void Invoke(
-        GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
-        GM_ADDR do_, GM_ADDR dh, GM_ADDR dv,
-        GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
-        GM_ADDR w, GM_ADDR g_gamma,
-        GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
-        GM_ADDR userWS, const ChunkBwdDqkwgTilingData *tilingData)
-    {
-        FixedLengthStrategy fixedStrategy{tilingData->BT, tilingData->T, tilingData->numChunks, tilingData->HV};
-        ChunkBwdDqkwgKernelImpl<typename DTypeTraitsDqkwg<D_T_Q>::type, typename DTypeTraitsDqkwg<D_T_G>::type, V>(
-            q, k, v, g, h, do_, dh, dv, cu_seqlens, chunk_indices, w, g_gamma,
-            dq, dk, dw, dg, userWS, tilingData, fixedStrategy);
-    }
-};
+         // AIV (Vector) 端执行
+         if ASCEND_IS_AIV {
+             TPipe tPipe; // 创建 TPipe 用于 Vector 端流水
+             ChunkBwdDqkwgVectorProcess<DTYPE_Q, DTYPE_G> vectorProcess(
+                 q, k, v, g, h,
+                 do_, dh, dv, cu_seqlens, chunk_indices, nullptr,        //mask = nullptr
+                 dq, dk, dw, dg,
+                 userWorkspace
+             );
+             vectorProcess.Init(tilingData, &tPipe);
+             vectorProcess.Process();
+         }
 
-template <int D_T_Q, int D_T_G, int V>
-struct ChunkBwdDqkwgDispatch<CHUNK_BWD_DQKWG_STRATEGY_VAR_LEN, D_T_Q, D_T_G, V> {
-    __aicore__ inline static void Invoke(
-        GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
-        GM_ADDR do_, GM_ADDR dh, GM_ADDR dv,
-        GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
-        GM_ADDR w, GM_ADDR g_gamma,
-        GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
-        GM_ADDR userWS, const ChunkBwdDqkwgTilingData *tilingData)
-    {
-        VariableLengthStrategy variableStrategy{tilingData->BT, tilingData->T, tilingData->numChunks,
-                                                 cu_seqlens, chunk_indices};
-        ChunkBwdDqkwgKernelImpl<typename DTypeTraitsDqkwg<D_T_Q>::type, typename DTypeTraitsDqkwg<D_T_G>::type, V>(
-            q, k, v, g, h, do_, dh, dv, cu_seqlens, chunk_indices, w, g_gamma,
-            dq, dk, dw, dg, userWS, tilingData, variableStrategy);
-    }
-};
+     }
 
-} // namespace GDN
-
-#ifndef TORCH_MODE
-template <uint64_t strategy, int D_T_Q, int D_T_G, int V>
-__global__ __aicore__ void chunk_bwd_dqkwg(
-    GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
-    GM_ADDR do_, GM_ADDR dh, GM_ADDR dv,
-    GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
-    GM_ADDR w, GM_ADDR g_gamma,
-    GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
-    GM_ADDR workspace, GM_ADDR tiling)
-{
-    GM_ADDR userWS = AscendC::GetUserWorkspace(workspace);
-    if (userWS == nullptr) {
-        return;
-    }
-    REGISTER_TILING_DEFAULT(GDN::ChunkBwdDqkwgTilingData);
-    GET_TILING_DATA_WITH_STRUCT(GDN::ChunkBwdDqkwgTilingData, tilingData, tiling);
-    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
-
-    AscendCUtils::SetOverflow(1);
-
-    GDN::ChunkBwdDqkwgDispatch<strategy, D_T_Q, D_T_G, V>::Invoke(
-        q, k, v, g, h, do_, dh, dv, cu_seqlens, chunk_indices, w, g_gamma,
-        dq, dk, dw, dg, userWS, &tilingData);
-}
-#endif
+     return;
+ }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg.cpp
@@ -33,8 +33,8 @@
      GM_ADDR chunk_indices,  // [num_chunks, 2] (optional)
      GM_ADDR w,
      GM_ADDR g_gamma,
-     GM_ADDR dq,             // [B, HV, T, K] - output
-     GM_ADDR dk,             // [B, HV, T, K] - output
+     GM_ADDR dq,             // [B, HK, T, K] - output
+     GM_ADDR dk,             // [B, HK, T, K] - output
      GM_ADDR dw,             // [B, HV, T, K] - output
      GM_ADDR dg,             // [B, HV, T] - output (fp32)
      GM_ADDR workspace,      // workspace buffer

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_common.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_common.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
+ * Copyright (c) 2026 Tianjin University, Ltd.
  * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
  * the BSD 3-Clause License (the "License").
  * Please refer to the License for details. You may not use this file except in compliance with the License.
@@ -12,171 +12,200 @@
  * \brief ChunkBwdDqkwg 通用常量和定义
  */
 
-#ifndef CHUNK_BWD_DQKWG_COMMON_H
-#define CHUNK_BWD_DQKWG_COMMON_H
+ #ifndef CHUNK_BWD_DQKWG_COMMON_H
+ #define CHUNK_BWD_DQKWG_COMMON_H
 
-#include "kernel_operator.h"
-#include "chunk_bwd_dqkwg_struct.h"
+ #include "kernel_operator.h"
 
-constexpr uint64_t CONST_B = 1;
-constexpr uint64_t CONST_HV = 4;
-constexpr uint64_t CONST_HK = 4;
-constexpr uint64_t CONST_T = 2816;
-constexpr uint64_t CONST_K = 128;
-constexpr uint64_t CONST_V = 128;
-constexpr uint64_t CONST_BT = 64;
-constexpr uint64_t CONST_NUM_CHUNKS = 44;
-constexpr int32_t CAL_NUM_FLOAT = 64;
-constexpr uint64_t SYNC_PART1_AIC_AIV = 10;
-constexpr uint64_t SYNC_PART1_AIV_AIC = 11;
-constexpr uint64_t SYNC_PART2_AIC_AIV = 20;
-constexpr uint64_t SYNC_PART2_AIV_AIC = 21;
-constexpr uint64_t SYNC_PART3_AIC_AIV = 30;
-constexpr uint64_t SYNC_PART3_AIV_AIC = 31;
-constexpr uint64_t SYNC_PART4_AIC_AIV = 40;
-constexpr uint64_t SYNC_PART4_AIV_AIC = 41;
-constexpr uint64_t SYNC_PART5_AIC_AIV = 50;
-constexpr uint64_t SYNC_PART5_AIV_AIC = 51;
-constexpr uint64_t SYNC_PART6_AIC_AIV = 60;
-constexpr uint64_t SYNC_PART6_AIV_AIC = 61;
-constexpr uint64_t SYNC_PART7_AIC_AIV = 70;
-constexpr uint64_t SYNC_PART7_AIV_AIC = 71;
-constexpr uint64_t SYNC_AIV_AIC_FLAG_0 = 3;
-constexpr uint64_t SYNC_AIC_AIV_FLAG_0 = 5;
+ constexpr uint64_t CONST_B = 1;
+ constexpr uint64_t CONST_HV = 4;
+ constexpr uint64_t CONST_HK = 4;
+ constexpr uint64_t CONST_T = 2816;
+ constexpr uint64_t CONST_K = 128;
+ constexpr uint64_t CONST_V = 128;
+ constexpr uint64_t CONST_BT = 64;
+ constexpr uint64_t CONST_NUM_CHUNKS = 44;//CONST_T / CONST_BT;  // 32
+ constexpr int32_t CAL_NUM_FLOAT = 64; // API一次能处理256B，能计算64个float元素
 
-constexpr uint32_t UB_SIZE = 192 * 1024;
-constexpr uint32_t ONE_BLOCK_32 = 32;
-constexpr uint32_t FP32_PER_REPEAT = 64;
-constexpr uint32_t FP16_PER_BLOCK = 16;
+ // ============================================================================
+ // CV 深融合同步信号 (chunk-interleaved A/B/C/D pipeline) —— raw 信用流水 (与基线同机制)
+ //
+ // 每个 mixed core 取自己的 chunk 子集; 任务流按 part-major / chunk-minor, 跨 4 stage 连续:
+ //   task = [A(c0..cM-1), B(c0..cM-1), C(c0..cM-1), D(c0..cM-1)]  (L = 4*M), 无 SyncAll。
+ //
+ // 为什么用 raw 信用 flag 而不是 CrossCoreFlagWithReverse:
+ //   反转 flag (prepare_wy 用) 本质是相位翻转的"近 lockstep 屏障", prepare_wy 的真正并发来自
+ //   workspace 双缓冲 (workspaceBufferCount=2) 让 AIC 写 task i+1 的 slot 同时 AIV 读 task i 的 slot。
+ //   本算子单次 per-chunk 反转握手 + 全量寻址没有这种错位, 反转 flag 会把 cube/vector 压成 lockstep
+ //   (窗口≈0) => 退化为串行 (cube_total + vector_total) => 性能劣化。
+ //   raw 信用 flag 是计数信号量 (与基线 new_dqkwg/main 完全相同的机制): vector 预置 N 个信用,
+ //   cube 每 task 先 WaitCredit (消耗 1 信用) 再算, 算完 SetReady; 这样 cube 可真正领先 vector N 个 task,
+ //   实现重叠。
+ //
+ // 信用流水 (连续, 单次预置/无 drain):
+ //   vector 启动时 (stage A 之前) 预置 N 个信用 (每个 AIV sub-block 各 SetCredit N 次, 0x2)。
+ //   cube  每 task : WaitCredit(节流到领先 <=N) -> 算该 chunk 全部 head -> SetCubeReady (PIPE_FIX)。
+ //   vector每 task : WaitCubeReady -> 处理全部 head -> SetVecCredit (PIPE_MTE3, 回 1 信用)。
+ //   计数: cube WaitCredit L 次; vector SetCredit (预置 N + L) 次 => 末尾余 N 信用 (单次 launch 无害,
+ //         无需 drain, 不会死锁)。cube SetCubeReady L 次 == 每 AIV sub-block WaitCubeReady L 次。
+ //
+ // 窗口 N 与正确性:
+ //   N <= M (每核 chunk 数) 保证 cube 领先不超过 M, 从而 C_cube(c)=task 2M+c 计算时 vector 已完成
+ //   >= 2M+c-N >= M+c = B_vector(c) => ds_temp(c) 已就绪; 同理 mm6 复用 wsDw、mm7 复用 wsMm5 安全。
+ //   In group mode N = min(groupSize, M), so C/D cannot outrun B_vector.
+ // ============================================================================
+ constexpr uint64_t SYNC_AIC_AIV_FLAG_0 = 5;  // cube -> vector: 数据 ready (与基线一致)
+ constexpr uint64_t SYNC_AIV_AIC_FLAG_0 = 3;  // vector -> cube: 信用 credit (与基线一致)
 
-constexpr uint32_t FP16_SIZE = 2;
-constexpr uint32_t FP32_SIZE = 4;
-constexpr uint32_t BF16_SIZE = 2;
+ // Cross-stage temporaries use a per-core group-aligned ring. Short-lived
+ // temporaries use an independent shallow ring. The host passes the cross ring
+ // depth in wsBtxKSyncSlotsPerHead; short depth is fixed here.
+ constexpr uint32_t DqkwgShortRingDepth = 8;
 
-#define CEIL_DIV(x, y) (((x) + (y) - 1) / (y))
-#define ALIGN_UP(x, align) (((x) + (align) - 1) / (align) * (align))
+ // short 环深自适应: dw/mm6/mul1 的存活窗口只需 2G-1 个 slot (G=groupRingDepth/4)。固定 8 是按最大 G=4 配的,
+ // 但大 H / 大 BT 的 memory-bound case 实际 G=1~2 时, 深度 8 严重过配 -> 环装不进 L2 -> FixPipe/MTE2 疯狂 miss。
+ // 按 G 收缩到 2G-1 (地板 2, 保证 G=1 时仍有双缓冲) 可大幅减小环、贴近 L2。cube/vector/tiling 必须用同一公式。
+ __aicore__ inline uint32_t DqkwgShortRingDepthFromGroup(uint32_t groupRingDepth) {
+     uint32_t d = groupRingDepth / 2;               // = 2G (>= 2G-1 所需余量; G=4 时 =8 复现原值, G<4 时收缩)
+     return d >= 2 ? d : 2;                         // 地板 2 (G=1 仍保双缓冲)
+ }
 
-template<typename T>
-struct TypeTraits {
-    using ComputeType = float;
-    static constexpr bool needsCast = true;
-};
+ // ---- chunk-group-major: group each core's chunks and run A->B->C->D in-group ----
+ // G = crossRingDepth / 4. The final group may merge a small tail, so short
+ // rings must have at least 2G-1 slots for the largest supported G=4.
+ __aicore__ inline uint32_t DqkwgGroupSizeFromRingDepth(uint32_t ringDepth) {
+     uint32_t groupSize = ringDepth / 4;
+     return groupSize == 0 ? 1 : groupSize;
+ }
 
-template<>
-struct TypeTraits<half> {
-    using ComputeType = float;
-    static constexpr bool needsCast = true;
-};
+ // Given this core's current group start, return the group end (exclusive).
+ // Cube/vector must use the same grouping so ready/credit order and ring slots
+ // match exactly.
+ __aicore__ inline uint32_t DqkwgGroupEnd(uint32_t loopBase, uint32_t coreLoops, uint32_t coreNum, uint32_t ringDepth) {
+     if (loopBase >= coreLoops || coreNum == 0) { return coreLoops; }
+     uint32_t groupSize = DqkwgGroupSizeFromRingDepth(ringDepth);
+     uint32_t left = (coreLoops - loopBase + coreNum - 1) / coreNum;     // 本核从 loopBase 起还剩几个 chunk
+     uint32_t take = (left <= 2 * groupSize - 1) ? left : groupSize;  // 尾巴合并: 剩 <=2G-1 整块取完
+     uint32_t end = loopBase + take * coreNum;
+     return (end < coreLoops) ? end : coreLoops;
+ }
 
-namespace GDN {
+ __aicore__ inline uint64_t DqkwgGroupRingSlot(uint32_t coreIdx, uint32_t loopBase, uint32_t loopIdx,
+                                               uint32_t coreNum, uint32_t ringDepth) {
+     uint32_t groupSize = DqkwgGroupSizeFromRingDepth(ringDepth);
+     uint32_t firstChunk = (coreNum != 0) ? ((loopBase - coreIdx) / coreNum) : 0;
+     uint32_t parity = (firstChunk / groupSize) % 2;
+     uint32_t pos = (coreNum != 0) ? ((loopIdx - loopBase) / coreNum) : 0;
+     uint64_t slotInCore = (uint64_t)parity * (2 * groupSize) + (uint64_t)pos;
+     return (uint64_t)coreIdx * ringDepth + slotInCore;
+ }
 
-__aicore__ inline int64_t CeilDiv(int64_t dividend, int64_t divisor)
-{
-    if (unlikely(divisor == 0)) {
-        return 0;
-    }
-    return (dividend + divisor - 1) / divisor;
-}
+ __aicore__ inline uint64_t DqkwgShortRingSlot(uint32_t coreIdx, uint32_t loopIdx, uint32_t coreNum,
+                                               uint32_t shortRingDepth) {
+     uint32_t j = (coreNum != 0) ? ((loopIdx - coreIdx) / coreNum) : 0;
+     return (uint64_t)coreIdx * shortRingDepth + (uint64_t)(j % shortRingDepth);
+ }
 
-struct IndexResult {
-    int64_t curBatchId;
-    int64_t curTokenId;
-    int64_t chunkLen;
+ __aicore__ inline uint64_t DqkwgBtxKRingElemOffset(uint32_t coreIdx, uint32_t loopBase, uint32_t loopIdx,
+                                                    uint32_t coreNum, uint32_t h, uint64_t H, uint64_t BT, uint64_t K,
+                                                    uint32_t ringDepth) {
+     uint64_t slot = DqkwgGroupRingSlot(coreIdx, loopBase, loopIdx, coreNum, ringDepth);
+     return (slot * H + (uint64_t)h) * (BT * K);
+ }
 
-    __aicore__ inline IndexResult() : curBatchId(0), curTokenId(0), chunkLen(0)
-    {
-    }
+ __aicore__ inline uint64_t DqkwgBtbRingElemOffset(uint32_t coreIdx, uint32_t loopBase, uint32_t loopIdx,
+                                                   uint32_t coreNum, uint32_t h, uint64_t H, uint64_t BT,
+                                                   uint32_t ringDepth) {
+     uint64_t slot = DqkwgGroupRingSlot(coreIdx, loopBase, loopIdx, coreNum, ringDepth);
+     return (slot * H + (uint64_t)h) * (BT * BT);
+ }
 
-    __aicore__ inline IndexResult(int64_t curBatchId_, int64_t curTokenId_, int64_t chunkLen_)
-        : curBatchId(curBatchId_), curTokenId(curTokenId_), chunkLen(chunkLen_)
-    {
-    }
-};
+ __aicore__ inline uint64_t DqkwgScalarRingElemOffset(uint32_t coreIdx, uint32_t loopBase, uint32_t loopIdx,
+                                                      uint32_t coreNum, uint32_t h, uint64_t H,
+                                                      uint32_t ringDepth) {
+     uint64_t slot = DqkwgGroupRingSlot(coreIdx, loopBase, loopIdx, coreNum, ringDepth);
+     return slot * H + (uint64_t)h;
+ }
 
-struct FixedLengthStrategy {
-    int64_t chunkSize;
-    int64_t lenT;
-    int64_t chunkNumForT;
-    int64_t chunkLenTail;
-    int64_t HV;
+ __aicore__ inline uint64_t DqkwgShortBtxKRingElemOffset(uint32_t coreIdx, uint32_t loopIdx, uint32_t coreNum,
+                                                         uint32_t h, uint64_t H, uint64_t BT, uint64_t K,
+                                                         uint32_t shortRingDepth) {
+     uint64_t slot = DqkwgShortRingSlot(coreIdx, loopIdx, coreNum, shortRingDepth);
+     return (slot * H + (uint64_t)h) * (BT * K);
+ }
 
-    __aicore__ inline FixedLengthStrategy(int64_t chunkSize_, int64_t lenT_, int64_t chunkNumForT_, int64_t HV_ = 0)
-        : chunkSize(chunkSize_), lenT(lenT_), chunkNumForT(chunkNumForT_), HV(HV_)
-    {
-        chunkLenTail = lenT - (chunkNumForT - 1) * chunkSize;
-    }
+ __aicore__ inline uint64_t DqkwgShortBtbRingElemOffset(uint32_t coreIdx, uint32_t loopIdx, uint32_t coreNum,
+                                                        uint32_t h, uint64_t H, uint64_t BT,
+                                                        uint32_t shortRingDepth) {
+     uint64_t slot = DqkwgShortRingSlot(coreIdx, loopIdx, coreNum, shortRingDepth);
+     return (slot * H + (uint64_t)h) * (BT * BT);
+ }
 
-    __aicore__ inline void calculate(int64_t loopIdx, IndexResult &result) const
-    {
-        int64_t curChunkId = loopIdx % chunkNumForT;
-        int64_t bIdx = loopIdx / chunkNumForT;
-        result.curTokenId = curChunkId * chunkSize;
-        result.chunkLen = curChunkId == chunkNumForT - 1 ? chunkLenTail : chunkSize;
-        result.curBatchId = bIdx;
-    }
-};
+ // cube 端: 产出 ready (FixPipe 写回 GM 后) / 取一个信用 (节流, 默认 wait 模式与基线一致)
+ __aicore__ inline void SetCubeReady() {
+     AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+ }
+ __aicore__ inline void WaitCredit() {
+     AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+ }
+ // vector 端: 等待 cube ready (MTE2 读 GM 前) / 回一个信用 (MTE3 写 GM 后)
+ __aicore__ inline void WaitCubeReady() {
+     AscendC::CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
+ }
+ __aicore__ inline void SetVecCredit() {
+     AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
+ }
 
-struct VariableLengthStrategy {
-    int64_t chunkSize;
-    int64_t lenT;
-    int64_t chunkNumForT;
-    AscendC::GlobalTensor<int64_t> cuSeqlensGm;
-    AscendC::GlobalTensor<int64_t> chunkIndicesGm;
+ constexpr uint32_t UB_SIZE = 192 * 1024;  // 192KB
+ constexpr uint32_t ONE_BLOCK_32 = 32;
+ constexpr uint32_t FP32_PER_REPEAT = 64;
+ constexpr uint32_t FP16_PER_BLOCK = 16;  // 32 bytes / 2 bytes per fp16
 
-    __aicore__ inline VariableLengthStrategy(int64_t chunkSize_, int64_t lenT_, int64_t chunkNumForT_,
-                                             GM_ADDR cuSeqlens_, GM_ADDR chunkIndices_)
-    {
-        chunkSize = chunkSize_;
-        lenT = lenT_;
-        chunkNumForT = chunkNumForT_;
-        cuSeqlensGm.SetGlobalBuffer((__gm__ int64_t *)cuSeqlens_);
-        chunkIndicesGm.SetGlobalBuffer((__gm__ int64_t *)chunkIndices_);
-    }
+ constexpr uint32_t FP16_SIZE = 2;
+ constexpr uint32_t FP32_SIZE = 4;
+ constexpr uint32_t BF16_SIZE = 2;
 
-    __aicore__ inline void calculate(int64_t loopIdx, IndexResult &result) const
-    {
-        int64_t curSeqId = chunkIndicesGm.GetValue(loopIdx * 2);
-        int64_t curSeqChunkId = chunkIndicesGm.GetValue(loopIdx * 2 + 1);
-        int64_t bos = cuSeqlensGm.GetValue(curSeqId);
-        int64_t eos = cuSeqlensGm.GetValue(curSeqId + 1);
-        int64_t curSeqT = eos - bos;
-        int64_t chunkStartToken = curSeqChunkId * chunkSize;
-        int64_t chunkEndToken = chunkStartToken + chunkSize;
-        chunkEndToken = chunkEndToken > curSeqT ? curSeqT : chunkEndToken;
-        result.curBatchId = 0;
-        result.curTokenId = bos + chunkStartToken;
-        result.chunkLen = chunkEndToken - chunkStartToken;
-    }
-};
+ #define CEIL_DIV(x, y) (((x) + (y) - 1) / (y))
+ #define ALIGN_UP(x, align) (((x) + (align) - 1) / (align) * (align))
 
-} // namespace GDN
+ template<typename T>
+ struct TypeTraits {
+     using ComputeType = float;  // 默认计算类型为 fp32
+     static constexpr bool needsCast = true;
+ };
 
-__aicore__ void inline GetChunkOffset(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, uint64_t B, uint64_t HV, uint64_t T,
-                                      uint64_t chunkSize, uint32_t loopIdx, uint32_t &bos, uint32_t &eos)
-{
-    if (cu_seqlens == nullptr) {
-        uint32_t coreLoopsInB = CEIL_DIV(T, chunkSize);
-        uint32_t chunkIdx = loopIdx % coreLoopsInB;
-        uint32_t bIdx = loopIdx / coreLoopsInB;
-        bos = chunkIdx * chunkSize;
-        eos = bos + chunkSize > T ? T : bos + chunkSize;
-        bos += (bIdx * HV * T);
-        eos += (bIdx * HV * T);
-    } else {
-        AscendC::GlobalTensor<uint64_t> cuSeqlensTensor;
-        AscendC::GlobalTensor<uint64_t> chunkIndicesTensor;
-        cuSeqlensTensor.SetGlobalBuffer((__gm__ uint64_t *)cu_seqlens);
-        chunkIndicesTensor.SetGlobalBuffer((__gm__ uint64_t *)chunk_indices);
+ template<>
+ struct TypeTraits<half> {
+     using ComputeType = float;
+     static constexpr bool needsCast = true;
+ };
 
-        uint32_t seqIdx = chunkIndicesTensor.GetValue(2 * loopIdx);
-        uint32_t chunkIdx = chunkIndicesTensor.GetValue(2 * loopIdx + 1);
-        uint32_t curSeqBegin = cuSeqlensTensor.GetValue(seqIdx);
-        uint32_t curSeqEnd = cuSeqlensTensor.GetValue(seqIdx + 1);
-        bos = curSeqBegin + chunkIdx * chunkSize;
-        eos = bos + chunkSize > curSeqEnd ? curSeqEnd : bos + chunkSize;
-    }
+ __aicore__ void inline GetChunkOffset(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, uint64_t B, uint64_t HV, uint64_t T,
+                                       uint64_t chunkSize, uint32_t loopIdx, uint32_t &bos, uint32_t &eos)
+ {
+     if (cu_seqlens == nullptr) {
+         uint32_t coreLoopsInB = CEIL_DIV(T, chunkSize);
+         uint32_t chunkIdx = loopIdx % coreLoopsInB;
+         uint32_t bIdx = loopIdx / coreLoopsInB;
+         bos = chunkIdx * chunkSize;
+         eos = bos + chunkSize > T ? T : bos + chunkSize;
+         bos += (bIdx * HV * T);
+         eos += (bIdx * HV * T);
+     } else {
+         AscendC::GlobalTensor<uint64_t> cuSeqlensTensor;
+         AscendC::GlobalTensor<uint64_t> chunkIndicesTensor;
+         cuSeqlensTensor.SetGlobalBuffer((__gm__ uint64_t *)cu_seqlens);
+         chunkIndicesTensor.SetGlobalBuffer((__gm__ uint64_t *)chunk_indices);
 
-    return;
-}
+         uint32_t seqIdx = chunkIndicesTensor.GetValue(2 * loopIdx);
+         uint32_t chunkIdx = chunkIndicesTensor.GetValue(2 * loopIdx + 1);
+         uint32_t curSeqBegin = cuSeqlensTensor.GetValue(seqIdx);
+         uint32_t curSeqEnd = cuSeqlensTensor.GetValue(seqIdx + 1);
+         bos = curSeqBegin + chunkIdx * chunkSize;
+         eos = bos + chunkSize > curSeqEnd ? curSeqEnd : bos + chunkSize;
+     }
 
-#endif  // CHUNK_BWD_DQKWG_COMMON_H
+     return;
+ }
+
+ #endif  // CHUNK_BWD_DQKWG_COMMON_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
+ * Copyright (c) 2026 Tianjin University, Ltd.
  * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
  * the BSD 3-Clause License (the "License").
  * Please refer to the License for details. You may not use this file except in compliance with the License.
@@ -11,799 +11,886 @@
  * \file chunk_bwd_dqkwg_cube.h
  */
 
-#ifndef CHUNK_BWD_DQKWG_CUBE_H
-#define CHUNK_BWD_DQKWG_CUBE_H
+ #ifndef CHUNK_BWD_DQKWG_CUBE_H
+ #define CHUNK_BWD_DQKWG_CUBE_H
 
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
-    #define CATLASS_ARCH 3510
-#include "chunk_bwd_dqkwg_common.h"
-#include "catlass/arch/arch.hpp"
-#include "catlass/catlass.hpp"
-#include "catlass/gemm/block/block_mmad.hpp"
-#include "catlass/gemm/block/block_swizzle.hpp"
-#include "catlass/gemm/device/device_gemm.hpp"
-#include "catlass/gemm/dispatch_policy.hpp"
-#include "catlass/gemm/gemm_type.hpp"
-#include "catlass/layout/layout.hpp"
-#include "catlass/status.hpp"
-#include "tla/layout.hpp"
-#include "tla/tensor.hpp"
- using _0 = tla::Int<0>;
- 	 using _1 = tla::Int<1>;
- 	 using _2 = tla::Int<2>;
- 	 using _4 = tla::Int<4>;
- 	 using _8 = tla::Int<8>;
- 	 using _16 = tla::Int<16>;
- 	 using _32 = tla::Int<32>;
- 	 using _64 = tla::Int<64>;
- 	 using _128 = tla::Int<128>;
- 	 using _256 = tla::Int<256>;
- 	 using _512 = tla::Int<512>;
- 	 using _1024 = tla::Int<1024>;
- 	 using _2048 = tla::Int<2048>;
- 	 using _4096 = tla::Int<4096>;
- 	 using _8192 = tla::Int<8192>;
- 	 using _16384 = tla::Int<16384>;
- 	 using _32768 = tla::Int<32768>;
- 	 using _65536 = tla::Int<65536>;
- 	 #else
- 	 #define CATLASS_ARCH 2201
- 	 #include "chunk_bwd_dqkwg_common.h"
- 	 #include "catlass/arch/arch.hpp"
- 	 #include "catlass/catlass.hpp"
- 	 #include "catlass/gemm/block/block_mmad.hpp"
- 	 #include "catlass/gemm/block/block_swizzle.hpp"
- 	 #include "catlass/gemm/device/device_gemm.hpp"
- 	 #include "catlass/gemm/dispatch_policy.hpp"
- 	 #include "catlass/gemm/gemm_type.hpp"
- 	 #include "catlass/layout/layout.hpp"
- 	 #include "catlass/status.hpp"
- 	 #include "tla/layout.hpp"
- 	 #include "tla/tensor.hpp"
- 	 #endif
-using namespace tla;
-using namespace Catlass;
-using namespace AscendC;
+ #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+     #define CATLASS_ARCH 3510
+ #include "chunk_bwd_dqkwg_common.h"
+ #include "catlass/arch/arch.hpp"
+ #include "catlass/catlass.hpp"
+ #include "catlass/gemm/block/block_mmad.hpp"
+ #include "catlass/gemm/block/block_swizzle.hpp"
+ #include "catlass/gemm/device/device_gemm.hpp"
+ #include "catlass/gemm/dispatch_policy.hpp"
+ #include "catlass/gemm/gemm_type.hpp"
+ #include "catlass/layout/layout.hpp"
+ #include "catlass/status.hpp"
+ #include "tla/layout.hpp"
+ #include "tla/tensor.hpp"
+  using _0 = tla::Int<0>;
+       using _1 = tla::Int<1>;
+       using _2 = tla::Int<2>;
+       using _4 = tla::Int<4>;
+       using _8 = tla::Int<8>;
+       using _16 = tla::Int<16>;
+       using _32 = tla::Int<32>;
+       using _64 = tla::Int<64>;
+       using _128 = tla::Int<128>;
+       using _256 = tla::Int<256>;
+       using _512 = tla::Int<512>;
+       using _1024 = tla::Int<1024>;
+       using _2048 = tla::Int<2048>;
+       using _4096 = tla::Int<4096>;
+       using _8192 = tla::Int<8192>;
+       using _16384 = tla::Int<16384>;
+       using _32768 = tla::Int<32768>;
+       using _65536 = tla::Int<65536>;
+       #else
+       #define CATLASS_ARCH 2201
+       #include "chunk_bwd_dqkwg_common.h"
+       #include "catlass/arch/arch.hpp"
+       #include "catlass/catlass.hpp"
+       #include "catlass/gemm/block/block_mmad.hpp"
+       #include "catlass/gemm/block/block_swizzle.hpp"
+       #include "catlass/gemm/device/device_gemm.hpp"
+       #include "catlass/gemm/dispatch_policy.hpp"
+       #include "catlass/gemm/gemm_type.hpp"
+       #include "catlass/layout/layout.hpp"
+       #include "catlass/status.hpp"
+       #include "tla/layout.hpp"
+       #include "tla/tensor.hpp"
+       #endif
+ using namespace tla;
+ using namespace Catlass;
+ using namespace AscendC;
 
 namespace Catlass::Gemm::Kernel {
 
-/**
- * ChunkBwdDqkwg Cube Kernel 模板类
- * 
- * 模板参数:
- * - BlockMmadPart1_: Part 1 的矩阵乘法 (dv @ h^T -> dw)
- * - BlockMmadPart2_: Part 2 的矩阵乘法 (q @ k^T -> mm5)
- * - BlockMmadPart3_: Part 3 的矩阵乘法 (do @ v^T -> ds)
- * - BlockMmadPart4_: Part 4 的矩阵乘法 (do @ h^T -> dq)
- * - BlockMmadPart5_: Part 5 的矩阵乘法 (v @ dh -> dk)
- * - BlockMmadPart6_: Part 6 的矩阵乘法 (ds @ k -> dq+=)
- * - BlockMmadPart7_: Part 7 的矩阵乘法 (ds^T @ q -> dk+=)
- */
-template <
-    class BlockMmadPart1_,  // dv @ h^T -> dw
-    class BlockMmadPart2_,  // q @ k^T -> mm5
-    class BlockMmadPart3_,  // do @ v^T -> ds
-    class BlockMmadPart4_,  // do @ h^T -> dq
-    class BlockMmadPart5_,  // v @ dh -> dk
-    class BlockMmadPart6_,  // ds @ k -> dq
-    class BlockMmadPart7_   // ds^T @ q -> dk
->
-class ChunkBwdDqkwgTla {
-public:
-    using BlockMmadPart1 = BlockMmadPart1_;
-    using BlockMmadPart2 = BlockMmadPart2_;
-    using BlockMmadPart3 = BlockMmadPart3_;
-    using BlockMmadPart4 = BlockMmadPart4_;
-    using BlockMmadPart5 = BlockMmadPart5_;
-    using BlockMmadPart6 = BlockMmadPart6_;
-    using BlockMmadPart7 = BlockMmadPart7_;
-    
-    using ArchTag = typename BlockMmadPart1::ArchTag;
-    
-    // 数据类型定义 (基于 Part 2: q @ k^T)
-    using ElementA = typename BlockMmadPart2::ElementA;
-    using ElementB = typename BlockMmadPart2::ElementB;
-    using ElementC = typename BlockMmadPart2::ElementC;
-    
-    // Layout 定义
-    using LayoutRowMajor = layout::RowMajor;
-    using LayoutColMajor = layout::ColumnMajor;
-    
-    /// Parameters structure
-    struct Params {
-        // 输入指针
-        GM_ADDR ptrQ;      // [B, HK, T, K]
-        GM_ADDR ptrK;      // [B, HK, T, K]
-        GM_ADDR ptrV;      // [B, HV, T, V]
-        GM_ADDR ptrG;      // [B, HV, T]
-        GM_ADDR ptrH;      // [B, HV, num_chunks, K, V]
-        GM_ADDR ptrDo;     // [B, HV, T, V]
-        GM_ADDR ptrDh;     // [B, HV, num_chunks, K, V]
-        GM_ADDR ptrDv;     // [B, HV, T, V]
-        //varlen
-        GM_ADDR ptrCuSeqLens;
-        GM_ADDR ptrChunkIndices;
-        
-        // 输出指针
-        GM_ADDR ptrDq;     // [B, HV, T, K]
-        GM_ADDR ptrDk;     // [B, HV, T, K]
-        GM_ADDR ptrDw;     // [B, HV, T, K]
-        GM_ADDR ptrDg;     // [B, HV, T]
-        
-        // Workspace 指针
-        GM_ADDR ptrWorkspace;
-        
-        // Workspace 偏移
-        uint64_t wsDwOffset;
-        uint64_t wsDgLastOffset;
-        uint64_t wsMm5Offset;
-        uint64_t wsDsTempOffset;
-        uint64_t wsMm6Offset;
-        uint64_t wsMm7Offset;
-        
-        // 形状参数
-        uint64_t B;
-        uint64_t HV;            // number of heads for V-dim tensors
-        uint64_t HK;            // number of heads for K-dim tensors, HV = n_ratio * HK
-        uint64_t T;
-        uint64_t K;
-        uint64_t V;
-        uint64_t BT;
-        uint64_t numChunks;
-        uint64_t n_ratio;       // HV / HK
-        uint64_t isVarLen;
-        
-        float scale;
-        
-        CATLASS_DEVICE
-        Params() {}
-        
-        CATLASS_DEVICE
-        Params(
-            GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
-            GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
-            GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
-            GM_ADDR workspace,
-            uint64_t B, uint64_t HV, uint64_t HK, uint64_t T, uint64_t K, uint64_t V, uint64_t BT, uint64_t numChunks, uint64_t n_ratio,
-            uint64_t wsDw, uint64_t wsDgLast, uint64_t wsMm5, uint64_t wsDsTemp, uint64_t wsMm6, uint64_t wsMm7,
-            float s, uint64_t isVarLen
-        ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
-            ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLens(cu_seqlen), ptrChunkIndices(chunk_indices),
-            ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
-            ptrWorkspace(workspace),
-            wsDwOffset(wsDw), wsDgLastOffset(wsDgLast),
-            wsMm5Offset(wsMm5), wsDsTempOffset(wsDsTemp), wsMm6Offset(wsMm6), wsMm7Offset(wsMm7),
-            scale(s), B(B), HV(HV), HK(HK), T(T), K(K), V(V), BT(BT), numChunks(numChunks), n_ratio(n_ratio), isVarLen(isVarLen) {}
-    };
-    
-    CATLASS_DEVICE
-    ChunkBwdDqkwgTla() {}
-    
-    template <int32_t CORE_TYPE = g_coreType>
-    CATLASS_DEVICE
-    void operator()(Params const &params);
-    
     /**
-     * AIC (Cube) 执行入口
+     * TileGemmDirect: Single-shot tile-level GEMM replacing BlockMmadTla.
+     * Directly performs GM→L1→L0→Mmad→FixPipe→GM without tiling loops or pingpong buffers.
+     * Optimal when all matrix dimensions fit in a single L0 tile (M≤128, N≤128, K≤128).
+     *
+     * Compared to BlockMmadTla<MmadPingpong>:
+     *  - No multi-stage L1/L0 buffers (1 stage vs 2)
+     *  - No nested tiling loops (kL1×mL0×kL0×nL0 all = 1 for our sizes)
+     *  - Minimal event overhead: 4 Set + 4 Wait per GEMM vs ~20+ in Block
+     *  - Half the L1/L0 memory usage (no pingpong double-buffering)
      */
-    template <>
-    CATLASS_DEVICE
-    void operator()<AscendC::AIC>(Params const &params) {
-        Arch::Resource<ArchTag> resource;
-        uint32_t coreIdx = AscendC::GetBlockIdx();
-        uint32_t coreNum = AscendC::GetBlockNum();
-        
-        uint32_t coreLoops = params.B * params.numChunks;
-        
-        // Layout 创建
-        auto layoutBTxK = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.K);
-        auto layoutKxBT = LayoutColMajor::MakeLayout<ElementA>(params.K, params.BT);
-        auto layoutBTxV = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.V);
-        auto layoutVxBT = LayoutColMajor::MakeLayout<ElementA>(params.V, params.BT);
-        auto layoutBTxBT = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.BT);
-        auto layoutBTxBT_T = LayoutColMajor::MakeLayout<ElementA>(params.BT, params.BT);
-        auto layoutKxV = LayoutRowMajor::MakeLayout<ElementA>(params.K, params.V);
-        auto layoutVxK = LayoutColMajor::MakeLayout<ElementA>(params.V, params.K);
+    template <class ArchTag_, class ElementC_, class TileCopy_>
+    struct TileGemmDirect {
+        using ArchTag = ArchTag_;
+        using TileCopy = TileCopy_;
+        using ElementA = typename TileCopy::ElementA;
+        using ElementB = typename TileCopy::ElementB;
+        using ElementC = ElementC_;
+        using ElementAccumulator = typename TileCopy::ElementAccumulator;
 
-        uint32_t bos = 0;
-        uint32_t eos = 0;
+        using LayoutTagL1A = typename TileCopy::LayoutTagL1A;
+        using LayoutTagL1B = typename TileCopy::LayoutTagL1B;
+        using LayoutTagL0A = typename TileCopy::LayoutTagL0A;
+        using LayoutTagL0B = typename TileCopy::LayoutTagL0B;
+        using CopyL1ToL0A = typename TileCopy::CopyL1ToL0A;
+        using CopyL1ToL0B = typename TileCopy::CopyL1ToL0B;
+        using TileMmadType = Tile::TileMmadTla<ArchTag, ElementA, LayoutTagL1A>;
 
-        // ========== Part 1: b_dw = b_dv @ b_h^T ==========
+        // Single L0 tile dimensions (max supported by AtlasA2 Cube)
+        static constexpr uint32_t TILE_M = 128;
+        static constexpr uint32_t TILE_N = 128;
+        static constexpr uint32_t TILE_K = 128;
+
+        // Single-stage buffer sizes (no pingpong)
+        static constexpr uint32_t L1A_TILE_SIZE = TILE_M * TILE_K * sizeof(ElementA);
+        static constexpr uint32_t L1B_TILE_SIZE = TILE_K * TILE_N * sizeof(ElementB);
+
+        // Static L1 layouts for tile-sized buffers
+        static constexpr auto L1A_LAYOUT =
+            tla::MakeLayout<ElementA, LayoutTagL1A>(tla::Int<TILE_M>{}, tla::Int<TILE_K>{});
+        static constexpr auto L1B_LAYOUT =
+            tla::MakeLayout<ElementB, LayoutTagL1B>(tla::Int<TILE_K>{}, tla::Int<TILE_N>{});
+
+        /// Construct: allocate single-stage buffers, initialize events
+        CATLASS_DEVICE
+        TileGemmDirect(Arch::Resource<ArchTag> &resource)
         {
-            BlockMmadPart1 blockMmadPart1(resource);
-            auto layoutH = LayoutColMajor::MakeLayout<ElementA>(params.K, params.V);
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
-                                params.BT, loopIdx, bos, eos);
-                uint32_t actual_chunk_len = eos-bos;
-                uint32_t bIdx = loopIdx / params.numChunks;
-                uint32_t chunkIdx = loopIdx % params.numChunks;
+            if ASCEND_IS_AIC {
+                AscendC::SetMMLayoutTransform(true);
 
-                GemmCoord actualBlockShape{
-                    static_cast<uint32_t>(actual_chunk_len),
-                    static_cast<uint32_t>(params.K),
-                    static_cast<uint32_t>(params.V)
-                };
+                // Allocate single-stage buffers from resource pools
+                l1ABuf = resource.l1Buf.template GetBufferByByte<ElementA>(0);
+                l1BBuf = resource.l1Buf.template GetBufferByByte<ElementB>(L1A_TILE_SIZE);
+                l0ABuf = resource.l0ABuf.template GetBufferByByte<ElementA>(0);
+                l0BBuf = resource.l0BBuf.template GetBufferByByte<ElementB>(0);
+                l0CBuf = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(0);
 
-                for (uint32_t h = 0; h < params.HV; h++) {
-                    // h is hv_idx; compute hk_idx for q/k access
-                    uint32_t hk_idx = h / params.n_ratio;
-
-                    // dv: [B, HV, T, V] -> offset = (hv_idx * T + bos) * V
-                    uint64_t dvOffset = (h * params.T + bos) * params.V;
-
-                    // h_state: [B, HV, num_chunks, K, V] -> offset = ((bIdx * HV + hv_idx) * numChunks + chunkIdx) * K * V
-                    uint64_t hOffset = ((bIdx * params.HV + h) * params.numChunks + chunkIdx) * params.K * params.V;
-
-                    // dw output: [B, HV, T, K] -> offset = (hv_idx * T + bos) * K
-                    uint64_t dwOffset = (h * params.T + bos) * params.K;
-
-                    GlobalTensor<ElementA> gmDv;
-                    gmDv.SetGlobalBuffer((__gm__ ElementA *)params.ptrDv + dvOffset);
-                    // gmDv.SetGlobalBuffer((__gm__ ElementA *)params.ptrDv);
-                    GlobalTensor<ElementA> gmH;
-                    gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
-                    // gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH);
-                    GlobalTensor<ElementC> gmDw;
-                    // gmDw.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDwOffset) + dwOffset);
-                    gmDw.SetGlobalBuffer((__gm__ ElementC *)params.ptrDw + dwOffset);
-
-                    auto tensorDv = tla::MakeTensor(gmDv, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
-                    auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});  // h^T
-                    auto tensorDw = tla::MakeTensor(gmDw, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                    
-                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-
-                    auto tensorBlockDv = GetTile(tensorDv, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), 
-                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDw = GetTile(tensorDw, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    
-                    blockMmadPart1(tensorBlockDv, tensorBlockH, tensorBlockDw, actualBlockShape);
-
-
-                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
-
-                }
+                // Initialize events: buffers are initially free
+                AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(0);  // L1 free for MTE2 write
+                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(0);     // L0A/L0B free for MTE1 write
             }
-            // 最终同步(后移)
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
         }
-        AscendC::SyncAll<false>();
 
-        // ========== Part 2: mm5 = q @ k^T (纯 Cube) ==========
+        /// Destructor: drain pending events
+        CATLASS_DEVICE
+        ~TileGemmDirect()
         {
-            BlockMmadPart2 blockMmadPart2(resource);
-            
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
-                                params.BT, loopIdx, bos, eos);
-                uint32_t actual_chunk_len = eos-bos;
-                uint32_t bIdx = loopIdx / params.numChunks;
-                uint32_t chunkIdx = loopIdx % params.numChunks;
-                
-                GemmCoord actualBlockShape{
-                    static_cast<uint32_t>(actual_chunk_len),
-                    static_cast<uint32_t>(actual_chunk_len),
-                    static_cast<uint32_t>(params.K)
-                };
-                
-                for (uint32_t h = 0; h < params.HV; h++) {
-                    // h is hv_idx; compute hk_idx for q/k access
-                    uint32_t hk_idx = h / params.n_ratio;
-                    
-                    // q, k: [B, HK, T, K] -> offset uses HK for batch stride, not HV
-                    uint64_t bos_hk = bos - static_cast<uint64_t>(bIdx) * static_cast<uint64_t>(params.HV - params.HK) * params.T;
-                    uint64_t qkOffset = (hk_idx * params.T + bos_hk) * params.K;
-                    // mm5: workspace [B, HV, T, BT] -> offset = (hv_idx * T + bos) * BT
-                    uint64_t mm5Offset = (h * params.T + bos) * params.BT;
-                    
-                    GlobalTensor<ElementA> gmQ;
-                    gmQ.SetGlobalBuffer((__gm__ ElementA *)params.ptrQ + qkOffset);
-                    GlobalTensor<ElementA> gmK;
-                    gmK.SetGlobalBuffer((__gm__ ElementA *)params.ptrK + qkOffset);
-                    GlobalTensor<ElementC> gmMm5;
-                    gmMm5.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm5Offset) + mm5Offset);
+            if ASCEND_IS_AIC {
+                AscendC::SetMMLayoutTransform(false);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(0);
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(0);
+            }
+        }
 
-                    auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                    auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutKxBT), Arch::PositionGM{});  // k^T
-                    auto tensorMm5 = tla::MakeTensor(gmMm5, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
+        /// Perform a single-tile GEMM: C = A @ B
+        template <class TensorA, class TensorB, class TensorC>
+        CATLASS_DEVICE
+        void operator()(TensorA &tensorA, TensorB &tensorB, TensorC &tensorC, GemmCoord const &actualShape)
+        {
+            using CopyGmToL1A = typename TileCopy::template CopyGmToL1A<TensorA>;
+            using CopyGmToL1B = typename TileCopy::template CopyGmToL1B<TensorB>;
+    #if (defined(CATLASS_ARCH) && CATLASS_ARCH == 2201)
+            using CopyL0CToGm = typename TileCopy::template CopyL0CToGm<TensorC>;
+    #endif
+    #if (defined(CATLASS_ARCH) && CATLASS_ARCH == 3510)
+            using CopyL0CToGm = typename TileCopy::template CopyL0CToDst<TensorC>;
+    #endif
 
-                    auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0), 
-                                                 tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), 
-                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockMm5 = GetTile(tensorMm5, tla::MakeCoord(0, 0), 
-                                                   tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    
-                    blockMmadPart2(tensorBlockQ, tensorBlockK, tensorBlockMm5, actualBlockShape);
+            CopyGmToL1A copyGmToL1A;
+            CopyGmToL1B copyGmToL1B;
+            CopyL1ToL0A copyL1ToL0A;
+            CopyL1ToL0B copyL1ToL0B;
+            CopyL0CToGm copyL0CToGm;
+            TileMmadType tileMmad;
 
-                }
+            uint32_t m = actualShape.m();
+            uint32_t k = actualShape.k();
+            uint32_t n = actualShape.n();
+
+            // Avoid gemv mode on AtlasA2
+            uint32_t mActual = m;
+            if constexpr (std::is_same_v<ArchTag, Arch::AtlasA2>) {
+                if (mActual == 1) mActual = 16;
             }
 
-        }
-        AscendC::SyncAll<false>();
+            // Create L1 tensor views (static tile-size layout)
+            auto tensorL1A = tla::MakeTensor(l1ABuf, L1A_LAYOUT, Arch::PositionL1{});
+            auto tensorL1B = tla::MakeTensor(l1BBuf, L1B_LAYOUT, Arch::PositionL1{});
 
-        // ========== Part 3: b_ds = b_do @ b_v^T ==========
-        {
-            BlockMmadPart3 blockMmadPart3(resource);
-            
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+            // ---- Step 1: GM → L1 (MTE2) ----
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(0);  // Wait L1 free
+            copyGmToL1A(tensorL1A, tensorA);
+            copyGmToL1B(tensorL1B, tensorB);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(0);   // Signal L1 data ready
+
+            // ---- Step 2: L1 → L0A/L0B (MTE1) ----
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(0);  // Wait L1 data ready
+            AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(0);     // Wait L0A/L0B free
+
+            auto layoutL0A = tla::MakeLayout<ElementA, LayoutTagL0A>(mActual, k);
+            auto tensorL0A = tla::MakeTensor(l0ABuf, layoutL0A, Arch::PositionL0A{});
+            auto tensorTileL1A = GetTile(tensorL1A, tla::MakeCoord(0, 0), tla::MakeShape(mActual, k));
+            copyL1ToL0A(tensorL0A, tensorTileL1A);
+
+            auto layoutL0B = tla::MakeLayout<ElementB, LayoutTagL0B>(k, n);
+            auto tensorL0B = tla::MakeTensor(l0BBuf, layoutL0B, Arch::PositionL0B{});
+            auto tensorTileL1B = GetTile(tensorL1B, tla::MakeCoord(0, 0), tla::MakeShape(k, n));
+            copyL1ToL0B(tensorL0B, tensorTileL1B);
+
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(0);   // Signal L1 free
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(0);      // Signal L0 data ready
+
+            // ---- Step 3: Mmad (Cube) ----
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(0);
+
+            auto layoutL0C = tla::MakeLayoutL0C(mActual, n);
+            auto tensorL0C = tla::MakeTensor(l0CBuf, layoutL0C, Arch::PositionL0C{});
+
+            tileMmad(tensorL0C, tensorL0A, tensorL0B, mActual, n, k, true, 0b11);
+
+            AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(0);      // Signal L0A/L0B free
+
+            // ---- Step 4: L0C → GM (FixPipe, auto-triggered by unitFlag=0b11) ----
+            copyL0CToGm(tensorC, tensorL0C, 0b11);
+        }
+
+    private:
+        AscendC::LocalTensor<ElementA> l1ABuf;
+        AscendC::LocalTensor<ElementB> l1BBuf;
+        AscendC::LocalTensor<ElementA> l0ABuf;
+        AscendC::LocalTensor<ElementB> l0BBuf;
+        AscendC::LocalTensor<ElementAccumulator> l0CBuf;
+    };
+
+    /**
+     * ChunkBwdDqkwg Cube Kernel 模板类 (CV 深融合, chunk-interleaved A/B/C/D)
+     *
+     * 4 个 stage 的 cube GEMM:
+     * - A_cube: Part1 dw = dv @ h^T  和  Part2 mm5 = q @ k^T
+     * - B_cube: Part3 ds = do @ v^T
+     * - C_cube: Part4 dq_inner = do @ h^T  和  Part6 mm6 = ds_temp @ k
+     * - D_cube: Part5 dk_inner = v @ dh   和  Part7 mm7 = ds_temp^T @ q
+     *
+     * 模板参数 (沿用原 7-part 命名, 实际按 A/B/C/D 调度):
+     * - BlockMmadPart1_: dv @ h^T -> dw
+     * - BlockMmadPart2_: q @ k^T -> mm5
+     * - BlockMmadPart3_: do @ v^T -> ds
+     * - BlockMmadPart4_: do @ h^T -> dq
+     * - BlockMmadPart5_: v @ dh -> dk
+     * - BlockMmadPart6_: ds @ k -> dq+=
+     * - BlockMmadPart7_: ds^T @ q -> dk+=
+     */
+    template <
+        class BlockMmadPart1_,  // dv @ h^T -> dw
+        class BlockMmadPart2_,  // q @ k^T -> mm5
+        class BlockMmadPart3_,  // do @ v^T -> ds
+        class BlockMmadPart4_,  // do @ h^T -> dq
+        class BlockMmadPart5_,  // v @ dh -> dk
+        class BlockMmadPart6_,  // ds @ k -> dq
+        class BlockMmadPart7_   // ds^T @ q -> dk
+    >
+    class ChunkBwdDqkwgTla {
+    public:
+        using BlockMmadPart1 = BlockMmadPart1_;
+        using BlockMmadPart2 = BlockMmadPart2_;
+        using BlockMmadPart3 = BlockMmadPart3_;
+        using BlockMmadPart4 = BlockMmadPart4_;
+        using BlockMmadPart5 = BlockMmadPart5_;
+        using BlockMmadPart6 = BlockMmadPart6_;
+        using BlockMmadPart7 = BlockMmadPart7_;
+
+        using ArchTag = typename BlockMmadPart1::ArchTag;
+
+        // 数据类型定义 (基于 Part 2: q @ k^T)
+        using ElementA = typename BlockMmadPart2::ElementA;
+        using ElementB = typename BlockMmadPart2::ElementB;
+        using ElementC = typename BlockMmadPart2::ElementC;
+
+        // Layout 定义
+        using LayoutRowMajor = layout::RowMajor;
+        using LayoutColMajor = layout::ColumnMajor;
+
+        // CV 深融合: raw 信用流水, 无 flag 对象 (helper 用固定 flag id)。详见 chunk_bwd_dqkwg_common.h。
+
+        /// Parameters structure
+        struct Params {
+            // 输入指针
+            GM_ADDR ptrQ;      // [B, HK, T, K]
+            GM_ADDR ptrK;      // [B, HK, T, K]
+            GM_ADDR ptrV;      // [B, HV, T, V]
+            GM_ADDR ptrG;      // [B, HV, T]
+            GM_ADDR ptrH;      // [B, HV, num_chunks, K, V]
+            GM_ADDR ptrDo;     // [B, HV, T, V]
+            GM_ADDR ptrDh;     // [B, HV, num_chunks, K, V]
+            GM_ADDR ptrDv;     // [B, HV, T, V]
+            //varlen
+            GM_ADDR ptrCuSeqLens;
+            GM_ADDR ptrChunkIndices;
+
+            // 输出指针
+            GM_ADDR ptrDq;     // [B, HV, T, K]
+            GM_ADDR ptrDk;     // [B, HV, T, K]
+            GM_ADDR ptrDw;     // [B, HV, T, K]
+            GM_ADDR ptrDg;     // [B, HV, T]
+
+            // Workspace 指针
+            GM_ADDR ptrWorkspace;
+
+            // Workspace 偏移
+            uint64_t wsDwOffset;
+            uint64_t wsBtxKSyncSlotsPerHead;
+            uint64_t wsDgLastOffset;
+            uint64_t wsMm5Offset;
+            uint64_t wsDsTempOffset;
+            uint64_t wsMm6Offset;
+            uint64_t wsMm7Offset;
+
+            // 形状参数 (GVA: H 拆为 HV/HK, HV = n_ratio * HK)
+            uint64_t B;// = CONST_B;
+            uint64_t HV;           // value 侧 head 数 (v/g/h/do/dh/dv 及全部输出), == 原 H
+            uint64_t HK;           // key/query 侧 head 数 (q/k), HV = n_ratio * HK
+            uint64_t T;// = CONST_T;
+            uint64_t K;// = CONST_K;
+            uint64_t V;// = CONST_V;
+            uint64_t BT;// = CONST_BT;
+            uint64_t numChunks;// = CONST_NUM_CHUNKS;
+            uint64_t n_ratio;      // HV / HK
+            // uint64_t chunkSize = 64;
+            uint64_t isVarLen;
+
+            // 其他参数
+            float scale;
+            uint64_t aicCoreNum = 0;  // CV 深融合 blockDim (cube/vector 共用), 由 host tiling 给出
+
+            CATLASS_DEVICE
+            Params() {}
+
+            CATLASS_DEVICE
+            Params(
+                GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
+                GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
+                GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
+                GM_ADDR workspace,
+                uint64_t B, uint64_t HV, uint64_t HK, uint64_t T, uint64_t K, uint64_t V, uint64_t BT, uint64_t numChunks, uint64_t n_ratio,
+                uint64_t wsDw, uint64_t wsBtxKSlots, uint64_t wsDgLast, uint64_t wsMm5, uint64_t wsDsTemp,
+                uint64_t wsMm6, uint64_t wsMm7,
+                float s, uint64_t isVarLen
+            ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
+                ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLens(cu_seqlen), ptrChunkIndices(chunk_indices),
+                ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
+                ptrWorkspace(workspace),
+                wsDwOffset(wsDw), wsBtxKSyncSlotsPerHead(wsBtxKSlots), wsDgLastOffset(wsDgLast),
+                wsMm5Offset(wsMm5), wsDsTempOffset(wsDsTemp), wsMm6Offset(wsMm6), wsMm7Offset(wsMm7),
+                scale(s), B(B), HV(HV), HK(HK), T(T), K(K), V(V), BT(BT), numChunks(numChunks), n_ratio(n_ratio), isVarLen(isVarLen) {}
+        };
+
+        CATLASS_DEVICE
+        ChunkBwdDqkwgTla() {}
+
+        template <int32_t CORE_TYPE = g_coreType>
+        CATLASS_DEVICE
+        void operator()(Params const &params);
+
+        /**
+         * AIC (Cube) 执行入口 (CV 深融合, chunk-interleaved A/B/C/D, raw 信用流水)
+         *
+         * 每核任务流: A(c0..cM-1), B(c0..cM-1), C(c0..cM-1), D(c0..cM-1) (L = 4*M), 跨 stage 连续。
+         * 每个 (stage, chunk) task: 先 WaitCredit (节流, cube 领先 vector <=N 个 task),
+         * chunk 内全部 head 数据 ready 后 SetCubeReady 一次。vector 预置 N=min(groupSize, M) 个信用。
+         * N<=M 保证 C_cube/D_cube 读 B_vector 产出的 ds_temp 时其已就绪。
+         */
+        template <>
+        CATLASS_DEVICE
+        void operator()<AscendC::AIC>(Params const &params) {
+            Arch::Resource<ArchTag> resource;
+            uint32_t coreIdx = AscendC::GetBlockIdx();
+            uint32_t coreNum = params.aicCoreNum;   // CV 深融合 blockDim (cube/vector 共用)
+
+            uint32_t coreLoops = params.B * params.numChunks;
+
+            // Layout 创建
+            auto layoutBTxK = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.K);
+            auto layoutKxBT = LayoutColMajor::MakeLayout<ElementA>(params.K, params.BT);
+            auto layoutBTxV = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.V);
+            auto layoutVxBT = LayoutColMajor::MakeLayout<ElementA>(params.V, params.BT);
+            auto layoutBTxBT = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.BT);
+            auto layoutBTxBT_T = LayoutColMajor::MakeLayout<ElementA>(params.BT, params.BT);
+            auto layoutKxV = LayoutRowMajor::MakeLayout<ElementA>(params.K, params.V);
+            auto layoutVxK = LayoutColMajor::MakeLayout<ElementA>(params.V, params.K);
+
+            uint32_t bos = 0;
+            uint32_t eos = 0;
+
+            // raw 信用流水: cube 每 task 先 WaitCredit (节流到领先 vector <=N 个 task), 算完 SetCubeReady。
+            // vector 预置 N=min(groupSize, M) 个信用 (见 vector.h)。N<=M 保证 C/D 读 ds_temp 安全。
+            // cube WaitCredit 总次数 == L (==4M); 与 vector 端预置 N + SetCredit L 对应, 末尾余 N 信用 (无害)。
+            // 现按 chunk-group-major 组织: 外层按 G 个 chunk 一组, 组内 A->B->C->D 连着做 (组的输入在 L2 内复用)。
+
+            uint32_t loopBase = coreIdx;
+            while (loopBase < coreLoops) {
+                uint32_t loopEnd = DqkwgGroupEnd(loopBase, coreLoops, coreNum,
+                                                 (uint32_t)params.wsBtxKSyncSlotsPerHead);
+            // ========== A_cube: dw = dv @ h^T, 然后 mm5 = q @ k^T ==========
+            for (uint32_t loopIdx = loopBase; loopIdx < loopEnd; loopIdx += coreNum) {
                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
                                 params.BT, loopIdx, bos, eos);
-                uint32_t actual_chunk_len = eos-bos;
+                uint32_t actual_chunk_len = eos - bos;
                 uint32_t bIdx = loopIdx / params.numChunks;
                 uint32_t chunkIdx = loopIdx % params.numChunks;
-                
+
+                // --- Part1: dw = dv @ h^T -> wsDw ---
+                {
+                    GemmCoord actualBlockShape{
+                        static_cast<uint32_t>(actual_chunk_len),
+                        static_cast<uint32_t>(params.K),
+                        static_cast<uint32_t>(params.V)
+                    };
+                    WaitCredit();
+                    BlockMmadPart1 blockMmadPart1(resource);
+                    for (uint32_t h = 0; h < params.HV; h++) {
+                        uint64_t dvOffset = (h * params.T + bos) * params.V;
+                        uint64_t hOffset = ((bIdx * params.HV + h) * params.numChunks + chunkIdx) * params.K * params.V;
+                        // dw 写 short 环槽 (深度自适应 2G-1, 贴 L2): 偏移由 (coreIdx,loopIdx,coreNum,h) 算出
+                        uint64_t dwRingOffset = DqkwgShortBtxKRingElemOffset(coreIdx, loopIdx, coreNum, h,
+                                                                              params.HV, params.BT, params.K,
+                                                                              DqkwgShortRingDepthFromGroup((uint32_t)params.wsBtxKSyncSlotsPerHead));
+
+                        GlobalTensor<ElementA> gmDv;
+                        gmDv.SetGlobalBuffer((__gm__ ElementA *)params.ptrDv + dvOffset);
+                        GlobalTensor<ElementA> gmH;
+                        gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
+                        GlobalTensor<ElementC> gmDw;
+                        gmDw.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDwOffset) + dwRingOffset);
+
+                        auto tensorDv = tla::MakeTensor(gmDv, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                        auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});  // h^T
+                        auto tensorDw = tla::MakeTensor(gmDw, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+
+                        auto tensorBlockDv = GetTile(tensorDv, tla::MakeCoord(0, 0),
+                                                      tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                        auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                        auto tensorBlockDw = GetTile(tensorDw, tla::MakeCoord(0, 0),
+                                                      tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+
+                        blockMmadPart1(tensorBlockDv, tensorBlockH, tensorBlockDw, actualBlockShape);
+                        AscendC::PipeBarrier<PIPE_FIX>();
+                    }
+                    // A_vector consumes only dw. mm5 is consumed later by B_vector,
+                    // after the cube stream has finished all A tasks.
+                    AscendC::PipeBarrier<PIPE_FIX>();
+                    SetCubeReady();
+                }
+                // --- Part2: mm5 = q @ k^T -> wsMm5 (B_vector 在后续 stage 消费) ---
+                {
+                    GemmCoord actualBlockShape{
+                        static_cast<uint32_t>(actual_chunk_len),
+                        static_cast<uint32_t>(actual_chunk_len),
+                        static_cast<uint32_t>(params.K)
+                    };
+                    BlockMmadPart2 blockMmadPart2(resource);
+                    for (uint32_t h = 0; h < params.HV; h++) {
+                        // GVA: q/k 为 HK 头; hv_idx=h -> hk_idx=h/n_ratio, 并把 HV-based bos 修正为 HK-based
+                        uint32_t hk_idx = h / params.n_ratio;
+                        uint64_t bos_hk = bos - static_cast<uint64_t>(bIdx) * static_cast<uint64_t>(params.HV - params.HK) * params.T;
+                        uint64_t qkOffset = (hk_idx * params.T + bos_hk) * params.K;
+                        uint64_t mm5Offset = DqkwgBtxKRingElemOffset(coreIdx, loopBase, loopIdx, coreNum, h,
+                                                                      params.HV, params.BT, params.K,
+                                                                      (uint32_t)params.wsBtxKSyncSlotsPerHead);
+
+                        GlobalTensor<ElementA> gmQ;
+                        gmQ.SetGlobalBuffer((__gm__ ElementA *)params.ptrQ + qkOffset);
+                        GlobalTensor<ElementA> gmK;
+                        gmK.SetGlobalBuffer((__gm__ ElementA *)params.ptrK + qkOffset);
+                        GlobalTensor<ElementC> gmMm5;
+                        gmMm5.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm5Offset) + mm5Offset);
+
+                        auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                        auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutKxBT), Arch::PositionGM{});  // k^T
+                        auto tensorMm5 = tla::MakeTensor(gmMm5, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
+
+                        auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                        auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                        auto tensorBlockMm5 = GetTile(tensorMm5, tla::MakeCoord(0, 0),
+                                                       tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+
+                        blockMmadPart2(tensorBlockQ, tensorBlockK, tensorBlockMm5, actualBlockShape);
+                        AscendC::PipeBarrier<PIPE_FIX>();
+                    }
+                }
+                AscendC::PipeBarrier<PIPE_FIX>();
+                }
+
+            // ========== B_cube: ds = do @ v^T -> wsDsTemp ==========
+            for (uint32_t loopIdx = loopBase; loopIdx < loopEnd; loopIdx += coreNum) {
+                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
+                                params.BT, loopIdx, bos, eos);
+                uint32_t actual_chunk_len = eos - bos;
+                uint32_t bIdx = loopIdx / params.numChunks;
+                uint32_t chunkIdx = loopIdx % params.numChunks;
+
                 GemmCoord actualBlockShape{
                     static_cast<uint32_t>(actual_chunk_len),
                     static_cast<uint32_t>(actual_chunk_len),
                     static_cast<uint32_t>(params.V)
                 };
-                
+                BlockMmadPart3 blockMmadPart3(resource);
+                WaitCredit();
                 for (uint32_t h = 0; h < params.HV; h++) {
-                    // h is hv_idx
-                    // do, v: [B, HV, T, V]
                     uint64_t dvOffset = (h * params.T + bos) * params.V;
-                    // ds_temp: workspace [B, HV, T, BT]
-                    uint64_t dsOffset = (h * params.T + bos) * params.BT;
-                    
+                    uint64_t dsOffset = DqkwgBtbRingElemOffset(coreIdx, loopBase, loopIdx, coreNum, h,
+                                                               params.HV, params.BT,
+                                                               (uint32_t)params.wsBtxKSyncSlotsPerHead);
+
                     GlobalTensor<ElementA> gmDo;
                     gmDo.SetGlobalBuffer((__gm__ ElementA *)params.ptrDo + dvOffset);
                     GlobalTensor<ElementA> gmV;
                     gmV.SetGlobalBuffer((__gm__ ElementA *)params.ptrV + dvOffset);
                     GlobalTensor<ElementC> gmDs;
                     gmDs.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
-                    
+
                     auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
                     auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutVxBT), Arch::PositionGM{});  // v^T
                     auto tensorDs = tla::MakeTensor(gmDs, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
-                    
-                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-                    // AscendC::PipeBarrier<PIPE_MTE2>();
-                    auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0), 
+
+                    auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0),
                                                   tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), 
+                    auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0),
                                                  tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDs = GetTile(tensorDs, tla::MakeCoord(0, 0), 
+                    auto tensorBlockDs = GetTile(tensorDs, tla::MakeCoord(0, 0),
                                                   tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    
+
                     blockMmadPart3(tensorBlockDo, tensorBlockV, tensorBlockDs, actualBlockShape);
-
-                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+                    AscendC::PipeBarrier<PIPE_FIX>();
                 }
+                AscendC::PipeBarrier<PIPE_FIX>();
+                SetCubeReady();
             }
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-        }
-        AscendC::SyncAll<false>();
 
-        // ========== Part 4: b_dq = b_do @ b_h^T ==========
-        {
-            BlockMmadPart4 blockMmadPart4(resource);
-            
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+            // ========== C_cube: dq_inner = do @ h^T -> ptrDq, 然后 mm6 = ds_temp @ k -> wsMm6 ==========
+            // mm6 读取 B_vector 产出的 ds_temp(c); 进入 C_cube(c0)=task 2M 时 vector 已完成到 task 2M-2 >= B_vector(c0)=task M (M>=2)。
+            for (uint32_t loopIdx = loopBase; loopIdx < loopEnd; loopIdx += coreNum) {
                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
                                 params.BT, loopIdx, bos, eos);
-                uint32_t actual_chunk_len = eos-bos;
+                uint32_t actual_chunk_len = eos - bos;
                 uint32_t bIdx = loopIdx / params.numChunks;
                 uint32_t chunkIdx = loopIdx % params.numChunks;
-                
-                GemmCoord actualBlockShape{
-                    static_cast<uint32_t>(actual_chunk_len),
-                    static_cast<uint32_t>(params.K),
-                    static_cast<uint32_t>(params.V)
-                };
-                
+
+                WaitCredit();
                 for (uint32_t h = 0; h < params.HV; h++) {
-                    // h is hv_idx; compute hk_idx for q/k access
-                    uint32_t hk_idx = h / params.n_ratio;
-                    
-                    // do: [B, HV, T, V]
-                    uint64_t doOffset = (h * params.T + bos) * params.V;
-                    // h_state: [B, HV, num_chunks, K, V]
-                    uint64_t hOffset = ((bIdx * params.HV + h) * params.numChunks + chunkIdx) * params.K * params.V;
+                    // --- Part4: dq_inner = do @ h^T -> ptrDq ---
+                    {
+                        GemmCoord actualBlockShape{
+                            static_cast<uint32_t>(actual_chunk_len),
+                            static_cast<uint32_t>(params.K),
+                            static_cast<uint32_t>(params.V)
+                        };
+                        uint64_t doOffset = (h * params.T + bos) * params.V;
+                        uint64_t hOffset = ((bIdx * params.HV + h) * params.numChunks + chunkIdx) * params.K * params.V;
+                        uint64_t dqOffset = (h * params.T + bos) * params.K;
 
-                    // dq: [B, HV, T, K]
-                    uint64_t dqOffset = (h * params.T + bos) * params.K;
-                    
-                    GlobalTensor<ElementA> gmDo;
-                    gmDo.SetGlobalBuffer((__gm__ ElementA *)params.ptrDo + doOffset);
-                    GlobalTensor<ElementA> gmH;
-                    gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
-                    GlobalTensor<ElementC> gmDq;
-                    gmDq.SetGlobalBuffer((__gm__ ElementC *)params.ptrDq + dqOffset);
-                    
-                    auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
-                    auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});  // h^T: [V, K]
-                    auto tensorDq = tla::MakeTensor(gmDq, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                    
-                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
+                        GlobalTensor<ElementA> gmDo;
+                        gmDo.SetGlobalBuffer((__gm__ ElementA *)params.ptrDo + doOffset);
+                        GlobalTensor<ElementA> gmH;
+                        gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
+                        GlobalTensor<ElementC> gmDq;
+                        gmDq.SetGlobalBuffer((__gm__ ElementC *)params.ptrDq + dqOffset);
 
-                    auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), 
-                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDq = GetTile(tensorDq, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    
-                    blockMmadPart4(tensorBlockDo, tensorBlockH, tensorBlockDq, actualBlockShape);
+                        auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                        auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});
+                        auto tensorDq = tla::MakeTensor(gmDq, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
 
-                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
-                }
-            }
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-        }
-        AscendC::SyncAll<false>();
-
-        // ========== Part 5: b_dk = b_v @ b_dh ==========
-        {
-            BlockMmadPart5 blockMmadPart5(resource);
-            
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
-                                params.BT, loopIdx, bos, eos);
-                uint32_t actual_chunk_len = eos-bos;
-                uint32_t bIdx = loopIdx / params.numChunks;
-                uint32_t chunkIdx = loopIdx % params.numChunks;
-                
-                GemmCoord actualBlockShape{
-                    static_cast<uint32_t>(actual_chunk_len),
-                    static_cast<uint32_t>(params.K),
-                    static_cast<uint32_t>(params.V)
-                };
-                
-                for (uint32_t h = 0; h < params.HV; h++) {
-                    // h is hv_idx
-                    // v: [B, HV, T, V]
-                    uint64_t vOffset = (h * params.T + bos) * params.V;
-                    // dh: [B, HV, num_chunks, K, V]  -> 需要转置访问 [V, K]
-                    uint64_t dhOffset = ((bIdx * params.HV + h) * params.numChunks + chunkIdx) * params.K * params.V;
-                    // dk: [B, HV, T, K]
-                    uint64_t dkOffset = (h * params.T + bos) * params.K;
-                    
-                    GlobalTensor<ElementA> gmV;
-                    gmV.SetGlobalBuffer((__gm__ ElementA *)params.ptrV + vOffset);
-                    GlobalTensor<ElementA> gmDh;
-                    gmDh.SetGlobalBuffer((__gm__ ElementA *)params.ptrDh + dhOffset);
-                    GlobalTensor<ElementC> gmDk;
-                    gmDk.SetGlobalBuffer((__gm__ ElementC *)params.ptrDk + dkOffset);
-                    
-                    auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
-                    auto tensorDh = tla::MakeTensor(gmDh, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});  // dh: [V, K]
-                    auto tensorDk = tla::MakeTensor(gmDk, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                    
-                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-
-                    auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), 
-                                                 tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockDh = GetTile(tensorDh, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDk = GetTile(tensorDk, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    
-                    blockMmadPart5(tensorBlockV, tensorBlockDh, tensorBlockDk, actualBlockShape);
-
-                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
-                }
-            }
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-        }
-        AscendC::SyncAll<false>();
-
-        // ========== Part 6: mm6 = b_ds_temp @ b_k ==========
-        // 结果累加到 dq
-        {
-            BlockMmadPart6 blockMmadPart6(resource);
-            
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
-                                params.BT, loopIdx, bos, eos);
-                uint32_t actual_chunk_len = eos-bos;
-                uint32_t bIdx = loopIdx / params.numChunks;
-                uint32_t chunkIdx = loopIdx % params.numChunks;
-                
-                GemmCoord actualBlockShape{
-                    static_cast<uint32_t>(actual_chunk_len),
-                    static_cast<uint32_t>(params.K),
-                    static_cast<uint32_t>(actual_chunk_len)
-                };
-                
-                for (uint32_t h = 0; h < params.HV; h++) {
-                    // h is hv_idx; compute hk_idx for k access
-                    uint32_t hk_idx = h / params.n_ratio;
-                    
-                    // ds_temp: workspace [B, HV, T, BT]
-                    uint64_t dsOffset = (h * params.T + bos) * params.BT;
-                    // k: [B, HK, T, K] -> offset uses HK for batch stride, not HV
-                    uint64_t bos_hk = bos - static_cast<uint64_t>(bIdx) * static_cast<uint64_t>(params.HV - params.HK) * params.T;
-                    uint64_t kOffset = (hk_idx * params.T + bos_hk) * params.K;
-                    // dq: [B, HV, T, K] - 累加
-                    uint64_t dqOffset = (h * params.T + bos) * params.K;
-                    
-                    GlobalTensor<ElementA> gmDsTemp;
-                    gmDsTemp.SetGlobalBuffer((__gm__ ElementA *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
-                    GlobalTensor<ElementA> gmK;
-                    gmK.SetGlobalBuffer((__gm__ ElementA *)params.ptrK + kOffset);
-                    GlobalTensor<ElementC> gmDq;
-                    gmDq.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm5Offset) + dqOffset);
-
-                    auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
-                    auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                    auto tensorDq = tla::MakeTensor(gmDq, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                    
-                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-                    
-                    auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0), 
+                        auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0),
                                                       tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), 
-                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDq = GetTile(tensorDq, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    
-                    blockMmadPart6(tensorBlockDsTemp, tensorBlockK, tensorBlockDq, actualBlockShape);
-// if(h==0&&loopIdx==7){
-//     DumpTensor(gmDsTemp[63*64],__LINE__,64);
-//     DumpTensor(gmK[63*128],__LINE__,64);
-//     DumpTensor(gmDq[63*128],__LINE__,64);
-// }
-                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+                        auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                        auto tensorBlockDq = GetTile(tensorDq, tla::MakeCoord(0, 0),
+                                                      tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+
+                        BlockMmadPart4 blockMmadPart4(resource);
+                        blockMmadPart4(tensorBlockDo, tensorBlockH, tensorBlockDq, actualBlockShape);
+                    }
+                    // --- Part6: mm6 = ds_temp @ k -> wsMm6 (复用 wsDw) ---
+                    {
+                        GemmCoord actualBlockShape{
+                            static_cast<uint32_t>(actual_chunk_len),
+                            static_cast<uint32_t>(params.K),
+                            static_cast<uint32_t>(actual_chunk_len)
+                        };
+                        uint64_t dsOffset = DqkwgBtbRingElemOffset(coreIdx, loopBase, loopIdx, coreNum, h,
+                                                                   params.HV, params.BT,
+                                                                   (uint32_t)params.wsBtxKSyncSlotsPerHead);
+                        // GVA: k 为 HK 头
+                        uint32_t hk_idx = h / params.n_ratio;
+                        uint64_t bos_hk = bos - static_cast<uint64_t>(bIdx) * static_cast<uint64_t>(params.HV - params.HK) * params.T;
+                        uint64_t kOffset = (hk_idx * params.T + bos_hk) * params.K;
+
+                        GlobalTensor<ElementA> gmDsTemp;
+                        gmDsTemp.SetGlobalBuffer((__gm__ ElementA *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
+                        GlobalTensor<ElementA> gmK;
+                        gmK.SetGlobalBuffer((__gm__ ElementA *)params.ptrK + kOffset);
+                        GlobalTensor<ElementC> gmMm6;  // mm6 复用 dw short 环区 (stage C 内消费, 与 dw 同槽)
+                        uint64_t mm6RingOffset = DqkwgShortBtxKRingElemOffset(coreIdx, loopIdx, coreNum, h,
+                                                                              params.HV, params.BT, params.K,
+                                                                              DqkwgShortRingDepthFromGroup((uint32_t)params.wsBtxKSyncSlotsPerHead));
+                        gmMm6.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm6Offset) + mm6RingOffset);
+
+                        auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
+                        auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                        auto tensorMm6 = tla::MakeTensor(gmMm6, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+
+                        auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0),
+                                                          tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                        auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                        auto tensorBlockMm6 = GetTile(tensorMm6, tla::MakeCoord(0, 0),
+                                                       tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+
+                        BlockMmadPart6 blockMmadPart6(resource);
+                        blockMmadPart6(tensorBlockDsTemp, tensorBlockK, tensorBlockMm6, actualBlockShape);
+                        AscendC::PipeBarrier<PIPE_FIX>();
+                    }
                 }
+                AscendC::PipeBarrier<PIPE_FIX>();
+                SetCubeReady();
             }
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-        }
-        AscendC::SyncAll<false>();
-        // ========== Part 7: mm7 = b_ds_temp^T @ b_q ==========
-        // 结果累加到 dk
-        {
-            BlockMmadPart7 blockMmadPart7(resource);
-            
-            for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+
+            // ========== D_cube: dk_inner = v @ dh -> ptrDk, 然后 mm7 = ds_temp^T @ q -> wsMm7 ==========
+            for (uint32_t loopIdx = loopBase; loopIdx < loopEnd; loopIdx += coreNum) {
                 GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.HV, params.T,
                                 params.BT, loopIdx, bos, eos);
-                uint32_t actual_chunk_len = eos-bos;
+                uint32_t actual_chunk_len = eos - bos;
                 uint32_t bIdx = loopIdx / params.numChunks;
                 uint32_t chunkIdx = loopIdx % params.numChunks;
-                
-                GemmCoord actualBlockShape{
-                    static_cast<uint32_t>(actual_chunk_len),
-                    static_cast<uint32_t>(params.K),
-                    static_cast<uint32_t>(actual_chunk_len)
-                };
-                
+
+                WaitCredit();
                 for (uint32_t h = 0; h < params.HV; h++) {
-                    // h is hv_idx; compute hk_idx for q access
-                    uint32_t hk_idx = h / params.n_ratio;
-                    
-                    // ds_temp^T: workspace [B, HV, T, BT]
-                    uint64_t dsOffset = (h * params.T + bos) * params.BT;
-                    // q: [B, HK, T, K] -> offset uses HK for batch stride, not HV
-                    uint64_t bos_hk = bos - static_cast<uint64_t>(bIdx) * static_cast<uint64_t>(params.HV - params.HK) * params.T;
-                    uint64_t qOffset = (hk_idx * params.T + bos_hk) * params.K;
+                    // --- Part5: dk_inner = v @ dh -> ptrDk ---
+                    {
+                        GemmCoord actualBlockShape{
+                            static_cast<uint32_t>(actual_chunk_len),
+                            static_cast<uint32_t>(params.K),
+                            static_cast<uint32_t>(params.V)
+                        };
+                        uint64_t vOffset = (h * params.T + bos) * params.V;
+                        uint64_t dhOffset = ((bIdx * params.HV + h) * params.numChunks + chunkIdx) * params.K * params.V;
+                        uint64_t dkOffset = (h * params.T + bos) * params.K;
 
-                    // dk: [B, HV, T, K] - 累加
-                    uint64_t dkOffset = (h * params.T + bos) * params.K;
-                    
-                    GlobalTensor<ElementA> gmDsTemp;
-                    gmDsTemp.SetGlobalBuffer((__gm__ ElementA *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
-                    GlobalTensor<ElementA> gmQ;
-                    gmQ.SetGlobalBuffer((__gm__ ElementA *)params.ptrQ + qOffset);
-                    GlobalTensor<ElementC> gmDk;
-                    gmDk.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm5Offset) + dkOffset);
-                    
-                    auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT_T), Arch::PositionGM{});  // Transposed
-                    auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                    auto tensorDk = tla::MakeTensor(gmDk, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                    
-                    AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-                    
-                    auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0), 
-                                                      tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                    auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0), 
-                                                 tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                    auto tensorBlockDk = GetTile(tensorDk, tla::MakeCoord(0, 0), 
-                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-                    
-                    blockMmadPart7(tensorBlockDsTemp, tensorBlockQ, tensorBlockDk, actualBlockShape);
-// if(h==0&&loopIdx==0){
-//     DumpTensor(gmDsTemp,__LINE__,64);
-//     DumpTensor(gmQ,__LINE__,64);
-//     DumpTensor(gmDk,__LINE__,64);
-// }
-                    AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_0);
+                        GlobalTensor<ElementA> gmV;
+                        gmV.SetGlobalBuffer((__gm__ ElementA *)params.ptrV + vOffset);
+                        GlobalTensor<ElementA> gmDh;
+                        gmDh.SetGlobalBuffer((__gm__ ElementA *)params.ptrDh + dhOffset);
+                        GlobalTensor<ElementC> gmDk;
+                        gmDk.SetGlobalBuffer((__gm__ ElementC *)params.ptrDk + dkOffset);
+
+                        auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                        auto tensorDh = tla::MakeTensor(gmDh, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});
+                        auto tensorDk = tla::MakeTensor(gmDk, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+
+                        auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                        auto tensorBlockDh = GetTile(tensorDh, tla::MakeCoord(0, 0),
+                                                      tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                        auto tensorBlockDk = GetTile(tensorDk, tla::MakeCoord(0, 0),
+                                                      tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+
+                        BlockMmadPart5 blockMmadPart5(resource);
+                        blockMmadPart5(tensorBlockV, tensorBlockDh, tensorBlockDk, actualBlockShape);
+                    }
+                    // --- Part7: mm7 = ds_temp^T @ q -> wsMm7 (复用 wsMm5) ---
+                    {
+                        GemmCoord actualBlockShape{
+                            static_cast<uint32_t>(actual_chunk_len),
+                            static_cast<uint32_t>(params.K),
+                            static_cast<uint32_t>(actual_chunk_len)
+                        };
+                        uint64_t dsOffset = DqkwgBtbRingElemOffset(coreIdx, loopBase, loopIdx, coreNum, h,
+                                                                   params.HV, params.BT,
+                                                                   (uint32_t)params.wsBtxKSyncSlotsPerHead);
+                        // GVA: q 为 HK 头
+                        uint32_t hk_idx = h / params.n_ratio;
+                        uint64_t bos_hk = bos - static_cast<uint64_t>(bIdx) * static_cast<uint64_t>(params.HV - params.HK) * params.T;
+                        uint64_t qOffset = (hk_idx * params.T + bos_hk) * params.K;
+
+                        GlobalTensor<ElementA> gmDsTemp;
+                        gmDsTemp.SetGlobalBuffer((__gm__ ElementA *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
+                        GlobalTensor<ElementA> gmQ;
+                        gmQ.SetGlobalBuffer((__gm__ ElementA *)params.ptrQ + qOffset);
+                        GlobalTensor<ElementC> gmMm7;  // mm7 复用 mm5 的 group 环槽 (stage D 写, mm5 已在 stage B 消费完; 单写, 同 stride 无跨核冲突)
+                        uint64_t mm7RingOffset = DqkwgBtxKRingElemOffset(coreIdx, loopBase, loopIdx, coreNum, h,
+                                                                         params.HV, params.BT, params.K,
+                                                                         (uint32_t)params.wsBtxKSyncSlotsPerHead);
+                        gmMm7.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm7Offset) + mm7RingOffset);
+
+                        auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT_T), Arch::PositionGM{});
+                        auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                        auto tensorMm7 = tla::MakeTensor(gmMm7, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+
+                        auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0),
+                                                          tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                        auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                        auto tensorBlockMm7 = GetTile(tensorMm7, tla::MakeCoord(0, 0),
+                                                       tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+
+                        BlockMmadPart7 blockMmadPart7(resource);
+                        blockMmadPart7(tensorBlockDsTemp, tensorBlockQ, tensorBlockMm7, actualBlockShape);
+                        AscendC::PipeBarrier<PIPE_FIX>();
+                    }
                 }
+                AscendC::PipeBarrier<PIPE_FIX>();
+                SetCubeReady();
             }
-            
-            // 最终同步
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-            AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_0);
-        }
+                loopBase = loopEnd;
+            }  // while group (chunk-group-major)
 
+            // 无 drain: 信用流水末尾余 N 个未消耗信用 (单次 launch 无害), cube WaitCredit/SetCubeReady 各 L 次。
+        }
+    };
+
+    } // namespace Catlass::Gemm::Kernel
+
+    /**
+     * Cube Process 类 (AIC 端入口)
+     */
+    template <typename DataType, typename GType>
+    class ChunkBwdDqkwgCubeProcess {
+    public:
+        __aicore__ inline ChunkBwdDqkwgCubeProcess(
+            GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
+            GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
+            GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
+            GM_ADDR workspace
+        ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
+            ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLen(cu_seqlen), ptrChunkIndices(chunk_indices),
+            ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
+            ptrWorkspace(workspace) {}
+
+        __aicore__ inline void Init(const ChunkBwdDqkwgTilingData &tiling);
+        __aicore__ inline void Process();
+
+    private:
+        // 输入输出指针
+        GM_ADDR ptrQ;
+        GM_ADDR ptrK;
+        GM_ADDR ptrV;
+        GM_ADDR ptrG;
+        GM_ADDR ptrH;
+        GM_ADDR ptrDo;
+        GM_ADDR ptrDh;
+        GM_ADDR ptrDv;
+        GM_ADDR ptrCuSeqLen;
+        GM_ADDR ptrChunkIndices;
+        GM_ADDR ptrDq;
+        GM_ADDR ptrDk;
+        GM_ADDR ptrDw;
+        GM_ADDR ptrDg;
+        GM_ADDR ptrWorkspace;
+
+        // Tiling 参数
+        uint64_t B = CONST_B;
+        uint64_t HV = CONST_HV;
+        uint64_t HK = CONST_HK;
+        uint64_t n_ratio = 1;
+        uint64_t T = CONST_T;
+        uint64_t K = CONST_K;
+        uint64_t V = CONST_V;
+        uint64_t BT = CONST_BT;
+        uint64_t numChunks = CONST_NUM_CHUNKS;
+        float scale;
+        uint64_t isVarLen;
+        uint64_t aicCoreNum;  // CV 深融合 blockDim (cube/vector 共用)
+
+        // Workspace 偏移
+        uint64_t wsDwOffset;
+        uint64_t wsBtxKSyncSlotsPerHead;
+        uint64_t wsDgLastOffset;
+        uint64_t wsMm5Offset;
+        uint64_t wsDsTempOffset;
+        uint64_t wsMm6Offset;
+        uint64_t wsMm7Offset;
+    };
+
+    template <typename DataType, typename GType>
+    __aicore__ inline void ChunkBwdDqkwgCubeProcess<DataType, GType>::Init(const ChunkBwdDqkwgTilingData &tiling) {
+        scale = tiling.scale;
+        B = tiling.B;
+        HV = tiling.HV;
+        HK = tiling.HK;
+        n_ratio = (HK > 0) ? (HV / HK) : 1;
+        T = tiling.T;
+        K = tiling.K;
+        V = tiling.V;
+        BT = tiling.BT;
+        numChunks = tiling.numChunks;
+        aicCoreNum = tiling.aicCoreNum;
+        wsDwOffset = tiling.wsDwOffset;
+        wsBtxKSyncSlotsPerHead = tiling.wsBtxKSyncSlotsPerHead;
+        wsDgLastOffset = tiling.wsDgLastOffset;
+        wsMm5Offset = tiling.wsMm5Offset;
+        wsDsTempOffset = tiling.wsDsTempOffset;
+        wsMm6Offset = tiling.wsMm6Offset;
+        wsMm7Offset = tiling.wsMm7Offset;
+        isVarLen = tiling.isVarLen;
     }
-};
 
-} // namespace Catlass::Gemm::Kernel
+    template <typename DataType, typename GType>
+    __aicore__ inline void ChunkBwdDqkwgCubeProcess<DataType, GType>::Process() {
+        using namespace Catlass;
+        using namespace Catlass::Gemm;
 
-/**
- * Cube Process 类 (AIC 端入口)
- */
-template <typename DataType, typename GType>
-class ChunkBwdDqkwgCubeProcess {
-public:
-    __aicore__ inline ChunkBwdDqkwgCubeProcess(
-        GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
-        GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
-        GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
-        GM_ADDR workspace
-    ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
-        ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLen(cu_seqlen), ptrChunkIndices(chunk_indices),
-        ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
-        ptrWorkspace(workspace) {}
-    
-    __aicore__ inline void Init(const GDN::ChunkBwdDqkwgTilingData &tiling);
-    __aicore__ inline void Process();
-    
-private:
-    // 输入输出指针
-    GM_ADDR ptrQ;
-    GM_ADDR ptrK;
-    GM_ADDR ptrV;
-    GM_ADDR ptrG;
-    GM_ADDR ptrH;
-    GM_ADDR ptrDo;
-    GM_ADDR ptrDh;
-    GM_ADDR ptrDv;
-    GM_ADDR ptrCuSeqLen;
-    GM_ADDR ptrChunkIndices;
-    GM_ADDR ptrDq;
-    GM_ADDR ptrDk;
-    GM_ADDR ptrDw;
-    GM_ADDR ptrDg;
-    GM_ADDR ptrWorkspace;
-    
-    // Tiling 参数
-    uint64_t B = CONST_B;
-    uint64_t HV = CONST_HV;
-    uint64_t HK = CONST_HK;
-    uint64_t T = CONST_T;
-    uint64_t K = CONST_K;
-    uint64_t V = CONST_V;
-    uint64_t BT = CONST_BT;
-    uint64_t numChunks = CONST_NUM_CHUNKS;
-    uint64_t n_ratio = 1;
-    float scale;
-    uint64_t isVarLen;
-    
-    // Workspace 偏移
-    uint64_t wsDwOffset;
-    uint64_t wsDgLastOffset;
-    uint64_t wsMm5Offset;
-    uint64_t wsDsTempOffset;
-    uint64_t wsMm6Offset;
-    uint64_t wsMm7Offset;
-};
+        // Layout 类型定义
+        using LayoutRowMajor = layout::RowMajor;
+        using LayoutColMajor = layout::ColumnMajor;
 
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgCubeProcess<DataType, GType>::Init(const GDN::ChunkBwdDqkwgTilingData &tiling) {
+        // 架构和策略定义
+        using ArchTag = Arch::AtlasA2;
+        using DispatchPolicy = Gemm::MmadPingpong<ArchTag, true>;
+        using L1TileShape = tla::Shape<_128, _128, _256>;
+        using L0TileShape = tla::Shape<_128, _128, _128>;
 
-/*
-    // 设置 workspace 偏移
-    // wsDwOffset = 0;
-    wsDgLastOffset = 0;//B * HV * numChunks * sizeof(float);
-    // wsDgLastOffset = ((wsDgLastOffset + 31) / 32) * 32;
-    wsMm5Offset = wsDgLastOffset + ((B * HV * numChunks * sizeof(float) + 31) / 32) * 32;
-    // wsMm5Offset = wsMm5Offset;
-    wsDsTempOffset = wsMm5Offset + B * HV * T * BT * sizeof(DataType);
-    wsMm6Offset = wsDsTempOffset + B * HV * T * BT * sizeof(DataType);
-    wsMm7Offset = wsMm6Offset + B * HV * T * K * sizeof(DataType);
-*/
-    // printf("[cube] wsDgLastOffset %d,wsMm5Offset %d,wsDsTempOffset %d, wsMm6Offset %d wsMm7Offset %d\n",wsDgLastOffset,wsMm5Offset,wsDsTempOffset,wsMm6Offset, wsMm7Offset);
-////////////////////tiling/////
-    scale = tiling.scale;
-    B = tiling.B;
-    HV = tiling.HV;
-    HK = tiling.HK;
-    T = tiling.T;
-    K = tiling.K;
-    V = tiling.V;
-    BT = tiling.BT;
-    numChunks = tiling.numChunks;
-    n_ratio = (HK > 0) ? (HV / HK) : 1;
-    wsDgLastOffset = tiling.wsDgLastOffset;
-    // wsDgLastOffset = ((wsDgLastOffset + 31) / 32) * 32;
-    wsMm5Offset = tiling.wsMm5Offset;
-    // wsMm5Offset = wsMm5Offset;
-    wsDsTempOffset = tiling.wsDsTempOffset;
-    // wsMm6Offset = tiling.wsMm6Offset;
-    // wsMm7Offset = tiling.wsMm7Offset;
-    isVarLen = tiling.isVarLen;
-// printf("[cube] DTYPE_G %d, float %d\n",sizeof(DTYPE_G),sizeof(float));
-}
+        // Part 1: dv @ h^T -> dw  [BT, V] @ [V, K] -> [BT, K]
+        using TileCopyPart1 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart1 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart1>;
 
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgCubeProcess<DataType, GType>::Process() {
-    using namespace Catlass;
-    using namespace Catlass::Gemm;
-    
-    // Layout 类型定义
-    using LayoutRowMajor = layout::RowMajor;
-    using LayoutColMajor = layout::ColumnMajor;
-    
-    // 架构和策略定义
- #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
- 	     using ArchTag = Arch::Ascend950;
- 	 #else
- 	     using ArchTag = Arch::AtlasA2;
- 	 #endif
- 	     using DispatchPolicy = Gemm::MmadPingpong<ArchTag, true, false>;
-    using DispatchPolicy = Gemm::MmadPingpong<ArchTag, true>;
-    using L1TileShape = tla::Shape<_128, _128, _256>;
-    using L0TileShape = tla::Shape<_128, _128, _128>;
-    // using L1TileShape = tla::Shape<_128, _256, _256>;
-    // using L0TileShape = tla::Shape<_128, _256, _64>;
-    // Part 1: dv @ h^T -> dw  [BT, V] @ [V, K] -> [BT, K]
-    using TileCopyPart1 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
-    using BlockMmadPart1 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart1>;
-    
-    // Part 2: q @ k^T -> mm5  [BT, K] @ [K, BT] -> [BT, BT]
-    using TileCopyPart2 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
-    using BlockMmadPart2 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart2>;
-    
-    // Part 3: do @ v^T -> ds  [BT, V] @ [V, BT] -> [BT, BT]
-    using TileCopyPart3 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
-    using BlockMmadPart3 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart3>;
-    
-    // Part 4: do @ h^T -> dq  [BT, V] @ [V, K] -> [BT, K]
-    using TileCopyPart4 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
-    using BlockMmadPart4 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart4>;
-    
-    // Part 5: v @ dh -> dk  [BT, V] @ [V, K] -> [BT, K]
-    using TileCopyPart5 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
-    using BlockMmadPart5 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart5>;
-    
-    // Part 6: ds @ k -> dq+=  [BT, BT] @ [BT, K] -> [BT, K]
-    using TileCopyPart6 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
-    using BlockMmadPart6 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart6>;
-    
-    // Part 7: ds^T @ q -> dk+=  [BT, BT] @ [BT, K] -> [BT, K]
-    using TileCopyPart7 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutColMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
-    using BlockMmadPart7 = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart7>;
-    
-    // Kernel 实例
-    using MatmulKernel = Kernel::ChunkBwdDqkwgTla<
-        BlockMmadPart1, BlockMmadPart2, BlockMmadPart3, BlockMmadPart4,
-        BlockMmadPart5, BlockMmadPart6, BlockMmadPart7
-    >;
-    
-    MatmulKernel kernel;
-    typename MatmulKernel::Params params(
-        ptrQ, ptrK, ptrV, ptrG, ptrH,
-        ptrDo, ptrDh, ptrDv, ptrCuSeqLen, ptrChunkIndices,
-        ptrDq, ptrDk, ptrDw, ptrDg,
-        ptrWorkspace, B, HV, HK, T, K, V, BT, numChunks, n_ratio,
-        wsDwOffset, wsDgLastOffset, wsMm5Offset, wsDsTempOffset, wsMm6Offset, wsMm7Offset,
-        scale, isVarLen
-    );
-    
-    kernel(params);
-}
+        // Part 2: q @ k^T -> mm5  [BT, K] @ [K, BT] -> [BT, BT]
+        using TileCopyPart2 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart2 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart2>;
 
-#endif  // CHUNK_BWD_DQKWG_CUBE_H
+        // Part 3: do @ v^T -> ds  [BT, V] @ [V, BT] -> [BT, BT]
+        using TileCopyPart3 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart3 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart3>;
+
+        // Part 4: do @ h^T -> dq  [BT, V] @ [V, K] -> [BT, K]
+        using TileCopyPart4 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart4 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart4>;
+
+        // Part 5: v @ dh -> dk  [BT, V] @ [V, K] -> [BT, K]
+        using TileCopyPart5 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart5 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart5>;
+
+        // Part 6: ds @ k -> dq+=  [BT, BT] @ [BT, K] -> [BT, K]
+        using TileCopyPart6 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart6 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart6>;
+
+        // Part 7: ds^T @ q -> dk+=  [BT, BT] @ [BT, K] -> [BT, K]
+        using TileCopyPart7 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutColMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart7 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart7>;
+
+        // Kernel 实例
+        using MatmulKernel = Kernel::ChunkBwdDqkwgTla<
+            BlockMmadPart1, BlockMmadPart2, BlockMmadPart3, BlockMmadPart4,
+            BlockMmadPart5, BlockMmadPart6, BlockMmadPart7
+        >;
+
+        // V=256 makes Part1/3/4/5 use a 256-wide reduction dimension. TileGemmDirect is a single
+        // 128-wide tile, so keep the fast direct path for V<=128 and use the tiled CATLASS path only
+        // for the V=256 corner case.
+        using TileCopyPart1Tiled = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart1Tiled = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart1Tiled>;
+        using TileCopyPart2Tiled = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart2Tiled = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart2Tiled>;
+        using TileCopyPart3Tiled = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart3Tiled = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart3Tiled>;
+        using TileCopyPart4Tiled = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart4Tiled = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart4Tiled>;
+        using TileCopyPart5Tiled = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart5Tiled = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart5Tiled>;
+        using TileCopyPart6Tiled = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart6Tiled = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart6Tiled>;
+        using TileCopyPart7Tiled = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutColMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
+        using BlockMmadPart7Tiled = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart7Tiled>;
+        using MatmulKernelTiled = Kernel::ChunkBwdDqkwgTla<
+            BlockMmadPart1Tiled, BlockMmadPart2Tiled, BlockMmadPart3Tiled, BlockMmadPart4Tiled,
+            BlockMmadPart5Tiled, BlockMmadPart6Tiled, BlockMmadPart7Tiled
+        >;
+
+        if (V > 128) {
+            MatmulKernelTiled kernel;
+            typename MatmulKernelTiled::Params params(
+                ptrQ, ptrK, ptrV, ptrG, ptrH,
+                ptrDo, ptrDh, ptrDv, ptrCuSeqLen, ptrChunkIndices,
+                ptrDq, ptrDk, ptrDw, ptrDg,
+                ptrWorkspace, B, HV, HK, T, K, V, BT, numChunks, n_ratio,
+                wsDwOffset, wsBtxKSyncSlotsPerHead, wsDgLastOffset, wsMm5Offset, wsDsTempOffset, wsMm6Offset, wsMm7Offset,
+                scale, isVarLen
+            );
+            params.aicCoreNum = aicCoreNum;
+            kernel(params);
+        } else {
+            MatmulKernel kernel;
+            typename MatmulKernel::Params params(
+                ptrQ, ptrK, ptrV, ptrG, ptrH,
+                ptrDo, ptrDh, ptrDv, ptrCuSeqLen, ptrChunkIndices,
+                ptrDq, ptrDk, ptrDw, ptrDg,
+                ptrWorkspace, B, HV, HK, T, K, V, BT, numChunks, n_ratio,
+                wsDwOffset, wsBtxKSyncSlotsPerHead, wsDgLastOffset, wsMm5Offset, wsDsTempOffset, wsMm6Offset, wsMm7Offset,
+                scale, isVarLen
+            );
+            params.aicCoreNum = aicCoreNum;
+            kernel(params);
+        }
+    }
+
+    #endif  // CHUNK_BWD_DQKWG_CUBE_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
@@ -287,8 +287,8 @@ namespace Catlass::Gemm::Kernel {
             GM_ADDR ptrChunkIndices;
 
             // 输出指针
-            GM_ADDR ptrDq;     // [B, HV, T, K]
-            GM_ADDR ptrDk;     // [B, HV, T, K]
+            GM_ADDR ptrDq;     // [B, HK, T, K]
+            GM_ADDR ptrDk;     // [B, HK, T, K]
             GM_ADDR ptrDw;     // [B, HV, T, K]
             GM_ADDR ptrDg;     // [B, HV, T]
 
@@ -306,7 +306,7 @@ namespace Catlass::Gemm::Kernel {
 
             // 形状参数 (GVA: H 拆为 HV/HK, HV = n_ratio * HK)
             uint64_t B;// = CONST_B;
-            uint64_t HV;           // value 侧 head 数 (v/g/h/do/dh/dv 及全部输出), == 原 H
+            uint64_t HV;           // value 侧 head 数 (v/g/h/do/dh/dv/dw/dg), == 原 H
             uint64_t HK;           // key/query 侧 head 数 (q/k), HV = n_ratio * HK
             uint64_t T;// = CONST_T;
             uint64_t K;// = CONST_K;
@@ -536,10 +536,11 @@ namespace Catlass::Gemm::Kernel {
                 uint32_t actual_chunk_len = eos - bos;
                 uint32_t bIdx = loopIdx / params.numChunks;
                 uint32_t chunkIdx = loopIdx % params.numChunks;
+                const bool gvaMode = params.HV != params.HK;
 
                 WaitCredit();
                 for (uint32_t h = 0; h < params.HV; h++) {
-                    // --- Part4: dq_inner = do @ h^T -> ptrDq ---
+                    // --- Part4: dq_inner = do @ h^T ---
                     {
                         GemmCoord actualBlockShape{
                             static_cast<uint32_t>(actual_chunk_len),
@@ -549,13 +550,20 @@ namespace Catlass::Gemm::Kernel {
                         uint64_t doOffset = (h * params.T + bos) * params.V;
                         uint64_t hOffset = ((bIdx * params.HV + h) * params.numChunks + chunkIdx) * params.K * params.V;
                         uint64_t dqOffset = (h * params.T + bos) * params.K;
+                        uint64_t dqTempOffset = DqkwgBtxKRingElemOffset(coreIdx, loopBase, loopIdx, coreNum, h,
+                                                                         params.HV, params.BT, params.K,
+                                                                         (uint32_t)params.wsBtxKSyncSlotsPerHead);
 
                         GlobalTensor<ElementA> gmDo;
                         gmDo.SetGlobalBuffer((__gm__ ElementA *)params.ptrDo + doOffset);
                         GlobalTensor<ElementA> gmH;
                         gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
                         GlobalTensor<ElementC> gmDq;
-                        gmDq.SetGlobalBuffer((__gm__ ElementC *)params.ptrDq + dqOffset);
+                        if (gvaMode) {
+                            gmDq.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm5Offset) + dqTempOffset);
+                        } else {
+                            gmDq.SetGlobalBuffer((__gm__ ElementC *)params.ptrDq + dqOffset);
+                        }
 
                         auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
                         auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});
@@ -623,10 +631,11 @@ namespace Catlass::Gemm::Kernel {
                 uint32_t actual_chunk_len = eos - bos;
                 uint32_t bIdx = loopIdx / params.numChunks;
                 uint32_t chunkIdx = loopIdx % params.numChunks;
+                const bool gvaMode = params.HV != params.HK;
 
                 WaitCredit();
                 for (uint32_t h = 0; h < params.HV; h++) {
-                    // --- Part5: dk_inner = v @ dh -> ptrDk ---
+                    // --- Part5: dk_inner = v @ dh ---
                     {
                         GemmCoord actualBlockShape{
                             static_cast<uint32_t>(actual_chunk_len),
@@ -636,13 +645,20 @@ namespace Catlass::Gemm::Kernel {
                         uint64_t vOffset = (h * params.T + bos) * params.V;
                         uint64_t dhOffset = ((bIdx * params.HV + h) * params.numChunks + chunkIdx) * params.K * params.V;
                         uint64_t dkOffset = (h * params.T + bos) * params.K;
+                        uint64_t dkTempOffset = DqkwgShortBtxKRingElemOffset(
+                            coreIdx, loopIdx, coreNum, h, params.HV, params.BT, params.K,
+                            DqkwgShortRingDepthFromGroup((uint32_t)params.wsBtxKSyncSlotsPerHead));
 
                         GlobalTensor<ElementA> gmV;
                         gmV.SetGlobalBuffer((__gm__ ElementA *)params.ptrV + vOffset);
                         GlobalTensor<ElementA> gmDh;
                         gmDh.SetGlobalBuffer((__gm__ ElementA *)params.ptrDh + dhOffset);
                         GlobalTensor<ElementC> gmDk;
-                        gmDk.SetGlobalBuffer((__gm__ ElementC *)params.ptrDk + dkOffset);
+                        if (gvaMode) {
+                            gmDk.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm6Offset) + dkTempOffset);
+                        } else {
+                            gmDk.SetGlobalBuffer((__gm__ ElementC *)params.ptrDk + dkOffset);
+                        }
 
                         auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
                         auto tensorDh = tla::MakeTensor(gmDh, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
@@ -821,7 +821,11 @@ namespace Catlass::Gemm::Kernel {
         using LayoutColMajor = layout::ColumnMajor;
 
         // 架构和策略定义
-        using ArchTag = Arch::AtlasA2;
+        #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+            using ArchTag = Arch::Ascend950;
+        #else
+            using ArchTag = Arch::AtlasA2;
+        #endif
         using DispatchPolicy = Gemm::MmadPingpong<ArchTag, true>;
         using L1TileShape = tla::Shape<_128, _128, _256>;
         using L0TileShape = tla::Shape<_128, _128, _128>;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
+ * Copyright (c) 2026 Tianjin University, Ltd.
  * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
  * the BSD 3-Clause License (the "License").
  * Please refer to the License for details. You may not use this file except in compliance with the License.
@@ -9,1416 +9,1321 @@
 
 /*!
  * \file chunk_bwd_dqkwg_vector.h
+ *
+ * CV 深融合 (chunk-interleaved A/B/C/D) 的 AIV (Vector) 端。
+ *
+ * 与 cube 端镜像: 每核任务流 A(c0..cM-1), B(...), C(...), D(...)。
+ * 每个 (stage, chunk) task: 两个 AIV sub-block 各 WaitCubeReady 一次,
+ * 处理完该 chunk 全部 head (sub-block 内部按 head / row 切分) 后各 SetVectorDone 一次。
+ * cube 落后处理: vector 处理 task[i] 时 cube 已在做 task[i+1]。
+ *
+ * stage 映射 (与 cube 对应):
+ *   A_vector = 原 Part1 vector (dw 取负 + dg_last) + 原 Part2 vector (mul1)
+ *   B_vector = 原 Part3 vector (ds_temp + dg 部分)
+ *   C_vector = 原 Part4 + Part6 vector (dq 最终 + dg)
+ *   D_vector = 原 Part5 + Part7 vector (dk 最终 + dg 最终, 含 dg_last 重算)
+ *
+ * 同步计数平衡 (区别于 cv_merge 死锁版本): 无 preseed, 无 per-head flag, 无 stage drain;
+ * 每个 AIV sub-block 每 task 恰好 1 次 WaitCubeReady + 1 次 SetVectorDone。
  */
 
-#ifndef CHUNK_BWD_DQKWG_VECTOR_H
-#define CHUNK_BWD_DQKWG_VECTOR_H
-
-#include "chunk_bwd_dqkwg_common.h"
-#include "kernel_operator.h"
-
-using namespace AscendC;
-
-template <typename DataType, typename GType>
-class ChunkBwdDqkwgVectorProcess {
-public:
-    __aicore__ inline ChunkBwdDqkwgVectorProcess(
-        GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
-        GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices, GM_ADDR mask_a,
-        GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
-        GM_ADDR workspace
-    );
-    
-    __aicore__ inline void Init(const GDN::ChunkBwdDqkwgTilingData &tiling, TPipe *pipe_);
-    __aicore__ inline void Process();
-    
-private:
-    // 7 个 Part 的处理函数
-    __aicore__ inline void ProcessPart1();  // dw = -dv @ h^T, dg_last 计算
-    __aicore__ inline void ProcessPart2();  // 等待 mm5 完成
-    __aicore__ inline void ProcessPart3();  // ds 处理, dg 部分计算
-    __aicore__ inline void ProcessPart4();  // dq 处理, dg 累加
-    __aicore__ inline void ProcessPart5();  // dk 处理, dg 最终计算
-    __aicore__ inline void ProcessPart6();  // dq 累加
-    __aicore__ inline void ProcessPart7();  // dk 累加
-    
-    // 辅助函数
-    __aicore__ inline void ComputeExpScalar(float input, float &output);
-    __aicore__ inline void ApplyLowerTriangularMask(LocalTensor<float> &tensor, uint32_t size);
-    __aicore__ inline void ReduceSumX(LocalTensor<float> &src, LocalTensor<float> &dst,
-                                      uint32_t rows, uint32_t cols, int axis);
-    
-private:
-    // 输入输出指针
-    GM_ADDR ptrQ;
-    GM_ADDR ptrK;
-    GM_ADDR ptrV;
-    GM_ADDR ptrG;
-    GM_ADDR ptrH;
-    GM_ADDR ptrDo;
-    GM_ADDR ptrDh;
-    GM_ADDR ptrDv;
-    GM_ADDR ptrCuSeqLen;
-    GM_ADDR ptrChunkIndices;
-    GM_ADDR ptrMaskA;
-    GM_ADDR ptrDq;
-    GM_ADDR ptrDk;
-    GM_ADDR ptrDw;
-    GM_ADDR ptrDg;
-    GM_ADDR ptrWorkspace;
-    
-    // Tiling 参数
-    uint64_t B;
-    uint64_t HV;
-    uint64_t HK;
-    uint64_t T;
-    uint64_t K;
-    uint64_t V;
-    uint64_t BT;
-    uint64_t numChunks;
-    float scale;
-    int isVarLen;
-    uint32_t mul0RowNum = 0;
-    uint64_t n_ratio = 1;
-    
-    // Workspace 偏移
-    uint64_t wsDwOffset;
-    uint64_t wsDgLastOffset;
-    uint64_t wsMm5Offset;
-    uint64_t wsDsTempOffset;
-    uint64_t wsMm6Offset;
-    uint64_t wsMm7Offset;
-    uint64_t wsMul1Offset;
-    int BUFFER_NUM = 1;
-    
-    // Pipeline
-    TPipe *pipe = nullptr;
-    
-    // Global Tensors
-    GlobalTensor<DataType> gmQ, gmK, gmV, gmDo, gmH, gmDh, gmDv;
-    GlobalTensor<DataType> gmDq, gmDk, gmDw;
-    GlobalTensor<GType> gmG, gmDg;
-    GlobalTensor<DataType> gmWorkspace;
-    GlobalTensor<float> gmDgLast;
-    GlobalTensor<DataType> gmMm5, gmDsTemp, gmMul1, gmMm6, gmMm7;
-    
-    // Queues (用于流水)
-    TQue<TPosition::VECIN, 2> inQue1;
-    TQue<TPosition::VECIN, 2> inQue2;
-    TQue<TPosition::VECIN, 2> inQue3;
-    TQue<TPosition::VECIN, 2> inQue4;  //用于Add0累加
-    TQue<TPosition::VECIN, 2> inQue5;  //用于Part5 Add4中间结果
-    TQue<TPosition::VECIN, 2> inQue6;  //用于Part5 gLast中间结果
-    TQue<TPosition::VECOUT, 2> outQue1;
-    TQue<TPosition::VECOUT, 2> outQue2;
-
-    
-    // Calc Buffers (UB 空间)
-    TBuf<TPosition::VECCALC> calcBuf1;  // 主计算缓冲区 (fp32)
-    TBuf<TPosition::VECCALC> calcBuf2;  // 辅助计算缓冲区 (fp32)
-    TBuf<TPosition::VECCALC> calcBuf3;  // Exp 缓冲区
-    TBuf<TPosition::VECCALC> calcBuf4;  // 中间结果
-    TBuf<TPosition::VECCALC> gBuf;      // g 值缓冲区
-    TBuf<TPosition::VECCALC> dgBuf;     // dg 值缓冲区
-    
-    // UB 空间常量
-    static constexpr uint32_t UB_BLOCK_SIZE = 32;
-    static constexpr uint32_t FP32_ELEMENTS_PER_BLOCK = 8;
-    static constexpr uint32_t FP16_ELEMENTS_PER_BLOCK = 16;
-};
-
-// ============== 构造函数 ==============
-template <typename DataType, typename GType>
-__aicore__ inline ChunkBwdDqkwgVectorProcess<DataType, GType>::ChunkBwdDqkwgVectorProcess(
-    GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
-    GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices, GM_ADDR mask_a,
-    GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
-    GM_ADDR workspace
-) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
-    ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLen(cu_seqlen), ptrChunkIndices(chunk_indices), ptrMaskA(mask_a),
-    ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
-    ptrWorkspace(workspace) {}
-
-// ============== 初始化 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::Init(const GDN::ChunkBwdDqkwgTilingData &tiling, TPipe *pipe_) {
-    pipe = pipe_;
-
-    scale = tiling.scale;
-    B = tiling.B;
-    HV = tiling.HV;
-    HK = tiling.HK;
-    T = tiling.T;
-    K = tiling.K;
-    V = tiling.V;
-    BT = tiling.BT;
-    numChunks = tiling.numChunks;
-    n_ratio = (HK > 0) ? (HV / HK) : 1;
-    wsDgLastOffset = tiling.wsDgLastOffset;
-    wsMm5Offset = tiling.wsMm5Offset;
-    wsDsTempOffset = tiling.wsDsTempOffset;
-    // wsMm6Offset = tiling.wsMm6Offset;
-    // wsMm7Offset = tiling.wsMm7Offset;
-    // wsMul1Offset = tiling.wsMul1Offset;
-    uint64_t dgLastSize = tiling.dgLastSize;
-    isVarLen = tiling.isVarLen;
-    mul0RowNum = tiling.mul0RowNum;
-
-    if (BT == 64) {
-        BUFFER_NUM = 2;
-    } else {
-        BUFFER_NUM = 1;
-    }
-
-    gmQ.SetGlobalBuffer((__gm__ DataType *)ptrQ);
-    gmK.SetGlobalBuffer((__gm__ DataType *)ptrK);
-    gmV.SetGlobalBuffer((__gm__ DataType *)ptrV);
-    gmG.SetGlobalBuffer((__gm__ GType *)ptrG);
-    gmH.SetGlobalBuffer((__gm__ DataType *)ptrH);
-    gmDo.SetGlobalBuffer((__gm__ DataType *)ptrDo);
-    gmDh.SetGlobalBuffer((__gm__ DataType *)ptrDh);
-    gmDv.SetGlobalBuffer((__gm__ DataType *)ptrDv);
-
-    gmDq.SetGlobalBuffer((__gm__ DataType *)ptrDq);
-    gmDk.SetGlobalBuffer((__gm__ DataType *)ptrDk);
-    gmDw.SetGlobalBuffer((__gm__ DataType *)ptrDw);
-    gmDg.SetGlobalBuffer((__gm__ GType *)ptrDg);
-
-    gmWorkspace.SetGlobalBuffer((__gm__ DataType *)ptrWorkspace);
-    gmDgLast.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t*)ptrWorkspace + wsDgLastOffset));     //中间结果使用float
-
-    gmMm5.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm5Offset));
-    gmDsTemp.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsDsTempOffset));
-    // gmMm6.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm6Offset));
-    // gmMm7.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm7Offset));
-    gmMm6.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm5Offset));
-    gmMm7.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm5Offset));
-    // gmMul1.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMul1Offset));
-    gmMul1.SetGlobalBuffer((__gm__ DataType *)ptrDq);
-}
-
-// ============== 主处理函数 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::Process() {
-    // Part 1: dw 和 dg_last 计算
-    ProcessPart1();
-    pipe->Reset();
-    AscendC::SyncAll<false>();
-    // Part 2: 等待 mm5 (q @ k^T) 完成
-    ProcessPart2();
-    pipe->Reset();
-    AscendC::SyncAll<false>();
-    // Part 3: ds 处理和 dg 部分计算
-    ProcessPart3();
-    pipe->Reset();
-    AscendC::SyncAll<false>();
-    // Part 4: dq 处理
-    ProcessPart4();
-    pipe->Reset();
-    AscendC::SyncAll<false>();
-    // Part 5: dk 处理和 dg 最终计算
-    ProcessPart5();
-    pipe->Reset();
-    AscendC::SyncAll<false>();
-    // Part 6: dq 累加
-    ProcessPart6();
-    pipe->Reset();
-    AscendC::SyncAll<false>();
-    // Part 7: dk 累加
-    ProcessPart7();
-}
-
-// ============== Part 1: dw 和 dg_last 计算 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart1() {
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNum = GetBlockNum();
-    // printf("coreIdx %d, coreNum %d\n", coreIdx, coreNum);
-    uint32_t coreLoops = B * numChunks;
-    
-    // 分配 UB 空间
-    // Part 1 的 Vector 部分主要处理:
-    // 1. h * dh 的逐元素乘法和求和 -> dg_last
-    // 2. dw 的负号处理
-    
-    const uint32_t hDhSize = mul0RowNum * V;  // h 和 dh 的大小
-    const uint32_t dwSize = BT * K;
-    uint32_t BT_sub = BT;
-    uint32_t BT_sub_offset = 0;
-
-    uint32_t dwSize_sub = BT_sub * K;
-    uint32_t vecTaskIdx = 0;
-
-    uint32_t maxSize = (2 * hDhSize) > dwSize ? (2 * hDhSize) : dwSize;
-
-    // 初始化 buffers
-    pipe->InitBuffer(inQue1, BUFFER_NUM, maxSize * sizeof(DataType));  // h 和 dh 共用一个输入队列
-    pipe->InitBuffer(outQue1, BUFFER_NUM, sizeof(float) * 8);  // dg_last (对齐到 32 字节)
-    pipe->InitBuffer(outQue2, BUFFER_NUM, dwSize * sizeof(DataType));
-    pipe->InitBuffer(calcBuf1, maxSize * sizeof(float));
-    pipe->InitBuffer(calcBuf3, hDhSize * sizeof(float));
-    auto tensorHFp32 = calcBuf1.Get<float>();
-    auto tensorDhFp32 = tensorHFp32[hDhSize];
-    auto tensorSumFp32 = calcBuf3.Get<float>();
-
-    // 发送同步信号给 Cube
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-        uint32_t bIdx = loopIdx / numChunks;
-        uint32_t chunkIdx = loopIdx % numChunks;
-        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, HV, T, BT, loopIdx, bos, eos);
-        BT_sub = eos-bos;
-        dwSize_sub = BT_sub * K;
-        
-        for (uint32_t h = 0; h < HV; h++) {
-            ++vecTaskIdx;
-            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-                continue;
-            }
-            // h is hv_idx; h_state, dh: [B, HV, num_chunks, K, V]
-            uint64_t hOffset = ((bIdx * HV + h) * numChunks + chunkIdx) * K * V;
-            // dw: [B, HV, T, K]
-            uint64_t dwOffset = (h * T + bos) * K;
-            // dg_last: [B, HV, num_chunks]
-            uint64_t dgLastOffset = (bIdx * HV + h) * numChunks + chunkIdx;
-
-            // ========== 计算 dg_last = sum(h * dh) ==========
-            // 等待 Cube 信号 (dw Cube 计算)
-            for(uint32_t row = 0; row < K; row += mul0RowNum) {
-                // CopyIn: h 和 dh
-                {
-                    auto tensorHIn = inQue1.AllocTensor<DataType>();
-                    auto tensorDhIn = tensorHIn[hDhSize];
-                    DataCopy(tensorDhIn, gmDh[hOffset + row * V], hDhSize);
-                    DataCopy(tensorHIn, gmH[hOffset + row * V], hDhSize);
-                    inQue1.EnQue(tensorHIn);
-                }
-                // Compute: h * dh -> reduceSum
-                {
-                    auto tensorHIn = inQue1.DeQue<DataType>();
-                    auto tensorDhIn = tensorHIn[hDhSize];
-                    // Cast to fp32 (bf16 不支持直接 Mul)
-                    Cast(tensorHFp32, tensorHIn, RoundMode::CAST_NONE, hDhSize);
-                    Cast(tensorDhFp32, tensorDhIn, RoundMode::CAST_NONE, hDhSize);
-                    PipeBarrier<PIPE_V>();
-
-                    // 逐元素乘法
-                    if(row == 0) {
-                        Mul(tensorSumFp32, tensorHFp32, tensorDhFp32, hDhSize);
-                    } else {
-                        Mul(tensorHFp32, tensorHFp32, tensorDhFp32, hDhSize);
-                        PipeBarrier<PIPE_V>();
-                        Add(tensorSumFp32, tensorSumFp32, tensorHFp32, hDhSize);
-                    }
-
-                    PipeBarrier<PIPE_V>();
-                    inQue1.FreeTensor(tensorHIn);
-                }
-            }
-            {
-                uint32_t remainNum = hDhSize;
-                while(remainNum > 64) {
-                    remainNum = remainNum / 2;
-                    Add(tensorSumFp32, tensorSumFp32, tensorSumFp32[remainNum], remainNum);
-                    PipeBarrier<PIPE_V>();
-                }
-                auto tensorDgLastOut = outQue1.AllocTensor<float>();
-                WholeReduceSum(tensorDgLastOut, tensorSumFp32, 64, 1, 1, 1, 8);
-                outQue1.EnQue(tensorDgLastOut);
-            }
-            {
-                auto tensorDgLastOut = outQue1.DeQue<float>();
-
-                DataCopyParams dataCopyParams;
-                dataCopyParams.blockCount = 1;
-                dataCopyParams.blockLen = 1*sizeof(float);
-                dataCopyParams.srcStride = 0;
-                dataCopyParams.dstStride = 0;
-                DataCopyPad(gmDgLast[dgLastOffset], tensorDgLastOut,dataCopyParams);
-
-                outQue1.FreeTensor(tensorDgLastOut);
-            }
-
-
-
-            // ========== 处理 dw: 取负号 ==========
-            // Cube 计算的是 dv @ h^T, 需要乘以 -1
-            // 从 workspace 读取 dw, 乘以 -1, 写回最终输出
-            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-            // CopyIn: dw from workspace
-            {
-                auto tensorDwIn = inQue1.AllocTensor<DataType>();
-                DataCopy(tensorDwIn, gmDw[dwOffset], dwSize_sub);
-                inQue1.EnQue(tensorDwIn);
-            }
-
-            // Compute: -dw
-            {
-                auto tensorDwIn = inQue1.DeQue<DataType>();
-                auto tensorDwOut = outQue2.AllocTensor<DataType>();
-                
-                // Cast to fp32, 乘以 -1, cast back
-                Cast(tensorHFp32, tensorDwIn, RoundMode::CAST_NONE, dwSize_sub);
-                PipeBarrier<PIPE_V>();
-                Muls(tensorHFp32, tensorHFp32, -1.0f, dwSize_sub);
-                PipeBarrier<PIPE_V>();
-                Cast(tensorDwOut, tensorHFp32, RoundMode::CAST_RINT, dwSize_sub);
-                inQue1.FreeTensor(tensorDwIn);
-                outQue2.EnQue(tensorDwOut);
-            }
-            
-            // CopyOut: dw to final output
-            {
-                auto tensorDwOut = outQue2.DeQue<DataType>();
-                DataCopy(gmDw[dwOffset], tensorDwOut, dwSize_sub);
-
-                outQue2.FreeTensor(tensorDwOut);
-            }
-
-            // 通知 Cube 继续
-            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-        }
-    }
-
-}
-
-// ============== Part 2: 等待 mm5 完成 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart2() {
-    // Part 2 MUL1 + and(m_A)
-    
-    constexpr int32_t BLOCK_SIZE = 32; // API一次能处理256B，能计算64个float元素
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNum = GetBlockNum();
-    uint32_t coreLoops = B * numChunks;
-    uint32_t real_BT = BT;
-
-    uint32_t BT_sub = real_BT;
-    uint32_t BT_sub_start = 0;
-    uint32_t BT_sub_end = BT_sub;
-
-    uint32_t dsSize_sub = BT_sub * BT;
-    uint32_t dsSize_sub_offset = 0;
-    const uint32_t gSize = BT;
-    
-    // 初始化 buffers
-    
-    pipe->InitBuffer(inQue3, 2, gSize * sizeof(float));        // g values
-    pipe->InitBuffer(outQue1, 2, dsSize_sub * sizeof(float) / 2);   // ds_temp output   32K/8K
-
-    pipe->InitBuffer(calcBuf1, BT * 8 * sizeof(float));             // g in fp32
-    pipe->InitBuffer(calcBuf2, BT * sizeof(float));            // g temp [BT,1]
-    pipe->InitBuffer(calcBuf3, BT * sizeof(float));            // g temp [1,BT]
-    pipe->InitBuffer(calcBuf4, BLOCK_SIZE);
-
-    auto tensorBrcbTemp = calcBuf1.Get<float>();
-    auto tensorGFp32Left = calcBuf2.Get<float>();
-    auto tensorGFp32Right = calcBuf3.Get<float>();
-    auto tensorZeroFp32 = calcBuf4.template Get<float>();
-    
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    uint32_t bos_orig = 0;
-    uint32_t eos_orig = 0;
-    // 发送同步信号
-
-    //初始化zero
-    AscendC::Duplicate<float>(tensorZeroFp32, float(0.0), BLOCK_SIZE / sizeof(float));
-    PipeBarrier<PIPE_V>();
-    //搬入m_A
-
-    const uint32_t maskASize = 64*64*sizeof(float);//BT * BT / 8 * sizeof(uint8_t);
-    pipe->InitBuffer(inQue1, 1, maskASize);    // m_A from input
-    auto tensorMaskA = inQue1.AllocTensor<float>();
-
-    Duplicate(tensorMaskA,static_cast<float>(0),64 * 64);
-    PipeBarrier<PIPE_V>();
-    for(int i = 0; i < 64; i++) {
-        Duplicate(tensorMaskA[i * 64], 1.0f, i + 1);
-    }
-    PipeBarrier<PIPE_V>();
-
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, HV, T, BT, loopIdx, bos, eos);
-        bos_orig = bos;
-        eos_orig = eos;
-        uint32_t vec_core_0_length = (eos_orig - bos_orig) >= (BT / 2) ? (BT / 2) : (eos_orig - bos_orig);
-        uint32_t vec_core_1_length = (eos_orig - bos_orig) >= (BT / 2) ? (eos_orig - bos_orig - (BT / 2)) : 0;
-        if (GetSubBlockIdx() == 0) {
-            BT_sub_start = 0;
-            BT_sub_end = vec_core_0_length;
-            eos = bos + vec_core_0_length;
-        } else {
-            BT_sub_start = vec_core_0_length;
-            BT_sub_end = eos_orig - bos_orig;
-            bos = bos + vec_core_0_length;
-        }
-        
-        uint32_t real_BT= eos-bos;
-        uint32_t real_BT_align = ALIGN_UP((eos-bos), 16);
-        dsSize_sub = (eos-bos) * BT;
-        uint32_t bIdx = loopIdx / numChunks;
-        uint32_t chunkIdx = loopIdx % numChunks;
-
-        for (uint32_t h = 0; h < HV; h++) {
-            if (real_BT == 0) {
-                continue;
-            }
-
-            // h is hv_idx
-            // g: [B, HV, T]
-            uint64_t gOffset = (h * T + bos_orig);
-            // ds, mm5, ds_temp: [B, HV, T, BT]
-            uint64_t dsOffset = (h * T + bos) * BT;
-            // CopyIn: g
-            {
-                auto tensorGIn = inQue3.AllocTensor<GType>();
-
-                DataCopyParams dataCopyParams;
-                dataCopyParams.blockCount = 1;
-                dataCopyParams.blockLen = (eos_orig-bos_orig)*sizeof(GType);
-                dataCopyParams.srcStride = 0;
-                dataCopyParams.dstStride = 0;
-                DataCopyPad(tensorGIn, gmG[gOffset],dataCopyParams,{false, 0, 0, 0});
-
-                inQue3.EnQue(tensorGIn);
-            }
-
-            // Compute MUL1
-            {
-                auto tensorGIn = inQue3.DeQue<GType>();
-                auto tensorDsTempOut = outQue1.AllocTensor<float>();
-
-                // g 可能已经是 fp32
-                if constexpr (std::is_same<GType, float>::value) {
-                    DataCopy(tensorGFp32Left, tensorGIn, gSize);
-                } else {
-                    Cast(tensorGFp32Left, tensorGIn, RoundMode::CAST_NONE, gSize);
-                }
-                PipeBarrier<PIPE_V>();
-
-                Muls(tensorGFp32Right, tensorGFp32Left, static_cast<float>(-1), gSize);
-
-                Brcb(tensorBrcbTemp, tensorGFp32Left[BT_sub_start], CEIL_DIV(real_BT, 8), {1, 8}); // Brcb处理数据个数需要8对齐 [BT,8]
-                PipeBarrier<PIPE_V>();
-
-                // copy tensorGFp32Right  chunkLen / 2行
-                if (BT == 64) {
-
-                    AscendC::Add(tensorDsTempOut, tensorGFp32Right, tensorBrcbTemp, CAL_NUM_FLOAT, real_BT,
-                                {1, 1, 0, 8, 0, 1});
-
-                    PipeBarrier<PIPE_V>();
-                    Mins(tensorDsTempOut, tensorDsTempOut, static_cast<float>(0.0), real_BT * BT);
-
-                    PipeBarrier<PIPE_V>();
-                    Exp(tensorDsTempOut, tensorDsTempOut, real_BT * BT);
-                    PipeBarrier<PIPE_V>();
-
-                } else {
-                    AscendC::Copy(tensorDsTempOut, tensorGFp32Right, CAL_NUM_FLOAT, real_BT, {1, 1, 16, 0});
-                    PipeBarrier<PIPE_V>();
-                    AscendC::Copy(tensorDsTempOut[CAL_NUM_FLOAT], tensorGFp32Right[CAL_NUM_FLOAT], CAL_NUM_FLOAT,
-                                real_BT, {1, 1, 16, 0});
-                    PipeBarrier<PIPE_V>();
-                    AscendC::Add(tensorDsTempOut, tensorDsTempOut, tensorBrcbTemp, CAL_NUM_FLOAT, real_BT,
-                                {1, 1, 0, 16, 16, 1});
-                    PipeBarrier<PIPE_V>();
-                    AscendC::Add(tensorDsTempOut[CAL_NUM_FLOAT], tensorDsTempOut[CAL_NUM_FLOAT], tensorBrcbTemp,
-                                CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
-                    PipeBarrier<PIPE_V>();
-                    Mins(tensorDsTempOut, tensorDsTempOut, static_cast<float>(0.0), real_BT * BT);
-                    PipeBarrier<PIPE_V>();
-                    Exp(tensorDsTempOut, tensorDsTempOut, real_BT * BT);
-                }
-
-                PipeBarrier<PIPE_V>();
-
-                if(BT==64) {    //TODO： MASK
-                    Mul(tensorDsTempOut,tensorDsTempOut,tensorMaskA[BT_sub_start*64],32*64);
-                    PipeBarrier<PIPE_V>();
-                } else {
-                    BinaryRepeatParams binaryRepeatParams{1,1,1,16,16,8};
-                    UnaryRepeatParams unaryRepeatParams{1,1,16,8};
-                    PipeBarrier<PIPE_V>();
-                    if (BT_sub_start == 0) {    // vec 0 : 0..64
-                        Mul(tensorDsTempOut,tensorDsTempOut,tensorMaskA,64,64,binaryRepeatParams);
-                        PipeBarrier<PIPE_V>();
-                        Muls(tensorDsTempOut[64],tensorDsTempOut[64],static_cast<float>(0),64,64,unaryRepeatParams);
-                        PipeBarrier<PIPE_V>();
-                    }
-                    else {      // vec 0 : 64..128
-                        Mul(tensorDsTempOut[64],tensorDsTempOut[64],tensorMaskA,64,64,binaryRepeatParams);
-                        PipeBarrier<PIPE_V>();
-                    }
-
-                }
-
-                AscendC::Muls(tensorDsTempOut, tensorDsTempOut, static_cast<float>(scale), real_BT * BT);
-                PipeBarrier<PIPE_V>();
-
-                //Ds是 fp16/bf16
-                Cast(tensorDsTempOut.template ReinterpretCast<DataType>(), tensorDsTempOut, RoundMode::CAST_RINT, real_BT * BT);
-
-                inQue3.FreeTensor(tensorGIn);
-                outQue1.EnQue(tensorDsTempOut);
-            }
-
-            // CopyOut
-            {
-                auto tensorDsTempOut = outQue1.DeQue<float>();
-                DataCopy(gmMul1[dsOffset], tensorDsTempOut.template ReinterpretCast<DataType>(), real_BT * BT);
-
-                outQue1.FreeTensor(tensorDsTempOut);
-            }
-        }
-    }
-    inQue1.FreeTensor<float>(tensorMaskA);
-}
-
-// ============== Part 3: ds 处理和 dg 部分计算 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart3() {
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNum = GetBlockNum();
-    uint32_t coreLoops = B * numChunks;
-    uint32_t real_BT = BT; // TODO：如果BT不对齐
-
-    uint32_t BT_sub = real_BT;
-    uint32_t BT_sub_start = 0;
-    uint32_t BT_sub_end = BT_sub;
-
-
-    uint32_t dsSize_sub = BT_sub * BT;
-    uint32_t dsSize_sub_offset = 0;
-    const uint32_t gSize = BT;
-
-    // 初始化 buffers
-    pipe->InitBuffer(inQue1, BUFFER_NUM, dsSize_sub * sizeof(float));    // ds from Cube
-    pipe->InitBuffer(inQue2, BUFFER_NUM, dsSize_sub * sizeof(float));    // mm5/mul1 from workspace
-    pipe->InitBuffer(outQue1, BUFFER_NUM, dsSize_sub * sizeof(DataType));   // ds_temp output   32K/8K
-    pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(float));       // dg output
-
-    pipe->InitBuffer(calcBuf4, gSize * sizeof(float));        // m_A
-    pipe->InitBuffer(gBuf, gSize * sizeof(float));             // g in fp32
-    pipe->InitBuffer(dgBuf, gSize * sizeof(float));            // dg temp
-
-    auto tensorMaskA = calcBuf4.Get<float>();
-    auto tensorGFp32 = gBuf.Get<float>();
-    auto tensorDgTemp = dgBuf.Get<float>();
-
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    uint32_t vecTaskIdx = 0;
-    // 发送同步信号
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, HV, T, BT, loopIdx, bos, eos);
-        BT_sub_end = eos-bos;
-        uint32_t real_BT= eos-bos;
-        dsSize_sub = (eos-bos) * BT;
-        uint32_t bIdx = loopIdx / numChunks;
-        uint32_t chunkIdx = loopIdx % numChunks;
-
-        for (uint32_t h = 0; h < HV; h++) {
-            ++vecTaskIdx;
-            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-                continue;
-            }
-
-            // h is hv_idx
-            // g: [B, HV, T]
-            uint64_t gOffset = (h * T + bos);
-            // ds, mm5, ds_temp: [B, HV, T, BT]
-            uint64_t dsOffset = (h * T + bos) * BT;
-
-            // dg: [B, HV, T]
-            uint64_t dgOffset = gOffset;
-
-            // 等待 Cube 完成 ds 计算
-            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-
-            // CopyIn: ds (Cube output), g
-            {
-                auto tensorDsIn = inQue1.AllocTensor<DataType>();
-                auto tensorMul1In = inQue2.AllocTensor<DataType>();
-
-                DataCopy(tensorDsIn[BT * BT], gmDsTemp[dsOffset + dsSize_sub_offset], dsSize_sub);
-                DataCopy(tensorMul1In[BT * BT], gmMul1[dsOffset + dsSize_sub_offset], dsSize_sub);
-
-                inQue1.EnQue(tensorDsIn);
-                inQue2.EnQue(tensorMul1In);
-            }
-
-            // Compute MUL1
-            {
-                auto tensorDsInFp16 = inQue1.DeQue<DataType>();
-                auto tensorDsInFp32 = tensorDsInFp16.template ReinterpretCast<float>();
-
-                auto tensorDsTempOut = outQue1.AllocTensor<DataType>();
-
-                auto tensorMul1InFp16 = inQue2.DeQue<DataType>();
-                auto tensorMul1InFp32 = tensorMul1InFp16.template ReinterpretCast<float>();
-                auto tensorDgOut = outQue2.AllocTensor<float>();
-
-                // Cast to fp32
-                Cast(tensorDsInFp32, tensorDsInFp16[BT * BT], RoundMode::CAST_NONE, dsSize_sub);
-
-                
-                Cast(tensorMul1InFp32, tensorMul1InFp16[BT * BT], RoundMode::CAST_NONE, dsSize_sub);
-                PipeBarrier<PIPE_V>();
-                // b_ds_temp = b_ds * mul1 (已经应用了掩码)
-                Mul(tensorDsInFp32, tensorDsInFp32, tensorMul1InFp32, dsSize_sub);
-                inQue2.FreeTensor(tensorMul1InFp32);
-
-                //搬入MM5,复用Mul1空间
-                auto tensorMm5InFp16Tmp = inQue2.AllocTensor<DataType>();
-                DataCopy(tensorMm5InFp16Tmp[BT * BT], gmMm5[dsOffset + dsSize_sub_offset], dsSize_sub);
-                inQue2.EnQue(tensorMm5InFp16Tmp);
-                auto tensorMm5InFp16 = inQue2.DeQue<DataType>();
-
-                auto tensorMm5InFp32 = tensorMm5InFp16.template ReinterpretCast<float>();
-                Cast(tensorMm5InFp32, tensorMm5InFp16[BT * BT], RoundMode::CAST_NONE, dsSize_sub);
-                PipeBarrier<PIPE_V>();
-                // Calcute ds_temp * mm5 and after
-
-                Mul(tensorMm5InFp32, tensorDsInFp32, tensorMm5InFp32, dsSize_sub); // b_ds2 = b_ds_temp * mm5
-                Cast(tensorDsTempOut, tensorDsInFp32, RoundMode::CAST_RINT, dsSize_sub);  //ds_tmp -> fp16, tensorDsFp32已经空闲
-
-                // axis=1: 对每行求和 -> [BT] +Add0.C
-                Duplicate(tensorDgOut, static_cast<float>(0.0), BT);
-                PipeBarrier<PIPE_V>();
-
-                // reducesum
-                uint64_t wholeReduceSumCnt = CeilDiv(real_BT, FP32_PER_REPEAT);
-                uint32_t remainCnt = real_BT % FP32_PER_REPEAT;
-                if(remainCnt > 0) {
-                    uint32_t DuplicateOffset = wholeReduceSumCnt * FP32_PER_REPEAT - FP32_PER_REPEAT;
-                    uint64_t mask[1] = {0xffffffffffffffff};
-                    mask[0] <<= remainCnt;
-                    for (uint32_t row = BT_sub_start; row < BT_sub_end; row++) {
-                        Duplicate(tensorMm5InFp32[row * BT + DuplicateOffset], 0.0f, mask, 1, 1, 8);
-                    }
-                    PipeBarrier<PIPE_V>();
-                }
-                for (uint32_t i = BT_sub_start; i < BT_sub_end; i++) {
-                    WholeReduceSum(tensorDsInFp32[i * 8], tensorMm5InFp32[i * BT],
-                                   FP32_PER_REPEAT, wholeReduceSumCnt, 1, 1, 8);
-                }
-                PipeBarrier<PIPE_V>();
-                WholeReduceSum(tensorDgOut, tensorDsInFp32, wholeReduceSumCnt, real_BT, 1, 1, 1);
-
-                // axis=0: 对每列求和 -> [BT] -Add0.D
-                PipeBarrier<PIPE_V>();
-                uint32_t remain_row = real_BT;
-                uint32_t CalcCnt = 0;
-                uint32_t Offset = 0;
-                while (remain_row > 1) {
-                    CalcCnt = (remain_row / 2) * BT;
-                    remain_row = CeilDiv(remain_row, 2);
-                    Offset = remain_row * BT;
-                    Add(tensorMm5InFp32, tensorMm5InFp32, tensorMm5InFp32[Offset], CalcCnt);
-                    PipeBarrier<PIPE_V>();
-                }
-                Sub(tensorDgOut, tensorDgOut, tensorMm5InFp32, BT);
-                PipeBarrier<PIPE_V>();
-                // 保存 tensorDgOut 供后续 Part 使用
-                if constexpr (!std::is_same<GType, float>::value) {
-                    Cast(tensorDgOut.template ReinterpretCast<GType>(), tensorDgOut, RoundMode::CAST_RINT, gSize);
-                }
-
-                inQue1.FreeTensor(tensorDsInFp16);
-                inQue2.FreeTensor(tensorMm5InFp16);
-
-                outQue1.EnQue(tensorDsTempOut);
-                outQue2.EnQue(tensorDgOut);
-            }
-            
-            // CopyOut
-            {
-                auto tensorDsTempOut = outQue1.DeQue<DataType>();
-                auto tensorDgOut = outQue2.DeQue<float>();
-
-                DataCopy(gmDsTemp[dsOffset + dsSize_sub_offset], tensorDsTempOut, dsSize_sub);
-
-                DataCopyParams dataCopyParams;
-                dataCopyParams.blockCount = 1;
-                dataCopyParams.blockLen = real_BT * sizeof(GType);
-                dataCopyParams.srcStride = 0;
-                dataCopyParams.dstStride = 0;
-                // dg 写入最终输出
-                if constexpr (std::is_same<GType, float>::value) {
-                    DataCopyPad(gmDg[dgOffset], tensorDgOut,dataCopyParams);
-                } else {
-                    // 需要 cast
-                    DataCopyPad(gmDg[dgOffset], tensorDgOut.template ReinterpretCast<GType>(), dataCopyParams);
-                }
-
-                outQue1.FreeTensor(tensorDsTempOut);
-                outQue2.FreeTensor(tensorDgOut);
-            }
-
-            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-        }
-
-    }
-
-}
-
-
-
-// ============== Part 4: dq 处理 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart4() {
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNum = GetBlockNum();
-    uint32_t coreLoops = B * numChunks;
-    
-    uint32_t dqSize = BT * K;
-    uint32_t real_BT = BT;
-
-
-    uint32_t BT_sub = real_BT;
-    uint32_t BT_sub_start = 0;
-    uint32_t BT_sub_end = BT_sub;
-    
-    uint32_t dqSize_sub = BT_sub * K;
-    uint32_t dqSize_sub_offset = BT_sub_start * K;
-    const uint32_t gSize = BT;
-    // 初始化 buffers
-    pipe->InitBuffer(inQue1, BUFFER_NUM, dqSize_sub * sizeof(float));    // dq from Cube   //64K
-    pipe->InitBuffer(inQue2, BUFFER_NUM, dqSize_sub * sizeof(float));    // q
-    pipe->InitBuffer(inQue3, BUFFER_NUM, gSize * sizeof(GType));        // g
-    pipe->InitBuffer(inQue4, BUFFER_NUM, gSize * sizeof(GType));        // g             
-    pipe->InitBuffer(outQue1, BUFFER_NUM, dqSize_sub * sizeof(DataType));   // dq output
-    pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(float));       // dg partial
-
-    pipe->InitBuffer(calcBuf3, gSize * (8) * sizeof(float));        //第一次reducesum结果：[BT, 8]
-    pipe->InitBuffer(gBuf, gSize * sizeof(float));
-    pipe->InitBuffer(dgBuf, gSize * sizeof(float));
-    
-    auto tensorShareTmpFp32 = calcBuf3.Get<float>();
-    auto tensorGFp32 = gBuf.Get<float>();
-    auto tensorDgAdd = dgBuf.Get<float>();
-
-    uint32_t vecTaskIdx = 0;
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, HV, T,
-                        BT, loopIdx, bos, eos);
-        uint32_t actual_chunk_len = eos-bos;
-        dqSize_sub = actual_chunk_len * K;
-        BT_sub_end = actual_chunk_len;
-        BT_sub = actual_chunk_len;
-        uint32_t bIdx = loopIdx / numChunks;
-        uint32_t chunkIdx = loopIdx % numChunks;
-        
-        for (uint32_t h = 0; h < HV; h++) {
-            // h is hv_idx; compute hk_idx for q/k access
-            uint32_t hk_idx = h / n_ratio;
-            ++vecTaskIdx;
-            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-                continue;
-            }
-            // q: [B, HK, T, K], dq: [B, HV, T, K]
-            uint64_t bos_hk = bos - static_cast<uint64_t>(bIdx) * static_cast<uint64_t>(HV - HK) * T;
-            uint64_t qkOffset = (hk_idx * T + bos_hk) * K;
-            uint64_t dqOffset = (h * T + bos) * K;
-            // g, dg: [B, HV, T]
-            uint64_t gOffset = (h * T + bos);
-            
-            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-            // CopyIn
-            {
-                auto tensorDqIn = inQue1.AllocTensor<DataType>();
-                auto tensorQIn = inQue2.AllocTensor<DataType>();
-                auto tensorGIn = inQue3.AllocTensor<GType>();
-                auto tensorDgIn = inQue4.AllocTensor<GType>();
-                
-                DataCopy(tensorDqIn[dqSize_sub], gmDq[dqOffset + dqSize_sub_offset], dqSize_sub);
-
-                DataCopy(tensorQIn[dqSize_sub], gmQ[qkOffset + dqSize_sub_offset], dqSize_sub);
-
-                DataCopyParams dataCopyParams;
-                dataCopyParams.blockCount = 1;
-                dataCopyParams.blockLen = actual_chunk_len*sizeof(GType);
-                dataCopyParams.srcStride = 0;
-                dataCopyParams.dstStride = 0;
-                DataCopyPad(tensorGIn, gmG[gOffset],dataCopyParams,{false, 0, 0, 0});
-                DataCopyPad(tensorDgIn, gmDg[gOffset],dataCopyParams,{false, 0, 0, 0});
-
-                inQue1.EnQue(tensorDqIn);
-                inQue2.EnQue(tensorQIn);
-                inQue3.EnQue(tensorGIn);
-                inQue4.EnQue(tensorDgIn);
-            }
-            
-            // Compute
-            {
-                auto tensorDqInFp16 = inQue1.DeQue<DataType>();
-                auto tensorDqInFp32 = tensorDqInFp16.template ReinterpretCast<float>();
-                auto tensorQInFp16 = inQue2.DeQue<DataType>();
-                auto tensorQInFp32 = tensorQInFp16.template ReinterpretCast<float>();
-                auto tensorGIn = inQue3.DeQue<GType>();
-                auto tensorDgIn = inQue4.DeQue<GType>();
-                auto tensorDqOut = outQue1.AllocTensor<DataType>();
-                auto tensorDgOut = outQue2.AllocTensor<float>();
-
-                // Cast
-                Cast(tensorDqInFp32, tensorDqInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
-                Cast(tensorQInFp32, tensorQInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
-                if constexpr (std::is_same<GType, float>::value) {
-                    DataCopy(tensorGFp32, tensorGIn, gSize);
-                } else {
-                    Cast(tensorGFp32, tensorGIn, RoundMode::CAST_NONE, gSize);
-                }
-                PipeBarrier<PIPE_V>();
-
-                // mul3 = exp(g) * scale
-                // b_dq_temp = b_dq * mul3 (broadcast along K dimension)
-                Exp(tensorGFp32, tensorGFp32, gSize);
-                PipeBarrier<PIPE_V>();
-
-                Muls(tensorGFp32, tensorGFp32, static_cast<float>(scale), gSize);       //mul3 = exp(g) * scale
-                PipeBarrier<PIPE_V>();
-
-                Brcb(tensorShareTmpFp32, tensorGFp32, CEIL_DIV(real_BT, 8), {1, 8}); // Brcb处理数据个数需要8对齐 [BT,8]
-                PipeBarrier<PIPE_V>();
-                AscendC::Mul(tensorDqInFp32, tensorDqInFp32, tensorShareTmpFp32, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
-                AscendC::Mul(tensorDqInFp32[CAL_NUM_FLOAT], tensorDqInFp32[CAL_NUM_FLOAT], tensorShareTmpFp32, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
-
-                PipeBarrier<PIPE_V>();
-                Mul(tensorQInFp32, tensorDqInFp32, tensorQInFp32, dqSize_sub);
-
-                // Add0.A = reduceSum((q * dq), axis=1)
-                // axis=1: 对每行求和 -> [BT] +Add0.A
-
-                PipeBarrier<PIPE_V>();
-
-                // reducesum
-                uint64_t wholeReduceSumCnt = CeilDiv(K, FP32_PER_REPEAT);
-                for (uint32_t i = BT_sub_start; i < BT_sub_end; i++) {
-                    WholeReduceSum(tensorShareTmpFp32[i * 8], tensorQInFp32[i * K],
-                                   FP32_PER_REPEAT, wholeReduceSumCnt, 1, 1, 8);
-                }
-                PipeBarrier<PIPE_V>();
-                WholeReduceSum(tensorDgOut, tensorShareTmpFp32, wholeReduceSumCnt, actual_chunk_len, 1, 1, 1);
-
-                //累加tensorDgIn += + tensorDgOut
-                if constexpr (std::is_same<GType, float>::value) {
-                    DataCopy(tensorDgAdd, tensorDgIn, real_BT);
-                } else {
-                    Cast(tensorDgAdd, tensorDgIn, RoundMode::CAST_NONE, real_BT);
-                }
-
-                PipeBarrier<PIPE_V>();
-                Add(tensorDgOut, tensorDgAdd, tensorDgOut, real_BT);
-
-                PipeBarrier<PIPE_V>();
-
-                if constexpr (!std::is_same<GType, float>::value) {
-                    Cast(tensorDgOut.template ReinterpretCast<GType>(), tensorDgOut, RoundMode::CAST_RINT, gSize);
-                }
-
-                Cast(tensorDqOut, tensorDqInFp32, RoundMode::CAST_RINT, dqSize_sub);
-
-                inQue1.FreeTensor(tensorDqInFp16);
-                inQue2.FreeTensor(tensorQInFp16);
-                inQue3.FreeTensor(tensorGIn);
-                inQue4.FreeTensor(tensorDgIn);
-                outQue1.EnQue(tensorDqOut);
-                outQue2.EnQue(tensorDgOut);
-            }
-            // CopyOut: dq to final output, dg accumulate
-            {
-                auto tensorDqOut = outQue1.DeQue<DataType>();
-                auto tensorDgOut = outQue2.DeQue<GType>();
-
-                DataCopy(gmDq[dqOffset + dqSize_sub_offset], tensorDqOut, dqSize_sub);
-
-                // 累加到 dg (读取现有值, 加上新值, 写回)
-                // 简化: 直接累加 (需要在 Part 5 中处理最终值)
-                // dg 写入最终输出
-                DataCopyParams dataCopyParams;
-                dataCopyParams.blockCount = 1;
-                dataCopyParams.blockLen = BT_sub * sizeof(GType);
-                dataCopyParams.srcStride = 0;
-                dataCopyParams.dstStride = 0;
-                DataCopyPad(gmDg[gOffset + BT_sub_start], tensorDgOut,dataCopyParams);
-
-                outQue1.FreeTensor(tensorDqOut);
-                outQue2.FreeTensor(tensorDgOut);
-            }
-            
-            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-        }
-    }
-}
-
-
-// ============== Part 5: dk 处理和 dg 最终计算 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart5() {
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNum = GetBlockNum();
-    uint32_t coreLoops = B * numChunks;
-    
-    uint32_t dkSize = BT * K;
-    uint32_t gSize = BT;
-    uint32_t real_BT = BT;
-    
-    // 初始化 buffers
-    pipe->InitBuffer(inQue1, BUFFER_NUM, dkSize * sizeof(float));
-    pipe->InitBuffer(inQue2, BUFFER_NUM, dkSize * sizeof(float));
-    pipe->InitBuffer(inQue3, BUFFER_NUM, gSize * sizeof(GType));
-    pipe->InitBuffer(inQue4, BUFFER_NUM, gSize * sizeof(GType));
-    // pipe->InitBuffer(inQue5, BUFFER_NUM, 16 * sizeof(float));    // add4中间结果及广播结果
-    // pipe->InitBuffer(inQue6, BUFFER_NUM, 16 * sizeof(float));    // part5 gLast中间结果
-    pipe->InitBuffer(outQue1, BUFFER_NUM, dkSize * sizeof(DataType));
-    pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(GType));
-
-    pipe->InitBuffer(calcBuf1, gSize * 8 * sizeof(float));  //gLast
-    pipe->InitBuffer(calcBuf2, gSize * 8 * sizeof(float));  //dgLast
-    pipe->InitBuffer(calcBuf4, gSize * sizeof(float));
-    pipe->InitBuffer(gBuf, gSize * sizeof(float));
-    pipe->InitBuffer(dgBuf, gSize * 8 * sizeof(float));
-
-    auto tensorGFp32 = gBuf.Get<float>();
-    auto tensorDgFinal = dgBuf.Get<float>();
-    auto tensorGLastFp32Tmp = calcBuf1.Get<float>();
-    auto tensorDgLastFp32Tmp = calcBuf2.Get<float>();
-    auto tensorDgTmp = calcBuf4.Get<float>();
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    uint32_t vecTaskIdx = 0;
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, HV, T, BT, loopIdx, bos, eos);
-        uint32_t actual_chunk_len = eos - bos;
-        real_BT = actual_chunk_len;
-        dkSize = actual_chunk_len * K;
-        uint32_t real_BT_aligned = (real_BT + 15) / 16 * 16;
-        uint32_t bIdx = loopIdx / numChunks;
-        uint32_t chunkIdx = loopIdx % numChunks;
-        
-        for (uint32_t h = 0; h < HV; h++) {
-            // h is hv_idx; compute hk_idx for k access
-            uint32_t hk_idx = h / n_ratio;
-            ++vecTaskIdx;
-            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-                continue;
-            }
-            // k: [B, HK, T, K], dk: [B, HV, T, K]
-            uint64_t bos_hk = bos - static_cast<uint64_t>(bIdx) * static_cast<uint64_t>(HV - HK) * T;
-            uint64_t kOffset = (hk_idx * T + bos_hk) * K;
-            uint64_t dkOffset = (h * T + bos) * K;
-            // g, dg: [B, HV, T]
-            uint64_t gOffset = (h * T + bos);
-            // dg_last: [B, HV, num_chunks]
-            uint64_t dgLastOffset = (bIdx * HV + h) * numChunks + chunkIdx;
-            
-            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-
-            // CopyIn
-            {
-                auto tensorDkIn = inQue1.AllocTensor<DataType>();
-                auto tensorKIn = inQue2.AllocTensor<DataType>();
-                auto tensorGIn = inQue3.AllocTensor<GType>();
-                auto tensorDgIn = inQue4.AllocTensor<GType>();
-                
-                DataCopy(tensorDkIn[dkSize], gmDk[dkOffset], dkSize);
-                DataCopy(tensorKIn[dkSize], gmK[kOffset], dkSize);
-
-                DataCopyParams dataCopyParams;
-                dataCopyParams.blockCount = 1;
-                dataCopyParams.blockLen = actual_chunk_len*sizeof(GType);
-                dataCopyParams.srcStride = 0;
-                dataCopyParams.dstStride = 0;
-                DataCopyPad(tensorGIn, gmG[gOffset],dataCopyParams,{false, 0, 0, 0});
-                DataCopyPad(tensorDgIn, gmDg[gOffset],dataCopyParams,{false, 0, 0, 0});
-
-                inQue1.EnQue(tensorDkIn);
-                inQue2.EnQue(tensorKIn);
-                inQue3.EnQue(tensorGIn);
-                inQue4.EnQue(tensorDgIn);
-                // inQue5.EnQue(tensorDgLastIn);
-                // inQue6.EnQue(tensorGLastIn);
-            }
-            
-            // Compute
-            {
-                auto tensorDkIn = inQue1.DeQue<DataType>();
-                auto tensorDkFp32 = tensorDkIn.template ReinterpretCast<float>();
-                auto tensorKIn = inQue2.DeQue<DataType>();
-                auto tensorKFp32 = tensorKIn.template ReinterpretCast<float>();
-                auto tensorGIn = inQue3.DeQue<GType>();
-                auto tensorDgIn = inQue4.DeQue<GType>();
-                // auto tensorDgLastFp32 = inQue5.DeQue<float>();
-                // auto tensorGLast = inQue6.DeQue<GType>();
-                // auto tensorGLastFp32 = tensorGLast.template ReinterpretCast<float>();
-                auto tensorDkOut = outQue1.AllocTensor<DataType>();
-                auto tensorDgOut = outQue2.AllocTensor<GType>();
-
-                // Cast
-                Cast(tensorDkFp32, tensorDkIn[dkSize], RoundMode::CAST_NONE, dkSize);
-
-                Cast(tensorKFp32, tensorKIn[dkSize], RoundMode::CAST_NONE, dkSize);
-                PipeBarrier<PIPE_V>();
-
-                if constexpr (std::is_same<GType, float>::value) {
-                    DataCopy(tensorGFp32, tensorGIn, BT);
-                    DataCopy(tensorDgTmp, tensorDgIn, BT);
-                } else {
-                    Cast(tensorGFp32, tensorGIn, RoundMode::CAST_NONE, real_BT_aligned);
-                    // Cast(tensorGLastFp32, tensorGLast, RoundMode::CAST_NONE, 1);
-                    Cast(tensorDgTmp, tensorDgIn, RoundMode::CAST_NONE, real_BT_aligned);
-                }
-                PipeBarrier<PIPE_V>();
-
-                // uint32_t lastIdx = actual_chunk_len - 1;
-                //MUL2
-                uint32_t last_line_no = (actual_chunk_len - 1) / 8 * 8; // 最后一行的行号
-                uint32_t last_line_idx = actual_chunk_len - 1 - last_line_no;
-                Brcb(tensorDgFinal, tensorGFp32[last_line_no], 1, {1, 8}); // [8,8] 只有第last_line_idx行有效 = gLast
-                PipeBarrier<PIPE_V>();
-                Muls(tensorGFp32, tensorGFp32, -1.0f, real_BT_aligned);
-                DataCopy(tensorGLastFp32Tmp, tensorDgFinal[last_line_idx * 8], 8); // tensorDgFinal暂存dg值，后续计算dgLast
-
-                PipeBarrier<PIPE_V>();
-
-                AscendC::Add(tensorGFp32, tensorGFp32, tensorDgFinal[last_line_idx * 8], CAL_NUM_FLOAT, BT / CAL_NUM_FLOAT, {1, 1, 0, 8, 8, 0});
-                PipeBarrier<PIPE_V>();
-
-                Exp(tensorGFp32, tensorGFp32, real_BT_aligned);
-                PipeBarrier<PIPE_V>();
-
-                // dgLast:使用tensorDgLast[0]替代
-                // tensorDkFp32:        tensorDgFinal:gsize * 8 * float
-                Brcb(tensorDgFinal, tensorGFp32, CEIL_DIV(real_BT, 8), {1, 8}); // Brcb处理数据个数需要8对齐 [BT,8]
-                PipeBarrier<PIPE_V>();
-                AscendC::Mul(tensorDkFp32, tensorDkFp32, tensorDgFinal, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
-
-                AscendC::Mul(tensorDkFp32[CAL_NUM_FLOAT], tensorDkFp32[CAL_NUM_FLOAT], tensorDgFinal, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
-                PipeBarrier<PIPE_V>();
-
-                Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);      //dk -> fp16 tensorDkFp32
-
-                Mul(tensorKFp32, tensorKFp32, tensorDkFp32, dkSize);    // mul8 = dk * k
-                PipeBarrier<PIPE_V>();
-
-                // Add0.B = (dk_temp * k).reduceSum(axis=1)
-                // axis=1: 对每行求和 -> [BT] +Add0.B
-
-                // reducesum
-                uint64_t wholeReduceSumCnt = CeilDiv(K, FP32_PER_REPEAT);
-                for (uint32_t i = 0; i < actual_chunk_len; i++) {
-                    WholeReduceSum(tensorDgFinal[i * 8], tensorKFp32[i * K],
-                                   FP32_PER_REPEAT, wholeReduceSumCnt, 1, 1, 8);
-                }
-                PipeBarrier<PIPE_V>();
-                WholeReduceSum(tensorGFp32, tensorDgFinal, wholeReduceSumCnt, actual_chunk_len, 1, 1, 1);
-
-                // float totalSum = 0.0f;
-                PipeBarrier<PIPE_V>();
-
-                //Sum0: [actual_chunk_len] -> [1]
-                uint64_t sum0SumCnt = CeilDiv(actual_chunk_len, FP32_PER_REPEAT);
-                uint32_t remainCnt = actual_chunk_len % FP32_PER_REPEAT;
-                if(remainCnt > 0) {
-                    uint32_t DuplicateOffset = sum0SumCnt * FP32_PER_REPEAT - FP32_PER_REPEAT;
-                    uint64_t mask[1] = {0xffffffffffffffff};
-                    mask[0] <<= remainCnt;
-
-                    Duplicate(tensorGFp32[(sum0SumCnt-1)*FP32_PER_REPEAT], 0.0f, mask, 1, 1, 8);
-
-                    PipeBarrier<PIPE_V>();
-                }
-                WholeReduceSum(tensorDkFp32, tensorGFp32, FP32_PER_REPEAT, sum0SumCnt, 1, 1, 8);
-                // PipeBarrier<PIPE_ALL>();
-                PipeBarrier<PIPE_V>();
-                WholeReduceSum(tensorDgFinal, tensorDkFp32, sum0SumCnt, 1, 1, 1, 8);
-
-                // tensorGLastFp32[0]已经是最后一个位置的 g 值
-                float dgLast = gmDgLast.GetValue(dgLastOffset); // tensorDgTmp暂存dg值，获取最后一个位置的dgLast
-                Duplicate(tensorDgLastFp32Tmp, dgLast, 8); // 广播 dgLast
-                Exp(tensorGLastFp32Tmp, tensorGLastFp32Tmp, 8);
-                PipeBarrier<PIPE_V>();
-                Mul(tensorDgLastFp32Tmp, tensorDgLastFp32Tmp, tensorGLastFp32Tmp, 8);
-                PipeBarrier<PIPE_V>();
-                Add(tensorDgLastFp32Tmp, tensorDgLastFp32Tmp, tensorDgFinal, 8);  //add4 = tensorDgLastFp32Tmp[0]
-
-
-                Sub(tensorGFp32, tensorDgTmp, tensorGFp32, BT); //Add.0 最终结果
-
-                PipeBarrier<PIPE_V>();
-                Brcb(tensorDgFinal, tensorDgLastFp32Tmp, 1, {1, 8}); // [8,8] 只有第一行有效
-                PipeBarrier<PIPE_V>();
-                uint64_t offset = (real_BT - 1) / 8 * 8; // 每行8个float
-                uint64_t mask[1] = {0};
-                mask[0] = 1ULL << (real_BT - 1 - offset); // 计算掩码，只有最后一个位置有效
-
-                Add(tensorGFp32[offset], tensorGFp32[offset], tensorDgFinal, mask, 1, {1,1,1,8,8,8});
-
-                PipeBarrier<PIPE_V>();
-                if constexpr (std::is_same<GType, float>::value) {
-                    DataCopy(tensorDgOut, tensorGFp32, BT);
-                } else {
-                    Cast(tensorDgOut, tensorGFp32, RoundMode::CAST_RINT, BT);
-                }
-                PipeBarrier<PIPE_V>();
-
-
-                // 处理最后一个位置的 dg
-                // b_dg_last *= exp(g_last)
-                // is_last_mask: 只有最后一个位置添加 dgLastTerm
-
-                // 读取之前 Part 3/4 计算的 dg, 累加
-                // (简化处理, 实际应该从 GM 读取并累加)
-
-                inQue1.FreeTensor(tensorDkIn);
-                inQue2.FreeTensor(tensorKIn);
-                inQue3.FreeTensor(tensorGIn);
-                inQue4.FreeTensor(tensorDgIn);
-                // inQue5.FreeTensor(tensorDgLastFp32);
-                // inQue6.FreeTensor(tensorGLast);
-                outQue1.EnQue(tensorDkOut);
-                outQue2.EnQue(tensorDgOut);
-            }
-            
-            // CopyOut
-            {
-                auto tensorDkOut = outQue1.DeQue<DataType>();
-                auto tensorDgOut = outQue2.DeQue<GType>();
-
-                DataCopy(gmDk[dkOffset], tensorDkOut, dkSize);
-
-                // dg 需要与之前的累加
-                // 累加到 dg (读取现有值, 加上新值, 写回)
-                // 简化: 直接累加 (需要在 Part 5 中处理最终值)
-                // dg 写入最终输出
-                DataCopyParams dataCopyParams;
-                dataCopyParams.blockCount = 1;
-                dataCopyParams.blockLen = real_BT * sizeof(GType);
-                dataCopyParams.srcStride = 0;
-                dataCopyParams.dstStride = 0;
-                DataCopyPad(gmDg[gOffset], tensorDgOut, dataCopyParams);
-                outQue1.FreeTensor(tensorDkOut);
-                outQue2.FreeTensor(tensorDgOut);
-            }
-
-            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-        }
-    }
-}
-
-
-// ============== Part 6: dq 累加 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart6() {
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNum = GetBlockNum();
-    uint32_t coreLoops = B * numChunks;
-    
-    uint32_t dqSize = BT * K;
-    
-    // 初始化 buffers
-    pipe->InitBuffer(inQue1, BUFFER_NUM, dqSize * sizeof(float));    // dq current
-    pipe->InitBuffer(inQue2, BUFFER_NUM, dqSize * sizeof(float));    // mm6 from Cube
-    pipe->InitBuffer(outQue1, BUFFER_NUM, dqSize * sizeof(DataType));
-
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    uint32_t vecTaskIdx = 0;
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, HV, T,
-                        BT, loopIdx, bos, eos);
-        uint32_t actual_chunk_len = eos - bos;
-        dqSize = actual_chunk_len * K;
-        uint32_t bIdx = loopIdx / numChunks;
-        uint32_t chunkIdx = loopIdx % numChunks;
-        
-        for (uint32_t h = 0; h < HV; h++) {
-            ++vecTaskIdx;
-            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-                continue;
-            }
-            // dq: [B, HV, T, K]
-            uint64_t dqOffset = (h * T + bos) * K;
-            
-            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-            
-            // Part 6 的 Vector 工作是将 Cube 计算的 mm6 累加到 dq
-            // CopyIn
-            {
-                auto tensorDqIn = inQue1.AllocTensor<DataType>();
-                auto tensorMM6In = inQue2.AllocTensor<DataType>();
-                
-                DataCopy(tensorDqIn[dqSize], gmDq[dqOffset], dqSize);
-                DataCopy(tensorMM6In[dqSize], gmMm6[dqOffset], dqSize);
-
-                inQue1.EnQue(tensorDqIn);
-                inQue2.EnQue(tensorMM6In);
-            }
-
-            //Compute
-            {
-                auto tensorDqIn = inQue1.DeQue<DataType>();
-                auto tensorDqFp32 = tensorDqIn.template ReinterpretCast<float>();
-                auto tensorMM6In = inQue2.DeQue<DataType>();
-                auto tensorMM6Fp32 = tensorMM6In.template ReinterpretCast<float>();
-                auto tensorDqOut = outQue1.AllocTensor<DataType>();
-                // Cast
-
-                Cast(tensorDqFp32, tensorDqIn[dqSize], RoundMode::CAST_NONE, dqSize);
-                // PipeBarrier<PIPE_V>();
-                Cast(tensorMM6Fp32, tensorMM6In[dqSize], RoundMode::CAST_NONE, dqSize);
-                PipeBarrier<PIPE_V>();
-
-                Add(tensorDqFp32, tensorDqFp32, tensorMM6Fp32, dqSize);
-
-                PipeBarrier<PIPE_V>();
-                Cast(tensorDqOut, tensorDqFp32, RoundMode::CAST_RINT, dqSize);
-
-                PipeBarrier<PIPE_V>();
-                inQue1.FreeTensor(tensorDqIn);
-                inQue2.FreeTensor(tensorMM6In);
-                outQue1.EnQue<DataType>(tensorDqOut);
-            }
-
-            //CopyOut
-            {
-                auto tensorDqOut = outQue1.DeQue<DataType>();
-                DataCopy(gmDq[dqOffset], tensorDqOut, dqSize);
-                outQue1.FreeTensor(tensorDqOut);
-            }
-            
-            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-        }
-    }
-}
-
-// ============== Part 7: dk 累加 ==============
-template <typename DataType, typename GType>
-__aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessPart7() {
-    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
-    uint32_t coreNum = GetBlockNum();
-    uint32_t coreLoops = B * numChunks;
-    
-    uint32_t dkSize = BT * K;
-    
-    // 初始化 buffers
-    pipe->InitBuffer(inQue1, BUFFER_NUM, dkSize * sizeof(float));    // dk current
-    pipe->InitBuffer(inQue2, BUFFER_NUM, dkSize * sizeof(float));    // mm6 from Cube
-    pipe->InitBuffer(outQue1, BUFFER_NUM, dkSize * sizeof(DataType));
-
-    uint32_t bos = 0;
-    uint32_t eos = 0;
-    uint32_t vecTaskIdx = 0;
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-
-    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-        GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, HV, T,
-                        BT, loopIdx, bos, eos);
-        uint32_t actual_chunk_len = eos - bos;
-        dkSize = actual_chunk_len * K;
-        uint32_t bIdx = loopIdx / numChunks;
-        uint32_t chunkIdx = loopIdx % numChunks;
-        
-        for (uint32_t h = 0; h < HV; h++) {
-            ++vecTaskIdx;
-            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
-                CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-                CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-                continue;
-            }
-            // dk: [B, HV, T, K]
-            uint64_t dkOffset = (h * T + bos) * K;
-            
-            CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_0);
-            
-            // Part 7 的 Vector 工作是将 Cube 计算的 mm7 累加到 dk
-            // CopyIn
-            {
-                auto tensorDkIn = inQue1.AllocTensor<DataType>();
-                auto tensorMm7In = inQue2.AllocTensor<DataType>();
-                
-                DataCopy(tensorDkIn[dkSize], gmDk[dkOffset], dkSize);
-                DataCopy(tensorMm7In[dkSize], gmMm7[dkOffset], dkSize);
-
-                inQue1.EnQue(tensorDkIn);
-                inQue2.EnQue(tensorMm7In);
-            }
-
-            //Compute
-            {
-                auto tensorDkIn = inQue1.DeQue<DataType>();
-                auto tensorDkFp32 = tensorDkIn.template ReinterpretCast<float>();
-                auto tensorMm7In = inQue2.DeQue<DataType>();
-                auto tensorMm7Fp32 = tensorMm7In.template ReinterpretCast<float>();
-                auto tensorDkOut = outQue1.AllocTensor<DataType>();
-
-                // Cast
-                Cast(tensorDkFp32, tensorDkIn[dkSize], RoundMode::CAST_NONE, dkSize);
-                // PipeBarrier<PIPE_V>();
-                Cast(tensorMm7Fp32, tensorMm7In[dkSize], RoundMode::CAST_NONE, dkSize);
-                PipeBarrier<PIPE_V>();
-                Add(tensorDkFp32, tensorDkFp32, tensorMm7Fp32, dkSize);
-                PipeBarrier<PIPE_V>();
-                Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);
-
-                PipeBarrier<PIPE_V>();
-                inQue1.FreeTensor(tensorDkIn);
-                inQue2.FreeTensor(tensorMm7In);
-                outQue1.EnQue<DataType>(tensorDkOut);
-            }
-
-            //CopyOut
-            {
-                auto tensorDkOut = outQue1.DeQue<DataType>();
-                DataCopy(gmDk[dkOffset], tensorDkOut, dkSize);
-
-                outQue1.FreeTensor(tensorDkOut);
-            }
-
-            CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
-        }
-    }
-}
-
-#endif  // CHUNK_BWD_DQKWG_VECTOR_H
+ #ifndef CHUNK_BWD_DQKWG_VECTOR_H
+ #define CHUNK_BWD_DQKWG_VECTOR_H
+
+ #include "chunk_bwd_dqkwg_common.h"
+ #include "kernel_operator.h"
+
+ using namespace AscendC;
+
+ template <typename DataType, typename GType>
+ class ChunkBwdDqkwgVectorProcess {
+ public:
+     __aicore__ inline ChunkBwdDqkwgVectorProcess(
+         GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
+         GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices, GM_ADDR mask_a,
+         GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
+         GM_ADDR workspace
+     );
+
+     __aicore__ inline void Init(const ChunkBwdDqkwgTilingData &tiling, TPipe *pipe_);
+     __aicore__ inline void Process();
+
+ private:
+     // 4 个 stage 的处理函数 (CV 深融合)
+     __aicore__ inline void ProcessAVector(uint32_t loopBase, uint32_t loopEnd);  // 原 Part1 (dw 取负 + dg_last) + 原 Part2 (mul1)
+     __aicore__ inline void ProcessBVector(uint32_t loopBase, uint32_t loopEnd);  // 原 Part3 (ds_temp + dg 部分)
+     __aicore__ inline void ProcessCVector(uint32_t loopBase, uint32_t loopEnd);  // 原 Part4 + Part6 (dq 最终)
+     __aicore__ inline void ProcessDVector(uint32_t loopBase, uint32_t loopEnd);  // 原 Part5 + Part7 (dk 最终 + dg 最终)
+     __aicore__ inline void ResetStagePipe();
+
+     // mul1 一个 row-half 的计算 (= A 的 Part2 per-head 内核, 输出 fp32 到 outFp32[half] )。
+     // A (小 case) 调它后 cast+写 GM; B (大 case) 调它两次 (两个 row-half) 后直接乘 ds, 省掉 mul1 GM 往返。
+     __aicore__ inline void ComputeMul1HalfFp32(const LocalTensor<float> &outFp32, const LocalTensor<float> &tensorMaskA,
+                                                uint64_t gOffset, uint32_t BT_sub_start, uint32_t real_BT,
+                                                uint32_t actual_chunk_len);
+
+     // 辅助函数
+     __aicore__ inline void ComputeExpScalar(float input, float &output);
+     __aicore__ inline void ApplyLowerTriangularMask(LocalTensor<float> &tensor, uint32_t size);
+     __aicore__ inline void ReduceSumX(LocalTensor<float> &src, LocalTensor<float> &dst,
+                                       uint32_t rows, uint32_t cols, int axis);
+     __aicore__ inline void CopyGateWithPad(LocalTensor<GType> &dst, GlobalTensor<GType> &src,
+                                            uint64_t offset, uint32_t validLen, uint32_t totalLen);
+     __aicore__ inline void RefineSmallDw(LocalTensor<float> &dw, uint64_t dvOffset,
+                                          uint64_t hOffset, uint32_t rows);
+     __aicore__ inline void RepairDwChunkHeadBlock(LocalTensor<DataType> &dwOut,
+                                                   LocalTensor<DataType> &tmp,
+                                                   LocalTensor<float> &work,
+                                                   LocalTensor<float> &scratch,
+                                                   uint64_t dvOffset,
+                                                   uint64_t hOffset,
+                                                   uint32_t rows);
+
+ private:
+     // 输入输出指针
+     GM_ADDR ptrQ;
+     GM_ADDR ptrK;
+     GM_ADDR ptrV;
+     GM_ADDR ptrG;
+     GM_ADDR ptrH;
+     GM_ADDR ptrDo;
+     GM_ADDR ptrDh;
+     GM_ADDR ptrDv;
+     GM_ADDR ptrCuSeqLen;
+     GM_ADDR ptrChunkIndices;
+     GM_ADDR ptrMaskA;
+     GM_ADDR ptrDq;
+     GM_ADDR ptrDk;
+     GM_ADDR ptrDw;
+     GM_ADDR ptrDg;
+     GM_ADDR ptrWorkspace;
+
+     // Tiling 参数 (GVA: H 拆为 HV/HK, HV = n_ratio * HK)
+     uint64_t B;
+     uint64_t HV;           // value 侧 head 数 (== 原 H)
+     uint64_t HK;           // key/query 侧 head 数, HV = n_ratio * HK
+     uint64_t T;
+     uint64_t K;
+     uint64_t V;
+     uint64_t BT;
+     uint64_t numChunks;
+     float scale;
+     int isVarLen;
+     uint32_t mul0RowNum = 0;
+     uint64_t n_ratio = 1;     // GVA: HV / HK
+     uint32_t aicCoreNum = 0;  // CV 深融合 blockDim (cube/vector 共用)
+
+     // Workspace 偏移
+     uint64_t wsDwOffset;
+     uint64_t wsBtxKSyncSlotsPerHead;
+     uint64_t wsDgLastOffset;
+     uint64_t wsMm5Offset;
+     uint64_t wsDsTempOffset;
+     uint64_t wsMm6Offset;
+     uint64_t wsMm7Offset;
+     uint64_t wsMul1Offset;
+     int BUFFER_NUM = 1;
+
+     // Pipeline
+     TPipe *pipe = nullptr;
+
+     // CV 深融合: raw 信用流水, 无 flag 对象 (helper 用固定 flag id, 与 cube 端共用)。
+
+     // Global Tensors
+     GlobalTensor<DataType> gmQ, gmK, gmV, gmDo, gmH, gmDh, gmDv;
+     GlobalTensor<DataType> gmDq, gmDk, gmDw;
+     GlobalTensor<GType> gmG, gmDg;
+     GlobalTensor<DataType> gmWorkspace;
+     GlobalTensor<float> gmDgLast;
+     GlobalTensor<DataType> gmDwWorkspace;
+     GlobalTensor<DataType> gmMm5, gmDsTemp, gmMul1, gmMm6, gmMm7;
+
+     // Queues (用于流水)
+     TQue<TPosition::VECIN, 2> inQue1;
+     TQue<TPosition::VECIN, 2> inQue2;
+     TQue<TPosition::VECIN, 2> inQue3;
+     TQue<TPosition::VECIN, 2> inQue4;  //用于Add0累加
+     TQue<TPosition::VECIN, 2> inQue5;  //用于Part5 Add4中间结果
+     TQue<TPosition::VECIN, 2> inQue6;  //用于Part5 gLast中间结果
+     TQue<TPosition::VECOUT, 2> outQue1;
+     TQue<TPosition::VECOUT, 2> outQue2;
+
+
+     // Calc Buffers (UB 空间)
+     TBuf<TPosition::VECCALC> calcBuf1;  // 主计算缓冲区 (fp32)
+     TBuf<TPosition::VECCALC> calcBuf2;  // 辅助计算缓冲区 (fp32)
+     TBuf<TPosition::VECCALC> calcBuf3;  // Exp 缓冲区
+     TBuf<TPosition::VECCALC> calcBuf4;  // 中间结果
+     TBuf<TPosition::VECCALC> gBuf;      // g 值缓冲区 / A_vector mask
+     TBuf<TPosition::VECCALC> dgBuf;     // dg 值缓冲区
+
+     // UB 空间常量
+     static constexpr uint32_t UB_BLOCK_SIZE = 32;
+     static constexpr uint32_t FP32_ELEMENTS_PER_BLOCK = 8;
+     static constexpr uint32_t FP16_ELEMENTS_PER_BLOCK = 16;
+ };
+
+ // ============== 构造函数 ==============
+ template <typename DataType, typename GType>
+ __aicore__ inline ChunkBwdDqkwgVectorProcess<DataType, GType>::ChunkBwdDqkwgVectorProcess(
+     GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
+     GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices, GM_ADDR mask_a,
+     GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
+     GM_ADDR workspace
+ ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
+     ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLen(cu_seqlen), ptrChunkIndices(chunk_indices), ptrMaskA(mask_a),
+     ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
+     ptrWorkspace(workspace) {}
+
+ // ============== 初始化 ==============
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::Init(const ChunkBwdDqkwgTilingData &tiling, TPipe *pipe_) {
+     pipe = pipe_;
+
+     scale = tiling.scale;
+     B = tiling.B;
+     HV = tiling.HV;
+     HK = tiling.HK;
+     n_ratio = (HK > 0) ? (HV / HK) : 1;
+     T = tiling.T;
+     K = tiling.K;
+     V = tiling.V;
+     BT = tiling.BT;
+     numChunks = tiling.numChunks;
+     aicCoreNum = tiling.aicCoreNum;
+     wsDwOffset = tiling.wsDwOffset;
+     wsBtxKSyncSlotsPerHead = tiling.wsBtxKSyncSlotsPerHead;
+     wsDgLastOffset = tiling.wsDgLastOffset;
+     wsMm5Offset = tiling.wsMm5Offset;
+     wsDsTempOffset = tiling.wsDsTempOffset;
+     wsMm6Offset = tiling.wsMm6Offset;
+     wsMm7Offset = tiling.wsMm7Offset;
+     wsMul1Offset = tiling.wsMul1Offset;
+     uint64_t dgLastSize = tiling.dgLastSize;
+     isVarLen = tiling.isVarLen;
+     mul0RowNum = tiling.mul0RowNum;
+
+     if (BT == 64) {
+         BUFFER_NUM = 2;
+     } else {
+         BUFFER_NUM = 1;
+     }
+
+     gmQ.SetGlobalBuffer((__gm__ DataType *)ptrQ);
+     gmK.SetGlobalBuffer((__gm__ DataType *)ptrK);
+     gmV.SetGlobalBuffer((__gm__ DataType *)ptrV);
+     gmG.SetGlobalBuffer((__gm__ GType *)ptrG);
+     gmH.SetGlobalBuffer((__gm__ DataType *)ptrH);
+     gmDo.SetGlobalBuffer((__gm__ DataType *)ptrDo);
+     gmDh.SetGlobalBuffer((__gm__ DataType *)ptrDh);
+     gmDv.SetGlobalBuffer((__gm__ DataType *)ptrDv);
+
+     gmDq.SetGlobalBuffer((__gm__ DataType *)ptrDq);
+     gmDk.SetGlobalBuffer((__gm__ DataType *)ptrDk);
+     gmDw.SetGlobalBuffer((__gm__ DataType *)ptrDw);
+     gmDg.SetGlobalBuffer((__gm__ GType *)ptrDg);
+
+     gmWorkspace.SetGlobalBuffer((__gm__ DataType *)ptrWorkspace);
+     gmDwWorkspace.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsDwOffset));
+     gmDgLast.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t*)ptrWorkspace + wsDgLastOffset));     //中间结果使用float
+
+     gmMm5.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm5Offset));
+     gmDsTemp.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsDsTempOffset));
+     gmMm6.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm6Offset));
+     gmMm7.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm7Offset));
+     gmMul1.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMul1Offset));
+ }
+
+ // ============== 主处理函数 (CV 深融合: A -> B -> C -> D, 每 stage 内 chunk 级与 cube 流水) ==============
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::Process() {
+     // raw 信用流水: 启动时预置 N = min(groupSize, M) 个信用 (M = 本核 chunk 数),
+     // 使 cube 可领先 vector 最多 N 个 task (真正并发); N<=M 保证 C/D 读 ds_temp 安全。
+     // 两个 AIV sub-block 各预置 N 次 (0x2 汇合 => cube 看到 N 个信用)。
+     // stage 之间无 SyncAll, 信用 flag 跨 stage 连续 (pipe->Reset 只重置 UB buffer, 不影响 flag)。
+     uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+     uint32_t coreNum = aicCoreNum;
+     uint32_t coreLoops = B * numChunks;
+     uint32_t M = (coreIdx < coreLoops) ? ((coreLoops - 1 - coreIdx) / coreNum + 1) : 0;
+     uint32_t groupSize = DqkwgGroupSizeFromRingDepth((uint32_t)wsBtxKSyncSlotsPerHead);
+     uint32_t preseed = M < groupSize ? M : groupSize;
+     for (uint32_t i = 0; i < preseed; i++) {
+         SetVecCredit();
+     }
+
+     // 跨 stage 的 vector->vector GM 数据 (mul1: A->B; dg: B->C->D; dg_last: A->D) 由同一 AIV sub-block
+     // 顺序读写。(每个 (c,h) 的 dg/mul1/dg_last 由同一 sub-block 跨 A/B/C/D 处理 => 无需 SyncAll)
+     // 固定长度路径 stage 间只 drain MTE3, 保持热路径开销; varlen 下每组 chunk 长度不齐, stage/group
+     // 边界 reset pipe 前必须 drain 全 pipeline, 避免 V/MTE2 尾部操作与 pipe->Reset 竞态导致偶发 head 损坏。
+     // chunk-group-major: 外层按 G 个 chunk 一组 (与 cube 用同一 DqkwgGroupEnd 算组边界, 握手顺序一致),
+     //   组内 A->B->C->D 连着做 -> 这组的输入张量只从 HBM 读一次、在 L2 内被 4 个 stage 复用 (砍 MTE2 重复搬运)。
+     //   stage 间仍 PipeBarrier<MTE3>+Reset (drain mul1/dg/dg_last 跨 stage GM 可见); 组末额外 Reset 供下组 A 干净开始。
+     //   信用 flag 跨组连续 (preseed 一次); ds_temp 安全靠每组 >= N (DqkwgGroupEnd 的尾巴合并保证)。
+     uint32_t loopBase = coreIdx;
+     while (loopBase < coreLoops) {
+         uint32_t loopEnd = DqkwgGroupEnd(loopBase, coreLoops, coreNum, (uint32_t)wsBtxKSyncSlotsPerHead);
+         ProcessAVector(loopBase, loopEnd);
+         ResetStagePipe();
+         ProcessBVector(loopBase, loopEnd);
+         ResetStagePipe();
+         ProcessCVector(loopBase, loopEnd);
+         ResetStagePipe();
+         ProcessDVector(loopBase, loopEnd);
+         ResetStagePipe();
+         loopBase = loopEnd;
+     }
+ }
+
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ResetStagePipe() {
+     if (isVarLen != 0) {
+         AscendC::PipeBarrier<PIPE_ALL>();
+     } else {
+         AscendC::PipeBarrier<PIPE_MTE3>();
+     }
+     pipe->Reset();
+ }
+
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::CopyGateWithPad(
+     LocalTensor<GType> &dst, GlobalTensor<GType> &src, uint64_t offset, uint32_t validLen, uint32_t totalLen) {
+     if (validLen == totalLen) {
+         DataCopy(dst, src[offset], totalLen);
+         return;
+     }
+     Duplicate(dst, static_cast<GType>(0), totalLen);
+     TEventID eventId = GetTPipePtr()->FetchEventID(HardEvent::V_MTE2);
+     SetFlag<HardEvent::V_MTE2>(eventId);
+     WaitFlag<HardEvent::V_MTE2>(eventId);
+     if (validLen == 0) {
+         return;
+     }
+
+     DataCopyExtParams copyParams{1, static_cast<uint32_t>(validLen * sizeof(GType)), 0, 0, 0};
+     constexpr uint32_t elemsPerBlock = UB_BLOCK_SIZE / sizeof(GType);
+     uint8_t rightPadding = static_cast<uint8_t>((elemsPerBlock - (validLen % elemsPerBlock)) % elemsPerBlock);
+     DataCopyPadExtParams<GType> padParams{true, 0, rightPadding, 0};
+     DataCopyPad(dst, src[offset], copyParams, padParams);
+ }
+
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::RefineSmallDw(
+     LocalTensor<float> &dw, uint64_t dvOffset, uint64_t hOffset, uint32_t rows) {
+     if constexpr (std::is_same<DataType, half>::value) {
+         constexpr float refineAbsMin = 3.0e-5f;
+         constexpr float refineAbsMax = 2.0e-4f;
+         uint32_t kLimit = static_cast<uint32_t>(K);
+         uint32_t vLimit = static_cast<uint32_t>(V);
+         for (uint32_t r = 0; r < rows; ++r) {
+             for (uint32_t kIdx = 0; kIdx < kLimit; ++kIdx) {
+                 uint32_t outIdx = r * kLimit + kIdx;
+                 float val = dw.GetValue(outIdx);
+                 float absVal = val >= 0.0f ? val : -val;
+                 bool refineSmall = absVal >= refineAbsMin && absVal <= refineAbsMax;
+                 bool refineChunkHeadZero = r == 0 && absVal <= refineAbsMax;
+                 bool refineChunkHeadRepairCols = r == 0 && kIdx < FP16_ELEMENTS_PER_BLOCK;
+                 if (refineSmall || refineChunkHeadZero || refineChunkHeadRepairCols) {
+                     float sum = 0.0f;
+                     for (uint32_t vIdx = 0; vIdx < vLimit; ++vIdx) {
+                         float dvVal = static_cast<float>(gmDv.GetValue(dvOffset + r * vLimit + vIdx));
+                         float hVal = static_cast<float>(gmH.GetValue(hOffset + kIdx * vLimit + vIdx));
+                         sum += dvVal * hVal;
+                     }
+                     dw.SetValue(outIdx, sum);
+                 }
+             }
+         }
+     }
+ }
+
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::RepairDwChunkHeadBlock(
+     LocalTensor<DataType> &dwOut, LocalTensor<DataType> &tmp, LocalTensor<float> &work,
+     LocalTensor<float> &scratch, uint64_t dvOffset, uint64_t hOffset, uint32_t rows) {
+     if constexpr (std::is_same<DataType, half>::value) {
+         if (rows == 0 || K < FP16_ELEMENTS_PER_BLOCK || V < FP32_PER_REPEAT) {
+             return;
+         }
+
+         constexpr uint32_t repairCols = FP16_ELEMENTS_PER_BLOCK;
+         uint32_t vLimit = static_cast<uint32_t>(V);
+         uint32_t reduceRepeats = vLimit / FP32_PER_REPEAT;
+         if (reduceRepeats == 0) {
+             return;
+         }
+
+         TEventID eventVToMte2 = GetTPipePtr()->FetchEventID(HardEvent::V_MTE2);
+         SetFlag<HardEvent::V_MTE2>(eventVToMte2);
+         WaitFlag<HardEvent::V_MTE2>(eventVToMte2);
+         DataCopy(tmp, gmDv[dvOffset], vLimit);
+         DataCopy(tmp[vLimit], gmH[hOffset], repairCols * vLimit);
+
+         TEventID eventId = GetTPipePtr()->FetchEventID(HardEvent::MTE2_V);
+         SetFlag<HardEvent::MTE2_V>(eventId);
+         WaitFlag<HardEvent::MTE2_V>(eventId);
+
+         Cast(scratch, tmp, RoundMode::CAST_NONE, vLimit);
+         Cast(work, tmp[vLimit], RoundMode::CAST_NONE, repairCols * vLimit);
+         PipeBarrier<PIPE_V>();
+
+         for (uint32_t kIdx = 0; kIdx < repairCols; ++kIdx) {
+             Mul(work[kIdx * vLimit], work[kIdx * vLimit], scratch, vLimit);
+         }
+         PipeBarrier<PIPE_V>();
+
+         for (uint32_t kIdx = 0; kIdx < repairCols; ++kIdx) {
+             WholeReduceSum(scratch[kIdx * FP32_ELEMENTS_PER_BLOCK], work[kIdx * vLimit],
+                            FP32_PER_REPEAT, reduceRepeats, 1, 1, FP32_ELEMENTS_PER_BLOCK);
+         }
+         PipeBarrier<PIPE_V>();
+
+         WholeReduceSum(work, scratch, reduceRepeats, repairCols, 1, 1, 1);
+         PipeBarrier<PIPE_V>();
+
+         Muls(work, work, -1.0f, repairCols);
+         PipeBarrier<PIPE_V>();
+         Cast(dwOut, work, RoundMode::CAST_RINT, repairCols);
+         PipeBarrier<PIPE_V>();
+     }
+ }
+
+ // mul1 一个 row-half 的计算: 输出 fp32 因果掩码 exp 到 outFp32 (该 half 的 [real_BT, BT], 行优先)。
+ // 内核与 ProcessAVector Part2 完全一致 (同 buffer: inQue3 g / calcBuf1 brcb / calcBuf2,3 g±)。
+ // 调用方需先 InitBuffer 这些 buffer 并构建 tensorMaskA。outFp32 必须指向该 half 的行起点。
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ComputeMul1HalfFp32(
+     const LocalTensor<float> &outFp32, const LocalTensor<float> &tensorMaskA,
+     uint64_t gOffset, uint32_t BT_sub_start, uint32_t real_BT, uint32_t actual_chunk_len) {
+     if (real_BT == 0) { return; }
+     const uint32_t gSize = BT;
+     auto tensorBrcbTemp = calcBuf1.Get<float>();
+     auto tensorGFp32Left = calcBuf2.Get<float>();
+     auto tensorGFp32Right = calcBuf3.Get<float>();
+     {
+         auto tensorGIn = inQue3.AllocTensor<GType>();
+         CopyGateWithPad(tensorGIn, gmG, gOffset, actual_chunk_len, gSize);
+         inQue3.EnQue(tensorGIn);
+     }
+     auto tensorGIn = inQue3.DeQue<GType>();
+     if constexpr (std::is_same<GType, float>::value) {
+         DataCopy(tensorGFp32Left, tensorGIn, gSize);
+     } else {
+         Cast(tensorGFp32Left, tensorGIn, RoundMode::CAST_NONE, gSize);
+     }
+     PipeBarrier<PIPE_V>();
+     Muls(tensorGFp32Right, tensorGFp32Left, static_cast<float>(-1), gSize);
+     Brcb(tensorBrcbTemp, tensorGFp32Left[BT_sub_start], CEIL_DIV(real_BT, 8), {1, 8});
+     PipeBarrier<PIPE_V>();
+     if (BT == 64) {
+         AscendC::Add(outFp32, tensorGFp32Right, tensorBrcbTemp, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 8, 0, 1});
+         PipeBarrier<PIPE_V>();
+         Mins(outFp32, outFp32, static_cast<float>(0.0), real_BT * BT);
+         PipeBarrier<PIPE_V>();
+         Exp(outFp32, outFp32, real_BT * BT);
+         PipeBarrier<PIPE_V>();
+     } else {
+         AscendC::Copy(outFp32, tensorGFp32Right, CAL_NUM_FLOAT, real_BT, {1, 1, 16, 0});
+         PipeBarrier<PIPE_V>();
+         AscendC::Copy(outFp32[CAL_NUM_FLOAT], tensorGFp32Right[CAL_NUM_FLOAT], CAL_NUM_FLOAT, real_BT, {1, 1, 16, 0});
+         PipeBarrier<PIPE_V>();
+         AscendC::Add(outFp32, outFp32, tensorBrcbTemp, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+         PipeBarrier<PIPE_V>();
+         AscendC::Add(outFp32[CAL_NUM_FLOAT], outFp32[CAL_NUM_FLOAT], tensorBrcbTemp, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+         PipeBarrier<PIPE_V>();
+         Mins(outFp32, outFp32, static_cast<float>(0.0), real_BT * BT);
+         PipeBarrier<PIPE_V>();
+         Exp(outFp32, outFp32, real_BT * BT);
+     }
+     PipeBarrier<PIPE_V>();
+     if (BT == 64) {
+         Mul(outFp32, outFp32, tensorMaskA[BT_sub_start * 64], 32 * 64);
+     } else {
+         BinaryRepeatParams binaryRepeatParams{1, 1, 1, 16, 16, 8};
+         UnaryRepeatParams unaryRepeatParams{1, 1, 16, 8};
+         if (BT_sub_start == 0) {
+             Mul(outFp32, outFp32, tensorMaskA, 64, 64, binaryRepeatParams);
+             PipeBarrier<PIPE_V>();
+             Muls(outFp32[64], outFp32[64], static_cast<float>(0), 64, 64, unaryRepeatParams);
+         } else {
+             Mul(outFp32[64], outFp32[64], tensorMaskA, 64, 64, binaryRepeatParams);
+         }
+         PipeBarrier<PIPE_V>();
+     }
+     AscendC::Muls(outFp32, outFp32, static_cast<float>(scale), real_BT * BT);
+     PipeBarrier<PIPE_V>();
+     inQue3.FreeTensor(tensorGIn);
+ }
+
+ // ============== A_vector: 原 Part1 (dw 取负 + dg_last) + 原 Part2 (mul1) ==============
+ // 每 chunk: WaitCubeReady 一次 -> Part1 (head-split) + Part2 (row-split) -> SetVectorDone 一次。
+ // 依赖: Part1 读 wsDw(由 A_cube 产出); Part2(mul1) 仅依赖 g, 写入 dq scratch 供 B_vector 消费。
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessAVector(uint32_t loopBase, uint32_t loopEnd) {
+     uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+     uint32_t coreNum = aicCoreNum;
+     uint32_t coreLoops = B * numChunks;
+     uint32_t subBlockIdx = GetSubBlockIdx();
+     uint32_t subBlockNum = GetSubBlockNum();
+
+     const uint32_t hDhSize = mul0RowNum * V;
+     const uint32_t dwSize = BT * K;
+     const uint32_t gSize = BT;
+     // 诊断 (同 ProcessBVector): 大 case 缩小 mul1 GM 写, 配合 B 端缩小读, 把 mul1 整个往返流量去掉 (~3.2GB), 看 perf。
+     const bool largeMemBound_diag =
+         ((uint64_t)B * HV * T * K * 2 + (uint64_t)B * HV * T * BT * 2 + (uint64_t)B * HV * numChunks * 4) > (512ULL * 1024 * 1024);
+     const uint32_t maxSize = (2 * hDhSize) > dwSize ? (2 * hDhSize) : dwSize;
+
+     // ----- Part1 buffers (h/dh, dw) -----
+     uint32_t inQue1Bytes = 2 * hDhSize * sizeof(DataType);
+     uint32_t dwWorkspaceBytes = (dwSize > (FP16_ELEMENTS_PER_BLOCK * V + V) ? dwSize : (FP16_ELEMENTS_PER_BLOCK * V + V)) * sizeof(DataType);
+     if (dwWorkspaceBytes > inQue1Bytes) {
+         inQue1Bytes = dwWorkspaceBytes;
+     }
+     pipe->InitBuffer(inQue1, BUFFER_NUM, inQue1Bytes);                       // Part1: h/dh and dw repair tmp
+     pipe->InitBuffer(inQue3, 2, gSize * sizeof(float));                       // Part2: g
+     pipe->InitBuffer(outQue1, BUFFER_NUM, sizeof(float) * 8);                 // Part1: dg_last (32B 对齐)
+     // outQue2: Part1 dw 输出 与 Part2 mul1 输出 复用 (同 chunk 内 Part1 先于 Part2, 顺序复用)
+     uint32_t mul1OutBytes = (gSize * BT) * sizeof(float) / 2;
+     uint32_t outQue2Bytes = dwSize * sizeof(DataType);
+     if (mul1OutBytes > outQue2Bytes) { outQue2Bytes = mul1OutBytes; }
+     pipe->InitBuffer(outQue2, BUFFER_NUM, outQue2Bytes);
+     pipe->InitBuffer(calcBuf1, maxSize * sizeof(float));                      // Part1 h/dh fp32 与 Part2 brcb temp 复用
+     uint32_t calcBuf2Elems = (BT > V ? BT : V);
+     if (FP16_ELEMENTS_PER_BLOCK * FP32_ELEMENTS_PER_BLOCK > calcBuf2Elems) {
+         calcBuf2Elems = FP16_ELEMENTS_PER_BLOCK * FP32_ELEMENTS_PER_BLOCK;
+     }
+     pipe->InitBuffer(calcBuf2, calcBuf2Elems * sizeof(float));               // Part2 g temp / dw repair scratch
+     uint32_t calcBuf3Bytes = hDhSize * sizeof(float);
+     if (BT * sizeof(float) > calcBuf3Bytes) { calcBuf3Bytes = BT * sizeof(float); }
+     pipe->InitBuffer(calcBuf3, calcBuf3Bytes);                               // Part1 sum 与 Part2 g temp [1,BT] 复用
+     pipe->InitBuffer(calcBuf4, UB_BLOCK_SIZE);                               // Part2: zero
+     pipe->InitBuffer(gBuf, 64 * 64 * sizeof(float));                         // Part2: 下三角 mask (常驻)
+
+     auto tensorMaskA = gBuf.Get<float>();
+     auto tensorZeroFp32 = calcBuf4.template Get<float>();
+
+     // Part2 mask 一次构建 (常驻整个 A stage)
+     AscendC::Duplicate<float>(tensorZeroFp32, float(0.0), UB_BLOCK_SIZE / sizeof(float));
+     Duplicate(tensorMaskA, 0.0f, 64 * 64);
+     PipeBarrier<PIPE_V>();
+     for (uint32_t i = 0; i < 64; i++) {
+         Duplicate(tensorMaskA[i * 64], 1.0f, i + 1);
+     }
+     PipeBarrier<PIPE_V>();
+
+     uint32_t bos = 0;
+     uint32_t eos = 0;
+     for (uint32_t loopIdx = loopBase; loopIdx < loopEnd; loopIdx += coreNum) {
+         uint32_t bIdx = loopIdx / numChunks;
+         uint32_t chunkIdx = loopIdx % numChunks;
+         GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, HV, T, BT, loopIdx, bos, eos);
+         uint32_t actual_chunk_len = eos - bos;
+         uint32_t BT_sub = actual_chunk_len;
+         uint32_t dwSize_sub = BT_sub * K;
+         WaitCubeReady();
+
+         // ---------- Part1: dg_last = sum(h*dh), dw = -dw (head-split) ----------
+         {
+             auto tensorHFp32 = calcBuf1.Get<float>();
+             auto tensorDhFp32 = tensorHFp32[hDhSize];
+             auto tensorSumFp32 = calcBuf3.Get<float>();
+             for (uint32_t h = 0; h < HV; h++) {
+                 if (h % subBlockNum != subBlockIdx) {
+                     continue;
+                 }
+                 uint64_t hOffset = ((bIdx * HV + h) * numChunks + chunkIdx) * K * V;
+                 uint64_t dwOffset = (h * T + bos) * K;  // 最终输出 ptrDw 仍全局寻址
+                 uint64_t dwRingOffset = DqkwgShortBtxKRingElemOffset(coreIdx, loopIdx, coreNum, h, HV, BT, K,
+                                                                       DqkwgShortRingDepthFromGroup((uint32_t)wsBtxKSyncSlotsPerHead));
+
+                 uint64_t dgLastOffset = DqkwgScalarRingElemOffset(coreIdx, loopBase, loopIdx, coreNum, h, HV,
+                                                                   (uint32_t)wsBtxKSyncSlotsPerHead);
+
+                 // ===== dg_last = sum(h * dh) =====
+                 // CV 融合优化: 在 cube-bound 的 stage A 算 (被 cube 的 2H 个 matmul 藏住), 写 wsDgLast;
+                 //   vector-bound 的 D_vector 改为读 wsDgLast, 省掉 D 的 h/dh 读 + K*V 归约 (给瓶颈减负)。
+                 for (uint32_t row = 0; row < K; row += mul0RowNum) {
+                     {
+                         auto tensorHIn = inQue1.AllocTensor<DataType>();
+                         auto tensorDhIn = tensorHIn[hDhSize];
+                         DataCopy(tensorDhIn, gmDh[hOffset + row * V], hDhSize);
+                         DataCopy(tensorHIn, gmH[hOffset + row * V], hDhSize);
+                         inQue1.EnQue(tensorHIn);
+                     }
+                     {
+                         auto tensorHIn = inQue1.DeQue<DataType>();
+                         auto tensorDhIn = tensorHIn[hDhSize];
+                         Cast(tensorHFp32, tensorHIn, RoundMode::CAST_NONE, hDhSize);
+                         Cast(tensorDhFp32, tensorDhIn, RoundMode::CAST_NONE, hDhSize);
+                         PipeBarrier<PIPE_V>();
+                         if (row == 0) {
+                             Mul(tensorSumFp32, tensorHFp32, tensorDhFp32, hDhSize);
+                         } else {
+                             Mul(tensorHFp32, tensorHFp32, tensorDhFp32, hDhSize);
+                             PipeBarrier<PIPE_V>();
+                             Add(tensorSumFp32, tensorSumFp32, tensorHFp32, hDhSize);
+                         }
+                         PipeBarrier<PIPE_V>();
+                         inQue1.FreeTensor(tensorHIn);
+                     }
+                 }
+                 {
+                     uint32_t remainNum = hDhSize;
+                     while (remainNum > 64) {
+                         remainNum = remainNum / 2;
+                         Add(tensorSumFp32, tensorSumFp32, tensorSumFp32[remainNum], remainNum);
+                         PipeBarrier<PIPE_V>();
+                     }
+                     auto tensorDgLastOut = outQue1.AllocTensor<float>();
+                     WholeReduceSum(tensorDgLastOut, tensorSumFp32, 64, 1, 1, 1, 8);
+                     PipeBarrier<PIPE_V>();
+                     outQue1.EnQue(tensorDgLastOut);
+                 }
+                 {
+                     auto tensorDgLastOut = outQue1.DeQue<float>();
+                     DataCopyParams dataCopyParams;
+                     dataCopyParams.blockCount = 1;
+                     dataCopyParams.blockLen = sizeof(float);
+                     dataCopyParams.srcStride = 0;
+                     dataCopyParams.dstStride = 0;
+                     DataCopyPad(gmDgLast[dgLastOffset], tensorDgLastOut, dataCopyParams);
+                     PipeBarrier<PIPE_MTE3>();
+                     outQue1.FreeTensor(tensorDgLastOut);
+                 }
+
+                 // ===== dw = -dw, then vector-repair row-0 first block =====
+                 {
+                     auto tensorDwOut = outQue2.AllocTensor<DataType>();
+                     auto tensorDwTmp = inQue1.AllocTensor<DataType>();
+                     {
+                         TEventID evV2M = GetTPipePtr()->FetchEventID(HardEvent::V_MTE2);
+                         SetFlag<HardEvent::V_MTE2>(evV2M);
+                         WaitFlag<HardEvent::V_MTE2>(evV2M);
+                     }
+                     DataCopy(tensorDwOut, gmDwWorkspace[dwRingOffset], dwSize_sub);
+                     {
+                         TEventID evM2V = GetTPipePtr()->FetchEventID(HardEvent::MTE2_V);
+                         SetFlag<HardEvent::MTE2_V>(evM2V);
+                         WaitFlag<HardEvent::MTE2_V>(evM2V);
+                     }
+                     Cast(tensorHFp32, tensorDwOut, RoundMode::CAST_NONE, dwSize_sub);
+                     PipeBarrier<PIPE_V>();
+                     Muls(tensorHFp32, tensorHFp32, -1.0f, dwSize_sub);
+                     PipeBarrier<PIPE_V>();
+                     Cast(tensorDwOut, tensorHFp32, RoundMode::CAST_RINT, dwSize_sub);
+                     PipeBarrier<PIPE_V>();
+                     auto tensorRepairWork = calcBuf3.Get<float>();
+                     auto tensorRepairScratch = calcBuf2.Get<float>();
+                     RepairDwChunkHeadBlock(tensorDwOut, tensorDwTmp, tensorRepairWork, tensorRepairScratch,
+                                            (h * T + bos) * V, hOffset, actual_chunk_len);
+                     inQue1.FreeTensor(tensorDwTmp);
+                     outQue2.EnQue(tensorDwOut);
+                 }
+                 {
+                     auto tensorDwOut = outQue2.DeQue<DataType>();
+                     DataCopy(gmDw[dwOffset], tensorDwOut, dwSize_sub);
+                     PipeBarrier<PIPE_MTE3>();
+                     outQue2.FreeTensor(tensorDwOut);
+                 }
+             }
+         }
+
+         // ---------- Part2: mul1 = scale * M * exp(min(0, g[i]-g[j])) (row-split) ----------
+         // 大 memory-bound case: 跳过 Part2 (不算/不写 mul1), 改由 vector B 从输入 g 现读现算 (内联), 省掉 mul1 的 GM 往返
+         // (~3.2GB for step2_12); 小 case 不变, 仍这里算+写 GM。判据 largeMemBound 与 host tiling / B 端同公式。
+         if (!largeMemBound_diag) {
+             uint32_t vec_core_0_length = actual_chunk_len >= (BT / 2) ? (BT / 2) : actual_chunk_len;
+             uint32_t bos_p2 = bos;
+             uint32_t BT_sub_start = 0;
+             if (subBlockIdx == 0) {
+                 BT_sub_start = 0;
+             } else {
+                 BT_sub_start = vec_core_0_length;
+                 bos_p2 = bos + vec_core_0_length;
+             }
+             uint32_t eos_p2 = (subBlockIdx == 0) ? (bos + vec_core_0_length) : eos;
+             uint32_t real_BT = (eos_p2 > bos_p2) ? (eos_p2 - bos_p2) : 0;
+
+             auto tensorBrcbTemp = calcBuf1.Get<float>();
+             auto tensorGFp32Left = calcBuf2.Get<float>();
+             auto tensorGFp32Right = calcBuf3.Get<float>();
+             for (uint32_t h = 0; h < HV; h++) {
+                 if (real_BT == 0) {
+                     continue;
+                 }
+                 uint64_t gOffset = (h * T + bos);   // 整 chunk 的 g (从原始 bos)
+                 uint64_t mul1Offset = DqkwgShortBtbRingElemOffset(coreIdx, loopIdx, coreNum, h, HV, BT,
+                                                                   DqkwgShortRingDepthFromGroup((uint32_t)wsBtxKSyncSlotsPerHead)) +
+                                       static_cast<uint64_t>(BT_sub_start) * BT;
+
+                 {
+                     auto tensorGIn = inQue3.AllocTensor<GType>();
+                     CopyGateWithPad(tensorGIn, gmG, gOffset, actual_chunk_len, gSize);
+                     inQue3.EnQue(tensorGIn);
+                 }
+                 {
+                     auto tensorGIn = inQue3.DeQue<GType>();
+                     auto tensorDsTempOut = outQue2.AllocTensor<float>();
+
+                     if constexpr (std::is_same<GType, float>::value) {
+                         DataCopy(tensorGFp32Left, tensorGIn, gSize);
+                     } else {
+                         Cast(tensorGFp32Left, tensorGIn, RoundMode::CAST_NONE, gSize);
+                     }
+                     PipeBarrier<PIPE_V>();
+
+                     Muls(tensorGFp32Right, tensorGFp32Left, static_cast<float>(-1), gSize);
+                     Brcb(tensorBrcbTemp, tensorGFp32Left[BT_sub_start], CEIL_DIV(real_BT, 8), {1, 8});
+                     PipeBarrier<PIPE_V>();
+
+                     if (BT == 64) {
+                         AscendC::Add(tensorDsTempOut, tensorGFp32Right, tensorBrcbTemp, CAL_NUM_FLOAT, real_BT,
+                                     {1, 1, 0, 8, 0, 1});
+                         PipeBarrier<PIPE_V>();
+                         Mins(tensorDsTempOut, tensorDsTempOut, static_cast<float>(0.0), real_BT * BT);
+                         PipeBarrier<PIPE_V>();
+                         Exp(tensorDsTempOut, tensorDsTempOut, real_BT * BT);
+                         PipeBarrier<PIPE_V>();
+                     } else {
+                         AscendC::Copy(tensorDsTempOut, tensorGFp32Right, CAL_NUM_FLOAT, real_BT, {1, 1, 16, 0});
+                         PipeBarrier<PIPE_V>();
+                         AscendC::Copy(tensorDsTempOut[CAL_NUM_FLOAT], tensorGFp32Right[CAL_NUM_FLOAT], CAL_NUM_FLOAT,
+                                     real_BT, {1, 1, 16, 0});
+                         PipeBarrier<PIPE_V>();
+                         AscendC::Add(tensorDsTempOut, tensorDsTempOut, tensorBrcbTemp, CAL_NUM_FLOAT, real_BT,
+                                     {1, 1, 0, 16, 16, 1});
+                         PipeBarrier<PIPE_V>();
+                         AscendC::Add(tensorDsTempOut[CAL_NUM_FLOAT], tensorDsTempOut[CAL_NUM_FLOAT], tensorBrcbTemp,
+                                     CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+                         PipeBarrier<PIPE_V>();
+                         Mins(tensorDsTempOut, tensorDsTempOut, static_cast<float>(0.0), real_BT * BT);
+                         PipeBarrier<PIPE_V>();
+                         Exp(tensorDsTempOut, tensorDsTempOut, real_BT * BT);
+                     }
+                     PipeBarrier<PIPE_V>();
+
+                     if (BT == 64) {
+                         Mul(tensorDsTempOut, tensorDsTempOut, tensorMaskA[BT_sub_start * 64], 32 * 64);
+                     } else {
+                         BinaryRepeatParams binaryRepeatParams{1, 1, 1, 16, 16, 8};
+                         UnaryRepeatParams unaryRepeatParams{1, 1, 16, 8};
+                         if (BT_sub_start == 0) {
+                             Mul(tensorDsTempOut, tensorDsTempOut, tensorMaskA, 64, 64, binaryRepeatParams);
+                             PipeBarrier<PIPE_V>();
+                             Muls(tensorDsTempOut[64], tensorDsTempOut[64], static_cast<float>(0), 64, 64, unaryRepeatParams);
+                         } else {
+                             Mul(tensorDsTempOut[64], tensorDsTempOut[64], tensorMaskA, 64, 64, binaryRepeatParams);
+                         }
+                         PipeBarrier<PIPE_V>();
+                     }
+
+                     AscendC::Muls(tensorDsTempOut, tensorDsTempOut, static_cast<float>(scale), real_BT * BT);
+                     PipeBarrier<PIPE_V>();
+
+                     Cast(tensorDsTempOut.template ReinterpretCast<DataType>(), tensorDsTempOut, RoundMode::CAST_RINT, real_BT * BT);
+
+                     inQue3.FreeTensor(tensorGIn);
+                     outQue2.EnQue(tensorDsTempOut);
+                 }
+                 {
+                     auto tensorDsTempOut = outQue2.DeQue<float>();
+                     DataCopy(gmMul1[mul1Offset], tensorDsTempOut.template ReinterpretCast<DataType>(), real_BT * BT);
+                     outQue2.FreeTensor(tensorDsTempOut);
+                 }
+             }
+         }
+         PipeBarrier<PIPE_MTE3>();
+         SetVecCredit();
+     }
+ }
+
+ // ============== B_vector: 原 Part3 (ds_temp + dg 部分) ==============
+ // 每 chunk: WaitCubeReady 一次 -> head-split 处理 (读 ds(B_cube), mul1(A_vector), mm5(A_cube)) -> SetVectorDone 一次。
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessBVector(uint32_t loopBase, uint32_t loopEnd) {
+     uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+     uint32_t coreNum = aicCoreNum;
+     uint32_t coreLoops = B * numChunks;
+     uint32_t subBlockIdx = GetSubBlockIdx();
+     uint32_t subBlockNum = GetSubBlockNum();
+
+     uint32_t dsSize_full = BT * BT;
+     const uint32_t gSize = BT;
+
+     // 大 memory-bound case: mul1 不走 GM, 改在 vector B 从输入 g 现读现算 (= A Part2 内核 ComputeMul1HalfFp32),
+     // 省掉 mul1 的 [BT,BT] GM 往返 (~3.2GB for step2_12)。判据与 host tiling / vector A 同公式; 小 case 仍读 GM。
+     const bool largeMemBound_diag =
+         ((uint64_t)B * HV * T * K * 2 + (uint64_t)B * HV * T * BT * 2 + (uint64_t)B * HV * numChunks * 4) > (512ULL * 1024 * 1024);
+
+     pipe->InitBuffer(inQue1, BUFFER_NUM, dsSize_full * sizeof(float));    // ds from Cube (含 reinterpret)
+     pipe->InitBuffer(inQue2, BUFFER_NUM, dsSize_full * sizeof(float));    // mm5/mul1 from workspace (或大 case 内联算 mul1)
+     pipe->InitBuffer(outQue1, BUFFER_NUM, dsSize_full * sizeof(DataType));   // ds_temp output
+     pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(float));       // dg output
+     pipe->InitBuffer(dgBuf, gSize * sizeof(float));
+     // mul1 内联所需 (大 case): inQue3=g, calcBuf1=brcb, calcBuf2/3=g±, gBuf=64x64 因果 mask (复用 gBuf 放大)
+     pipe->InitBuffer(inQue3, 2, gSize * sizeof(float));
+     pipe->InitBuffer(calcBuf1, gSize * 8 * sizeof(float));
+     pipe->InitBuffer(calcBuf2, gSize * sizeof(float));
+     pipe->InitBuffer(calcBuf3, gSize * sizeof(float));
+     pipe->InitBuffer(gBuf, 64 * 64 * sizeof(float));
+
+     auto tensorMaskA = gBuf.Get<float>();
+     if (largeMemBound_diag) {
+         Duplicate(tensorMaskA, 0.0f, 64 * 64);
+         PipeBarrier<PIPE_V>();
+         for (uint32_t i = 0; i < 64; i++) {
+             Duplicate(tensorMaskA[i * 64], 1.0f, i + 1);
+         }
+         PipeBarrier<PIPE_V>();
+     }
+
+     uint32_t bos = 0;
+     uint32_t eos = 0;
+     for (uint32_t loopIdx = loopBase; loopIdx < loopEnd; loopIdx += coreNum) {
+         GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, HV, T, BT, loopIdx, bos, eos);
+         uint32_t real_BT = eos - bos;
+         uint32_t dsSize_sub = real_BT * BT;
+         WaitCubeReady();
+
+         for (uint32_t h = 0; h < HV; h++) {
+             if (h % subBlockNum != subBlockIdx) {
+                 continue;
+             }
+             uint64_t gOffset = (h * T + bos);
+             uint64_t dsOffset = DqkwgBtbRingElemOffset(coreIdx, loopBase, loopIdx, coreNum, h, HV, BT,
+                                                        (uint32_t)wsBtxKSyncSlotsPerHead);
+             uint64_t mul1Offset = DqkwgShortBtbRingElemOffset(coreIdx, loopIdx, coreNum, h, HV, BT,
+                                                               DqkwgShortRingDepthFromGroup((uint32_t)wsBtxKSyncSlotsPerHead));
+             uint64_t mm5Offset = DqkwgBtxKRingElemOffset(coreIdx, loopBase, loopIdx, coreNum, h, HV, BT, K,
+                                                          (uint32_t)wsBtxKSyncSlotsPerHead);
+             uint64_t dgOffset = gOffset;
+
+             {
+                 auto tensorDsIn = inQue1.AllocTensor<DataType>();
+                 DataCopy(tensorDsIn[BT * BT], gmDsTemp[dsOffset], dsSize_sub);
+                 inQue1.EnQue(tensorDsIn);
+                 if (!largeMemBound_diag) {
+                     // 小 case: mul1 仍从 GM 读 (vector A 写)
+                     auto tensorMul1In = inQue2.AllocTensor<DataType>();
+                     DataCopy(tensorMul1In[BT * BT], gmMul1[mul1Offset], dsSize_sub);
+                     inQue2.EnQue(tensorMul1In);
+                 }
+             }
+             {
+                 auto tensorDsInFp16 = inQue1.DeQue<DataType>();
+                 auto tensorDsInFp32 = tensorDsInFp16.template ReinterpretCast<float>();
+                 auto tensorDsTempOut = outQue1.AllocTensor<DataType>();
+                 auto tensorDgOut = outQue2.AllocTensor<float>();
+
+                 Cast(tensorDsInFp32, tensorDsInFp16[BT * BT], RoundMode::CAST_NONE, dsSize_sub);
+
+                 LocalTensor<DataType> tensorMul1In;
+                 LocalTensor<float> tensorMul1InFp32;
+                 if (largeMemBound_diag) {
+                     // 大 case: mul1 不读 GM, 在此从 g 内联算两个 row-half (= A Part2 内核), 写入 inQue2 buffer (fp32)。
+                     tensorMul1In = inQue2.AllocTensor<DataType>();
+                     tensorMul1InFp32 = tensorMul1In.template ReinterpretCast<float>();
+                     uint32_t vec0 = real_BT >= (BT / 2) ? (BT / 2) : real_BT;       // 与 A 的 vec_core_0_length 一致
+                     uint32_t rb1 = (real_BT > vec0) ? (real_BT - vec0) : 0;
+                     ComputeMul1HalfFp32(tensorMul1InFp32, tensorMaskA, gOffset, 0, vec0, real_BT);
+                     if (rb1 > 0) {
+                         ComputeMul1HalfFp32(tensorMul1InFp32[vec0 * BT], tensorMaskA, gOffset, vec0, rb1, real_BT);
+                     }
+                 } else {
+                     tensorMul1In = inQue2.DeQue<DataType>();
+                     tensorMul1InFp32 = tensorMul1In.template ReinterpretCast<float>();
+                     Cast(tensorMul1InFp32, tensorMul1In[BT * BT], RoundMode::CAST_NONE, dsSize_sub);
+                 }
+                 PipeBarrier<PIPE_V>();
+                 // b_ds_temp = b_ds * mul1 (已应用掩码)
+                 Mul(tensorDsInFp32, tensorDsInFp32, tensorMul1InFp32, dsSize_sub);
+                 inQue2.FreeTensor(tensorMul1In);
+
+                 // 搬入 mm5, 复用 mul1 空间
+                 auto tensorMm5InFp16Tmp = inQue2.AllocTensor<DataType>();
+                 DataCopy(tensorMm5InFp16Tmp[BT * BT], gmMm5[mm5Offset], dsSize_sub);
+                 inQue2.EnQue(tensorMm5InFp16Tmp);
+                 auto tensorMm5InFp16 = inQue2.DeQue<DataType>();
+                 auto tensorMm5InFp32 = tensorMm5InFp16.template ReinterpretCast<float>();
+                 Cast(tensorMm5InFp32, tensorMm5InFp16[BT * BT], RoundMode::CAST_NONE, dsSize_sub);
+                 PipeBarrier<PIPE_V>();
+
+                 Mul(tensorMm5InFp32, tensorDsInFp32, tensorMm5InFp32, dsSize_sub); // b_ds2 = b_ds_temp * mm5
+                 Cast(tensorDsTempOut, tensorDsInFp32, RoundMode::CAST_RINT, dsSize_sub);  // ds_temp -> fp16
+
+                 Duplicate(tensorDgOut, static_cast<float>(0.0), BT);
+                 PipeBarrier<PIPE_V>();
+
+                 // 行求和 -> [BT] (+Add0.C)
+                 uint64_t wholeReduceSumCnt = CeilDiv(real_BT, FP32_PER_REPEAT);
+                 uint32_t remainCnt = real_BT % FP32_PER_REPEAT;
+                 if (remainCnt > 0) {
+                     uint32_t DuplicateOffset = wholeReduceSumCnt * FP32_PER_REPEAT - FP32_PER_REPEAT;
+                     uint64_t mask[1] = {0xffffffffffffffff};
+                     mask[0] <<= remainCnt;
+                     for (uint32_t row = 0; row < real_BT; row++) {
+                         Duplicate(tensorMm5InFp32[row * BT + DuplicateOffset], 0.0f, mask, 1, 1, 8);
+                     }
+                     PipeBarrier<PIPE_V>();
+                 }
+                 for (uint32_t i = 0; i < real_BT; i++) {
+                     WholeReduceSum(tensorDsInFp32[i * 8], tensorMm5InFp32[i * BT],
+                                    FP32_PER_REPEAT, wholeReduceSumCnt, 1, 1, 8);
+                 }
+                 PipeBarrier<PIPE_V>();
+                 WholeReduceSum(tensorDgOut, tensorDsInFp32, wholeReduceSumCnt, real_BT, 1, 1, 1);
+
+                 // 列求和 -> [BT] (-Add0.D)
+                 PipeBarrier<PIPE_V>();
+                 uint32_t remain_row = real_BT;
+                 uint32_t CalcCnt = 0;
+                 uint32_t Offset = 0;
+                 while (remain_row > 1) {
+                     CalcCnt = (remain_row / 2) * BT;
+                     remain_row = CeilDiv(remain_row, 2);
+                     Offset = remain_row * BT;
+                     Add(tensorMm5InFp32, tensorMm5InFp32, tensorMm5InFp32[Offset], CalcCnt);
+                     PipeBarrier<PIPE_V>();
+                 }
+                 Sub(tensorDgOut, tensorDgOut, tensorMm5InFp32, BT);
+                 PipeBarrier<PIPE_V>();
+                 if constexpr (!std::is_same<GType, float>::value) {
+                     Cast(tensorDgOut.template ReinterpretCast<GType>(), tensorDgOut, RoundMode::CAST_RINT, gSize);
+                 }
+
+                 inQue1.FreeTensor(tensorDsInFp16);
+                 inQue2.FreeTensor(tensorMm5InFp16);
+                 outQue1.EnQue(tensorDsTempOut);
+                 outQue2.EnQue(tensorDgOut);
+             }
+             {
+                 auto tensorDsTempOut = outQue1.DeQue<DataType>();
+                 auto tensorDgOut = outQue2.DeQue<float>();
+                 DataCopy(gmDsTemp[dsOffset], tensorDsTempOut, dsSize_sub);
+
+                 DataCopyParams dataCopyParams;
+                 dataCopyParams.blockCount = 1;
+                 dataCopyParams.blockLen = real_BT * sizeof(GType);
+                 dataCopyParams.srcStride = 0;
+                 dataCopyParams.dstStride = 0;
+                 if constexpr (std::is_same<GType, float>::value) {
+                     DataCopyPad(gmDg[dgOffset], tensorDgOut, dataCopyParams);
+                 } else {
+                     DataCopyPad(gmDg[dgOffset], tensorDgOut.template ReinterpretCast<GType>(), dataCopyParams);
+                 }
+                 outQue1.FreeTensor(tensorDsTempOut);
+                 outQue2.FreeTensor(tensorDgOut);
+             }
+             PipeBarrier<PIPE_MTE3>();
+         }
+         PipeBarrier<PIPE_MTE3>();
+         SetVecCredit();
+     }
+ }
+
+ // ============== C_vector: 原 Part4 + Part6 (dq 最终 + dg) ==============
+ // C_cube 在一次 SetCubeReady 前已产出 dq_inner(ptrDq) 与 mm6(wsMm6); C_vector 一次 WaitCubeReady 后
+ // 同时读取二者 (无 per-head phase 握手), 计算 dq_state/dg 并 dq += mm6。
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessCVector(uint32_t loopBase, uint32_t loopEnd) {
+     uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+     uint32_t coreNum = aicCoreNum;
+     uint32_t coreLoops = B * numChunks;
+     uint32_t subBlockIdx = GetSubBlockIdx();
+     uint32_t subBlockNum = GetSubBlockNum();
+
+     uint32_t dqSize = BT * K;
+     const uint32_t gSize = BT;
+
+     pipe->InitBuffer(inQue1, BUFFER_NUM, dqSize * sizeof(float));    // dq_inner from Cube
+     pipe->InitBuffer(inQue2, BUFFER_NUM, dqSize * sizeof(float));    // q / mm6 复用
+     pipe->InitBuffer(inQue3, BUFFER_NUM, gSize * sizeof(GType));     // g
+     pipe->InitBuffer(inQue4, BUFFER_NUM, gSize * sizeof(GType));     // dg
+     pipe->InitBuffer(outQue1, BUFFER_NUM, dqSize * sizeof(DataType));   // dq output
+     pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(float));       // dg partial
+
+     pipe->InitBuffer(calcBuf3, gSize * 8 * sizeof(float));        // 第一次 reducesum 结果 [BT,8]
+     pipe->InitBuffer(gBuf, gSize * sizeof(float));
+     pipe->InitBuffer(dgBuf, gSize * sizeof(float));
+
+     auto tensorShareTmpFp32 = calcBuf3.Get<float>();
+     auto tensorGFp32 = gBuf.Get<float>();
+     auto tensorDgAdd = dgBuf.Get<float>();
+
+     uint32_t bos = 0;
+     uint32_t eos = 0;
+     for (uint32_t loopIdx = loopBase; loopIdx < loopEnd; loopIdx += coreNum) {
+         GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, HV, T, BT, loopIdx, bos, eos);
+         uint32_t actual_chunk_len = eos - bos;
+         uint32_t real_BT = actual_chunk_len;
+         uint32_t dqSize_sub = actual_chunk_len * K;
+         WaitCubeReady();
+
+         for (uint32_t h = 0; h < HV; h++) {
+             if (h % subBlockNum != subBlockIdx) {
+                 continue;
+             }
+             // GVA: q 为 HK 头, dq 为 HV 头
+             uint32_t hk_idx = h / n_ratio;
+             uint32_t bIdx = loopIdx / numChunks;
+             uint64_t bos_hk = bos - static_cast<uint64_t>(bIdx) * static_cast<uint64_t>(HV - HK) * T;
+             uint64_t qkOffset = (hk_idx * T + bos_hk) * K;   // q (HK)
+             uint64_t dqOffset = (h * T + bos) * K;           // dq (HV)
+             uint64_t gOffset = (h * T + bos);
+
+             // CopyIn: dq_inner, q, g, dg
+             {
+                 auto tensorDqIn = inQue1.AllocTensor<DataType>();
+                 auto tensorQIn = inQue2.AllocTensor<DataType>();
+                 auto tensorGIn = inQue3.AllocTensor<GType>();
+                 auto tensorDgIn = inQue4.AllocTensor<GType>();
+                 DataCopy(tensorDqIn[dqSize_sub], gmDq[dqOffset], dqSize_sub);
+                 DataCopy(tensorQIn[dqSize_sub], gmQ[qkOffset], dqSize_sub);
+                 CopyGateWithPad(tensorGIn, gmG, gOffset, actual_chunk_len, gSize);
+                 CopyGateWithPad(tensorDgIn, gmDg, gOffset, actual_chunk_len, gSize);
+                 inQue1.EnQue(tensorDqIn);
+                 inQue2.EnQue(tensorQIn);
+                 inQue3.EnQue(tensorGIn);
+                 inQue4.EnQue(tensorDgIn);
+             }
+             {
+                 auto tensorDqInFp16 = inQue1.DeQue<DataType>();
+                 auto tensorDqInFp32 = tensorDqInFp16.template ReinterpretCast<float>();
+                 auto tensorQInFp16 = inQue2.DeQue<DataType>();
+                 auto tensorQInFp32 = tensorQInFp16.template ReinterpretCast<float>();
+                 auto tensorGIn = inQue3.DeQue<GType>();
+                 auto tensorDgIn = inQue4.DeQue<GType>();
+                 auto tensorDgOut = outQue2.AllocTensor<float>();
+
+                 Cast(tensorDqInFp32, tensorDqInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
+                 Cast(tensorQInFp32, tensorQInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
+                 if constexpr (std::is_same<GType, float>::value) {
+                     DataCopy(tensorGFp32, tensorGIn, gSize);
+                 } else {
+                     Cast(tensorGFp32, tensorGIn, RoundMode::CAST_NONE, gSize);
+                 }
+                 PipeBarrier<PIPE_V>();
+
+                 // dq_state = dq_inner * exp(g)[:,None] * scale
+                 Exp(tensorGFp32, tensorGFp32, gSize);
+                 PipeBarrier<PIPE_V>();
+                 Muls(tensorGFp32, tensorGFp32, static_cast<float>(scale), gSize);
+                 PipeBarrier<PIPE_V>();
+                 Brcb(tensorShareTmpFp32, tensorGFp32, CEIL_DIV(real_BT, 8), {1, 8});
+                 PipeBarrier<PIPE_V>();
+                 AscendC::Mul(tensorDqInFp32, tensorDqInFp32, tensorShareTmpFp32, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+                 AscendC::Mul(tensorDqInFp32[CAL_NUM_FLOAT], tensorDqInFp32[CAL_NUM_FLOAT], tensorShareTmpFp32, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+                 PipeBarrier<PIPE_V>();
+
+                 // dg_C = row_sum(dq_state * q)
+                 Mul(tensorQInFp32, tensorDqInFp32, tensorQInFp32, dqSize_sub);
+                 PipeBarrier<PIPE_V>();
+                 uint64_t wholeReduceSumCnt = CeilDiv(K, FP32_PER_REPEAT);
+                 for (uint32_t i = 0; i < real_BT; i++) {
+                     WholeReduceSum(tensorShareTmpFp32[i * 8], tensorQInFp32[i * K],
+                                    FP32_PER_REPEAT, wholeReduceSumCnt, 1, 1, 8);
+                 }
+                 PipeBarrier<PIPE_V>();
+                 WholeReduceSum(tensorDgOut, tensorShareTmpFp32, wholeReduceSumCnt, actual_chunk_len, 1, 1, 1);
+
+                 // 用 gSize(=BT, padding 已补 0) 而非裸 real_BT: UB->UB DataCopy / Cast 的 count 必须 >=1 个
+                 // 32B block(fp32 即 >=8 元素)。varlen 下残长 <8 的 partial chunk 用 real_BT 会触发
+                 // "VEC illegal configuration"(AICore 507015)。tensorDgIn 已被 CopyGateWithPad padding 到 gSize,
+                 // 后面 Add 仍只取前 real_BT 个有效元素 => 对满块/>=8 残长字节等价, 只修 <8 残长的崩溃。
+                 if constexpr (std::is_same<GType, float>::value) {
+                     DataCopy(tensorDgAdd, tensorDgIn, gSize);
+                 } else {
+                     Cast(tensorDgAdd, tensorDgIn, RoundMode::CAST_NONE, gSize);
+                 }
+                 PipeBarrier<PIPE_V>();
+                 Add(tensorDgOut, tensorDgAdd, tensorDgOut, real_BT);
+                 PipeBarrier<PIPE_V>();
+                 if constexpr (!std::is_same<GType, float>::value) {
+                     Cast(tensorDgOut.template ReinterpretCast<GType>(), tensorDgOut, RoundMode::CAST_RINT, gSize);
+                 }
+
+                 inQue2.FreeTensor(tensorQInFp16);
+                 inQue3.FreeTensor(tensorGIn);
+                 inQue4.FreeTensor(tensorDgIn);
+                 outQue2.EnQue(tensorDgOut);
+
+                 // dg 写回
+                 {
+                     auto tensorDgOutDeq = outQue2.DeQue<GType>();
+                     DataCopyParams dataCopyParams;
+                     dataCopyParams.blockCount = 1;
+                     dataCopyParams.blockLen = real_BT * sizeof(GType);
+                     dataCopyParams.srcStride = 0;
+                     dataCopyParams.dstStride = 0;
+                     DataCopyPad(gmDg[gOffset], tensorDgOutDeq, dataCopyParams);
+                     outQue2.FreeTensor(tensorDgOutDeq);
+                 }
+
+                 // dq += mm6 (从 wsMm6 环形区读取, dq_state 仍在 UB)
+                 {
+                     auto tensorMm6In = inQue2.AllocTensor<DataType>();
+                     uint64_t mm6RingOffset = DqkwgShortBtxKRingElemOffset(coreIdx, loopIdx, coreNum, h, HV, BT, K,
+                                                                           DqkwgShortRingDepthFromGroup((uint32_t)wsBtxKSyncSlotsPerHead));
+                     DataCopy(tensorMm6In[dqSize_sub], gmMm6[mm6RingOffset], dqSize_sub);  // mm6 compact ring
+                     inQue2.EnQue(tensorMm6In);
+                 }
+                 {
+                     auto tensorMm6InFp16 = inQue2.DeQue<DataType>();
+                     auto tensorMm6Fp32 = tensorMm6InFp16.template ReinterpretCast<float>();
+                     auto tensorDqOut = outQue1.AllocTensor<DataType>();
+                     Cast(tensorMm6Fp32, tensorMm6InFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
+                     PipeBarrier<PIPE_V>();
+                     Add(tensorDqInFp32, tensorDqInFp32, tensorMm6Fp32, dqSize_sub);
+                     PipeBarrier<PIPE_V>();
+                     Cast(tensorDqOut, tensorDqInFp32, RoundMode::CAST_RINT, dqSize_sub);
+                     inQue1.FreeTensor(tensorDqInFp16);
+                     inQue2.FreeTensor(tensorMm6InFp16);
+                     outQue1.EnQue(tensorDqOut);
+                 }
+                 {
+                     auto tensorDqOut = outQue1.DeQue<DataType>();
+                     DataCopy(gmDq[dqOffset], tensorDqOut, dqSize_sub);
+                     outQue1.FreeTensor(tensorDqOut);
+                 }
+             }
+             PipeBarrier<PIPE_MTE3>();
+         }
+         PipeBarrier<PIPE_MTE3>();
+         SetVecCredit();
+     }
+ }
+
+ // ============== D_vector: 原 Part5 + Part7 (dk 最终 + dg 最终) ==============
+ // D_cube 在一次 SetCubeReady 前已产出 dk_inner(ptrDk) 与 mm7(wsMm7); D_vector 一次 WaitCubeReady 后
+ // 读取二者, 完成 dk_state / dg 最终 / dk += mm7。dg_last 本地重算 (与原 Part5 一致)。
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::ProcessDVector(uint32_t loopBase, uint32_t loopEnd) {
+     uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+     uint32_t coreNum = aicCoreNum;
+     uint32_t coreLoops = B * numChunks;
+     uint32_t subBlockIdx = GetSubBlockIdx();
+     uint32_t subBlockNum = GetSubBlockNum();
+
+     uint32_t dkSize = BT * K;
+     const uint32_t gSize = BT;
+
+     constexpr int32_t part5BufferNum = 1;
+     pipe->InitBuffer(inQue1, part5BufferNum, dkSize * sizeof(float));
+     pipe->InitBuffer(inQue2, part5BufferNum, dkSize * sizeof(float));
+     pipe->InitBuffer(inQue3, BUFFER_NUM, gSize * sizeof(GType));
+     pipe->InitBuffer(inQue4, BUFFER_NUM, gSize * sizeof(GType));
+     pipe->InitBuffer(outQue1, part5BufferNum, dkSize * sizeof(DataType));
+     pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(GType));
+
+     pipe->InitBuffer(calcBuf1, gSize * 8 * sizeof(float));  // gLast
+     pipe->InitBuffer(calcBuf2, gSize * 8 * sizeof(float));  // dgLast
+     pipe->InitBuffer(calcBuf4, gSize * sizeof(float));
+     pipe->InitBuffer(gBuf, gSize * sizeof(float));
+     pipe->InitBuffer(dgBuf, gSize * 8 * sizeof(float));
+
+     auto tensorGFp32 = gBuf.Get<float>();
+     auto tensorDgFinal = dgBuf.Get<float>();
+     auto tensorGLastFp32Tmp = calcBuf1.Get<float>();
+     auto tensorDgLastFp32Tmp = calcBuf2.Get<float>();
+     auto tensorDgTmp = calcBuf4.Get<float>();
+
+     uint32_t bos = 0;
+     uint32_t eos = 0;
+     for (uint32_t loopIdx = loopBase; loopIdx < loopEnd; loopIdx += coreNum) {
+         GetChunkOffset(ptrCuSeqLen, ptrChunkIndices, B, HV, T, BT, loopIdx, bos, eos);
+         uint32_t actual_chunk_len = eos - bos;
+         uint32_t real_BT = actual_chunk_len;
+         uint32_t real_BT_aligned = (real_BT + 15) / 16 * 16;
+         dkSize = actual_chunk_len * K;
+         uint32_t bIdx = loopIdx / numChunks;
+         uint32_t chunkIdx = loopIdx % numChunks;
+         WaitCubeReady();
+
+         for (uint32_t h = 0; h < HV; h++) {
+             if (h % subBlockNum != subBlockIdx) {
+                 continue;
+             }
+             // GVA: k 为 HK 头, dk 为 HV 头
+             uint32_t hk_idx = h / n_ratio;
+             uint64_t bos_hk = bos - static_cast<uint64_t>(bIdx) * static_cast<uint64_t>(HV - HK) * T;
+             uint64_t kOffset = (hk_idx * T + bos_hk) * K;    // k (HK)
+             uint64_t dkOffset = (h * T + bos) * K;           // dk (HV)
+             uint64_t gOffset = (h * T + bos);
+
+             // CV 融合优化: 读 A_vector 算好的 dg_last = sum(h*dh) (替代本地重算, 省 D 的 h/dh 读 + K*V 归约)。
+             // 跨 stage 可见性由 Process() 中 A->B->C->D 的 PipeBarrier<PIPE_ALL> 保证; A(c,h)/D(c,h) 同 sub-block。
+             // 输出格式与原重算一致: tensorGLastFp32Tmp[16..23] = 8 份 dg_last。
+             {
+                 uint64_t dgLastOffset = DqkwgScalarRingElemOffset(coreIdx, loopBase, loopIdx, coreNum, h, HV,
+                                                                   (uint32_t)wsBtxKSyncSlotsPerHead);
+                 {
+                     DataCopyExtParams copyParams{1, sizeof(float), 0, 0, 0};
+                     DataCopyPadExtParams<float> padParams{true, 0, 7, 0};
+                     DataCopyPad(tensorDgLastFp32Tmp[8], gmDgLast[dgLastOffset], copyParams, padParams);
+                 }
+                 TEventID eDg = GetTPipePtr()->FetchEventID(HardEvent::MTE2_V);
+                 SetFlag<HardEvent::MTE2_V>(eDg);
+                 WaitFlag<HardEvent::MTE2_V>(eDg);
+                 Brcb(tensorGLastFp32Tmp[16], tensorDgLastFp32Tmp[8], 1, {1, 8});  // 广播到 [16..23] 8 份
+                 PipeBarrier<PIPE_V>();
+             }
+
+             // CopyIn: dk_inner, k, g, dg
+             {
+                 auto tensorDkIn = inQue1.AllocTensor<DataType>();
+                 auto tensorKIn = inQue2.AllocTensor<DataType>();
+                 auto tensorGIn = inQue3.AllocTensor<GType>();
+                 auto tensorDgIn = inQue4.AllocTensor<GType>();
+                 DataCopy(tensorDkIn[dkSize], gmDk[dkOffset], dkSize);
+                 DataCopy(tensorKIn[dkSize], gmK[kOffset], dkSize);
+                 CopyGateWithPad(tensorGIn, gmG, gOffset, actual_chunk_len, gSize);
+                 CopyGateWithPad(tensorDgIn, gmDg, gOffset, actual_chunk_len, gSize);
+                 inQue1.EnQue(tensorDkIn);
+                 inQue2.EnQue(tensorKIn);
+                 inQue3.EnQue(tensorGIn);
+                 inQue4.EnQue(tensorDgIn);
+             }
+             {
+                 auto tensorDkIn = inQue1.DeQue<DataType>();
+                 auto tensorDkFp32 = tensorDkIn.template ReinterpretCast<float>();
+                 auto tensorKIn = inQue2.DeQue<DataType>();
+                 auto tensorKFp32 = tensorKIn.template ReinterpretCast<float>();
+                 auto tensorGIn = inQue3.DeQue<GType>();
+                 auto tensorDgIn = inQue4.DeQue<GType>();
+                 auto tensorDgOut = outQue2.AllocTensor<GType>();
+
+                 Cast(tensorDkFp32, tensorDkIn[dkSize], RoundMode::CAST_NONE, dkSize);
+                 Cast(tensorKFp32, tensorKIn[dkSize], RoundMode::CAST_NONE, dkSize);
+                 PipeBarrier<PIPE_V>();
+
+                 if constexpr (std::is_same<GType, float>::value) {
+                     DataCopy(tensorGFp32, tensorGIn, BT);
+                     DataCopy(tensorDgTmp, tensorDgIn, BT);
+                 } else {
+                     Cast(tensorGFp32, tensorGIn, RoundMode::CAST_NONE, real_BT_aligned);
+                     Cast(tensorDgTmp, tensorDgIn, RoundMode::CAST_NONE, real_BT_aligned);
+                 }
+                 PipeBarrier<PIPE_V>();
+
+                 // MUL2: dk_state = dk_inner * exp(-g + g_last)[:,None]
+                 uint32_t last_line_no = (actual_chunk_len - 1) / 8 * 8;
+                 uint32_t last_line_idx = actual_chunk_len - 1 - last_line_no;
+                 Brcb(tensorDgFinal, tensorGFp32[last_line_no], 1, {1, 8}); // [8,8] 第 last_line_idx 行 = gLast
+                 PipeBarrier<PIPE_V>();
+                 Muls(tensorGFp32, tensorGFp32, -1.0f, real_BT_aligned);
+                 DataCopy(tensorGLastFp32Tmp, tensorDgFinal[last_line_idx * 8], 8);
+                 PipeBarrier<PIPE_V>();
+                 AscendC::Add(tensorGFp32, tensorGFp32, tensorDgFinal[last_line_idx * 8], CAL_NUM_FLOAT, BT / CAL_NUM_FLOAT, {1, 1, 0, 8, 8, 0});
+                 PipeBarrier<PIPE_V>();
+                 Exp(tensorGFp32, tensorGFp32, real_BT_aligned);
+                 PipeBarrier<PIPE_V>();
+
+                 Brcb(tensorDgFinal, tensorGFp32, CEIL_DIV(real_BT, 8), {1, 8});
+                 PipeBarrier<PIPE_V>();
+                 AscendC::Mul(tensorDkFp32, tensorDkFp32, tensorDgFinal, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+                 AscendC::Mul(tensorDkFp32[CAL_NUM_FLOAT], tensorDkFp32[CAL_NUM_FLOAT], tensorDgFinal, CAL_NUM_FLOAT, real_BT, {1, 1, 0, 16, 16, 1});
+                 PipeBarrier<PIPE_V>();
+
+                 Mul(tensorKFp32, tensorKFp32, tensorDkFp32, dkSize);    // mul8 = dk_state * k
+                 PipeBarrier<PIPE_V>();
+
+                 // Add0.B = row_sum(dk_state * k)
+                 uint64_t wholeReduceSumCnt = CeilDiv(K, FP32_PER_REPEAT);
+                 for (uint32_t i = 0; i < actual_chunk_len; i++) {
+                     WholeReduceSum(tensorDgFinal[i * 8], tensorKFp32[i * K],
+                                    FP32_PER_REPEAT, wholeReduceSumCnt, 1, 1, 8);
+                 }
+                 PipeBarrier<PIPE_V>();
+                 WholeReduceSum(tensorGFp32, tensorDgFinal, wholeReduceSumCnt, actual_chunk_len, 1, 1, 1);
+                 PipeBarrier<PIPE_V>();
+
+                 // Sum0: [actual_chunk_len] -> [1]
+                 uint64_t sum0SumCnt = CeilDiv(actual_chunk_len, FP32_PER_REPEAT);
+                 uint32_t remainCnt = actual_chunk_len % FP32_PER_REPEAT;
+                 if (remainCnt > 0) {
+                     uint64_t mask[1] = {0xffffffffffffffff};
+                     mask[0] <<= remainCnt;
+                     Duplicate(tensorGFp32[(sum0SumCnt - 1) * FP32_PER_REPEAT], 0.0f, mask, 1, 1, 8);
+                     PipeBarrier<PIPE_V>();
+                 }
+                 WholeReduceSum(tensorDgLastFp32Tmp, tensorGFp32, FP32_PER_REPEAT, sum0SumCnt, 1, 1, 8);
+                 PipeBarrier<PIPE_V>();
+                 WholeReduceSum(tensorDgFinal, tensorDgLastFp32Tmp, sum0SumCnt, 1, 1, 1, 8);
+                 PipeBarrier<PIPE_V>();
+                 Brcb(tensorDgLastFp32Tmp, tensorDgFinal, 1, {1, 8});
+                 PipeBarrier<PIPE_V>();
+                 DataCopy(tensorDgFinal, tensorDgLastFp32Tmp, 8);
+                 PipeBarrier<PIPE_V>();
+                 Exp(tensorGLastFp32Tmp, tensorGLastFp32Tmp, 8);
+                 PipeBarrier<PIPE_V>();
+                 Mul(tensorDgLastFp32Tmp[16], tensorGLastFp32Tmp[16], tensorGLastFp32Tmp, 8);
+                 PipeBarrier<PIPE_V>();
+                 Add(tensorDgLastFp32Tmp[16], tensorDgLastFp32Tmp[16], tensorDgFinal, 8);  // add4 = dg_last_term
+
+                 Sub(tensorGFp32, tensorDgTmp, tensorGFp32, BT); // Add.0 最终结果 (dg_B+dg_C+dg_D)
+                 PipeBarrier<PIPE_V>();
+                 Brcb(tensorDgFinal, tensorDgLastFp32Tmp[16], 1, {1, 8});
+                 PipeBarrier<PIPE_V>();
+                 uint64_t offset = (real_BT - 1) / 8 * 8;
+                 uint64_t mask[1] = {0};
+                 mask[0] = 1ULL << (real_BT - 1 - offset);  // 仅最后一个位置加 dg_last_term
+                 Add(tensorGFp32[offset], tensorGFp32[offset], tensorDgFinal, mask, 1, {1, 1, 1, 8, 8, 8});
+                 PipeBarrier<PIPE_V>();
+                 if constexpr (std::is_same<GType, float>::value) {
+                     DataCopy(tensorDgOut, tensorGFp32, BT);
+                 } else {
+                     Cast(tensorDgOut, tensorGFp32, RoundMode::CAST_RINT, BT);
+                 }
+                 PipeBarrier<PIPE_V>();
+
+                 inQue2.FreeTensor(tensorKIn);
+                 inQue3.FreeTensor(tensorGIn);
+                 inQue4.FreeTensor(tensorDgIn);
+                 outQue2.EnQue(tensorDgOut);
+                 {
+                     auto tensorDgOutDeq = outQue2.DeQue<GType>();
+                     DataCopyParams dataCopyParams;
+                     dataCopyParams.blockCount = 1;
+                     dataCopyParams.blockLen = real_BT * sizeof(GType);
+                     dataCopyParams.srcStride = 0;
+                     dataCopyParams.dstStride = 0;
+                     DataCopyPad(gmDg[gOffset], tensorDgOutDeq, dataCopyParams);
+                     outQue2.FreeTensor(tensorDgOutDeq);
+                 }
+
+                 // dk += mm7 (从 wsMm7 读取, dk_state 仍在 UB)
+                 {
+                     auto tensorMm7In = inQue2.AllocTensor<DataType>();
+                     uint64_t mm7RingOffset = DqkwgBtxKRingElemOffset(coreIdx, loopBase, loopIdx, coreNum, h, HV, BT, K,
+                                                                      (uint32_t)wsBtxKSyncSlotsPerHead);  // mm7 用 group 环 (与 cube 一致)
+                     DataCopy(tensorMm7In[dkSize], gmMm7[mm7RingOffset], dkSize);
+                     inQue2.EnQue(tensorMm7In);
+                 }
+                 {
+                     auto tensorMm7In = inQue2.DeQue<DataType>();
+                     auto tensorMm7Fp32 = tensorMm7In.template ReinterpretCast<float>();
+                     auto tensorDkOut = outQue1.AllocTensor<DataType>();
+                     Cast(tensorMm7Fp32, tensorMm7In[dkSize], RoundMode::CAST_NONE, dkSize);
+                     PipeBarrier<PIPE_V>();
+                     Add(tensorDkFp32, tensorDkFp32, tensorMm7Fp32, dkSize);
+                     PipeBarrier<PIPE_V>();
+                     Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);
+                     inQue1.FreeTensor(tensorDkIn);
+                     inQue2.FreeTensor(tensorMm7In);
+                     outQue1.EnQue(tensorDkOut);
+                 }
+                 {
+                     auto tensorDkOut = outQue1.DeQue<DataType>();
+                     DataCopy(gmDk[dkOffset], tensorDkOut, dkSize);
+                     outQue1.FreeTensor(tensorDkOut);
+                 }
+             }
+             PipeBarrier<PIPE_MTE3>();
+         }
+         PipeBarrier<PIPE_MTE3>();
+         SetVecCredit();
+     }
+ }
+
+
+ #endif  // CHUNK_BWD_DQKWG_VECTOR_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
@@ -55,6 +55,7 @@
      __aicore__ inline void ProcessCVector(uint32_t loopBase, uint32_t loopEnd);  // 原 Part4 + Part6 (dq 最终)
      __aicore__ inline void ProcessDVector(uint32_t loopBase, uint32_t loopEnd);  // 原 Part5 + Part7 (dk 最终 + dg 最终)
      __aicore__ inline void ResetStagePipe();
+     __aicore__ inline void FenceGvaAccumReadAfterWrite();
 
      // mul1 一个 row-half 的计算 (= A 的 Part2 per-head 内核, 输出 fp32 到 outFp32[half] )。
      // A (小 case) 调它后 cast+写 GM; B (大 case) 调它两次 (两个 row-half) 后直接乘 ds, 省掉 mul1 GM 往返。
@@ -282,6 +283,13 @@
          AscendC::PipeBarrier<PIPE_MTE3>();
      }
      pipe->Reset();
+ }
+
+ template <typename DataType, typename GType>
+ __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::FenceGvaAccumReadAfterWrite() {
+     TEventID eventId = GetTPipePtr()->FetchEventID(HardEvent::MTE3_MTE2);
+     SetFlag<HardEvent::MTE3_MTE2>(eventId);
+     WaitFlag<HardEvent::MTE3_MTE2>(eventId);
  }
 
  template <typename DataType, typename GType>
@@ -934,6 +942,7 @@
 
      uint32_t dqSize = BT * K;
      const uint32_t gSize = BT;
+     const bool gvaMode = HV != HK;
 
      pipe->InitBuffer(inQue1, BUFFER_NUM, dqSize * sizeof(float));    // dq_inner from Cube
      pipe->InitBuffer(inQue2, BUFFER_NUM, dqSize * sizeof(float));    // q / mm6 复用
@@ -960,15 +969,17 @@
          WaitCubeReady();
 
          for (uint32_t h = 0; h < HV; h++) {
-             if (h % subBlockNum != subBlockIdx) {
+             uint32_t hk_idx = h / n_ratio;
+             uint32_t ownerHead = gvaMode ? hk_idx : h;
+             if (ownerHead % subBlockNum != subBlockIdx) {
                  continue;
              }
-             // GVA: q 为 HK 头, dq 为 HV 头
-             uint32_t hk_idx = h / n_ratio;
              uint32_t bIdx = loopIdx / numChunks;
              uint64_t bos_hk = bos - static_cast<uint64_t>(bIdx) * static_cast<uint64_t>(HV - HK) * T;
              uint64_t qkOffset = (hk_idx * T + bos_hk) * K;   // q (HK)
-             uint64_t dqOffset = (h * T + bos) * K;           // dq (HV)
+             uint64_t dqOutOffset = (hk_idx * T + bos_hk) * K; // dq (HK)
+             uint64_t dqTempOffset = DqkwgBtxKRingElemOffset(coreIdx, loopBase, loopIdx, coreNum, h, HV, BT, K,
+                                                             (uint32_t)wsBtxKSyncSlotsPerHead);
              uint64_t gOffset = (h * T + bos);
 
              // CopyIn: dq_inner, q, g, dg
@@ -977,7 +988,11 @@
                  auto tensorQIn = inQue2.AllocTensor<DataType>();
                  auto tensorGIn = inQue3.AllocTensor<GType>();
                  auto tensorDgIn = inQue4.AllocTensor<GType>();
-                 DataCopy(tensorDqIn[dqSize_sub], gmDq[dqOffset], dqSize_sub);
+                 if (gvaMode) {
+                     DataCopy(tensorDqIn[dqSize_sub], gmMm5[dqTempOffset], dqSize_sub);
+                 } else {
+                     DataCopy(tensorDqIn[dqSize_sub], gmDq[dqOutOffset], dqSize_sub);
+                 }
                  DataCopy(tensorQIn[dqSize_sub], gmQ[qkOffset], dqSize_sub);
                  CopyGateWithPad(tensorGIn, gmG, gOffset, actual_chunk_len, gSize);
                  CopyGateWithPad(tensorDgIn, gmDg, gOffset, actual_chunk_len, gSize);
@@ -1070,19 +1085,32 @@
                  {
                      auto tensorMm6InFp16 = inQue2.DeQue<DataType>();
                      auto tensorMm6Fp32 = tensorMm6InFp16.template ReinterpretCast<float>();
-                     auto tensorDqOut = outQue1.AllocTensor<DataType>();
                      Cast(tensorMm6Fp32, tensorMm6InFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
                      PipeBarrier<PIPE_V>();
                      Add(tensorDqInFp32, tensorDqInFp32, tensorMm6Fp32, dqSize_sub);
                      PipeBarrier<PIPE_V>();
+                     inQue2.FreeTensor(tensorMm6InFp16);
+                     if (gvaMode && (h % n_ratio != 0)) {
+                         FenceGvaAccumReadAfterWrite();
+                         auto tensorDqAccumIn = inQue2.AllocTensor<DataType>();
+                         DataCopy(tensorDqAccumIn[dqSize_sub], gmDq[dqOutOffset], dqSize_sub);
+                         inQue2.EnQue(tensorDqAccumIn);
+                         auto tensorDqAccumInFp16 = inQue2.DeQue<DataType>();
+                         auto tensorDqAccumFp32 = tensorDqAccumInFp16.template ReinterpretCast<float>();
+                         Cast(tensorDqAccumFp32, tensorDqAccumInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
+                         PipeBarrier<PIPE_V>();
+                         Add(tensorDqInFp32, tensorDqInFp32, tensorDqAccumFp32, dqSize_sub);
+                         PipeBarrier<PIPE_V>();
+                         inQue2.FreeTensor(tensorDqAccumInFp16);
+                     }
+                     auto tensorDqOut = outQue1.AllocTensor<DataType>();
                      Cast(tensorDqOut, tensorDqInFp32, RoundMode::CAST_RINT, dqSize_sub);
                      inQue1.FreeTensor(tensorDqInFp16);
-                     inQue2.FreeTensor(tensorMm6InFp16);
                      outQue1.EnQue(tensorDqOut);
                  }
                  {
                      auto tensorDqOut = outQue1.DeQue<DataType>();
-                     DataCopy(gmDq[dqOffset], tensorDqOut, dqSize_sub);
+                     DataCopy(gmDq[dqOutOffset], tensorDqOut, dqSize_sub);
                      outQue1.FreeTensor(tensorDqOut);
                  }
              }
@@ -1106,6 +1134,7 @@
 
      uint32_t dkSize = BT * K;
      const uint32_t gSize = BT;
+     const bool gvaMode = HV != HK;
 
      constexpr int32_t part5BufferNum = 1;
      pipe->InitBuffer(inQue1, part5BufferNum, dkSize * sizeof(float));
@@ -1140,14 +1169,17 @@
          WaitCubeReady();
 
          for (uint32_t h = 0; h < HV; h++) {
-             if (h % subBlockNum != subBlockIdx) {
+             uint32_t hk_idx = h / n_ratio;
+             uint32_t ownerHead = gvaMode ? hk_idx : h;
+             if (ownerHead % subBlockNum != subBlockIdx) {
                  continue;
              }
-             // GVA: k 为 HK 头, dk 为 HV 头
-             uint32_t hk_idx = h / n_ratio;
              uint64_t bos_hk = bos - static_cast<uint64_t>(bIdx) * static_cast<uint64_t>(HV - HK) * T;
              uint64_t kOffset = (hk_idx * T + bos_hk) * K;    // k (HK)
-             uint64_t dkOffset = (h * T + bos) * K;           // dk (HV)
+             uint64_t dkOutOffset = (hk_idx * T + bos_hk) * K; // dk (HK)
+             uint64_t dkTempOffset = DqkwgShortBtxKRingElemOffset(
+                 coreIdx, loopIdx, coreNum, h, HV, BT, K,
+                 DqkwgShortRingDepthFromGroup((uint32_t)wsBtxKSyncSlotsPerHead));
              uint64_t gOffset = (h * T + bos);
 
              // CV 融合优化: 读 A_vector 算好的 dg_last = sum(h*dh) (替代本地重算, 省 D 的 h/dh 读 + K*V 归约)。
@@ -1174,7 +1206,11 @@
                  auto tensorKIn = inQue2.AllocTensor<DataType>();
                  auto tensorGIn = inQue3.AllocTensor<GType>();
                  auto tensorDgIn = inQue4.AllocTensor<GType>();
-                 DataCopy(tensorDkIn[dkSize], gmDk[dkOffset], dkSize);
+                 if (gvaMode) {
+                     DataCopy(tensorDkIn[dkSize], gmMm6[dkTempOffset], dkSize);
+                 } else {
+                     DataCopy(tensorDkIn[dkSize], gmDk[dkOutOffset], dkSize);
+                 }
                  DataCopy(tensorKIn[dkSize], gmK[kOffset], dkSize);
                  CopyGateWithPad(tensorGIn, gmG, gOffset, actual_chunk_len, gSize);
                  CopyGateWithPad(tensorDgIn, gmDg, gOffset, actual_chunk_len, gSize);
@@ -1302,19 +1338,32 @@
                  {
                      auto tensorMm7In = inQue2.DeQue<DataType>();
                      auto tensorMm7Fp32 = tensorMm7In.template ReinterpretCast<float>();
-                     auto tensorDkOut = outQue1.AllocTensor<DataType>();
                      Cast(tensorMm7Fp32, tensorMm7In[dkSize], RoundMode::CAST_NONE, dkSize);
                      PipeBarrier<PIPE_V>();
                      Add(tensorDkFp32, tensorDkFp32, tensorMm7Fp32, dkSize);
                      PipeBarrier<PIPE_V>();
+                     inQue2.FreeTensor(tensorMm7In);
+                     if (gvaMode && (h % n_ratio != 0)) {
+                         FenceGvaAccumReadAfterWrite();
+                         auto tensorDkAccumIn = inQue2.AllocTensor<DataType>();
+                         DataCopy(tensorDkAccumIn[dkSize], gmDk[dkOutOffset], dkSize);
+                         inQue2.EnQue(tensorDkAccumIn);
+                         auto tensorDkAccumInFp16 = inQue2.DeQue<DataType>();
+                         auto tensorDkAccumFp32 = tensorDkAccumInFp16.template ReinterpretCast<float>();
+                         Cast(tensorDkAccumFp32, tensorDkAccumInFp16[dkSize], RoundMode::CAST_NONE, dkSize);
+                         PipeBarrier<PIPE_V>();
+                         Add(tensorDkFp32, tensorDkFp32, tensorDkAccumFp32, dkSize);
+                         PipeBarrier<PIPE_V>();
+                         inQue2.FreeTensor(tensorDkAccumInFp16);
+                     }
+                     auto tensorDkOut = outQue1.AllocTensor<DataType>();
                      Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);
                      inQue1.FreeTensor(tensorDkIn);
-                     inQue2.FreeTensor(tensorMm7In);
                      outQue1.EnQue(tensorDkOut);
                  }
                  {
                      auto tensorDkOut = outQue1.DeQue<DataType>();
-                     DataCopy(gmDk[dkOffset], tensorDkOut, dkSize);
+                     DataCopy(gmDk[dkOutOffset], tensorDkOut, dkSize);
                      outQue1.FreeTensor(tensorDkOut);
                  }
              }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/ATK/chunk_bwd_dqkwg_cpu.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/ATK/chunk_bwd_dqkwg_cpu.py
@@ -106,6 +106,8 @@ def chunk_bwd_dqkwg_cpu(
     B, T, HK, K = q.shape
     HV = v.shape[2]
     V = v.shape[-1]
+    if HK <= 0 or HV <= 0 or HV % HK != 0:
+        raise ValueError(f"GVA requires HV divisible by HK, got HV={HV}, HK={HK}")
     n_ratio = HV // HK  # HV = n_ratio * HK
     datatype = q.dtype
     gtype = g.dtype
@@ -114,9 +116,9 @@ def chunk_bwd_dqkwg_cpu(
         gtype = torch.float64
     g_gamma = None
     
-    # 输出使用 HV 维度
-    dq = torch.zeros((B, T, HV, K), dtype=datatype)
-    dk = torch.zeros((B, T, HV, K), dtype=datatype)
+    # Keep per-value-head contributions first, then reduce them into key heads.
+    dq_hv = torch.zeros((B, T, HV, K), dtype=datatype)
+    dk_hv = torch.zeros((B, T, HV, K), dtype=datatype)
     dg = torch.zeros_like(g) if g is not None else None
     dw = torch.zeros((B, T, HV, K), dtype=datatype)
     w = torch.zeros((B, T, HV, K), dtype=datatype)
@@ -355,8 +357,8 @@ def chunk_bwd_dqkwg_cpu(
                     # print(h_idx,i_t,"dk_total",dk_total)
 
 
-                dq[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dq_total
-                dk[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dk_total
+                dq_hv[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dq_total.to(datatype)
+                dk_hv[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dk_total.to(datatype)
 
                 # if RANDOM_DATA == False:
                 #     pass
@@ -407,5 +409,8 @@ def chunk_bwd_dqkwg_cpu(
                 # 但如果发生，通常 cu_seqlens[i] 是第 i 个样本的长度。
                 # 简化起见，我们假设 input 是 packed flat tensor 如果 cu_seqlens 存在。
                 pass 
+
+    dq = dq_hv.view(B, T, HK, n_ratio, K).sum(dim=3).to(datatype)
+    dk = dk_hv.view(B, T, HK, n_ratio, K).sum(dim=3).to(datatype)
 
     return dq, dk, dw, dg

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/chunk_bwd_dqkwg_cpu.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/tests/chunk_bwd_dqkwg_cpu.py
@@ -112,13 +112,15 @@ def chunk_bwd_dqkwg_cpu(
     B, T, HK, K = q.shape
     HV = v.shape[2]
     V = v.shape[-1]
+    if HK <= 0 or HV <= 0 or HV % HK != 0:
+        raise ValueError(f"GVA requires HV divisible by HK, got HV={HV}, HK={HK}")
     n_ratio = HV // HK  # HV = n_ratio * HK
 
     g_gamma = None
     
-    # 输出使用 HV 维度
-    dq = torch.zeros((B, T, HV, K), dtype=datatype)
-    dk = torch.zeros((B, T, HV, K), dtype=datatype)
+    # Keep per-value-head contributions first, then reduce them into key heads.
+    dq_hv = torch.zeros((B, T, HV, K), dtype=datatype)
+    dk_hv = torch.zeros((B, T, HV, K), dtype=datatype)
     dg = torch.zeros_like(g) if g is not None else None
     dw = torch.zeros((B, T, HV, K), dtype=datatype)
     w = torch.zeros((B, T, HV, K), dtype=datatype)
@@ -358,8 +360,8 @@ def chunk_bwd_dqkwg_cpu(
                     # print(h_idx,i_t,"dk_total",dk_total)
 
 
-                dq[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dq_total
-                dk[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dk_total
+                dq_hv[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dq_total.to(datatype)
+                dk_hv[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dk_total.to(datatype)
 
                 # if RANDOM_DATA == False:
                 #     pass
@@ -410,5 +412,8 @@ def chunk_bwd_dqkwg_cpu(
                 # 但如果发生，通常 cu_seqlens[i] 是第 i 个样本的长度。
                 # 简化起见，我们假设 input 是 packed flat tensor 如果 cu_seqlens 存在。
                 pass 
+
+    dq = dq_hv.view(B, T, HK, n_ratio, K).sum(dim=3).to(datatype)
+    dk = dk_hv.view(B, T, HK, n_ratio, K).sum(dim=3).to(datatype)
 
     return dq, dk, dw, dg

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -173,17 +173,10 @@ at::Tensor npu_prepare_wy_repr_bwd_da(const at::Tensor & k, const at::Tensor & v
 ::std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor> npu_chunk_bwd_dqkwg(const at::Tensor & q, const at::Tensor & k, const at::Tensor & v, const at::Tensor & g, const at::Tensor & h, const at::Tensor & dox, const at::Tensor & dh, const at::Tensor & dv, int64_t chunk_size, at::OptionalIntArrayRef cu_seqlens, at::OptionalIntArrayRef chunk_indices, const c10::optional<at::Tensor> & w, const c10::optional<at::Tensor> & g_gamma, c10::optional<double> scale, c10::optional<bool> use_exp2, c10::optional<bool> transpose_state_layout)
 {
     // 获取输入 q 的维度信息
-    auto q_sizes = q.sizes();
-    auto v_sizes = v.sizes();
-    int64_t batch_size = q_sizes[0];
-    int64_t num_heads = v_sizes[1];
-    int64_t seq_len = q_sizes[2];
-    int64_t head_dim = q_sizes[3];
-    
-    // 使用具体 shape 创建，但保持相同的 dtype/device
-    at::Tensor dq = at::empty({batch_size, num_heads, seq_len, head_dim}, q.options());
-    at::Tensor dk = at::empty({batch_size, num_heads, seq_len, head_dim}, q.options());
-    at::Tensor dw = at::empty({batch_size, num_heads, seq_len, head_dim}, q.options());
+    const int64_t value_num_heads = v.size(1);
+    at::Tensor dq = at::empty({q.size(0), value_num_heads, q.size(2), q.size(3)}, q.options());
+    at::Tensor dk = at::empty({q.size(0), value_num_heads, q.size(2), q.size(3)}, q.options());
+    at::Tensor dw = at::empty({q.size(0), value_num_heads, q.size(2), q.size(3)}, q.options());
     at::Tensor dg = at::empty_like(g);
 
     // scale处理

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -172,10 +172,17 @@ at::Tensor npu_prepare_wy_repr_bwd_da(const at::Tensor & k, const at::Tensor & v
 
 ::std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor> npu_chunk_bwd_dqkwg(const at::Tensor & q, const at::Tensor & k, const at::Tensor & v, const at::Tensor & g, const at::Tensor & h, const at::Tensor & dox, const at::Tensor & dh, const at::Tensor & dv, int64_t chunk_size, at::OptionalIntArrayRef cu_seqlens, at::OptionalIntArrayRef chunk_indices, const c10::optional<at::Tensor> & w, const c10::optional<at::Tensor> & g_gamma, c10::optional<double> scale, c10::optional<bool> use_exp2, c10::optional<bool> transpose_state_layout)
 {
-    // 获取输入 q 的维度信息
+    const int64_t key_num_heads = q.size(1);
     const int64_t value_num_heads = v.size(1);
-    at::Tensor dq = at::empty({q.size(0), value_num_heads, q.size(2), q.size(3)}, q.options());
-    at::Tensor dk = at::empty({q.size(0), value_num_heads, q.size(2), q.size(3)}, q.options());
+    TORCH_CHECK(
+        key_num_heads > 0 && value_num_heads > 0 && value_num_heads % key_num_heads == 0,
+        "npu_chunk_bwd_dqkwg: GVA requires value heads divisible by key heads; Hk=",
+        key_num_heads,
+        " Hv=",
+        value_num_heads);
+
+    at::Tensor dq = at::empty_like(q);
+    at::Tensor dk = at::empty_like(k);
     at::Tensor dw = at::empty({q.size(0), value_num_heads, q.size(2), q.size(3)}, q.options());
     at::Tensor dg = at::empty_like(g);
 


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @alvazu
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
