### PR TITLE
fix: 提升 dqkwg GVA dq/dk 累加精度

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
@@ -236,6 +236,9 @@ ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* contex
     const size_t groupBtbSize = align32(static_cast<size_t>(ringCoreSlots) * groupRingDepth * HV *BT * BT * FP16_SIZE);
     const size_t shortBtbSize = align32(static_cast<size_t>(ringCoreSlots) * adaptiveShortDepth * HV *BT * BT * FP16_SIZE);
     size_t dgLastSize = align32(static_cast<size_t>(ringCoreSlots) * groupRingDepth * HV *FP32_SIZE);
+    const bool gvaMode = HV != HK;
+    const size_t gvaBtxKSize = gvaMode ? align32(static_cast<size_t>(ringCoreSlots) * groupRingDepth * HV * BT * K * FP32_SIZE) : 0;
+    const size_t gvaShortBtxKSize = gvaMode ? align32(static_cast<size_t>(ringCoreSlots) * adaptiveShortDepth * HV * BT * K * FP32_SIZE) : 0;
 
     size_t offset = 0;
     size_t wsDwOffset = offset;
@@ -252,6 +255,12 @@ ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* contex
 
     size_t wsDgLastOffset = offset;
     offset += dgLastSize;
+
+    size_t wsGvaBtxKOffset = offset;
+    offset += gvaBtxKSize;
+
+    size_t wsGvaShortBtxKOffset = offset;
+    offset += gvaShortBtxKSize;
 
     size_t wsMm6Offset = wsDwOffset;
     size_t wsMm7Offset = wsMm5Offset;
@@ -289,6 +298,8 @@ ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* contex
     tilingData.set_wsMm6Offset(wsMm6Offset);
     tilingData.set_wsMm7Offset(wsMm7Offset);
     tilingData.set_wsMul1Offset(wsMul1Offset);
+    tilingData.set_wsGvaBtxKOffset(wsGvaBtxKOffset);
+    tilingData.set_wsGvaShortBtxKOffset(wsGvaShortBtxKOffset);
 
     // 检查是否有 cu_seqlens 输入来判断 IS_VARLEN
     tilingData.set_isVarLen(isVarLen);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.h
@@ -49,6 +49,8 @@ BEGIN_TILING_DATA_DEF(ChunkBwdDqkwgTilingData)
     TILING_DATA_FIELD_DEF(uint64_t, wsMm6Offset);        // PartC: mm6 / GVA D: dk_inner
     TILING_DATA_FIELD_DEF(uint64_t, wsMm7Offset);        // PartD: mm7 复用已释放的 wsMm5
     TILING_DATA_FIELD_DEF(uint64_t, wsMul1Offset);       // independent short BT x BT ring for mul1
+    TILING_DATA_FIELD_DEF(uint64_t, wsGvaBtxKOffset);    // GVA-only fp32 group BT x K ring: dq_inner / mm7
+    TILING_DATA_FIELD_DEF(uint64_t, wsGvaShortBtxKOffset); // GVA-only fp32 short BT x K ring: mm6 / dk_inner
 
     // 其他偏移
     TILING_DATA_FIELD_DEF(uint64_t, totalWorkspaceSize); // 总 workspace 大小

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
@@ -238,6 +238,7 @@ namespace Catlass::Gemm::Kernel {
      * - BlockMmadPart5_: v @ dh -> dk
      * - BlockMmadPart6_: ds @ k -> dq+=
      * - BlockMmadPart7_: ds^T @ q -> dk+=
+     * - BlockMmadPart4/5/6/7Gva_: same C/D outputs, but fp32 C workspace for GVA aggregation
      */
     template <
         class BlockMmadPart1_,  // dv @ h^T -> dw
@@ -246,7 +247,11 @@ namespace Catlass::Gemm::Kernel {
         class BlockMmadPart4_,  // do @ h^T -> dq
         class BlockMmadPart5_,  // v @ dh -> dk
         class BlockMmadPart6_,  // ds @ k -> dq
-        class BlockMmadPart7_   // ds^T @ q -> dk
+        class BlockMmadPart7_,  // ds^T @ q -> dk
+        class BlockMmadPart4Gva_,  // do @ h^T -> dq fp32 workspace
+        class BlockMmadPart5Gva_,  // v @ dh -> dk fp32 workspace
+        class BlockMmadPart6Gva_,  // ds @ k -> dq+= fp32 workspace
+        class BlockMmadPart7Gva_   // ds^T @ q -> dk+= fp32 workspace
     >
     class ChunkBwdDqkwgTla {
     public:
@@ -257,6 +262,10 @@ namespace Catlass::Gemm::Kernel {
         using BlockMmadPart5 = BlockMmadPart5_;
         using BlockMmadPart6 = BlockMmadPart6_;
         using BlockMmadPart7 = BlockMmadPart7_;
+        using BlockMmadPart4Gva = BlockMmadPart4Gva_;
+        using BlockMmadPart5Gva = BlockMmadPart5Gva_;
+        using BlockMmadPart6Gva = BlockMmadPart6Gva_;
+        using BlockMmadPart7Gva = BlockMmadPart7Gva_;
 
         using ArchTag = typename BlockMmadPart1::ArchTag;
 
@@ -303,6 +312,8 @@ namespace Catlass::Gemm::Kernel {
             uint64_t wsDsTempOffset;
             uint64_t wsMm6Offset;
             uint64_t wsMm7Offset;
+            uint64_t wsGvaBtxKOffset;
+            uint64_t wsGvaShortBtxKOffset;
 
             // 形状参数 (GVA: H 拆为 HV/HK, HV = n_ratio * HK)
             uint64_t B;// = CONST_B;
@@ -332,7 +343,7 @@ namespace Catlass::Gemm::Kernel {
                 GM_ADDR workspace,
                 uint64_t B, uint64_t HV, uint64_t HK, uint64_t T, uint64_t K, uint64_t V, uint64_t BT, uint64_t numChunks, uint64_t n_ratio,
                 uint64_t wsDw, uint64_t wsBtxKSlots, uint64_t wsDgLast, uint64_t wsMm5, uint64_t wsDsTemp,
-                uint64_t wsMm6, uint64_t wsMm7,
+                uint64_t wsMm6, uint64_t wsMm7, uint64_t wsGvaBtxK, uint64_t wsGvaShortBtxK,
                 float s, uint64_t isVarLen
             ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
                 ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLens(cu_seqlen), ptrChunkIndices(chunk_indices),
@@ -340,6 +351,7 @@ namespace Catlass::Gemm::Kernel {
                 ptrWorkspace(workspace),
                 wsDwOffset(wsDw), wsBtxKSyncSlotsPerHead(wsBtxKSlots), wsDgLastOffset(wsDgLast),
                 wsMm5Offset(wsMm5), wsDsTempOffset(wsDsTemp), wsMm6Offset(wsMm6), wsMm7Offset(wsMm7),
+                wsGvaBtxKOffset(wsGvaBtxK), wsGvaShortBtxKOffset(wsGvaShortBtxK),
                 scale(s), B(B), HV(HV), HK(HK), T(T), K(K), V(V), BT(BT), numChunks(numChunks), n_ratio(n_ratio), isVarLen(isVarLen) {}
         };
 
@@ -369,6 +381,7 @@ namespace Catlass::Gemm::Kernel {
 
             // Layout 创建
             auto layoutBTxK = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.K);
+            auto layoutBTxKFp32 = LayoutRowMajor::MakeLayout<float>(params.BT, params.K);
             auto layoutKxBT = LayoutColMajor::MakeLayout<ElementA>(params.K, params.BT);
             auto layoutBTxV = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.V);
             auto layoutVxBT = LayoutColMajor::MakeLayout<ElementA>(params.V, params.BT);
@@ -558,26 +571,41 @@ namespace Catlass::Gemm::Kernel {
                         gmDo.SetGlobalBuffer((__gm__ ElementA *)params.ptrDo + doOffset);
                         GlobalTensor<ElementA> gmH;
                         gmH.SetGlobalBuffer((__gm__ ElementA *)params.ptrH + hOffset);
-                        GlobalTensor<ElementC> gmDq;
                         if (gvaMode) {
-                            gmDq.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm5Offset) + dqTempOffset);
+                            GlobalTensor<float> gmDq;
+                            gmDq.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsGvaBtxKOffset) + dqTempOffset);
+
+                            auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                            auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});
+                            auto tensorDq = tla::MakeTensor(gmDq, MakeLayoutFromTag(layoutBTxKFp32), Arch::PositionGM{});
+
+                            auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0),
+                                                          tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                            auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0),
+                                                         tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                            auto tensorBlockDq = GetTile(tensorDq, tla::MakeCoord(0, 0),
+                                                          tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+
+                            BlockMmadPart4Gva blockMmadPart4(resource);
+                            blockMmadPart4(tensorBlockDo, tensorBlockH, tensorBlockDq, actualBlockShape);
                         } else {
+                            GlobalTensor<ElementC> gmDq;
                             gmDq.SetGlobalBuffer((__gm__ ElementC *)params.ptrDq + dqOffset);
+
+                            auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                            auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});
+                            auto tensorDq = tla::MakeTensor(gmDq, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+
+                            auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0),
+                                                          tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                            auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0),
+                                                         tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                            auto tensorBlockDq = GetTile(tensorDq, tla::MakeCoord(0, 0),
+                                                          tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+
+                            BlockMmadPart4 blockMmadPart4(resource);
+                            blockMmadPart4(tensorBlockDo, tensorBlockH, tensorBlockDq, actualBlockShape);
                         }
