### PR TITLE
ci: sync v26.6.0 workflows with main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: read
       statuses: write
     env:
       CI_MODE: ${{ needs.prepare.outputs.ci_mode }}
@@ -401,7 +402,82 @@ jobs:
 
       - name: 运行 NPU CI 容器
         working-directory: repo
-        run: bash ci/run_ci_container.sh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          NPU_CI_PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+          NPU_CI_TARGET_SHA: ${{ needs.prepare.outputs.head_sha }}
+          NPU_CI_HEAD_POLL_SECONDS: '60'
+          CI_CONTAINER_NAME: fla-npu-ci-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+
+          get_pr_head_sha() {
+            python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          repo = os.environ["GITHUB_REPOSITORY"]
+          pr_number = os.environ["NPU_CI_PR_NUMBER"]
+          token = os.environ["GITHUB_TOKEN"]
+          url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}"
+          request = urllib.request.Request(
+              url,
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {token}",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=30) as response:
+              data = json.load(response)
+          print(data["head"]["sha"])
+          PY
+          }
+
+          mark_stale() {
+            local current_sha="$1"
+            echo "[CI][ERROR] PR head changed while NPU CI was running; target=${NPU_CI_TARGET_SHA}, current=${current_sha}."
+            {
+              echo "NPU_CI_STALE=true"
+              echo "NPU_CI_STALE_HEAD=${current_sha}"
+            } >>"$GITHUB_ENV"
+            docker rm -f "$CI_CONTAINER_NAME" >/dev/null 2>&1 || true
+          }
+
+          if current_sha="$(get_pr_head_sha)"; then
+            if [[ "$current_sha" != "$NPU_CI_TARGET_SHA" ]]; then
+              mark_stale "$current_sha"
+              exit 1
+            fi
+          else
+            echo "[CI][WARN] Unable to check PR head before starting NPU CI; continuing."
+          fi
+
+          bash ci/run_ci_container.sh &
+          ci_pid=$!
+          stale=0
+          while kill -0 "$ci_pid" >/dev/null 2>&1; do
+            sleep "$NPU_CI_HEAD_POLL_SECONDS"
+            if ! kill -0 "$ci_pid" >/dev/null 2>&1; then
+              break
+            fi
+            if ! current_sha="$(get_pr_head_sha)"; then
+              echo "[CI][WARN] Unable to check PR head while NPU CI is running; continuing."
+              continue
+            fi
+            if [[ "$current_sha" != "$NPU_CI_TARGET_SHA" ]]; then
+              stale=1
+              mark_stale "$current_sha"
+              wait "$ci_pid" || true
+              break
+            fi
+          done
+
+          if [[ "$stale" == "1" ]]; then
+            exit 1
+          fi
+          wait "$ci_pid"
 
       - name: 发布 NPU CI 状态
         if: always()
@@ -409,20 +485,131 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            const state = '${{ job.status }}' === 'success' ? 'success' : 'failure';
+            const fs = require('fs');
+            const jobState = '${{ job.status }}' === 'success' ? 'success' : 'failure';
             const mode = ${{ toJson(needs.prepare.outputs.ci_mode) }};
             const ops = ${{ toJson(needs.prepare.outputs.ops) }};
             const sha = ${{ toJson(needs.prepare.outputs.head_sha) }};
             const prNumber = ${{ toJson(needs.prepare.outputs.pr_number) }};
             const commentId = ${{ toJson(needs.prepare.outputs.comment_id) }};
             const targetUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            let currentHeadSha = process.env.NPU_CI_STALE_HEAD || sha;
