### PR TITLE
fix: 修复 v26.6.0 chunk_bwd_dv_local GVA-FIX4 超时

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_common.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_common.h
@@ -27,6 +27,8 @@ constexpr uint64_t SYNC_AIV_AIC_FLAG_1 = 1;
 constexpr uint64_t SYNC_AIV_AIC_FLAG_2 = 2;
 constexpr uint64_t SYNC_AIC_AIV_FLAG_3 = 3;
 constexpr uint64_t SYNC_AIC_AIV_FLAG_4 = 4;
+constexpr uint64_t SYNC_AIV_AIC_GATED_READY_FLAG = SYNC_AIV_AIC_FLAG_1;
+constexpr uint64_t SYNC_AIC_AIV_GATED_FREE_FLAG = SYNC_AIC_AIV_FLAG_4;
 
 __aicore__ inline int64_t CeilDiv(int64_t dividend, int64_t divisor)
 {

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_cube.h
@@ -26,6 +26,7 @@
 #include "catlass/gemm/gemm_type.hpp"
 #include "catlass/layout/layout.hpp"
 #include "catlass/status.hpp"
+#include "catlass/arch/cross_core_sync.hpp"
 #include "tla/layout.hpp"
 #include "tla/tensor.hpp"
 using _128 = tla::Int<128>;
@@ -54,6 +55,8 @@ template <typename QKVT, typename GT, typename Strategy, int V>
 class ChunkBwdDvLocalCube {
 private:
     Strategy strategy;
+    Catlass::Arch::CrossCoreFlagWithReverse<> aivToAicGatedReadyFlag{
+        SYNC_AIV_AIC_GATED_READY_FLAG, SYNC_AIC_AIV_GATED_FREE_FLAG};
 
 public:
     __aicore__ inline ChunkBwdDvLocalCube(const Strategy &s) : strategy(s)
@@ -163,7 +166,7 @@ __aicore__ inline void ChunkBwdDvLocalCube<QKVT, GT, Strategy, V>::Process()
                 int64_t qkHead = scheduleIdx - p1SlotNum;
                 if (qkHead < H_qk) {
                     for (int64_t doGroup = 0; doGroup < hRatio; doGroup++) {
-                        AscendC::CrossCoreWaitFlag(SYNC_AIV_AIC_FLAG_1);
+                        Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_FIX>(aivToAicGatedReadyFlag);
                     }
                     BlockMmadV blockMmadV(resource);
                     for (int64_t doGroup = 0; doGroup < hRatio; doGroup++) {

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_vector.h
@@ -16,6 +16,8 @@
 #define CHUNK_BWD_DV_LOCAL_VECTOR_H
 
 #include "chunk_bwd_dv_local_struct.h"
+#include "chunk_bwd_dv_local_common.h"
+#include "catlass/arch/cross_core_sync.hpp"
 #include "kernel_operator.h"
 
 namespace GDN {
@@ -24,6 +26,8 @@ template <typename QKVT, typename GT, typename Strategy>
 class ChunkBwdDvLocalVector {
 private:
     Strategy strategy;
+    Catlass::Arch::CrossCoreFlagWithReverse<> aivToAicGatedReadyFlag{
+        SYNC_AIV_AIC_GATED_READY_FLAG, SYNC_AIC_AIV_GATED_FREE_FLAG};
 
 public:
     __aicore__ inline ChunkBwdDvLocalVector(const Strategy &s) : strategy(s)
@@ -200,7 +204,7 @@ __aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessChunk(c
             if (doHead % hRatio == 0) {
                 AscendC::CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_3);
             }
-            AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_1);
+            Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(aivToAicGatedReadyFlag);
             continue;
         }
         int64_t baseGOffset = indexResult.curBatchId * H_do * T + doHead * T + indexResult.curTokenId;
@@ -320,7 +324,7 @@ __aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessChunk(c
         AscendC::DataCopy(workspaceGm[taskOffset], kqOutLocalTensor, taskLineNum * strategy.chunkSize);
 
         kqTQueOut.FreeTensor(kqOutLocalTensor);
-        AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_1);
+        Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(aivToAicGatedReadyFlag);
     }
 }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/tests/test.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/tests/test.py
@@ -593,6 +593,8 @@ if __name__ == "__main__":
     test_chunk_bwd_dv_local_fix(B=2, H_qk=4, T=512, K=128, V=256, chunk_size=64, scale=0.0625, ktype=torch.bfloat16, gtype=torch.bfloat16, h_ratio=2, case_name="GVA_F4")
     # GVA-F5: h_ratio=2, H_qk=8, H_do=16, float16
     test_chunk_bwd_dv_local_fix(B=2, H_qk=8, T=1024, K=128, V=128, chunk_size=64, scale=0.0625, ktype=torch.float16, gtype=torch.float16, h_ratio=2, case_name="GVA_F5")
+    # GVA-FIX4: h_ratio=32, H_qk=2, H_do=64, short T, V=256, fp16/fp32 gate
+    test_chunk_bwd_dv_local_fix(B=176, H_qk=2, T=24, K=128, V=256, chunk_size=64, scale=0.0625, ktype=torch.float16, gtype=torch.float32, h_ratio=32, case_name="GVA-FIX4")
     # GVA-V1: h_ratio=2, variable length
     test_chunk_bwd_dv_local_variable(B=1, H_qk=4, T=512, K=128, V=128, chunk_size=64, scale=0.0625, cu_seqlens_len=4, ktype=torch.bfloat16, gtype=torch.bfloat16, h_ratio=2, case_name="GVA_V1")
     # GVA-V2: h_ratio=4, variable length


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: #155
- 背景与目标: 将 `chunk_bwd_dv_local` GVA-FIX4 超时修复同步到 `v26.6.0` 分支。
- 本 PR 解决的问题: AIV 到 AIC gated ready 使用单向跨核 flag 时，连续 ready 信号可能积压；改为带 reverse/free ack 的双向握手，避免超时。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: `chunk_bwd_dv_local`
- 涉及目录 / 文件:
  - `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_common.h`
  - `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_cube.h`
  - `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_vector.h`
  - `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/tests/test.py`
- 责任人 / 提交人: @chen-linxin
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不改变接口和支持范围；新增覆盖 GVA-FIX4 回归场景。
- 明确不包含的范围: 不修改启动核数，不调整 tiling，不修改 README，不修改接口定义。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 不涉及 ABI 变更。

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

本 PR 为同一修复同步到 `v26.6.0` 分支。cherry-pick 干净通过，已执行 PR diff 空白检查。

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.x | `bash build.sh --pkg --soc=ascend910b --ops=chunk_bwd_dv_local` | 通过 | 同一修复在主 PR 分支已验证通过 |
| A3 | `ascend910_93` |  |  | 未执行 | 本次未覆盖 |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.x | `bash build.sh --pkg --soc=ascend910b --vendor_name=custom` | 通过 | 同一修复在主 PR 分支已验证通过 |
| A3 | `ascend910_93` |  |  | 未执行 | 本次未覆盖 |
| A5 | `ascend950` |  |  | 未执行 | 本次未覆盖 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/tests/test.py` | 通过 | 同一修复在主 PR 分支已验证：GVA-FIX4 通过；单算子全量 30 条结果全部通过 |
| A3 | `ascend910_93` |  | 未执行 | 本次未覆盖 |
| A5 | `ascend950` |  | 未执行 | 本次未覆盖 |

- 精度对比: 同一修复在主 PR 分支已完成 GVA-FIX4 和单算子全量验证。
- 性能对比: 未单独执行性能对比。
- 边界 / 异常场景: 新增 `h_ratio=32`、`H_qk=2`、`V=256`、fp16/fp32 gate 回归用例。
- 未覆盖风险: 本 PR 分支未重复执行完整单算子验证；A3/A5 未在本轮覆盖。

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未通过 | 同一修复在主 PR 分支执行时，`case1_current_default` 在前向阶段 AICore 异常，未进入本 PR 修改的 backward 算子 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 本次未覆盖 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 本次未覆盖 |

- 端到端场景说明: 默认 Example/ST 用例。
- 与本 PR 修改算子的关联: 该用例包含 backward 流程，但已知失败发生在前向同步点，尚未进入 `chunk_bwd_dv_local`。
- 未覆盖原因及补充计划: 前向阶段异常需另行定位后再补充完整 Example/ST 通过结果。

</details>

## 兼容性、风险与回退

- 兼容性说明: 不改变接口、shape 支持范围或 ABI。
- 风险点: 新增跨核 reverse/free ack 使用现有 flag，需要关注后续与其他同步协议的 flag 分配一致性。
- 回退方案: 回退本 PR 提交即可恢复原 AIV->AIC 单向 ready 同步。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

本 PR 为 #156 的 `v26.6.0` 同步 PR，复用 Issue #155。README 未纳入本次改动。