-
-                        auto tensorDo = tla::MakeTensor(gmDo, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
-                        auto tensorH = tla::MakeTensor(gmH, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});
-                        auto tensorDq = tla::MakeTensor(gmDq, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-
-                        auto tensorBlockDo = GetTile(tensorDo, tla::MakeCoord(0, 0),
-                                                      tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                        auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0),
-                                                     tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                        auto tensorBlockDq = GetTile(tensorDq, tla::MakeCoord(0, 0),
-                                                      tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-
-                        BlockMmadPart4 blockMmadPart4(resource);
-                        blockMmadPart4(tensorBlockDo, tensorBlockH, tensorBlockDq, actualBlockShape);
                     }
                     // --- Part6: mm6 = ds_temp @ k -> wsMm6 (复用 wsDw) ---
                     {
@@ -598,25 +626,44 @@ namespace Catlass::Gemm::Kernel {
                         gmDsTemp.SetGlobalBuffer((__gm__ ElementA *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
                         GlobalTensor<ElementA> gmK;
                         gmK.SetGlobalBuffer((__gm__ ElementA *)params.ptrK + kOffset);
-                        GlobalTensor<ElementC> gmMm6;  // mm6 复用 dw short 环区 (stage C 内消费, 与 dw 同槽)
                         uint64_t mm6RingOffset = DqkwgShortBtxKRingElemOffset(coreIdx, loopIdx, coreNum, h,
                                                                               params.HV, params.BT, params.K,
                                                                               DqkwgShortRingDepthFromGroup((uint32_t)params.wsBtxKSyncSlotsPerHead));
-                        gmMm6.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm6Offset) + mm6RingOffset);
+                        if (gvaMode) {
+                            GlobalTensor<float> gmMm6;
+                            gmMm6.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsGvaShortBtxKOffset) + mm6RingOffset);
 
-                        auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
-                        auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                        auto tensorMm6 = tla::MakeTensor(gmMm6, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                            auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
+                            auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                            auto tensorMm6 = tla::MakeTensor(gmMm6, MakeLayoutFromTag(layoutBTxKFp32), Arch::PositionGM{});
 
-                        auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0),
-                                                          tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                        auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0),
-                                                     tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                        auto tensorBlockMm6 = GetTile(tensorMm6, tla::MakeCoord(0, 0),
-                                                       tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                            auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0),
+                                                              tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                            auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0),
+                                                         tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                            auto tensorBlockMm6 = GetTile(tensorMm6, tla::MakeCoord(0, 0),
+                                                           tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
 
-                        BlockMmadPart6 blockMmadPart6(resource);
-                        blockMmadPart6(tensorBlockDsTemp, tensorBlockK, tensorBlockMm6, actualBlockShape);
+                            BlockMmadPart6Gva blockMmadPart6(resource);
+                            blockMmadPart6(tensorBlockDsTemp, tensorBlockK, tensorBlockMm6, actualBlockShape);
+                        } else {
+                            GlobalTensor<ElementC> gmMm6;  // mm6 复用 dw short 环区 (stage C 内消费, 与 dw 同槽)
+                            gmMm6.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm6Offset) + mm6RingOffset);
+
+                            auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT), Arch::PositionGM{});
+                            auto tensorK = tla::MakeTensor(gmK, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                            auto tensorMm6 = tla::MakeTensor(gmMm6, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+
+                            auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0),
+                                                              tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                            auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0),
+                                                         tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                            auto tensorBlockMm6 = GetTile(tensorMm6, tla::MakeCoord(0, 0),
+                                                           tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+
+                            BlockMmadPart6 blockMmadPart6(resource);
+                            blockMmadPart6(tensorBlockDsTemp, tensorBlockK, tensorBlockMm6, actualBlockShape);
+                        }
                         AscendC::PipeBarrier<PIPE_FIX>();
                     }
                 }
