### PR TITLE
build: speed up multi-soc wheel packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ source /usr/local/Ascend/ascend-toolkit/set_env.sh
 FLA_NPU_SOC=ascend910b python -m pip wheel --no-build-isolation --no-deps . -w dist
 ```
 
+如果需要在同一套 Python、PyTorch、torch-npu、C++ ABI 和 CPU 架构下连续构建多个 SoC wheel，可以使用批量脚本：
+
+```sh
+python scripts/build_multi_soc_wheels.py --soc ascend910b,ascend910_93,ascend950 --jobs 16 -w dist
+```
+
+批量脚本会让第一颗 SoC 完整编译 `torch_custom` 适配扩展，后续 SoC 只复用同一个 `custom_aclnn_extension_lib*.so`；AscendC OPP run 包仍会按每颗 SoC 独立重编并内嵌到各自 wheel 中，脚本也会检查 wheel 内只有目标 SoC 的 kernel config、且包含内嵌 `libcust_opapi.so`。如果 A2/A3 需要基于 CANN 8.5.2，而 A5 需要基于 CANN 9.0.0 及以上，请在对应 CANN 环境中分开执行批量命令，不要把 CANN 要求不同的 SoC 放到同一次构建里。
+
 如果已经做过一次完整编译，之后只修改少量算子源码，可以复用上一次 CMake build 目录做完整 wheel 的真增量构建：
 
 ```sh
@@ -60,10 +68,12 @@ FLA_NPU_SOC=ascend910b FLA_NPU_INCREMENTAL_BUILD=1 python -m pip wheel --no-buil
 | 环境变量 | 可选范围 | 作用 / 建议 | 默认 |
 |---|---|---|---|
 | `FLA_NPU_SOC` | `ascend910b` / `ascend910_93` / `ascend950` | 目标芯片；按实际运行机器选择 | `ascend910b` |
+| `FLA_NPU_BUILD_JOBS` | 正整数，如 `16` | 传递给底层 `build.sh -jN`，控制 AscendC OPP 编译并发 | 空，使用 `build.sh` 默认值 |
 | `FLA_NPU_INCREMENTAL_BUILD` | `TRUE` / `FALSE` | 复用 `build/` 做完整 wheel 的真增量构建；本地反复调试可设 `TRUE`，release wheel 或干净验证建议保持 `FALSE` | `FALSE` |
 | `FLA_NPU_OPS` | 逗号分隔的算子名，如 `chunk_fwd_o,recompute_wu_fwd` | 仅构建指定算子；用于单算子定位，不要用于 release wheel | 空 |
 | `FLA_NPU_SKIP_RUN_BUILD` | `TRUE` / `FALSE` | 跳过 run 包编译；仅在已准备好匹配的 `build_out/fla-npu-*.run` 且只重打 wheel 时可设 `TRUE`，常规构建建议保持 `FALSE` | `FALSE` |
 | `FLA_NPU_SKIP_RUN_INSTALL` | `TRUE` / `FALSE` | 跳过将 run 包安装产物内嵌到 wheel；会得到不含内嵌 OPP 的 wheel，除非使用外部 OPP 调试，否则建议保持 `FALSE` | `FALSE` |
+| `FLA_NPU_REUSE_TORCH_CUSTOM_SO` | `custom_aclnn_extension_lib*.so` 路径 | 复用已有 `torch_custom` 扩展，仅适合同一 Python ABI、PyTorch、torch-npu、C++ ABI、CPU 架构和源码版本；常规多 SoC 构建优先使用 `scripts/build_multi_soc_wheels.py` 自动管理 | 空 |
 | `FLA_NPU_DISABLE_LOCAL_VERSION` | `TRUE` / `FALSE` | wheel 版本号不追加 SOC/torch/ABI 本地版本；内部统一发版需要固定版本号时可设 `TRUE`，日常构建建议保持 `FALSE` 以区分产物兼容范围 | `FALSE` |
 
 布尔变量设为 `TRUE` 时也接受 `1`、`YES`、`ON`；未设置或其他值按 `FALSE` 处理。

