### PR TITLE
ci: sync live merge history probing to v26.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
         with:
           repository: ${{ github.repository }}
           ref: refs/heads/${{ needs.prepare.outputs.base_ref }}
-          fetch-depth: 1
+          fetch-depth: 50
           path: repo
 
       - name: 等待后重试拉取目标分支代码
@@ -329,7 +329,7 @@ jobs:
         with:
           repository: ${{ github.repository }}
           ref: refs/heads/${{ needs.prepare.outputs.base_ref }}
-          fetch-depth: 1
+          fetch-depth: 50
           path: repo
 
       - name: 再次等待后重试拉取目标分支代码
@@ -345,7 +345,7 @@ jobs:
         with:
           repository: ${{ github.repository }}
           ref: refs/heads/${{ needs.prepare.outputs.base_ref }}
-          fetch-depth: 1
+          fetch-depth: 50
           path: repo
 
       - name: 现场合并 PR 代码
@@ -360,7 +360,14 @@ jobs:
             if [ "$delay" != "0" ]; then
               sleep "$delay"
             fi
-            git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
+            git fetch --no-tags --prune --no-recurse-submodules --depth=50 origin \
+              "+refs/pull/${NPU_CI_PR_NUMBER}/head:refs/remotes/pull/${NPU_CI_PR_NUMBER}/head"
+          }
+
+          deepen_merge_history() {
+            echo "[CI] Shallow checkout does not contain merge base; deepening base and PR head history."
+            git fetch --no-tags --prune --no-recurse-submodules --deepen=200 origin \
+              "+refs/heads/${NPU_CI_BASE_REF}:refs/remotes/origin/${NPU_CI_BASE_REF}" \
               "+refs/pull/${NPU_CI_PR_NUMBER}/head:refs/remotes/pull/${NPU_CI_PR_NUMBER}/head"
           }
 
@@ -370,10 +377,18 @@ jobs:
             echo "[CI][ERROR] PR head changed before merge; target=${NPU_CI_TARGET_SHA}, fetched=${fetched_head}."
             exit 1
           fi
+          if ! git merge-base HEAD "refs/remotes/pull/${NPU_CI_PR_NUMBER}/head" >/dev/null; then
+            deepen_merge_history
+          fi
+          if ! git merge-base HEAD "refs/remotes/pull/${NPU_CI_PR_NUMBER}/head" >/dev/null; then
+            echo "[CI][ERROR] Unable to find merge base between current base ${NPU_CI_BASE_REF} and PR head after deepening history."
+            exit 1
+          fi
 
           git merge --no-ff --no-edit "refs/remotes/pull/${NPU_CI_PR_NUMBER}/head"
         env:
           NPU_CI_PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+          NPU_CI_BASE_REF: ${{ needs.prepare.outputs.base_ref }}
           NPU_CI_TARGET_SHA: ${{ needs.prepare.outputs.head_sha }}
 
       - name: 拉取可信 CI 脚本（第 1 次）

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,7 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          pr_head_ref="refs/remotes/pull/${NPU_CI_PR_NUMBER}/head"
 
           retry_fetch_pr_head() {
             local delay="$1"
@@ -361,31 +362,48 @@ jobs:
               sleep "$delay"
             fi
             git fetch --no-tags --prune --no-recurse-submodules --depth=50 origin \
-              "+refs/pull/${NPU_CI_PR_NUMBER}/head:refs/remotes/pull/${NPU_CI_PR_NUMBER}/head"
+              "+refs/pull/${NPU_CI_PR_NUMBER}/head:${pr_head_ref}"
           }
 