+            let staleRun = process.env.NPU_CI_STALE === 'true';
+            try {
+              const { data: currentPr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: Number(prNumber),
+              });
+              currentHeadSha = currentPr.head.sha;
+              staleRun = staleRun || currentHeadSha !== sha;
+            } catch (error) {
+              core.warning(`Unable to inspect current PR head before publishing NPU CI status: ${error.message}`);
+            }
+            const state = staleRun ? 'failure' : jobState;
+            const staleDescription = `PR head 已变化，本次结果失效`;
+            const accuracyReportPath = 'repo/output/gdr_accuracy_report.json';
+            const formatValue = (value) => {
+              if (typeof value === 'number') {
+                return Number.isFinite(value) ? value.toExponential(3) : String(value);
+              }
+              if (typeof value === 'boolean') {
+                return value ? 'true' : 'false';
+              }
+              return value === undefined || value === null || value === '' ? '-' : String(value);
+            };
+            const truncateDescription = (value) => value.length > 140 ? `${value.slice(0, 137)}...` : value;
+            const readAccuracyReport = () => {
+              try {
+                if (!fs.existsSync(accuracyReportPath)) {
+                  return null;
+                }
+                return JSON.parse(fs.readFileSync(accuracyReportPath, 'utf8'));
+              } catch (error) {
+                core.warning(`Unable to read GDR accuracy report: ${error.message}`);
+                return null;
+              }
+            };
+            const accuracyReport = readAccuracyReport();
+            const accuracyStatus = (() => {
+              if (staleRun) {
+                return { state: 'failure', description: staleDescription };
+              }
+              if (!accuracyReport || !accuracyReport.summary) {
+                return { state: 'failure', description: '精度报告未生成' };
+              }
+              const summary = accuracyReport.summary;
+              const total = Number(summary.accuracy_total || 0);
+              const passed = Number(summary.accuracy_passed || 0);
+              const failed = Number(summary.accuracy_failed || 0);
+              const notRun = Number(summary.accuracy_not_run || 0);
+              if (total === 0) {
+                return { state: 'failure', description: '未发现精度检查用例' };
+              }
+              if (failed > 0 || notRun > 0) {
+                return {
+                  state: 'failure',
+                  description: truncateDescription(`精度检查失败：通过 ${passed}/${total}，失败 ${failed}，未执行 ${notRun}`),
+                };
+              }
+              return {
+                state: 'success',
+                description: truncateDescription(`精度检查通过：${passed}/${total} 个用例`),
+              };
+            })();
+            const formatAccuracyComment = (report) => {
+              const lines = ['', '### 精度检查详情', ''];
+              if (!report || !report.summary) {
+                lines.push('未生成精度报告。');
+                return lines;
+              }
+              const summary = report.summary;
+              lines.push(
+                `精度用例：通过 ${summary.accuracy_passed || 0}/${summary.accuracy_total || 0}，` +
+                  `失败 ${summary.accuracy_failed || 0}，未执行 ${summary.accuracy_not_run || 0}。`
+              );
+              lines.push('');
+              lines.push('| 用例 | Tensor | 结果 | tol | cosine | cos_min | max_abs | mean_abs | rmse | bad_frac | golden |');
+              lines.push('| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |');
+              for (const item of report.cases || []) {
+                const caseName = item.name || '-';
+                const caseStatus = item.accuracy_status || item.status || '-';
+                const golden = item.golden || '-';
+                const metrics = item.metrics || [];
+                if (metrics.length === 0) {
+                  lines.push(`| ${caseName} | - | ${caseStatus} | - | - | - | - | - | - | - | ${golden} |`);
+                  continue;
+                }
+                for (const metric of metrics) {
+                  const metricOk = metric.finite === true && metric.allclose === true && metric.cosine_ok === true;
+                  lines.push(
+                    `| ${caseName} | ${metric.tensor || '-'} | ${metricOk ? '通过' : '失败'} | ` +
+                      `${formatValue(metric.tol)} | ${formatValue(metric.cosine)} | ${formatValue(metric.cos_min)} | ` +
+                      `${formatValue(metric.max_abs)} | ${formatValue(metric.mean_abs)} | ${formatValue(metric.rmse)} | ` +
+                      `${formatValue(metric.bad_frac)} | ${golden} |`
+                  );
+                }
+              }
+              return lines;
+            };
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha,
               state,
               context: 'NPU CI / 手动验证',
