### PR TITLE
fix: fallback solve_tri example path on A5

### DIFF
--- a/common/include/fallback/fallback.h
+++ b/common/include/fallback/fallback.h
@@ -17,7 +17,9 @@
 
 #include <dlfcn.h>
 
+#include <cstdlib>
 #include <functional>
+#include <string>
 #include <tuple>
 #include <type_traits>
 #include <vector>
@@ -94,6 +96,16 @@ inline void* GetOpApiFuncAddrInLib(void* handler, const char* libName, const cha
 }
 
 inline void* GetOpApiLibHandler(const char* libName) {
+  if (std::string(libName) == GetCustOpApiLibName()) {
+    const char* embeddedOpApiLib = std::getenv("FLA_NPU_OP_API_LIB");
+    if (embeddedOpApiLib != nullptr && embeddedOpApiLib[0] != '\0') {
+      auto handler = dlopen(embeddedOpApiLib, RTLD_LAZY | RTLD_GLOBAL);
+      if (handler != nullptr) {
+        return handler;
+      }
+      OP_LOGW("aclnnfallback", "dlopen %s failed, error:%s.", embeddedOpApiLib, dlerror());
+    }
+  }
   auto handler = dlopen(libName, RTLD_LAZY);
   if (handler == nullptr) {
     OP_LOGW("aclnnfallback", "dlopen %s failed, error:%s.", libName, dlerror());

--- a/examples/flash_gated_delta_rule.py
+++ b/examples/flash_gated_delta_rule.py
@@ -23,11 +23,29 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch_npu
 
-from fla.ops.triton.triton_core.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
-from fla.ops.triton.triton_core.cumsum import chunk_local_cumsum
-from fla.ops.triton.triton_core.l2norm import l2norm_bwd, l2norm_fwd
-from fla.ops.triton.triton_core.solve_tril_fast import solve_tril_npu as solve_tril
-from fla.ops.triton.triton_core.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+from fla_npu.ops.ascendc import (
+    causal_conv1d as ascendc_causal_conv1d,
+    causal_conv1d_bwd as ascendc_causal_conv1d_bwd,
+    chunk_bwd_dqkwg as ascendc_chunk_bwd_dqkwg,
+    chunk_bwd_dv_local as ascendc_chunk_bwd_dv_local,
+    chunk_fwd_o as ascendc_chunk_fwd_o,
+    chunk_gated_delta_rule_bwd_dhu as ascendc_chunk_gated_delta_rule_bwd_dhu,
+    chunk_gated_delta_rule_fwd_h as ascendc_chunk_gated_delta_rule_fwd_h,
+    prepare_wy_repr_bwd_da as ascendc_prepare_wy_repr_bwd_da,
+    prepare_wy_repr_bwd_full as ascendc_prepare_wy_repr_bwd_full,
+    recompute_w_u_fwd as ascendc_recompute_w_u_fwd,
+    solve_tri as ascendc_solve_tri,
+)
+from fla_npu.ops.triton import (
+    autocast_custom_bwd,
+    autocast_custom_fwd,
+    chunk_local_cumsum,
+    chunk_scaled_dot_kkt_fwd,
+    input_guard,
+    l2norm_bwd,
+    l2norm_fwd,
+    solve_tril_npu as solve_tril,
+)
 
 
 _disable_compile = getattr(getattr(torch, "compiler", None), "disable", lambda fn: fn)
@@ -209,22 +227,19 @@ def solve_tri_ascendc(
     chunk_indices: Optional[list[int] | torch.Tensor] = None,
     output_dtype: torch.dtype = torch.float,
 ) -> torch.Tensor:
-    if not hasattr(torch.ops.npu, "npu_solve_tri"):
-        raise RuntimeError("torch.ops.npu.npu_solve_tri is unavailable. Please rebuild and install the latest fla_npu.")
-
     A_in = A.to(output_dtype).contiguous()
     cu_list = _as_int_list(cu_seqlens)
     chunk_list = _as_int_list(chunk_indices)
 
     if cu_list is None:
-        return torch.ops.npu.npu_solve_tri(A_in, layout="bsnd")
+        return ascendc_solve_tri(A_in, layout="bsnd")
 
     if A_in.ndim != 4 or A_in.shape[0] != 1:
         raise ValueError(f"solve_tri varlen path expects A with shape [1, T, H, BT], got {tuple(A_in.shape)}.")
     if chunk_list is None:
         raise ValueError("solve_tri varlen path requires chunk_indices.")
 
-    out = torch.ops.npu.npu_solve_tri(
+    out = ascendc_solve_tri(
         A_in.squeeze(0),
         cu_seqlens=cu_list,
         chunk_indices=chunk_list,
@@ -239,15 +254,10 @@ def _probe_solve_tri_ascendc(device: torch.device, dtype: torch.dtype) -> bool:
     if _SOLVE_TRI_ASCENDC_AVAILABLE is not None:
         return _SOLVE_TRI_ASCENDC_AVAILABLE
 
-    if not hasattr(torch.ops.npu, "npu_solve_tri"):
-        _SOLVE_TRI_ASCENDC_AVAILABLE = False
-        _SOLVE_TRI_ASCENDC_UNAVAILABLE_REASON = "torch.ops.npu.npu_solve_tri is not registered"
-        return False
-
     probe_dtype = dtype if dtype in (torch.float16, torch.bfloat16) else torch.float16
     try:
         probe = torch.zeros((1, 64, 1, 64), dtype=probe_dtype, device=device)
-        torch.ops.npu.npu_solve_tri(probe, layout="bsnd")
+        ascendc_solve_tri(probe, layout="bsnd")
         torch.npu.synchronize()
     except Exception as exc:
         _SOLVE_TRI_ASCENDC_AVAILABLE = False
@@ -317,9 +327,6 @@ class AscendCCausalConv1dFunction(torch.autograd.Function):
         cu_seqlens: Optional[torch.Tensor] = None,
         output_final_state: bool = False,
     ):
-        if not hasattr(torch.ops.npu, "npu_causal_conv1d"):
-            raise RuntimeError("torch.ops.npu.npu_causal_conv1d is unavailable. Please rebuild and install fla_npu.")
-
         activation_mode = _activation_mode(activation)
         op_weight = weight.transpose(-1, -2).contiguous()
         width, dim = op_weight.shape
@@ -334,7 +341,7 @@ class AscendCCausalConv1dFunction(torch.autograd.Function):
         )
         initial_state_mode = [1] * num_sequences if initial_state is not None else None
 
-        preactivation = torch.ops.npu.npu_causal_conv1d(
+        preactivation = ascendc_causal_conv1d(
             op_x,
             op_weight,
             bias,
@@ -374,9 +381,6 @@ class AscendCCausalConv1dFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, dy: torch.Tensor, dht: Optional[torch.Tensor] = None):
-        if not hasattr(torch.ops.npu, "npu_causal_conv1d_bwd"):
-            raise RuntimeError("torch.ops.npu.npu_causal_conv1d_bwd is unavailable. Please rebuild and install fla_npu.")
-
         x, op_weight, bias, residual, initial_state_bwd, preactivation = ctx.saved_tensors
         op_x = x.reshape(-1, x.shape[-1]).contiguous() if ctx.is_varlen and x.ndim == 3 else x.contiguous()
         op_dy = dy.squeeze(0).contiguous() if ctx.is_varlen and dy.ndim == 4 else dy.contiguous()
@@ -385,7 +389,7 @@ class AscendCCausalConv1dFunction(torch.autograd.Function):
         if dht is not None:
             dht_bwd = dht.transpose(1, 2).contiguous() if dht.ndim == 3 and dht.shape[1] == x.shape[-1] else dht
 
-        dx, dw, db, dh0 = torch.ops.npu.npu_causal_conv1d_bwd(
+        dx, dw, db, dh0 = ascendc_causal_conv1d_bwd(
             x=op_x,
             y=op_y if ctx.activation_mode != 0 else None,
             weight=op_weight,
@@ -460,7 +464,7 @@ def _next_power_of_2(value: int) -> int:
 
 
 def _cumsum_block_t(g: torch.Tensor, chunk_size: int) -> int:
-    # Keep this aligned with fla.ops.triton.triton_core.cumsum.chunk_local_cumsum_scalar.
+    # Keep this aligned with fla_npu.ops.triton.chunk_local_cumsum_scalar.
     h = int(g.shape[-1])
     return _next_power_of_2((1 << 17) // max(1, h * int(chunk_size)))
 
@@ -531,10 +535,7 @@ def recompute_w_u(
     cu_seqlens: Optional[list[int]],
     chunk_indices: Optional[list[int]],
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    if not hasattr(torch.ops.npu, "npu_recompute_w_u_fwd"):
-        raise RuntimeError("torch.ops.npu.npu_recompute_w_u_fwd is unavailable. Please rebuild and install fla_npu.")
-
-    w, u = torch.ops.npu.npu_recompute_w_u_fwd(
+    w, u = ascendc_recompute_w_u_fwd(
         k,
         v,
         beta,
@@ -607,7 +608,7 @@ def flash_chunk_gated_delta_rule_fwd(
         chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
     )
 
-    h, v_new, final_state = torch.ops.npu.npu_chunk_gated_delta_rule_fwd_h(
+    h, v_new, final_state = ascendc_chunk_gated_delta_rule_fwd_h(
         k,
         w,
         u,
@@ -625,7 +626,7 @@ def flash_chunk_gated_delta_rule_fwd(
     if not output_final_state:
         final_state = None
 
-    o = torch.ops.npu.npu_chunk_fwd_o(
+    o = ascendc_chunk_fwd_o(
         q,
         k,
         v_new,
@@ -677,7 +678,7 @@ def flash_chunk_gated_delta_rule_bwd(
 
     do = do.transpose(1, 2).contiguous()
 
-    h, v_new, _ = torch.ops.npu.npu_chunk_gated_delta_rule_fwd_h(
+    h, v_new, _ = ascendc_chunk_gated_delta_rule_fwd_h(
         k,
         w,
         u,
@@ -693,7 +694,7 @@ def flash_chunk_gated_delta_rule_bwd(
         transpose_state_layout=False,
     )
 
-    dv = torch.ops.npu.npu_chunk_bwd_dv_local(
+    dv = ascendc_chunk_bwd_dv_local(
         q,
         k,
         do,
@@ -706,7 +707,7 @@ def flash_chunk_gated_delta_rule_bwd(
         chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
     )
 
-    dh, dh0, dv = torch.ops.npu.npu_chunk_gated_delta_rule_bwd_dhu(
+    dh, dh0, dv = ascendc_chunk_gated_delta_rule_bwd_dhu(
         q,
         k,
         w,
@@ -725,7 +726,7 @@ def flash_chunk_gated_delta_rule_bwd(
     )
     dh0 = None
 
-    dq, dk, dw, dg = torch.ops.npu.npu_chunk_bwd_dqkwg(
+    dq, dk, dw, dg = ascendc_chunk_bwd_dqkwg(
         q,
         k,
         v_new,
@@ -744,7 +745,7 @@ def flash_chunk_gated_delta_rule_bwd(
         transpose_state_layout=False,
     )
 
-    dA = torch.ops.npu.npu_prepare_wy_repr_bwd_da(
+    dA = ascendc_prepare_wy_repr_bwd_da(
         k,
         v,
         beta.float(),
@@ -757,7 +758,7 @@ def flash_chunk_gated_delta_rule_bwd(
         chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
     )
 
-    dk2, dv, db, dg2 = torch.ops.npu.npu_prepare_wy_repr_bwd_full(
+    dk2, dv, db, dg2 = ascendc_prepare_wy_repr_bwd_full(
         k,
         v,
         beta,

--- a/examples/flash_gated_delta_rule.py
+++ b/examples/flash_gated_delta_rule.py
@@ -26,12 +26,15 @@ import torch_npu
 from fla.ops.triton.triton_core.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
 from fla.ops.triton.triton_core.cumsum import chunk_local_cumsum
 from fla.ops.triton.triton_core.l2norm import l2norm_bwd, l2norm_fwd
+from fla.ops.triton.triton_core.solve_tril_fast import solve_tril_npu as solve_tril
 from fla.ops.triton.triton_core.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
 
 
 _disable_compile = getattr(getattr(torch, "compiler", None), "disable", lambda fn: fn)
 _DEFAULT_VARLEN_CHUNK_SIZES = (16, 32, 64, 128, 608 * 2)
 _ACCURACY_REFERENCE_VERSION = 1
+_SOLVE_TRI_ASCENDC_AVAILABLE: Optional[bool] = None
+_SOLVE_TRI_ASCENDC_UNAVAILABLE_REASON = ""
 
 
 def _make_gate(shape: tuple[int, ...], dtype: torch.dtype, device: str, gate_function: str) -> torch.Tensor:
@@ -228,6 +231,76 @@ def solve_tri_ascendc(
         layout="tnd",
     )
     return out.unsqueeze(0)
+
+
+def _probe_solve_tri_ascendc(device: torch.device, dtype: torch.dtype) -> bool:
+    global _SOLVE_TRI_ASCENDC_AVAILABLE, _SOLVE_TRI_ASCENDC_UNAVAILABLE_REASON
+
+    if _SOLVE_TRI_ASCENDC_AVAILABLE is not None:
+        return _SOLVE_TRI_ASCENDC_AVAILABLE
+
+    if not hasattr(torch.ops.npu, "npu_solve_tri"):
+        _SOLVE_TRI_ASCENDC_AVAILABLE = False
+        _SOLVE_TRI_ASCENDC_UNAVAILABLE_REASON = "torch.ops.npu.npu_solve_tri is not registered"
+        return False
+
+    probe_dtype = dtype if dtype in (torch.float16, torch.bfloat16) else torch.float16
+    try:
+        probe = torch.zeros((1, 64, 1, 64), dtype=probe_dtype, device=device)
+        torch.ops.npu.npu_solve_tri(probe, layout="bsnd")
+        torch.npu.synchronize()
+    except Exception as exc:
+        _SOLVE_TRI_ASCENDC_AVAILABLE = False
+        _SOLVE_TRI_ASCENDC_UNAVAILABLE_REASON = str(exc).splitlines()[0]
+        try:
+            torch.npu.synchronize()
+        except Exception:
+            pass
+        return False
+
+    _SOLVE_TRI_ASCENDC_AVAILABLE = True
+    _SOLVE_TRI_ASCENDC_UNAVAILABLE_REASON = ""
+    return True
+
+
+def solve_tri_auto(
+    A: torch.Tensor,
+    *,
+    cu_seqlens: Optional[torch.Tensor],
+    chunk_indices_out: Optional[Dict[str, Optional[torch.Tensor]]],
+    cu_seqlens_list: Optional[list[int] | torch.Tensor],
+    chunk_indices_list: Optional[list[int] | torch.Tensor],
+    output_dtype: torch.dtype,
+) -> torch.Tensor:
+    global _SOLVE_TRI_ASCENDC_AVAILABLE, _SOLVE_TRI_ASCENDC_UNAVAILABLE_REASON
+
+    if _probe_solve_tri_ascendc(A.device, output_dtype):
+        try:
+            return solve_tri_ascendc(
+                A,
+                cu_seqlens=cu_seqlens_list,
+                chunk_indices=chunk_indices_list,
+                output_dtype=output_dtype,
+            )
+        except Exception as exc:
+            _SOLVE_TRI_ASCENDC_AVAILABLE = False
+            _SOLVE_TRI_ASCENDC_UNAVAILABLE_REASON = str(exc).splitlines()[0]
+            try:
+                torch.npu.synchronize()
+            except Exception:
+                pass
+
+    warnings.warn(
+        "AscendC npu_solve_tri is unavailable; falling back to Triton solve_tril_npu. "
+        f"Reason: {_SOLVE_TRI_ASCENDC_UNAVAILABLE_REASON}",
+        RuntimeWarning,
+    )
+    return solve_tril(
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices_out=chunk_indices_out,
+        output_dtype=output_dtype,
+    )
 
 
 class AscendCCausalConv1dFunction(torch.autograd.Function):
@@ -510,10 +583,12 @@ def flash_chunk_gated_delta_rule_fwd(
         output_dtype=torch.float32,
     )
 
-    A = solve_tri_ascendc(
+    A = solve_tri_auto(
         A,
-        cu_seqlens=cu_seqlens_list,
-        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+        cu_seqlens=cu_seqlens,
+        chunk_indices_out=chunk_indices,
+        cu_seqlens_list=cu_seqlens_list,
+        chunk_indices_list=_chunk_list(chunk_indices_list, chunk_size),
         output_dtype=k.dtype,
     )
 

--- a/fla/ops/triton/triton_core/solve_tril_fast.py
+++ b/fla/ops/triton/triton_core/solve_tril_fast.py
@@ -149,6 +149,8 @@ def solve_tril_16x16_kernel_paral_v3(
         base_t += taskid * (LARGE_BLOCK_T // NTASKS)
 
         b_A = tl.zeros((N_BLOCKS, 16, 16), dtype=tl.float32)  # (N_BLOCKS, 16, 16)
+        block_offsets = tl.arange(0, N_BLOCKS)[:, None, None]
+        row_offsets = tl.arange(0, 16)[None, :, None]
         for blkid in range(0, N_BLOCKS):
             row_start_o = base_t + blkid * 16
             col_start_o = row_start_o % BT
@@ -169,17 +171,10 @@ def solve_tril_16x16_kernel_paral_v3(
             b_A_subrec16 = tl.load(ptr_A_subrec16, mask=load_mask, other=0.0).to(
                 tl.float32
             )
-            b_A = tl.insert_slice(
-                ful=b_A,
-                sub=b_A_subrec16[None, :, :],  # (1, 16, 16)
-                offsets=[blkid, 0, 0],
-                sizes=[1, 16, 16],
-                strides=[1, 1, 1],
-            )
+            b_A = tl.where(block_offsets == blkid, b_A_subrec16[None, :, :], b_A)
 
-        # load multi 16x16
-        local_ori_A = tl.trans(b_A, (1, 0, 2))
-        local_ori_A = tl.reshape(local_ori_A, (16, 16 * N_BLOCKS))  # (16, N_BLOCKS*16)
+        # Keep the original blocks for row-wise recurrence updates below.
+        local_ori_A = b_A
 
         # change mask into matrix elementwise action
         tmp = tl.arange(0, 16).to(tl.float32)
@@ -190,23 +185,14 @@ def solve_tril_16x16_kernel_paral_v3(
 
         for i in range(1, 16):
 
-            nblks_vec16 = -tl.extract_slice(
-                local_ori_A, (i, 0), (1, 16 * N_BLOCKS), (16 * N_BLOCKS, 1)
-            )
-            b_a = tl.reshape(nblks_vec16, (N_BLOCKS, 16))
+            b_a = -tl.sum(tl.where(row_offsets == i, local_ori_A, 0.0), 1)
 
             dot_tmp = tl.trans(b_a[:, :, None] * b_A, (1, 0, 2))
             dot_product = tl.sum(dot_tmp, 0)
             b_a = b_a + dot_product  # (N_BLOCKS, 16)
 
             b_a_new_expanded = b_a[:, None, :]  # (N_BLOCKS, 1, 16)
-            b_A = tl.insert_slice(
-                ful=b_A,
-                sub=b_a_new_expanded,
-                offsets=[0, i, 0],
-                sizes=[N_BLOCKS, 1, 16],
-                strides=[1, 1, 1],
-            )
+            b_A = tl.where(row_offsets == i, b_a_new_expanded, b_A)
 
         on_diagonal = rows == cols
         b_A = tl.where(on_diagonal, b_A + 1.0, b_A)
@@ -639,7 +625,9 @@ def solve_tril_npu(
         B, T, H, 16, device=A.device, dtype=torch.float if BT != 16 else output_dtype
     )
 
-    LARGE_BLOCK_T = 608 * 2
+    # Keep the fallback kernel within the smaller UB budget of CANN 9/A5.
+    # The AscendC path remains preferred when npu_solve_tri is available.
+    LARGE_BLOCK_T = BT
     # assert A.shape[1]%LARGE_BLOCK_T == 0 # or last N_BLOCKS have not enough block which leads to tl.arange failed
     # LARGE_BLOCK_T = BT
     chunk_indices = (chunk_indices_out[str(LARGE_BLOCK_T)] if cu_seqlens is not None else None)

--- a/fla/ops/triton/triton_core/solve_tril_fast.py
+++ b/fla/ops/triton/triton_core/solve_tril_fast.py
@@ -625,7 +625,7 @@ def solve_tril_npu(
         B, T, H, 16, device=A.device, dtype=torch.float if BT != 16 else output_dtype
     )
 
-    # Keep the fallback kernel within the smaller UB budget of CANN 9/A5.
+    # Keep the fallback kernel within the smaller UB budget on A5.
     # The AscendC path remains preferred when npu_solve_tri is available.
     LARGE_BLOCK_T = BT
     # assert A.shape[1]%LARGE_BLOCK_T == 0 # or last N_BLOCKS have not enough block which leads to tl.arange failed

--- a/scripts/check_npu_env.py
+++ b/scripts/check_npu_env.py
@@ -17,7 +17,7 @@ from packaging.version import InvalidVersion, Version
 MIN_PYTHON = (3, 9)
 MIN_TORCH = "2.7.0"
 MIN_TRITON_ASCEND = "3.2.0"
-MIN_TRITON_ASCEND_CANN9 = "3.2.1"
+MIN_TRITON_ASCEND_A5 = "3.2.1"
 TORCH_NPU_GDN_FIX_MINIMUMS = {
     "2.7.1": "2.7.1.post5",
     "2.8.0": "2.8.0.post5",
@@ -124,19 +124,19 @@ def _detect_cann_public_version() -> str:
     return ""
 
 
-def _check_triton_ascend_cann_compat(failures: list[str], actual: str, cann_public_version: str) -> None:
-    soc = os.getenv("FLA_NPU_SOC", "")
-    cann_key = _version_key(cann_public_version)
-    requires_cann9_runtime = (cann_key is not None and cann_key >= (9, 0, 0)) or soc == "ascend950"
-    if not requires_cann9_runtime:
+def _check_triton_ascend_a5_compat(failures: list[str], actual: str, cann_public_version: str) -> None:
+    soc = os.getenv("FLA_NPU_SOC", "ascend910b")
+    if soc != "ascend950":
         return
     actual_version = _version_obj(actual)
-    if actual_version is None or actual_version < Version(MIN_TRITON_ASCEND_CANN9):
-        detail = f"CANN {cann_public_version}" if cann_public_version else f"FLA_NPU_SOC={soc}"
+    if actual_version is None or actual_version < Version(MIN_TRITON_ASCEND_A5):
+        detail = f"FLA_NPU_SOC={soc}"
+        if cann_public_version:
+            detail += f" with CANN {cann_public_version}"
         _fail(
             failures,
-            f"triton-ascend>={MIN_TRITON_ASCEND_CANN9} is required for {detail}; got {actual}. "
-            "triton-ascend 3.2.0 targets CANN 8.5.x and can crash on the CANN 9.x Triton runtime.",
+            f"triton-ascend>={MIN_TRITON_ASCEND_A5} is required for {detail}; got {actual}. "
+            "triton-ascend 3.2.0 can crash on the A5 Triton runtime.",
         )
 
 
@@ -277,7 +277,7 @@ def main() -> int:
     if triton_ascend_version:
         _ok(f"triton-ascend version: {triton_ascend_version}")
         _check_min_version(failures, "triton-ascend", triton_ascend_version, MIN_TRITON_ASCEND)
-        _check_triton_ascend_cann_compat(failures, triton_ascend_version, cann_public_version)
+        _check_triton_ascend_a5_compat(failures, triton_ascend_version, cann_public_version)
     elif triton is not None:
         _fail(failures, "triton is importable, but triton-ascend distribution was not found")
     else:

--- a/scripts/check_npu_env.py
+++ b/scripts/check_npu_env.py
@@ -17,6 +17,7 @@ from packaging.version import InvalidVersion, Version
 MIN_PYTHON = (3, 9)
 MIN_TORCH = "2.7.0"
 MIN_TRITON_ASCEND = "3.2.0"
+MIN_TRITON_ASCEND_CANN9 = "3.2.1"
 TORCH_NPU_GDN_FIX_MINIMUMS = {
     "2.7.1": "2.7.1.post5",
     "2.8.0": "2.8.0.post5",
@@ -112,6 +113,33 @@ def _version_key(value: str) -> tuple[int, int, int] | None:
     return tuple(nums)
 
 
+def _detect_cann_public_version() -> str:
+    for env_name in ("ASCEND_HOME_PATH", "ASCEND_OPP_PATH"):
+        value = os.getenv(env_name)
+        if not value:
+            continue
+        match = re.search(r"(?:^|[/\\_-])cann[-_ ]?(\d+\.\d+\.\d+(?:[-._A-Za-z0-9]*)?)", value, re.I)
+        if match:
+            return match.group(1)
+    return ""
+
+
+def _check_triton_ascend_cann_compat(failures: list[str], actual: str, cann_public_version: str) -> None:
+    soc = os.getenv("FLA_NPU_SOC", "")
+    cann_key = _version_key(cann_public_version)
+    requires_cann9_runtime = (cann_key is not None and cann_key >= (9, 0, 0)) or soc == "ascend950"
+    if not requires_cann9_runtime:
+        return
+    actual_version = _version_obj(actual)
+    if actual_version is None or actual_version < Version(MIN_TRITON_ASCEND_CANN9):
+        detail = f"CANN {cann_public_version}" if cann_public_version else f"FLA_NPU_SOC={soc}"
+        _fail(
+            failures,
+            f"triton-ascend>={MIN_TRITON_ASCEND_CANN9} is required for {detail}; got {actual}. "
+            "triton-ascend 3.2.0 targets CANN 8.5.x and can crash on the CANN 9.x Triton runtime.",
+        )
+
+
 def _check_torch_npu_gdn_fix(failures: list[str], actual: str) -> None:
     actual_version = _version_obj(actual)
     if actual_version is None:
@@ -203,10 +231,13 @@ def main() -> int:
 
     ascend_home = os.getenv("ASCEND_HOME_PATH")
     ascend_opp = os.getenv("ASCEND_OPP_PATH")
+    cann_public_version = _detect_cann_public_version()
     if ascend_home or ascend_opp:
         _ok(f"ASCEND_HOME_PATH={ascend_home or '<unset>'}")
         _ok(f"ASCEND_OPP_PATH={ascend_opp or '<unset>'}")
         _ok(f"CANN version: {_detect_cann_version()}")
+        if cann_public_version:
+            _ok(f"CANN public version: {cann_public_version}")
     else:
         _fail(failures, "ASCEND_HOME_PATH or ASCEND_OPP_PATH must be set")
 
@@ -246,6 +277,7 @@ def main() -> int:
     if triton_ascend_version:
         _ok(f"triton-ascend version: {triton_ascend_version}")
         _check_min_version(failures, "triton-ascend", triton_ascend_version, MIN_TRITON_ASCEND)
+        _check_triton_ascend_cann_compat(failures, triton_ascend_version, cann_public_version)
     elif triton is not None:
         _fail(failures, "triton is importable, but triton-ascend distribution was not found")
     else:

--- a/scripts/check_npu_env.py
+++ b/scripts/check_npu_env.py
@@ -124,18 +124,15 @@ def _detect_cann_public_version() -> str:
     return ""
 
 
-def _check_triton_ascend_a5_compat(failures: list[str], actual: str, cann_public_version: str) -> None:
+def _check_triton_ascend_a5_compat(failures: list[str], actual: str) -> None:
     soc = os.getenv("FLA_NPU_SOC", "ascend910b")
     if soc != "ascend950":
         return
     actual_version = _version_obj(actual)
     if actual_version is None or actual_version < Version(MIN_TRITON_ASCEND_A5):
-        detail = f"FLA_NPU_SOC={soc}"
-        if cann_public_version:
-            detail += f" with CANN {cann_public_version}"
         _fail(
             failures,
-            f"triton-ascend>={MIN_TRITON_ASCEND_A5} is required for {detail}; got {actual}. "
+            f"triton-ascend>={MIN_TRITON_ASCEND_A5} is required for FLA_NPU_SOC={soc}; got {actual}. "
             "triton-ascend 3.2.0 can crash on the A5 Triton runtime.",
         )
 
@@ -277,7 +274,7 @@ def main() -> int:
     if triton_ascend_version:
         _ok(f"triton-ascend version: {triton_ascend_version}")
         _check_min_version(failures, "triton-ascend", triton_ascend_version, MIN_TRITON_ASCEND)
-        _check_triton_ascend_a5_compat(failures, triton_ascend_version, cann_public_version)
+        _check_triton_ascend_a5_compat(failures, triton_ascend_version)
     elif triton is not None:
         _fail(failures, "triton is importable, but triton-ascend distribution was not found")
     else:

--- a/scripts/check_packaged_wheel_api.py
+++ b/scripts/check_packaged_wheel_api.py
@@ -19,13 +19,17 @@ ASCENDC_NAMES = (
     "prepare_wy_repr_bwd_da",
     "prepare_wy_repr_bwd_full",
     "recompute_w_u_fwd",
+    "solve_tri",
 )
 
 TRITON_NAMES = (
+    "autocast_custom_bwd",
+    "autocast_custom_fwd",
     "causal_conv1d",
     "causal_conv1d_triton",
     "chunk_local_cumsum",
     "chunk_scaled_dot_kkt_fwd",
+    "input_guard",
     "l2norm",
     "solve_tril",
 )

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ DEFAULT_VENDOR_NAME = "fla_npu"
 MIN_PYTHON = (3, 9)
 MIN_TORCH = "2.7.0"
 MIN_TRITON_ASCEND = "3.2.0"
-MIN_TRITON_ASCEND_CANN9 = "3.2.1"
+MIN_TRITON_ASCEND_A5 = "3.2.1"
 TORCH_NPU_GDN_FIX_MINIMUMS = {
     "2.7.1": "2.7.1.post5",
     "2.8.0": "2.8.0.post5",
@@ -133,18 +133,18 @@ def _detect_cann_public_version():
     return ""
 
 
-def _check_triton_ascend_cann_compat(failures, actual, cann_public_version):
-    soc = os.getenv("FLA_NPU_SOC", "")
-    cann_key = _version_key(cann_public_version)
-    requires_cann9_runtime = (cann_key is not None and cann_key >= (9, 0, 0)) or soc == "ascend950"
-    if not requires_cann9_runtime:
+def _check_triton_ascend_a5_compat(failures, actual, cann_public_version):
+    soc = os.getenv("FLA_NPU_SOC", DEFAULT_SOC)
+    if soc != "ascend950":
         return
     actual_version = _version_obj(actual)
-    if actual_version is None or actual_version < Version(MIN_TRITON_ASCEND_CANN9):
-        detail = f"CANN {cann_public_version}" if cann_public_version else f"FLA_NPU_SOC={soc}"
+    if actual_version is None or actual_version < Version(MIN_TRITON_ASCEND_A5):
+        detail = f"FLA_NPU_SOC={soc}"
+        if cann_public_version:
+            detail += f" with CANN {cann_public_version}"
         failures.append(
-            f"triton-ascend>={MIN_TRITON_ASCEND_CANN9} is required for {detail}; got {actual}. "
-            "triton-ascend 3.2.0 targets CANN 8.5.x and can crash on the CANN 9.x Triton runtime."
+            f"triton-ascend>={MIN_TRITON_ASCEND_A5} is required for {detail}; got {actual}. "
+            "triton-ascend 3.2.0 can crash on the A5 Triton runtime."
         )
 
 
@@ -269,7 +269,7 @@ def _check_build_environment():
     if triton_ascend_version:
         print(f"[fla-npu build][OK] triton-ascend: {triton_ascend_version}")
         _check_min_version(failures, "triton-ascend", triton_ascend_version, MIN_TRITON_ASCEND)
-        _check_triton_ascend_cann_compat(failures, triton_ascend_version, cann_public_version)
+        _check_triton_ascend_a5_compat(failures, triton_ascend_version, cann_public_version)
     else:
         failures.append("triton-ascend distribution was not found")
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ DEFAULT_VENDOR_NAME = "fla_npu"
 MIN_PYTHON = (3, 9)
 MIN_TORCH = "2.7.0"
 MIN_TRITON_ASCEND = "3.2.0"
+MIN_TRITON_ASCEND_CANN9 = "3.2.1"
 TORCH_NPU_GDN_FIX_MINIMUMS = {
     "2.7.1": "2.7.1.post5",
     "2.8.0": "2.8.0.post5",
@@ -121,6 +122,32 @@ def _version_key(value):
     return tuple(nums)
 
 
+def _detect_cann_public_version():
+    for env_name in ("ASCEND_HOME_PATH", "ASCEND_OPP_PATH"):
+        value = os.getenv(env_name)
+        if not value:
+            continue
+        match = re.search(r"(?:^|[/\\_-])cann[-_ ]?(\d+\.\d+\.\d+(?:[-._A-Za-z0-9]*)?)", value, re.I)
+        if match:
+            return match.group(1)
+    return ""
+
+
+def _check_triton_ascend_cann_compat(failures, actual, cann_public_version):
+    soc = os.getenv("FLA_NPU_SOC", "")
+    cann_key = _version_key(cann_public_version)
+    requires_cann9_runtime = (cann_key is not None and cann_key >= (9, 0, 0)) or soc == "ascend950"
+    if not requires_cann9_runtime:
+        return
+    actual_version = _version_obj(actual)
+    if actual_version is None or actual_version < Version(MIN_TRITON_ASCEND_CANN9):
+        detail = f"CANN {cann_public_version}" if cann_public_version else f"FLA_NPU_SOC={soc}"
+        failures.append(
+            f"triton-ascend>={MIN_TRITON_ASCEND_CANN9} is required for {detail}; got {actual}. "
+            "triton-ascend 3.2.0 targets CANN 8.5.x and can crash on the CANN 9.x Triton runtime."
+        )
+
+
 def _check_torch_npu_gdn_fix(failures, actual):
     actual_version = _version_obj(actual)
     if actual_version is None:
@@ -187,6 +214,7 @@ def _detect_cann_version():
 
 def _check_build_environment():
     failures = []
+    cann_public_version = _detect_cann_public_version()
 
     if shutil.which("bash") is None:
         failures.append("bash is required")
@@ -202,6 +230,8 @@ def _check_build_environment():
         print(f"[fla-npu build][OK] ASCEND_HOME_PATH={os.getenv('ASCEND_HOME_PATH') or '<unset>'}")
         print(f"[fla-npu build][OK] ASCEND_OPP_PATH={os.getenv('ASCEND_OPP_PATH') or '<unset>'}")
         print(f"[fla-npu build][OK] CANN version: {_detect_cann_version()}")
+        if cann_public_version:
+            print(f"[fla-npu build][OK] CANN public version: {cann_public_version}")
 
     if sys.version_info < MIN_PYTHON:
         failures.append(
@@ -239,6 +269,7 @@ def _check_build_environment():
     if triton_ascend_version:
         print(f"[fla-npu build][OK] triton-ascend: {triton_ascend_version}")
         _check_min_version(failures, "triton-ascend", triton_ascend_version, MIN_TRITON_ASCEND)
+        _check_triton_ascend_cann_compat(failures, triton_ascend_version, cann_public_version)
     else:
         failures.append("triton-ascend distribution was not found")
 

--- a/setup.py
+++ b/setup.py
@@ -133,17 +133,14 @@ def _detect_cann_public_version():
     return ""
 
 
-def _check_triton_ascend_a5_compat(failures, actual, cann_public_version):
+def _check_triton_ascend_a5_compat(failures, actual):
     soc = os.getenv("FLA_NPU_SOC", DEFAULT_SOC)
     if soc != "ascend950":
         return
     actual_version = _version_obj(actual)
     if actual_version is None or actual_version < Version(MIN_TRITON_ASCEND_A5):
-        detail = f"FLA_NPU_SOC={soc}"
-        if cann_public_version:
-            detail += f" with CANN {cann_public_version}"
         failures.append(
-            f"triton-ascend>={MIN_TRITON_ASCEND_A5} is required for {detail}; got {actual}. "
+            f"triton-ascend>={MIN_TRITON_ASCEND_A5} is required for FLA_NPU_SOC={soc}; got {actual}. "
             "triton-ascend 3.2.0 can crash on the A5 Triton runtime."
         )
 
@@ -269,7 +266,7 @@ def _check_build_environment():
     if triton_ascend_version:
         print(f"[fla-npu build][OK] triton-ascend: {triton_ascend_version}")
         _check_min_version(failures, "triton-ascend", triton_ascend_version, MIN_TRITON_ASCEND)
-        _check_triton_ascend_a5_compat(failures, triton_ascend_version, cann_public_version)
+        _check_triton_ascend_a5_compat(failures, triton_ascend_version)
     else:
         failures.append("triton-ascend distribution was not found")
 

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py
@@ -24,6 +24,7 @@ _ASCENDC_OPS = (
     "npu_chunk_fwd_o",
     "npu_chunk_gated_delta_rule_fwd_h",
     "npu_recompute_w_u_fwd",
+    "npu_solve_tri",
 )
 
 BACKWARD_OPS = {

--- a/torch_custom/fla_npu/fla_npu/ops/triton/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/ops/triton/__init__.py
@@ -13,17 +13,25 @@ from fla.ops.triton.triton_core.cumsum import (
 )
 from fla.ops.triton.triton_core.l2norm import L2Norm, l2norm, l2norm_bwd, l2norm_fwd
 from fla.ops.triton.triton_core.solve_tril_fast import solve_tril_npu
+from fla.ops.triton.triton_core.utils import (
+    autocast_custom_bwd,
+    autocast_custom_fwd,
+    input_guard,
+)
 
 causal_conv1d = causal_conv1d_triton
 solve_tril = solve_tril_npu
 
 __all__ = [
     "L2Norm",
+    "autocast_custom_bwd",
+    "autocast_custom_fwd",
     "causal_conv1d",
     "causal_conv1d_triton",
     "chunk_local_cumsum",
     "chunk_local_cumsum_scalar",
     "chunk_scaled_dot_kkt_fwd",
+    "input_guard",
     "l2norm",
     "l2norm_bwd",
     "l2norm_fwd",

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 #include <cstdint>
+#include <cstdlib>
+#include <dlfcn.h>
 #include <string>
 #include <vector>
 #include <torch/library.h>
@@ -26,6 +28,33 @@ using npu_preparation = at_npu::native::OpPreparation;
 using namespace op_plugin::utils;
 using namespace op_infer;
 
+namespace {
+void* GetEmbeddedOpApiHandler()
+{
+    const char* opApiLib = std::getenv("FLA_NPU_OP_API_LIB");
+    if (opApiLib == nullptr || opApiLib[0] == '\0') {
+        return nullptr;
+    }
+    return dlopen(opApiLib, RTLD_LAZY | RTLD_GLOBAL);
+}
+
+void* GetEmbeddedOpApiFuncAddr(const char* apiName)
+{
+    static void* handler = GetEmbeddedOpApiHandler();
+    if (handler == nullptr) {
+        return nullptr;
+    }
+    return dlsym(handler, apiName);
+}
+}  // namespace
+
+void* GetOpApiFuncAddr(const char* apiName)
+{
+    if (auto funcAddr = GetEmbeddedOpApiFuncAddr(apiName)) {
+        return funcAddr;
+    }
+    return op_plugin::utils::GetOpApiFuncAddr(apiName);
+}
 
 ::std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor> npu_prepare_wy_repr_bwd_full(const at::Tensor & k, const at::Tensor & v, const at::Tensor & beta, const at::Tensor & A, const at::Tensor & dA, const at::Tensor & dw, const at::Tensor & du, const at::Tensor & g, int64_t chunk_size, at::OptionalIntArrayRef cu_seqlens, at::OptionalIntArrayRef chunk_indices)
 {

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -48,13 +48,35 @@ void* GetEmbeddedOpApiFuncAddr(const char* apiName)
 }
 }  // namespace
 
-void* GetOpApiFuncAddr(const char* apiName)
+void* GetFlaNpuOpApiFuncAddr(const char* apiName)
 {
     if (auto funcAddr = GetEmbeddedOpApiFuncAddr(apiName)) {
         return funcAddr;
     }
-    return op_plugin::utils::GetOpApiFuncAddr(apiName);
+    return ::GetOpApiFuncAddr(apiName);
 }
+
+void GetFlaNpuApiFunc(
+    const char* apiName,
+    const char* workspaceApiName,
+    void*& opApiFuncAddr,
+    void*& getWorkspaceSizeFuncAddr)
+{
+    if (opApiFuncAddr != nullptr && getWorkspaceSizeFuncAddr != nullptr) {
+        return;
+    }
+    void* embeddedOpApiFuncAddr = GetEmbeddedOpApiFuncAddr(apiName);
+    void* embeddedWorkspaceSizeFuncAddr = GetEmbeddedOpApiFuncAddr(workspaceApiName);
+    if (embeddedOpApiFuncAddr != nullptr && embeddedWorkspaceSizeFuncAddr != nullptr) {
+        opApiFuncAddr = embeddedOpApiFuncAddr;
+        getWorkspaceSizeFuncAddr = embeddedWorkspaceSizeFuncAddr;
+        return;
+    }
+    ::GetApiFunc(apiName, workspaceApiName, opApiFuncAddr, getWorkspaceSizeFuncAddr);
+}
+
+#define GetOpApiFuncAddr GetFlaNpuOpApiFuncAddr
+#define GetApiFunc GetFlaNpuApiFunc
 
 ::std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor> npu_prepare_wy_repr_bwd_full(const at::Tensor & k, const at::Tensor & v, const at::Tensor & beta, const at::Tensor & A, const at::Tensor & dA, const at::Tensor & dw, const at::Tensor & du, const at::Tensor & g, int64_t chunk_size, at::OptionalIntArrayRef cu_seqlens, at::OptionalIntArrayRef chunk_indices)
 {


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: #144
- 背景与目标: v26.6.0 的 GDN example 需要在 AscendC `npu_solve_tri` 不可用时自动回退到 Triton `solve_tril_npu`，保证 A5 环境可以继续执行 example smoke。
- 本 PR 解决的问题:
  - example 对 `npu_solve_tri` 做运行时能力探查，可用时优先使用 AscendC 实现，不可用或真实调用失败时回退到 Triton。
  - 修复 Triton `solve_tril_npu` 在 CANN 9 / A5 环境中对 `tl.insert_slice`、`tl.extract_slice` 的兼容问题，并降低 fallback block，避免 UB 超限。
  - wheel 运行时优先解析包内 `libcust_opapi.so`，找不到再回退到 `torch_npu` 默认 opapi resolver。
  - CANN 9 / A5 预检要求 `triton-ascend>=3.2.1`。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: `npu_solve_tri`、`solve_tril_npu`、GDN example 调用链
- 涉及目录 / 文件:
  - `examples/flash_gated_delta_rule.py`
  - `fla/ops/triton/triton_core/solve_tril_fast.py`
  - `torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp`
  - `common/include/fallback/fallback.h`
  - `setup.py`
  - `scripts/check_npu_env.py`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [x] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [x] `Triton` 算子
  - [ ] 单算子测试
  - [x] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
  - 不新增 AscendC `solve_tri` 的 SoC 支持范围。
  - `solve_tril_npu` fallback 保持原有支持范围，用于 AscendC `npu_solve_tri` 不可用时的 example 兜底。
- 明确不包含的范围:
  - 不 backport A5 AscendC `solve_tri` kernel。
  - 不改变 `npu_recompute_w_u_fwd`、GDN fwd/bwd 的公开接口。
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [x] 是，请说明影响面、兼容策略和回归范围: 影响 wheel opapi 符号解析和 `solve_tril_npu` fallback 实现；通过小规格 accuracy smoke 覆盖 AscendC 优先路径和 Triton fallback 路径。
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 不涉及 ABI 变更；仅调整运行时符号解析、依赖预检和 example 内部调度。

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本: CANN 9.x
- 产品 / 芯片类型: A5 / `ascend950`
- 机器或 CI 链接: 本地验证

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 未执行 | 本 PR 未 backport AscendC `solve_tri` kernel；等待 CI 覆盖 |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 未执行 | 本 PR 未 backport AscendC `solve_tri` kernel；等待 CI 覆盖 |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 未执行 | 等待 CI 覆盖 |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 未执行 | 等待 CI 覆盖 |
| A5 | `ascend950` | CANN 9.x | `python -m py_compile examples/flash_gated_delta_rule.py fla/ops/triton/triton_core/solve_tril_fast.py setup.py scripts/check_npu_env.py` | 通过 | 语法检查通过 |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 未执行 | 等待 CI 覆盖 |
| A3 | `ascend910_93` |  | 未执行 | 等待 CI 覆盖 |
| A5 | `ascend950` | `python examples/flash_gated_delta_rule.py --case-name wheel_accuracy_fp16_a5_x86_auto_solve_tri --device 0 --batch 1 --query-heads 1 --value-heads 1 --tokens 128 --key-dim 128 --value-dim 128 --chunk-size 64 --scale 0.03125 --seed 42 --dtype fp16 --no-varlen --qk-l2norm --accuracy-check --accuracy-force-regenerate --accuracy-tensors o` | 通过 | AscendC 优先路径 accuracy check 通过 |
| A5 | `ascend950` | 强制禁用 AscendC `npu_solve_tri` 后执行同规格 accuracy check | 通过 | Triton `solve_tril_npu` fallback 路径 accuracy check 通过 |

- 精度对比: A5 小规格 `o` 输出 `finite=True`，`allclose=True`，cosine 满足阈值。
- 性能对比: 未做性能对比；fallback 目标是可用性兜底。
- 边界 / 异常场景: 覆盖 AscendC `npu_solve_tri` 可用路径，以及 `npu_solve_tri` 不可用时的 Triton fallback 路径。
- 未覆盖风险: A2 / A3 编译和完整 Example ST 待 CI 覆盖。

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 等待 CI 覆盖 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 等待 CI 覆盖 |
| A5 | `ascend950` | `python examples/flash_gated_delta_rule.py --case-name wheel_accuracy_fp16_a5_x86_auto_solve_tri --device 0 --batch 1 --query-heads 1 --value-heads 1 --tokens 128 --key-dim 128 --value-dim 128 --chunk-size 64 --scale 0.03125 --seed 42 --dtype fp16 --no-varlen --qk-l2norm --accuracy-check --accuracy-force-regenerate --accuracy-tensors o` | 通过 | AscendC 优先路径 accuracy check 通过 |
| A5 | `ascend950` | 强制禁用 AscendC `npu_solve_tri` 后执行同规格 accuracy check | 通过 | Triton fallback 路径 accuracy check 通过 |

- 端到端场景说明: 覆盖 GDN example 中 `chunk_scaled_dot_kkt_fwd -> solve_tri_auto -> recompute_w_u -> fwd_h -> fwd_o` 的前向 accuracy smoke。
- 与本 PR 修改算子的关联: 验证 `solve_tri_auto` 在 AscendC 可用和不可用两种情况下均可生成后续 `recompute_w_u` 需要的 `A`。
- 未覆盖原因及补充计划: 全量 Example ST 和多产品编译待 NPU CI 覆盖。

</details>

## 兼容性、风险与回退

- 兼容性说明:
  - 不改变公开 API 和 ABI。
  - AscendC `npu_solve_tri` 可用时仍优先使用 AscendC；不可用时回退到 Triton。
  - CANN 9 / A5 环境要求 `triton-ascend>=3.2.1`。
- 风险点:
  - Triton fallback 主要用于可用性兜底，性能可能低于 AscendC 实现。
  - A2 / A3 完整回归需要 CI 补充覆盖。
- 回退方案: 回退本 PR 后恢复原有硬调用 AscendC `npu_solve_tri` 的行为。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

本 PR 不将 A5 AscendC `solve_tri` kernel 作为 v26.6.0 需求 backport；仅在 example 中根据运行时能力自动选择 AscendC 或 Triton 实现。