-          deepen_merge_history() {
-            echo "[CI] Shallow checkout does not contain merge base; deepening base and PR head history."
-            git fetch --no-tags --prune --no-recurse-submodules --deepen=200 origin \
+          fetch_more_history() {
+            local deepen_by="$1"
+            echo "[CI] Merge base not found in shallow history; deepening by ${deepen_by} commits."
+            git fetch --no-tags --prune --no-recurse-submodules --deepen="${deepen_by}" origin \
               "+refs/heads/${NPU_CI_BASE_REF}:refs/remotes/origin/${NPU_CI_BASE_REF}" \
-              "+refs/pull/${NPU_CI_PR_NUMBER}/head:refs/remotes/pull/${NPU_CI_PR_NUMBER}/head"
+              "+refs/pull/${NPU_CI_PR_NUMBER}/head:${pr_head_ref}"
+          }
+
+          ensure_merge_base() {
+            if git merge-base HEAD "${pr_head_ref}" >/dev/null; then
+              return 0
+            fi
+            for deepen_by in 50 100 200 400 800 1600 3200; do
+              fetch_more_history "${deepen_by}"
+              if git merge-base HEAD "${pr_head_ref}" >/dev/null; then
+                return 0
+              fi
+            done
+            if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+              echo "[CI] Merge base still not found; unshallowing repository as final probe."
+              git fetch --no-tags --prune --no-recurse-submodules --unshallow origin \
+                "+refs/heads/${NPU_CI_BASE_REF}:refs/remotes/origin/${NPU_CI_BASE_REF}" \
+                "+refs/pull/${NPU_CI_PR_NUMBER}/head:${pr_head_ref}"
+            fi
+            git merge-base HEAD "${pr_head_ref}" >/dev/null
           }
 
           retry_fetch_pr_head 0 || retry_fetch_pr_head 15 || retry_fetch_pr_head 30
-          fetched_head="$(git rev-parse "refs/remotes/pull/${NPU_CI_PR_NUMBER}/head")"
+          fetched_head="$(git rev-parse "${pr_head_ref}")"
           if [ "$fetched_head" != "$NPU_CI_TARGET_SHA" ]; then
             echo "[CI][ERROR] PR head changed before merge; target=${NPU_CI_TARGET_SHA}, fetched=${fetched_head}."
             exit 1
           fi
-          if ! git merge-base HEAD "refs/remotes/pull/${NPU_CI_PR_NUMBER}/head" >/dev/null; then
-            deepen_merge_history
-          fi
-          if ! git merge-base HEAD "refs/remotes/pull/${NPU_CI_PR_NUMBER}/head" >/dev/null; then
-            echo "[CI][ERROR] Unable to find merge base between current base ${NPU_CI_BASE_REF} and PR head after deepening history."
+          if ! ensure_merge_base; then
+            echo "[CI][ERROR] Unable to find merge base between current base ${NPU_CI_BASE_REF} and PR head after probing history."
             exit 1
           fi
 
-          git merge --no-ff --no-edit "refs/remotes/pull/${NPU_CI_PR_NUMBER}/head"
+          git merge --no-ff --no-edit "${pr_head_ref}"
         env:
           NPU_CI_PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
           NPU_CI_BASE_REF: ${{ needs.prepare.outputs.base_ref }}


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

已阅读仓库模板中的 NPU CI 门禁说明。本 PR 修改 v26.6.0 分支的 CI 现场合并逻辑，合入前仍需按仓库规则完成 NPU CI 与 review 门禁。

## 关联 Issue / 背景

- 关联 Issue: #134
- 背景与目标: v26.6.0 分支需要与主线保持一致的 NPU CI 行为；CI 在浅历史 checkout 下现场合并 PR 时，可能因为本地历史不包含真实共同祖先，误报 refusing to merge unrelated histories。
- 本 PR 解决的问题: 将 v26.6.0 分支的固定加深历史逻辑同步为逐步探查 merge-base，并在仓库仍为 shallow 时使用完整历史兜底。

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: 不涉及
- 涉及目录 / 文件: .github/workflows/ci.yml
- 责任人 / 提交人: @weinachuan
- 修改范围: CI 工作流脚本；不修改 op_host、InferShape、Tiling、op_kernel、op_api、torch_custom、Triton、单算子测试、example/ST 用例或文档。
- 输入 / 输出 / shape / dtype / format 支持范围: 不涉及
- 明确不包含的范围: 不修改算子实现、用例规格、构建产物或公共接口
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 def、aclnn 接口或 torch 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 weinachuan 检视通过
- ABI 不兼容风险说明: 不涉及

## 兼容性、风险与回退

- 兼容性说明: 仅调整 CI 现场合并前的历史获取策略，不改变算子代码、测试入口或 PR 触发协议。
- 风险点: 当浅历史中找不到 merge-base 时，CI 会额外拉取历史，失败场景下耗时可能略有增加。
- 回退方案: 回退本 PR 对 .github/workflows/ci.yml 的修改即可恢复原逻辑。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 feat:, fix:, perf:, docs:
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

验证结果:

- git diff --check 通过
- workflow YAML 解析通过
- 已检查 workflow 中不包含代理配置
- 已检查现场合并步骤包含逐步探查 merge-base、最终完整历史兜底以及 PR head commit 校验
- 已确认 ci/example_st_cases.json 中启用的 example case 数量保持为 4