--- a/scripts/build_multi_soc_wheels.py
+++ b/scripts/build_multi_soc_wheels.py
@@ -1,0 +1,358 @@
+"""Build multiple FLA NPU wheels while reusing the torch_custom extension.
+
+The AscendC OPP payload is rebuilt for every SoC. Only the torch_custom Python
+extension is reused, and only after the first full wheel build produces it for
+the current Python ABI, torch, torch_npu, source tree, and CPU architecture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from fla_npu_artifacts import get_arch, get_branch_name, get_commit_id  # noqa: E402
+
+
+DEFAULT_SOCS = ("ascend910b", "ascend910_93", "ascend950")
+IGNORED_SOURCE_PATTERNS = (
+    ".git",
+    ".ci-cache",
+    ".history",
+    "__pycache__",
+    "*.pyc",
+    "cmake-build-*",
+)
+IGNORED_SOURCE_PATHS = (
+    "build",
+    "build_out",
+    "dist",
+    "output",
+    "torch_custom/fla_npu/build",
+    "torch_custom/fla_npu/dist",
+    "torch_custom/fla_npu/fla_npu.egg-info",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--soc",
+        action="append",
+        default=[],
+        help=(
+            "Target SoC. May be passed multiple times or as a comma-separated list. "
+            "Default: ascend910b,ascend910_93,ascend950."
+        ),
+    )
+    parser.add_argument("-w", "--wheel-dir", default="dist", help="Output wheel directory.")
+    parser.add_argument(
+        "--work-dir",
+        default="build/multi_soc_wheels",
+        help="Temporary isolated source/cache directory under build/. It is recreated by default.",
+    )
+    parser.add_argument(
+        "--keep-work-dir",
+        action="store_true",
+        help="Keep the temporary isolated source directories after the build.",
+    )
+    parser.add_argument(
+        "--jobs",
+        type=int,
+        default=None,
+        help="Forward FLA_NPU_BUILD_JOBS to setup.py, which calls build.sh -jN.",
+    )
+    parser.add_argument(
+        "--python",
+        default=sys.executable,
+        help="Python executable used for pip wheel. Default: current interpreter.",
+    )
+    parser.add_argument(
+        "--no-reuse-torch-custom",
+        action="store_true",
+        help="Build torch_custom from scratch for every SoC.",
+    )
+    parser.add_argument(
+        "--reuse-torch-custom-so",
+        default="",
+        help="Use an existing custom_aclnn_extension_lib*.so instead of building the first one.",
+    )
+    return parser.parse_args()
+
+
+def split_socs(values: list[str]) -> list[str]:
+    socs: list[str] = []
+    for value in values:
+        socs.extend(part.strip() for part in value.split(",") if part.strip())
+    return socs or list(DEFAULT_SOCS)
+
+
+def canonical_soc_dir(soc: str) -> str:
+    compact = re.sub(r"[^A-Za-z0-9]+", "", soc).lower()
+    if compact in {"910b", "ascend910b"}:
+        return "ascend910b"
+    if compact in {"a3", "91093", "ascend91093"}:
+        return "ascend910_93"
+    if compact in {"950", "ascend950"}:
+        return "ascend950"
+    return soc
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def run(cmd: list[str], cwd: Path, env: dict[str, str]) -> None:
+    printable = " ".join(cmd)
+    print(f"[multi-soc wheel] START {printable}", flush=True)
+    start = time.monotonic()
+    subprocess.run(cmd, cwd=str(cwd), env=env, check=True)
+    print(f"[multi-soc wheel] DONE in {time.monotonic() - start:.1f}s: {printable}", flush=True)
+
+
+def output(cmd: list[str], cwd: Path, env: dict[str, str]) -> str:
+    return subprocess.check_output(cmd, cwd=str(cwd), env=env, encoding="utf-8").strip()
+
+
+def python_extension_suffix(python: str, cwd: Path, env: dict[str, str]) -> str:
+    code = "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX') or '.so')"
+    return output([python, "-c", code], cwd, env)
+
+
+def validate_reuse_so(path: Path, python: str, cwd: Path, env: dict[str, str]) -> Path:
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file():
+        raise RuntimeError(f"--reuse-torch-custom-so does not point to a file: {resolved}")
+    if not resolved.name.startswith("custom_aclnn_extension_lib"):
+        raise RuntimeError(
+            "--reuse-torch-custom-so must point to custom_aclnn_extension_lib*.so, "
+            f"got {resolved.name}"
+        )
+    expected_suffix = python_extension_suffix(python, cwd, env)
+    if not resolved.name.endswith(expected_suffix):
+        raise RuntimeError(
+            "--reuse-torch-custom-so Python ABI or architecture does not match this build. "
+            f"Expected suffix {expected_suffix!r}, got {resolved.name!r}."
+        )
+    if resolved.stat().st_size <= 0:
+        raise RuntimeError(f"--reuse-torch-custom-so is empty: {resolved}")
+    return resolved
+
+
+def safe_rmtree(path: Path, repo_root: Path) -> None:
+    resolved = path.resolve()
+    build_root = (repo_root / "build").resolve()
+    if resolved == build_root or build_root not in resolved.parents:
+        raise RuntimeError(f"Refusing to remove work dir outside {build_root}: {resolved}")
+    if resolved.exists():
+        shutil.rmtree(resolved)
+
+
+def copy_source(repo_root: Path, dst: Path) -> None:
+    root = repo_root.resolve()
+    ignored_paths = set(IGNORED_SOURCE_PATHS)
+
+    def ignore(src: str, names: list[str]) -> set[str]:
+        src_path = Path(src).resolve()
+        try:
+            rel_dir = src_path.relative_to(root)
+        except ValueError:
+            rel_dir = Path()
+
+        ignored: set[str] = set()
+        for name in names:
+            rel_path = name if rel_dir == Path(".") else (rel_dir / name).as_posix()
+            if rel_path in ignored_paths:
+                ignored.add(name)
+                continue
+            if any(fnmatch.fnmatch(name, pattern) for pattern in IGNORED_SOURCE_PATTERNS):
+                ignored.add(name)
+        return ignored
+
+    shutil.copytree(repo_root, dst, ignore=ignore)
+
+
+def build_env(repo_root: Path, soc: str, args: argparse.Namespace, reuse_so: Path | None) -> dict[str, str]:
+    env = os.environ.copy()
+    env["FLA_NPU_SOC"] = soc
+    env.setdefault("FLA_NPU_ARCH", get_arch())
+    env.setdefault("FLA_NPU_BRANCH_NAME", get_branch_name(repo_root))
+    env.setdefault("FLA_NPU_COMMIT_ID", get_commit_id(repo_root))
+    if args.jobs is not None:
+        if args.jobs <= 0:
+            raise RuntimeError(f"--jobs must be positive, got {args.jobs}")
+        env["FLA_NPU_BUILD_JOBS"] = str(args.jobs)
+    if reuse_so:
+        # The reused extension is a host-side torch_custom adapter. It is only
+        # safe within one Python ABI / torch / torch_npu / C++ ABI / CPU arch
+        # combination; each wheel still rebuilds and embeds its own SoC OPP.
+        env["FLA_NPU_REUSE_TORCH_CUSTOM_SO"] = str(reuse_so.resolve())
+    else:
+        env.pop("FLA_NPU_REUSE_TORCH_CUSTOM_SO", None)
+    return env
+
+
+def expected_wheel_name(src: Path, python: str, env: dict[str, str]) -> str:
+    return output([python, "scripts/fla_npu_artifacts.py", "wheel-filename"], src, env)
+
+
+def find_single_torch_custom_so(src: Path) -> Path:
+    package_dir = src / "torch_custom" / "fla_npu" / "fla_npu"
+    so_files = sorted(package_dir.glob("custom_aclnn_extension_lib*.so"))
+    if len(so_files) != 1:
+        raise RuntimeError(f"Expected one torch_custom extension under {package_dir}, got {len(so_files)}")
+    return so_files[0]
+
+
+def inspect_wheel(wheel: Path, expected_soc_dir: str, expected_so_hash: str | None) -> str:
+    with zipfile.ZipFile(wheel) as zf:
+        names = zf.namelist()
+        so_names = [
+            name
+            for name in names
+            if name.endswith(".so") and "custom_aclnn_extension_lib" in name
+        ]
+        if len(so_names) != 1:
+            raise RuntimeError(f"{wheel.name}: expected one torch_custom extension, got {len(so_names)}")
+        so_hash = hashlib.sha256(zf.read(so_names[0])).hexdigest()
+        if expected_so_hash and so_hash != expected_so_hash:
+            raise RuntimeError(
+                f"{wheel.name}: reused torch_custom hash mismatch, "
+                f"expected {expected_so_hash}, got {so_hash}"
+            )
+
+        joined_names = "\n".join(names)
+        soc_dirs = sorted(set(re.findall(r"op_impl/ai_core/tbe/kernel/config/([^/]+)/", joined_names)))
+        if soc_dirs != [expected_soc_dir]:
+            raise RuntimeError(
+                f"{wheel.name}: expected only SoC config dir {expected_soc_dir}, got {soc_dirs}"
+            )
+
+        opapi_libs = [name for name in names if name.endswith("op_api/lib/libcust_opapi.so")]
+        if len(opapi_libs) != 1:
+            raise RuntimeError(f"{wheel.name}: expected one embedded libcust_opapi.so, got {len(opapi_libs)}")
+
+    print(
+        f"[multi-soc wheel][OK] {wheel.name}: "
+        f"torch_custom_sha256={so_hash}, soc_config={expected_soc_dir}, libcust_opapi=1"
+    )
+    return so_hash
+
+
+def build_one(
+    repo_root: Path,
+    work_dir: Path,
+    wheel_dir: Path,
+    cache_dir: Path,
+    soc: str,
+    args: argparse.Namespace,
+    reuse_so: Path | None,
+    expected_so_hash: str | None,
+) -> tuple[Path, Path, str, int]:
+    src = work_dir / f"src_{canonical_soc_dir(soc)}"
+    if src.exists():
+        shutil.rmtree(src)
+    copy_source(repo_root, src)
+
+    env = build_env(repo_root, soc, args, reuse_so)
+    expected_name = expected_wheel_name(src, args.python, env)
+    wheel_path = wheel_dir / expected_name
+    if wheel_path.exists():
+        wheel_path.unlink()
+
+    start = time.monotonic()
+    run(
+        [args.python, "-m", "pip", "wheel", ".", "-w", str(wheel_dir), "--no-build-isolation", "--no-deps"],
+        src,
+        env,
+    )
+    elapsed = int(time.monotonic() - start)
+    if not wheel_path.is_file():
+        raise RuntimeError(f"Expected wheel was not produced: {wheel_path}")
+
+    built_so = find_single_torch_custom_so(src)
+    if reuse_so is None and not args.no_reuse_torch_custom:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cached_so = cache_dir / built_so.name
+        shutil.copy2(built_so, cached_so)
+    else:
+        cached_so = reuse_so or built_so
+
+    expected_hash_for_wheel = None if args.no_reuse_torch_custom else expected_so_hash
+    so_hash = inspect_wheel(wheel_path, canonical_soc_dir(soc), expected_hash_for_wheel)
+    if expected_so_hash is None and not args.no_reuse_torch_custom:
+        expected_so_hash = so_hash
+
+    return wheel_path, cached_so, expected_so_hash, elapsed
+
+
+def main() -> int:
+    args = parse_args()
+    if args.no_reuse_torch_custom and args.reuse_torch_custom_so:
+        raise RuntimeError("--no-reuse-torch-custom cannot be used with --reuse-torch-custom-so")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    wheel_dir = (repo_root / args.wheel_dir).resolve()
+    work_dir = (repo_root / args.work_dir).resolve()
+    cache_dir = work_dir / "torch_custom_cache"
+    socs = split_socs(args.soc)
+
+    wheel_dir.mkdir(parents=True, exist_ok=True)
+    if not args.keep_work_dir:
+        safe_rmtree(work_dir, repo_root)
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    reuse_so = (
+        validate_reuse_so(Path(args.reuse_torch_custom_so), args.python, repo_root, os.environ.copy())
+        if args.reuse_torch_custom_so
+        else None
+    )
+    expected_so_hash = sha256_file(reuse_so) if reuse_so else None
+    produced: list[tuple[str, Path, int]] = []
+
+    try:
+        for index, soc in enumerate(socs):
+            # First build produces the torch_custom extension from source; later
+            # SoCs reuse that exact .so while setup.py still rebuilds the SoC OPP
+            # run package. Use --no-reuse-torch-custom for compatibility probes.
+            current_reuse = None if (args.no_reuse_torch_custom or (index == 0 and reuse_so is None)) else reuse_so
+            wheel_path, cached_so, expected_so_hash, elapsed = build_one(
+                repo_root,
+                work_dir,
+                wheel_dir,
+                cache_dir,
+                soc,
+                args,
+                current_reuse,
+                expected_so_hash,
+            )
+            produced.append((soc, wheel_path, elapsed))
+            if reuse_so is None and not args.no_reuse_torch_custom:
+                reuse_so = cached_so
+                expected_so_hash = sha256_file(reuse_so)
+                print(f"[multi-soc wheel] Cached torch_custom extension at {reuse_so}")
+    finally:
+        if not args.keep_work_dir:
+            safe_rmtree(work_dir, repo_root)
+
+    print("[multi-soc wheel] Produced wheels:")
+    for soc, wheel_path, elapsed in produced:
+        print(f"  {soc}: {wheel_path.name} ({elapsed}s, sha256={sha256_file(wheel_path)})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,16 @@
 import importlib
 from importlib import metadata as importlib_metadata
 import importlib.util
+import hashlib
 import os
 import shutil
 import stat
 import subprocess
 import sys
+import sysconfig
 import re
 import time
+from contextlib import contextmanager
 from pathlib import Path
 
 from packaging.version import InvalidVersion, Version
@@ -77,6 +80,89 @@ def _read_requirements():
 
 def _env_flag(name):
     return os.getenv(name, "FALSE").upper() in {"1", "TRUE", "YES", "ON"}
+
+
+def _env_value(name):
+    return os.getenv(name, "").strip()
+
+
+def _build_jobs_arg():
+    jobs = _env_value("FLA_NPU_BUILD_JOBS")
+    if not jobs:
+        return []
+    if not re.fullmatch(r"[1-9]\d*", jobs):
+        raise RuntimeError(f"FLA_NPU_BUILD_JOBS must be a positive integer, got {jobs!r}")
+    return [f"-j{jobs}"]
+
+
+def _reuse_torch_extension_path():
+    value = _env_value("FLA_NPU_REUSE_TORCH_CUSTOM_SO")
+    return Path(value).expanduser().resolve() if value else None
+
+
+def _torch_extension_suffix():
+    return sysconfig.get_config_var("EXT_SUFFIX") or ".so"
+
+
+def _sha256_file(path):
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_fast_npu_smi_shim():
+    shim_dir = REPO_ROOT / "build" / ".fla_npu_build_tools"
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    shim = shim_dir / "npu-smi"
+    # Only shadow `npu-smi info`. Other subcommands are forwarded to the real
+    # binary where possible so build helpers that expect npu-smi still behave normally.
+    shim.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'if [ "${1:-}" = "info" ]; then',
+                "  exit 1",
+                "fi",
+                "for candidate in /usr/local/Ascend/driver/tools/npu-smi /usr/local/bin/npu-smi /usr/bin/npu-smi /usr/sbin/npu-smi /bin/npu-smi; do",
+                '  if [ -x "${candidate}" ] && [ "${candidate}" != "$0" ]; then',
+                '    exec "${candidate}" "$@"',
+                "  fi",
+                "done",
+                "exit 1",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IXUSR)
+    return shim_dir
+
+
+def _torch_build_env():
+    env = os.environ.copy()
+    env.setdefault("TORCH_DEVICE_BACKEND_AUTOLOAD", "0")
+    if os.name != "nt":
+        # Build-only workaround: triton-ascend probes `npu-smi info` during import.
+        # Some compile hosts can hang there until its 100s timeout even though PCI
+        # probing has already identified the target SoC. Keep the probe fast here
+        # without changing runtime imports from the installed wheel.
+        shim_dir = _write_fast_npu_smi_shim()
+        env["PATH"] = f"{shim_dir}:{env.get('PATH', '')}"
+    return env
+
+
+@contextmanager
+def _temporary_environ(env):
+    previous = os.environ.copy()
+    os.environ.clear()
+    os.environ.update(env)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(previous)
 
 
 def _run(cmd, cwd, env=None):
@@ -224,49 +310,58 @@ def _check_build_environment():
     else:
         print(f"[fla-npu build][OK] Python: {sys.version.split()[0]}")
 
-    torch = None
-    torch_npu = None
-    for module in ("torch", "torch_npu"):
-        try:
-            loaded = importlib.import_module(module)
-            print(f"[fla-npu build][OK] {module}: {getattr(loaded, '__version__', '<unknown>')}")
-            if module == "torch":
-                torch = loaded
-            else:
-                torch_npu = loaded
-        except Exception as exc:
-            failures.append(f"{module}: {exc}")
-
-    if torch is not None:
-        _check_min_version(failures, "torch", getattr(torch, "__version__", ""), MIN_TORCH)
-    if torch_npu is not None:
-        _check_torch_npu_gdn_fix(failures, getattr(torch_npu, "__version__", ""))
-
-    triton_ascend_version = _distribution_version("triton-ascend")
-    try:
-        triton = importlib.import_module("triton")
-        print(f"[fla-npu build][OK] triton: {getattr(triton, '__file__', '<unknown>')}")
-    except Exception as exc:
-        failures.append(f"triton: {exc}")
-
-    if triton_ascend_version:
-        print(f"[fla-npu build][OK] triton-ascend: {triton_ascend_version}")
-        _check_min_version(failures, "triton-ascend", triton_ascend_version, MIN_TRITON_ASCEND)
-        _check_triton_ascend_a5_compat(failures, triton_ascend_version)
-    else:
-        failures.append("triton-ascend distribution was not found")
-
-    if not _env_flag("FLA_NPU_SKIP_TORCH_GEN"):
-        for module in TORCHNPUGEN_MODULES:
+    reuse_torch_extension = _reuse_torch_extension_path()
+    build_env = _torch_build_env()
+    with _temporary_environ(build_env):
+        torch = None
+        torch_npu = None
+        for module in ("torch", "torch_npu"):
             try:
-                spec = importlib.util.find_spec(module)
+                loaded = importlib.import_module(module)
+                print(f"[fla-npu build][OK] {module}: {getattr(loaded, '__version__', '<unknown>')}")
+                if module == "torch":
+                    torch = loaded
+                else:
+                    torch_npu = loaded
             except Exception as exc:
                 failures.append(f"{module}: {exc}")
-                continue
-            if spec is None:
-                failures.append(f"{module}: not found")
-            else:
-                print(f"[fla-npu build][OK] {module}: {spec.origin or 'namespace package'}")
+
+        if torch is not None:
+            _check_min_version(failures, "torch", getattr(torch, "__version__", ""), MIN_TORCH)
+        if torch_npu is not None:
+            _check_torch_npu_gdn_fix(failures, getattr(torch_npu, "__version__", ""))
+
+        triton_ascend_version = _distribution_version("triton-ascend")
+        try:
+            triton = importlib.import_module("triton")
+            print(f"[fla-npu build][OK] triton: {getattr(triton, '__file__', '<unknown>')}")
+        except Exception as exc:
+            failures.append(f"triton: {exc}")
+
+        if triton_ascend_version:
+            print(f"[fla-npu build][OK] triton-ascend: {triton_ascend_version}")
+            _check_min_version(failures, "triton-ascend", triton_ascend_version, MIN_TRITON_ASCEND)
+            _check_triton_ascend_a5_compat(failures, triton_ascend_version)
+        else:
+            failures.append("triton-ascend distribution was not found")
+
+        if not _env_flag("FLA_NPU_SKIP_TORCH_GEN") and not reuse_torch_extension:
+            for module in TORCHNPUGEN_MODULES:
+                try:
+                    spec = importlib.util.find_spec(module)
+                except Exception as exc:
+                    failures.append(f"{module}: {exc}")
+                    continue
+                if spec is None:
+                    failures.append(f"{module}: not found")
+                else:
+                    print(f"[fla-npu build][OK] {module}: {spec.origin or 'namespace package'}")
+
+    build_jobs = _build_jobs_arg()
+    if build_jobs:
+        print(f"[fla-npu build][OK] FLA_NPU_BUILD_JOBS={build_jobs[0][2:]}")
+    if reuse_torch_extension:
+        print(f"[fla-npu build][OK] FLA_NPU_REUSE_TORCH_CUSTOM_SO={reuse_torch_extension}")
 
     print(f"[fla-npu build][OK] FLA_NPU_SOC={os.getenv('FLA_NPU_SOC', DEFAULT_SOC)}")
     print(f"[fla-npu build][OK] FLA NPU vendor={DEFAULT_VENDOR_NAME}")
@@ -334,6 +429,7 @@ def _build_run_package():
             "--pkg",
             f"--vendor_name={DEFAULT_VENDOR_NAME}",
         ]
+        cmd.extend(_build_jobs_arg())
         if incremental:
             cmd.append("--incremental")
         if ops_filter:
@@ -491,8 +587,13 @@ def _stage_run_package(run_file, opp_root):
 
 
 def _build_torch_extension_inplace():
+    reuse_so = _reuse_torch_extension_path()
+    if reuse_so:
+        _reuse_torch_extension_inplace(reuse_so)
+        return
+
     if not _env_flag("FLA_NPU_SKIP_TORCH_GEN"):
-        _run(["bash", "gen.sh", "npu_custom.yaml"], TORCH_EXTENSION_DIR)
+        _run(["bash", "gen.sh", "npu_custom.yaml"], TORCH_EXTENSION_DIR, env=_torch_build_env())
 
     build_dir = TORCH_EXTENSION_DIR / "build"
     if build_dir.exists():
@@ -500,7 +601,11 @@ def _build_torch_extension_inplace():
     for so_file in FLA_NPU_PACKAGE_DIR.glob("custom_aclnn_extension_lib*.so"):
         so_file.unlink()
 
-    _run([sys.executable, "setup.py", "build_ext", "--force", "--inplace"], TORCH_EXTENSION_DIR)
+    _run(
+        [sys.executable, "setup.py", "build_ext", "--force", "--inplace"],
+        TORCH_EXTENSION_DIR,
+        env=_torch_build_env(),
+    )
 
     so_files = sorted(FLA_NPU_PACKAGE_DIR.glob("custom_aclnn_extension_lib*.so"))
     if not so_files:
@@ -508,6 +613,58 @@ def _build_torch_extension_inplace():
             "custom_aclnn_extension_lib*.so was not produced under "
             f"{FLA_NPU_PACKAGE_DIR}"
         )
+
+
+def _validate_torch_extension_so(so_file):
+    so_file = Path(so_file).resolve()
+    expected_suffix = _torch_extension_suffix()
+    if not so_file.is_file():
+        raise RuntimeError(f"FLA_NPU_REUSE_TORCH_CUSTOM_SO does not point to a file: {so_file}")
+    if not so_file.name.startswith("custom_aclnn_extension_lib"):
+        raise RuntimeError(
+            "FLA_NPU_REUSE_TORCH_CUSTOM_SO must point to custom_aclnn_extension_lib*.so, "
+            f"got {so_file.name}"
+        )
+    if not so_file.name.endswith(expected_suffix):
+        raise RuntimeError(
+            "FLA_NPU_REUSE_TORCH_CUSTOM_SO Python ABI or architecture does not match this build. "
+            f"Expected suffix {expected_suffix!r}, got {so_file.name!r}."
+        )
+    if so_file.stat().st_size <= 0:
+        raise RuntimeError(f"FLA_NPU_REUSE_TORCH_CUSTOM_SO is empty: {so_file}")
+    return so_file
+
+
+def _clear_torch_extension_so(exclude=None):
+    exclude = Path(exclude).resolve() if exclude else None
+    for so_file in FLA_NPU_PACKAGE_DIR.glob("custom_aclnn_extension_lib*.so"):
+        resolved = so_file.resolve()
+        if exclude and resolved == exclude:
+            continue
+        so_file.unlink()
+
+
+def _reuse_torch_extension_inplace(source_so):
+    source_so = _validate_torch_extension_so(source_so)
+    target_so = FLA_NPU_PACKAGE_DIR / source_so.name
+    FLA_NPU_PACKAGE_DIR.mkdir(parents=True, exist_ok=True)
+
+    if source_so.resolve() == target_so.resolve():
+        _clear_torch_extension_so(exclude=source_so)
+    else:
+        _clear_torch_extension_so()
+        shutil.copy2(source_so, target_so)
+
+    so_files = sorted(FLA_NPU_PACKAGE_DIR.glob("custom_aclnn_extension_lib*.so"))
+    if len(so_files) != 1:
+        raise RuntimeError(
+            "Expected exactly one reused custom_aclnn_extension_lib*.so under "
+            f"{FLA_NPU_PACKAGE_DIR}, got {len(so_files)}"
+        )
+    print(
+        "[fla-npu build] Reused torch_custom extension "
+        f"{source_so} -> {so_files[0]} (sha256={_sha256_file(so_files[0])})"
+    )
 
 
 _EXTERNAL_BUILD_DONE = False


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: https://github.com/flashserve/flash-linear-attention-npu/issues/147
- 背景与目标: 支持 A2 / A3 / A5 多 SoC wheel 一键批量构建，并缩短重复构建耗时。
- 本 PR 解决的问题:
  - 新增多 SoC wheel 批量构建脚本，自动复用同一环境下的 `torch_custom` 扩展。
  - 每颗 SoC 仍独立重编并内嵌 AscendC OPP run 包，避免复用错误的 SoC 产物。
  - 构建期规避 `npu-smi info` 探测卡顿，不影响 wheel 安装后的运行时导入行为。

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: 不涉及具体算子实现修改
- 涉及目录 / 文件: `setup.py`, `scripts/build_multi_soc_wheels.py`, `README.md`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不涉及算子输入输出、shape、dtype、format 支持范围变化
- 明确不包含的范围: 不修改 AscendC / Triton 算子实现；不改变安装后 runtime 调用路径；不跨 Python ABI、PyTorch、torch_npu、C++ ABI 或 CPU 架构复用 `torch_custom` 扩展
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无。不改变算子 ABI；`torch_custom` 复用仅用于同一 host 兼容组合下的构建加速。

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops= --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops= --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops= --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops= --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops= --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_.py # 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh  # 不传  时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

## 修改算子测试

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | `python scripts/build_multi_soc_wheels.py --jobs 16 -w dist` | 未执行 | 本 PR 未修改算子实现；待 CI 或 release 构建补充 aarch64 / CANN 8.5 环境验证 |
| A3 | `ascend910_93` | 未执行 | `python scripts/build_multi_soc_wheels.py --jobs 16 -w dist` | 未执行 | 本 PR 未修改算子实现；待 CI 或 release 构建补充 aarch64 / CANN 8.5 环境验证 |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | CANN 9.x | `python scripts/build_multi_soc_wheels.py --jobs 16 -w dist` | 通过 | 生成 `910b.x86_64-py3-none-any.whl`；单包耗时 113s；wheel 内 SoC config 和 `libcust_opapi.so` 校验通过 |
| A3 | `ascend910_93` | CANN 9.x | `python scripts/build_multi_soc_wheels.py --jobs 16 -w dist` | 通过 | 生成 `910_93.x86_64-py3-none-any.whl`；单包耗时 87s；复用 `torch_custom` hash 校验通过 |
| A5 | `ascend950` | CANN 9.x | `python scripts/build_multi_soc_wheels.py --jobs 16 -w dist` | 通过 | 生成 `950.x86_64-py3-none-any.whl`；单包耗时 95s；复用 `torch_custom` hash 校验通过 |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 不涉及 | 未执行 | 本 PR 未修改算子计算逻辑 |
| A3 | `ascend910_93` | 不涉及 | 未执行 | 本 PR 未修改算子计算逻辑 |
| A5 | `ascend950` | 不涉及 | 未执行 | 本 PR 未修改算子计算逻辑 |

- 精度对比: 不涉及算子精度变更
- 性能对比: 构建耗时验证通过；x86_64 A2/A3/A5 三包总耗时 297s，后续包复用 `torch_custom` 成功
- 边界 / 异常场景: 验证默认导入链路在 `npu-smi info` 卡顿场景会超时；构建期环境规避后 `torch` / `torch_npu` / `torchnpugen` 导入通过，且 A5 PCI 探测仍可识别
- 未覆盖风险: 尚未在所有 CANN / CPU 架构组合上跑全量 release 矩阵；多 SoC 复用仅限同一 Python ABI、PyTorch、torch_npu、C++ ABI、CPU 架构和源码版本

## 整体 Example ST 验证

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 本 PR 仅修改构建打包流程，待 NPU CI 验证 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 本 PR 仅修改构建打包流程，待 NPU CI 验证 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 本 PR 仅修改构建打包流程，待 NPU CI 验证 |

- 端到端场景说明: 不涉及 example 逻辑变更
- 与本 PR 修改算子的关联: 不涉及算子实现；需确认打包后的 wheel 不破坏运行时加载
- 未覆盖原因及补充计划: PR 创建后触发 `/run-npu-ci quick` 补充 Example ST 验证

## 兼容性、风险与回退

- 兼容性说明:
  - 新增批量构建脚本，不改变原有 `pip wheel`、`build.sh --pkg`、增量编译入口。
  - `FLA_NPU_REUSE_TORCH_CUSTOM_SO` 会校验扩展文件名和 Python 扩展后缀；README 明确其兼容边界。
  - 构建期 `npu-smi info` shim 只作用于 setup.py 的 build 子进程，不进入 wheel 运行时环境。
- 风险点:
  - 不能跨 Python ABI、PyTorch、torch_npu、C++ ABI、CPU 架构或源码版本复用 `torch_custom` 扩展。
  - A2/A3 与 A5 如果依赖不同 CANN 版本，应在对应 CANN 环境中分开构建。
- 回退方案: 回退本 PR 后恢复每个 SoC 独立执行 `pip wheel` 的原流程。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

评审重点:

- `scripts/build_multi_soc_wheels.py` 只复用 host 侧 `torch_custom` 扩展；AscendC OPP run 包仍按每个 SoC 单独构建并校验。
- `setup.py` 中的 `npu-smi info` shim 只用于构建期 import 加速，目的是规避部分环境中 `triton-ascend` 导入阶段等待 `npu-smi info` 超时；安装后的 wheel 不会携带该 shim。
- 原有单 SoC `pip wheel`、`build.sh --pkg`、增量构建方式仍可使用。