@@ -653,26 +700,41 @@ namespace Catlass::Gemm::Kernel {
                         gmV.SetGlobalBuffer((__gm__ ElementA *)params.ptrV + vOffset);
                         GlobalTensor<ElementA> gmDh;
                         gmDh.SetGlobalBuffer((__gm__ ElementA *)params.ptrDh + dhOffset);
-                        GlobalTensor<ElementC> gmDk;
                         if (gvaMode) {
-                            gmDk.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm6Offset) + dkTempOffset);
+                            GlobalTensor<float> gmDk;
+                            gmDk.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsGvaShortBtxKOffset) + dkTempOffset);
+
+                            auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                            auto tensorDh = tla::MakeTensor(gmDh, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});
+                            auto tensorDk = tla::MakeTensor(gmDk, MakeLayoutFromTag(layoutBTxKFp32), Arch::PositionGM{});
+
+                            auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0),
+                                                         tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                            auto tensorBlockDh = GetTile(tensorDh, tla::MakeCoord(0, 0),
+                                                          tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                            auto tensorBlockDk = GetTile(tensorDk, tla::MakeCoord(0, 0),
+                                                          tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+
+                            BlockMmadPart5Gva blockMmadPart5(resource);
+                            blockMmadPart5(tensorBlockV, tensorBlockDh, tensorBlockDk, actualBlockShape);
                         } else {
+                            GlobalTensor<ElementC> gmDk;
                             gmDk.SetGlobalBuffer((__gm__ ElementC *)params.ptrDk + dkOffset);
+
+                            auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
+                            auto tensorDh = tla::MakeTensor(gmDh, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});
+                            auto tensorDk = tla::MakeTensor(gmDk, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+
+                            auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0),
+                                                         tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                            auto tensorBlockDh = GetTile(tensorDh, tla::MakeCoord(0, 0),
+                                                          tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                            auto tensorBlockDk = GetTile(tensorDk, tla::MakeCoord(0, 0),
+                                                          tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+
+                            BlockMmadPart5 blockMmadPart5(resource);
+                            blockMmadPart5(tensorBlockV, tensorBlockDh, tensorBlockDk, actualBlockShape);
                         }
-
-                        auto tensorV = tla::MakeTensor(gmV, MakeLayoutFromTag(layoutBTxV), Arch::PositionGM{});
-                        auto tensorDh = tla::MakeTensor(gmDh, MakeLayoutFromTag(layoutVxK), Arch::PositionGM{});
-                        auto tensorDk = tla::MakeTensor(gmDk, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-
-                        auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0),
-                                                     tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                        auto tensorBlockDh = GetTile(tensorDh, tla::MakeCoord(0, 0),
-                                                      tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                        auto tensorBlockDk = GetTile(tensorDk, tla::MakeCoord(0, 0),
-                                                      tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-
-                        BlockMmadPart5 blockMmadPart5(resource);
-                        blockMmadPart5(tensorBlockV, tensorBlockDh, tensorBlockDk, actualBlockShape);
                     }
                     // --- Part7: mm7 = ds_temp^T @ q -> wsMm7 (复用 wsMm5) ---
                     {
@@ -693,25 +755,44 @@ namespace Catlass::Gemm::Kernel {
                         gmDsTemp.SetGlobalBuffer((__gm__ ElementA *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsDsTempOffset) + dsOffset);
                         GlobalTensor<ElementA> gmQ;
                         gmQ.SetGlobalBuffer((__gm__ ElementA *)params.ptrQ + qOffset);
-                        GlobalTensor<ElementC> gmMm7;  // mm7 复用 mm5 的 group 环槽 (stage D 写, mm5 已在 stage B 消费完; 单写, 同 stride 无跨核冲突)
                         uint64_t mm7RingOffset = DqkwgBtxKRingElemOffset(coreIdx, loopBase, loopIdx, coreNum, h,
                                                                          params.HV, params.BT, params.K,
                                                                          (uint32_t)params.wsBtxKSyncSlotsPerHead);
-                        gmMm7.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm7Offset) + mm7RingOffset);
+                        if (gvaMode) {
+                            GlobalTensor<float> gmMm7;
+                            gmMm7.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsGvaBtxKOffset) + mm7RingOffset);
 
-                        auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT_T), Arch::PositionGM{});
-                        auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
-                        auto tensorMm7 = tla::MakeTensor(gmMm7, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                            auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT_T), Arch::PositionGM{});
+                            auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                            auto tensorMm7 = tla::MakeTensor(gmMm7, MakeLayoutFromTag(layoutBTxKFp32), Arch::PositionGM{});
 
-                        auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0),
-                                                          tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
-                        auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0),
-                                                     tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
-                        auto tensorBlockMm7 = GetTile(tensorMm7, tla::MakeCoord(0, 0),
-                                                       tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                            auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0),
+                                                              tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                            auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0),
+                                                         tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                            auto tensorBlockMm7 = GetTile(tensorMm7, tla::MakeCoord(0, 0),
+                                                           tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
 
-                        BlockMmadPart7 blockMmadPart7(resource);
-                        blockMmadPart7(tensorBlockDsTemp, tensorBlockQ, tensorBlockMm7, actualBlockShape);
+                            BlockMmadPart7Gva blockMmadPart7(resource);
+                            blockMmadPart7(tensorBlockDsTemp, tensorBlockQ, tensorBlockMm7, actualBlockShape);
+                        } else {
+                            GlobalTensor<ElementC> gmMm7;  // mm7 复用 mm5 的 group 环槽 (stage D 写, mm5 已在 stage B 消费完; 单写, 同 stride 无跨核冲突)
+                            gmMm7.SetGlobalBuffer((__gm__ ElementC *)((__gm__ uint8_t*)params.ptrWorkspace + params.wsMm7Offset) + mm7RingOffset);
+
+                            auto tensorDsTemp = tla::MakeTensor(gmDsTemp, MakeLayoutFromTag(layoutBTxBT_T), Arch::PositionGM{});
+                            auto tensorQ = tla::MakeTensor(gmQ, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+                            auto tensorMm7 = tla::MakeTensor(gmMm7, MakeLayoutFromTag(layoutBTxK), Arch::PositionGM{});
+
+                            auto tensorBlockDsTemp = GetTile(tensorDsTemp, tla::MakeCoord(0, 0),
+                                                              tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                            auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0),
+                                                         tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                            auto tensorBlockMm7 = GetTile(tensorMm7, tla::MakeCoord(0, 0),
+                                                           tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+
+                            BlockMmadPart7 blockMmadPart7(resource);
+                            blockMmadPart7(tensorBlockDsTemp, tensorBlockQ, tensorBlockMm7, actualBlockShape);
+                        }
                         AscendC::PipeBarrier<PIPE_FIX>();
                     }
                 }