-              description: state === 'success' ? `NPU CI 通过 (${mode}+example)` : `NPU CI 失败 (${mode}+example)`,
+              description: staleRun
+                ? staleDescription
+                : (state === 'success' ? `NPU CI 通过 (${mode}+example)` : `NPU CI 失败 (${mode}+example)`),
+              target_url: targetUrl,
+            });
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state: accuracyStatus.state,
+              context: 'NPU CI / 精度检查',
+              description: accuracyStatus.description,
               target_url: targetUrl,
             });
             const result = state === 'success' ? '通过' : '失败';
@@ -432,10 +619,13 @@ jobs:
               '',
               `- 模式：\`${mode}\``,
               `- 触发人：@${context.actor}`,
+              staleRun ? `- 失效原因：PR head 已变化，触发时 \`${sha}\`，当前 \`${currentHeadSha}\`` : '',
               '- Example ST：必跑',
               '- Example ST 用例：全部 enabled 用例',
+              `- 精度检查：${accuracyStatus.description}`,
               ops ? `- 算子：\`${ops}\`` : '',
               `- 运行链接：[NPU CI #${context.runNumber}](${targetUrl})`,
+              ...formatAccuracyComment(accuracyReport),
             ].filter(Boolean).join('\n');
 
             try {

--- a/.github/workflows/npu-ci-default-status.yml
+++ b/.github/workflows/npu-ci-default-status.yml
@@ -25,6 +25,7 @@ jobs:
             }
 
             const contextName = 'NPU CI / 手动验证';
+            const accuracyContextName = 'NPU CI / 精度检查';
             const marker = `<!-- npu-ci:pr=${pr.number}:sha=${pr.head.sha} -->`;
             const isCommitUpdate = context.payload.action === 'synchronize';
             const pendingDescription = isCommitUpdate
@@ -64,6 +65,22 @@ jobs:
                 target_url: pr.html_url,
               });
             }
