### PR TITLE
fix(dqkwg): 修复 A5 L0C 到 UB 行主序配置编译失败

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
@@ -19,6 +19,11 @@
  #include "chunk_bwd_dqkwg_common.h"
  #include "catlass/arch/arch.hpp"
  #include "catlass/catlass.hpp"
+ namespace Catlass::Gemm::Tile {
+#if !defined(__NPU_ARCH__) || (__NPU_ARCH__ != 3510)
+ constexpr AscendC::FixpipeConfig CFG_ROW_MAJOR_UB = {AscendC::CO2Layout::ROW_MAJOR, true};
+#endif
+ } // namespace Catlass::Gemm::Tile
  #include "catlass/gemm/block/block_mmad.hpp"
  #include "catlass/gemm/block/block_swizzle.hpp"
  #include "catlass/gemm/device/device_gemm.hpp"


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

按仓库合入门禁要求执行；如需 NPU CI，请由具备权限的维护者按仓库流程触发。

## 关联 Issue / 背景

- 关联 Issue: 无，当前为直接修复 A5 包编译失败问题。
- 背景与目标: `chunk_bwd_dqkwg` 的 A5 (`ascend950`) 编译路径会进入 CATLASS A5 L0C 到 UB copy 逻辑，该路径需要 row-major UB fixpipe 配置。
- 本 PR 解决的问题: 在 `chunk_bwd_dqkwg` 算子私有编译单元内补齐 `CFG_ROW_MAJOR_UB` 兼容定义，不修改公共 helper 或 CMake 配置，修复 A5 包编译失败。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: `chunk_bwd_dqkwg`
- 涉及目录 / 文件:
  - `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h`
- 责任人 / 提交人: @ZhangYi2026
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不改变既有输入、输出、shape、dtype 或 format 支持范围。
- 明确不包含的范围: 不包含公共 helper、CMake 配置、算子接口、tiling 策略、安装验证、精度验证或性能验证。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要检视通过
- ABI 不兼容风险说明: 不涉及 ABI 变更。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

执行 A5 包编译验证；本次未执行安装、精度、性能和整体 ST 验证。

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  |  | 未执行 | 本次仅验证 A5 包编译 |
| A3 | `ascend910_93` |  |  | 未执行 | 本次仅验证 A5 包编译 |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  |  | 未执行 | 本次仅验证 A5 包编译 |
| A3 | `ascend910_93` |  |  | 未执行 | 本次仅验证 A5 包编译 |
| A5 | `ascend950` | CANN 9.0 及以上 | `bash build.sh --pkg --ops=chunk_bwd_dqkwg --soc=ascend950 -j4` | 通过 | 生成 `.run` 包；未发现编译错误或失败 |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 未执行 | 本次仅验证 A5 包编译 |
| A3 | `ascend910_93` |  | 未执行 | 本次仅验证 A5 包编译 |
| A5 | `ascend950` |  | 未执行 | 本次仅验证 A5 包编译，未执行精度测试 |

- 精度对比: 未执行。
- 性能对比: 未执行。
- 边界 / 异常场景: 未执行。
- 未覆盖风险: 仍需由后续 CI 或人工验证覆盖 A2 / A3 编译、单算子精度、性能和整体 ST。

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 未执行 | 本次仅验证 A5 包编译 |
| A3 | `ascend910_93` |  | 未执行 | 本次仅验证 A5 包编译 |
| A5 | `ascend950` |  | 未执行 | 本次仅验证 A5 包编译 |

- 端到端场景说明: 未执行。
- 与本 PR 修改算子的关联: 本 PR 修复 `chunk_bwd_dqkwg` A5 包编译失败，整体 ST 待后续补充。
- 未覆盖原因及补充计划: 本次按修复范围仅完成编译验证；后续由 CI 或人工验证补齐。

</details>

## 兼容性、风险与回退

- 兼容性说明: 不改变公开接口和运行时语义；兼容定义限制在 `chunk_bwd_dqkwg` 算子私有头文件的 A5 编译路径内。
- 风险点: 该修复只覆盖 A5 包编译失败，未覆盖安装、精度、性能和整体 ST。
- 回退方案: 回退本 PR 单提交即可恢复原行为。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

本 PR 只包含 `chunk_bwd_dqkwg` A5 编译修复相关的最小改动。