@@ -786,6 +867,8 @@ namespace Catlass::Gemm::Kernel {
         uint64_t wsDsTempOffset;
         uint64_t wsMm6Offset;
         uint64_t wsMm7Offset;
+        uint64_t wsGvaBtxKOffset;
+        uint64_t wsGvaShortBtxKOffset;
     };
 
     template <typename DataType, typename GType>
@@ -808,6 +891,8 @@ namespace Catlass::Gemm::Kernel {
         wsDsTempOffset = tiling.wsDsTempOffset;
         wsMm6Offset = tiling.wsMm6Offset;
         wsMm7Offset = tiling.wsMm7Offset;
+        wsGvaBtxKOffset = tiling.wsGvaBtxKOffset;
+        wsGvaShortBtxKOffset = tiling.wsGvaShortBtxKOffset;
         isVarLen = tiling.isVarLen;
     }
 
@@ -845,23 +930,32 @@ namespace Catlass::Gemm::Kernel {
         // Part 4: do @ h^T -> dq  [BT, V] @ [V, K] -> [BT, K]
         using TileCopyPart4 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
         using BlockMmadPart4 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart4>;
+        using TileCopyPart4Gva = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, float, LayoutRowMajor>;
+        using BlockMmadPart4Gva = Kernel::TileGemmDirect<ArchTag, float, TileCopyPart4Gva>;
 
         // Part 5: v @ dh -> dk  [BT, V] @ [V, K] -> [BT, K]
         using TileCopyPart5 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
         using BlockMmadPart5 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart5>;
+        using TileCopyPart5Gva = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, float, LayoutRowMajor>;
+        using BlockMmadPart5Gva = Kernel::TileGemmDirect<ArchTag, float, TileCopyPart5Gva>;
 
         // Part 6: ds @ k -> dq+=  [BT, BT] @ [BT, K] -> [BT, K]
         using TileCopyPart6 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
         using BlockMmadPart6 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart6>;
+        using TileCopyPart6Gva = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutRowMajor, float, LayoutRowMajor>;
+        using BlockMmadPart6Gva = Kernel::TileGemmDirect<ArchTag, float, TileCopyPart6Gva>;
 
         // Part 7: ds^T @ q -> dk+=  [BT, BT] @ [BT, K] -> [BT, K]
         using TileCopyPart7 = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutColMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
         using BlockMmadPart7 = Kernel::TileGemmDirect<ArchTag, DataType, TileCopyPart7>;
+        using TileCopyPart7Gva = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutColMajor, DataType, LayoutRowMajor, float, LayoutRowMajor>;
+        using BlockMmadPart7Gva = Kernel::TileGemmDirect<ArchTag, float, TileCopyPart7Gva>;
 
         // Kernel 实例
         using MatmulKernel = Kernel::ChunkBwdDqkwgTla<
             BlockMmadPart1, BlockMmadPart2, BlockMmadPart3, BlockMmadPart4,
-            BlockMmadPart5, BlockMmadPart6, BlockMmadPart7
+            BlockMmadPart5, BlockMmadPart6, BlockMmadPart7,
+            BlockMmadPart4Gva, BlockMmadPart5Gva, BlockMmadPart6Gva, BlockMmadPart7Gva
         >;
 
         // V=256 makes Part1/3/4/5 use a 256-wide reduction dimension. TileGemmDirect is a single
@@ -875,15 +969,24 @@ namespace Catlass::Gemm::Kernel {
         using BlockMmadPart3Tiled = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart3Tiled>;
         using TileCopyPart4Tiled = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
         using BlockMmadPart4Tiled = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart4Tiled>;
+        using TileCopyPart4GvaTiled = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, float, LayoutRowMajor>;
+        using BlockMmadPart4GvaTiled = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, float, void, TileCopyPart4GvaTiled>;
         using TileCopyPart5Tiled = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, DataType, LayoutRowMajor>;
         using BlockMmadPart5Tiled = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart5Tiled>;
+        using TileCopyPart5GvaTiled = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutColMajor, float, LayoutRowMajor>;
+        using BlockMmadPart5GvaTiled = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, float, void, TileCopyPart5GvaTiled>;
         using TileCopyPart6Tiled = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
         using BlockMmadPart6Tiled = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart6Tiled>;
+        using TileCopyPart6GvaTiled = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutRowMajor, DataType, LayoutRowMajor, float, LayoutRowMajor>;
+        using BlockMmadPart6GvaTiled = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, float, void, TileCopyPart6GvaTiled>;
         using TileCopyPart7Tiled = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutColMajor, DataType, LayoutRowMajor, DataType, LayoutRowMajor>;
         using BlockMmadPart7Tiled = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, DataType, void, TileCopyPart7Tiled>;
+        using TileCopyPart7GvaTiled = Gemm::Tile::PackedTileCopyTla<ArchTag, DataType, LayoutColMajor, DataType, LayoutRowMajor, float, LayoutRowMajor>;
+        using BlockMmadPart7GvaTiled = Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, DataType, DataType, float, void, TileCopyPart7GvaTiled>;
         using MatmulKernelTiled = Kernel::ChunkBwdDqkwgTla<
             BlockMmadPart1Tiled, BlockMmadPart2Tiled, BlockMmadPart3Tiled, BlockMmadPart4Tiled,
-            BlockMmadPart5Tiled, BlockMmadPart6Tiled, BlockMmadPart7Tiled
+            BlockMmadPart5Tiled, BlockMmadPart6Tiled, BlockMmadPart7Tiled,
+            BlockMmadPart4GvaTiled, BlockMmadPart5GvaTiled, BlockMmadPart6GvaTiled, BlockMmadPart7GvaTiled
         >;
 
         if (V > 128) {
@@ -894,6 +997,7 @@ namespace Catlass::Gemm::Kernel {
                 ptrDq, ptrDk, ptrDw, ptrDg,
                 ptrWorkspace, B, HV, HK, T, K, V, BT, numChunks, n_ratio,
                 wsDwOffset, wsBtxKSyncSlotsPerHead, wsDgLastOffset, wsMm5Offset, wsDsTempOffset, wsMm6Offset, wsMm7Offset,
+                wsGvaBtxKOffset, wsGvaShortBtxKOffset,
                 scale, isVarLen
             );
             params.aicCoreNum = aicCoreNum;
@@ -906,6 +1010,7 @@ namespace Catlass::Gemm::Kernel {
                 ptrDq, ptrDk, ptrDw, ptrDg,
                 ptrWorkspace, B, HV, HK, T, K, V, BT, numChunks, n_ratio,
                 wsDwOffset, wsBtxKSyncSlotsPerHead, wsDgLastOffset, wsMm5Offset, wsDsTempOffset, wsMm6Offset, wsMm7Offset,
+                wsGvaBtxKOffset, wsGvaShortBtxKOffset,
                 scale, isVarLen
             );
             params.aicCoreNum = aicCoreNum;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
@@ -123,6 +123,8 @@
      uint64_t wsMm6Offset;
      uint64_t wsMm7Offset;
      uint64_t wsMul1Offset;
+     uint64_t wsGvaBtxKOffset;
+     uint64_t wsGvaShortBtxKOffset;
      int BUFFER_NUM = 1;
 
      // Pipeline
@@ -138,6 +140,7 @@
      GlobalTensor<float> gmDgLast;
      GlobalTensor<DataType> gmDwWorkspace;
      GlobalTensor<DataType> gmMm5, gmDsTemp, gmMul1, gmMm6, gmMm7;
+     GlobalTensor<float> gmGvaBtxK, gmGvaShortBtxK;
 
      // Queues (用于流水)
      TQue<TPosition::VECIN, 2> inQue1;
@@ -200,6 +203,8 @@
      wsMm6Offset = tiling.wsMm6Offset;
      wsMm7Offset = tiling.wsMm7Offset;
      wsMul1Offset = tiling.wsMul1Offset;
+     wsGvaBtxKOffset = tiling.wsGvaBtxKOffset;
+     wsGvaShortBtxKOffset = tiling.wsGvaShortBtxKOffset;
      uint64_t dgLastSize = tiling.dgLastSize;
      isVarLen = tiling.isVarLen;
      mul0RowNum = tiling.mul0RowNum;
@@ -233,6 +238,8 @@
      gmMm6.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm6Offset));
      gmMm7.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMm7Offset));
      gmMul1.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsMul1Offset));