+            const accuracyStatuses = statuses
+              .filter((status) => status.context === accuracyContextName)
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+            const latestAccuracyStatus = accuracyStatuses[0];
+
+            if (!latestAccuracyStatus) {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: pr.head.sha,
+                state: 'pending',
+                context: accuracyContextName,
+                description: pendingDescription,
+                target_url: pr.html_url,
+              });
+            }
 
             const body = [
               marker,
@@ -71,7 +88,7 @@ jobs:
               '',
               '- 当前状态：未执行',
               isCommitUpdate ? '- 原因：PR head commit 已变化，旧 commit 的 NPU CI 结果不再生效' : '',
-              '- 合入要求：当前 commit 必须通过 `NPU CI / 手动验证`',
+              '- 合入要求：当前 commit 必须通过 `NPU CI / 手动验证` 和 `NPU CI / 精度检查`',
               '- 触发命令：仓库 Admin 权限账号在本 PR 评论 `/run-npu-ci quick` 或 `/run-npu-ci full`',
               '- 可请求触发的 CI 账号：仓库 Admin 权限账号',
               '- Example ST：必跑',


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 NPU CI / 手动验证 pending，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 NPU CI / 手动验证 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（weinachuan 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub Actions 页面选择 NPU CI，点击 Run workflow，填写本 PR 编号。
> - 在 PR 评论区发送 /run-npu-ci quick 或 /run-npu-ci full。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 ci/example_st_cases.json 中启用的 Example/ST 用例；当前 case1_current_default 保持原始 shape。新增 GVA、Vdim=256 等场景时，请在用例文件中显式填写 B、T、chunk_size、query_head、alue_head、Kdim、Vdim 等 shape 字段，以及 gate_source、gate_function、initial_state、output_final_state、qk_l2norm 等行为字段。
> - Example ST 必须使用 Ascend PyTorch 26.1.0-beta.1 release family 的配套 	orch_npu wheel（已包含 	orchnpugen 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 op-plugin 重新编译或安装不属于该 release family 的旧版 	orch-npu。
> - 修改算子 def、clnn 接口入参类型，或修改 	orch 接口入参类型等导致不满足 ABI 一致性的改动，必须由 weinachuan 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 weinachuan。
> - NPU CI 部署与排障教程见 [docs/Fla-npu仓CI部署教程.md](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: Closes #126
- 背景与目标: v26.6.0 分支的 NPU CI workflow 与 main 分支存在差异，需要同步主线 CI 行为。
- 本 PR 解决的问题: 同步 NPU CI 手动验证、精度检查状态、PR head 变更失效保护和默认 pending 状态逻辑。

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: 不涉及具体算子
- 涉及目录 / 文件:
  - .github/workflows/ci.yml
  - .github/workflows/npu-ci-default-status.yml
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] op_host / 算子定义
  - [ ] InferShape / 参数校验
  - [ ] Tiling 策略
  - [ ] op_kernel / Ascend C Kernel
  - [ ] op_api / aclnn 接口
  - [ ] 	orch_custom 适配
  - [ ] Triton 算子
  - [ ] 单算子测试
  - [ ] xample / ST 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不涉及
- 明确不包含的范围: 不修改算子实现、接口、tiling、kernel、example/ST 用例内容
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 def、clnn 接口或 	orch 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 weinachuan 检视通过
- ABI 不兼容风险说明: 不涉及

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 --soc 参数的对应关系如下:

| 产品 | --soc |
| --- | --- |
| A2 | scend910b |
| A3 | scend910_93 |
| A5 | scend950 |

</details>

<details>
<summary>验证方法</summary>

本 PR 仅同步 GitHub Actions workflow，不修改算子实现、接口或测试用例。提交前完成以下静态验证：

- git diff --check：通过
- 已确认 .github/workflows/ci.yml 与 main 分支对应文件一致
- 已确认 .github/workflows/npu-ci-default-status.yml 与 main 分支对应文件一致

NPU CI 未在本地执行；本 PR 创建后按仓库规则由 Admin 触发。

</details>

<details>
<summary>修改算子测试</summary>

本 PR 不涉及具体算子，未执行单算子编译或算子测试。

| 产品 | --soc | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | scend910b | 不涉及 | 未执行 | 仅同步 workflow |
| A3 | scend910_93 | 不涉及 | 未执行 | 仅同步 workflow |
| A5 | scend950 | 不涉及 | 未执行 | 仅同步 workflow |

- 精度对比: 不涉及
- 性能对比: 不涉及
- 边界 / 异常场景: 不涉及
- 未覆盖风险: workflow 变更需要通过 PR 上的 GitHub Actions 实际验证

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 Example ST 未在本地执行；本 PR 创建后按仓库规则由 Admin 触发 NPU CI。

| 产品 | --soc | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | scend910b | python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json | 未执行 | 本 PR 仅同步 workflow |
| A3 | scend910_93 | python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json | 未执行 | 本 PR 仅同步 workflow |
| A5 | scend950 | python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json | 未执行 | 本 PR 仅同步 workflow |

- 端到端场景说明: 不涉及算子端到端逻辑变更
- 与本 PR 修改算子的关联: 不涉及具体算子
- 未覆盖原因及补充计划: PR 创建后通过仓库 NPU CI 验证 workflow 行为

</details>

## 兼容性、风险与回退

- 兼容性说明: 仅同步 GitHub Actions workflow，与 main 分支 CI 行为保持一致。
- 风险点: CI 状态上下文增加 NPU CI / 精度检查，v26.6.0 分支合入检查需要同步识别该状态。
- 回退方案: 如同步后影响 release 分支 CI，可回退本 PR 恢复原 workflow。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 eat:, ix:, perf:, docs:
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

本 PR 将 v26.6.0 分支的 NPU CI workflow 同步到 main 分支当前行为，包含 PR head 变更失效保护、独立精度检查状态和默认 pending 状态更新。
