### PR TITLE
gdn_op

### DIFF
--- a/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d/op_host/causal_conv1d_tiling_validation.h
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d/op_host/causal_conv1d_tiling_validation.h
@@ -78,6 +78,28 @@ inline ge::graphStatus ValidateAlignedDim(gert::TilingContext *context, int64_t 
     return ge::GRAPH_SUCCESS;
 }
 
+inline ge::graphStatus CheckQslInfo(gert::TilingContext *context, bool &qslAbsent, int64_t &qslSize)
+{
+    auto qslShapePtr = context->GetOptionalInputShape(QUERY_START_LOC_INDEX);
+    const gert::CompileTimeTensorDesc *qslDesc = context->GetOptionalInputDesc(QUERY_START_LOC_INDEX);
+    if (qslShapePtr != nullptr) {
+        const auto qslStorageShape = qslShapePtr->GetStorageShape();
+        const int64_t qslDimNum = qslStorageShape.GetDimNum();
+        qslAbsent = (qslDimNum == 0) || (qslDimNum == 1 && qslStorageShape.GetDim(0) <= 0);
+        if (!qslAbsent) {
+            auto qslShape = EnsureNotScalar(qslStorageShape);
+            OP_CHECK_IF(qslShape.GetDimNum() != 1, OP_LOGE(context, "queryStartLoc must be 1D"),
+                        return ge::GRAPH_FAILED);
+            qslSize = qslShape.GetDim(0);
+            OP_CHECK_IF(qslSize < 1, OP_LOGE(context, "queryStartLoc.size must be >= 1"), return ge::GRAPH_FAILED);
+            OP_CHECK_NULL_WITH_CONTEXT(context, qslDesc);
+            OP_CHECK_IF(qslDesc->GetDataType() != ge::DT_INT64, OP_LOGE(context, "queryStartLoc dtype must be int64"),
+                        return ge::GRAPH_FAILED);
+        }
+    }
+    return ge::GRAPH_SUCCESS;
+}
+
 inline ge::graphStatus GetShapeDtypeInfo(gert::TilingContext *context, const CausalConv1dAttrInfo &attrInfo,
                                          CausalConv1dTilingData &tiling, bool &hasBias)
 {
@@ -97,6 +119,11 @@ inline ge::graphStatus GetShapeDtypeInfo(gert::TilingContext *context, const Cau
     int64_t batch = 0;
     int64_t inputMode = 0;
     int64_t headNum = tiling.headNum;
+
+    bool qslAbsent = true;
+    int64_t qslSize = 0;
+    OP_CHECK_IF(CheckQslInfo(context, qslAbsent, qslSize) != ge::GRAPH_SUCCESS,
+                OP_LOGE(context, "Check queryStartLoc info error"), return ge::GRAPH_FAILED);
 
     if (xShape.GetDimNum() == 2) {
         if (isDecodeMode) {
@@ -124,8 +151,12 @@ inline ge::graphStatus GetShapeDtypeInfo(gert::TilingContext *context, const Cau
                 return ge::GRAPH_FAILED);
         }
     } else if (xShape.GetDimNum() == 3) {
-        inputMode = 1;
         batch = xShape.GetDim(0);
+        if (batch == 1 && !qslAbsent) {
+            inputMode = 0;
+        } else {
+            inputMode = 1;
+        }
         seqLen = xShape.GetDim(1);
         dim = xShape.GetDim(2);
         cuSeqlen = batch * seqLen;
@@ -173,26 +204,6 @@ inline ge::graphStatus GetShapeDtypeInfo(gert::TilingContext *context, const Cau
     OP_CHECK_IF(sDim != dim, OP_LOGE(context, "convStates.shape[2] must equal dim"), return ge::GRAPH_FAILED);
     OP_CHECK_IF(stateLen < (width - 1), OP_LOGE(context, "convStates.shape[1] must be >= width-1"),
                 return ge::GRAPH_FAILED);
-
-    auto qslShapePtr = context->GetOptionalInputShape(QUERY_START_LOC_INDEX);
-    const gert::CompileTimeTensorDesc *qslDesc = context->GetOptionalInputDesc(QUERY_START_LOC_INDEX);
-    bool qslAbsent = true;
-    int64_t qslSize = 0;
-    if (qslShapePtr != nullptr) {
-        const auto qslStorageShape = qslShapePtr->GetStorageShape();
-        const int64_t qslDimNum = qslStorageShape.GetDimNum();
-        qslAbsent = (qslDimNum == 0) || (qslDimNum == 1 && qslStorageShape.GetDim(0) <= 0);
-        if (!qslAbsent) {
-            auto qslShape = EnsureNotScalar(qslStorageShape);
-            OP_CHECK_IF(qslShape.GetDimNum() != 1, OP_LOGE(context, "queryStartLoc must be 1D"),
-                        return ge::GRAPH_FAILED);
-            qslSize = qslShape.GetDim(0);
-            OP_CHECK_IF(qslSize < 1, OP_LOGE(context, "queryStartLoc.size must be >= 1"), return ge::GRAPH_FAILED);
-            OP_CHECK_NULL_WITH_CONTEXT(context, qslDesc);
-            OP_CHECK_IF(qslDesc->GetDataType() != ge::DT_INT64, OP_LOGE(context, "queryStartLoc dtype must be int64"),
-                        return ge::GRAPH_FAILED);
-        }
-    }
 
     if (qslAbsent) {
         OP_CHECK_IF(inputMode == 0, OP_LOGE(context, "queryStartLoc is required in 2D varlen mode (inputMode=0)"),

--- a/torch_custom/fla_npu/fla_npu/ops/gated_delta_net.py
+++ b/torch_custom/fla_npu/fla_npu/ops/gated_delta_net.py
@@ -1,0 +1,794 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+import warnings
+from typing import Dict, Optional
+
+# Large default smoke shapes can exceed Triton-NPU's default launch-grid limit.
+os.environ["TRITON_ALL_BLOCKS_PARALLEL"] = "1"
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import torch
+import torch_npu
+
+from fla.ops.triton.triton_core.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
+from fla.ops.triton.triton_core.cumsum import chunk_local_cumsum
+from fla.ops.triton.triton_core.l2norm import l2norm_bwd, l2norm_fwd
+from fla.ops.triton.triton_core.solve_tril_fast import solve_tril_npu as solve_tril
+from fla.ops.triton.triton_core.utils import (
+    autocast_custom_bwd,
+    autocast_custom_fwd, 
+    input_guard,
+)
+
+
+_disable_compile = getattr(
+    getattr(torch, "compiler", None), "disable", lambda fn: fn
+)
+_DEFAULT_VARLEN_CHUNK_SIZES = (16, 32, 64, 128, 608 * 2)
+
+def cdiv_torch(a, b):
+    return (a + b - 1) // b
+
+def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
+    return cu_seqlens[1:] - cu_seqlens[:-1]
+
+def prepare_chunk_indices(cu_seqlens: torch.LongTensor, chunk_size: int) -> torch.LongTensor:
+    indices = torch.cat(
+        [torch.arange(n) for n in cdiv_torch(prepare_lens(cu_seqlens), chunk_size).tolist()]
+    )
+    return torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(cu_seqlens)
+
+def prepare_chunk_indices_list(cu_seqlens: list[int] | torch.LongTensor, chunk_size: int) -> list[int]:
+    if isinstance(cu_seqlens, torch.Tensor):
+        cu_seqlens = [int(x) for x in cu_seqlens.detach().cpu().tolist()]
+
+    indices: list[int] = []
+    for seq_idx in range(len(cu_seqlens) - 1):
+        length = int(cu_seqlens[seq_idx + 1]) - int(cu_seqlens[seq_idx])
+        if length <= 0:
+            continue
+        for chunk_idx in range((length + chunk_size - 1) // chunk_size):
+            indices.extend([seq_idx, chunk_idx])
+    return indices
+
+def _as_int_list(value: Optional[list[int] | torch.Tensor]) -> Optional[list[int]]:
+    if value is None:
+        return None
+    if isinstance(value, torch.Tensor):
+        return [int(x) for x in value.detach().cpu().flatten().tolist()]
+    return [int(x) for x in value]
+
+def _as_chunk_dict(
+    value: Optional[Dict[str, Optional[torch.LongTensor]] | torch.LongTensor],
+    chunk_size: int,
+) -> Dict[str, Optional[torch.LongTensor]]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    return {str(chunk_size): value}
+
+def _as_chunk_list_dict(
+    value: Optional[Dict[str, Optional[list[int]]] | list[int] | torch.Tensor],
+    chunk_size: int,
+) -> Dict[str, Optional[list[int]]]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return {str(k): _as_int_list(v) for k, v in value.items()}
+    return {str(chunk_size): _as_int_list(value)}
+
+def _next_power_of_2(value: int) -> int:
+    value = max(1, int(value))
+    return 1 << (value - 1).bit_length()
+
+def _cumsum_block_t(g: torch.Tensor, chunk_size: int) -> int:
+    """Keep this aligned with fla.ops.triton.triton_core.cumsum.chunk_local_cumsum_scalar."""
+    h = int(g.shape[-1])
+    return _next_power_of_2((1 << 17) // max(1, h * int(chunk_size)))
+
+def _ensure_varlen_metadata(
+    g: torch.Tensor,
+    cu_seqlens: Optional[torch.LongTensor],
+    cu_seqlens_list: Optional[list[int]],
+    chunk_indices: Optional[Dict[str, Optional[torch.LongTensor]] | torch.LongTensor],
+    chunk_indices_list: Optional[Dict[str, Optional[list[int]]] | list[int] | torch.Tensor],
+    chunk_size: int,
+) -> tuple[
+    Optional[torch.LongTensor],
+    Optional[list[int]],
+    Optional[Dict[str, Optional[torch.LongTensor]]],
+    Optional[Dict[str, Optional[list[int]]]],
+]:
+    if cu_seqlens is None:
+        return None, None, None, None
+
+    cu_seqlens = cu_seqlens.to(device=g.device, dtype=torch.int64)
+    cu_seqlens_list = _as_int_list(cu_seqlens_list) or _as_int_list(cu_seqlens)
+    assert cu_seqlens_list is not None
+
+    tensor_indices = _as_chunk_dict(chunk_indices, chunk_size)
+    list_indices = _as_chunk_list_dict(chunk_indices_list, chunk_size)
+
+    required_sizes = set(_DEFAULT_VARLEN_CHUNK_SIZES)
+    required_sizes.add(int(chunk_size))
+    required_sizes.add(_cumsum_block_t(g, chunk_size))
+
+    for size in required_sizes:
+        key = str(size)
+        if key not in tensor_indices or tensor_indices[key] is None:
+            tensor_indices[key] = prepare_chunk_indices(cu_seqlens, size)
+        if key not in list_indices or list_indices[key] is None:
+            list_indices[key] = prepare_chunk_indices_list(cu_seqlens_list, size)
+    return cu_seqlens, cu_seqlens_list, tensor_indices, list_indices
+
+def _chunk_tensor(
+    chunk_indices: Optional[Dict[str, Optional[torch.LongTensor]]],
+    chunk_size: int,
+) -> Optional[torch.LongTensor]:
+    if chunk_indices is None:
+        return None
+    return chunk_indices.get(str(chunk_size))
+
+def _chunk_list(
+    chunk_indices_list: Optional[Dict[str, Optional[list[int]]]],
+    chunk_size: int,
+) -> Optional[list[int]]:
+    if chunk_indices_list is None:
+        return None
+    return chunk_indices_list.get(str(chunk_size))
+
+def flash_chunk_gated_delta_rule_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: Optional[torch.Tensor],
+    output_final_state: bool,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    cu_seqlens_list: Optional[list[int]] = None,
+    chunk_indices: Optional[Dict[str, Optional[torch.LongTensor]]] = None,
+    chunk_indices_list: Optional[Dict[str, Optional[list[int]]]] = None,
+    chunk_size: int = 64,
+):
+    g = chunk_local_cumsum(
+        g,
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens,
+        chunk_indices_out=chunk_indices,
+        head_first=False,
+    )
+
+    A = chunk_scaled_dot_kkt_fwd(
+        k=k,
+        g=g,
+        beta=beta,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=_chunk_tensor(chunk_indices, chunk_size),
+        chunk_size=chunk_size,
+        output_dtype=torch.float32,
+    )
+
+    A = solve_tril(
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices_out=chunk_indices,
+        output_dtype=k.dtype,
+    )
+
+    g = g.transpose(1, 2).contiguous()
+    beta = beta.transpose(1, 2).contiguous().float()
+    A = A.transpose(1, 2).contiguous()
+
+    w, u = torch.ops.npu.npu_recompute_w_u_fwd(
+        k,
+        v,
+        beta,
+        A,
+        chunk_size,
+        g=g,
+        gk=None,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    h, v_new, final_state = torch.ops.npu.npu_chunk_gated_delta_rule_fwd_h(
+        k,
+        w,
+        u,
+        g=g,
+        gk=None,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        chunk_size=chunk_size,
+        save_new_value=True,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+        use_exp2=False,
+        transpose_state_layout=False,
+    )
+    if not output_final_state:
+        final_state = None
+
+    o = torch.ops.npu.npu_chunk_fwd_o(
+        q,
+        k,
+        v_new,
+        h,
+        scale,
+        g=g,
+        g_gamma=None,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+        chunk_size=chunk_size,
+        transpose_state_layout=False,
+    )
+
+    g = g.transpose(1, 2).contiguous()
+    o = o.transpose(1, 2).contiguous()
+    return g, o, A, final_state
+
+def flash_chunk_gated_delta_rule_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    scale: float,
+    initial_state: Optional[torch.Tensor],
+    do: torch.Tensor,
+    dht: Optional[torch.Tensor],
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    cu_seqlens_list: Optional[list[int]] = None,
+    chunk_indices: Optional[Dict[str, Optional[torch.LongTensor]]] = None,
+    chunk_indices_list: Optional[Dict[str, Optional[list[int]]]] = None,
+    chunk_size: int = 64,
+):
+    g = g.transpose(1, 2).contiguous()
+    beta = beta.transpose(1, 2).contiguous().float()
+
+    w, u = torch.ops.npu.npu_recompute_w_u_fwd(
+        k,
+        v,
+        beta,
+        A,
+        chunk_size,
+        g=g,
+        gk=None,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    do = do.transpose(1, 2).contiguous()
+
+    h, v_new, _ = torch.ops.npu.npu_chunk_gated_delta_rule_fwd_h(
+        k,
+        w,
+        u,
+        g=g,
+        gk=None,
+        initial_state=initial_state,
+        output_final_state=False,
+        chunk_size=chunk_size,
+        save_new_value=True,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+        use_exp2=False,
+        transpose_state_layout=False,
+    )
+
+    dv = torch.ops.npu.npu_chunk_bwd_dv_local(
+        q,
+        k,
+        do,
+        g,
+        scale,
+        chunk_size,
+        g_gamma=None,
+        A=A,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    dh, dh0, dv = torch.ops.npu.npu_chunk_gated_delta_rule_bwd_dhu(
+        q,
+        k,
+        w,
+        do,
+        dv,
+        scale,
+        chunk_size,
+        g=g,
+        gK=None,
+        h0=None,
+        dht=None,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+        use_exp2=False,
+        transpose_state_layout=False,
+    )
+    dh0 = None
+
+    dq, dk, dw, dg = torch.ops.npu.npu_chunk_bwd_dqkwg(
+        q,
+        k,
+        v_new,
+        g,
+        h,
+        do,
+        dh,
+        dv,
+        chunk_size,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+        w=None,
+        g_gamma=None,
+        scale=scale,
+        use_exp2=False,
+        transpose_state_layout=False,
+    )
+
+    dA = torch.ops.npu.npu_prepare_wy_repr_bwd_da(
+        k,
+        v,
+        beta.float(),
+        A,
+        dw,
+        dv,
+        g.float(),
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    dk2, dv, db, dg2 = torch.ops.npu.npu_prepare_wy_repr_bwd_full(
+        k,
+        v,
+        beta,
+        A,
+        dA,
+        dw,
+        dv,
+        g,
+        chunk_size,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    db = db.transpose(1, 2).contiguous()
+    dg2 = dg2.transpose(1, 2).contiguous()
+    dg = dg.transpose(1, 2).contiguous()
+
+    dk.add_(dk2)
+    dg.add_(dg2)
+    if dg.dtype != torch.float32:
+        raise ValueError(f"dg current type is {dg.dtype}, should be float32")
+
+    dg = chunk_local_cumsum(
+        dg,
+        chunk_size=chunk_size,
+        reverse=True,
+        cu_seqlens=cu_seqlens,
+        chunk_indices_out=chunk_indices,
+        head_first=False,
+    )
+
+    return dq, dk, dv, db, dg, dh0
+
+class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
+    @staticmethod
+    @input_guard
+    @autocast_custom_fwd
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        scale: float,
+        initial_state: Optional[torch.Tensor],
+        output_final_state: bool,
+        cu_seqlens: Optional[torch.LongTensor] = None,
+        cu_seqlens_list: Optional[list[int]] = None,
+        chunk_indices: Optional[Dict[str, Optional[torch.LongTensor]]] = None,
+        chunk_indices_list: Optional[Dict[str, Optional[list[int]]]] = None,
+        use_qk_l2norm_in_kernel: bool = False,
+        chunk_size: int = 64,
+    ):
+        if use_qk_l2norm_in_kernel:
+            q, q_rstd = l2norm_fwd(q)
+            k, k_rstd = l2norm_fwd(k)
+        else:
+            q_rstd, k_rstd = None, None
+
+        g, o, A, final_state = flash_chunk_gated_delta_rule_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_list=cu_seqlens_list,
+            chunk_indices=chunk_indices,
+            chunk_indices_list=chunk_indices_list,
+            chunk_size=chunk_size,
+        )
+
+        ctx.save_for_backward(q, k, v, g, beta, A)
+        ctx.q_rstd = q_rstd
+        ctx.k_rstd = k_rstd
+        ctx.initial_state = initial_state
+        ctx.cu_seqlens = cu_seqlens
+        ctx.scale = scale
+        ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
+        ctx.chunk_size = chunk_size
+        ctx.cu_seqlens_list = cu_seqlens_list
+        ctx.chunk_indices = chunk_indices
+        ctx.chunk_indices_list = chunk_indices_list
+        return o.to(q.dtype), final_state
+
+    @staticmethod
+    @input_guard
+    @autocast_custom_bwd
+    def backward(ctx, do: torch.Tensor, dht: Optional[torch.Tensor]):
+        q, k, v, g, beta, A = ctx.saved_tensors
+        dq, dk, dv, db, dg, dh0 = flash_chunk_gated_delta_rule_bwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            A=A,
+            scale=ctx.scale,
+            initial_state=ctx.initial_state,
+            do=do,
+            dht=dht,
+            cu_seqlens=ctx.cu_seqlens,
+            cu_seqlens_list=ctx.cu_seqlens_list,
+            chunk_indices=ctx.chunk_indices,
+            chunk_indices_list=ctx.chunk_indices_list,
+            chunk_size=ctx.chunk_size,
+        )
+        if ctx.use_qk_l2norm_in_kernel:
+            dq = l2norm_bwd(q, ctx.q_rstd, dq)
+            dk = l2norm_bwd(k, ctx.k_rstd, dk)
+        return (
+            dq.to(q),
+            dk.to(k),
+            dv.to(v),
+            dg.to(g),
+            db.to(beta),
+            None,
+            dh0,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+@_disable_compile
+def flash_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    cu_seqlens_list: Optional[list[int]] = None,
+    chunk_indices: Optional[Dict[str, Optional[torch.LongTensor]] | torch.LongTensor] = None,
+    chunk_indices_list: Optional[Dict[str, Optional[list[int]]] | list[int] | torch.Tensor] = None,
+    chunk_size: int = 64,
+    head_first: bool = False,
+):
+    r"""
+    Flash-linear-attention NPU port of xtuner's GDN entry.
+
+    Layout:
+        q, k: [B, H, T, K]
+        v:    [B, H, T, V]
+        g:    [B, T, H]
+        beta: [B, T, H]
+
+    Returns:
+        o: [B, T, H, V]
+        final_state: [N, H, K, V] when output_final_state=True, else None
+    """
+    if q.dtype != k.dtype or k.dtype != v.dtype:
+        raise ValueError(
+            f"q current type is {q.dtype}, k current type is {k.dtype}, "
+            f"v current type is {v.dtype}; they should be equal"
+        )
+    if q.dtype == torch.float32:
+        raise ValueError(
+            "ChunkGatedDeltaRuleFunction does not support float32. "
+            "Please use float16/bfloat16."
+        )
+    if beta.ndim != 3 or g.ndim != 3:
+        raise ValueError("g and beta must be rank-3 tensors with shape [B, T, H].")
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+        raise ValueError("q, k and v must be rank-4 tensors with shape [B, H, T, D].")
+    if q.shape[:3] != k.shape[:3] or q.shape[:3] != v.shape[:3]:
+        raise ValueError(
+            f"q/k/v shape prefixes must match, got {q.shape}, {k.shape}, {v.shape}."
+        )
+    if g.shape != beta.shape:
+        raise ValueError(f"g and beta shapes must match, got {g.shape} and {beta.shape}.")
+    if g.shape[0] != q.shape[0] or g.shape[1] != q.shape[2] or g.shape[2] != q.shape[1]:
+        raise ValueError(
+            "Expected q/k/v in [B, H, T, D] and g/beta in [B, T, H]; "
+            f"got q={tuple(q.shape)}, g={tuple(g.shape)}."
+        )
+
+    if head_first:
+        warnings.warn(
+            "head_first is kept only for API compatibility. "
+            "This NPU port always expects q/k/v as [B, H, T, D].",
+            stacklevel=2,
+        )
+    if chunk_size != 2 ** (chunk_size.bit_length() - 1):
+        raise ValueError(f"chunk_size must be a power of 2, got {chunk_size}.")
+
+    if cu_seqlens is not None:
+        cu_seqlens, cu_seqlens_list, chunk_indices, chunk_indices_list = _ensure_varlen_metadata(
+            g=g,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_list=cu_seqlens_list,
+            chunk_indices=chunk_indices,
+            chunk_indices_list=chunk_indices_list,
+            chunk_size=chunk_size,
+        )
+        if q.shape[0] != 1:
+            raise ValueError(
+                f"The batch size is expected to be 1 rather than {q.shape[0]} when using cu_seqlens. "
+                "Please flatten variable-length inputs before processing."
+            )
+        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens_list) - 1:
+            raise ValueError(
+                "The number of initial states is expected to match the number of input sequences, "
+                f"got initial_state.shape[0]={initial_state.shape[0]} and "
+                f"sequences={len(cu_seqlens_list) - 1}."
+            )
+    else:
+        cu_seqlens_list = None
+        chunk_indices = None
+        chunk_indices_list = None
+
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    o, final_state = ChunkGatedDeltaRuleFunction.apply(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        float(scale),
+        initial_state,
+        output_final_state,
+        cu_seqlens,
+        cu_seqlens_list,
+        chunk_indices,
+        chunk_indices_list,
+        use_qk_l2norm_in_kernel,
+        chunk_size,
+    )
+    return o, final_state
+
+def _gated_rms_norm(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    inp_dtype = x.dtype
+    normed, _ = torch_npu.npu_rms_norm(x.to(inp_dtype), weight.to(inp_dtype), eps)
+    gate_silu = torch_npu.npu_silu(gate.to(inp_dtype))
+    return (normed.float() * gate_silu).to(inp_dtype)
+
+class CausalConv1dFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: Optional[torch.Tensor],
+        conv_states: torch.Tensor,
+        query_start_loc: Optional[list[int]],
+        cache_indices: Optional[list[int]],
+        initial_state_mode: Optional[list[int]],
+        num_accepted_tokens: Optional[list[int]],
+        activation_mode: int,
+        pad_slot_id: int,
+        run_mode: int,
+        head_num: int,
+    ):
+        y = torch.ops.npu.npu_causal_conv1d(
+            x,
+            weight=weight,
+            bias=bias,
+            conv_states=conv_states,
+            query_start_loc=query_start_loc,
+            cache_indices=cache_indices,
+            initial_state_mode=initial_state_mode,
+            num_accepted_tokens=num_accepted_tokens,
+            activation_mode=activation_mode,
+            pad_slot_id=pad_slot_id,
+            run_mode=run_mode,
+            head_num=head_num,
+        )
+        ctx.save_for_backward(x, y, weight)
+        ctx.query_start_loc = query_start_loc
+        ctx.activation_mode = activation_mode
+        ctx.head_num = head_num
+        return y
+
+    @staticmethod
+    def backward(ctx, dy: torch.Tensor):
+        x, y, weight = ctx.saved_tensors
+        input_layout = "BNSD" if ctx.head_num > 0 else "BSND"
+
+        dx, dw, _db, _dh0 = torch.ops.npu.npu_causal_conv1d_bwd(
+            x,
+            y,
+            weight,
+            dy,
+            initial_state=None,
+            dht=None,
+            query_start_loc=ctx.query_start_loc,
+            activation=ctx.activation_mode,
+            input_layout=input_layout,
+        )
+        return dx, dw, None, None, None, None, None, None, None, None, None, None
+
+@_disable_compile
+@input_guard
+def gated_delta_net_op(
+    x: torch.Tensor,
+    *,
+    in_proj_qkv_weight: torch.Tensor,
+    in_proj_z_weight: torch.Tensor,
+    in_proj_b_weight: torch.Tensor,
+    in_proj_a_weight: torch.Tensor,
+    conv_weight: torch.Tensor,
+    norm_weight: torch.Tensor,
+    out_proj_weight: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    num_value_heads: int,
+    num_key_heads: int,
+    key_head_dim: int,
+    value_head_dim: int,
+    conv_kernel_size: int = 4,
+    chunk_size: int = 64,
+    rms_norm_eps: float = 1e-6,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    conv_states: Optional[torch.Tensor] = None,
+    cache_indices: Optional[list[int]] = None,
+) -> torch.Tensor:
+    if num_value_heads % num_key_heads != 0:
+        raise ValueError(
+            f"num_value_heads ({num_value_heads}) must be a multiple of "
+            f"num_key_heads ({num_key_heads})."
+        )
+    if chunk_size & (chunk_size - 1) != 0:
+        raise ValueError(f"chunk_size must be a power of 2, got {chunk_size}.")
+    if x.dim() != 3:
+        raise ValueError(
+            f"gated_delta_net_op expects 3D input [B, T, H], got {tuple(x.shape)}."
+        )
+    if key_head_dim != value_head_dim:
+        raise ValueError(
+            "gated_delta_net_op (NPU) requires key_head_dim == value_head_dim for "
+            "head-first causal-conv1d output. "
+            f"got key_head_dim={key_head_dim}, value_head_dim={value_head_dim}."
+        )
+
+    B, T, _ = x.shape
+    key_dim = num_key_heads * key_head_dim
+    value_dim = num_value_heads * value_head_dim
+    conv_dim = 2 * key_dim + value_dim
+    repeat = num_value_heads // num_key_heads
+
+    if cu_seqlens is not None:
+        if B != 1:
+            raise ValueError(
+                f"gated_delta_net_op in varlen mode requires B=1, got B={B}."
+            )
+        if cu_seqlens.device != x.device:
+            cu_seqlens = cu_seqlens.to(x.device)
+    cu_list = cu_seqlens.detach().tolist() if cu_seqlens is not None else None
+    cu_seqlens_list: Optional[list[int]] = cu_list if cu_list is not None else None
+
+    mixed_qkv = torch.matmul(x, in_proj_qkv_weight.T)
+    z = torch.matmul(x, in_proj_z_weight.T).reshape(B, T, num_value_heads, value_head_dim)
+    b = torch.matmul(x, in_proj_b_weight.T)
+    a = torch.matmul(x, in_proj_a_weight.T)
+
+    if cu_seqlens is not None:
+        n_sequences = int(cu_seqlens.shape[0]) - 1
+        query_start_loc = cu_seqlens.to(torch.int32).tolist()
+    else:
+        n_sequences = B
+        query_start_loc = None
+
+    if conv_states is None:
+        conv_states = x.new_zeros(
+            (n_sequences, conv_kernel_size - 1, conv_dim),
+            dtype=x.dtype,
+        )
+
+    head_num = 2 * num_key_heads + num_value_heads
+
+    if conv_weight.shape[0] >= 16 and conv_weight.shape[1] <= 4 and conv_weight.is_contiguous():
+        warnings.warn(
+            f"npu_causal_conv1d does not support transposed weight shape={tuple(conv_weight.shape)}，"
+            "op need to transpose weight inner, which may cause performance loss",
+            stacklevel=1,
+        )
+        conv_weight = conv_weight.transpose(0, 1)
+
+    mixed_qkv = CausalConv1dFunction.apply(
+        mixed_qkv,
+        conv_weight,
+        None,                # bias
+        conv_states,
+        query_start_loc,
+        cache_indices,
+        None,                # initial_state_mode
+        None,                # num_accepted_tokens
+        1,                   # activation_mode = silu
+        -1,                  # pad_slot_id
+        0,                   # run_mode = prefill
+        head_num,            # >0:head-first 输出,省去 Q/K/V 的后续 transpose
+    )
+
+    q_pre, k_pre, v_pre = mixed_qkv.split(
+        [num_key_heads, num_key_heads, num_value_heads], dim=1,
+    )
+    query = q_pre.contiguous()
+    key = k_pre.contiguous()
+    value = v_pre.contiguous()
+
+    beta = b.sigmoid()
+    g = -A_log.float().exp() * torch.nn.functional.softplus(a.float() + dt_bias)
+
+    if repeat > 1:
+        query = query.repeat_interleave(repeat, dim=1)
+        key = key.repeat_interleave(repeat, dim=1)
+
+    core_attn_out, _ = flash_gated_delta_rule(
+        query, key, value, g=g, beta=beta,
+        output_final_state=False, use_qk_l2norm_in_kernel=True,
+        cu_seqlens=cu_seqlens, cu_seqlens_list=cu_seqlens_list,
+        chunk_indices=None, chunk_indices_list=None,
+        chunk_size=chunk_size,
+    )
+
+    core_flat = core_attn_out.reshape(-1, value_head_dim)
+    z_flat = z.reshape(-1, value_head_dim)
+    norm_out = _gated_rms_norm(core_flat, z_flat, norm_weight, rms_norm_eps)
+    norm_out = norm_out.reshape(B, T, value_dim)
+
+    return torch.matmul(norm_out, out_proj_weight.T)
+
+__all__ = ["gated_delta_net_op"]

--- a/torch_custom/fla_npu/test/test.sh
+++ b/torch_custom/fla_npu/test/test.sh
@@ -106,6 +106,7 @@ run_test "chunk_bwd_dqkwg"                 "python3 test_npu_chunk_bwd_dqkwg.py"
 run_test "gdn_fwd_o"                       "bash run_gdn_fwd_o.sh"
 run_test "gdn_fwd_h"                       "bash run_gdn_fwd_h.sh"
 run_test "recompute_wu_fwd"                "python3 test_npu_recompute_w_u_fwd.py"
+run_test "gdn_op"                          "python3 test_gdn_op.py"
 
 echo ""
 echo "=========================================="

--- a/torch_custom/fla_npu/test/test_gdn_op.py
+++ b/torch_custom/fla_npu/test/test_gdn_op.py
@@ -1,0 +1,235 @@
+"""Smoke test for gated_delta_net_op.
+Usage:
+    python test_gdn_op.py [--device 0] [--dtype bf16]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import torch
+import torch.nn as nn
+
+torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
+torch.npu.set_compile_mode(jit_compile=False)
+
+from fla_npu.ops.gated_delta_net import gated_delta_net_op  # noqa: E402
+
+
+# ════════════════════════════════════════════════════════════════════════════════
+#  Weight bank helper
+# ════════════════════════════════════════════════════════════════════════════════
+
+
+class _GdnWeightBank(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        num_v_heads: int,
+        num_k_heads: int,
+        key_head_dim: int,
+        value_head_dim: int,
+        conv_kernel_size: int = 4,
+    ):
+        super().__init__()
+        self.num_v_heads = num_v_heads
+        self.num_k_heads = num_k_heads
+        self.key_head_dim = key_head_dim
+        self.value_head_dim = value_head_dim
+
+        key_dim = num_k_heads * key_head_dim
+        value_dim = num_v_heads * value_head_dim
+        conv_dim = 2 * key_dim + value_dim
+
+        self.in_proj_qkv_weight = nn.Parameter(torch.empty(conv_dim, hidden_size))
+        self.in_proj_z_weight = nn.Parameter(torch.empty(value_dim, hidden_size))
+        self.in_proj_b_weight = nn.Parameter(torch.empty(num_v_heads, hidden_size))
+        self.in_proj_a_weight = nn.Parameter(torch.empty(num_v_heads, hidden_size))
+        self.conv_weight = nn.Parameter(torch.empty(conv_kernel_size, conv_dim))
+        self.norm_weight = nn.Parameter(torch.ones(value_head_dim))
+        self.out_proj_weight = nn.Parameter(torch.empty(hidden_size, value_dim))
+        self.A_log = nn.Parameter(torch.log(torch.rand(num_v_heads) * 15.99 + 0.01))
+        self.dt_bias = nn.Parameter(torch.ones(num_v_heads))
+
+        self._init_weights()
+
+    def _init_weights(self):
+        for p in (
+            self.in_proj_qkv_weight,
+            self.in_proj_z_weight,
+            self.in_proj_b_weight,
+            self.in_proj_a_weight,
+            self.out_proj_weight,
+        ):
+            nn.init.xavier_uniform_(p)
+        nn.init.kaiming_uniform_(self.conv_weight, a=5**0.5)
+
+
+def _npu_gdn_forward(bank: _GdnWeightBank, x: torch.Tensor, cu_seqlens=None, chunk_size=64) -> torch.Tensor:
+    return gated_delta_net_op(
+        x,
+        in_proj_qkv_weight=bank.in_proj_qkv_weight,
+        in_proj_z_weight=bank.in_proj_z_weight,
+        in_proj_b_weight=bank.in_proj_b_weight,
+        in_proj_a_weight=bank.in_proj_a_weight,
+        conv_weight=bank.conv_weight,
+        norm_weight=bank.norm_weight,
+        out_proj_weight=bank.out_proj_weight,
+        A_log=bank.A_log,
+        dt_bias=bank.dt_bias,
+        num_value_heads=bank.num_v_heads,
+        num_key_heads=bank.num_k_heads,
+        key_head_dim=bank.key_head_dim,
+        value_head_dim=bank.value_head_dim,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+    )
+
+
+# ════════════════════════════════════════════════════════════════════════════════
+#  Smoke tests
+# ════════════════════════════════════════════════════════════════════════════════
+
+
+def _run_case(
+    name: str,
+    hidden_size: int,
+    num_v_heads: int,
+    num_k_heads: int,
+    head_dim: int,
+    T: int,
+    dtype: torch.dtype,
+    cu_seqlens=None,
+    chunk_size: int = 64,
+) -> bool:
+    """单次调用验证:前向输出 finite + 反向梯度 finite。"""
+    print(f"\n=== {name} ===")
+    torch.manual_seed(42)
+
+    bank = _GdnWeightBank(hidden_size, num_v_heads, num_k_heads, head_dim, head_dim)
+    bank = bank.to("npu", dtype=dtype)
+
+    x_npu = torch.randn(1, T, hidden_size, dtype=dtype, device="npu", requires_grad=True)
+
+    # ---- forward ----
+    try:
+        out = _npu_gdn_forward(bank, x_npu, cu_seqlens=cu_seqlens, chunk_size=chunk_size)
+        torch.npu.synchronize()
+    except Exception as e:
+        print(f"  [FAIL] forward raised: {e}")
+        return False
+
+    fwd_finite = torch.isfinite(out.float()).all().item()
+    print(f"  forward: shape={tuple(out.shape)}, finite={fwd_finite}")
+    if not fwd_finite:
+        print("  [FAIL] forward output contains NaN/Inf")
+        return False
+
+    # ---- backward ----
+    try:
+        loss = out.float().square().mean()
+        loss.backward()
+        torch.npu.synchronize()
+    except Exception as e:
+        print(f"  [FAIL] backward raised: {e}")
+        return False
+
+    all_ok = True
+
+    # 检查 x.grad
+    grad = x_npu.grad
+    if grad is None:
+        print("  [FAIL] x.grad is None")
+        all_ok = False
+    else:
+        g_finite = torch.isfinite(grad.float()).all().item()
+        g_norm = grad.float().norm().item()
+        print(f"  x.grad: finite={g_finite}, norm={g_norm:.6f}")
+        all_ok = all_ok and g_finite
+
+    weight_grads = {
+        "in_proj_qkv": bank.in_proj_qkv_weight.grad,
+        "conv": bank.conv_weight.grad,
+        "norm": bank.norm_weight.grad,
+        "out_proj": bank.out_proj_weight.grad,
+        "A_log": bank.A_log.grad,
+        "dt_bias": bank.dt_bias.grad,
+    }
+    for wname, g in weight_grads.items():
+        if g is None:
+            print(f"  [FAIL] {wname}.grad is None")
+            all_ok = False
+        else:
+            g_finite = torch.isfinite(g.float()).all().item()
+            g_norm = g.float().norm().item()
+            print(f"  {wname}.grad: finite={g_finite}, norm={g_norm:.6f}")
+            all_ok = all_ok and g_finite
+
+    status = "PASS" if all_ok else "FAIL"
+    print(f"  [{status}] {name}")
+    return all_ok
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--dtype", choices=["bf16", "fp16"], default="bf16")
+    args = parser.parse_args()
+
+    torch.npu.set_device(args.device)
+    dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float16
+
+    results = {}
+
+    # 1. basic: num_v == num_k
+    results["basic"] = _run_case(
+        "basic (v=k=4, T=64)",
+        hidden_size=64, num_v_heads=4, num_k_heads=4, head_dim=128, T=64,
+        dtype=dtype,
+    )
+
+    # 2. group head: num_v > num_k
+    results["grouped_heads"] = _run_case(
+        "grouped_heads (v=8, k=2, T=64)",
+        hidden_size=128, num_v_heads=8, num_k_heads=2, head_dim=128, T=64,
+        dtype=dtype,
+    )
+
+    # 3. varlen
+    cu_seqlens = torch.tensor([0, 32, 64], dtype=torch.int64, device="npu")
+    results["varlen"] = _run_case(
+        "varlen (cu_seqlens=[0,32,64])",
+        hidden_size=64, num_v_heads=4, num_k_heads=2, head_dim=128, T=64,
+        dtype=dtype, cu_seqlens=cu_seqlens,
+    )
+
+    # 4. fp16
+    if args.dtype == "bf16":
+        results["fp16"] = _run_case(
+            "fp16 (v=k=4, T=64)",
+            hidden_size=64, num_v_heads=4, num_k_heads=4, head_dim=128, T=64,
+            dtype=torch.float16,
+        )
+
+    # ---- summary ----
+    print("\n" + "=" * 60)
+    print("Summary:")
+    all_pass = True
+    for name, ok in results.items():
+        status = "PASS" if ok else "FAIL"
+        print(f"  {name}: {status}")
+        all_pass = all_pass and ok
+
+    print(f"\nOverall: {'ALL PASS' if all_pass else 'SOME FAILED'}")
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @jiangbo96
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