+     gmGvaBtxK.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t*)ptrWorkspace + wsGvaBtxKOffset));
+     gmGvaShortBtxK.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t*)ptrWorkspace + wsGvaShortBtxKOffset));
  }
 
  // ============== 主处理函数 (CV 深融合: A -> B -> C -> D, 每 stage 内 chunk 级与 cube 流水) ==============
@@ -943,8 +950,10 @@
      uint32_t dqSize = BT * K;
      const uint32_t gSize = BT;
      const bool gvaMode = HV != HK;
+     const bool gvaUbAccum = gvaMode && (BT == 64);
+     const int32_t cBufferNum = gvaUbAccum ? 1 : BUFFER_NUM;
 
-     pipe->InitBuffer(inQue1, BUFFER_NUM, dqSize * sizeof(float));    // dq_inner from Cube
+     pipe->InitBuffer(inQue1, cBufferNum, dqSize * sizeof(float));    // dq_inner from Cube
      pipe->InitBuffer(inQue2, BUFFER_NUM, dqSize * sizeof(float));    // q / mm6 复用
      pipe->InitBuffer(inQue3, BUFFER_NUM, gSize * sizeof(GType));     // g
      pipe->InitBuffer(inQue4, BUFFER_NUM, gSize * sizeof(GType));     // dg
@@ -955,6 +964,11 @@
      pipe->InitBuffer(gBuf, gSize * sizeof(float));
      pipe->InitBuffer(dgBuf, gSize * sizeof(float));
 
+     LocalTensor<float> tensorDqGvaAccum;
+     if (gvaUbAccum) {
+         pipe->InitBuffer(calcBuf1, dqSize * sizeof(float));
+         tensorDqGvaAccum = calcBuf1.Get<float>();
+     }
      auto tensorShareTmpFp32 = calcBuf3.Get<float>();
      auto tensorGFp32 = gBuf.Get<float>();
      auto tensorDgAdd = dgBuf.Get<float>();
@@ -989,7 +1003,7 @@
                  auto tensorGIn = inQue3.AllocTensor<GType>();
                  auto tensorDgIn = inQue4.AllocTensor<GType>();
                  if (gvaMode) {
-                     DataCopy(tensorDqIn[dqSize_sub], gmMm5[dqTempOffset], dqSize_sub);
+                     DataCopy(tensorDqIn.template ReinterpretCast<float>(), gmGvaBtxK[dqTempOffset], dqSize_sub);
                  } else {
                      DataCopy(tensorDqIn[dqSize_sub], gmDq[dqOutOffset], dqSize_sub);
                  }
@@ -1010,7 +1024,9 @@
                  auto tensorDgIn = inQue4.DeQue<GType>();
                  auto tensorDgOut = outQue2.AllocTensor<float>();
 
-                 Cast(tensorDqInFp32, tensorDqInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
+                 if (!gvaMode) {
+                     Cast(tensorDqInFp32, tensorDqInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
+                 }
                  Cast(tensorQInFp32, tensorQInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
                  if constexpr (std::is_same<GType, float>::value) {
                      DataCopy(tensorGFp32, tensorGIn, gSize);
@@ -1079,39 +1095,65 @@
                      auto tensorMm6In = inQue2.AllocTensor<DataType>();
                      uint64_t mm6RingOffset = DqkwgShortBtxKRingElemOffset(coreIdx, loopIdx, coreNum, h, HV, BT, K,
                                                                            DqkwgShortRingDepthFromGroup((uint32_t)wsBtxKSyncSlotsPerHead));
-                     DataCopy(tensorMm6In[dqSize_sub], gmMm6[mm6RingOffset], dqSize_sub);  // mm6 compact ring
+                     if (gvaMode) {
+                         DataCopy(tensorMm6In.template ReinterpretCast<float>(), gmGvaShortBtxK[mm6RingOffset], dqSize_sub);
+                     } else {
+                         DataCopy(tensorMm6In[dqSize_sub], gmMm6[mm6RingOffset], dqSize_sub);  // mm6 compact ring
+                     }
                      inQue2.EnQue(tensorMm6In);
                  }
                  {
                      auto tensorMm6InFp16 = inQue2.DeQue<DataType>();
                      auto tensorMm6Fp32 = tensorMm6InFp16.template ReinterpretCast<float>();
-                     Cast(tensorMm6Fp32, tensorMm6InFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
+                     if (!gvaMode) {
+                         Cast(tensorMm6Fp32, tensorMm6InFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
+                     }
                      PipeBarrier<PIPE_V>();
                      Add(tensorDqInFp32, tensorDqInFp32, tensorMm6Fp32, dqSize_sub);
                      PipeBarrier<PIPE_V>();
                      inQue2.FreeTensor(tensorMm6InFp16);
-                     if (gvaMode && (h % n_ratio != 0)) {
-                         FenceGvaAccumReadAfterWrite();
-                         auto tensorDqAccumIn = inQue2.AllocTensor<DataType>();
-                         DataCopy(tensorDqAccumIn[dqSize_sub], gmDq[dqOutOffset], dqSize_sub);
-                         inQue2.EnQue(tensorDqAccumIn);
-                         auto tensorDqAccumInFp16 = inQue2.DeQue<DataType>();
-                         auto tensorDqAccumFp32 = tensorDqAccumInFp16.template ReinterpretCast<float>();
-                         Cast(tensorDqAccumFp32, tensorDqAccumInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
+                     if (gvaUbAccum) {
+                         bool firstHeadInGroup = (h % n_ratio) == 0;
+                         bool lastHeadInGroup = (h % n_ratio) == (n_ratio - 1);
+                         if (firstHeadInGroup) {
+                             Duplicate(tensorDqGvaAccum, 0.0f, dqSize_sub);
+                             PipeBarrier<PIPE_V>();
+                         }
+                         Add(tensorDqGvaAccum, tensorDqGvaAccum, tensorDqInFp32, dqSize_sub);
                          PipeBarrier<PIPE_V>();
-                         Add(tensorDqInFp32, tensorDqInFp32, tensorDqAccumFp32, dqSize_sub);
-                         PipeBarrier<PIPE_V>();
-                         inQue2.FreeTensor(tensorDqAccumInFp16);
+                         if (lastHeadInGroup) {
+                             auto tensorDqOut = outQue1.AllocTensor<DataType>();
+                             Cast(tensorDqOut, tensorDqGvaAccum, RoundMode::CAST_RINT, dqSize_sub);
+                             inQue1.FreeTensor(tensorDqInFp16);
+                             outQue1.EnQue(tensorDqOut);
+                             auto tensorDqOutDeq = outQue1.DeQue<DataType>();
+                             DataCopy(gmDq[dqOutOffset], tensorDqOutDeq, dqSize_sub);
+                             outQue1.FreeTensor(tensorDqOutDeq);
+                         } else {
+                             inQue1.FreeTensor(tensorDqInFp16);
+                         }
+                     } else {
+                         if (gvaMode && (h % n_ratio != 0)) {
+                             FenceGvaAccumReadAfterWrite();
+                             auto tensorDqAccumIn = inQue2.AllocTensor<DataType>();
+                             DataCopy(tensorDqAccumIn[dqSize_sub], gmDq[dqOutOffset], dqSize_sub);
+                             inQue2.EnQue(tensorDqAccumIn);
+                             auto tensorDqAccumInFp16 = inQue2.DeQue<DataType>();
+                             auto tensorDqAccumFp32 = tensorDqAccumInFp16.template ReinterpretCast<float>();
+                             Cast(tensorDqAccumFp32, tensorDqAccumInFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
+                             PipeBarrier<PIPE_V>();
+                             Add(tensorDqInFp32, tensorDqInFp32, tensorDqAccumFp32, dqSize_sub);
+                             PipeBarrier<PIPE_V>();
+                             inQue2.FreeTensor(tensorDqAccumInFp16);
+                         }
+                         auto tensorDqOut = outQue1.AllocTensor<DataType>();
+                         Cast(tensorDqOut, tensorDqInFp32, RoundMode::CAST_RINT, dqSize_sub);
+                         inQue1.FreeTensor(tensorDqInFp16);
+                         outQue1.EnQue(tensorDqOut);
+                         auto tensorDqOutDeq = outQue1.DeQue<DataType>();
+                         DataCopy(gmDq[dqOutOffset], tensorDqOutDeq, dqSize_sub);
+                         outQue1.FreeTensor(tensorDqOutDeq);
                      }
-                     auto tensorDqOut = outQue1.AllocTensor<DataType>();
-                     Cast(tensorDqOut, tensorDqInFp32, RoundMode::CAST_RINT, dqSize_sub);
-                     inQue1.FreeTensor(tensorDqInFp16);
-                     outQue1.EnQue(tensorDqOut);
-                 }
-                 {
-                     auto tensorDqOut = outQue1.DeQue<DataType>();
-                     DataCopy(gmDq[dqOutOffset], tensorDqOut, dqSize_sub);
-                     outQue1.FreeTensor(tensorDqOut);
                  }
              }
              PipeBarrier<PIPE_MTE3>();
@@ -1135,6 +1177,7 @@
      uint32_t dkSize = BT * K;
      const uint32_t gSize = BT;
      const bool gvaMode = HV != HK;
+     const bool gvaUbAccum = gvaMode && (BT == 64);
 
      constexpr int32_t part5BufferNum = 1;
      pipe->InitBuffer(inQue1, part5BufferNum, dkSize * sizeof(float));
@@ -1146,6 +1189,11 @@
 
      pipe->InitBuffer(calcBuf1, gSize * 8 * sizeof(float));  // gLast
      pipe->InitBuffer(calcBuf2, gSize * 8 * sizeof(float));  // dgLast
+     LocalTensor<float> tensorDkGvaAccum;
+     if (gvaUbAccum) {
+         pipe->InitBuffer(calcBuf3, dkSize * sizeof(float));
+         tensorDkGvaAccum = calcBuf3.Get<float>();
+     }
      pipe->InitBuffer(calcBuf4, gSize * sizeof(float));
      pipe->InitBuffer(gBuf, gSize * sizeof(float));
      pipe->InitBuffer(dgBuf, gSize * 8 * sizeof(float));
@@ -1207,7 +1255,7 @@
                  auto tensorGIn = inQue3.AllocTensor<GType>();
                  auto tensorDgIn = inQue4.AllocTensor<GType>();
                  if (gvaMode) {
-                     DataCopy(tensorDkIn[dkSize], gmMm6[dkTempOffset], dkSize);
+                     DataCopy(tensorDkIn.template ReinterpretCast<float>(), gmGvaShortBtxK[dkTempOffset], dkSize);
                  } else {
                      DataCopy(tensorDkIn[dkSize], gmDk[dkOutOffset], dkSize);
                  }
@@ -1228,7 +1276,9 @@
                  auto tensorDgIn = inQue4.DeQue<GType>();
                  auto tensorDgOut = outQue2.AllocTensor<GType>();
 
-                 Cast(tensorDkFp32, tensorDkIn[dkSize], RoundMode::CAST_NONE, dkSize);
+                 if (!gvaMode) {
+                     Cast(tensorDkFp32, tensorDkIn[dkSize], RoundMode::CAST_NONE, dkSize);
+                 }
                  Cast(tensorKFp32, tensorKIn[dkSize], RoundMode::CAST_NONE, dkSize);
                  PipeBarrier<PIPE_V>();
 
@@ -1332,39 +1382,65 @@
                      auto tensorMm7In = inQue2.AllocTensor<DataType>();
                      uint64_t mm7RingOffset = DqkwgBtxKRingElemOffset(coreIdx, loopBase, loopIdx, coreNum, h, HV, BT, K,
                                                                       (uint32_t)wsBtxKSyncSlotsPerHead);  // mm7 用 group 环 (与 cube 一致)
-                     DataCopy(tensorMm7In[dkSize], gmMm7[mm7RingOffset], dkSize);
+                     if (gvaMode) {
+                         DataCopy(tensorMm7In.template ReinterpretCast<float>(), gmGvaBtxK[mm7RingOffset], dkSize);
+                     } else {
+                         DataCopy(tensorMm7In[dkSize], gmMm7[mm7RingOffset], dkSize);
+                     }
                      inQue2.EnQue(tensorMm7In);
                  }
                  {
                      auto tensorMm7In = inQue2.DeQue<DataType>();
                      auto tensorMm7Fp32 = tensorMm7In.template ReinterpretCast<float>();
-                     Cast(tensorMm7Fp32, tensorMm7In[dkSize], RoundMode::CAST_NONE, dkSize);
+                     if (!gvaMode) {
+                         Cast(tensorMm7Fp32, tensorMm7In[dkSize], RoundMode::CAST_NONE, dkSize);
+                     }
                      PipeBarrier<PIPE_V>();
                      Add(tensorDkFp32, tensorDkFp32, tensorMm7Fp32, dkSize);
                      PipeBarrier<PIPE_V>();
                      inQue2.FreeTensor(tensorMm7In);
-                     if (gvaMode && (h % n_ratio != 0)) {
-                         FenceGvaAccumReadAfterWrite();
-                         auto tensorDkAccumIn = inQue2.AllocTensor<DataType>();
-                         DataCopy(tensorDkAccumIn[dkSize], gmDk[dkOutOffset], dkSize);
-                         inQue2.EnQue(tensorDkAccumIn);
-                         auto tensorDkAccumInFp16 = inQue2.DeQue<DataType>();
-                         auto tensorDkAccumFp32 = tensorDkAccumInFp16.template ReinterpretCast<float>();
-                         Cast(tensorDkAccumFp32, tensorDkAccumInFp16[dkSize], RoundMode::CAST_NONE, dkSize);
+                     if (gvaUbAccum) {
+                         bool firstHeadInGroup = (h % n_ratio) == 0;
+                         bool lastHeadInGroup = (h % n_ratio) == (n_ratio - 1);
+                         if (firstHeadInGroup) {
+                             Duplicate(tensorDkGvaAccum, 0.0f, dkSize);
+                             PipeBarrier<PIPE_V>();
+                         }
+                         Add(tensorDkGvaAccum, tensorDkGvaAccum, tensorDkFp32, dkSize);
                          PipeBarrier<PIPE_V>();
-                         Add(tensorDkFp32, tensorDkFp32, tensorDkAccumFp32, dkSize);
-                         PipeBarrier<PIPE_V>();
-                         inQue2.FreeTensor(tensorDkAccumInFp16);
+                         if (lastHeadInGroup) {
+                             auto tensorDkOut = outQue1.AllocTensor<DataType>();
+                             Cast(tensorDkOut, tensorDkGvaAccum, RoundMode::CAST_RINT, dkSize);
+                             inQue1.FreeTensor(tensorDkIn);
+                             outQue1.EnQue(tensorDkOut);
+                             auto tensorDkOutDeq = outQue1.DeQue<DataType>();
+                             DataCopy(gmDk[dkOutOffset], tensorDkOutDeq, dkSize);
+                             outQue1.FreeTensor(tensorDkOutDeq);
+                         } else {
+                             inQue1.FreeTensor(tensorDkIn);
+                         }
+                     } else {
+                         if (gvaMode && (h % n_ratio != 0)) {
+                             FenceGvaAccumReadAfterWrite();
+                             auto tensorDkAccumIn = inQue2.AllocTensor<DataType>();
+                             DataCopy(tensorDkAccumIn[dkSize], gmDk[dkOutOffset], dkSize);
+                             inQue2.EnQue(tensorDkAccumIn);
+                             auto tensorDkAccumInFp16 = inQue2.DeQue<DataType>();
+                             auto tensorDkAccumFp32 = tensorDkAccumInFp16.template ReinterpretCast<float>();
+                             Cast(tensorDkAccumFp32, tensorDkAccumInFp16[dkSize], RoundMode::CAST_NONE, dkSize);
+                             PipeBarrier<PIPE_V>();
+                             Add(tensorDkFp32, tensorDkFp32, tensorDkAccumFp32, dkSize);
+                             PipeBarrier<PIPE_V>();
+                             inQue2.FreeTensor(tensorDkAccumInFp16);
+                         }
+                         auto tensorDkOut = outQue1.AllocTensor<DataType>();
+                         Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);
+                         inQue1.FreeTensor(tensorDkIn);
+                         outQue1.EnQue(tensorDkOut);
+                         auto tensorDkOutDeq = outQue1.DeQue<DataType>();
+                         DataCopy(gmDk[dkOutOffset], tensorDkOutDeq, dkSize);
+                         outQue1.FreeTensor(tensorDkOutDeq);
                      }
-                     auto tensorDkOut = outQue1.AllocTensor<DataType>();
-                     Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);
-                     inQue1.FreeTensor(tensorDkIn);
-                     outQue1.EnQue(tensorDkOut);
-                 }
-                 {
-                     auto tensorDkOut = outQue1.DeQue<DataType>();
-                     DataCopy(gmDk[dkOutOffset], tensorDkOut, dkSize);
-                     outQue1.FreeTensor(tensorDkOut);
                  }
              }
              PipeBarrier<PIPE_MTE3>();


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，需要按仓库要求触发并确认当前 head commit 的 NPU CI 状态。

## 关联 Issue / 背景

- 关联 Issue: 无需关联 Issue，本 PR 为 `chunk_bwd_dqkwg` 算子内部精度修复
- 背景与目标: GVA 场景下 `dq` / `dk` 多个 value head 聚合到 key head 时，bf16 中间结果反复写回再读出参与累加，容易放大累加误差
- 本 PR 解决的问题: 减少 GVA `dq` / `dk` 聚合过程中的中间 cast 损失，提升固定 seed 精度回归稳定性

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: `chunk_bwd_dqkwg`
- 涉及目录 / 文件:
  - `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp`
  - `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.h`
  - `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h`
  - `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h`
- 责任人 / 提交人: @ZhangYi2026
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [x] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不改变已有输入、输出、shape、dtype、format 支持范围
- 明确不包含的范围: 不包含算子接口、torch 适配、测试脚本、文档和公共模块修改
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要指定评审人检视通过
- ABI 不兼容风险说明: 无

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

已按本 PR 修改范围执行源码格式检查、PR 文件范围检查、A2 / A3 / A5 目标编译验证、A3 安装与产物一致性校验、`torch_custom` 构建、固定 seed 缓存精度回归、目标 step2 精度回归，以及整体 Example/ST 精度回归。PR 描述不记录执行机器、环境路径、临时目录或日志路径。

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | CANN 9.0 及以上 | `bash build.sh --pkg --soc=ascend910b --ops=chunk_bwd_dqkwg --vendor_name=fla_npu` | 通过 | 构建通过，生成目标产物 |
| A3 | `ascend910_93` | CANN 9.0 及以上 | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_bwd_dqkwg --vendor_name=fla_npu` | 通过 | 构建通过，生成目标产物 |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | CANN 9.0 及以上 | `bash build.sh --pkg --soc=ascend910b --ops=chunk_bwd_dqkwg --vendor_name=fla_npu` | 通过 | 构建通过，生成目标产物 |
| A3 | `ascend910_93` | CANN 9.0 及以上 | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_bwd_dqkwg --vendor_name=fla_npu` | 通过 | 构建、安装与产物一致性校验通过 |
| A5 | `ascend950` | CANN 9.0 及以上 | `bash build.sh --pkg --soc=ascend950 --ops=chunk_bwd_dqkwg --vendor_name=fla_npu` | 通过 | 按本次验证口径仅做目标编译验证，构建通过 |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `chunk_bwd_dqkwg` 目标编译验证 | 通过 | 构建通过 |
| A3 | `ascend910_93` | 固定 seed 缓存精度回归；目标 step2 精度回归；GVA / 非 GVA 回归 | 通过 | `case_step2_06`、`case_step2_10` 精度通过；缓存 golden 回归通过 |
| A5 | `ascend950` | `chunk_bwd_dqkwg` 目标编译验证 | 通过 | 按本次验证口径仅做目标编译验证，构建通过 |

- 精度对比: 固定 seed 缓存 golden 用例 `case_13`、`case_17`、`case_21` 通过；目标 step2 用例 `case_step2_06`、`case_step2_10` 通过，且均命中缓存 golden，未重新生成 CPU golden
- 性能对比: 未执行性能测试，本 PR 主要验证精度修复与构建兼容性
- 边界 / 异常场景: 覆盖 GVA 与非 GVA 回归、变长 Example/ST 场景、TND Example/ST 场景
- 未覆盖风险: A5 按本次验证口径仅做目标编译验证，未做 A5 上机运行；后续可由仓库门禁继续补充平台级回归

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 本次按目标编译验证口径覆盖 | 通过 | 构建通过 |
| A3 | `ascend910_93` | 执行 `ci/example_st_cases.json` 中启用的 Example/ST 精度用例 | 通过 | 共 4 个用例，运行 4 个，通过 4 个，失败 0 个 |
| A5 | `ascend950` | 本次按目标编译验证口径覆盖 | 通过 | 构建通过，未做 A5 上机运行 |

- 端到端场景说明: A3 Example/ST 覆盖默认场景、dense 精度场景、varlen 场景和 TND 场景，`o` / `dq` / `dk` / `dv` / `dbeta` / `dg` 相关输出精度均通过
- 与本 PR 修改算子的关联: 本 PR 修改 `chunk_bwd_dqkwg` GVA `dq` / `dk` 累加路径，Example/ST 用于确认 GDN 端到端调用链未被破坏
- 未覆盖原因及补充计划: A5 本次不做上机运行，仅做目标编译验证；后续可由仓库门禁补充平台级回归

</details>

## 兼容性、风险与回退

- 兼容性说明: 不改变外部接口和 shape / dtype / format 支持范围；非 GVA 路径保留原有逻辑
- 风险点: GVA 路径新增 fp32 workspace，workspace 使用量增加；A5 本次仅完成目标编译验证，未做上机运行
- 回退方案: 回退本 PR 单提交即可恢复原有 GVA workspace 与累加逻辑
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [x] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

实现上为 GVA C / D stage 增加 fp32 中间 workspace，并在 vector 侧对 `dq` / `dk` 按 head group 在 UB 中完成 fp32 聚合，最后统一写回输出，减少逐 head 写回 bf16 后再次读出累加带来的精度损失。

单独 import smoke 在打印成功标记后，于进程退出阶段出现运行时析构异常；后续构建、安装、固定 seed 缓存精度回归和 Example/ST 精度回归均可执行并通过，因此未将其判定为 `chunk_bwd_dqkwg` 精度失败。Example/ST 精度回归使用临时 wrapper 保持同一测试脚本与参数，并在脚本完成后直接退出，用于规避退出阶段析构异常；4 个精度用例均通过。