### PR TITLE
feat: 解耦 fla_npu 导入与 legacy torch ops 加载

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,13 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 name: NPU CI
 
 on:
@@ -301,6 +311,7 @@ jobs:
       CI_MODE: ${{ needs.prepare.outputs.ci_mode }}
       CI_OPS: ${{ needs.prepare.outputs.ops }}
       CI_RUN_EXAMPLE_ST: 'true'
+      CI_RUN_SCOPED_WHEEL_INSTALL_CHECK: 'true'
       CI_IMAGE: fla-npu-ci:8.5.0-910b
     steps:
       - name: 拉取当前目标分支代码（第 1 次）

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ python -m pip install --force-reinstall --no-deps dist/flash_linear_attention_np
 
 #### 方式 B 产物安装
 
-先确认方式 A 的完整 wheel 已经安装到当前 Python 环境，然后安装 run 包。安装器会在覆盖前列出当前 run 包携带的算子；由于 `libcust_opapi.so`、tiling so、proto so 会被当前局部 run 包整体替换，安装器也会列出已安装 wheel 中不在当前 run 包范围内、替换后将不可用的算子。安装器还会列出 `op_api/include/aclnnop` 中新增、删除、修改的 aclnn ABI 头文件；删除只按当前 run 包携带的算子范围判断，非 `--quiet` 模式需要确认后才继续。
+先确认方式 A 的完整 wheel 已经安装到当前 Python 环境，然后安装 run 包。安装器会在覆盖前列出当前 run 包携带的算子，并用红/黄/绿标出安装后的算子状态：红色表示安装后不可用，包括不在当前 run 包范围内但会受局部 `libcust_opapi.so`、tiling so、proto so 整体替换影响的算子，以及当前 run 包内但 aclnn ABI 修改或删除的算子；黄色表示新增或无法完整确认的 ABI；绿色表示当前 run 包内且 aclnn ABI 一致的算子。安装器还会列出 `op_api/include/aclnnop` 中新增、删除、修改的 aclnn ABI 头文件；删除只按当前 run 包携带的算子范围判断，非 `--quiet` 模式需要确认后才继续。
 
 ```sh
 # 覆盖当前 Python 环境中 flash-linear-attention-npu wheel 内嵌的 OPP

--- a/README.md
+++ b/README.md
@@ -76,10 +76,13 @@ FLA_NPU_SOC=ascend910b FLA_NPU_INCREMENTAL_BUILD=1 python -m pip wheel --no-buil
 # 编译 GDN 算子 run 包，注意 --soc 需指定为当前机器芯片类型 {ascend910b/ascend910_93/ascend950}
 bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu
 
-# 单独编译 torch_custom 适配 wheel
+# 单独编译 Python runtime wheel
 cd torch_custom/fla_npu
-bash gen.sh npu_custom.yaml
 python3 setup.py bdist_wheel
+
+# 如需继续验证旧 torch.ops.npu 路径，可显式编译 legacy PyTorch C++ extension
+FLA_NPU_BUILD_LEGACY_EXTENSION=1 bash gen.sh npu_custom.yaml
+FLA_NPU_BUILD_LEGACY_EXTENSION=1 python3 setup.py bdist_wheel
 ```
 
 ### Step 3. 安装
@@ -105,7 +108,7 @@ source ${FLA_NPU_OPP_INSTALL_PATH}/vendors/fla_npu_transformer/bin/set_env.bash
 python -m pip install --force-reinstall --no-deps torch_custom/fla_npu/dist/fla_npu-*.whl
 ```
 
-`import fla_npu` 是轻量导入，不会自动导入 `torch` / `torch_npu`，也不会自动注册 `torch.ops.npu`。只有显式调用 `fla_npu.load_legacy_torch_ops()` 时，才会加载兼容旧 `torch.ops.npu.*` 调用的扩展库，并优先使用 wheel 内嵌 OPP，找不到时继续从 `FLA_NPU_OPP_PATH`、`ASCEND_CUSTOM_OPP_PATH` 和 `ASCEND_OPP_PATH` 查找已安装 OPP。
+`import fla_npu` 是轻量导入，不会自动导入 `torch` / `torch_npu`，也不会自动注册 `torch.ops.npu`。默认 wheel 通过 Python ctypes 直调 aclnn/opapi，推荐使用 `fla_npu.ops.ascendc`；`torch_npu.ops.*` 会在导入 `fla_npu.ops.ascendc` 后挂到同一套 Python wrapper。只有用 `FLA_NPU_BUILD_LEGACY_EXTENSION=1` 额外编出 legacy 扩展时，才可显式调用 `fla_npu.load_legacy_torch_ops()` 兼容旧 `torch.ops.npu.*`。
 
 ### Step 4. 测试安装成功
 
@@ -113,11 +116,11 @@ python -m pip install --force-reinstall --no-deps torch_custom/fla_npu/dist/fla_
 
 ```sh
 python -c "import fla_npu; print(fla_npu.is_legacy_torch_ops_loaded())"
-python -c "import fla_npu; fla_npu.load_legacy_torch_ops(); import torch; print(hasattr(torch.ops.npu, 'npu_chunk_fwd_o'))"
+python -c "from fla_npu.ops import ascendc; import torch_npu; print(hasattr(torch_npu.ops, 'chunk_fwd_o'))"
 python scripts/check_packaged_wheel_api.py
 ```
 
-`torch.ops.npu.*` 是兼容旧代码的过渡用法，调用时会产生 `FutureWarning`，后续版本不再支持。新代码优先使用 `fla_npu.ops.ascendc` 下的稳定 Python 入口。
+`torch.ops.npu.*` 是 legacy extension 的过渡用法，后续版本不再支持。新代码优先使用 `fla_npu.ops.ascendc` 下的稳定 Python 入口。
 
 ### 测试单算子
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ FLA_NPU_SOC=ascend910b FLA_NPU_INCREMENTAL_BUILD=1 python -m pip wheel --no-buil
 
 #### 方式 B：【备选】单独编译算子 run 包和 Python wheel
 
-只有在已经安装方式 A 的完整 wheel、但需要快速替换少量算子的 Ascend C 产物时，才建议使用该方式。run 包安装时会把当前 run 包里的 `packages/vendors/fla_npu_transformer` 合并覆盖到当前 Python 环境已安装的 `site-packages/fla_npu/opp/vendors/fla_npu_transformer`，从而更新 `aclnn`、tiling、kernel 和相关配置。
+只有在已经安装方式 A 的完整 wheel、但需要快速替换少量算子的 Ascend C 产物时，才建议使用该方式。`--ops=op1,op2,...` 只会生成指定算子的 run 包；run 包安装时会把当前 run 包里的 `packages/vendors/fla_npu_transformer` 合并覆盖到当前 Python 环境已安装的 `site-packages/fla_npu/opp/vendors/fla_npu_transformer`，从而更新 `aclnn`、tiling、kernel 和相关配置。
 
 ```sh
 # 编译一个或多个算子 run 包，--soc 需指定为当前机器芯片类型 {ascend910b/ascend910_93/ascend950}
@@ -99,7 +99,7 @@ python -m pip install --force-reinstall --no-deps dist/flash_linear_attention_np
 
 #### 方式 B 产物安装
 
-先确认方式 A 的完整 wheel 已经安装到当前 Python 环境，然后安装 run 包。安装器会在覆盖前列出 `op_api/include/aclnnop` 中新增、删除、修改的 aclnn ABI 头文件；删除只按当前 run 包携带的算子范围判断，非 `--quiet` 模式需要确认后才继续。
+先确认方式 A 的完整 wheel 已经安装到当前 Python 环境，然后安装 run 包。安装器会在覆盖前列出当前 run 包携带的算子；由于 `libcust_opapi.so`、tiling so、proto so 会被当前局部 run 包整体替换，安装器也会列出已安装 wheel 中不在当前 run 包范围内、替换后将不可用的算子。安装器还会列出 `op_api/include/aclnnop` 中新增、删除、修改的 aclnn ABI 头文件；删除只按当前 run 包携带的算子范围判断，非 `--quiet` 模式需要确认后才继续。
 
 ```sh
 # 覆盖当前 Python 环境中 flash-linear-attention-npu wheel 内嵌的 OPP

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ python -m pip install --force-reinstall --no-deps dist/flash_linear_attention_np
 
 #### 方式 B 产物安装
 
-先确认方式 A 的完整 wheel 已经安装到当前 Python 环境，然后安装 run 包。安装器会在覆盖前列出当前 run 包携带的算子，并用红/黄/绿标出安装后的算子状态：红色表示安装后不可用，包括不在当前 run 包范围内但会受局部 `libcust_opapi.so`、tiling so、proto so 整体替换影响的算子，以及当前 run 包内但 aclnn ABI 修改或删除的算子；黄色表示新增或无法完整确认的 ABI；绿色表示当前 run 包内且 aclnn ABI 一致的算子。安装器还会列出 `op_api/include/aclnnop` 中新增、删除、修改的 aclnn ABI 头文件；删除只按当前 run 包携带的算子范围判断，非 `--quiet` 模式需要确认后才继续。
+先确认方式 A 的完整 wheel 已经安装到当前 Python 环境，然后安装 run 包。安装器会在覆盖前列出当前 run 包携带的算子，并标出安装后的算子状态：`WARNING` 表示安装后不可用，包括不在当前 run 包范围内但会受局部 `libcust_opapi.so`、tiling so、proto so 整体替换影响的算子，以及当前 run 包内但 aclnn ABI 修改或删除的算子；`NOTICE` 表示新增或无法完整确认的 ABI，需要确认当前 Python wheel 是否已有对应 wrapper；`OK` 表示当前 run 包内且 aclnn ABI 一致的算子。`op_api/include/aclnnop` 中新增、删除、修改的 aclnn ABI 头文件会合并显示到对应算子的状态原因里；删除只按当前 run 包携带的算子范围判断，非 `--quiet` 模式只在状态表后确认一次。
 
 ```sh
 # 覆盖当前 Python 环境中 flash-linear-attention-npu wheel 内嵌的 OPP

--- a/README.md
+++ b/README.md
@@ -105,16 +105,19 @@ source ${FLA_NPU_OPP_INSTALL_PATH}/vendors/fla_npu_transformer/bin/set_env.bash
 python -m pip install --force-reinstall --no-deps torch_custom/fla_npu/dist/fla_npu-*.whl
 ```
 
-`import fla_npu` 会优先使用 wheel 内嵌 OPP，找不到时会继续从 `FLA_NPU_OPP_PATH`、`ASCEND_CUSTOM_OPP_PATH` 和 `ASCEND_OPP_PATH` 查找已安装 OPP。
+`import fla_npu` 是轻量导入，不会自动导入 `torch` / `torch_npu`，也不会自动注册 `torch.ops.npu`。只有显式调用 `fla_npu.load_legacy_torch_ops()` 时，才会加载兼容旧 `torch.ops.npu.*` 调用的扩展库，并优先使用 wheel 内嵌 OPP，找不到时继续从 `FLA_NPU_OPP_PATH`、`ASCEND_CUSTOM_OPP_PATH` 和 `ASCEND_OPP_PATH` 查找已安装 OPP。
 
 ### Step 4. 测试安装成功
 
 安装后两种方式均可用以下命令验证：
 
 ```sh
-python -c "import fla_npu; import torch; print(hasattr(torch.ops.npu, 'npu_chunk_fwd_o'))"
+python -c "import fla_npu; print(fla_npu.is_legacy_torch_ops_loaded())"
+python -c "import fla_npu; fla_npu.load_legacy_torch_ops(); import torch; print(hasattr(torch.ops.npu, 'npu_chunk_fwd_o'))"
 python scripts/check_packaged_wheel_api.py
 ```
+
+`torch.ops.npu.*` 是兼容旧代码的过渡用法，调用时会产生 `FutureWarning`，后续版本不再支持。新代码优先使用 `fla_npu.ops.ascendc` 下的稳定 Python 入口。
 
 ### 测试单算子
 

--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ FLA_NPU_SOC=ascend910b FLA_NPU_INCREMENTAL_BUILD=1 python -m pip wheel --no-buil
 
 布尔变量设为 `TRUE` 时也接受 `1`、`YES`、`ON`；未设置或其他值按 `FALSE` 处理。
 
-#### 方式 B：【备选】编译自定义算子包 + torch_custom 框架
+#### 方式 B：【备选】单独编译算子 run 包和 Python wheel
 
-只有在需要分开调试 OPP run 包和 torch 适配 wheel 时，才建议使用该方式。release wheel 和普通安装优先使用方式 A。
+只有在已经安装方式 A 的完整 wheel、但需要快速替换少量算子的 Ascend C 产物时，才建议使用该方式。run 包安装时会把当前 run 包里的 `packages/vendors/fla_npu_transformer` 合并覆盖到当前 Python 环境已安装的 `site-packages/fla_npu/opp/vendors/fla_npu_transformer`，从而更新 `aclnn`、tiling、kernel 和相关配置。
 
 ```sh
-# 编译 GDN 算子 run 包，注意 --soc 需指定为当前机器芯片类型 {ascend910b/ascend910_93/ascend950}
-bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu
+# 编译一个或多个算子 run 包，--soc 需指定为当前机器芯片类型 {ascend910b/ascend910_93/ascend950}
+bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu --ops=chunk_fwd_o
 
-# 单独编译 Python runtime wheel
+# 如果 Python wrapper 也有修改，再单独编译 Python runtime wheel
 cd torch_custom/fla_npu
 python3 setup.py bdist_wheel
 
@@ -99,14 +99,19 @@ python -m pip install --force-reinstall --no-deps dist/flash_linear_attention_np
 
 #### 方式 B 产物安装
 
-先安装 run 包，再安装 torch_custom wheel。运行 Python 前需要 source custom OPP 的 `set_env.bash`，或设置 `FLA_NPU_OPP_PATH` 指向 OPP root / vendor 目录。
+先确认方式 A 的完整 wheel 已经安装到当前 Python 环境，然后安装 run 包。安装器会在覆盖前列出 `op_api/include/aclnnop` 中新增、删除、修改的 aclnn ABI 头文件；删除只按当前 run 包携带的算子范围判断，非 `--quiet` 模式需要确认后才继续。
 
 ```sh
-export FLA_NPU_OPP_INSTALL_PATH=/path/to/fla_npu_opp
-./build_out/fla-npu-*.run --quiet --install-path=${FLA_NPU_OPP_INSTALL_PATH}
-source ${FLA_NPU_OPP_INSTALL_PATH}/vendors/fla_npu_transformer/bin/set_env.bash
+# 覆盖当前 Python 环境中 flash-linear-attention-npu wheel 内嵌的 OPP
+./build_out/fla-npu-*.run --install
+# 或等价写法
+./build_out/fla-npu-*.run --full
+
+# 如果 Python wrapper 也有修改，再安装单独编译出的 wheel
 python -m pip install --force-reinstall --no-deps torch_custom/fla_npu/dist/fla_npu-*.whl
 ```
+
+安装 run 包后需要重启 Python 进程，已经 `dlopen` 的 `libcust_opapi.so` 不会在同一进程内热替换。
 
 `import fla_npu` 是轻量导入，不会自动导入 `torch` / `torch_npu`，也不会自动注册 `torch.ops.npu`。默认 wheel 通过 Python ctypes 直调 aclnn/opapi，推荐使用 `fla_npu.ops.ascendc`；`torch_npu.ops.*` 会在导入 `fla_npu.ops.ascendc` 后挂到同一套 Python wrapper。只有用 `FLA_NPU_BUILD_LEGACY_EXTENSION=1` 额外编出 legacy 扩展时，才可显式调用 `fla_npu.load_legacy_torch_ops()` 兼容旧 `torch.ops.npu.*`。
 

--- a/ci/run_checks.sh
+++ b/ci/run_checks.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 set -euo pipefail
 
 repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -154,10 +164,14 @@ build_and_check_wheel_api() {
         exit 1
     fi
     python3 -m pip install --force-reinstall --no-deps "${wheels[0]}"
-    python3 scripts/check_packaged_wheel_api.py
+    wheel_api_args=()
+    if [[ "${CI_CHECK_TRITON_API:-false}" == "true" ]]; then
+        wheel_api_args+=(--check-triton)
+    fi
+    python3 scripts/check_packaged_wheel_api.py "${wheel_api_args[@]}"
 }
 
-install_custom_opp_package() {
+find_single_run_package() {
     shopt -s nullglob
     local run_files=(build_out/fla-npu-*.run build/fla-npu-*.run)
     shopt -u nullglob
@@ -167,12 +181,18 @@ install_custom_opp_package() {
         exit 1
     fi
     if (( ${#run_files[@]} > 1 )); then
-        echo "[CI][WARN] Multiple .run packages found; installing ${run_files[0]}."
+        echo "[CI][WARN] Multiple .run packages found; using ${run_files[0]}." >&2
     fi
+    printf '%s\n' "${run_files[0]}"
+}
 
-    echo "[CI] Installing custom OPP package: ${run_files[0]}"
-    chmod +x "${run_files[0]}"
-    "${run_files[0]}" --quiet
+install_custom_opp_package() {
+    local run_file
+    run_file="$(find_single_run_package)"
+
+    echo "[CI] Installing custom OPP package: ${run_file}"
+    chmod +x "${run_file}"
+    "${run_file}" --quiet
 
     local vendor_name="fla_npu"
     local vendor_dir="fla_npu_transformer"
@@ -191,6 +211,60 @@ install_custom_opp_package() {
     fi
     export LD_LIBRARY_PATH="${op_api_lib}:${LD_LIBRARY_PATH:-}"
     echo "[CI] Custom OPP op_api lib: ${op_api_lib}"
+}
+
+check_scoped_wheel_opp_install() {
+    local scoped_op="${CI_SCOPED_WHEEL_INSTALL_OP:-chunk_fwd_o}"
+    local run_file
+    local install_log
+
+    echo "[CI] Checking scoped run package replacement of installed wheel OPP: ${scoped_op}"
+    build_and_check_wheel_api
+
+    rm -rf build build_out
+    bash build.sh --pkg --soc="$ci_soc" --vendor_name=fla_npu --ops="$scoped_op" -j"$ci_jobs"
+    run_file="$(find_single_run_package)"
+    chmod +x "$run_file"
+
+    install_log="$(mktemp)"
+    "$run_file" --full --quiet 2>&1 | tee "$install_log"
+
+    if ! grep -q "Operator support status after installing this run package" "$install_log"; then
+        echo "[CI][ERROR] Scoped run package install did not print the operator support status table." >&2
+        exit 1
+    fi
+    if ! grep -q "$scoped_op" "$install_log"; then
+        echo "[CI][ERROR] Scoped run package install output did not mention ${scoped_op}." >&2
+        exit 1
+    fi
+    if ! grep -q "WARNING" "$install_log"; then
+        echo "[CI][ERROR] Scoped run package install did not warn about operators outside the scoped build." >&2
+        exit 1
+    fi
+    if grep -q "aclnn ABI header changes detected before installing this run package" "$install_log"; then
+        echo "[CI][ERROR] Scoped run package install printed the removed duplicate ABI warning block." >&2
+        exit 1
+    fi
+    if grep -q "Continue to overwrite the installed wheel OPP" "$install_log"; then
+        echo "[CI][ERROR] Scoped run package install printed the removed duplicate confirmation prompt." >&2
+        exit 1
+    fi
+
+    python3 - <<'PY'
+import pathlib
+import fla_npu
+
+package_dir = pathlib.Path(fla_npu.__file__).resolve().parent
+vendor_dir = package_dir / "opp" / "vendors" / "fla_npu_transformer"
+required = [
+    vendor_dir / "op_api" / "lib" / "libcust_opapi.so",
+    vendor_dir / "op_api" / "lib" / "libopapi.so",
+]
+missing = [path.name for path in required if not path.exists()]
+if missing:
+    raise SystemExit("Missing scoped wheel OPP files: " + ", ".join(missing))
+print("[CI] Scoped wheel OPP install check passed.")
+PY
 }
 
 check_example_python_deps() {
@@ -274,4 +348,8 @@ if [[ "${CI_RUN_EXAMPLE_ST:-true}" == "true" ]]; then
         example_st_args+=(--case-filter "$CI_EXAMPLE_CASE_FILTER")
     fi
     python3 ci/run_example_st_cases.py "${example_st_args[@]}"
+fi
+
+if [[ "${CI_RUN_SCOPED_WHEEL_INSTALL_CHECK:-false}" == "true" ]]; then
+    check_scoped_wheel_opp_install
 fi

--- a/ci/run_ci_container.sh
+++ b/ci/run_ci_container.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 set -euo pipefail
 
 repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -161,6 +171,9 @@ docker run --rm \
     -e CI_RUN_TORCH_TESTS="${CI_RUN_TORCH_TESTS:-false}" \
     -e CI_RUN_EXAMPLE_ST="${CI_RUN_EXAMPLE_ST:-true}" \
     -e CI_RUN_WHEEL_API_CHECK="${CI_RUN_WHEEL_API_CHECK:-false}" \
+    -e CI_CHECK_TRITON_API="${CI_CHECK_TRITON_API:-false}" \
+    -e CI_RUN_SCOPED_WHEEL_INSTALL_CHECK="${CI_RUN_SCOPED_WHEEL_INSTALL_CHECK:-false}" \
+    -e CI_SCOPED_WHEEL_INSTALL_OP="${CI_SCOPED_WHEEL_INSTALL_OP:-chunk_fwd_o}" \
     -e CI_EXAMPLE_CASES_FILE="${CI_EXAMPLE_CASES_FILE:-ci/example_st_cases.json}" \
     -e CI_EXAMPLE_CASE_FILTER="${CI_EXAMPLE_CASE_FILTER:-}" \
     -e CI_ACCURACY_REPORT_FILE="${CI_ACCURACY_REPORT_FILE:-output/gdr_accuracy_report.json}" \

--- a/cmake/cust_opapi_dlog_stub.cpp
+++ b/cmake/cust_opapi_dlog_stub.cpp
@@ -1,0 +1,20 @@
+// CANN opdev/op_log.h declares these helpers, but some torch_npu/CANN
+// combinations do not export them into the process. Keep the custom opapi
+// library self-contained so ctypes loading does not depend on PyTorch
+// dispatcher-side symbols; real runtime definitions override these weak
+// no-op fallbacks when they are available.
+#include <cstdint>
+
+__attribute__((weak)) void DlogRecordInner(int32_t moduleId, int32_t level, const char *fmt, ...)
+{
+    (void)moduleId;
+    (void)level;
+    (void)fmt;
+}
+
+__attribute__((weak)) int32_t CheckLogLevelInner(int32_t moduleId, int32_t level)
+{
+    (void)moduleId;
+    (void)level;
+    return 0;
+}

--- a/cmake/custom_build.cmake
+++ b/cmake/custom_build.cmake
@@ -67,6 +67,7 @@ if (BUILD_OPEN_PROJECT)
     )
     target_sources(cust_opapi PRIVATE
             ${CMAKE_CURRENT_BINARY_DIR}/cust_opapi_stub.cpp
+            ${CMAKE_CURRENT_LIST_DIR}/cust_opapi_dlog_stub.cpp
     )
     target_compile_options(cust_opapi PRIVATE
             $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++1z>

--- a/cmake/custom_build.cmake
+++ b/cmake/custom_build.cmake
@@ -1037,11 +1037,9 @@ if (NOT ENABLE_BUILT_IN AND BUILD_OPEN_PROJECT)
     )
 
     # modify VENDOR_NAME in install.sh and upgrade.sh
-    if (EXISTS ${ASCEND_PROJECT_DIR}/fwk_modules/scripts)
-        set(ASCEND_PROJECT_DIR_SCRIPTS_PATH ${ASCEND_PROJECT_DIR}/fwk_modules/scripts)
-    else()
-        set(ASCEND_PROJECT_DIR_SCRIPTS_PATH ${CMAKE_SOURCE_DIR}/cmake/scripts/custom)
-    endif()
+    # Use the repository-owned custom package scripts so scoped wheel-OPP
+    # replacement behavior is deterministic across CANN releases.
+    set(ASCEND_PROJECT_DIR_SCRIPTS_PATH ${CMAKE_SOURCE_DIR}/cmake/scripts/custom)
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/scripts/install.sh ${CMAKE_CURRENT_BINARY_DIR}/scripts/upgrade.sh
             COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/scripts
             COMMAND cp -r ${ASCEND_PROJECT_DIR_SCRIPTS_PATH}/* ${CMAKE_CURRENT_BINARY_DIR}/scripts/

--- a/cmake/scripts/custom/help.info
+++ b/cmake/scripts/custom/help.info
@@ -1,6 +1,6 @@
   --install                         Merge this run package into the active Python flash-linear-attention-npu wheel OPP
   --full                            Same as --install
-                                    Lists package operators, red/yellow/green support status, and scoped aclnn ABI changes
+                                    Lists package operators, support status, and scoped aclnn ABI changes
   --install-path                    Install operator package to specific dir path
   --install-for-all                 Allow other users to use the operator package
   --quiet                           Quiet install mode

--- a/cmake/scripts/custom/help.info
+++ b/cmake/scripts/custom/help.info
@@ -1,2 +1,6 @@
+  --install                         Merge this run package into the active Python flash-linear-attention-npu wheel OPP
+  --full                            Same as --install
+                                    Lists package operators, red/yellow/green support status, and scoped aclnn ABI changes
   --install-path                    Install operator package to specific dir path
   --install-for-all                 Allow other users to use the operator package
+  --quiet                           Quiet install mode

--- a/cmake/scripts/custom/install.sh
+++ b/cmake/scripts/custom/install.sh
@@ -151,6 +151,12 @@ collect_vendor_op_names() {
 
         if [ -d "${kernel_root}" ]; then
             while IFS= read -r src_op_dir; do
+                local rel_dir="${src_op_dir#${kernel_root}/}"
+                case "${rel_dir}" in
+                    config/*)
+                        continue
+                        ;;
+                esac
                 to_snake_name "$(basename "${src_op_dir}")"
             done < <(find "${kernel_root}" -mindepth 2 -maxdepth 2 -type d | sort)
         fi
@@ -405,6 +411,11 @@ merge_vendor_to_wheel_opp() {
     if [ -d "${src_kernel_root}" ]; then
         while IFS= read -r src_op_dir; do
             rel_dir="${src_op_dir#${src_kernel_root}/}"
+            case "${rel_dir}" in
+                config/*)
+                    continue
+                    ;;
+            esac
             dst_op_dir="${dst_kernel_root}/${rel_dir}"
             if [ -d "${dst_op_dir}" ]; then
                 rm -rf "${dst_op_dir}"

--- a/cmake/scripts/custom/install.sh
+++ b/cmake/scripts/custom/install.sh
@@ -17,8 +17,9 @@ target_custom=0
 sourcedir=$PWD/packages
 vendordir=vendors/$vendor_name
 
-QUIET="y"
+QUIET="n"
 INSTALL_FOR_ALL="n"
+WHEEL_INSTALL="n"
 
 
 while true
@@ -26,6 +27,10 @@ do
     case $1 in
     --quiet)
         QUIET="y"
+        shift
+    ;;
+    --full|--install)
+        WHEEL_INSTALL="y"
         shift
     ;;
     --install-path=*)
@@ -50,6 +55,434 @@ log() {
     cur_date=`date +"%Y-%m-%d %H:%M:%S"`
     echo "[ops_custom] [$cur_date] "$1
 }
+
+get_python_bin() {
+    local candidate
+    for candidate in python python3; do
+        if command -v "${candidate}" >/dev/null 2>&1 && "${candidate}" -c 'import sys; raise SystemExit(0 if sys.version_info[0] >= 3 else 1)' >/dev/null 2>&1; then
+            command -v "${candidate}"
+            return
+        fi
+    done
+    echo ""
+}
+
+get_wheel_opp_root() {
+    local python_bin
+    python_bin=$(get_python_bin)
+    if [ -z "${python_bin}" ]; then
+        log "[ERROR] python is required to locate the installed fla_npu wheel OPP."
+        exit 1
+    fi
+
+    "${python_bin}" - <<'PY'
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.find_spec("fla_npu")
+if spec is None or spec.origin is None:
+    raise SystemExit("fla_npu is not importable. Install flash-linear-attention-npu wheel first.")
+
+package_dir = Path(spec.origin).resolve().parent
+print(package_dir / "opp")
+PY
+}
+
+copy_wheel_file() {
+    local src_file="$1"
+    local dst_file="$2"
+    mkdir -p "$(dirname "${dst_file}")"
+    cp -a "${src_file}" "${dst_file}"
+}
+
+to_snake_name() {
+    echo "$1" | sed -E 's/([A-Z]+)([A-Z][a-z])/\1_\2/g; s/([a-z0-9])([A-Z])/\1_\2/g' | tr '[:upper:]' '[:lower:]'
+}
+
+color_status_tag() {
+    local color="$1"
+    local tag="$2"
+    local red
+    local yellow
+    local green
+    local reset
+
+    red=$(printf '\033[31m')
+    yellow=$(printf '\033[33m')
+    green=$(printf '\033[32m')
+    reset=$(printf '\033[0m')
+
+    case "${color}" in
+        red)
+            printf '%b[%s]%b' "${red}" "${tag}" "${reset}"
+            ;;
+        yellow)
+            printf '%b[%s]%b' "${yellow}" "${tag}" "${reset}"
+            ;;
+        green)
+            printf '%b[%s]%b' "${green}" "${tag}" "${reset}"
+            ;;
+        *)
+            printf '[%s]' "${tag}"
+            ;;
+    esac
+}
+
+collect_vendor_op_names() {
+    local vendor_dir="$1"
+    local abi_dir="${vendor_dir}/op_api/include/aclnnop"
+    local kernel_root="${vendor_dir}/op_impl/ai_core/tbe/kernel"
+
+    (
+        if [ -d "${abi_dir}" ]; then
+            while IFS= read -r header_file; do
+                local file_name
+                file_name=$(basename "${header_file}")
+                case "${file_name}" in
+                    aclnn_ops_transformer*.h)
+                        continue
+                        ;;
+                    aclnn_*.h)
+                        echo "${file_name}" | sed -E 's/^aclnn_(.*)\.h$/\1/'
+                        ;;
+                esac
+            done < <(find "${abi_dir}" -type f -name 'aclnn_*.h' | sort)
+        fi
+
+        if [ -d "${kernel_root}" ]; then
+            while IFS= read -r src_op_dir; do
+                to_snake_name "$(basename "${src_op_dir}")"
+            done < <(find "${kernel_root}" -mindepth 2 -maxdepth 2 -type d | sort)
+        fi
+    ) | sort -u
+}
+
+collect_op_aclnn_abi_changes() {
+    local src_vendor="$1"
+    local dst_vendor="$2"
+    local op_name="$3"
+    local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
+    local dst_abi_dir="${dst_vendor}/op_api/include/aclnnop"
+    local rel_file
+
+    for rel_file in "aclnn_${op_name}.h" "level2/aclnn_${op_name}.h"; do
+        if [ -f "${src_abi_dir}/${rel_file}" ] && [ ! -f "${dst_abi_dir}/${rel_file}" ]; then
+            echo "ADDED ${rel_file}"
+        elif [ -f "${src_abi_dir}/${rel_file}" ] && [ -f "${dst_abi_dir}/${rel_file}" ] && ! cmp -s "${src_abi_dir}/${rel_file}" "${dst_abi_dir}/${rel_file}"; then
+            echo "MODIFIED ${rel_file}"
+        elif [ ! -f "${src_abi_dir}/${rel_file}" ] && [ -f "${dst_abi_dir}/${rel_file}" ]; then
+            echo "DELETED ${rel_file}"
+        fi
+    done
+}
+
+op_has_source_aclnn_header() {
+    local src_vendor="$1"
+    local op_name="$2"
+    local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
+
+    [ -f "${src_abi_dir}/aclnn_${op_name}.h" ] || [ -f "${src_abi_dir}/level2/aclnn_${op_name}.h" ]
+}
+
+format_change_summary() {
+    local change_file="$1"
+    local summary=""
+    local line
+
+    while IFS= read -r line; do
+        if [ -z "${summary}" ]; then
+            summary="${line}"
+        else
+            summary="${summary}; ${line}"
+        fi
+    done <"${change_file}"
+    echo "${summary}"
+}
+
+log_colored_op_status() {
+    local level="$1"
+    local color="$2"
+    local tag="$3"
+    local op_name="$4"
+    local reason="$5"
+
+    log "[${level}]   $(color_status_tag "${color}" "${tag}") ${op_name} - ${reason}"
+}
+
+log_op_scope_file() {
+    local title="$1"
+    local op_file="$2"
+    local level="$3"
+    local op_name
+
+    log "[${level}] ${title}"
+    if [ ! -s "${op_file}" ]; then
+        log "[${level}]   (none detected)"
+        return
+    fi
+
+    while IFS= read -r op_name; do
+        log "[${level}]   ${op_name}"
+    done <"${op_file}"
+}
+
+log_included_op_status() {
+    local src_vendor="$1"
+    local dst_vendor="$2"
+    local op_name="$3"
+    local changes_file
+    local summary
+
+    changes_file=$(mktemp)
+    collect_op_aclnn_abi_changes "${src_vendor}" "${dst_vendor}" "${op_name}" >"${changes_file}"
+    summary=$(format_change_summary "${changes_file}")
+
+    if grep -qE '^(MODIFIED|DELETED) ' "${changes_file}"; then
+        log_colored_op_status "WARNING" "red" "RED" "${op_name}" "unsupported after install because aclnn ABI changed: ${summary}"
+    elif grep -q '^ADDED ' "${changes_file}"; then
+        log_colored_op_status "WARNING" "yellow" "YELLOW" "${op_name}" "included in run package, but aclnn ABI is new in the installed wheel: ${summary}"
+    elif ! op_has_source_aclnn_header "${src_vendor}" "${op_name}"; then
+        log_colored_op_status "WARNING" "yellow" "YELLOW" "${op_name}" "included in run package, but no aclnn ABI header was found to compare"
+    else
+        log_colored_op_status "INFO" "green" "GREEN" "${op_name}" "included in run package and aclnn ABI is unchanged"
+    fi
+
+    rm -f "${changes_file}"
+}
+
+confirm_partial_shared_lib_impact() {
+    local src_vendor="$1"
+    local dst_vendor="$2"
+    local src_ops_file
+    local dst_ops_file
+    local unavailable_ops_file
+    local op_name
+
+    src_ops_file=$(mktemp)
+    dst_ops_file=$(mktemp)
+    unavailable_ops_file=$(mktemp)
+
+    collect_vendor_op_names "${src_vendor}" >"${src_ops_file}"
+    collect_vendor_op_names "${dst_vendor}" >"${dst_ops_file}"
+    comm -23 "${dst_ops_file}" "${src_ops_file}" >"${unavailable_ops_file}"
+
+    log_op_scope_file "This run package contains operators:" "${src_ops_file}" "INFO"
+    log "[INFO] Operator support status after installing this run package:"
+    log "[INFO]   $(color_status_tag "red" "RED") unsupported after install"
+    log "[INFO]   $(color_status_tag "yellow" "YELLOW") requires manual attention"
+    log "[INFO]   $(color_status_tag "green" "GREEN") supported after install"
+
+    while IFS= read -r op_name; do
+        log_included_op_status "${src_vendor}" "${dst_vendor}" "${op_name}"
+    done <"${src_ops_file}"
+
+    if [ -s "${unavailable_ops_file}" ]; then
+        log "[WARNING] Installing this run package replaces shared opapi/tiling/proto libraries in the wheel with the scoped build from this package."
+        log "[WARNING] The following installed operators are not included in this run package and will not be usable after replacement:"
+        while IFS= read -r op_name; do
+            log_colored_op_status "WARNING" "red" "RED" "${op_name}" "not included in this run package; shared opapi/tiling/proto libraries will be replaced"
+        done <"${unavailable_ops_file}"
+    fi
+
+    rm -f "${src_ops_file}" "${dst_ops_file}" "${unavailable_ops_file}"
+
+    if [ "${QUIET}" = "y" ]; then
+        log "[WARNING] --quiet is set, treating scoped run package replacement impact as confirmed."
+        return
+    fi
+
+    log "[INFO] Continue to replace the installed wheel OPP with this scoped run package? [y/n]"
+    while true; do
+        read yn
+        if [ "${yn}" = "y" ]; then
+            return
+        elif [ "${yn}" = "n" ]; then
+            log "[INFO] Exit without installing run package."
+            exit 0
+        else
+            log "[WARNING] Input error, please input y or n to choose!"
+        fi
+    done
+}
+
+remove_deleted_aclnn_headers() {
+    local src_vendor="$1"
+    local dst_vendor="$2"
+    local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
+    local dst_abi_dir="${dst_vendor}/op_api/include/aclnnop"
+    local op_name
+    local rel_file
+
+    if [ ! -d "${src_abi_dir}" ] || [ ! -d "${dst_abi_dir}" ]; then
+        return
+    fi
+
+    while IFS= read -r op_name; do
+        for rel_file in "aclnn_${op_name}.h" "level2/aclnn_${op_name}.h"; do
+            if [ -f "${dst_abi_dir}/${rel_file}" ] && [ ! -f "${src_abi_dir}/${rel_file}" ]; then
+                rm -f "${dst_abi_dir}/${rel_file}"
+            fi
+        done
+    done < <(collect_vendor_op_names "${src_vendor}")
+}
+
+confirm_aclnn_abi_changes() {
+    local src_vendor="$1"
+    local dst_vendor="$2"
+    local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
+    local dst_abi_dir="${dst_vendor}/op_api/include/aclnnop"
+    local report_file
+    local src_file
+    local op_name
+    local rel_file
+
+    if [ ! -d "${src_abi_dir}" ]; then
+        log "[INFO] No aclnn ABI headers found in run package, skip ABI comparison."
+        return
+    fi
+
+    report_file=$(mktemp)
+
+    while IFS= read -r src_file; do
+        rel_file="${src_file#${src_abi_dir}/}"
+        if [ ! -f "${dst_abi_dir}/${rel_file}" ]; then
+            echo "ADDED    ${rel_file}" >>"${report_file}"
+        elif ! cmp -s "${src_file}" "${dst_abi_dir}/${rel_file}"; then
+            echo "MODIFIED ${rel_file}" >>"${report_file}"
+        fi
+    done < <(find "${src_abi_dir}" -type f | sort)
+
+    while IFS= read -r op_name; do
+        for rel_file in "aclnn_${op_name}.h" "level2/aclnn_${op_name}.h"; do
+            if [ -f "${dst_abi_dir}/${rel_file}" ] && [ ! -f "${src_abi_dir}/${rel_file}" ]; then
+                echo "DELETED  ${rel_file}" >>"${report_file}"
+            fi
+        done
+    done < <(collect_vendor_op_names "${src_vendor}")
+
+    if [ ! -s "${report_file}" ]; then
+        log "[INFO] No aclnn ABI header changes detected."
+        rm -f "${report_file}"
+        return
+    fi
+
+    log "[WARNING] aclnn ABI header changes detected before installing this run package:"
+    while IFS= read -r line; do
+        log "[WARNING]   ${line}"
+    done <"${report_file}"
+    rm -f "${report_file}"
+
+    if [ "${QUIET}" = "y" ]; then
+        log "[WARNING] --quiet is set, treating aclnn ABI changes as confirmed."
+        return
+    fi
+
+    log "[INFO] Continue to overwrite the installed wheel OPP? [y/n]"
+    while true; do
+        read yn
+        if [ "${yn}" = "y" ]; then
+            return
+        elif [ "${yn}" = "n" ]; then
+            log "[INFO] Exit without installing run package."
+            exit 0
+        else
+            log "[WARNING] Input error, please input y or n to choose!"
+        fi
+    done
+}
+
+merge_vendor_to_wheel_opp() {
+    local src_vendor="$1"
+    local dst_vendor="$2"
+    local src_kernel_root="${src_vendor}/op_impl/ai_core/tbe/kernel"
+    local dst_kernel_root="${dst_vendor}/op_impl/ai_core/tbe/kernel"
+    local src_op_dir
+    local rel_dir
+    local dst_op_dir
+
+    mkdir -p "${dst_vendor}"
+
+    if [ -d "${src_kernel_root}" ]; then
+        while IFS= read -r src_op_dir; do
+            rel_dir="${src_op_dir#${src_kernel_root}/}"
+            dst_op_dir="${dst_kernel_root}/${rel_dir}"
+            if [ -d "${dst_op_dir}" ]; then
+                rm -rf "${dst_op_dir}"
+            fi
+        done < <(find "${src_kernel_root}" -mindepth 2 -maxdepth 2 -type d)
+    fi
+
+    remove_deleted_aclnn_headers "${src_vendor}" "${dst_vendor}"
+
+    if command -v rsync >/dev/null 2>&1; then
+        rsync -a --checksum "${src_vendor}/" "${dst_vendor}/"
+    else
+        cp -a "${src_vendor}/." "${dst_vendor}/"
+    fi
+
+    if [ -f "${dst_vendor}/op_api/lib/libcust_opapi.so" ]; then
+        copy_wheel_file "${dst_vendor}/op_api/lib/libcust_opapi.so" "${dst_vendor}/op_api/lib/libopapi.so"
+    fi
+}
+
+update_wheel_vendors_config() {
+    local vendors_root="$1"
+    local config_file="${vendors_root}/config.ini"
+    local existing=""
+    local merged="${vendor_name}"
+    local item
+
+    mkdir -p "${vendors_root}"
+    if [ -f "${config_file}" ]; then
+        existing=$(grep -w "load_priority" "${config_file}" | tail -n 1 | cut --only-delimited -d"=" -f2-)
+    fi
+
+    IFS=',' read -ra vendor_items <<< "${existing}"
+    for item in "${vendor_items[@]}"; do
+        item=$(echo "${item}" | xargs)
+        if [ -n "${item}" ] && [ "${item}" != "${vendor_name}" ]; then
+            merged="${merged},${item}"
+        fi
+    done
+    echo "load_priority=${merged}" >"${config_file}"
+}
+
+install_wheel_opp_package() {
+    local src_vendor="${sourcedir}/${vendordir}"
+    local wheel_opp_root
+    local dst_vendor
+
+    if [ ! -d "${src_vendor}" ]; then
+        log "[ERROR] The run package does not contain ${src_vendor}."
+        exit 1
+    fi
+
+    wheel_opp_root=$(get_wheel_opp_root)
+    wheel_opp_root="${wheel_opp_root%/}"
+    dst_vendor="${wheel_opp_root}/${vendordir}"
+
+    if [ ! -d "${dst_vendor}" ]; then
+        log "[ERROR] Target wheel OPP vendor not found: ${dst_vendor}. Install the full flash-linear-attention-npu wheel first."
+        exit 1
+    fi
+
+    log "[INFO] Merge FLA NPU run package into installed wheel OPP root: ${wheel_opp_root}"
+    log "[INFO] Source vendor ${src_vendor}"
+    log "[INFO] Target vendor ${dst_vendor}"
+
+    confirm_partial_shared_lib_impact "${src_vendor}" "${dst_vendor}"
+    confirm_aclnn_abi_changes "${src_vendor}" "${dst_vendor}"
+    merge_vendor_to_wheel_opp "${src_vendor}" "${dst_vendor}"
+    update_wheel_vendors_config "${wheel_opp_root}/vendors"
+
+    log "[INFO] FLA NPU wheel OPP update completed. Restart Python processes to load the new libcust_opapi.so and kernels."
+    echo "SUCCESS"
+    exit 0
+}
+
+if [ "${WHEEL_INSTALL}" = "y" ]; then
+    install_wheel_opp_package
+fi
 
 if [ -n "${INSTALL_PATH}" ]; then
     if [[ ! "${INSTALL_PATH}" = /* ]]; then

--- a/cmake/scripts/custom/install.sh
+++ b/cmake/scripts/custom/install.sh
@@ -53,7 +53,7 @@ done
 
 log() {
     cur_date=`date +"%Y-%m-%d %H:%M:%S"`
-    echo "[ops_custom] [$cur_date] "$1
+    printf '[ops_custom] [%s] %s\n' "${cur_date}" "$1"
 }
 
 get_python_bin() {
@@ -99,31 +99,21 @@ to_snake_name() {
     echo "$1" | sed -E 's/([A-Z]+)([A-Z][a-z])/\1_\2/g; s/([a-z0-9])([A-Z])/\1_\2/g' | tr '[:upper:]' '[:lower:]'
 }
 
-color_status_tag() {
-    local color="$1"
-    local tag="$2"
-    local red
-    local yellow
-    local green
-    local reset
+support_status_tag() {
+    local status="$1"
 
-    red=$(printf '\033[31m')
-    yellow=$(printf '\033[33m')
-    green=$(printf '\033[32m')
-    reset=$(printf '\033[0m')
-
-    case "${color}" in
-        red)
-            printf '%b[%s]%b' "${red}" "${tag}" "${reset}"
+    case "${status}" in
+        warning)
+            printf 'WARNING'
             ;;
-        yellow)
-            printf '%b[%s]%b' "${yellow}" "${tag}" "${reset}"
+        notice)
+            printf 'NOTICE'
             ;;
-        green)
-            printf '%b[%s]%b' "${green}" "${tag}" "${reset}"
+        ok)
+            printf 'OK'
             ;;
         *)
-            printf '[%s]' "${tag}"
+            printf 'INFO'
             ;;
     esac
 }
@@ -205,14 +195,15 @@ format_change_summary() {
     echo "${summary}"
 }
 
-log_colored_op_status() {
+log_op_status() {
     local level="$1"
-    local color="$2"
-    local tag="$3"
-    local op_name="$4"
-    local reason="$5"
+    local status="$2"
+    local op_name="$3"
+    local reason="$4"
+    local tag
 
-    log "[${level}]   $(color_status_tag "${color}" "${tag}") ${op_name} - ${reason}"
+    tag=$(support_status_tag "${status}")
+    log "[${level}]   $(printf '%-7s %-36s - %s' "${tag}" "${op_name}" "${reason}")"
 }
 
 log_op_scope_file() {
@@ -244,13 +235,13 @@ log_included_op_status() {
     summary=$(format_change_summary "${changes_file}")
 
     if grep -qE '^(MODIFIED|DELETED) ' "${changes_file}"; then
-        log_colored_op_status "WARNING" "red" "RED" "${op_name}" "unsupported after install because aclnn ABI changed: ${summary}"
+        log_op_status "WARNING" "warning" "${op_name}" "unsupported after install because aclnn ABI changed: ${summary}"
     elif grep -q '^ADDED ' "${changes_file}"; then
-        log_colored_op_status "WARNING" "yellow" "YELLOW" "${op_name}" "included in run package, but aclnn ABI is new in the installed wheel: ${summary}"
+        log_op_status "WARNING" "notice" "${op_name}" "included in run package, but aclnn ABI is new in the installed wheel: ${summary}"
     elif ! op_has_source_aclnn_header "${src_vendor}" "${op_name}"; then
-        log_colored_op_status "WARNING" "yellow" "YELLOW" "${op_name}" "included in run package, but no aclnn ABI header was found to compare"
+        log_op_status "WARNING" "notice" "${op_name}" "included in run package, but no aclnn ABI header was found to compare"
     else
-        log_colored_op_status "INFO" "green" "GREEN" "${op_name}" "included in run package and aclnn ABI is unchanged"
+        log_op_status "INFO" "ok" "${op_name}" "included in run package and aclnn ABI is unchanged"
     fi
 
     rm -f "${changes_file}"
@@ -274,9 +265,9 @@ confirm_partial_shared_lib_impact() {
 
     log_op_scope_file "This run package contains operators:" "${src_ops_file}" "INFO"
     log "[INFO] Operator support status after installing this run package:"
-    log "[INFO]   $(color_status_tag "red" "RED") unsupported after install"
-    log "[INFO]   $(color_status_tag "yellow" "YELLOW") requires manual attention"
-    log "[INFO]   $(color_status_tag "green" "GREEN") supported after install"
+    log "[INFO]   $(printf '%-7s %s' "$(support_status_tag "warning")" "unsupported after install")"
+    log "[INFO]   $(printf '%-7s %s' "$(support_status_tag "notice")" "requires manual attention")"
+    log "[INFO]   $(printf '%-7s %s' "$(support_status_tag "ok")" "supported after install")"
 
     while IFS= read -r op_name; do
         log_included_op_status "${src_vendor}" "${dst_vendor}" "${op_name}"
@@ -286,7 +277,7 @@ confirm_partial_shared_lib_impact() {
         log "[WARNING] Installing this run package replaces shared opapi/tiling/proto libraries in the wheel with the scoped build from this package."
         log "[WARNING] The following installed operators are not included in this run package and will not be usable after replacement:"
         while IFS= read -r op_name; do
-            log_colored_op_status "WARNING" "red" "RED" "${op_name}" "not included in this run package; shared opapi/tiling/proto libraries will be replaced"
+            log_op_status "WARNING" "warning" "${op_name}" "not included in this run package; shared opapi/tiling/proto libraries will be replaced"
         done <"${unavailable_ops_file}"
     fi
 
@@ -330,71 +321,6 @@ remove_deleted_aclnn_headers() {
             fi
         done
     done < <(collect_vendor_op_names "${src_vendor}")
-}
-
-confirm_aclnn_abi_changes() {
-    local src_vendor="$1"
-    local dst_vendor="$2"
-    local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
-    local dst_abi_dir="${dst_vendor}/op_api/include/aclnnop"
-    local report_file
-    local src_file
-    local op_name
-    local rel_file
-
-    if [ ! -d "${src_abi_dir}" ]; then
-        log "[INFO] No aclnn ABI headers found in run package, skip ABI comparison."
-        return
-    fi
-
-    report_file=$(mktemp)
-
-    while IFS= read -r src_file; do
-        rel_file="${src_file#${src_abi_dir}/}"
-        if [ ! -f "${dst_abi_dir}/${rel_file}" ]; then
-            echo "ADDED    ${rel_file}" >>"${report_file}"
-        elif ! cmp -s "${src_file}" "${dst_abi_dir}/${rel_file}"; then
-            echo "MODIFIED ${rel_file}" >>"${report_file}"
-        fi
-    done < <(find "${src_abi_dir}" -type f | sort)
-
-    while IFS= read -r op_name; do
-        for rel_file in "aclnn_${op_name}.h" "level2/aclnn_${op_name}.h"; do
-            if [ -f "${dst_abi_dir}/${rel_file}" ] && [ ! -f "${src_abi_dir}/${rel_file}" ]; then
-                echo "DELETED  ${rel_file}" >>"${report_file}"
-            fi
-        done
-    done < <(collect_vendor_op_names "${src_vendor}")
-
-    if [ ! -s "${report_file}" ]; then
-        log "[INFO] No aclnn ABI header changes detected."
-        rm -f "${report_file}"
-        return
-    fi
-
-    log "[WARNING] aclnn ABI header changes detected before installing this run package:"
-    while IFS= read -r line; do
-        log "[WARNING]   ${line}"
-    done <"${report_file}"
-    rm -f "${report_file}"
-
-    if [ "${QUIET}" = "y" ]; then
-        log "[WARNING] --quiet is set, treating aclnn ABI changes as confirmed."
-        return
-    fi
-
-    log "[INFO] Continue to overwrite the installed wheel OPP? [y/n]"
-    while true; do
-        read yn
-        if [ "${yn}" = "y" ]; then
-            return
-        elif [ "${yn}" = "n" ]; then
-            log "[INFO] Exit without installing run package."
-            exit 0
-        else
-            log "[WARNING] Input error, please input y or n to choose!"
-        fi
-    done
 }
 
 merge_vendor_to_wheel_opp() {
@@ -482,7 +408,6 @@ install_wheel_opp_package() {
     log "[INFO] Target vendor ${dst_vendor}"
 
     confirm_partial_shared_lib_impact "${src_vendor}" "${dst_vendor}"
-    confirm_aclnn_abi_changes "${src_vendor}" "${dst_vendor}"
     merge_vendor_to_wheel_opp "${src_vendor}" "${dst_vendor}"
     update_wheel_vendors_config "${wheel_opp_root}/vendors"
 

--- a/examples/flash_gated_delta_rule.py
+++ b/examples/flash_gated_delta_rule.py
@@ -256,7 +256,9 @@ def _probe_solve_tri_ascendc(device: torch.device, dtype: torch.dtype) -> bool:
 
     probe_dtype = dtype if dtype in (torch.float16, torch.bfloat16) else torch.float16
     try:
-        probe = torch.zeros((1, 64, 1, 64), dtype=probe_dtype, device=device)
+        # solve_tri does not support D=64 on this path; probe a supported D=128
+        # shape so capability detection does not incorrectly force Triton fallback.
+        probe = torch.zeros((1, 64, 1, 128), dtype=probe_dtype, device=device)
         ascendc_solve_tri(probe, layout="bsnd")
         torch.npu.synchronize()
     except Exception as exc:

--- a/scripts/check_npu_env.py
+++ b/scripts/check_npu_env.py
@@ -10,12 +10,13 @@ import re
 import shutil
 import sys
 from importlib import metadata
+from typing import Optional, Tuple
 
 from packaging.version import InvalidVersion, Version
 
 
 MIN_PYTHON = (3, 9)
-MIN_TORCH = "2.7.0"
+MIN_TORCH = "2.6.0"
 MIN_TRITON_ASCEND = "3.2.0"
 MIN_TRITON_ASCEND_A5 = "3.2.1"
 TORCH_NPU_GDN_FIX_MINIMUMS = {
@@ -96,14 +97,14 @@ def _check_min_version(failures: list[str], name: str, actual: str, minimum: str
         _fail(failures, f"{name}>={minimum} is required, got {actual}")
 
 
-def _version_obj(value: str) -> Version | None:
+def _version_obj(value: str) -> Optional[Version]:
     try:
         return Version(value.split("+", 1)[0])
     except InvalidVersion:
         return None
 
 
-def _version_key(value: str) -> tuple[int, int, int] | None:
+def _version_key(value: str) -> Optional[Tuple[int, int, int]]:
     parts = re.findall(r"\d+", value.split("+", 1)[0])
     if not parts:
         return None
@@ -124,6 +125,9 @@ def _check_torch_npu_gdn_fix(failures: list[str], actual: str) -> None:
         return
 
     if actual_version >= Version(MIN_TORCH_NPU_FUTURE_FIX_FAMILY):
+        return
+
+    if minimum is None:
         return
 
     requirements = ", ".join(
@@ -190,7 +194,12 @@ def main() -> int:
     parser.add_argument(
         "--build-only",
         action="store_true",
-        help="Allow torch.npu.is_available() to be false, while still checking build dependencies.",
+        help="Only check dependencies required to build the Python-only wheel.",
+    )
+    parser.add_argument(
+        "--legacy-extension",
+        action="store_true",
+        help="Also check torch, torch_npu, torchnpugen and triton-ascend for legacy extension builds.",
     )
     parser.add_argument(
         "--skip-torchnpugen",
@@ -224,8 +233,14 @@ def main() -> int:
     else:
         _fail(failures, "ASCEND_HOME_PATH or ASCEND_OPP_PATH must be set")
 
-    torch = _import_module(failures, "torch")
-    torch_npu = _import_module(failures, "torch_npu")
+    check_runtime = not args.build_only or args.legacy_extension
+    if not check_runtime:
+        _ok("skipping torch/torch_npu/triton checks for Python-only wheel build")
+        torch = None
+        torch_npu = None
+    else:
+        torch = _import_module(failures, "torch")
+        torch_npu = _import_module(failures, "torch_npu")
 
     if torch is not None:
         torch_version = getattr(torch, "__version__", "<unknown>")
@@ -251,20 +266,23 @@ def main() -> int:
         _ok(f"torch_npu version: {torch_npu_version}")
         _check_torch_npu_gdn_fix(failures, torch_npu_version)
 
-    if not args.skip_torchnpugen:
+    if args.legacy_extension and not args.skip_torchnpugen:
         for module_name in TORCHNPUGEN_MODULES:
             _find_module(failures, module_name)
+    elif args.skip_torchnpugen:
+        _warn("skipping torchnpugen checks")
 
-    triton = _import_module(failures, "triton")
-    triton_ascend_version = _distribution_version("triton-ascend")
-    if triton_ascend_version:
-        _ok(f"triton-ascend version: {triton_ascend_version}")
-        _check_min_version(failures, "triton-ascend", triton_ascend_version, MIN_TRITON_ASCEND)
-        _check_triton_ascend_a5_compat(failures, triton_ascend_version)
-    elif triton is not None:
-        _fail(failures, "triton is importable, but triton-ascend distribution was not found")
-    else:
-        _fail(failures, "triton-ascend distribution was not found")
+    if check_runtime:
+        triton = _import_module(failures, "triton")
+        triton_ascend_version = _distribution_version("triton-ascend")
+        if triton_ascend_version:
+            _ok(f"triton-ascend version: {triton_ascend_version}")
+            _check_min_version(failures, "triton-ascend", triton_ascend_version, MIN_TRITON_ASCEND)
+            _check_triton_ascend_a5_compat(failures, triton_ascend_version)
+        elif triton is not None:
+            _fail(failures, "triton is importable, but triton-ascend distribution was not found")
+        else:
+            _fail(failures, "triton-ascend distribution was not found")
 
     if failures:
         print("\nEnvironment check failed:")

--- a/scripts/check_packaged_wheel_api.py
+++ b/scripts/check_packaged_wheel_api.py
@@ -1,8 +1,19 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 """Validate the installed flash-linear-attention-npu wheel API surface."""
 
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 
@@ -64,28 +75,49 @@ def _require_packaged_opp_configs(fla_npu_module) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--skip-triton", action="store_true", help="Only validate Ascend C APIs.")
+    parser.add_argument(
+        "--skip-triton",
+        action="store_true",
+        help="Deprecated compatibility flag. Triton API validation is opt-in by default.",
+    )
+    parser.add_argument(
+        "--check-triton",
+        action="store_true",
+        help="Also validate fla_npu.ops.triton exports. This may initialize the triton backend.",
+    )
+    parser.add_argument(
+        "--check-legacy-torch-npu",
+        action="store_true",
+        help="Also validate optional torch_npu.ops compatibility exports.",
+    )
     args = parser.parse_args()
 
     import fla_npu
-    import torch_npu
     from fla_npu.ops import ascendc
 
     if fla_npu.is_legacy_torch_ops_loaded():
         raise AssertionError("packaged wheel API check should not load legacy torch.ops.npu extension")
+    if "torch_npu" in sys.modules and not args.check_legacy_torch_npu:
+        raise AssertionError("packaged wheel API check should not import torch_npu by default")
 
     for name in ASCENDC_NAMES:
         _require_attr(ascendc, name, "fla_npu.ops.ascendc")
         _require_attr(ascendc, f"npu_{name}", "fla_npu.ops.ascendc")
-        _require_attr(torch_npu.ops, name, "torch_npu.ops")
-        _require_attr(torch_npu.ops, f"npu_{name}", "torch_npu.ops")
+
+    if args.check_legacy_torch_npu:
+        import torch_npu
+
+        ascendc.install_torch_npu_ops_compat()
+        for name in ASCENDC_NAMES:
+            _require_attr(torch_npu.ops, name, "torch_npu.ops")
+            _require_attr(torch_npu.ops, f"npu_{name}", "torch_npu.ops")
 
     _require_packaged_opp_configs(fla_npu)
 
     if ascendc.BACKWARD_OPS.get("causal_conv1d") != "causal_conv1d_bwd":
         raise AssertionError("causal_conv1d backward binding metadata is missing")
 
-    if not args.skip_triton:
+    if args.check_triton and not args.skip_triton:
         from fla_npu.ops import triton
 
         for name in TRITON_NAMES:

--- a/scripts/check_packaged_wheel_api.py
+++ b/scripts/check_packaged_wheel_api.py
@@ -7,8 +7,6 @@ from pathlib import Path
 
 
 ASCENDC_NAMES = (
-    "fast_gelu_custom",
-    "fast_gelu_custom_backward",
     "causal_conv1d",
     "causal_conv1d_bwd",
     "chunk_bwd_dqkwg",
@@ -70,9 +68,11 @@ def main() -> int:
     args = parser.parse_args()
 
     import fla_npu
-    fla_npu.load_legacy_torch_ops()
     import torch_npu
     from fla_npu.ops import ascendc
+
+    if fla_npu.is_legacy_torch_ops_loaded():
+        raise AssertionError("packaged wheel API check should not load legacy torch.ops.npu extension")
 
     for name in ASCENDC_NAMES:
         _require_attr(ascendc, name, "fla_npu.ops.ascendc")
@@ -84,8 +84,6 @@ def main() -> int:
 
     if ascendc.BACKWARD_OPS.get("causal_conv1d") != "causal_conv1d_bwd":
         raise AssertionError("causal_conv1d backward binding metadata is missing")
-    if ascendc.BACKWARD_OPS.get("fast_gelu_custom") != "fast_gelu_custom_backward":
-        raise AssertionError("fast_gelu_custom backward binding metadata is missing")
 
     if not args.skip_triton:
         from fla_npu.ops import triton

--- a/scripts/check_packaged_wheel_api.py
+++ b/scripts/check_packaged_wheel_api.py
@@ -70,6 +70,7 @@ def main() -> int:
     args = parser.parse_args()
 
     import fla_npu
+    fla_npu.load_legacy_torch_ops()
     import torch_npu
     from fla_npu.ops import ascendc
 

--- a/scripts/package/ops_transformer/scripts/help.info
+++ b/scripts/package/ops_transformer/scripts/help.info
@@ -1,6 +1,6 @@
   --install                         Merge this run package into the active Python flash-linear-attention-npu wheel OPP
   --full                            Same as --install
-    The installer lists scoped aclnn ABI header changes before overwriting the wheel OPP
+    The installer lists package operators, disabled installed operators, and scoped aclnn ABI changes
     --quiet                         Quiet install mode
   --uninstall                       Uninstall product with compatible run package which is installed before
     --install-path=<path>           Uninstall specific ops_transformer dir path

--- a/scripts/package/ops_transformer/scripts/help.info
+++ b/scripts/package/ops_transformer/scripts/help.info
@@ -1,6 +1,6 @@
   --install                         Merge this run package into the active Python flash-linear-attention-npu wheel OPP
   --full                            Same as --install
-    The installer lists package operators, disabled installed operators, and scoped aclnn ABI changes
+    The installer lists package operators, red/yellow/green support status, and scoped aclnn ABI changes
     --quiet                         Quiet install mode
   --uninstall                       Uninstall product with compatible run package which is installed before
     --install-path=<path>           Uninstall specific ops_transformer dir path

--- a/scripts/package/ops_transformer/scripts/help.info
+++ b/scripts/package/ops_transformer/scripts/help.info
@@ -1,6 +1,6 @@
   --install                         Merge this run package into the active Python flash-linear-attention-npu wheel OPP
   --full                            Same as --install
-    The installer lists package operators, red/yellow/green support status, and scoped aclnn ABI changes
+    The installer lists package operators, support status, and scoped aclnn ABI changes
     --quiet                         Quiet install mode
   --uninstall                       Uninstall product with compatible run package which is installed before
     --install-path=<path>           Uninstall specific ops_transformer dir path

--- a/scripts/package/ops_transformer/scripts/help.info
+++ b/scripts/package/ops_transformer/scripts/help.info
@@ -1,7 +1,7 @@
-  --full                            Install full mode
-    --install-path=<path>           Install product to specific dir path
-    --install-for-all               Install for all user
-    --quiet                         Quiet install mode, skip human-computer interactions
+  --install                         Merge this run package into the active Python flash-linear-attention-npu wheel OPP
+  --full                            Same as --install
+    The installer lists scoped aclnn ABI header changes before overwriting the wheel OPP
+    --quiet                         Quiet install mode
   --uninstall                       Uninstall product with compatible run package which is installed before
     --install-path=<path>           Uninstall specific ops_transformer dir path
   --upgrade                         Upgrade product immediately

--- a/scripts/package/ops_transformer/scripts/install.sh
+++ b/scripts/package/ops_transformer/scripts/install.sh
@@ -430,6 +430,35 @@ to_snake_name() {
   echo "$1" | sed -E 's/([A-Z]+)([A-Z][a-z])/\1_\2/g; s/([a-z0-9])([A-Z])/\1_\2/g' | tr '[:upper:]' '[:lower:]'
 }
 
+color_status_tag() {
+  local color="$1"
+  local tag="$2"
+  local red
+  local yellow
+  local green
+  local reset
+
+  red=$(printf '\033[31m')
+  yellow=$(printf '\033[33m')
+  green=$(printf '\033[32m')
+  reset=$(printf '\033[0m')
+
+  case "${color}" in
+    red)
+      printf '%b[%s]%b' "${red}" "${tag}" "${reset}"
+      ;;
+    yellow)
+      printf '%b[%s]%b' "${yellow}" "${tag}" "${reset}"
+      ;;
+    green)
+      printf '%b[%s]%b' "${green}" "${tag}" "${reset}"
+      ;;
+    *)
+      printf '[%s]' "${tag}"
+      ;;
+  esac
+}
+
 collect_vendor_op_names() {
   local vendor_dir="$1"
   local abi_dir="${vendor_dir}/op_api/include/aclnnop"
@@ -459,6 +488,58 @@ collect_vendor_op_names() {
   ) | sort -u
 }
 
+collect_op_aclnn_abi_changes() {
+  local src_vendor="$1"
+  local dst_vendor="$2"
+  local op_name="$3"
+  local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
+  local dst_abi_dir="${dst_vendor}/op_api/include/aclnnop"
+  local rel_file
+
+  for rel_file in "aclnn_${op_name}.h" "level2/aclnn_${op_name}.h"; do
+    if [ -f "${src_abi_dir}/${rel_file}" ] && [ ! -f "${dst_abi_dir}/${rel_file}" ]; then
+      echo "ADDED ${rel_file}"
+    elif [ -f "${src_abi_dir}/${rel_file}" ] && [ -f "${dst_abi_dir}/${rel_file}" ] && ! cmp -s "${src_abi_dir}/${rel_file}" "${dst_abi_dir}/${rel_file}"; then
+      echo "MODIFIED ${rel_file}"
+    elif [ ! -f "${src_abi_dir}/${rel_file}" ] && [ -f "${dst_abi_dir}/${rel_file}" ]; then
+      echo "DELETED ${rel_file}"
+    fi
+  done
+}
+
+op_has_source_aclnn_header() {
+  local src_vendor="$1"
+  local op_name="$2"
+  local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
+
+  [ -f "${src_abi_dir}/aclnn_${op_name}.h" ] || [ -f "${src_abi_dir}/level2/aclnn_${op_name}.h" ]
+}
+
+format_change_summary() {
+  local change_file="$1"
+  local summary=""
+  local line
+
+  while IFS= read -r line; do
+    if [ -z "${summary}" ]; then
+      summary="${line}"
+    else
+      summary="${summary}; ${line}"
+    fi
+  done <"${change_file}"
+  echo "${summary}"
+}
+
+log_colored_op_status() {
+  local level="$1"
+  local color="$2"
+  local tag="$3"
+  local op_name="$4"
+  local reason="$5"
+
+  logandprint "[${level}]:   $(color_status_tag "${color}" "${tag}") ${op_name} - ${reason}"
+}
+
 log_op_scope_file() {
   local title="$1"
   local op_file="$2"
@@ -476,12 +557,37 @@ log_op_scope_file() {
   done <"${op_file}"
 }
 
+log_included_op_status() {
+  local src_vendor="$1"
+  local dst_vendor="$2"
+  local op_name="$3"
+  local changes_file
+  local summary
+
+  changes_file=$(mktemp)
+  collect_op_aclnn_abi_changes "${src_vendor}" "${dst_vendor}" "${op_name}" >"${changes_file}"
+  summary=$(format_change_summary "${changes_file}")
+
+  if grep -qE '^(MODIFIED|DELETED) ' "${changes_file}"; then
+    log_colored_op_status "WARNING" "red" "RED" "${op_name}" "unsupported after install because aclnn ABI changed: ${summary}"
+  elif grep -q '^ADDED ' "${changes_file}"; then
+    log_colored_op_status "WARNING" "yellow" "YELLOW" "${op_name}" "included in run package, but aclnn ABI is new in the installed wheel: ${summary}"
+  elif ! op_has_source_aclnn_header "${src_vendor}" "${op_name}"; then
+    log_colored_op_status "WARNING" "yellow" "YELLOW" "${op_name}" "included in run package, but no aclnn ABI header was found to compare"
+  else
+    log_colored_op_status "INFO" "green" "GREEN" "${op_name}" "included in run package and aclnn ABI is unchanged"
+  fi
+
+  rm -f "${changes_file}"
+}
+
 confirm_partial_shared_lib_impact() {
   local src_vendor="$1"
   local dst_vendor="$2"
   local src_ops_file
   local dst_ops_file
   local unavailable_ops_file
+  local op_name
 
   src_ops_file=$(mktemp)
   dst_ops_file=$(mktemp)
@@ -493,13 +599,25 @@ confirm_partial_shared_lib_impact() {
 
   log_op_scope_file "This run package contains operators:" "${src_ops_file}" "INFO"
 
+  logandprint "[INFO]: Operator support status after installing this run package:"
+  logandprint "[INFO]:   $(color_status_tag "red" "RED") unsupported after install"
+  logandprint "[INFO]:   $(color_status_tag "yellow" "YELLOW") requires manual attention"
+  logandprint "[INFO]:   $(color_status_tag "green" "GREEN") supported after install"
+
+  while IFS= read -r op_name; do
+    log_included_op_status "${src_vendor}" "${dst_vendor}" "${op_name}"
+  done <"${src_ops_file}"
+
   if [ ! -s "${unavailable_ops_file}" ]; then
     rm -f "${src_ops_file}" "${dst_ops_file}" "${unavailable_ops_file}"
     return
   fi
 
   logandprint "[WARNING]: Installing this run package replaces shared opapi/tiling/proto libraries in the wheel with the scoped build from this package."
-  log_op_scope_file "The following installed operators are not included in this run package and will not be usable after replacement:" "${unavailable_ops_file}" "WARNING"
+  logandprint "[WARNING]: The following installed operators are not included in this run package and will not be usable after replacement:"
+  while IFS= read -r op_name; do
+    log_colored_op_status "WARNING" "red" "RED" "${op_name}" "not included in this run package; shared opapi/tiling/proto libraries will be replaced"
+  done <"${unavailable_ops_file}"
   rm -f "${src_ops_file}" "${dst_ops_file}" "${unavailable_ops_file}"
 
   if [ "${IS_QUIET}" = "y" ]; then

--- a/scripts/package/ops_transformer/scripts/install.sh
+++ b/scripts/package/ops_transformer/scripts/install.sh
@@ -430,16 +430,16 @@ to_snake_name() {
   echo "$1" | sed -E 's/([A-Z]+)([A-Z][a-z])/\1_\2/g; s/([a-z0-9])([A-Z])/\1_\2/g' | tr '[:upper:]' '[:lower:]'
 }
 
-collect_source_op_names() {
-  local src_vendor="$1"
-  local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
-  local src_kernel_root="${src_vendor}/op_impl/ai_core/tbe/kernel"
+collect_vendor_op_names() {
+  local vendor_dir="$1"
+  local abi_dir="${vendor_dir}/op_api/include/aclnnop"
+  local kernel_root="${vendor_dir}/op_impl/ai_core/tbe/kernel"
 
   (
-    if [ -d "${src_abi_dir}" ]; then
-      while IFS= read -r src_file; do
+    if [ -d "${abi_dir}" ]; then
+      while IFS= read -r header_file; do
         local file_name
-        file_name=$(basename "${src_file}")
+        file_name=$(basename "${header_file}")
         case "${file_name}" in
           aclnn_ops_transformer*.h)
             continue
@@ -448,15 +448,78 @@ collect_source_op_names() {
             echo "${file_name}" | sed -E 's/^aclnn_(.*)\.h$/\1/'
             ;;
         esac
-      done < <(find "${src_abi_dir}" -type f -name 'aclnn_*.h' | sort)
+      done < <(find "${abi_dir}" -type f -name 'aclnn_*.h' | sort)
     fi
 
-    if [ -d "${src_kernel_root}" ]; then
+    if [ -d "${kernel_root}" ]; then
       while IFS= read -r src_op_dir; do
         to_snake_name "$(basename "${src_op_dir}")"
-      done < <(find "${src_kernel_root}" -mindepth 2 -maxdepth 2 -type d | sort)
+      done < <(find "${kernel_root}" -mindepth 2 -maxdepth 2 -type d | sort)
     fi
   ) | sort -u
+}
+
+log_op_scope_file() {
+  local title="$1"
+  local op_file="$2"
+  local level="$3"
+  local op_name
+
+  logandprint "[${level}]: ${title}"
+  if [ ! -s "${op_file}" ]; then
+    logandprint "[${level}]:   (none detected)"
+    return
+  fi
+
+  while IFS= read -r op_name; do
+    logandprint "[${level}]:   ${op_name}"
+  done <"${op_file}"
+}
+
+confirm_partial_shared_lib_impact() {
+  local src_vendor="$1"
+  local dst_vendor="$2"
+  local src_ops_file
+  local dst_ops_file
+  local unavailable_ops_file
+
+  src_ops_file=$(mktemp)
+  dst_ops_file=$(mktemp)
+  unavailable_ops_file=$(mktemp)
+
+  collect_vendor_op_names "${src_vendor}" >"${src_ops_file}"
+  collect_vendor_op_names "${dst_vendor}" >"${dst_ops_file}"
+  comm -23 "${dst_ops_file}" "${src_ops_file}" >"${unavailable_ops_file}"
+
+  log_op_scope_file "This run package contains operators:" "${src_ops_file}" "INFO"
+
+  if [ ! -s "${unavailable_ops_file}" ]; then
+    rm -f "${src_ops_file}" "${dst_ops_file}" "${unavailable_ops_file}"
+    return
+  fi
+
+  logandprint "[WARNING]: Installing this run package replaces shared opapi/tiling/proto libraries in the wheel with the scoped build from this package."
+  log_op_scope_file "The following installed operators are not included in this run package and will not be usable after replacement:" "${unavailable_ops_file}" "WARNING"
+  rm -f "${src_ops_file}" "${dst_ops_file}" "${unavailable_ops_file}"
+
+  if [ "${IS_QUIET}" = "y" ]; then
+    logandprint "[WARNING]: --quiet is set, treating partial shared-library replacement impact as confirmed."
+    return
+  fi
+
+  logandprint "[INFO]: Continue to replace the installed wheel shared libraries with this scoped run package? [y/n]"
+  while true; do
+    read yn
+    if [ "${yn}" = "y" ]; then
+      return
+    elif [ "${yn}" = "n" ]; then
+      logandprint "[INFO]: Exit without installing run package."
+      exitlog
+      exit 0
+    else
+      echo "[WARNING]: Input error, please input y or n to choose!"
+    fi
+  done
 }
 
 remove_deleted_aclnn_headers() {
@@ -480,7 +543,7 @@ remove_deleted_aclnn_headers() {
         rm -f "${dst_abi_dir}/${rel_file}"
       fi
     done
-  done < <(collect_source_op_names "${src_vendor}")
+  done < <(collect_vendor_op_names "${src_vendor}")
 }
 
 merge_vendor_to_wheel_opp() {
@@ -587,7 +650,7 @@ confirm_aclnn_abi_changes() {
         echo "DELETED  ${rel_file}" >>"${report_file}"
       fi
     done
-  done < <(collect_source_op_names "${src_vendor}")
+  done < <(collect_vendor_op_names "${src_vendor}")
 
   if [ ! -s "${report_file}" ]; then
     logandprint "[INFO]: No aclnn ABI header changes detected."
@@ -654,6 +717,7 @@ install_wheel_opp_package() {
   logandprint "[INFO]: Source vendor ${src_vendor}"
   logandprint "[INFO]: Target vendor ${dst_vendor}"
 
+  confirm_partial_shared_lib_impact "${src_vendor}" "${dst_vendor}"
   confirm_aclnn_abi_changes "${src_vendor}" "${dst_vendor}"
   merge_vendor_to_wheel_opp "${src_vendor}" "${dst_vendor}"
   update_wheel_vendors_config "${wheel_opp_root}/vendors" "fla_npu_transformer"

--- a/scripts/package/ops_transformer/scripts/install.sh
+++ b/scripts/package/ops_transformer/scripts/install.sh
@@ -482,6 +482,12 @@ collect_vendor_op_names() {
 
     if [ -d "${kernel_root}" ]; then
       while IFS= read -r src_op_dir; do
+        local rel_dir="${src_op_dir#${kernel_root}/}"
+        case "${rel_dir}" in
+          config/*)
+            continue
+            ;;
+        esac
         to_snake_name "$(basename "${src_op_dir}")"
       done < <(find "${kernel_root}" -mindepth 2 -maxdepth 2 -type d | sort)
     fi
@@ -684,6 +690,11 @@ merge_vendor_to_wheel_opp() {
   if [ -d "${src_kernel_root}" ]; then
     while IFS= read -r src_op_dir; do
       local rel_dir="${src_op_dir#${src_kernel_root}/}"
+      case "${rel_dir}" in
+        config/*)
+          continue
+          ;;
+      esac
       local dst_op_dir="${dst_kernel_root}/${rel_dir}"
       if [ -d "${dst_op_dir}" ]; then
         rm -rf "${dst_op_dir}"

--- a/scripts/package/ops_transformer/scripts/install.sh
+++ b/scripts/package/ops_transformer/scripts/install.sh
@@ -430,31 +430,21 @@ to_snake_name() {
   echo "$1" | sed -E 's/([A-Z]+)([A-Z][a-z])/\1_\2/g; s/([a-z0-9])([A-Z])/\1_\2/g' | tr '[:upper:]' '[:lower:]'
 }
 
-color_status_tag() {
-  local color="$1"
-  local tag="$2"
-  local red
-  local yellow
-  local green
-  local reset
+support_status_tag() {
+  local status="$1"
 
-  red=$(printf '\033[31m')
-  yellow=$(printf '\033[33m')
-  green=$(printf '\033[32m')
-  reset=$(printf '\033[0m')
-
-  case "${color}" in
-    red)
-      printf '%b[%s]%b' "${red}" "${tag}" "${reset}"
+  case "${status}" in
+    warning)
+      printf 'WARNING'
       ;;
-    yellow)
-      printf '%b[%s]%b' "${yellow}" "${tag}" "${reset}"
+    notice)
+      printf 'NOTICE'
       ;;
-    green)
-      printf '%b[%s]%b' "${green}" "${tag}" "${reset}"
+    ok)
+      printf 'OK'
       ;;
     *)
-      printf '[%s]' "${tag}"
+      printf 'INFO'
       ;;
   esac
 }
@@ -536,14 +526,15 @@ format_change_summary() {
   echo "${summary}"
 }
 
-log_colored_op_status() {
+log_op_status() {
   local level="$1"
-  local color="$2"
-  local tag="$3"
-  local op_name="$4"
-  local reason="$5"
+  local status="$2"
+  local op_name="$3"
+  local reason="$4"
+  local tag
 
-  logandprint "[${level}]:   $(color_status_tag "${color}" "${tag}") ${op_name} - ${reason}"
+  tag=$(support_status_tag "${status}")
+  logandprint "[${level}]:   $(printf '%-7s %-36s - %s' "${tag}" "${op_name}" "${reason}")"
 }
 
 log_op_scope_file() {
@@ -575,13 +566,13 @@ log_included_op_status() {
   summary=$(format_change_summary "${changes_file}")
 
   if grep -qE '^(MODIFIED|DELETED) ' "${changes_file}"; then
-    log_colored_op_status "WARNING" "red" "RED" "${op_name}" "unsupported after install because aclnn ABI changed: ${summary}"
+    log_op_status "WARNING" "warning" "${op_name}" "unsupported after install because aclnn ABI changed: ${summary}"
   elif grep -q '^ADDED ' "${changes_file}"; then
-    log_colored_op_status "WARNING" "yellow" "YELLOW" "${op_name}" "included in run package, but aclnn ABI is new in the installed wheel: ${summary}"
+    log_op_status "WARNING" "notice" "${op_name}" "included in run package, but aclnn ABI is new in the installed wheel: ${summary}"
   elif ! op_has_source_aclnn_header "${src_vendor}" "${op_name}"; then
-    log_colored_op_status "WARNING" "yellow" "YELLOW" "${op_name}" "included in run package, but no aclnn ABI header was found to compare"
+    log_op_status "WARNING" "notice" "${op_name}" "included in run package, but no aclnn ABI header was found to compare"
   else
-    log_colored_op_status "INFO" "green" "GREEN" "${op_name}" "included in run package and aclnn ABI is unchanged"
+    log_op_status "INFO" "ok" "${op_name}" "included in run package and aclnn ABI is unchanged"
   fi
 
   rm -f "${changes_file}"
@@ -606,9 +597,9 @@ confirm_partial_shared_lib_impact() {
   log_op_scope_file "This run package contains operators:" "${src_ops_file}" "INFO"
 
   logandprint "[INFO]: Operator support status after installing this run package:"
-  logandprint "[INFO]:   $(color_status_tag "red" "RED") unsupported after install"
-  logandprint "[INFO]:   $(color_status_tag "yellow" "YELLOW") requires manual attention"
-  logandprint "[INFO]:   $(color_status_tag "green" "GREEN") supported after install"
+  logandprint "[INFO]:   $(printf '%-7s %s' "$(support_status_tag "warning")" "unsupported after install")"
+  logandprint "[INFO]:   $(printf '%-7s %s' "$(support_status_tag "notice")" "requires manual attention")"
+  logandprint "[INFO]:   $(printf '%-7s %s' "$(support_status_tag "ok")" "supported after install")"
 
   while IFS= read -r op_name; do
     log_included_op_status "${src_vendor}" "${dst_vendor}" "${op_name}"
@@ -622,7 +613,7 @@ confirm_partial_shared_lib_impact() {
   logandprint "[WARNING]: Installing this run package replaces shared opapi/tiling/proto libraries in the wheel with the scoped build from this package."
   logandprint "[WARNING]: The following installed operators are not included in this run package and will not be usable after replacement:"
   while IFS= read -r op_name; do
-    log_colored_op_status "WARNING" "red" "RED" "${op_name}" "not included in this run package; shared opapi/tiling/proto libraries will be replaced"
+    log_op_status "WARNING" "warning" "${op_name}" "not included in this run package; shared opapi/tiling/proto libraries will be replaced"
   done <"${unavailable_ops_file}"
   rm -f "${src_ops_file}" "${dst_ops_file}" "${unavailable_ops_file}"
 
@@ -749,70 +740,6 @@ update_wheel_vendors_config() {
   echo "load_priority=${merged}" >"${config_file}"
 }
 
-confirm_aclnn_abi_changes() {
-  local src_vendor="$1"
-  local dst_vendor="$2"
-  local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
-  local dst_abi_dir="${dst_vendor}/op_api/include/aclnnop"
-  local report_file
-
-  if [ ! -d "${src_abi_dir}" ]; then
-    logandprint "[INFO]: No aclnn ABI headers found in run package, skip ABI comparison."
-    return
-  fi
-
-  report_file=$(mktemp)
-
-  while IFS= read -r src_file; do
-    local rel_file="${src_file#${src_abi_dir}/}"
-    local dst_file="${dst_abi_dir}/${rel_file}"
-    if [ ! -f "${dst_file}" ]; then
-      echo "ADDED    ${rel_file}" >>"${report_file}"
-    elif ! cmp -s "${src_file}" "${dst_file}"; then
-      echo "MODIFIED ${rel_file}" >>"${report_file}"
-    fi
-  done < <(find "${src_abi_dir}" -type f | sort)
-
-  while IFS= read -r op_name; do
-    for rel_file in "aclnn_${op_name}.h" "level2/aclnn_${op_name}.h"; do
-      if [ -f "${dst_abi_dir}/${rel_file}" ] && [ ! -f "${src_abi_dir}/${rel_file}" ]; then
-        echo "DELETED  ${rel_file}" >>"${report_file}"
-      fi
-    done
-  done < <(collect_vendor_op_names "${src_vendor}")
-
-  if [ ! -s "${report_file}" ]; then
-    logandprint "[INFO]: No aclnn ABI header changes detected."
-    rm -f "${report_file}"
-    return
-  fi
-
-  logandprint "[WARNING]: aclnn ABI header changes detected before installing this run package:"
-  while IFS= read -r line; do
-    logandprint "[WARNING]:   ${line}"
-  done <"${report_file}"
-  rm -f "${report_file}"
-
-  if [ "${IS_QUIET}" = "y" ]; then
-    logandprint "[WARNING]: --quiet is set, treating aclnn ABI changes as confirmed."
-    return
-  fi
-
-  logandprint "[INFO]: Continue to overwrite the installed wheel OPP? [y/n]"
-  while true; do
-    read yn
-    if [ "${yn}" = "y" ]; then
-      return
-    elif [ "${yn}" = "n" ]; then
-      logandprint "[INFO]: Exit without installing run package."
-      exitlog
-      exit 0
-    else
-      echo "[WARNING]: Input error, please input y or n to choose!"
-    fi
-  done
-}
-
 install_wheel_opp_package() {
   if [ "${IS_INSTALL}" = "n" ]; then
     return
@@ -847,7 +774,6 @@ install_wheel_opp_package() {
   logandprint "[INFO]: Target vendor ${dst_vendor}"
 
   confirm_partial_shared_lib_impact "${src_vendor}" "${dst_vendor}"
-  confirm_aclnn_abi_changes "${src_vendor}" "${dst_vendor}"
   merge_vendor_to_wheel_opp "${src_vendor}" "${dst_vendor}"
   update_wheel_vendors_config "${wheel_opp_root}/vendors" "fla_npu_transformer"
 

--- a/scripts/package/ops_transformer/scripts/install.sh
+++ b/scripts/package/ops_transformer/scripts/install.sh
@@ -330,7 +330,7 @@ get_opts() {
   while true; do
     # skip 2 parameters avoid run pkg and directory as input parameter
     case "$1" in
-      --full)
+      --full|--install)
         IN_INSTALL_TYPE=$(echo ${1} | awk -F"--" '{print $2}')
         IS_INSTALL="y"
         CONFLICT_CMD_NUMS=$(expr $CONFLICT_CMD_NUMS + 1)
@@ -379,11 +379,288 @@ get_opts() {
 check_opts() {
   if [ "${CONFLICT_CMD_NUMS}" != 1 ]; then
     echo "[OpsTransformer] [ERROR]: ERR_NO:${PARAM_INVALID};ERR_DES:\
- only support one type: full/run/devel/upgrade/uninstall/check, operation execute failed!\
+ only support one type: install/full/upgrade/uninstall, operation execute failed!\
  Please use [--help] to see the usage."
     exitlog
     exit 1
   fi
+}
+
+get_python_bin() {
+  local candidate
+  for candidate in python python3; do
+    if command -v "${candidate}" >/dev/null 2>&1 && "${candidate}" -c 'import sys; raise SystemExit(0 if sys.version_info[0] >= 3 else 1)' >/dev/null 2>&1; then
+      command -v "${candidate}"
+      return
+    fi
+  done
+  echo ""
+}
+
+get_wheel_opp_root() {
+  local python_bin
+  python_bin=$(get_python_bin)
+  if [ -z "${python_bin}" ]; then
+    logandprint "[ERROR]: python is required to locate the installed fla_npu wheel OPP."
+    exitlog
+    exit 1
+  fi
+
+  "${python_bin}" - <<'PY'
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.find_spec("fla_npu")
+if spec is None or spec.origin is None:
+    raise SystemExit("fla_npu is not importable. Install flash-linear-attention-npu wheel first.")
+
+package_dir = Path(spec.origin).resolve().parent
+print(package_dir / "opp")
+PY
+}
+
+copy_wheel_file() {
+  local src_file="$1"
+  local dst_file="$2"
+  mkdir -p "$(dirname "${dst_file}")"
+  cp -a "${src_file}" "${dst_file}"
+}
+
+to_snake_name() {
+  echo "$1" | sed -E 's/([A-Z]+)([A-Z][a-z])/\1_\2/g; s/([a-z0-9])([A-Z])/\1_\2/g' | tr '[:upper:]' '[:lower:]'
+}
+
+collect_source_op_names() {
+  local src_vendor="$1"
+  local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
+  local src_kernel_root="${src_vendor}/op_impl/ai_core/tbe/kernel"
+
+  (
+    if [ -d "${src_abi_dir}" ]; then
+      while IFS= read -r src_file; do
+        local file_name
+        file_name=$(basename "${src_file}")
+        case "${file_name}" in
+          aclnn_ops_transformer*.h)
+            continue
+            ;;
+          aclnn_*.h)
+            echo "${file_name}" | sed -E 's/^aclnn_(.*)\.h$/\1/'
+            ;;
+        esac
+      done < <(find "${src_abi_dir}" -type f -name 'aclnn_*.h' | sort)
+    fi
+
+    if [ -d "${src_kernel_root}" ]; then
+      while IFS= read -r src_op_dir; do
+        to_snake_name "$(basename "${src_op_dir}")"
+      done < <(find "${src_kernel_root}" -mindepth 2 -maxdepth 2 -type d | sort)
+    fi
+  ) | sort -u
+}
+
+remove_deleted_aclnn_headers() {
+  local src_vendor="$1"
+  local dst_vendor="$2"
+  local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
+  local dst_abi_dir="${dst_vendor}/op_api/include/aclnnop"
+  local op_name
+  local rel_file
+
+  if [ ! -d "${src_abi_dir}" ] || [ ! -d "${dst_abi_dir}" ]; then
+    return
+  fi
+
+  # Only delete aclnn headers for operators carried by this run package. A
+  # partial run package intentionally omits unrelated operators, so treating all
+  # target-only headers as deleted would break incremental replacement.
+  while IFS= read -r op_name; do
+    for rel_file in "aclnn_${op_name}.h" "level2/aclnn_${op_name}.h"; do
+      if [ -f "${dst_abi_dir}/${rel_file}" ] && [ ! -f "${src_abi_dir}/${rel_file}" ]; then
+        rm -f "${dst_abi_dir}/${rel_file}"
+      fi
+    done
+  done < <(collect_source_op_names "${src_vendor}")
+}
+
+merge_vendor_to_wheel_opp() {
+  local src_vendor="$1"
+  local dst_vendor="$2"
+
+  if [ ! -d "${src_vendor}" ]; then
+    logandprint "[ERROR]: Source vendor directory not found: ${src_vendor}"
+    exitlog
+    exit 1
+  fi
+
+  mkdir -p "${dst_vendor}"
+
+  # A partial run package is expected to replace only the operators it carries.
+  # Remove matching per-operator kernel directories first so stale .o files from
+  # an older build cannot survive when a kernel filename changes.
+  local src_kernel_root="${src_vendor}/op_impl/ai_core/tbe/kernel"
+  local dst_kernel_root="${dst_vendor}/op_impl/ai_core/tbe/kernel"
+  if [ -d "${src_kernel_root}" ]; then
+    while IFS= read -r src_op_dir; do
+      local rel_dir="${src_op_dir#${src_kernel_root}/}"
+      local dst_op_dir="${dst_kernel_root}/${rel_dir}"
+      if [ -d "${dst_op_dir}" ]; then
+        rm -rf "${dst_op_dir}"
+      fi
+    done < <(find "${src_kernel_root}" -mindepth 2 -maxdepth 2 -type d)
+  fi
+
+  remove_deleted_aclnn_headers "${src_vendor}" "${dst_vendor}"
+
+  if command -v rsync >/dev/null 2>&1; then
+    rsync -a --checksum "${src_vendor}/" "${dst_vendor}/"
+  else
+    cp -a "${src_vendor}/." "${dst_vendor}/"
+  fi
+
+  if [ -f "${dst_vendor}/op_api/lib/libcust_opapi.so" ]; then
+    copy_wheel_file "${dst_vendor}/op_api/lib/libcust_opapi.so" "${dst_vendor}/op_api/lib/libopapi.so"
+  fi
+
+  mkdir -p "${dst_vendor}/bin"
+  cat >"${dst_vendor}/bin/set_env.bash" <<'EOF'
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENDOR_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+OPP_ROOT="$(cd "${VENDOR_DIR}/../.." && pwd)"
+export ASCEND_CUSTOM_OPP_PATH="${OPP_ROOT}:${VENDOR_DIR}:${ASCEND_CUSTOM_OPP_PATH}"
+export LD_LIBRARY_PATH="${VENDOR_DIR}/op_api/lib:${LD_LIBRARY_PATH}"
+EOF
+  chmod 755 "${dst_vendor}/bin/set_env.bash" 2>/dev/null
+}
+
+update_wheel_vendors_config() {
+  local vendors_root="$1"
+  local vendor_name="$2"
+  local config_file="${vendors_root}/config.ini"
+  mkdir -p "${vendors_root}"
+
+  local existing=""
+  if [ -f "${config_file}" ]; then
+    existing=$(grep -w "load_priority" "${config_file}" | tail -n 1 | cut --only-delimited -d"=" -f2-)
+  fi
+
+  local merged="${vendor_name}"
+  local item
+  IFS=',' read -ra vendor_items <<< "${existing}"
+  for item in "${vendor_items[@]}"; do
+    item=$(echo "${item}" | xargs)
+    if [ -n "${item}" ] && [ "${item}" != "${vendor_name}" ]; then
+      merged="${merged},${item}"
+    fi
+  done
+  echo "load_priority=${merged}" >"${config_file}"
+}
+
+confirm_aclnn_abi_changes() {
+  local src_vendor="$1"
+  local dst_vendor="$2"
+  local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
+  local dst_abi_dir="${dst_vendor}/op_api/include/aclnnop"
+  local report_file
+
+  if [ ! -d "${src_abi_dir}" ]; then
+    logandprint "[INFO]: No aclnn ABI headers found in run package, skip ABI comparison."
+    return
+  fi
+
+  report_file=$(mktemp)
+
+  while IFS= read -r src_file; do
+    local rel_file="${src_file#${src_abi_dir}/}"
+    local dst_file="${dst_abi_dir}/${rel_file}"
+    if [ ! -f "${dst_file}" ]; then
+      echo "ADDED    ${rel_file}" >>"${report_file}"
+    elif ! cmp -s "${src_file}" "${dst_file}"; then
+      echo "MODIFIED ${rel_file}" >>"${report_file}"
+    fi
+  done < <(find "${src_abi_dir}" -type f | sort)
+
+  while IFS= read -r op_name; do
+    for rel_file in "aclnn_${op_name}.h" "level2/aclnn_${op_name}.h"; do
+      if [ -f "${dst_abi_dir}/${rel_file}" ] && [ ! -f "${src_abi_dir}/${rel_file}" ]; then
+        echo "DELETED  ${rel_file}" >>"${report_file}"
+      fi
+    done
+  done < <(collect_source_op_names "${src_vendor}")
+
+  if [ ! -s "${report_file}" ]; then
+    logandprint "[INFO]: No aclnn ABI header changes detected."
+    rm -f "${report_file}"
+    return
+  fi
+
+  logandprint "[WARNING]: aclnn ABI header changes detected before installing this run package:"
+  while IFS= read -r line; do
+    logandprint "[WARNING]:   ${line}"
+  done <"${report_file}"
+  rm -f "${report_file}"
+
+  if [ "${IS_QUIET}" = "y" ]; then
+    logandprint "[WARNING]: --quiet is set, treating aclnn ABI changes as confirmed."
+    return
+  fi
+
+  logandprint "[INFO]: Continue to overwrite the installed wheel OPP? [y/n]"
+  while true; do
+    read yn
+    if [ "${yn}" = "y" ]; then
+      return
+    elif [ "${yn}" = "n" ]; then
+      logandprint "[INFO]: Exit without installing run package."
+      exitlog
+      exit 0
+    else
+      echo "[WARNING]: Input error, please input y or n to choose!"
+    fi
+  done
+}
+
+install_wheel_opp_package() {
+  if [ "${IS_INSTALL}" = "n" ]; then
+    return
+  fi
+
+  local src_vendors_root="${CURR_PATH}/../../../../ops_transformer/packages/vendors"
+  local src_vendor="${src_vendors_root}/fla_npu_transformer"
+  if [ ! -d "${src_vendor}" ]; then
+    logandprint "[ERROR]: The run package does not contain ${src_vendor}."
+    exitlog
+    exit 1
+  fi
+
+  local wheel_opp_root
+  wheel_opp_root=$(get_wheel_opp_root)
+  wheel_opp_root="${wheel_opp_root%/}"
+  if [ -z "${wheel_opp_root}" ]; then
+    logandprint "[ERROR]: Unable to locate wheel OPP root."
+    exitlog
+    exit 1
+  fi
+
+  local dst_vendor="${wheel_opp_root}/vendors/fla_npu_transformer"
+  if [ ! -d "${dst_vendor}" ]; then
+    logandprint "[ERROR]: Target wheel OPP vendor not found: ${dst_vendor}. Install the full flash-linear-attention-npu wheel first."
+    exitlog
+    exit 1
+  fi
+
+  logandprint "[INFO]: Merge FLA NPU run package into installed wheel OPP root: ${wheel_opp_root}"
+  logandprint "[INFO]: Source vendor ${src_vendor}"
+  logandprint "[INFO]: Target vendor ${dst_vendor}"
+
+  confirm_aclnn_abi_changes "${src_vendor}" "${dst_vendor}"
+  merge_vendor_to_wheel_opp "${src_vendor}" "${dst_vendor}"
+  update_wheel_vendors_config "${wheel_opp_root}/vendors" "fla_npu_transformer"
+
+  logandprint "[INFO]: FLA NPU wheel OPP update completed. Restart Python processes to load the new libcust_opapi.so and kernels."
+  exitlog
+  exit 0
 }
 
 # init target_dir and log for install
@@ -601,6 +878,8 @@ main() {
   get_opts "$@"
 
   check_opts
+
+  install_wheel_opp_package
 
   init_env
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ from fla_npu_artifacts import get_package_version, get_wheel_build_tag  # noqa: 
 DEFAULT_SOC = "ascend910b"
 DEFAULT_VENDOR_NAME = "fla_npu"
 MIN_PYTHON = (3, 9)
-MIN_TORCH = "2.7.0"
+MIN_TORCH = "2.6.0"
 MIN_TRITON_ASCEND = "3.2.0"
 MIN_TRITON_ASCEND_A5 = "3.2.1"
 TORCH_NPU_GDN_FIX_MINIMUMS = {
@@ -135,6 +135,9 @@ def _check_torch_npu_gdn_fix(failures, actual):
     if actual_version >= Version(MIN_TORCH_NPU_FUTURE_FIX_FAMILY):
         return
 
+    if minimum is None:
+        return
+
     requirements = ", ".join(
         f"{family}>={minimum}" for family, minimum in TORCH_NPU_GDN_FIX_MINIMUMS.items()
     )
@@ -200,6 +203,7 @@ def _detect_cann_version():
 
 def _check_build_environment():
     failures = []
+    build_legacy_extension = _env_flag("FLA_NPU_BUILD_LEGACY_EXTENSION")
 
     if shutil.which("bash") is None:
         failures.append("bash is required")
@@ -224,39 +228,42 @@ def _check_build_environment():
     else:
         print(f"[fla-npu build][OK] Python: {sys.version.split()[0]}")
 
-    torch = None
-    torch_npu = None
-    for module in ("torch", "torch_npu"):
+    if build_legacy_extension:
+        torch = None
+        torch_npu = None
+        for module in ("torch", "torch_npu"):
+            try:
+                loaded = importlib.import_module(module)
+                print(f"[fla-npu build][OK] {module}: {getattr(loaded, '__version__', '<unknown>')}")
+                if module == "torch":
+                    torch = loaded
+                else:
+                    torch_npu = loaded
+            except Exception as exc:
+                failures.append(f"{module}: {exc}")
+
+        if torch is not None:
+            _check_min_version(failures, "torch", getattr(torch, "__version__", ""), MIN_TORCH)
+        if torch_npu is not None:
+            _check_torch_npu_gdn_fix(failures, getattr(torch_npu, "__version__", ""))
+
+        triton_ascend_version = _distribution_version("triton-ascend")
         try:
-            loaded = importlib.import_module(module)
-            print(f"[fla-npu build][OK] {module}: {getattr(loaded, '__version__', '<unknown>')}")
-            if module == "torch":
-                torch = loaded
-            else:
-                torch_npu = loaded
+            triton = importlib.import_module("triton")
+            print(f"[fla-npu build][OK] triton: {getattr(triton, '__file__', '<unknown>')}")
         except Exception as exc:
-            failures.append(f"{module}: {exc}")
+            failures.append(f"triton: {exc}")
 
-    if torch is not None:
-        _check_min_version(failures, "torch", getattr(torch, "__version__", ""), MIN_TORCH)
-    if torch_npu is not None:
-        _check_torch_npu_gdn_fix(failures, getattr(torch_npu, "__version__", ""))
-
-    triton_ascend_version = _distribution_version("triton-ascend")
-    try:
-        triton = importlib.import_module("triton")
-        print(f"[fla-npu build][OK] triton: {getattr(triton, '__file__', '<unknown>')}")
-    except Exception as exc:
-        failures.append(f"triton: {exc}")
-
-    if triton_ascend_version:
-        print(f"[fla-npu build][OK] triton-ascend: {triton_ascend_version}")
-        _check_min_version(failures, "triton-ascend", triton_ascend_version, MIN_TRITON_ASCEND)
-        _check_triton_ascend_a5_compat(failures, triton_ascend_version)
+        if triton_ascend_version:
+            print(f"[fla-npu build][OK] triton-ascend: {triton_ascend_version}")
+            _check_min_version(failures, "triton-ascend", triton_ascend_version, MIN_TRITON_ASCEND)
+            _check_triton_ascend_a5_compat(failures, triton_ascend_version)
+        else:
+            failures.append("triton-ascend distribution was not found")
     else:
-        failures.append("triton-ascend distribution was not found")
+        print("[fla-npu build][OK] Skipping torch/torch_npu build-time checks for Python-only wheel")
 
-    if not _env_flag("FLA_NPU_SKIP_TORCH_GEN"):
+    if build_legacy_extension and not _env_flag("FLA_NPU_SKIP_TORCH_GEN"):
         for module in TORCHNPUGEN_MODULES:
             try:
                 spec = importlib.util.find_spec(module)
@@ -275,7 +282,8 @@ def _check_build_environment():
         raise RuntimeError(
             "Build environment check failed:\n  - "
             + "\n  - ".join(failures)
-            + "\nInstall matching CANN, torch, torch_npu, torchnpugen and triton-ascend first, "
+            + "\nInstall matching CANN and, when FLA_NPU_BUILD_LEGACY_EXTENSION=1, "
+              "torch, torch_npu, torchnpugen and triton-ascend first, "
               "then run `pip install --no-build-isolation .`."
         )
 
@@ -491,14 +499,19 @@ def _stage_run_package(run_file, opp_root):
 
 
 def _build_torch_extension_inplace():
+    for so_file in FLA_NPU_PACKAGE_DIR.glob("custom_aclnn_extension_lib*.so"):
+        so_file.unlink()
+
+    if not _env_flag("FLA_NPU_BUILD_LEGACY_EXTENSION"):
+        print("[fla-npu build] Skipping legacy PyTorch C++ extension build for Python-only wheel")
+        return
+
     if not _env_flag("FLA_NPU_SKIP_TORCH_GEN"):
         _run(["bash", "gen.sh", "npu_custom.yaml"], TORCH_EXTENSION_DIR)
 
     build_dir = TORCH_EXTENSION_DIR / "build"
     if build_dir.exists():
         shutil.rmtree(build_dir)
-    for so_file in FLA_NPU_PACKAGE_DIR.glob("custom_aclnn_extension_lib*.so"):
-        so_file.unlink()
 
     _run([sys.executable, "setup.py", "build_ext", "--force", "--inplace"], TORCH_EXTENSION_DIR)
 
@@ -564,7 +577,7 @@ setup(
         )
     ),
     package_dir={"fla_npu": str(FLA_NPU_PACKAGE_DIR.relative_to(REPO_ROOT))},
-    package_data={"fla_npu": ["custom_aclnn_extension_lib*.so", "opp/**/*"]},
+    package_data={"fla_npu": ["opp/**/*"]},
     include_package_data=True,
     license_files=[
         "LICENSE",

--- a/torch_custom/fla_npu/README.md
+++ b/torch_custom/fla_npu/README.md
@@ -1,199 +1,184 @@
-# fla_npu 样例说明
+# fla_npu Python 适配说明
 
-本样例是 **「自定义算子接入 - 结构化代码生成」** 的示例工程，演示如何通过 YAML 描述 + 代码生成工具，将自定义 aclnn 算子接入 PyTorch NPU 生态，并生成可参与 torch_npu 编译的适配代码。
+`torch_custom/fla_npu` 是 FLA NPU 的 Python runtime 与可选 legacy PyTorch dispatcher 适配工程。当前默认交付目标是：
 
-## 适用场景
+```python
+from fla_npu.ops import ascendc as ascendc_ops
 
-本样例适用于以下情况：
-
-- **需要接入自定义 aclnn 算子**：CANN 已提供 aclnn 接口（如 `aclnnFastGelu`），希望以 PyTorch 自定义算子的形式在 `torch_npu` 中暴露给用户。
-- **算子满足「结构化适配」条件**：  
-  aclnn 算子与目标 ATen IR 的语义一致，适配层**除申请 output tensor（shape/dtype 由输入推导）外，无其他复杂逻辑**。  
-  满足时即可用 YAML 做结构化描述，由工具自动生成 C++ 适配代码，无需手写适配层。
-
-
-不适用或需手写适配的情况：算子语义与 ATen 不一致、需要复杂 shape/type 推导、或需在适配层写额外逻辑时，应使用非结构化方式（如 opapi）。
-
-## 环境与依赖
-
-- **运行/编译依赖**：PyTorch、torch_npu、CANN。  
-  安装与版本要求见 [torch_npu 安装说明](https://gitcode.com/ascend/pytorch#%E5%AE%89%E8%A3%85)。
-
-
-## 目录与文件结构
-
-### 运行前
-```
-fla_npu/
-├── fla_npu/
-│   └── __init__.py                   # 构建用init文件
-├── deprecated.yaml                   # 废弃api配置
-├── gen.sh                            # 一键生成脚本：调用 torchnpugen 生成算子适配代码
-├── setup.py                          # 项目构建脚本，用于编译生成 whl 包
-├── npu_custom.yaml                   # 自定义算子 YAML（含前向/反向 ATen IR 与 aclnn 映射）
-├── npu_custom_derivatives.yaml       # 前向/反向绑定配置
-├── test_native_functions.yaml        # NPU backend 声明（生成 stub 等时会使用）
-├── test/
-│   └── test_npu_fast_gelu_custom.py  # 自定义算子测试脚本
-└── README.md
+out = ascendc_ops.npu_chunk_fwd_o(...)
 ```
 
+也可以按公开短名导入：
 
-
-### 运行后
-
-先执行 `gen.sh` 生成适配代码，再执行 `setup.py` 构建后，在 `./dist/`下得到 **`fla_npu*.whl`**：
-
-```
-fla_npu/
-├── ...         # 运行前已有文件保持不变
-├── build/      # gen.sh生成的中间产物
-├── op_plugin/  # gen.sh生成的中间产物
-├── torch_npu/  # gen.sh生成的中间产物
-├── dist/
-│   └── fla_npu*.whl # 最终生成的whl包
-└── ...
+```python
+from fla_npu.ops.ascendc import chunk_fwd_o
 ```
 
-使用方式：`pip install fla_npu*.whl` 安装后，先 source 已安装 custom OPP 的 `set_env.bash`，或设置 `FLA_NPU_OPP_PATH` 指向 OPP root / vendor 目录，即可在 Python 中调用本样例接入的自定义算子（推荐 `from fla_npu.ops.ascendc import fast_gelu_custom`，导入后也会兼容 `torch_npu.ops.fast_gelu_custom`）。
+默认路径通过 Python `ctypes` 直调已安装 OPP 里的 `libcust_opapi.so`，不依赖 PyTorch dispatcher 注册，也不会默认编译或加载 `torch_npu` 自定义扩展。旧的 `torch.ops.npu.*` / `torch_npu.ops.*` 兼容路径仍可做，但只作为迁移期可选能力，不推荐新增代码使用，也不会默认使能。
 
+## 默认交付件
 
-## 一键运行样例
+### Python runtime wheel
 
-若仅想快速跑通本样例（不修改算子），在 `fla_npu` 目录下**按顺序**执行：
+默认执行：
 
 ```bash
-# 1. 执行 setup.py 构建 Python runtime whl 包并安装
-python setup.py bdist_wheel
-cd dist
-pip install fla_npu*.whl --force-reinstall --no-deps
-
-# 2. 运行测试验证
-cd ..
-cd test && python test_npu_fast_gelu_custom.py
+python3 setup.py bdist_wheel
 ```
 
-测试通过即表示样例已跑通，可直接调用 `fla_npu.ops.ascendc.fast_gelu_custom` 或 `torch_npu.ops.fast_gelu_custom` 算子。
+会生成纯 Python wheel，核心内容包括：
 
----
+- `fla_npu/__init__.py`：定位并加载内嵌或外部 OPP。
+- `fla_npu/ops/ascendc/__init__.py`：稳定 Python 调用入口、短名导出和正反向自动绑定。
+- `fla_npu/ops/ascendc/_aclnn_ctypes.py`：具体算子的 Python wrapper，只描述输入输出、标量转换和算子级 ABI 特例。
+- `fla_npu/ops/ascendc/_runtime.py`：公共 ctypes runtime，封装 aclTensor/aclIntArray 描述符、workspace、stream 和异步 launch 生命周期。
+- `fla_npu/opp/vendors/fla_npu_transformer/...`：一键 wheel 打包时内嵌的 OPP 产物。
 
-**改成接入自己的算子时**：如果只使用 Python ctypes runtime，需要在 `fla_npu.ops.ascendc` 中补充 Python wrapper；如果还要兼容旧 `torch.ops.npu`，再跑 `gen.sh` 并使用 `FLA_NPU_BUILD_LEGACY_EXTENSION=1` 构建 legacy extension。
+### Ascend C OPP 产物
 
-## 使用步骤
+一键 wheel 或 run 包安装后，OPP vendor 目录为：
 
-### 1. 编写自定义算子 YAML（结构化描述）
-
-在 `npu_fast_gelu.yaml` 的 `custom` 段中，按「ATen IR ↔ aclnn」一一对应的方式填写。  
-是否可结构化的判断标准：**opapi 对应的 aclnn 与 ATen IR 语义一致，适配层除申请 output tensor 外无其他逻辑**。
-
-示例（前向 + 反向）：
-
-```yaml
-custom:
-  - func: npu_fast_gelu_custom(Tensor self) -> Tensor
-    op_api: all_version
-    gen_opapi:
-      out:
-        size: self
-        dtype: self
-      exec: aclnnFastGelu
-  - func: npu_fast_gelu_custom_backward(Tensor grad, Tensor self) -> Tensor
-    op_api: all_version
-    gen_opapi:
-      out:
-        size: grad
-        dtype: grad
-      exec: aclnnFastGeluBackward
+```text
+fla_npu/opp/vendors/fla_npu_transformer
 ```
 
-- `func`：PyTorch 侧暴露的算子签名（ATen IR 形式）。
-- `gen_opapi.out`：输出 tensor 的 shape/dtype 由哪个输入推导（如 `self` / `grad`）。
-- `exec`：实际调用的 aclnn 接口名。
+关键产物包括：
 
-### 2. 执行代码生成
+- `op_api/lib/libcust_opapi.so`：自定义 aclnn op_api 动态库。
+- `op_api/lib/libopapi.so`：wheel 内优先解析用的同名兼容副本。
+- `op_api/include/aclnnop/aclnn_*.h`：Python ctypes ABI 对齐依据。
+- `op_impl/ai_core/tbe/op_host/...`、`op_tiling/...`、`op_proto/...`：host、tiling、proto 动态库。
+- `op_impl/ai_core/tbe/kernel/...`：AI Core kernel `.o` 和 config。
 
-在 `fla_npu` 目录下执行：
+## 推荐调用方式
+
+新增或修改测试、example、上层业务时，默认使用：
+
+```python
+from fla_npu.ops import ascendc as ascendc_ops
+
+result = ascendc_ops.npu_recompute_w_u_fwd(...)
+```
+
+或者：
+
+```python
+from fla_npu.ops.ascendc import recompute_w_u_fwd
+
+result = recompute_w_u_fwd(...)
+```
+
+测试中不要默认调用：
+
+```python
+fla_npu.load_legacy_torch_ops()
+torch.ops.npu.npu_xxx(...)
+```
+
+这样可以避免把测试结果绑定到 PyTorch/torch_npu dispatcher ABI。
+
+## 新算子如何接入默认 runtime
+
+新增 Ascend C 算子后，Python 默认路径需要同步做以下适配：
+
+1. 在 `_aclnn_ctypes.py` 增加 `npu_xxx(...)` wrapper。
+2. wrapper 内按 `aclnn_xxx.h` 的函数签名顺序构造参数，常用转换如下：
+   - Tensor 输入/输出：`ctx.tensor(tensor, "name")`
+   - `Optional[list[int]]` / `Sequence[int]`：`ctx.int_array(values)`
+   - aclnn 签名中要求 Tensor 形式的索引：`ctx.int_tensor(values, device)`
+   - 标量：显式使用 `ctypes.c_int64`、`ctypes.c_double`、`ctypes.c_bool` 等。
+3. 在 wrapper 内申请输出 tensor，并把输出传给 `_call_aclnn(...)`。
+4. 如果 aclnn 参数里有 `char *`、字符串、或 ctypes 不能安全自动转换的参数，在 `_GET_WORKSPACE_ARGTYPES` 中补充 `GetWorkspaceSize` 的 `argtypes`。
+5. 在 `fla_npu/ops/ascendc/__init__.py` 的 `_ASCENDC_OPS` 中加入 `npu_xxx`，这样会自动导出 `npu_xxx` 和去掉 `npu_` 前缀后的短名。
+6. 如果存在明确的正反向关系，在 `BACKWARD_OPS` 中补充映射；需要 autograd 自动绑定时，在 `__init__.py` 中增加对应 `torch.autograd.Function` 包装。
+7. 新增或更新测试，默认调用 `fla_npu.ops.ascendc` 路径。
+
+新增算子通常不需要修改 `_runtime.py`，也不需要感知 `_AclTensor`、`_AclIntArray`、workspace 申请或 stream launch 细节。只有公共 ctypes 调发框架本身需要演进时，才修改 `_runtime.py`。
+
+示例骨架：
+
+```python
+def npu_my_op(x, weight, *, scale=1.0, indices=None):
+    out = _empty_like(x)
+    return _call_aclnn(
+        "aclnnMyOp",
+        lambda ctx: [
+            ctx.tensor(x, "x"),
+            ctx.tensor(weight, "weight"),
+            ctx.int_array(indices),
+            ctypes.c_double(float(scale)),
+            ctx.tensor(out, "out"),
+        ],
+        out,
+    )
+```
+
+## 构建和验证默认 runtime
+
+只构建 Python runtime wheel：
+
+```bash
+python3 setup.py bdist_wheel
+python3 -m pip install --force-reinstall --no-deps dist/fla_npu-*.whl
+```
+
+如果使用仓库根目录的一键 wheel，OPP 会内嵌到 `site-packages/fla_npu/opp`：
+
+```bash
+FLA_NPU_SOC=ascend910b python3 -m pip wheel --no-build-isolation --no-deps . -w dist
+python3 -m pip install --force-reinstall --no-deps dist/flash_linear_attention_npu-*.whl
+python3 scripts/check_packaged_wheel_api.py
+```
+
+单算子 run 包覆盖已安装 wheel 内嵌 OPP 时：
+
+```bash
+bash build.sh --pkg --soc=ascend910b --vendor_name=fla_npu --ops=chunk_fwd_o
+./build_out/fla-npu-*.run --full
+```
+
+安装器会列出 scoped run 包覆盖后的算子状态。`WARNING` 表示安装后不可用，`NOTICE` 表示需要人工关注，`OK` 表示 ABI 一致并继续可用。
+
+## legacy torch_npu / torch.ops.npu 路径
+
+如果确实需要兼容 `torch_npu.ops.xxx`，可以显式安装 Python wrapper：
+
+```python
+import torch_npu
+from fla_npu.ops import ascendc
+
+ascendc.install_torch_npu_ops_compat()
+torch_npu.ops.npu_xxx(...)
+```
+
+如果确实需要兼容更旧的 `torch.ops.npu.xxx` 调用：
+
+```python
+import fla_npu
+
+fla_npu.load_legacy_torch_ops()
+torch.ops.npu.npu_xxx(...)
+```
+
+则需要显式生成并构建 legacy extension：
 
 ```bash
 bash gen.sh npu_custom.yaml
+FLA_NPU_BUILD_LEGACY_EXTENSION=1 python3 setup.py bdist_wheel
 ```
 
-脚本会根据当前环境的 PyTorch 版本生成各类适配代码，用户无需关注。
+legacy 路径会生成或使用：
 
-### 4. 构建 whl 包并运行测试
+- `op_plugin/`
+- `torch_npu/csrc/`
+- `custom_aclnn_extension_lib*.so`
+- `npu_custom.yaml`、`test_native_functions.yaml`、`deprecated.yaml`
 
-执行 `setup.py` 构建，在 `./dist/`下得到 **`fla_npu*.whl`**：
+这些兼容路径不会默认使能。`torch.ops.npu` legacy extension 会重新绑定 PyTorch、Python、C++ ABI 和 torch_npu dispatcher 行为，因此只用于历史接口兼容或专项验证。新增算子默认不要以 legacy extension 作为唯一调用方式。
 
-```bash
-python setup.py bdist_wheel
-cd dist
-pip install fla_npu*.whl
-```
+## 测试要求
 
-安装完成后即可在代码中调用接入的自定义算子（如 `fla_npu.ops.ascendc.fast_gelu_custom` 或 `torch_npu.ops.fast_gelu_custom`）。例如用样例自带的测试用例验证：
-
-```bash
-cd test
-python test_npu_fast_gelu_custom.py
-```
-
-测试通过即说明算子已正确接入、结果与参考实现一致。
-
-注意运行测试脚本时不能在`fla_npu` 目录下执行，会受init文件所在同名路径影响。
-
-## 自用时的替换与扩展
-
-改成接入自己的算子时，**核心是把 YAML 里的内容换成自己算子的定义**：
-
-- **算子 YAML**（如 `npu_custom.yaml` 或自建 `my_op.yaml`）：在 `custom` 段中写上自己的 `func`、`gen_opapi.out`、`exec`（aclnn 接口名）等，格式参考本样例。
-- **gen.sh 参数**：若使用新文件名（如 `my_op.yaml`），则执行 `bash gen.sh my_op.yaml` 或 `bash gen.sh my_op.yaml`。
-- **测试脚本**：在 `test/` 下修改或新增测试，调用你暴露的算子名做数值验证。
-
-流程不变：先执行 `gen.sh`（传入你的 YAML），再执行 `setup.py` 构建得到 `fla_npu*.whl`，`pip install` 后即可调用。
-
-## gen.sh 结构与代码生成指令说明
-
-本节说明当前目录下 `gen.sh` 的脚本结构及其中调用的代码生成指令，便于有更个性化需求的用户自行调整（如修改输出路径、增删步骤、更换 YAML 等）。
-
-### 脚本参数与环境
-
-- **入参**：`gen.sh` 接收两个参数（第二个可选）。
-  - `$1`：算子 YAML 文件（必填），如 `npu_custom.yaml`。
-- **工作目录**：脚本会 `cd` 到自身所在目录（`fla_npu/`），后续路径均相对该目录。
-- **版本与目录名**：从当前环境的 `torch.__version__` 解析出 `PYTORCH_VERSION`（如 `2.7.0`），并得到目录后缀 `PYTORCH_VERSION_DIR`（如 `v2r7`），用于 `op_plugin/config/v2r7/` 等路径。
-- **环境变量**：脚本会设置并 `export`：
-  - `PYTORCH_VERSION`：PyTorch 版本号。
-  - `PYTORCH_CUSTOM_DERIVATIVES_PATH`：生成的 derivatives 文件路径，供后续 autograd 等使用。
-  - `ACLNN_EXTENSION_PATH`：当前样例根目录。
-  - `ACLNN_EXTENSION_SWITCH="TRUE"`：标识走 aclnn extension 逻辑（部分 torchnpugen 模块会据此分支）。
-- **创建的目录**：若不存在则会创建 `build`、`op_plugin`、`torch_npu`。
-
-### 代码生成指令（执行顺序）
-
-脚本按顺序调用以下 **torchnpugen** 模块，对应不同的代码生成步骤。可根据需要增删或改参数。
-
-| 顺序 | 模块 | 作用 | 主要参数 |
-|------|------|------|----------|
-| 1 | `torchnpugen.gen_op_plugin_functions` | 根据算子 YAML 生成并清洗 `op_plugin_functions.yaml`（ATen IR 与版本信息等） | `--version`、`--output_dir`（如 `op_plugin/config/v2r7/`）、`--source_yaml`（传入的算子 YAML） |
-| 2 | `torchnpugen.gen_derivatives` | 仅当传入 `$2` 时执行；根据 derivatives YAML 生成前反向绑定文件 `derivatives.yaml` | `--version`、`--output_dir`、`--source_yaml`（传入的 derivatives YAML） |
-| 3 | `torchnpugen.gen_op_backend` | 根据 `op_plugin_functions.yaml` 生成 op_plugin 对外接口与路由（如 OpInterface、OpApiInterface 等） | `--version`、`--output_dir`（`op_plugin/`）、`--source_yaml`（上一步生成的 `op_plugin_functions.yaml`）、`--deprecate_yaml` |
-| 4 | `torchnpugen.struct.gen_struct_opapi` | 根据算子 YAML 与 `op_plugin_functions.yaml` 生成 aclnn 结构化适配实现（如 `StructKernelNpuOpApi.cpp`） | `--output_dir`（`op_plugin/ops/opapi/`）、`--native_yaml`（`op_plugin_functions.yaml`）、`--struct_yaml`（传入的算子 YAML） |
-| 5 | `torchnpugen.gen_backend_stubs` | 根据 `test_native_functions.yaml` 等生成 torch_npu 侧 backend stub 代码到 `csrc/aten` | `--output_dir`、`--source_yaml`（当前为 `./test_native_functions.yaml`）、`--impl_path`、`--op_plugin_impl_path`、`--op_plugin_yaml_path` |
-| 6 | `torchnpugen.autograd.gen_autograd` | 根据 `test_native_functions.yaml` 生成 autograd 相关代码到 `csrc/aten` 与 `autograd` | `--out_dir`、`--autograd_dir`、`--npu_native_function_dir`（当前为 `./test_native_functions.yaml`） |
-
-- **步骤 1～4** 使用算子 YAML 和生成的 `op_plugin_functions.yaml`，产出在 `op_plugin/` 下，是 aclnn 扩展适配的核心。
-- **步骤 5～6** 使用 `test_native_functions.yaml`，产出在 `csrc/aten`、`autograd`，用于与 torch_npu 侧的注册与求导衔接。
-
-### 自定义时可调整的内容
-
-- **更换输入 YAML**：修改脚本入参或内部 `$YAML_FILE` / `$DERIVATIVES_YAML_FILE`，或增加新的 YAML 变量并传给对应模块的 `--source_yaml`、`--struct_yaml` 等。
-- **输出路径**：修改 `OUTPUT_DIR`、`OPAPI_OUTPUT_DIR`、`--output_dir`、`--out_dir`、`--autograd_dir` 等，使生成结果落到你希望的目录（需与 `setup.py` 的编译路径一致）。
-- **PyTorch 版本**：脚本已按当前环境自动解析版本；若需写死某版本，可改 `PYTORCH_VERSION` / `PYTORCH_VERSION_DIR` 的赋值。
-
-按上述说明即可在保留主流程的前提下，按需裁剪或扩展 `gen.sh` 中的指令与参数。
-
-## 小结
-
-- **适用**：自定义 aclnn 算子、语义与 ATen 对齐、适配层仅做 output 申请的结构化场景。
-- **执行流程**：默认执行 `setup.py` 构建 Python runtime wheel；如需旧 `torch.ops.npu` 路径，再执行 `gen.sh npu_custom.yaml` 并设置 `FLA_NPU_BUILD_LEGACY_EXTENSION=1` 构建 legacy extension。
-- **自用**：把 YAML 里的内容换成自己算子的定义后，Python runtime 需要补充对应 ctypes wrapper；legacy extension 继续通过 gen.sh 生成适配代码。
+- 新测试默认使用 `from fla_npu.ops import ascendc as ascendc_ops`。
+- 不要在默认测试里调用 `fla_npu.load_legacy_torch_ops()`。
+- 不要把 `torch.ops.npu.*` 作为默认正确性路径。
+- 如果 legacy 路径确实需要覆盖，应单独写清楚测试目的，并显式打开 `FLA_NPU_BUILD_LEGACY_EXTENSION=1`。

--- a/torch_custom/fla_npu/README.md
+++ b/torch_custom/fla_npu/README.md
@@ -55,7 +55,7 @@ fla_npu/
 └── ...
 ```
 
-使用方式：`pip install fla_npu*.whl` 安装后，先 source 已安装 custom OPP 的 `set_env.bash`，或设置 `FLA_NPU_OPP_PATH` 指向 OPP root / vendor 目录，即可在 Python 中调用本样例接入的自定义算子（如 `torch.ops.npu.npu_fast_gelu_custom`、`torch_npu.ops.fast_gelu_custom` 或 `from fla_npu.ops.ascendc import fast_gelu_custom`）。
+使用方式：`pip install fla_npu*.whl` 安装后，先 source 已安装 custom OPP 的 `set_env.bash`，或设置 `FLA_NPU_OPP_PATH` 指向 OPP root / vendor 目录，即可在 Python 中调用本样例接入的自定义算子（推荐 `from fla_npu.ops.ascendc import fast_gelu_custom`，导入后也会兼容 `torch_npu.ops.fast_gelu_custom`）。
 
 
 ## 一键运行样例
@@ -63,24 +63,21 @@ fla_npu/
 若仅想快速跑通本样例（不修改算子），在 `fla_npu` 目录下**按顺序**执行：
 
 ```bash
-# 1. 先执行 gen.sh，生成适配代码
-bash gen.sh npu_custom.yaml
-
-# 2. 再执行 setup.py 构建 whl 包并安装
+# 1. 执行 setup.py 构建 Python runtime whl 包并安装
 python setup.py bdist_wheel
 cd dist
 pip install fla_npu*.whl --force-reinstall --no-deps
 
-# 3. 运行测试验证
+# 2. 运行测试验证
 cd ..
 cd test && python test_npu_fast_gelu_custom.py
 ```
 
-测试通过即表示样例已跑通，可直接调用 `torch.ops.npu.npu_fast_gelu_custom`、`torch_npu.ops.fast_gelu_custom` 或 `fla_npu.ops.ascendc.fast_gelu_custom` 算子。
+测试通过即表示样例已跑通，可直接调用 `fla_npu.ops.ascendc.fast_gelu_custom` 或 `torch_npu.ops.fast_gelu_custom` 算子。
 
 ---
 
-**改成接入自己的算子时**：只需把 YAML 里的内容换成自己算子的定义（见下方「使用步骤」），然后同样先跑 `gen.sh`（传入你的 YAML 文件名），再跑 `setup.py` 即可。
+**改成接入自己的算子时**：如果只使用 Python ctypes runtime，需要在 `fla_npu.ops.ascendc` 中补充 Python wrapper；如果还要兼容旧 `torch.ops.npu`，再跑 `gen.sh` 并使用 `FLA_NPU_BUILD_LEGACY_EXTENSION=1` 构建 legacy extension。
 
 ## 使用步骤
 
@@ -125,7 +122,7 @@ bash gen.sh npu_custom.yaml
 
 ### 4. 构建 whl 包并运行测试
 
-在步骤 3 完成（gen.sh 已执行）后，再执行 `setup.py` 构建，在 `./dist/`下得到 **`fla_npu*.whl`**：
+执行 `setup.py` 构建，在 `./dist/`下得到 **`fla_npu*.whl`**：
 
 ```bash
 python setup.py bdist_wheel
@@ -133,7 +130,7 @@ cd dist
 pip install fla_npu*.whl
 ```
 
-安装完成后即可在代码中调用接入的自定义算子（如 `torch.ops.npu.npu_fast_gelu_custom`、`torch_npu.ops.fast_gelu_custom` 或 `fla_npu.ops.ascendc.fast_gelu_custom`）。例如用样例自带的测试用例验证：
+安装完成后即可在代码中调用接入的自定义算子（如 `fla_npu.ops.ascendc.fast_gelu_custom` 或 `torch_npu.ops.fast_gelu_custom`）。例如用样例自带的测试用例验证：
 
 ```bash
 cd test
@@ -197,6 +194,6 @@ python test_npu_fast_gelu_custom.py
 
 ## 小结
 
-- **适用**：自定义 aclnn 算子、语义与 ATen 对齐、适配层仅做 output 申请的结构化场景。  
-- **执行流程**：先执行 `gen.sh npu_custom.yaml` 生成适配代码，再执行 `setup.py` 构建得到 `fla_npu*.whl`，`pip install` 后即可调用接入的算子。  
-- **自用**：把 YAML 里的内容换成自己算子的定义，gen.sh 传入对应 YAML 文件名，同样先 gen.sh 再 setup.py 即可。
+- **适用**：自定义 aclnn 算子、语义与 ATen 对齐、适配层仅做 output 申请的结构化场景。
+- **执行流程**：默认执行 `setup.py` 构建 Python runtime wheel；如需旧 `torch.ops.npu` 路径，再执行 `gen.sh npu_custom.yaml` 并设置 `FLA_NPU_BUILD_LEGACY_EXTENSION=1` 构建 legacy extension。
+- **自用**：把 YAML 里的内容换成自己算子的定义后，Python runtime 需要补充对应 ctypes wrapper；legacy extension 继续通过 gen.sh 生成适配代码。

--- a/torch_custom/fla_npu/fla_npu/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/__init__.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
 import ctypes
-import importlib
 import os
 import pathlib
+from typing import Optional
 
 
 _PACKAGE_DIR = pathlib.Path(__file__).resolve().parent
 _DEFAULT_VENDOR_DIR = "fla_npu_transformer"
-_ASCENDC_EXTENSION_MODULE = None
-_ASCENDC_EXTENSION_LIBRARY: pathlib.Path | None = None
+_ASCENDC_OPAPI_LIBRARIES: Optional[list[ctypes.CDLL]] = None
 _LEGACY_TORCH_OPS_LOADED = False
-_LEGACY_TORCH_OPS_LIBRARY: pathlib.Path | None = None
+_LEGACY_TORCH_OPS_LIBRARY: Optional[pathlib.Path] = None
 
 
 def _prepend_env_path(name: str, value: pathlib.Path) -> None:
@@ -85,11 +84,51 @@ def _prepare_embedded_opp() -> pathlib.Path:
     _prepend_env_path("LD_LIBRARY_PATH", op_api_lib.parent)
     os.environ["FLA_NPU_OP_API_LIB"] = str(op_api_lib)
 
-    mode = getattr(os, "RTLD_GLOBAL", 0) | getattr(os, "RTLD_NOW", 0)
-    if op_api_alias.exists():
-        ctypes.CDLL(str(op_api_alias), mode=mode)
-    ctypes.CDLL(str(op_api_lib), mode=mode)
     return vendor_dir
+
+
+def _load_shared_library(path_or_name) -> Optional[ctypes.CDLL]:
+    mode = (
+        getattr(os, "RTLD_GLOBAL", 0)
+        | getattr(os, "RTLD_NOW", 0)
+        | getattr(os, "RTLD_NODELETE", 0)
+    )
+    try:
+        return ctypes.CDLL(str(path_or_name), mode=mode)
+    except OSError:
+        return None
+
+
+def load_ascendc_opapi_libraries() -> list[ctypes.CDLL]:
+    """Load embedded custom op_api and CANN aclnn libraries for ctypes calls."""
+
+    global _ASCENDC_OPAPI_LIBRARIES
+    if _ASCENDC_OPAPI_LIBRARIES is not None:
+        return _ASCENDC_OPAPI_LIBRARIES
+
+    vendor_dir = _prepare_embedded_opp()
+    op_api_dir = vendor_dir / "op_api" / "lib"
+    candidates = [
+        "libopapi.so",
+        op_api_dir / "libcust_opapi.so",
+    ]
+
+    libraries: list[ctypes.CDLL] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        key = str(candidate)
+        if key in seen:
+            continue
+        seen.add(key)
+        library = _load_shared_library(candidate)
+        if library is not None:
+            libraries.append(library)
+
+    if not libraries:
+        raise RuntimeError("Unable to load embedded FLA NPU or CANN op_api libraries.")
+
+    _ASCENDC_OPAPI_LIBRARIES = libraries
+    return libraries
 
 
 def _find_ascendc_extension_library() -> pathlib.Path:
@@ -122,21 +161,9 @@ def _preload_torch_npu_dependencies(torch_module, torch_npu_module) -> None:
 
 
 def load_ascendc_extension():
-    """Load the direct Ascend C Python extension without torch.ops dispatcher."""
+    """Backward-compatible alias for loading the decoupled Ascend C runtime."""
 
-    global _ASCENDC_EXTENSION_MODULE, _ASCENDC_EXTENSION_LIBRARY
-    if _ASCENDC_EXTENSION_MODULE is not None:
-        return _ASCENDC_EXTENSION_MODULE
-
-    _prepare_embedded_opp()
-
-    import torch
-    import torch_npu
-
-    _preload_torch_npu_dependencies(torch, torch_npu)
-    _ASCENDC_EXTENSION_LIBRARY = _find_ascendc_extension_library()
-    _ASCENDC_EXTENSION_MODULE = importlib.import_module("fla_npu.custom_aclnn_extension_lib")
-    return _ASCENDC_EXTENSION_MODULE
+    return load_ascendc_opapi_libraries()
 
 
 def load_legacy_torch_ops() -> pathlib.Path:
@@ -153,9 +180,11 @@ def load_legacy_torch_ops() -> pathlib.Path:
         return _LEGACY_TORCH_OPS_LIBRARY
 
     import torch
+    import torch_npu
 
-    load_ascendc_extension()
-    legacy_library = _ASCENDC_EXTENSION_LIBRARY or _find_ascendc_extension_library()
+    _prepare_embedded_opp()
+    _preload_torch_npu_dependencies(torch, torch_npu)
+    legacy_library = _find_ascendc_extension_library()
     torch.ops.load_library(str(legacy_library))
     from .ops.ascendc import install_legacy_torch_ops_warning, install_torch_npu_ops_compat
 
@@ -170,4 +199,9 @@ def is_legacy_torch_ops_loaded() -> bool:
     return _LEGACY_TORCH_OPS_LOADED
 
 
-__all__ = ["is_legacy_torch_ops_loaded", "load_ascendc_extension", "load_legacy_torch_ops"]
+__all__ = [
+    "is_legacy_torch_ops_loaded",
+    "load_ascendc_extension",
+    "load_ascendc_opapi_libraries",
+    "load_legacy_torch_ops",
+]

--- a/torch_custom/fla_npu/fla_npu/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/__init__.py
@@ -77,7 +77,6 @@ def _prepare_embedded_opp() -> pathlib.Path:
     op_api_lib = vendor_dir / "op_api" / "lib" / "libcust_opapi.so"
     if not op_api_lib.exists():
         raise FileNotFoundError(f"Embedded custom op_api library not found: {op_api_lib}")
-    op_api_alias = op_api_lib.with_name("libopapi.so")
 
     _prepend_env_path("ASCEND_CUSTOM_OPP_PATH", vendor_dir)
     _prepend_env_path("ASCEND_CUSTOM_OPP_PATH", opp_root)
@@ -88,15 +87,19 @@ def _prepare_embedded_opp() -> pathlib.Path:
 
 
 def _load_shared_library(path_or_name) -> Optional[ctypes.CDLL]:
+    try:
+        return _load_shared_library_required(path_or_name)
+    except OSError:
+        return None
+
+
+def _load_shared_library_required(path_or_name) -> ctypes.CDLL:
     mode = (
         getattr(os, "RTLD_GLOBAL", 0)
         | getattr(os, "RTLD_NOW", 0)
         | getattr(os, "RTLD_NODELETE", 0)
     )
-    try:
-        return ctypes.CDLL(str(path_or_name), mode=mode)
-    except OSError:
-        return None
+    return ctypes.CDLL(str(path_or_name), mode=mode)
 
 
 def load_ascendc_opapi_libraries() -> list[ctypes.CDLL]:
@@ -108,24 +111,16 @@ def load_ascendc_opapi_libraries() -> list[ctypes.CDLL]:
 
     vendor_dir = _prepare_embedded_opp()
     op_api_dir = vendor_dir / "op_api" / "lib"
-    candidates = [
-        "libopapi.so",
-        op_api_dir / "libcust_opapi.so",
-    ]
+    custom_opapi = op_api_dir / "libcust_opapi.so"
 
-    libraries: list[ctypes.CDLL] = []
-    seen: set[str] = set()
-    for candidate in candidates:
-        key = str(candidate)
-        if key in seen:
-            continue
-        seen.add(key)
-        library = _load_shared_library(candidate)
-        if library is not None:
-            libraries.append(library)
-
-    if not libraries:
-        raise RuntimeError("Unable to load embedded FLA NPU or CANN op_api libraries.")
+    try:
+        custom_library = _load_shared_library_required(custom_opapi)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Unable to load embedded FLA NPU custom op_api library: {custom_opapi}. "
+            f"Dynamic loader error: {exc}"
+        ) from exc
+    libraries = [custom_library]
 
     _ASCENDC_OPAPI_LIBRARIES = libraries
     return libraries

--- a/torch_custom/fla_npu/fla_npu/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/__init__.py
@@ -7,6 +7,8 @@ import pathlib
 
 _PACKAGE_DIR = pathlib.Path(__file__).resolve().parent
 _DEFAULT_VENDOR_DIR = "fla_npu_transformer"
+_LEGACY_TORCH_OPS_LOADED = False
+_LEGACY_TORCH_OPS_LIBRARY: pathlib.Path | None = None
 
 
 def _prepend_env_path(name: str, value: pathlib.Path) -> None:
@@ -65,7 +67,7 @@ def _prepare_embedded_opp() -> pathlib.Path:
     if not (os.environ.get("ASCEND_HOME_PATH") or os.environ.get("ASCEND_OPP_PATH")):
         raise RuntimeError(
             "CANN environment is not initialized. Please source the CANN set_env.sh "
-            "before importing fla_npu."
+            "before calling fla_npu.load_legacy_torch_ops()."
         )
 
     vendor_dir = _resolve_vendor_dir()
@@ -109,8 +111,19 @@ def _preload_torch_npu_dependencies(torch_module, torch_npu_module) -> None:
         _preload_library(lib_path)
 
 
-# Load the custom operator library
-def _load_opextension_so():
+def load_legacy_torch_ops() -> pathlib.Path:
+    """Load the legacy PyTorch dispatcher custom ops.
+
+    ``import fla_npu`` is intentionally lightweight and does not import torch,
+    torch_npu, or register ``torch.ops.npu`` kernels.  Call this function only
+    when old call sites such as ``torch.ops.npu.npu_chunk_fwd_o(...)`` must keep
+    working during the migration to the decoupled ``fla_npu.ops.ascendc`` API.
+    """
+
+    global _LEGACY_TORCH_OPS_LOADED, _LEGACY_TORCH_OPS_LIBRARY
+    if _LEGACY_TORCH_OPS_LOADED and _LEGACY_TORCH_OPS_LIBRARY is not None:
+        return _LEGACY_TORCH_OPS_LIBRARY
+
     _prepare_embedded_opp()
 
     import torch
@@ -124,10 +137,19 @@ def _load_opextension_so():
     if not so_files:
         raise FileNotFoundError(f"not find custom_aclnn_extension_lib*.so in {so_dir}")
 
-    atb_so_path = str(so_files[0])
-    torch.ops.load_library(atb_so_path)
-    from .ops.ascendc import install_torch_npu_ops_compat
+    legacy_library = so_files[0].resolve()
+    torch.ops.load_library(str(legacy_library))
+    from .ops.ascendc import install_legacy_torch_ops_warning, install_torch_npu_ops_compat
 
     install_torch_npu_ops_compat()
+    install_legacy_torch_ops_warning()
+    _LEGACY_TORCH_OPS_LOADED = True
+    _LEGACY_TORCH_OPS_LIBRARY = legacy_library
+    return legacy_library
 
-_load_opextension_so()
+
+def is_legacy_torch_ops_loaded() -> bool:
+    return _LEGACY_TORCH_OPS_LOADED
+
+
+__all__ = ["is_legacy_torch_ops_loaded", "load_legacy_torch_ops"]

--- a/torch_custom/fla_npu/fla_npu/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/__init__.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import ctypes
+import importlib
 import os
 import pathlib
 
 
 _PACKAGE_DIR = pathlib.Path(__file__).resolve().parent
 _DEFAULT_VENDOR_DIR = "fla_npu_transformer"
+_ASCENDC_EXTENSION_MODULE = None
+_ASCENDC_EXTENSION_LIBRARY: pathlib.Path | None = None
 _LEGACY_TORCH_OPS_LOADED = False
 _LEGACY_TORCH_OPS_LIBRARY: pathlib.Path | None = None
 
@@ -67,7 +70,7 @@ def _prepare_embedded_opp() -> pathlib.Path:
     if not (os.environ.get("ASCEND_HOME_PATH") or os.environ.get("ASCEND_OPP_PATH")):
         raise RuntimeError(
             "CANN environment is not initialized. Please source the CANN set_env.sh "
-            "before calling fla_npu.load_legacy_torch_ops()."
+            "before calling fla_npu Ascend C operators."
         )
 
     vendor_dir = _resolve_vendor_dir()
@@ -87,6 +90,13 @@ def _prepare_embedded_opp() -> pathlib.Path:
         ctypes.CDLL(str(op_api_alias), mode=mode)
     ctypes.CDLL(str(op_api_lib), mode=mode)
     return vendor_dir
+
+
+def _find_ascendc_extension_library() -> pathlib.Path:
+    so_files = list(_PACKAGE_DIR.glob("custom_aclnn_extension_lib*.so"))
+    if not so_files:
+        raise FileNotFoundError(f"not find custom_aclnn_extension_lib*.so in {_PACKAGE_DIR}")
+    return so_files[0].resolve()
 
 
 def _preload_library(path: pathlib.Path) -> None:
@@ -111,6 +121,24 @@ def _preload_torch_npu_dependencies(torch_module, torch_npu_module) -> None:
         _preload_library(lib_path)
 
 
+def load_ascendc_extension():
+    """Load the direct Ascend C Python extension without torch.ops dispatcher."""
+
+    global _ASCENDC_EXTENSION_MODULE, _ASCENDC_EXTENSION_LIBRARY
+    if _ASCENDC_EXTENSION_MODULE is not None:
+        return _ASCENDC_EXTENSION_MODULE
+
+    _prepare_embedded_opp()
+
+    import torch
+    import torch_npu
+
+    _preload_torch_npu_dependencies(torch, torch_npu)
+    _ASCENDC_EXTENSION_LIBRARY = _find_ascendc_extension_library()
+    _ASCENDC_EXTENSION_MODULE = importlib.import_module("fla_npu.custom_aclnn_extension_lib")
+    return _ASCENDC_EXTENSION_MODULE
+
+
 def load_legacy_torch_ops() -> pathlib.Path:
     """Load the legacy PyTorch dispatcher custom ops.
 
@@ -124,20 +152,10 @@ def load_legacy_torch_ops() -> pathlib.Path:
     if _LEGACY_TORCH_OPS_LOADED and _LEGACY_TORCH_OPS_LIBRARY is not None:
         return _LEGACY_TORCH_OPS_LIBRARY
 
-    _prepare_embedded_opp()
-
     import torch
-    import torch_npu
 
-    _preload_torch_npu_dependencies(torch, torch_npu)
-
-    so_dir = _PACKAGE_DIR
-    so_files = list(so_dir.glob('custom_aclnn_extension_lib*.so'))
-
-    if not so_files:
-        raise FileNotFoundError(f"not find custom_aclnn_extension_lib*.so in {so_dir}")
-
-    legacy_library = so_files[0].resolve()
+    load_ascendc_extension()
+    legacy_library = _ASCENDC_EXTENSION_LIBRARY or _find_ascendc_extension_library()
     torch.ops.load_library(str(legacy_library))
     from .ops.ascendc import install_legacy_torch_ops_warning, install_torch_npu_ops_compat
 
@@ -152,4 +170,4 @@ def is_legacy_torch_ops_loaded() -> bool:
     return _LEGACY_TORCH_OPS_LOADED
 
 
-__all__ = ["is_legacy_torch_ops_loaded", "load_legacy_torch_ops"]
+__all__ = ["is_legacy_torch_ops_loaded", "load_ascendc_extension", "load_legacy_torch_ops"]

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py
@@ -1,7 +1,18 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 """Ascend C backed FLA NPU operators.
 
-This module provides stable Python import paths backed by Python ctypes
-aclnn calls plus compatibility helpers for the legacy PyTorch dispatcher.
+This module provides stable Python import paths backed by Python ctypes aclnn
+calls.  Compatibility helpers for legacy torch_npu/torch.ops.npu call sites are
+kept opt-in and are not installed during normal import.
 """
 
 from __future__ import annotations
@@ -48,7 +59,7 @@ _DIRECT_RUNTIME_ERROR: Optional[Exception] = None
 
 
 def _prepare_direct_runtime(*, raise_on_error: bool = True) -> None:
-    """Prepare embedded OPP paths before torch_npu initializes the NPU runtime."""
+    """Prepare embedded OPP paths and load custom op_api libraries."""
 
     global _DIRECT_RUNTIME_ERROR, _DIRECT_RUNTIME_READY
     if _DIRECT_RUNTIME_READY:
@@ -352,7 +363,6 @@ globals()["fast_gelu_custom"] = fast_gelu_custom
 globals()["causal_conv1d"] = causal_conv1d
 
 _prepare_direct_runtime(raise_on_error=False)
-install_torch_npu_ops_compat()
 
 __all__ = [
     "BACKWARD_OPS",

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py
@@ -1,7 +1,7 @@
 """Ascend C backed FLA NPU operators.
 
-This module provides stable Python import paths backed by direct pybind
-Ascend C calls plus compatibility helpers for the legacy PyTorch dispatcher.
+This module provides stable Python import paths backed by Python ctypes
+aclnn calls plus compatibility helpers for the legacy PyTorch dispatcher.
 """
 
 from __future__ import annotations
@@ -9,7 +9,9 @@ from __future__ import annotations
 import functools
 import types
 import warnings
-from typing import Callable
+from typing import Callable, Optional
+
+from ._aclnn_ctypes import ASCENDC_CTYPES_OPS
 
 _ASCENDC_OPS = (
     "npu_fast_gelu_custom",
@@ -40,6 +42,33 @@ _LEGACY_TORCH_OPS_WARNING = (
     "in a future fla_npu release. Use fla_npu.ops.ascendc.{public_name}(...) "
     "or the decoupled Ascend C API instead."
 )
+
+_DIRECT_RUNTIME_READY = False
+_DIRECT_RUNTIME_ERROR: Optional[Exception] = None
+
+
+def _prepare_direct_runtime(*, raise_on_error: bool = True) -> None:
+    """Prepare embedded OPP paths before torch_npu initializes the NPU runtime."""
+
+    global _DIRECT_RUNTIME_ERROR, _DIRECT_RUNTIME_READY
+    if _DIRECT_RUNTIME_READY:
+        return
+
+    try:
+        import fla_npu
+
+        fla_npu.load_ascendc_opapi_libraries()
+    except Exception as exc:
+        _DIRECT_RUNTIME_ERROR = exc
+        if raise_on_error:
+            raise RuntimeError(
+                "Unable to initialize fla_npu Ascend C op_api libraries. "
+                "Please source the CANN set_env.sh before importing "
+                "fla_npu.ops.ascendc or calling Ascend C operators."
+            ) from exc
+    else:
+        _DIRECT_RUNTIME_ERROR = None
+        _DIRECT_RUNTIME_READY = True
 
 
 def _torch_npu_namespace():
@@ -72,12 +101,11 @@ def _get_torch_op(name: str):
 
 @functools.lru_cache(maxsize=None)
 def _get_direct_op(name: str):
-    import fla_npu
-
-    extension = fla_npu.load_ascendc_extension()
-    if not hasattr(extension, name):
-        raise AttributeError(f"fla_npu.custom_aclnn_extension_lib has no direct Ascend C op {name}.")
-    return getattr(extension, name)
+    _prepare_direct_runtime()
+    try:
+        return ASCENDC_CTYPES_OPS[name]
+    except KeyError as exc:
+        raise AttributeError(f"fla_npu.ops.ascendc has no ctypes Ascend C op {name}.") from exc
 
 
 def _warn_legacy_torch_op(name: str) -> None:
@@ -322,6 +350,9 @@ for _name in _ASCENDC_OPS:
 
 globals()["fast_gelu_custom"] = fast_gelu_custom
 globals()["causal_conv1d"] = causal_conv1d
+
+_prepare_direct_runtime(raise_on_error=False)
+install_torch_npu_ops_compat()
 
 __all__ = [
     "BACKWARD_OPS",

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py
@@ -1,14 +1,14 @@
 """Ascend C backed FLA NPU operators.
 
-The raw custom operators are registered under ``torch.ops.npu`` by
-``import fla_npu``.  This module provides stable Python import paths and a
-compatibility shim for older ``torch_npu.ops`` call sites.
+This module provides stable Python import paths and compatibility helpers for
+the legacy PyTorch dispatcher custom operators.
 """
 
 from __future__ import annotations
 
 import functools
 import types
+import warnings
 from typing import Callable
 
 _ASCENDC_OPS = (
@@ -34,6 +34,13 @@ BACKWARD_OPS = {
     "npu_causal_conv1d": "npu_causal_conv1d_bwd",
 }
 
+_LEGACY_TORCH_OPS_WARNING = (
+    "torch.ops.npu.{name} is a legacy FLA NPU compatibility API. This call path "
+    "depends on the PyTorch/torch_npu dispatcher ABI and will not be supported "
+    "in a future fla_npu release. Use fla_npu.ops.ascendc.{public_name}(...) "
+    "or the decoupled Ascend C API instead."
+)
+
 
 def _torch_npu_namespace():
     import torch
@@ -41,14 +48,83 @@ def _torch_npu_namespace():
     return torch.ops.npu
 
 
+def _ensure_legacy_torch_ops_loaded() -> None:
+    import fla_npu
+
+    is_loaded = getattr(fla_npu, "is_legacy_torch_ops_loaded", lambda: False)
+    if not is_loaded():
+        fla_npu.load_legacy_torch_ops()
+
+
 def _get_torch_op(name: str):
     namespace = _torch_npu_namespace()
     if not hasattr(namespace, name):
+        _ensure_legacy_torch_ops_loaded()
+        namespace = _torch_npu_namespace()
+    if not hasattr(namespace, name):
         raise AttributeError(
-            f"torch.ops.npu.{name} is not registered. Import fla_npu first and "
-            "make sure the custom extension loaded successfully."
+            f"torch.ops.npu.{name} is not registered. Call "
+            "fla_npu.load_legacy_torch_ops() first if you need the legacy "
+            "torch.ops.npu compatibility path."
         )
-    return getattr(namespace, name)
+    return _unwrap_legacy_torch_op(getattr(namespace, name))
+
+
+def _warn_legacy_torch_op(name: str) -> None:
+    warnings.warn(
+        _LEGACY_TORCH_OPS_WARNING.format(
+            name=name,
+            public_name=_strip_npu_prefix(name),
+        ),
+        FutureWarning,
+        stacklevel=3,
+    )
+
+
+def _unwrap_legacy_torch_op(op):
+    return getattr(op, "_fla_npu_original_op", op)
+
+
+class _LegacyTorchOpOverloadWarningWrapper:
+    _fla_npu_legacy_warning_wrapper = True
+
+    def __init__(self, name: str, overload):
+        self._fla_npu_name = name
+        self._fla_npu_original_op = overload
+
+    def __call__(self, *args, **kwargs):
+        _warn_legacy_torch_op(self._fla_npu_name)
+        return self._fla_npu_original_op(*args, **kwargs)
+
+    def __getattr__(self, name: str):
+        return getattr(self._fla_npu_original_op, name)
+
+    def __repr__(self) -> str:
+        return repr(self._fla_npu_original_op)
+
+
+class _LegacyTorchOpWarningWrapper:
+    _fla_npu_legacy_warning_wrapper = True
+
+    def __init__(self, name: str, op):
+        self._fla_npu_name = name
+        self._fla_npu_original_op = op
+        self.__name__ = name
+        self.__qualname__ = name
+        self.__doc__ = getattr(op, "__doc__", None)
+
+    def __call__(self, *args, **kwargs):
+        _warn_legacy_torch_op(self._fla_npu_name)
+        return self._fla_npu_original_op(*args, **kwargs)
+
+    def __getattr__(self, name: str):
+        value = getattr(self._fla_npu_original_op, name)
+        if callable(value):
+            return _LegacyTorchOpOverloadWarningWrapper(self._fla_npu_name, value)
+        return value
+
+    def __repr__(self) -> str:
+        return repr(self._fla_npu_original_op)
 
 
 def _make_raw_wrapper(name: str) -> Callable:
@@ -216,6 +292,19 @@ def install_torch_npu_ops_compat() -> None:
         setattr(ops, _strip_npu_prefix(name), globals()[_strip_npu_prefix(name)])
 
 
+def install_legacy_torch_ops_warning() -> None:
+    """Warn when users call legacy ``torch.ops.npu`` FLA NPU operators."""
+
+    namespace = _torch_npu_namespace()
+    for name in _ASCENDC_OPS:
+        if not hasattr(namespace, name):
+            continue
+        current = getattr(namespace, name)
+        if getattr(current, "_fla_npu_legacy_warning_wrapper", False):
+            continue
+        setattr(namespace, name, _LegacyTorchOpWarningWrapper(name, current))
+
+
 for _name in _ASCENDC_OPS:
     globals()[_name] = _make_raw_wrapper(_name)
     globals()[_strip_npu_prefix(_name)] = globals()[_name]
@@ -225,6 +314,7 @@ globals()["causal_conv1d"] = causal_conv1d
 
 __all__ = [
     "BACKWARD_OPS",
+    "install_legacy_torch_ops_warning",
     "install_torch_npu_ops_compat",
     *sorted(set(_ASCENDC_OPS)),
     *sorted({_strip_npu_prefix(name) for name in _ASCENDC_OPS}),

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py
@@ -1,7 +1,7 @@
 """Ascend C backed FLA NPU operators.
 
-This module provides stable Python import paths and compatibility helpers for
-the legacy PyTorch dispatcher custom operators.
+This module provides stable Python import paths backed by direct pybind
+Ascend C calls plus compatibility helpers for the legacy PyTorch dispatcher.
 """
 
 from __future__ import annotations
@@ -70,6 +70,16 @@ def _get_torch_op(name: str):
     return _unwrap_legacy_torch_op(getattr(namespace, name))
 
 
+@functools.lru_cache(maxsize=None)
+def _get_direct_op(name: str):
+    import fla_npu
+
+    extension = fla_npu.load_ascendc_extension()
+    if not hasattr(extension, name):
+        raise AttributeError(f"fla_npu.custom_aclnn_extension_lib has no direct Ascend C op {name}.")
+    return getattr(extension, name)
+
+
 def _warn_legacy_torch_op(name: str) -> None:
     warnings.warn(
         _LEGACY_TORCH_OPS_WARNING.format(
@@ -128,13 +138,13 @@ class _LegacyTorchOpWarningWrapper:
 
 
 def _make_raw_wrapper(name: str) -> Callable:
-    @functools.wraps(_get_torch_op)
+    @functools.wraps(_get_direct_op)
     def wrapper(*args, **kwargs):
-        return _get_torch_op(name)(*args, **kwargs)
+        return _get_direct_op(name)(*args, **kwargs)
 
     wrapper.__name__ = name
     wrapper.__qualname__ = name
-    wrapper.__doc__ = f"Call torch.ops.npu.{name}."
+    wrapper.__doc__ = f"Call the direct Ascend C binding for {name}."
     return wrapper
 
 
@@ -163,12 +173,12 @@ class _FastGeluCustomFunction:
             @staticmethod
             def forward(ctx, self):
                 ctx.save_for_backward(self)
-                return _get_torch_op("npu_fast_gelu_custom")(self)
+                return _get_direct_op("npu_fast_gelu_custom")(self)
 
             @staticmethod
             def backward(ctx, grad):
                 (self,) = ctx.saved_tensors
-                return _get_torch_op("npu_fast_gelu_custom_backward")(grad, self)
+                return _get_direct_op("npu_fast_gelu_custom_backward")(grad, self)
 
         return Function.apply(input_tensor)
 
@@ -178,7 +188,7 @@ def fast_gelu_custom(input_tensor):
 
     if _has_tensor_requiring_grad(input_tensor):
         return _FastGeluCustomFunction.apply(input_tensor)
-    return _get_torch_op("npu_fast_gelu_custom")(input_tensor)
+    return _get_direct_op("npu_fast_gelu_custom")(input_tensor)
 
 
 def causal_conv1d(
@@ -211,7 +221,7 @@ def causal_conv1d(
         and _has_tensor_requiring_grad(x, weight, bias)
     )
     if not can_bind_backward:
-        return _get_torch_op("npu_causal_conv1d")(
+        return _get_direct_op("npu_causal_conv1d")(
             x=x,
             weight=weight,
             bias=bias,
@@ -231,7 +241,7 @@ def causal_conv1d(
     class Function(torch.autograd.Function):
         @staticmethod
         def forward(ctx, x_, weight_, bias_, conv_states_):
-            y = _get_torch_op("npu_causal_conv1d")(
+            y = _get_direct_op("npu_causal_conv1d")(
                 x=x_,
                 weight=weight_,
                 bias=bias_,
@@ -249,6 +259,7 @@ def causal_conv1d(
             ctx.has_bias = bias_ is not None
             if bias_ is not None:
                 tensors.append(bias_)
+            ctx.activation_mode = activation_mode
             ctx.save_for_backward(*tensors)
             return y
 
@@ -258,7 +269,7 @@ def causal_conv1d(
             x_ = saved.pop(0)
             weight_ = saved.pop(0)
             bias_ = saved.pop(0) if ctx.has_bias else None
-            dx, dw, db, _ = _get_torch_op("npu_causal_conv1d_bwd")(
+            dx, dw, db, _ = _get_direct_op("npu_causal_conv1d_bwd")(
                 x=x_,
                 y=None if ctx.activation_mode == 0 else None,
                 weight=weight_,

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
@@ -1,0 +1,839 @@
+"""ctypes backed aclnn calls for FLA NPU Ascend C operators."""
+
+from __future__ import annotations
+
+import ctypes
+from collections import deque
+from typing import Iterable, Optional, Sequence
+
+
+ACL_SUCCESS = 0
+ACL_FORMAT_NCHW = 0
+ACL_FORMAT_ND = 2
+ACL_FORMAT_NCDHW = 30
+ACL_FORMAT_NCL = 47
+
+_ACL_FORMAT_BY_NAME = {
+    "NCHW": ACL_FORMAT_NCHW,
+    "ND": ACL_FORMAT_ND,
+    "NCDHW": ACL_FORMAT_NCDHW,
+    "NCL": ACL_FORMAT_NCL,
+}
+
+_RECENT_LAUNCH_STORAGE = deque(maxlen=128)
+
+_GET_WORKSPACE_ARGTYPES = {
+    "aclnnSolveTri": [
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_uint64),
+        ctypes.POINTER(ctypes.c_void_p),
+    ],
+}
+
+
+def _dtype_to_acl(dtype) -> int:
+    import torch
+
+    mapping = {
+        torch.float32: 0,  # ACL_FLOAT
+        torch.float16: 1,  # ACL_FLOAT16
+        torch.int8: 2,  # ACL_INT8
+        torch.int32: 3,  # ACL_INT32
+        torch.uint8: 4,  # ACL_UINT8
+        torch.int16: 6,  # ACL_INT16
+        torch.int64: 9,  # ACL_INT64
+        torch.float64: 11,  # ACL_DOUBLE
+        torch.bool: 12,  # ACL_BOOL
+        torch.bfloat16: 27,  # ACL_BF16
+    }
+    try:
+        return mapping[dtype]
+    except KeyError as exc:
+        raise TypeError(f"Unsupported dtype for aclnn tensor descriptor: {dtype}") from exc
+
+
+def _shape(tensor) -> tuple[int, ...]:
+    return tuple(int(dim) for dim in tensor.shape)
+
+
+def _stride(tensor) -> tuple[int, ...]:
+    return tuple(int(dim) for dim in tensor.stride())
+
+
+def _storage_numel(tensor) -> int:
+    try:
+        nbytes = tensor.untyped_storage().nbytes()
+    except AttributeError:
+        nbytes = tensor.storage().nbytes()
+    return int(nbytes // tensor.element_size())
+
+
+def _storage_data_ptr(tensor) -> int:
+    try:
+        return int(tensor.untyped_storage().data_ptr())
+    except AttributeError:
+        return int(tensor.storage().data_ptr())
+
+
+def _format(tensor) -> int:
+    try:
+        import torch_npu
+
+        npu_format = torch_npu.get_npu_format(tensor)
+    except Exception:
+        npu_format = None
+
+    if isinstance(npu_format, str):
+        acl_format = _ACL_FORMAT_BY_NAME.get(npu_format)
+        if acl_format is not None:
+            return acl_format
+    elif npu_format is not None:
+        try:
+            return int(npu_format)
+        except (TypeError, ValueError):
+            pass
+
+    dim = tensor.dim()
+    if dim == 3:
+        return ACL_FORMAT_NCL
+    if dim == 4:
+        return ACL_FORMAT_NCHW
+    if dim == 5:
+        return ACL_FORMAT_NCDHW
+    return ACL_FORMAT_ND
+
+
+def _ensure_npu_tensor(tensor, name: str):
+    if tensor is None:
+        return None
+    if not hasattr(tensor, "device") or tensor.device.type != "npu":
+        raise TypeError(f"{name} must be a torch NPU tensor, got {type(tensor)!r}.")
+    return tensor
+
+
+def _optional_bool(value, default: bool) -> bool:
+    return default if value is None else bool(value)
+
+
+def _optional_int(value, default: int) -> int:
+    return default if value is None else int(value)
+
+
+def _optional_float(value, default: float) -> float:
+    return default if value is None else float(value)
+
+
+def _chunk_num(total_tokens: int, chunk_size: int, chunk_indices: Optional[Sequence[int]]) -> int:
+    if chunk_indices is not None:
+        return len(chunk_indices) // 2
+    return (total_tokens + chunk_size - 1) // chunk_size
+
+
+def _current_stream_ptr() -> int:
+    import torch
+
+    stream = torch.npu.current_stream()
+    return int(getattr(stream, "npu_stream"))
+
+
+def _empty_like(tensor, *, dtype=None):
+    import torch
+
+    dtype = dtype or tensor.dtype
+    return torch.empty_like(tensor, dtype=dtype)
+
+
+def _empty(shape: Iterable[int], like, *, dtype=None):
+    import torch
+
+    return torch.empty(tuple(int(dim) for dim in shape), device=like.device, dtype=dtype or like.dtype)
+
+
+def _zeros(shape: Iterable[int], like, *, dtype=None):
+    import torch
+
+    return torch.zeros(tuple(int(dim) for dim in shape), device=like.device, dtype=dtype or like.dtype)
+
+
+class _AclTensor:
+    def __init__(self, runtime: "_AclnnRuntime", tensor):
+        tensor = _ensure_npu_tensor(tensor, "tensor")
+        self._runtime = runtime
+        self._tensor = tensor
+        self._shape = (ctypes.c_int64 * tensor.dim())(*_shape(tensor))
+        self._stride = (ctypes.c_int64 * tensor.dim())(*_stride(tensor))
+        self._storage_shape = (ctypes.c_int64 * 1)(_storage_numel(tensor))
+        self.ptr = runtime.acl_create_tensor(
+            self._shape,
+            ctypes.c_uint64(tensor.dim()),
+            ctypes.c_int(_dtype_to_acl(tensor.dtype)),
+            self._stride,
+            ctypes.c_int64(int(tensor.storage_offset())),
+            ctypes.c_int(_format(tensor)),
+            self._storage_shape,
+            ctypes.c_uint64(1),
+            ctypes.c_void_p(_storage_data_ptr(tensor)),
+        )
+        if not self.ptr:
+            raise RuntimeError("aclCreateTensor returned nullptr.")
+
+    def destroy(self) -> None:
+        if self.ptr:
+            self._runtime.acl_destroy_tensor(self.ptr)
+        self.ptr = None
+
+
+class _AclIntArray:
+    def __init__(self, runtime: "_AclnnRuntime", values: Optional[Sequence[int]]):
+        self._runtime = runtime
+        self.ptr = None
+        if values is None:
+            return
+        values = tuple(int(value) for value in values)
+        if not values:
+            return
+        self._values = (ctypes.c_int64 * len(values))(*values)
+        self.ptr = runtime.acl_create_int_array(self._values, ctypes.c_uint64(len(values)))
+        if not self.ptr:
+            raise RuntimeError("aclCreateIntArray returned nullptr.")
+
+    def destroy(self) -> None:
+        if self.ptr:
+            self._runtime.acl_destroy_int_array(self.ptr)
+        self.ptr = None
+
+
+class _CallContext:
+    def __init__(self, runtime: "_AclnnRuntime"):
+        self.runtime = runtime
+        self.resources = []
+        self.keepalive_tensors = []
+
+    def tensor(self, tensor, name: str = "tensor") -> ctypes.c_void_p:
+        if tensor is None:
+            return ctypes.c_void_p()
+        desc = _AclTensor(self.runtime, _ensure_npu_tensor(tensor, name))
+        self.resources.append(desc)
+        return ctypes.c_void_p(desc.ptr)
+
+    def int_array(self, values: Optional[Sequence[int]]) -> ctypes.c_void_p:
+        desc = _AclIntArray(self.runtime, values)
+        self.resources.append(desc)
+        return ctypes.c_void_p(desc.ptr or 0)
+
+    def int_tensor(self, values: Optional[Sequence[int]], device) -> ctypes.c_void_p:
+        if values is None:
+            return ctypes.c_void_p()
+        import torch
+
+        tensor = torch.as_tensor(tuple(int(value) for value in values), dtype=torch.int64, device=device)
+        self.keepalive_tensors.append(tensor)
+        return self.tensor(tensor, "int tensor")
+
+    def destroy(self) -> None:
+        for resource in reversed(self.resources):
+            resource.destroy()
+        self.resources.clear()
+
+
+class _AclnnRuntime:
+    def __init__(self):
+        import fla_npu
+
+        self._libraries = fla_npu.load_ascendc_opapi_libraries()
+        self._symbols = {}
+        self.acl_create_tensor = self.symbol("aclCreateTensor")
+        self.acl_create_tensor.argtypes = [
+            ctypes.POINTER(ctypes.c_int64),
+            ctypes.c_uint64,
+            ctypes.c_int,
+            ctypes.POINTER(ctypes.c_int64),
+            ctypes.c_int64,
+            ctypes.c_int,
+            ctypes.POINTER(ctypes.c_int64),
+            ctypes.c_uint64,
+            ctypes.c_void_p,
+        ]
+        self.acl_create_tensor.restype = ctypes.c_void_p
+
+        self.acl_destroy_tensor = self.symbol("aclDestroyTensor")
+        self.acl_destroy_tensor.argtypes = [ctypes.c_void_p]
+        self.acl_destroy_tensor.restype = ctypes.c_int
+
+        self.acl_create_int_array = self.symbol("aclCreateIntArray")
+        self.acl_create_int_array.argtypes = [ctypes.POINTER(ctypes.c_int64), ctypes.c_uint64]
+        self.acl_create_int_array.restype = ctypes.c_void_p
+
+        self.acl_destroy_int_array = self.symbol("aclDestroyIntArray")
+        self.acl_destroy_int_array.argtypes = [ctypes.c_void_p]
+        self.acl_destroy_int_array.restype = ctypes.c_int
+
+    def symbol(self, name: str):
+        if name in self._symbols:
+            return self._symbols[name]
+        for library in self._libraries:
+            try:
+                symbol = getattr(library, name)
+            except AttributeError:
+                continue
+            self._symbols[name] = symbol
+            return symbol
+        raise AttributeError(f"Unable to resolve aclnn symbol {name}.")
+
+    def call(self, name: str, args: Sequence[object], outputs: Sequence[object]):
+        get_workspace = self.symbol(f"{name}GetWorkspaceSize")
+        launch = self.symbol(name)
+        get_workspace.restype = ctypes.c_int
+        if name in _GET_WORKSPACE_ARGTYPES:
+            get_workspace.argtypes = _GET_WORKSPACE_ARGTYPES[name]
+        launch.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p]
+        launch.restype = ctypes.c_int
+        workspace_size = ctypes.c_uint64(0)
+        executor = ctypes.c_void_p()
+
+        ret = get_workspace(*args, ctypes.byref(workspace_size), ctypes.byref(executor))
+        if ret != ACL_SUCCESS:
+            raise RuntimeError(f"{name}GetWorkspaceSize failed with aclnnStatus={ret}.")
+
+        workspace = None
+        workspace_ptr = ctypes.c_void_p()
+        if workspace_size.value:
+            import torch
+
+            device = outputs[0].device
+            workspace = torch.empty((int(workspace_size.value),), dtype=torch.uint8, device=device)
+            workspace_ptr = ctypes.c_void_p(int(workspace.data_ptr()))
+
+        ret = launch(
+            workspace_ptr,
+            ctypes.c_uint64(workspace_size.value),
+            executor,
+            ctypes.c_void_p(_current_stream_ptr()),
+        )
+        if ret != ACL_SUCCESS:
+            raise RuntimeError(f"{name} failed with aclnnStatus={ret}.")
+        return workspace
+
+
+_RUNTIME: Optional[_AclnnRuntime] = None
+
+
+def _runtime() -> _AclnnRuntime:
+    global _RUNTIME
+    if _RUNTIME is None:
+        _RUNTIME = _AclnnRuntime()
+    return _RUNTIME
+
+
+def _finalize(outputs, workspace, keepalive_tensors):
+    _RECENT_LAUNCH_STORAGE.append((tuple(outputs), workspace, tuple(keepalive_tensors)))
+
+
+def _call_aclnn(name: str, build_args, outputs):
+    runtime = _runtime()
+    ctx = _CallContext(runtime)
+    outputs_tuple = outputs if isinstance(outputs, tuple) else (outputs,)
+    try:
+        args = build_args(ctx)
+        workspace = runtime.call(name, args, outputs_tuple)
+    finally:
+        ctx.destroy()
+    _finalize(outputs_tuple, workspace, ctx.keepalive_tensors)
+    return outputs
+
+
+def npu_fast_gelu_custom(self):
+    out = _empty_like(self)
+    return _call_aclnn(
+        "aclnnFastGelu",
+        lambda ctx: [ctx.tensor(self, "self"), ctx.tensor(out, "out")],
+        out,
+    )
+
+
+def npu_fast_gelu_custom_backward(grad, self):
+    out = _empty_like(grad)
+    return _call_aclnn(
+        "aclnnFastGeluBackward",
+        lambda ctx: [ctx.tensor(grad, "grad"), ctx.tensor(self, "self"), ctx.tensor(out, "out")],
+        out,
+    )
+
+
+def npu_prepare_wy_repr_bwd_full(
+    k,
+    v,
+    beta,
+    A,
+    dA,
+    dw,
+    du,
+    g,
+    chunk_size,
+    *,
+    cu_seqlens=None,
+    chunk_indices=None,
+):
+    dk = _empty_like(k)
+    dv = _empty_like(v)
+    dbeta = _empty_like(beta)
+    dg = _empty_like(g)
+    outputs = (dk, dv, dbeta, dg)
+    return _call_aclnn(
+        "aclnnPrepareWyReprBwdFull",
+        lambda ctx: [
+            ctx.tensor(k, "k"),
+            ctx.tensor(v, "v"),
+            ctx.tensor(beta, "beta"),
+            ctx.tensor(A, "A"),
+            ctx.tensor(dA, "dA"),
+            ctx.tensor(dw, "dw"),
+            ctx.tensor(du, "du"),
+            ctx.tensor(g, "g"),
+            ctx.int_array(cu_seqlens),
+            ctx.int_array(chunk_indices),
+            ctypes.c_int64(int(chunk_size)),
+            ctx.tensor(dk, "dk"),
+            ctx.tensor(dv, "dv"),
+            ctx.tensor(dbeta, "dbeta"),
+            ctx.tensor(dg, "dg"),
+        ],
+        outputs,
+    )
+
+
+def npu_chunk_gated_delta_rule_bwd_dhu(
+    q,
+    k,
+    w,
+    d_o,
+    dv,
+    scale,
+    chunk_size,
+    *,
+    g=None,
+    gK=None,
+    h0=None,
+    dht=None,
+    cu_seqlens=None,
+    chunk_indices=None,
+    use_exp2=False,
+    transpose_state_layout=False,
+):
+    q_shape = _shape(q)
+    dv_shape = _shape(dv)
+    B, _, T, K = q_shape
+    Hv, V = dv_shape[1], dv_shape[3]
+    NT = _chunk_num(T, int(chunk_size), chunk_indices)
+    dh = _empty((B, Hv, NT, K, V), q)
+    dh0 = _empty((B, Hv, NT, K, V), q) if h0 is not None else None
+    dv2 = _empty_like(dv)
+    outputs = (dh, dh0, dv2)
+    return _call_aclnn(
+        "aclnnChunkGatedDeltaRuleBwdDhu",
+        lambda ctx: [
+            ctx.tensor(q, "q"),
+            ctx.tensor(k, "k"),
+            ctx.tensor(w, "w"),
+            ctx.tensor(d_o, "d_o"),
+            ctx.tensor(dv, "dv"),
+            ctx.tensor(g, "g"),
+            ctx.tensor(gK, "gK"),
+            ctx.tensor(h0, "h0"),
+            ctx.tensor(dht, "dht"),
+            ctx.int_array(cu_seqlens),
+            ctx.int_array(chunk_indices),
+            ctypes.c_double(float(scale)),
+            ctypes.c_int64(int(chunk_size)),
+            ctx.tensor(dh, "dh"),
+            ctx.tensor(dh0, "dh0"),
+            ctx.tensor(dv2, "dv2"),
+        ],
+        outputs,
+    )
+
+
+def npu_chunk_bwd_dv_local(
+    q,
+    k,
+    d_o,
+    g,
+    scale,
+    chunk_size,
+    *,
+    g_gamma=None,
+    A=None,
+    cu_seqlens=None,
+    chunk_indices=None,
+):
+    out = _empty_like(d_o)
+    return _call_aclnn(
+        "aclnnChunkBwdDvLocal",
+        lambda ctx: [
+            ctx.tensor(q, "q"),
+            ctx.tensor(k, "k"),
+            ctx.tensor(d_o, "d_o"),
+            ctx.tensor(g, "g"),
+            ctx.tensor(g_gamma, "g_gamma"),
+            ctx.tensor(A, "A"),
+            ctx.int_array(cu_seqlens),
+            ctx.int_array(chunk_indices),
+            ctypes.c_double(float(scale)),
+            ctypes.c_int64(int(chunk_size)),
+            ctx.tensor(out, "out"),
+        ],
+        out,
+    )
+
+
+def npu_prepare_wy_repr_bwd_da(
+    k,
+    v,
+    beta,
+    A,
+    dw,
+    du,
+    g,
+    *,
+    chunk_size,
+    cu_seqlens=None,
+    chunk_indices=None,
+):
+    out = _empty_like(A)
+    return _call_aclnn(
+        "aclnnPrepareWyReprBwdDa",
+        lambda ctx: [
+            ctx.tensor(k, "k"),
+            ctx.tensor(v, "v"),
+            ctx.tensor(beta, "beta"),
+            ctx.tensor(A, "A"),
+            ctx.tensor(dw, "dw"),
+            ctx.tensor(du, "du"),
+            ctx.tensor(g, "g"),
+            ctx.int_array(cu_seqlens),
+            ctx.int_array(chunk_indices),
+            ctypes.c_int64(int(chunk_size)),
+            ctx.tensor(out, "dA"),
+        ],
+        out,
+    )
+
+
+def npu_chunk_bwd_dqkwg(
+    q,
+    k,
+    v,
+    g,
+    h,
+    dox,
+    dh,
+    dv,
+    chunk_size,
+    *,
+    cu_seqlens=None,
+    chunk_indices=None,
+    w=None,
+    g_gamma=None,
+    scale=None,
+    use_exp2=None,
+    transpose_state_layout=None,
+):
+    q_shape = _shape(q)
+    value_num_heads = int(v.shape[1])
+    dq = _empty_like(q)
+    dk = _empty_like(k)
+    dw = _empty((q_shape[0], value_num_heads, q_shape[2], q_shape[3]), q)
+    dg = _empty_like(g)
+    outputs = (dq, dk, dw, dg)
+    return _call_aclnn(
+        "aclnnChunkBwdDqkwg",
+        lambda ctx: [
+            ctx.tensor(q, "q"),
+            ctx.tensor(k, "k"),
+            ctx.tensor(v, "v"),
+            ctx.tensor(g, "g"),
+            ctx.tensor(h, "h"),
+            ctx.tensor(dox, "dox"),
+            ctx.tensor(dh, "dh"),
+            ctx.tensor(dv, "dv"),
+            ctx.int_array(cu_seqlens),
+            ctx.int_array(chunk_indices),
+            ctx.tensor(w, "w"),
+            ctx.tensor(g_gamma, "g_gamma"),
+            ctypes.c_float(_optional_float(scale, 1.0)),
+            ctypes.c_int64(int(chunk_size)),
+            ctypes.c_bool(_optional_bool(use_exp2, False)),
+            ctypes.c_bool(_optional_bool(transpose_state_layout, False)),
+            ctx.tensor(dq, "dq"),
+            ctx.tensor(dk, "dk"),
+            ctx.tensor(dw, "dw"),
+            ctx.tensor(dg, "dg"),
+        ],
+        outputs,
+    )
+
+
+def npu_chunk_fwd_o(
+    q,
+    k,
+    v,
+    h,
+    scale,
+    *,
+    g=None,
+    g_gamma=None,
+    cu_seqlens=None,
+    chunk_indices=None,
+    chunk_size=None,
+    transpose_state_layout=False,
+):
+    del g_gamma, transpose_state_layout
+    chunk_size = _optional_int(chunk_size, 64)
+    out = _empty_like(v)
+    return _call_aclnn(
+        "aclnnChunkFwdO",
+        lambda ctx: [
+            ctx.tensor(q, "q"),
+            ctx.tensor(k, "k"),
+            ctx.tensor(v, "v"),
+            ctx.tensor(h, "h"),
+            ctx.tensor(g, "g"),
+            ctx.int_array(cu_seqlens),
+            ctx.int_array(chunk_indices),
+            ctypes.c_double(float(scale)),
+            ctypes.c_int64(chunk_size),
+            ctx.tensor(out, "out"),
+        ],
+        out,
+    )
+
+
+def npu_chunk_gated_delta_rule_fwd_h(
+    k,
+    w,
+    u,
+    g=None,
+    *,
+    gk=None,
+    initial_state=None,
+    output_final_state=False,
+    chunk_size=None,
+    save_new_value=True,
+    cu_seqlens=None,
+    chunk_indices=None,
+    use_exp2=False,
+    transpose_state_layout=False,
+):
+    if g is None:
+        raise RuntimeError("npu_chunk_gated_delta_rule_fwd_h: g cannot be None.")
+    save_new_value = _optional_bool(save_new_value, True)
+    use_exp2 = _optional_bool(use_exp2, False)
+    transpose_state_layout = _optional_bool(transpose_state_layout, False)
+    if not save_new_value:
+        raise RuntimeError("npu_chunk_gated_delta_rule_fwd_h: save_new_value must be True.")
+    if use_exp2:
+        raise RuntimeError("npu_chunk_gated_delta_rule_fwd_h: use_exp2 must be False.")
+    if transpose_state_layout:
+        raise RuntimeError("npu_chunk_gated_delta_rule_fwd_h: transpose_state_layout must be False.")
+
+    output_final_state = _optional_bool(output_final_state, False)
+    chunk_size = _optional_int(chunk_size, 64)
+    B, _, T, K = _shape(k)
+    _, HV, _, V = _shape(u)
+    NT = _chunk_num(T, chunk_size, chunk_indices)
+    h_out = _zeros((B, HV, NT, K, V), k)
+    v_new_out = _empty_like(u)
+    if output_final_state:
+        N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
+        like = initial_state if initial_state is not None else h_out
+        final_state_out = _empty((N, HV, K, V), like)
+    else:
+        final_state_out = _empty((1,), k)
+    outputs = (h_out, v_new_out, final_state_out if output_final_state else None)
+    return _call_aclnn(
+        "aclnnChunkGatedDeltaRuleFwdH",
+        lambda ctx: [
+            ctx.tensor(k, "k"),
+            ctx.tensor(w, "w"),
+            ctx.tensor(u, "u"),
+            ctx.tensor(g, "g"),
+            ctx.tensor(gk, "gk"),
+            ctx.tensor(initial_state, "initial_state"),
+            ctypes.c_bool(output_final_state),
+            ctypes.c_int64(chunk_size),
+            ctypes.c_bool(save_new_value),
+            ctx.int_array(cu_seqlens),
+            ctx.int_array(chunk_indices),
+            ctypes.c_bool(use_exp2),
+            ctypes.c_bool(transpose_state_layout),
+            ctx.tensor(h_out, "h"),
+            ctx.tensor(v_new_out, "v_new"),
+            ctx.tensor(final_state_out, "final_state"),
+        ],
+        outputs,
+    )
+
+
+def npu_recompute_w_u_fwd(
+    k,
+    v,
+    beta,
+    A,
+    chunk_size,
+    *,
+    g=None,
+    gk=None,
+    cu_seqlens=None,
+    chunk_indices=None,
+):
+    w_shape = list(_shape(v))
+    w_shape[3] = int(k.shape[3])
+    w_out = _empty(w_shape, v, dtype=k.dtype)
+    u_out = _empty_like(v)
+    outputs = (w_out, u_out)
+    return _call_aclnn(
+        "aclnnRecomputeWUFwd",
+        lambda ctx: [
+            ctx.tensor(k, "k"),
+            ctx.tensor(v, "v"),
+            ctx.tensor(beta, "beta"),
+            ctx.tensor(A, "A"),
+            ctx.tensor(g, "g"),
+            ctx.tensor(gk, "gk"),
+            ctx.int_array(cu_seqlens),
+            ctx.int_array(chunk_indices),
+            ctypes.c_int64(int(chunk_size)),
+            ctx.tensor(w_out, "w"),
+            ctx.tensor(u_out, "u"),
+        ],
+        outputs,
+    )
+
+
+def _infer_causal_conv1d_y(x, head_num: int, run_mode: int):
+    x_dim = x.dim()
+    if run_mode == 0 and head_num > 0:
+        if x_dim == 3:
+            b, s, d_model = _shape(x)
+            return _empty((b, head_num, s, d_model // head_num), x)
+        if x_dim == 2:
+            s, d_model = _shape(x)
+            return _empty((head_num, s, d_model // head_num), x)
+    return _empty_like(x)
+
+
+def npu_causal_conv1d(
+    x,
+    weight,
+    bias=None,
+    conv_states=None,
+    *,
+    query_start_loc=None,
+    cache_indices=None,
+    initial_state_mode=None,
+    num_accepted_tokens=None,
+    activation_mode=0,
+    pad_slot_id=-1,
+    run_mode=0,
+    head_num=0,
+):
+    out = _infer_causal_conv1d_y(x, int(head_num), int(run_mode))
+    return _call_aclnn(
+        "aclnnCausalConv1d",
+        lambda ctx: [
+            ctx.tensor(x, "x"),
+            ctx.tensor(weight, "weight"),
+            ctx.tensor(bias, "bias"),
+            ctx.tensor(conv_states, "conv_states"),
+            ctx.int_tensor(query_start_loc, x.device),
+            ctx.int_tensor(cache_indices, x.device),
+            ctx.int_tensor(initial_state_mode, x.device),
+            ctx.int_tensor(num_accepted_tokens, x.device),
+            ctypes.c_int64(int(activation_mode)),
+            ctypes.c_int64(int(pad_slot_id)),
+            ctypes.c_int64(int(run_mode)),
+            ctypes.c_int64(int(head_num)),
+            ctx.tensor(out, "out"),
+        ],
+        out,
+    )
+
+
+def npu_causal_conv1d_bwd(
+    x,
+    y,
+    weight,
+    dy,
+    initial_state=None,
+    dht=None,
+    *,
+    query_start_loc=None,
+    activation=0,
+    input_layout="BSND",
+):
+    input_layout = str(input_layout)
+    width, dim = int(weight.shape[0]), int(weight.shape[1])
+    if input_layout == "BNSD":
+        batch = int(x.shape[0])
+        dx_shape = _shape(x)
+    elif input_layout in {"NTD", "TND"}:
+        if query_start_loc is None:
+            raise RuntimeError(f"query_start_loc is required for {input_layout} input.")
+        batch = len(query_start_loc) - 1
+        dx_shape = _shape(x)
+    else:
+        batch = int(x.shape[0])
+        dx_shape = _shape(x)
+    dx = _empty(dx_shape, x)
+    dw = _empty((width, dim), weight)
+    db = _empty((dim,), weight)
+    dh0 = _empty((batch, width, dim), x)
+    outputs = (dx, dw, db, dh0)
+    layout_buffer = ctypes.create_string_buffer(input_layout.encode("utf-8"))
+    return _call_aclnn(
+        "aclnnCausalConv1dBwd",
+        lambda ctx: [
+            ctx.tensor(x, "x"),
+            ctx.tensor(y, "y"),
+            ctx.tensor(weight, "weight"),
+            ctx.tensor(dy, "dy"),
+            ctx.tensor(initial_state, "initial_state"),
+            ctx.tensor(dht, "dht"),
+            ctx.int_array(query_start_loc),
+            ctypes.c_int64(int(activation)),
+            ctypes.cast(layout_buffer, ctypes.c_char_p),
+            ctx.tensor(dx, "dx"),
+            ctx.tensor(dw, "dw"),
+            ctx.tensor(db, "db"),
+            ctx.tensor(dh0, "dh0"),
+        ],
+        outputs,
+    )
+
+
+def npu_solve_tri(x, *, cu_seqlens=None, chunk_indices=None, layout="bsnd"):
+    x_contig = x.contiguous()
+    out = _empty_like(x_contig)
+    layout_arg = ctypes.c_char_p(str(layout).encode("utf-8"))
+    return _call_aclnn(
+        "aclnnSolveTri",
+        lambda ctx: [
+            ctx.tensor(x_contig, "x"),
+            ctx.int_array(cu_seqlens),
+            ctx.int_array(chunk_indices),
+            layout_arg,
+            ctx.tensor(out, "out"),
+        ],
+        out,
+    )
+
+
+ASCENDC_CTYPES_OPS = {
+    name: value
+    for name, value in globals().items()
+    if name.startswith("npu_") and callable(value)
+}

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
@@ -1,28 +1,59 @@
-"""ctypes backed aclnn calls for FLA NPU Ascend C operators."""
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""ctypes backed Python wrappers for FLA NPU Ascend C operators.
+
+This file intentionally contains only concrete operator wrappers and their ABI
+quirks.  Shared descriptor, workspace and stream handling lives in ``_runtime``
+so a new operator developer only needs to mirror the matching ``aclnn_*.h``
+signature here.
+"""
 
 from __future__ import annotations
 
 import ctypes
-from collections import deque
-from typing import Iterable, Optional, Sequence
 
+from ._runtime import (
+    call_aclnn as _runtime_call_aclnn,
+    chunk_num as _chunk_num,
+    empty as _empty,
+    empty_like as _empty_like,
+    optional_bool as _optional_bool,
+    optional_float as _optional_float,
+    optional_int as _optional_int,
+    shape as _shape,
+    zeros as _zeros,
+)
 
-ACL_SUCCESS = 0
-ACL_FORMAT_NCHW = 0
-ACL_FORMAT_ND = 2
-ACL_FORMAT_NCDHW = 30
-ACL_FORMAT_NCL = 47
-
-_ACL_FORMAT_BY_NAME = {
-    "NCHW": ACL_FORMAT_NCHW,
-    "ND": ACL_FORMAT_ND,
-    "NCDHW": ACL_FORMAT_NCDHW,
-    "NCL": ACL_FORMAT_NCL,
-}
-
-_RECENT_LAUNCH_STORAGE = deque(maxlen=128)
-
+# Most aclnn functions only receive pointer-sized descriptors and scalar ctypes
+# objects, so ctypes can call them without explicit argtypes.  Functions with C
+# strings or otherwise ambiguous scalar conversion are listed here to prevent
+# ctypes from narrowing or mis-converting arguments.
 _GET_WORKSPACE_ARGTYPES = {
+    "aclnnCausalConv1dBwd": [
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_int64,
+        ctypes.c_char_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_uint64),
+        ctypes.POINTER(ctypes.c_void_p),
+    ],
     "aclnnSolveTri": [
         ctypes.c_void_p,
         ctypes.c_void_p,
@@ -35,315 +66,13 @@ _GET_WORKSPACE_ARGTYPES = {
 }
 
 
-def _dtype_to_acl(dtype) -> int:
-    import torch
-
-    mapping = {
-        torch.float32: 0,  # ACL_FLOAT
-        torch.float16: 1,  # ACL_FLOAT16
-        torch.int8: 2,  # ACL_INT8
-        torch.int32: 3,  # ACL_INT32
-        torch.uint8: 4,  # ACL_UINT8
-        torch.int16: 6,  # ACL_INT16
-        torch.int64: 9,  # ACL_INT64
-        torch.float64: 11,  # ACL_DOUBLE
-        torch.bool: 12,  # ACL_BOOL
-        torch.bfloat16: 27,  # ACL_BF16
-    }
-    try:
-        return mapping[dtype]
-    except KeyError as exc:
-        raise TypeError(f"Unsupported dtype for aclnn tensor descriptor: {dtype}") from exc
-
-
-def _shape(tensor) -> tuple[int, ...]:
-    return tuple(int(dim) for dim in tensor.shape)
-
-
-def _stride(tensor) -> tuple[int, ...]:
-    return tuple(int(dim) for dim in tensor.stride())
-
-
-def _storage_numel(tensor) -> int:
-    try:
-        nbytes = tensor.untyped_storage().nbytes()
-    except AttributeError:
-        nbytes = tensor.storage().nbytes()
-    return int(nbytes // tensor.element_size())
-
-
-def _storage_data_ptr(tensor) -> int:
-    try:
-        return int(tensor.untyped_storage().data_ptr())
-    except AttributeError:
-        return int(tensor.storage().data_ptr())
-
-
-def _format(tensor) -> int:
-    try:
-        import torch_npu
-
-        npu_format = torch_npu.get_npu_format(tensor)
-    except Exception:
-        npu_format = None
-
-    if isinstance(npu_format, str):
-        acl_format = _ACL_FORMAT_BY_NAME.get(npu_format)
-        if acl_format is not None:
-            return acl_format
-    elif npu_format is not None:
-        try:
-            return int(npu_format)
-        except (TypeError, ValueError):
-            pass
-
-    dim = tensor.dim()
-    if dim == 3:
-        return ACL_FORMAT_NCL
-    if dim == 4:
-        return ACL_FORMAT_NCHW
-    if dim == 5:
-        return ACL_FORMAT_NCDHW
-    return ACL_FORMAT_ND
-
-
-def _ensure_npu_tensor(tensor, name: str):
-    if tensor is None:
-        return None
-    if not hasattr(tensor, "device") or tensor.device.type != "npu":
-        raise TypeError(f"{name} must be a torch NPU tensor, got {type(tensor)!r}.")
-    return tensor
-
-
-def _optional_bool(value, default: bool) -> bool:
-    return default if value is None else bool(value)
-
-
-def _optional_int(value, default: int) -> int:
-    return default if value is None else int(value)
-
-
-def _optional_float(value, default: float) -> float:
-    return default if value is None else float(value)
-
-
-def _chunk_num(total_tokens: int, chunk_size: int, chunk_indices: Optional[Sequence[int]]) -> int:
-    if chunk_indices is not None:
-        return len(chunk_indices) // 2
-    return (total_tokens + chunk_size - 1) // chunk_size
-
-
-def _current_stream_ptr() -> int:
-    import torch
-
-    stream = torch.npu.current_stream()
-    return int(getattr(stream, "npu_stream"))
-
-
-def _empty_like(tensor, *, dtype=None):
-    import torch
-
-    dtype = dtype or tensor.dtype
-    return torch.empty_like(tensor, dtype=dtype)
-
-
-def _empty(shape: Iterable[int], like, *, dtype=None):
-    import torch
-
-    return torch.empty(tuple(int(dim) for dim in shape), device=like.device, dtype=dtype or like.dtype)
-
-
-def _zeros(shape: Iterable[int], like, *, dtype=None):
-    import torch
-
-    return torch.zeros(tuple(int(dim) for dim in shape), device=like.device, dtype=dtype or like.dtype)
-
-
-class _AclTensor:
-    def __init__(self, runtime: "_AclnnRuntime", tensor):
-        tensor = _ensure_npu_tensor(tensor, "tensor")
-        self._runtime = runtime
-        self._tensor = tensor
-        self._shape = (ctypes.c_int64 * tensor.dim())(*_shape(tensor))
-        self._stride = (ctypes.c_int64 * tensor.dim())(*_stride(tensor))
-        self._storage_shape = (ctypes.c_int64 * 1)(_storage_numel(tensor))
-        self.ptr = runtime.acl_create_tensor(
-            self._shape,
-            ctypes.c_uint64(tensor.dim()),
-            ctypes.c_int(_dtype_to_acl(tensor.dtype)),
-            self._stride,
-            ctypes.c_int64(int(tensor.storage_offset())),
-            ctypes.c_int(_format(tensor)),
-            self._storage_shape,
-            ctypes.c_uint64(1),
-            ctypes.c_void_p(_storage_data_ptr(tensor)),
-        )
-        if not self.ptr:
-            raise RuntimeError("aclCreateTensor returned nullptr.")
-
-    def destroy(self) -> None:
-        if self.ptr:
-            self._runtime.acl_destroy_tensor(self.ptr)
-        self.ptr = None
-
-
-class _AclIntArray:
-    def __init__(self, runtime: "_AclnnRuntime", values: Optional[Sequence[int]]):
-        self._runtime = runtime
-        self.ptr = None
-        if values is None:
-            return
-        values = tuple(int(value) for value in values)
-        if not values:
-            return
-        self._values = (ctypes.c_int64 * len(values))(*values)
-        self.ptr = runtime.acl_create_int_array(self._values, ctypes.c_uint64(len(values)))
-        if not self.ptr:
-            raise RuntimeError("aclCreateIntArray returned nullptr.")
-
-    def destroy(self) -> None:
-        if self.ptr:
-            self._runtime.acl_destroy_int_array(self.ptr)
-        self.ptr = None
-
-
-class _CallContext:
-    def __init__(self, runtime: "_AclnnRuntime"):
-        self.runtime = runtime
-        self.resources = []
-        self.keepalive_tensors = []
-
-    def tensor(self, tensor, name: str = "tensor") -> ctypes.c_void_p:
-        if tensor is None:
-            return ctypes.c_void_p()
-        desc = _AclTensor(self.runtime, _ensure_npu_tensor(tensor, name))
-        self.resources.append(desc)
-        return ctypes.c_void_p(desc.ptr)
-
-    def int_array(self, values: Optional[Sequence[int]]) -> ctypes.c_void_p:
-        desc = _AclIntArray(self.runtime, values)
-        self.resources.append(desc)
-        return ctypes.c_void_p(desc.ptr or 0)
-
-    def int_tensor(self, values: Optional[Sequence[int]], device) -> ctypes.c_void_p:
-        if values is None:
-            return ctypes.c_void_p()
-        import torch
-
-        tensor = torch.as_tensor(tuple(int(value) for value in values), dtype=torch.int64, device=device)
-        self.keepalive_tensors.append(tensor)
-        return self.tensor(tensor, "int tensor")
-
-    def destroy(self) -> None:
-        for resource in reversed(self.resources):
-            resource.destroy()
-        self.resources.clear()
-
-
-class _AclnnRuntime:
-    def __init__(self):
-        import fla_npu
-
-        self._libraries = fla_npu.load_ascendc_opapi_libraries()
-        self._symbols = {}
-        self.acl_create_tensor = self.symbol("aclCreateTensor")
-        self.acl_create_tensor.argtypes = [
-            ctypes.POINTER(ctypes.c_int64),
-            ctypes.c_uint64,
-            ctypes.c_int,
-            ctypes.POINTER(ctypes.c_int64),
-            ctypes.c_int64,
-            ctypes.c_int,
-            ctypes.POINTER(ctypes.c_int64),
-            ctypes.c_uint64,
-            ctypes.c_void_p,
-        ]
-        self.acl_create_tensor.restype = ctypes.c_void_p
-
-        self.acl_destroy_tensor = self.symbol("aclDestroyTensor")
-        self.acl_destroy_tensor.argtypes = [ctypes.c_void_p]
-        self.acl_destroy_tensor.restype = ctypes.c_int
-
-        self.acl_create_int_array = self.symbol("aclCreateIntArray")
-        self.acl_create_int_array.argtypes = [ctypes.POINTER(ctypes.c_int64), ctypes.c_uint64]
-        self.acl_create_int_array.restype = ctypes.c_void_p
-
-        self.acl_destroy_int_array = self.symbol("aclDestroyIntArray")
-        self.acl_destroy_int_array.argtypes = [ctypes.c_void_p]
-        self.acl_destroy_int_array.restype = ctypes.c_int
-
-    def symbol(self, name: str):
-        if name in self._symbols:
-            return self._symbols[name]
-        for library in self._libraries:
-            try:
-                symbol = getattr(library, name)
-            except AttributeError:
-                continue
-            self._symbols[name] = symbol
-            return symbol
-        raise AttributeError(f"Unable to resolve aclnn symbol {name}.")
-
-    def call(self, name: str, args: Sequence[object], outputs: Sequence[object]):
-        get_workspace = self.symbol(f"{name}GetWorkspaceSize")
-        launch = self.symbol(name)
-        get_workspace.restype = ctypes.c_int
-        if name in _GET_WORKSPACE_ARGTYPES:
-            get_workspace.argtypes = _GET_WORKSPACE_ARGTYPES[name]
-        launch.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p]
-        launch.restype = ctypes.c_int
-        workspace_size = ctypes.c_uint64(0)
-        executor = ctypes.c_void_p()
-
-        ret = get_workspace(*args, ctypes.byref(workspace_size), ctypes.byref(executor))
-        if ret != ACL_SUCCESS:
-            raise RuntimeError(f"{name}GetWorkspaceSize failed with aclnnStatus={ret}.")
-
-        workspace = None
-        workspace_ptr = ctypes.c_void_p()
-        if workspace_size.value:
-            import torch
-
-            device = outputs[0].device
-            workspace = torch.empty((int(workspace_size.value),), dtype=torch.uint8, device=device)
-            workspace_ptr = ctypes.c_void_p(int(workspace.data_ptr()))
-
-        ret = launch(
-            workspace_ptr,
-            ctypes.c_uint64(workspace_size.value),
-            executor,
-            ctypes.c_void_p(_current_stream_ptr()),
-        )
-        if ret != ACL_SUCCESS:
-            raise RuntimeError(f"{name} failed with aclnnStatus={ret}.")
-        return workspace
-
-
-_RUNTIME: Optional[_AclnnRuntime] = None
-
-
-def _runtime() -> _AclnnRuntime:
-    global _RUNTIME
-    if _RUNTIME is None:
-        _RUNTIME = _AclnnRuntime()
-    return _RUNTIME
-
-
-def _finalize(outputs, workspace, keepalive_tensors):
-    _RECENT_LAUNCH_STORAGE.append((tuple(outputs), workspace, tuple(keepalive_tensors)))
-
-
 def _call_aclnn(name: str, build_args, outputs):
-    runtime = _runtime()
-    ctx = _CallContext(runtime)
-    outputs_tuple = outputs if isinstance(outputs, tuple) else (outputs,)
-    try:
-        args = build_args(ctx)
-        workspace = runtime.call(name, args, outputs_tuple)
-    finally:
-        ctx.destroy()
-    _finalize(outputs_tuple, workspace, ctx.keepalive_tensors)
-    return outputs
+    return _runtime_call_aclnn(
+        name,
+        build_args,
+        outputs,
+        get_workspace_argtypes=_GET_WORKSPACE_ARGTYPES.get(name),
+    )
 
 
 def npu_fast_gelu_custom(self):

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/_runtime.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/_runtime.py
@@ -1,0 +1,383 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""FLA NPU Ascend C 算子 Python wrapper 共用的 ctypes runtime。
+
+具体算子的 wrapper 只需要使用本模块导出的 ``call_aclnn`` 和 tensor/output
+辅助函数，不需要直接实例化 descriptor 或 runtime 类。这里的私有类只负责把
+torch tensor 转成 aclnn descriptor，并持有一次 launch 期间需要保活的临时资源。
+"""
+
+from __future__ import annotations
+
+import ctypes
+import sys
+from collections import deque
+from typing import Iterable, Optional, Sequence
+
+
+ACL_SUCCESS = 0
+ACL_FORMAT_NCHW = 0
+ACL_FORMAT_ND = 2
+ACL_FORMAT_NCDHW = 30
+ACL_FORMAT_NCL = 47
+
+_ACL_FORMAT_BY_NAME = {
+    "NCHW": ACL_FORMAT_NCHW,
+    "ND": ACL_FORMAT_ND,
+    "NCDHW": ACL_FORMAT_NCDHW,
+    "NCL": ACL_FORMAT_NCL,
+}
+
+# aclnn launch 是异步的。输出 tensor、workspace buffer，以及为可选 int-array
+# 输入临时创建的小 tensor，都必须至少存活到队列里的 kernel 消费完成。这里用
+# 一个小 ring 保活即可：普通用户 tensor 会由 torch stream 语义保活，而在常见
+# test/example 流程里，deque 回绕前旧 launch 通常已经执行完。
+_RECENT_LAUNCH_STORAGE = deque(maxlen=128)
+
+
+def dtype_to_acl(dtype) -> int:
+    import torch
+
+    mapping = {
+        torch.float32: 0,  # ACL_FLOAT
+        torch.float16: 1,  # ACL_FLOAT16
+        torch.int8: 2,  # ACL_INT8
+        torch.int32: 3,  # ACL_INT32
+        torch.uint8: 4,  # ACL_UINT8
+        torch.int16: 6,  # ACL_INT16
+        torch.int64: 9,  # ACL_INT64
+        torch.float64: 11,  # ACL_DOUBLE
+        torch.bool: 12,  # ACL_BOOL
+        torch.bfloat16: 27,  # ACL_BF16
+    }
+    try:
+        return mapping[dtype]
+    except KeyError as exc:
+        raise TypeError(f"Unsupported dtype for aclnn tensor descriptor: {dtype}") from exc
+
+
+def shape(tensor) -> tuple[int, ...]:
+    return tuple(int(dim) for dim in tensor.shape)
+
+
+def stride(tensor) -> tuple[int, ...]:
+    return tuple(int(dim) for dim in tensor.stride())
+
+
+def storage_numel(tensor) -> int:
+    try:
+        nbytes = tensor.untyped_storage().nbytes()
+    except AttributeError:
+        nbytes = tensor.storage().nbytes()
+    return int(nbytes // tensor.element_size())
+
+
+def storage_data_ptr(tensor) -> int:
+    try:
+        return int(tensor.untyped_storage().data_ptr())
+    except AttributeError:
+        return int(tensor.storage().data_ptr())
+
+
+def acl_format(tensor) -> int:
+    # torch_npu 能拿到内部 NPU layout tensor 的真实 storage format。但解耦后的
+    # runtime 默认不能 import torch_npu，因此这里只在别的代码已经加载 torch_npu
+    # 时复用它；否则按 tensor 逻辑维度做保守推断。
+    try:
+        torch_npu = sys.modules.get("torch_npu")
+        if torch_npu is None:
+            raise RuntimeError("torch_npu is not loaded")
+        npu_format = torch_npu.get_npu_format(tensor)
+    except Exception:
+        npu_format = None
+
+    if isinstance(npu_format, str):
+        acl_format_value = _ACL_FORMAT_BY_NAME.get(npu_format)
+        if acl_format_value is not None:
+            return acl_format_value
+    elif npu_format is not None:
+        try:
+            return int(npu_format)
+        except (TypeError, ValueError):
+            pass
+
+    dim = tensor.dim()
+    if dim == 3:
+        return ACL_FORMAT_NCL
+    if dim == 4:
+        return ACL_FORMAT_NCHW
+    if dim == 5:
+        return ACL_FORMAT_NCDHW
+    return ACL_FORMAT_ND
+
+
+def ensure_npu_tensor(tensor, name: str):
+    if tensor is None:
+        return None
+    if not hasattr(tensor, "device") or tensor.device.type != "npu":
+        raise TypeError(f"{name} must be a torch NPU tensor, got {type(tensor)!r}.")
+    return tensor
+
+
+def optional_bool(value, default: bool) -> bool:
+    return default if value is None else bool(value)
+
+
+def optional_int(value, default: int) -> int:
+    return default if value is None else int(value)
+
+
+def optional_float(value, default: float) -> float:
+    return default if value is None else float(value)
+
+
+def chunk_num(total_tokens: int, chunk_size: int, chunk_indices: Optional[Sequence[int]]) -> int:
+    if chunk_indices is not None:
+        return len(chunk_indices) // 2
+    return (total_tokens + chunk_size - 1) // chunk_size
+
+
+def current_stream_ptr() -> int:
+    import torch
+
+    stream = torch.npu.current_stream()
+    return int(getattr(stream, "npu_stream"))
+
+
+def empty_like(tensor, *, dtype=None):
+    import torch
+
+    dtype = dtype or tensor.dtype
+    return torch.empty_like(tensor, dtype=dtype)
+
+
+def empty(shape_: Iterable[int], like, *, dtype=None):
+    import torch
+
+    return torch.empty(tuple(int(dim) for dim in shape_), device=like.device, dtype=dtype or like.dtype)
+
+
+def zeros(shape_: Iterable[int], like, *, dtype=None):
+    import torch
+
+    return torch.zeros(tuple(int(dim) for dim in shape_), device=like.device, dtype=dtype or like.dtype)
+
+
+class _AclTensor:
+    """持有一次 aclnn 调用生命周期内的 aclTensor descriptor。"""
+
+    def __init__(self, runtime: "_AclnnRuntime", tensor):
+        tensor = ensure_npu_tensor(tensor, "tensor")
+        self._runtime = runtime
+        self._tensor = tensor
+        self._shape = (ctypes.c_int64 * tensor.dim())(*shape(tensor))
+        self._stride = (ctypes.c_int64 * tensor.dim())(*stride(tensor))
+        self._storage_shape = (ctypes.c_int64 * 1)(storage_numel(tensor))
+        self.ptr = runtime.acl_create_tensor(
+            self._shape,
+            ctypes.c_uint64(tensor.dim()),
+            ctypes.c_int(dtype_to_acl(tensor.dtype)),
+            self._stride,
+            ctypes.c_int64(int(tensor.storage_offset())),
+            ctypes.c_int(acl_format(tensor)),
+            self._storage_shape,
+            ctypes.c_uint64(1),
+            ctypes.c_void_p(storage_data_ptr(tensor)),
+        )
+        if not self.ptr:
+            raise RuntimeError("aclCreateTensor returned nullptr.")
+
+    def destroy(self) -> None:
+        if self.ptr:
+            self._runtime.acl_destroy_tensor(self.ptr)
+        self.ptr = None
+
+
+class _AclIntArray:
+    """为可选 Python sequence 输入持有一个 aclIntArray descriptor。"""
+
+    def __init__(self, runtime: "_AclnnRuntime", values: Optional[Sequence[int]]):
+        self._runtime = runtime
+        self.ptr = None
+        if values is None:
+            return
+        values = tuple(int(value) for value in values)
+        if not values:
+            return
+        self._values = (ctypes.c_int64 * len(values))(*values)
+        self.ptr = runtime.acl_create_int_array(self._values, ctypes.c_uint64(len(values)))
+        if not self.ptr:
+            raise RuntimeError("aclCreateIntArray returned nullptr.")
+
+    def destroy(self) -> None:
+        if self.ptr:
+            self._runtime.acl_destroy_int_array(self.ptr)
+        self.ptr = None
+
+
+class _CallContext:
+    """跟踪构造一次调用时创建的 descriptor 和临时 tensor。"""
+
+    def __init__(self, runtime: "_AclnnRuntime"):
+        self.runtime = runtime
+        self.resources = []
+        self.keepalive_tensors = []
+
+    def tensor(self, tensor, name: str = "tensor") -> ctypes.c_void_p:
+        if tensor is None:
+            return ctypes.c_void_p()
+        desc = _AclTensor(self.runtime, ensure_npu_tensor(tensor, name))
+        self.resources.append(desc)
+        return ctypes.c_void_p(desc.ptr)
+
+    def int_array(self, values: Optional[Sequence[int]]) -> ctypes.c_void_p:
+        desc = _AclIntArray(self.runtime, values)
+        self.resources.append(desc)
+        return ctypes.c_void_p(desc.ptr or 0)
+
+    def int_tensor(self, values: Optional[Sequence[int]], device) -> ctypes.c_void_p:
+        if values is None:
+            return ctypes.c_void_p()
+        import torch
+
+        # 部分 aclnn API 把可选 index array 建模成 Tensor 而不是 aclIntArray。
+        # 这里在目标 device 上创建这些小 tensor，并让它们在异步 launch 期间保活。
+        tensor = torch.as_tensor(tuple(int(value) for value in values), dtype=torch.int64, device=device)
+        self.keepalive_tensors.append(tensor)
+        return self.tensor(tensor, "int tensor")
+
+    def destroy(self) -> None:
+        for resource in reversed(self.resources):
+            resource.destroy()
+        self.resources.clear()
+
+
+class _AclnnRuntime:
+    """从已打包的 custom op_api 动态库里解析并缓存符号。"""
+
+    def __init__(self):
+        import fla_npu
+
+        self._libraries = fla_npu.load_ascendc_opapi_libraries()
+        self._symbols = {}
+        self.acl_create_tensor = self.symbol("aclCreateTensor")
+        self.acl_create_tensor.argtypes = [
+            ctypes.POINTER(ctypes.c_int64),
+            ctypes.c_uint64,
+            ctypes.c_int,
+            ctypes.POINTER(ctypes.c_int64),
+            ctypes.c_int64,
+            ctypes.c_int,
+            ctypes.POINTER(ctypes.c_int64),
+            ctypes.c_uint64,
+            ctypes.c_void_p,
+        ]
+        self.acl_create_tensor.restype = ctypes.c_void_p
+
+        self.acl_destroy_tensor = self.symbol("aclDestroyTensor")
+        self.acl_destroy_tensor.argtypes = [ctypes.c_void_p]
+        self.acl_destroy_tensor.restype = ctypes.c_int
+
+        self.acl_create_int_array = self.symbol("aclCreateIntArray")
+        self.acl_create_int_array.argtypes = [ctypes.POINTER(ctypes.c_int64), ctypes.c_uint64]
+        self.acl_create_int_array.restype = ctypes.c_void_p
+
+        self.acl_destroy_int_array = self.symbol("aclDestroyIntArray")
+        self.acl_destroy_int_array.argtypes = [ctypes.c_void_p]
+        self.acl_destroy_int_array.restype = ctypes.c_int
+
+    def symbol(self, name: str):
+        if name in self._symbols:
+            return self._symbols[name]
+        for library in self._libraries:
+            try:
+                symbol = getattr(library, name)
+            except AttributeError:
+                continue
+            self._symbols[name] = symbol
+            return symbol
+        raise AttributeError(f"Unable to resolve aclnn symbol {name}.")
+
+    def call(
+        self,
+        name: str,
+        args: Sequence[object],
+        outputs: Sequence[object],
+        *,
+        get_workspace_argtypes: Optional[Sequence[object]] = None,
+    ):
+        # aclnn 调用约定是两段式：第一段创建 executor 并返回 workspace 大小，
+        # 第二段传入 workspace 和 stream pointer 发起实际执行。workspace 使用
+        # 普通 torch NPU tensor 分配，从而跟随当前 PyTorch allocator 和 device。
+        get_workspace = self.symbol(f"{name}GetWorkspaceSize")
+        launch = self.symbol(name)
+        get_workspace.restype = ctypes.c_int
+        if get_workspace_argtypes is not None:
+            get_workspace.argtypes = list(get_workspace_argtypes)
+        launch.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p]
+        launch.restype = ctypes.c_int
+        workspace_size = ctypes.c_uint64(0)
+        executor = ctypes.c_void_p()
+
+        ret = get_workspace(*args, ctypes.byref(workspace_size), ctypes.byref(executor))
+        if ret != ACL_SUCCESS:
+            raise RuntimeError(f"{name}GetWorkspaceSize failed with aclnnStatus={ret}.")
+
+        workspace = None
+        workspace_ptr = ctypes.c_void_p()
+        if workspace_size.value:
+            import torch
+
+            device = outputs[0].device
+            workspace = torch.empty((int(workspace_size.value),), dtype=torch.uint8, device=device)
+            workspace_ptr = ctypes.c_void_p(int(workspace.data_ptr()))
+
+        ret = launch(
+            workspace_ptr,
+            ctypes.c_uint64(workspace_size.value),
+            executor,
+            ctypes.c_void_p(current_stream_ptr()),
+        )
+        if ret != ACL_SUCCESS:
+            raise RuntimeError(f"{name} failed with aclnnStatus={ret}.")
+        return workspace
+
+
+_RUNTIME: Optional[_AclnnRuntime] = None
+
+
+def runtime() -> _AclnnRuntime:
+    global _RUNTIME
+    if _RUNTIME is None:
+        _RUNTIME = _AclnnRuntime()
+    return _RUNTIME
+
+
+def finalize(outputs, workspace, keepalive_tensors):
+    _RECENT_LAUNCH_STORAGE.append((tuple(outputs), workspace, tuple(keepalive_tensors)))
+
+
+def call_aclnn(name: str, build_args, outputs, *, get_workspace_argtypes=None):
+    aclnn_runtime = runtime()
+    ctx = _CallContext(aclnn_runtime)
+    outputs_tuple = outputs if isinstance(outputs, tuple) else (outputs,)
+    try:
+        args = build_args(ctx)
+        workspace = aclnn_runtime.call(
+            name,
+            args,
+            outputs_tuple,
+            get_workspace_argtypes=get_workspace_argtypes,
+        )
+    finally:
+        ctx.destroy()
+    finalize(outputs_tuple, workspace, ctx.keepalive_tensors)
+    return outputs

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuPybind.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuPybind.cpp
@@ -1,0 +1,662 @@
+// Copyright (c) 2024 Tianjin University, Ltd
+// All rights reserved.
+//
+// Licensed under the BSD 3-Clause License  (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <pybind11/stl.h>
+#include <torch/extension.h>
+
+namespace py = pybind11;
+
+namespace op_api {
+
+at::Tensor npu_fast_gelu_custom(const at::Tensor &self);
+at::Tensor npu_fast_gelu_custom_backward(const at::Tensor &grad, const at::Tensor &self);
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> npu_prepare_wy_repr_bwd_full(
+    const at::Tensor &k,
+    const at::Tensor &v,
+    const at::Tensor &beta,
+    const at::Tensor &A,
+    const at::Tensor &dA,
+    const at::Tensor &dw,
+    const at::Tensor &du,
+    const at::Tensor &g,
+    int64_t chunk_size,
+    at::OptionalIntArrayRef cu_seqlens,
+    at::OptionalIntArrayRef chunk_indices);
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_chunk_gated_delta_rule_bwd_dhu(
+    const at::Tensor &q,
+    const at::Tensor &k,
+    const at::Tensor &w,
+    const at::Tensor &d_o,
+    const at::Tensor &dv,
+    double scale,
+    int64_t chunk_size,
+    const c10::optional<at::Tensor> &g,
+    const c10::optional<at::Tensor> &gK,
+    const c10::optional<at::Tensor> &h0,
+    const c10::optional<at::Tensor> &dht,
+    at::OptionalIntArrayRef cu_seqlens,
+    at::OptionalIntArrayRef chunk_indices,
+    c10::optional<bool> use_exp2,
+    c10::optional<bool> transpose_state_layout);
+
+at::Tensor npu_chunk_bwd_dv_local(
+    const at::Tensor &q,
+    const at::Tensor &k,
+    const at::Tensor &d_o,
+    const at::Tensor &g,
+    double scale,
+    int64_t chunk_size,
+    const c10::optional<at::Tensor> &g_gamma,
+    const c10::optional<at::Tensor> &A,
+    at::OptionalIntArrayRef cu_seqlens,
+    at::OptionalIntArrayRef chunk_indices);
+
+at::Tensor npu_prepare_wy_repr_bwd_da(
+    const at::Tensor &k,
+    const at::Tensor &v,
+    const at::Tensor &beta,
+    const at::Tensor &A,
+    const at::Tensor &dw,
+    const at::Tensor &du,
+    const at::Tensor &g,
+    int64_t chunk_size,
+    at::OptionalIntArrayRef cu_seqlens,
+    at::OptionalIntArrayRef chunk_indices);
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> npu_chunk_bwd_dqkwg(
+    const at::Tensor &q,
+    const at::Tensor &k,
+    const at::Tensor &v,
+    const at::Tensor &g,
+    const at::Tensor &h,
+    const at::Tensor &dox,
+    const at::Tensor &dh,
+    const at::Tensor &dv,
+    int64_t chunk_size,
+    at::OptionalIntArrayRef cu_seqlens,
+    at::OptionalIntArrayRef chunk_indices,
+    const c10::optional<at::Tensor> &w,
+    const c10::optional<at::Tensor> &g_gamma,
+    c10::optional<double> scale,
+    c10::optional<bool> use_exp2,
+    c10::optional<bool> transpose_state_layout);
+
+at::Tensor npu_chunk_fwd_o(
+    const at::Tensor &q,
+    const at::Tensor &k,
+    const at::Tensor &v,
+    const at::Tensor &h,
+    double scale,
+    const c10::optional<at::Tensor> &g,
+    const c10::optional<at::Tensor> &g_gamma,
+    at::OptionalIntArrayRef cu_seqlens,
+    at::OptionalIntArrayRef chunk_indices,
+    c10::optional<int64_t> chunk_size,
+    c10::optional<bool> transpose_state_layout);
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_chunk_gated_delta_rule_fwd_h(
+    const at::Tensor &k,
+    const at::Tensor &w,
+    const at::Tensor &u,
+    const c10::optional<at::Tensor> &g,
+    const c10::optional<at::Tensor> &gk,
+    const c10::optional<at::Tensor> &initial_state,
+    c10::optional<bool> output_final_state,
+    c10::optional<int64_t> chunk_size,
+    c10::optional<bool> save_new_value,
+    at::OptionalIntArrayRef cu_seqlens,
+    at::OptionalIntArrayRef chunk_indices,
+    c10::optional<bool> use_exp2,
+    c10::optional<bool> transpose_state_layout);
+
+std::tuple<at::Tensor, at::Tensor> npu_recompute_w_u_fwd(
+    const at::Tensor &k,
+    const at::Tensor &v,
+    const at::Tensor &beta,
+    const at::Tensor &A,
+    int64_t chunk_size,
+    const c10::optional<at::Tensor> &g,
+    const c10::optional<at::Tensor> &gK,
+    c10::OptionalIntArrayRef cu_seqlens,
+    c10::OptionalIntArrayRef chunk_indices);
+
+at::Tensor npu_causal_conv1d(
+    const at::Tensor &x,
+    const at::Tensor &weight,
+    const c10::optional<at::Tensor> &bias,
+    const at::Tensor &conv_states,
+    at::OptionalIntArrayRef query_start_loc,
+    at::OptionalIntArrayRef cache_indices,
+    at::OptionalIntArrayRef initial_state_mode,
+    at::OptionalIntArrayRef num_accepted_tokens,
+    int64_t activation_mode,
+    int64_t pad_slot_id,
+    int64_t run_mode,
+    int64_t head_num);
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> npu_causal_conv1d_bwd(
+    const at::Tensor &x,
+    const c10::optional<at::Tensor> &y,
+    const at::Tensor &weight,
+    const at::Tensor &dy,
+    const c10::optional<at::Tensor> &initial_state,
+    const c10::optional<at::Tensor> &dht,
+    at::OptionalIntArrayRef query_start_loc,
+    int64_t activation,
+    c10::string_view input_layout);
+
+at::Tensor npu_solve_tri(
+    const at::Tensor &x,
+    at::OptionalIntArrayRef cu_seqlens,
+    at::OptionalIntArrayRef chunk_indices,
+    c10::string_view layout);
+
+}  // namespace op_api
+
+namespace {
+
+using OptionalIntVector = c10::optional<std::vector<int64_t>>;
+
+OptionalIntVector optional_int_array(const py::object &value)
+{
+    if (value.is_none()) {
+        return c10::nullopt;
+    }
+    return value.cast<std::vector<int64_t>>();
+}
+
+at::OptionalIntArrayRef optional_int_array_ref(const OptionalIntVector &value)
+{
+    if (!value.has_value()) {
+        return c10::nullopt;
+    }
+    return at::IntArrayRef(value.value());
+}
+
+c10::optional<at::Tensor> optional_tensor(const py::object &value)
+{
+    if (value.is_none()) {
+        return c10::nullopt;
+    }
+    return value.cast<at::Tensor>();
+}
+
+at::Tensor tensor_or_undefined(const py::object &value)
+{
+    if (value.is_none()) {
+        return at::Tensor();
+    }
+    return value.cast<at::Tensor>();
+}
+
+template <typename T>
+c10::optional<T> optional_value(const py::object &value)
+{
+    if (value.is_none()) {
+        return c10::nullopt;
+    }
+    return value.cast<T>();
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> py_npu_prepare_wy_repr_bwd_full(
+    const at::Tensor &k,
+    const at::Tensor &v,
+    const at::Tensor &beta,
+    const at::Tensor &A,
+    const at::Tensor &dA,
+    const at::Tensor &dw,
+    const at::Tensor &du,
+    const at::Tensor &g,
+    int64_t chunk_size,
+    const py::object &cu_seqlens,
+    const py::object &chunk_indices)
+{
+    const auto cu_seqlens_vec = optional_int_array(cu_seqlens);
+    const auto chunk_indices_vec = optional_int_array(chunk_indices);
+    return op_api::npu_prepare_wy_repr_bwd_full(
+        k, v, beta, A, dA, dw, du, g, chunk_size,
+        optional_int_array_ref(cu_seqlens_vec),
+        optional_int_array_ref(chunk_indices_vec));
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> py_npu_chunk_gated_delta_rule_bwd_dhu(
+    const at::Tensor &q,
+    const at::Tensor &k,
+    const at::Tensor &w,
+    const at::Tensor &d_o,
+    const at::Tensor &dv,
+    double scale,
+    int64_t chunk_size,
+    const py::object &g,
+    const py::object &gK,
+    const py::object &h0,
+    const py::object &dht,
+    const py::object &cu_seqlens,
+    const py::object &chunk_indices,
+    const py::object &use_exp2,
+    const py::object &transpose_state_layout)
+{
+    const auto cu_seqlens_vec = optional_int_array(cu_seqlens);
+    const auto chunk_indices_vec = optional_int_array(chunk_indices);
+    return op_api::npu_chunk_gated_delta_rule_bwd_dhu(
+        q, k, w, d_o, dv, scale, chunk_size,
+        optional_tensor(g),
+        optional_tensor(gK),
+        optional_tensor(h0),
+        optional_tensor(dht),
+        optional_int_array_ref(cu_seqlens_vec),
+        optional_int_array_ref(chunk_indices_vec),
+        optional_value<bool>(use_exp2),
+        optional_value<bool>(transpose_state_layout));
+}
+
+at::Tensor py_npu_chunk_bwd_dv_local(
+    const at::Tensor &q,
+    const at::Tensor &k,
+    const at::Tensor &d_o,
+    const at::Tensor &g,
+    double scale,
+    int64_t chunk_size,
+    const py::object &g_gamma,
+    const py::object &A,
+    const py::object &cu_seqlens,
+    const py::object &chunk_indices)
+{
+    const auto cu_seqlens_vec = optional_int_array(cu_seqlens);
+    const auto chunk_indices_vec = optional_int_array(chunk_indices);
+    return op_api::npu_chunk_bwd_dv_local(
+        q, k, d_o, g, scale, chunk_size,
+        optional_tensor(g_gamma),
+        optional_tensor(A),
+        optional_int_array_ref(cu_seqlens_vec),
+        optional_int_array_ref(chunk_indices_vec));
+}
+
+at::Tensor py_npu_prepare_wy_repr_bwd_da(
+    const at::Tensor &k,
+    const at::Tensor &v,
+    const at::Tensor &beta,
+    const at::Tensor &A,
+    const at::Tensor &dw,
+    const at::Tensor &du,
+    const at::Tensor &g,
+    int64_t chunk_size,
+    const py::object &cu_seqlens,
+    const py::object &chunk_indices)
+{
+    const auto cu_seqlens_vec = optional_int_array(cu_seqlens);
+    const auto chunk_indices_vec = optional_int_array(chunk_indices);
+    return op_api::npu_prepare_wy_repr_bwd_da(
+        k, v, beta, A, dw, du, g, chunk_size,
+        optional_int_array_ref(cu_seqlens_vec),
+        optional_int_array_ref(chunk_indices_vec));
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> py_npu_chunk_bwd_dqkwg(
+    const at::Tensor &q,
+    const at::Tensor &k,
+    const at::Tensor &v,
+    const at::Tensor &g,
+    const at::Tensor &h,
+    const at::Tensor &dox,
+    const at::Tensor &dh,
+    const at::Tensor &dv,
+    int64_t chunk_size,
+    const py::object &cu_seqlens,
+    const py::object &chunk_indices,
+    const py::object &w,
+    const py::object &g_gamma,
+    const py::object &scale,
+    const py::object &use_exp2,
+    const py::object &transpose_state_layout)
+{
+    const auto cu_seqlens_vec = optional_int_array(cu_seqlens);
+    const auto chunk_indices_vec = optional_int_array(chunk_indices);
+    return op_api::npu_chunk_bwd_dqkwg(
+        q, k, v, g, h, dox, dh, dv, chunk_size,
+        optional_int_array_ref(cu_seqlens_vec),
+        optional_int_array_ref(chunk_indices_vec),
+        optional_tensor(w),
+        optional_tensor(g_gamma),
+        optional_value<double>(scale),
+        optional_value<bool>(use_exp2),
+        optional_value<bool>(transpose_state_layout));
+}
+
+at::Tensor py_npu_chunk_fwd_o(
+    const at::Tensor &q,
+    const at::Tensor &k,
+    const at::Tensor &v,
+    const at::Tensor &h,
+    double scale,
+    const py::object &g,
+    const py::object &g_gamma,
+    const py::object &cu_seqlens,
+    const py::object &chunk_indices,
+    const py::object &chunk_size,
+    const py::object &transpose_state_layout)
+{
+    const auto cu_seqlens_vec = optional_int_array(cu_seqlens);
+    const auto chunk_indices_vec = optional_int_array(chunk_indices);
+    return op_api::npu_chunk_fwd_o(
+        q, k, v, h, scale,
+        optional_tensor(g),
+        optional_tensor(g_gamma),
+        optional_int_array_ref(cu_seqlens_vec),
+        optional_int_array_ref(chunk_indices_vec),
+        optional_value<int64_t>(chunk_size),
+        optional_value<bool>(transpose_state_layout));
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> py_npu_chunk_gated_delta_rule_fwd_h(
+    const at::Tensor &k,
+    const at::Tensor &w,
+    const at::Tensor &u,
+    const py::object &g,
+    const py::object &gk,
+    const py::object &initial_state,
+    const py::object &output_final_state,
+    const py::object &chunk_size,
+    const py::object &save_new_value,
+    const py::object &cu_seqlens,
+    const py::object &chunk_indices,
+    const py::object &use_exp2,
+    const py::object &transpose_state_layout)
+{
+    const auto cu_seqlens_vec = optional_int_array(cu_seqlens);
+    const auto chunk_indices_vec = optional_int_array(chunk_indices);
+    return op_api::npu_chunk_gated_delta_rule_fwd_h(
+        k, w, u,
+        optional_tensor(g),
+        optional_tensor(gk),
+        optional_tensor(initial_state),
+        optional_value<bool>(output_final_state),
+        optional_value<int64_t>(chunk_size),
+        optional_value<bool>(save_new_value),
+        optional_int_array_ref(cu_seqlens_vec),
+        optional_int_array_ref(chunk_indices_vec),
+        optional_value<bool>(use_exp2),
+        optional_value<bool>(transpose_state_layout));
+}
+
+std::tuple<at::Tensor, at::Tensor> py_npu_recompute_w_u_fwd(
+    const at::Tensor &k,
+    const at::Tensor &v,
+    const at::Tensor &beta,
+    const at::Tensor &A,
+    int64_t chunk_size,
+    const py::object &g,
+    const py::object &gk,
+    const py::object &cu_seqlens,
+    const py::object &chunk_indices)
+{
+    const auto cu_seqlens_vec = optional_int_array(cu_seqlens);
+    const auto chunk_indices_vec = optional_int_array(chunk_indices);
+    return op_api::npu_recompute_w_u_fwd(
+        k, v, beta, A, chunk_size,
+        optional_tensor(g),
+        optional_tensor(gk),
+        optional_int_array_ref(cu_seqlens_vec),
+        optional_int_array_ref(chunk_indices_vec));
+}
+
+at::Tensor py_npu_causal_conv1d(
+    const at::Tensor &x,
+    const at::Tensor &weight,
+    const py::object &bias,
+    const py::object &conv_states,
+    const py::object &query_start_loc,
+    const py::object &cache_indices,
+    const py::object &initial_state_mode,
+    const py::object &num_accepted_tokens,
+    int64_t activation_mode,
+    int64_t pad_slot_id,
+    int64_t run_mode,
+    int64_t head_num)
+{
+    const auto query_start_loc_vec = optional_int_array(query_start_loc);
+    const auto cache_indices_vec = optional_int_array(cache_indices);
+    const auto initial_state_mode_vec = optional_int_array(initial_state_mode);
+    const auto num_accepted_tokens_vec = optional_int_array(num_accepted_tokens);
+    return op_api::npu_causal_conv1d(
+        x, weight,
+        optional_tensor(bias),
+        tensor_or_undefined(conv_states),
+        optional_int_array_ref(query_start_loc_vec),
+        optional_int_array_ref(cache_indices_vec),
+        optional_int_array_ref(initial_state_mode_vec),
+        optional_int_array_ref(num_accepted_tokens_vec),
+        activation_mode, pad_slot_id, run_mode, head_num);
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> py_npu_causal_conv1d_bwd(
+    const at::Tensor &x,
+    const py::object &y,
+    const at::Tensor &weight,
+    const at::Tensor &dy,
+    const py::object &initial_state,
+    const py::object &dht,
+    const py::object &query_start_loc,
+    int64_t activation,
+    const std::string &input_layout)
+{
+    const auto query_start_loc_vec = optional_int_array(query_start_loc);
+    return op_api::npu_causal_conv1d_bwd(
+        x,
+        optional_tensor(y),
+        weight,
+        dy,
+        optional_tensor(initial_state),
+        optional_tensor(dht),
+        optional_int_array_ref(query_start_loc_vec),
+        activation,
+        c10::string_view(input_layout.data(), input_layout.size()));
+}
+
+at::Tensor py_npu_solve_tri(
+    const at::Tensor &x,
+    const py::object &cu_seqlens,
+    const py::object &chunk_indices,
+    const std::string &layout)
+{
+    const auto cu_seqlens_vec = optional_int_array(cu_seqlens);
+    const auto chunk_indices_vec = optional_int_array(chunk_indices);
+    return op_api::npu_solve_tri(
+        x,
+        optional_int_array_ref(cu_seqlens_vec),
+        optional_int_array_ref(chunk_indices_vec),
+        c10::string_view(layout.data(), layout.size()));
+}
+
+}  // namespace
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    m.doc() = "Direct FLA NPU Ascend C bindings that bypass torch.ops dispatcher.";
+
+    m.def("npu_fast_gelu_custom", &op_api::npu_fast_gelu_custom, py::arg("self"));
+    m.def("npu_fast_gelu_custom_backward", &op_api::npu_fast_gelu_custom_backward, py::arg("grad"), py::arg("self"));
+    m.def(
+        "npu_causal_conv1d",
+        &py_npu_causal_conv1d,
+        py::arg("x"),
+        py::arg("weight"),
+        py::arg("bias") = py::none(),
+        py::arg("conv_states") = py::none(),
+        py::kw_only(),
+        py::arg("query_start_loc") = py::none(),
+        py::arg("cache_indices") = py::none(),
+        py::arg("initial_state_mode") = py::none(),
+        py::arg("num_accepted_tokens") = py::none(),
+        py::arg("activation_mode") = 0,
+        py::arg("pad_slot_id") = -1,
+        py::arg("run_mode") = 0,
+        py::arg("head_num") = 0);
+    m.def(
+        "npu_causal_conv1d_bwd",
+        &py_npu_causal_conv1d_bwd,
+        py::arg("x"),
+        py::arg("y"),
+        py::arg("weight"),
+        py::arg("dy"),
+        py::arg("initial_state") = py::none(),
+        py::arg("dht") = py::none(),
+        py::kw_only(),
+        py::arg("query_start_loc") = py::none(),
+        py::arg("activation") = 0,
+        py::arg("input_layout") = "BSND");
+    m.def(
+        "npu_prepare_wy_repr_bwd_full",
+        &py_npu_prepare_wy_repr_bwd_full,
+        py::arg("k"),
+        py::arg("v"),
+        py::arg("beta"),
+        py::arg("A"),
+        py::arg("dA"),
+        py::arg("dw"),
+        py::arg("du"),
+        py::arg("g"),
+        py::arg("chunk_size"),
+        py::kw_only(),
+        py::arg("cu_seqlens") = py::none(),
+        py::arg("chunk_indices") = py::none());
+    m.def(
+        "npu_chunk_gated_delta_rule_bwd_dhu",
+        &py_npu_chunk_gated_delta_rule_bwd_dhu,
+        py::arg("q"),
+        py::arg("k"),
+        py::arg("w"),
+        py::arg("d_o"),
+        py::arg("dv"),
+        py::arg("scale"),
+        py::arg("chunk_size"),
+        py::kw_only(),
+        py::arg("g") = py::none(),
+        py::arg("gK") = py::none(),
+        py::arg("h0") = py::none(),
+        py::arg("dht") = py::none(),
+        py::arg("cu_seqlens") = py::none(),
+        py::arg("chunk_indices") = py::none(),
+        py::arg("use_exp2") = false,
+        py::arg("transpose_state_layout") = false);
+    m.def(
+        "npu_chunk_bwd_dv_local",
+        &py_npu_chunk_bwd_dv_local,
+        py::arg("q"),
+        py::arg("k"),
+        py::arg("d_o"),
+        py::arg("g"),
+        py::arg("scale"),
+        py::arg("chunk_size"),
+        py::kw_only(),
+        py::arg("g_gamma") = py::none(),
+        py::arg("A") = py::none(),
+        py::arg("cu_seqlens") = py::none(),
+        py::arg("chunk_indices") = py::none());
+    m.def(
+        "npu_prepare_wy_repr_bwd_da",
+        &py_npu_prepare_wy_repr_bwd_da,
+        py::arg("k"),
+        py::arg("v"),
+        py::arg("beta"),
+        py::arg("A"),
+        py::arg("dw"),
+        py::arg("du"),
+        py::arg("g"),
+        py::kw_only(),
+        py::arg("chunk_size"),
+        py::arg("cu_seqlens") = py::none(),
+        py::arg("chunk_indices") = py::none());
+    m.def(
+        "npu_chunk_bwd_dqkwg",
+        &py_npu_chunk_bwd_dqkwg,
+        py::arg("q"),
+        py::arg("k"),
+        py::arg("v"),
+        py::arg("g"),
+        py::arg("h"),
+        py::arg("dox"),
+        py::arg("dh"),
+        py::arg("dv"),
+        py::arg("chunk_size"),
+        py::kw_only(),
+        py::arg("cu_seqlens") = py::none(),
+        py::arg("chunk_indices") = py::none(),
+        py::arg("w") = py::none(),
+        py::arg("g_gamma") = py::none(),
+        py::arg("scale") = py::none(),
+        py::arg("use_exp2") = py::none(),
+        py::arg("transpose_state_layout") = py::none());
+    m.def(
+        "npu_chunk_fwd_o",
+        &py_npu_chunk_fwd_o,
+        py::arg("q"),
+        py::arg("k"),
+        py::arg("v"),
+        py::arg("h"),
+        py::arg("scale"),
+        py::kw_only(),
+        py::arg("g") = py::none(),
+        py::arg("g_gamma") = py::none(),
+        py::arg("cu_seqlens") = py::none(),
+        py::arg("chunk_indices") = py::none(),
+        py::arg("chunk_size") = py::none(),
+        py::arg("transpose_state_layout") = false);
+    m.def(
+        "npu_chunk_gated_delta_rule_fwd_h",
+        &py_npu_chunk_gated_delta_rule_fwd_h,
+        py::arg("k"),
+        py::arg("w"),
+        py::arg("u"),
+        py::arg("g") = py::none(),
+        py::kw_only(),
+        py::arg("gk") = py::none(),
+        py::arg("initial_state") = py::none(),
+        py::arg("output_final_state") = false,
+        py::arg("chunk_size") = py::none(),
+        py::arg("save_new_value") = true,
+        py::arg("cu_seqlens") = py::none(),
+        py::arg("chunk_indices") = py::none(),
+        py::arg("use_exp2") = false,
+        py::arg("transpose_state_layout") = false);
+    m.def(
+        "npu_recompute_w_u_fwd",
+        &py_npu_recompute_w_u_fwd,
+        py::arg("k"),
+        py::arg("v"),
+        py::arg("beta"),
+        py::arg("A"),
+        py::arg("chunk_size"),
+        py::kw_only(),
+        py::arg("g") = py::none(),
+        py::arg("gk") = py::none(),
+        py::arg("cu_seqlens") = py::none(),
+        py::arg("chunk_indices") = py::none());
+    m.def(
+        "npu_solve_tri",
+        &py_npu_solve_tri,
+        py::arg("x"),
+        py::kw_only(),
+        py::arg("cu_seqlens") = py::none(),
+        py::arg("chunk_indices") = py::none(),
+        py::arg("layout") = "bsnd");
+}

--- a/torch_custom/fla_npu/setup.py
+++ b/torch_custom/fla_npu/setup.py
@@ -1,155 +1,135 @@
 import os
+import subprocess
 import sys
 import sysconfig
-import subprocess
-from setuptools import setup, Extension, find_packages
-import torch
-import torch_npu
-from torch.utils.cpp_extension import BuildExtension, CppExtension
 
-# Get PyTorch version
-PYTORCH_VERSION = subprocess.check_output([sys.executable, '-c', 'import torch; print(torch.__version__.split("+")[0])']).decode('utf-8').strip()
-version_parts = PYTORCH_VERSION.split('.')
-PYTORCH_VERSION_DIR = f"v{version_parts[0]}r{version_parts[1]}"
-
-# Set os env
-os.environ["PYTORCH_VERSION"] = PYTORCH_VERSION
-os.environ["PYTORCH_CUSTOM_DERIVATIVES_PATH"] = os.path.join(os.path.dirname(__file__), f"op-plugin/config/{PYTORCH_VERSION_DIR}/derivatives.yaml")
-os.environ["ACNN_EXTENSION_PATH"] = os.path.dirname(__file__)
-os.environ["ACNN_EXTENSION_SWITCH"] = "TRUE"
+from setuptools import find_packages, setup
 
 
-# Get all source files that need to be compiled
-def get_sources():
-    sources = []
-    # 添加csrc/aten目录下的源文件
-    aten_dir = os.path.join(os.path.dirname(__file__), "torch_npu/csrc/aten")
-    if os.path.exists(aten_dir):
-        for root, _, files in os.walk(aten_dir):
-            for file in files:
-                if file.endswith(".cpp") or file.endswith(".cc"):
-                    sources.append(os.path.join(root, file))
-    # 添加op-plugin/ops目录下的源文件
-    ops_dir = os.path.join(os.path.dirname(__file__), "op_plugin")
-    if os.path.exists(ops_dir):
-        for root, _, files in os.walk(ops_dir):
-            for file in files:
-                if file.endswith(".cpp") or file.endswith(".cc"):
-                    sources.append(os.path.join(root, file))
-
-    BUILD_EXCLUDE_LIST = [f"{aten_dir}/VariableTypeEverything.cpp",
-        f"{aten_dir}/ADInplaceOrViewTypeEverything.cpp",
-        f"{aten_dir}/python_functionsEverything.cpp",
-        f"{aten_dir}/RegisterFunctionalizationEverything.cpp"]
-
-    sources_new = [cur_file for cur_file in sources if cur_file not in BUILD_EXCLUDE_LIST]
-    print("====sources_new:", sources_new)
-
-    return sources_new
+def _env_flag(name):
+    return os.getenv(name, "FALSE").upper() in {"1", "TRUE", "YES", "ON"}
 
 
-# Get all needed head files
-def get_include_dirs():
-    PYTORCH_NPU_INSTALL_PATH = os.path.dirname(os.path.realpath(torch_npu.__file__))
-
-    include_dirs = []
-    # Add csrc/aten path
-    aten_dir = os.path.join(os.path.dirname(__file__), "torch_npu/csrc/aten")
-    if os.path.exists(aten_dir):
-        include_dirs.append(aten_dir)
-    # Add op-plugin path
-    ops_dir = os.path.join(os.path.dirname(__file__), "op_plugin")
-    if os.path.exists(ops_dir):
-        include_dirs.append(ops_dir)
-
-    base_dir = os.path.dirname(__file__)
-    if os.path.exists(base_dir):
-        include_dirs.append(base_dir)
-
-    torch_npu_dir = PYTORCH_NPU_INSTALL_PATH
-    include_dirs.append(os.path.join(torch_npu_dir, 'include'))
-    include_dirs.append(os.path.join(torch_npu_dir, 'include', 'third_party', 'acl', 'inc'))
-    include_dirs.append(os.path.join(torch_npu_dir, 'include', 'third_party', 'hccl', 'inc'))
-    include_dirs.append(os.path.join(torch_npu_dir, 'include', 'third_party', 'op-plugin'))
-    return include_dirs
-
-
-def get_compile_args():
-    compile_args = ["-std=c++17"]
-    # for Windows
-    if sys.platform == "win32":
-        compile_args.append("/MD")
-    # for Linux
-    elif sys.platform == "linux":
-        compile_args.append("-fPIC")
-    return compile_args
-
-
-def get_dependency_paths():
-    python_lib = sysconfig.get_config_var("LIBDIR")
-    torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib")
-    torch_npu_path = os.path.dirname(torch_npu.__file__)
-    torch_npu_lib = os.path.join(torch_npu_path, "lib")
-
-    all_libs = list([
-        python_lib,
-        torch_lib,
-        torch_npu_lib,
-    ])
-
-    return {
-        "all_libs": all_libs
-    }
-
-
-def get_vendor_dir_name():
-    return "fla_npu_transformer"
-
-
-def get_link_args():
-    link_args = []
-
-    link_args.append("-ltorch_npu")
-    link_args.append("-ltorch")
-    link_args.append("-lc10")
-
-    dep_paths = get_dependency_paths()
-    for lib_dir in dep_paths["all_libs"]:
-        link_args.append(f"-L{lib_dir}")
-
-    if sys.platform == "linux":
-        vendor_dir = get_vendor_dir_name()
-        link_args.extend([
-            "-Wl,--enable-new-dtags",
-            "-Wl,-rpath,$ORIGIN/../torch/lib",
-            "-Wl,-rpath,$ORIGIN/../torch_npu/lib",
-            f"-Wl,-rpath,$ORIGIN/opp/vendors/{vendor_dir}/op_api/lib",
-        ])
-    return link_args
-
-# Set extension configuration
-# Use CppExtension in PyTorch instead of the standard Extension for better PyTorch adaption
-extensions = [
-    CppExtension(
-        "fla_npu.custom_aclnn_extension_lib",
-        sources=get_sources(),
-        include_dirs=get_include_dirs(),
-        extra_compile_args=get_compile_args(),
-        extra_link_args=get_link_args(),
+def _setup_pure_python():
+    setup(
+        name="fla_npu",
+        version="1.0.0",
+        description="FLA NPU Python runtime",
+        packages=find_packages(),
+        package_data={"fla_npu": ["opp/**/*"]},
+        zip_safe=False,
     )
-]
 
-setup(
-    name="fla_npu",
-    version="1.0.0",
-    description="FLA NPU extension for PyTorch",
-    ext_modules=extensions,
-    cmdclass={
-        'build_ext': BuildExtension,
-    },
-    zip_safe=False,
-    install_requires=[
-        f"torch=={PYTORCH_VERSION}"
-    ],
-    packages=find_packages()
-)
+
+def _setup_legacy_extension():
+    import torch
+    import torch_npu
+    from torch.utils.cpp_extension import BuildExtension, CppExtension
+
+    pytorch_version = subprocess.check_output(
+        [sys.executable, "-c", 'import torch; print(torch.__version__.split("+")[0])']
+    ).decode("utf-8").strip()
+    version_parts = pytorch_version.split(".")
+    pytorch_version_dir = f"v{version_parts[0]}r{version_parts[1]}"
+
+    os.environ["PYTORCH_VERSION"] = pytorch_version
+    os.environ["PYTORCH_CUSTOM_DERIVATIVES_PATH"] = os.path.join(
+        os.path.dirname(__file__), f"op-plugin/config/{pytorch_version_dir}/derivatives.yaml"
+    )
+    os.environ["ACNN_EXTENSION_PATH"] = os.path.dirname(__file__)
+    os.environ["ACNN_EXTENSION_SWITCH"] = "TRUE"
+
+    def get_sources():
+        sources = []
+        aten_dir = os.path.join(os.path.dirname(__file__), "torch_npu/csrc/aten")
+        if os.path.exists(aten_dir):
+            for root, _, files in os.walk(aten_dir):
+                for file in files:
+                    if file.endswith((".cpp", ".cc")):
+                        sources.append(os.path.join(root, file))
+        ops_dir = os.path.join(os.path.dirname(__file__), "op_plugin")
+        if os.path.exists(ops_dir):
+            for root, _, files in os.walk(ops_dir):
+                for file in files:
+                    if file.endswith((".cpp", ".cc")):
+                        sources.append(os.path.join(root, file))
+
+        excluded = {
+            f"{aten_dir}/VariableTypeEverything.cpp",
+            f"{aten_dir}/ADInplaceOrViewTypeEverything.cpp",
+            f"{aten_dir}/python_functionsEverything.cpp",
+            f"{aten_dir}/RegisterFunctionalizationEverything.cpp",
+        }
+        return [source for source in sources if source not in excluded]
+
+    def get_include_dirs():
+        torch_npu_path = os.path.dirname(os.path.realpath(torch_npu.__file__))
+        base_dir = os.path.dirname(__file__)
+        include_dirs = []
+        for relative in ("torch_npu/csrc/aten", "op_plugin", "."):
+            path = os.path.join(base_dir, relative)
+            if os.path.exists(path):
+                include_dirs.append(path)
+        include_dirs.extend(
+            [
+                os.path.join(torch_npu_path, "include"),
+                os.path.join(torch_npu_path, "include", "third_party", "acl", "inc"),
+                os.path.join(torch_npu_path, "include", "third_party", "hccl", "inc"),
+                os.path.join(torch_npu_path, "include", "third_party", "op-plugin"),
+            ]
+        )
+        return include_dirs
+
+    def get_compile_args():
+        compile_args = ["-std=c++17"]
+        if sys.platform == "win32":
+            compile_args.append("/MD")
+        elif sys.platform == "linux":
+            compile_args.append("-fPIC")
+        return compile_args
+
+    def get_link_args():
+        torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib")
+        torch_npu_lib = os.path.join(os.path.dirname(torch_npu.__file__), "lib")
+        link_args = [
+            "-ltorch_npu",
+            "-ltorch",
+            "-lc10",
+            f"-L{sysconfig.get_config_var('LIBDIR')}",
+            f"-L{torch_lib}",
+            f"-L{torch_npu_lib}",
+        ]
+        if sys.platform == "linux":
+            link_args.extend(
+                [
+                    "-Wl,--enable-new-dtags",
+                    "-Wl,-rpath,$ORIGIN/../torch/lib",
+                    "-Wl,-rpath,$ORIGIN/../torch_npu/lib",
+                    "-Wl,-rpath,$ORIGIN/opp/vendors/fla_npu_transformer/op_api/lib",
+                ]
+            )
+        return link_args
+
+    setup(
+        name="fla_npu",
+        version="1.0.0",
+        description="FLA NPU legacy PyTorch extension",
+        ext_modules=[
+            CppExtension(
+                "fla_npu.custom_aclnn_extension_lib",
+                sources=get_sources(),
+                include_dirs=get_include_dirs(),
+                extra_compile_args=get_compile_args(),
+                extra_link_args=get_link_args(),
+            )
+        ],
+        cmdclass={"build_ext": BuildExtension},
+        zip_safe=False,
+        packages=find_packages(),
+    )
+
+
+if _env_flag("FLA_NPU_BUILD_LEGACY_EXTENSION"):
+    _setup_legacy_extension()
+else:
+    _setup_pure_python()

--- a/torch_custom/fla_npu/test/test.sh
+++ b/torch_custom/fla_npu/test/test.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 # GDN 全量测试入口
 # 用法:
 #   bash test.sh --device 0              # 在 device 0 上运行全量测试
@@ -42,6 +52,7 @@ if [[ -z "$TEST_DEVICE_ID" ]]; then
 fi
 
 export TEST_DEVICE_ID
+export TORCH_DEVICE_BACKEND_AUTOLOAD=1
 export TEST_LOG_DIR="$SCRIPT_DIR/test_output"
 mkdir -p "$TEST_LOG_DIR"
 

--- a/torch_custom/fla_npu/test/test_fwd_h.py
+++ b/torch_custom/fla_npu/test/test_fwd_h.py
@@ -1,3 +1,13 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 import os
 import sys
 import logging
@@ -5,14 +15,12 @@ import numpy as np
 import random
 import ml_dtypes
 import torch
-import torch_npu
 from ml_dtypes import bfloat16
 from dataclasses import dataclass
 import math
 # import custom_ops
-import fla_npu
+from fla_npu.ops import ascendc as ascendc_ops
 
-fla_npu.load_legacy_torch_ops()
 
 torch.npu.config.allow_internal_format = False
 torch.npu.set_compile_mode(jit_compile=False)
@@ -287,7 +295,7 @@ if __name__ == "__main__":
         return list(x)
 
     # 与 npu_custom.yaml / FLA chunk_gated_delta_rule_fwd_h 对齐：k,w,u 位置参数；g 及之后为关键字（g 当前不可为 None）
-    result = torch.ops.npu.npu_chunk_gated_delta_rule_fwd_h(
+    result = ascendc_ops.npu_chunk_gated_delta_rule_fwd_h(
         input_tensor.k.npu(),
         input_tensor.w.npu(),
         input_tensor.u.npu(),
@@ -303,7 +311,7 @@ if __name__ == "__main__":
         chunk_indices=_as_int_list(input_tensor.chunk_offsets),
     )
     print("after custom op")
-    torch_npu._C._npu_synchronize()
+    torch.npu.synchronize()
     print("after synchronize")
     save_data(input_tensor, output_tensor)
     result[0].cpu().view(torch.int16).numpy().tofile(os.path.join(WORKSPACE, "data", "h_npu.bin"))

--- a/torch_custom/fla_npu/test/test_fwd_h.py
+++ b/torch_custom/fla_npu/test/test_fwd_h.py
@@ -12,6 +12,8 @@ import math
 # import custom_ops
 import fla_npu
 
+fla_npu.load_legacy_torch_ops()
+
 torch.npu.config.allow_internal_format = False
 torch.npu.set_compile_mode(jit_compile=False)
 

--- a/torch_custom/fla_npu/test/test_fwd_o.py
+++ b/torch_custom/fla_npu/test/test_fwd_o.py
@@ -1,3 +1,13 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 import os
 import sys
 import logging
@@ -5,14 +15,12 @@ import numpy as np
 import random
 import ml_dtypes
 import torch
-import torch_npu
 from ml_dtypes import bfloat16
 from dataclasses import dataclass
 import math
 # import custom_ops
-import fla_npu
+from fla_npu.ops import ascendc as ascendc_ops
 
-fla_npu.load_legacy_torch_ops()
 
 torch.npu.config.allow_internal_format = False
 torch.npu.set_compile_mode(jit_compile=False)
@@ -313,7 +321,7 @@ if __name__ == "__main__":
     torch.npu.synchronize()
     print("step 6: before custom op")
 
-    result = torch.ops.npu.npu_chunk_fwd_o(
+    result = ascendc_ops.npu_chunk_fwd_o(
         q,
         k,
         v,

--- a/torch_custom/fla_npu/test/test_fwd_o.py
+++ b/torch_custom/fla_npu/test/test_fwd_o.py
@@ -12,6 +12,8 @@ import math
 # import custom_ops
 import fla_npu
 
+fla_npu.load_legacy_torch_ops()
+
 torch.npu.config.allow_internal_format = False
 torch.npu.set_compile_mode(jit_compile=False)
 

--- a/torch_custom/fla_npu/test/test_npu_bwd_dhu_gva.py
+++ b/torch_custom/fla_npu/test/test_npu_bwd_dhu_gva.py
@@ -1,3 +1,13 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 """bwd_dhu GVA 双标杆测试：随机输入直接测，无需 example dump。"""
 from __future__ import annotations
 
@@ -9,11 +19,9 @@ from dataclasses import dataclass
 from typing import Optional
 
 import ct
-import fla_npu
+from fla_npu.ops import ascendc as ascendc_ops
 
-fla_npu.load_legacy_torch_ops()
 import torch
-import torch_npu
 
 torch.npu.config.allow_internal_format = False
 torch.npu.set_compile_mode(jit_compile=False)
@@ -125,7 +133,7 @@ def run_case(case: BwdDhuCase, device: int, out_root: str, seed: int = 0) -> tup
         chunk_size=case.chunk_size, golden_mode="npu",
     )
 
-    dh_npu, _, dv2_npu = torch.ops.npu.npu_chunk_gated_delta_rule_bwd_dhu(
+    dh_npu, _, dv2_npu = ascendc_ops.npu_chunk_gated_delta_rule_bwd_dhu(
         q.npu(), k.npu(), w.npu(), do.npu(), dv.npu(),
         scale=scale,
         chunk_size=case.chunk_size,

--- a/torch_custom/fla_npu/test/test_npu_bwd_dhu_gva.py
+++ b/torch_custom/fla_npu/test/test_npu_bwd_dhu_gva.py
@@ -10,6 +10,8 @@ from typing import Optional
 
 import ct
 import fla_npu
+
+fla_npu.load_legacy_torch_ops()
 import torch
 import torch_npu
 

--- a/torch_custom/fla_npu/test/test_npu_causal_conv1d.py
+++ b/torch_custom/fla_npu/test/test_npu_causal_conv1d.py
@@ -1,13 +1,21 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 import unittest
 
 import os
 import torch
-import torch_npu
 import torch.nn.functional as F
 
-import fla_npu
+from fla_npu.ops import ascendc as ascendc_ops
 
-fla_npu.load_legacy_torch_ops()
 
 torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
 
@@ -178,8 +186,7 @@ class TestCausalConv1d(unittest.TestCase):
     atol = 5e-2
 
     def call_op(self, **kwargs):
-        self.assertTrue(hasattr(torch.ops.npu, "npu_causal_conv1d"))
-        return torch.ops.npu.npu_causal_conv1d(**kwargs)
+        return ascendc_ops.npu_causal_conv1d(**kwargs)
 
     def assertTensorClose(self, actual: torch.Tensor, expected: torch.Tensor, *, rtol=None, atol=None):
         rtol = self.rtol if rtol is None else rtol

--- a/torch_custom/fla_npu/test/test_npu_causal_conv1d.py
+++ b/torch_custom/fla_npu/test/test_npu_causal_conv1d.py
@@ -7,6 +7,8 @@ import torch.nn.functional as F
 
 import fla_npu
 
+fla_npu.load_legacy_torch_ops()
+
 torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
 
 

--- a/torch_custom/fla_npu/test/test_npu_causal_conv1d_bwd.py
+++ b/torch_custom/fla_npu/test/test_npu_causal_conv1d_bwd.py
@@ -1,12 +1,20 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 import os
 import unittest
 
 import torch
-import torch_npu
 
-import fla_npu
+from fla_npu.ops import ascendc as ascendc_ops
 
-fla_npu.load_legacy_torch_ops()
 
 
 torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
@@ -200,8 +208,7 @@ class TestCausalConv1dBwd(unittest.TestCase):
     atol = 8e-2
 
     def call_op(self, **kwargs):
-        self.assertTrue(hasattr(torch.ops.npu, "npu_causal_conv1d_bwd"))
-        return torch.ops.npu.npu_causal_conv1d_bwd(**kwargs)
+        return ascendc_ops.npu_causal_conv1d_bwd(**kwargs)
 
     def assertTensorClose(self, actual, expected, *, rtol=None, atol=None):
         rtol = self.rtol if rtol is None else rtol

--- a/torch_custom/fla_npu/test/test_npu_causal_conv1d_bwd.py
+++ b/torch_custom/fla_npu/test/test_npu_causal_conv1d_bwd.py
@@ -6,6 +6,8 @@ import torch_npu
 
 import fla_npu
 
+fla_npu.load_legacy_torch_ops()
+
 
 torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
 

--- a/torch_custom/fla_npu/test/test_npu_chunk_bwd_dqkwg.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_bwd_dqkwg.py
@@ -1,13 +1,21 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 import torch
-import torch_npu
 # from ct import single
 import torch
 import torch.nn.functional as F
 from typing import Tuple
 # import custom_ops
-import fla_npu
+from fla_npu.ops import ascendc as ascendc_ops
 
-fla_npu.load_legacy_torch_ops()
 import os
 
 # 当前文件所在目录
@@ -560,7 +568,7 @@ if __name__ == "__main__":
 
 
     print("==============start NPU=============")
-    torch_npu.npu.set_device(device_id)
+    torch.npu.set_device(device_id)
     print("dtype")
     q_npu = torch.transpose(q, 1, 2).to(dtype).npu()
     print("q_npu", q_npu.shape, q_npu.dtype)
@@ -586,7 +594,7 @@ if __name__ == "__main__":
     down_tri = q_npu
 
     print("qqqqqqqq")
-    dq_npu, dk_npu, dw_npu, dg_npu = torch.ops.npu.npu_chunk_bwd_dqkwg(
+    dq_npu, dk_npu, dw_npu, dg_npu = ascendc_ops.npu_chunk_bwd_dqkwg(
         q_npu, k_npu, v_npu, g_npu, h_npu, do_npu, dh_npu, dv_npu, chunk_size, cu_seqlens=cu_seqlens, w=None, g_gamma=None, chunk_indices=chunk_indices_npu, scale=scale, use_exp2=None, transpose_state_layout=None
     )
     print("custom_ops.npu_chunk_bwd_dqkwg done")

--- a/torch_custom/fla_npu/test/test_npu_chunk_bwd_dqkwg.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_bwd_dqkwg.py
@@ -6,6 +6,8 @@ import torch.nn.functional as F
 from typing import Tuple
 # import custom_ops
 import fla_npu
+
+fla_npu.load_legacy_torch_ops()
 import os
 
 # 当前文件所在目录

--- a/torch_custom/fla_npu/test/test_npu_chunk_bwd_dv_local.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_bwd_dv_local.py
@@ -1,5 +1,14 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 import torch
-import torch_npu
 import os
 from typing import Optional
 import math
@@ -7,9 +16,8 @@ import hashlib
 from golden import chunk_bwd_dv_local_fix, chunk_bwd_dv_local_variable, prepare_chunk_indices
 from utils import generate_cu_seqlens, compare_tensors_by_ratio, create_incremental_tensor, create_tensor, bool_matrix_to_uint8, get_tensor_md5, compare_tensors_md5
 import ct
-import fla_npu
+from fla_npu.ops import ascendc as ascendc_ops
 
-fla_npu.load_legacy_torch_ops()
 
 torch.npu.config.allow_internal_format = False
 torch.npu.set_compile_mode(jit_compile=False)
@@ -45,7 +53,7 @@ def test_variable():
     cu_seqlens_list = cu_seqlens.tolist()
     chunk_indices_list = chunk_indices.flatten().tolist()
 
-    dv = torch.ops.npu.npu_chunk_bwd_dv_local(q_npu, k_npu, d_o_npu, g_npu, scale=scale, chunk_size=chunk_size, g_gamma=None, A=None, cu_seqlens=cu_seqlens_list, chunk_indices=chunk_indices_list)
+    dv = ascendc_ops.npu_chunk_bwd_dv_local(q_npu, k_npu, d_o_npu, g_npu, scale=scale, chunk_size=chunk_size, g_gamma=None, A=None, cu_seqlens=cu_seqlens_list, chunk_indices=chunk_indices_list)
     ct.single(dv.cpu(), dv_golden)
 
 
@@ -73,7 +81,7 @@ def test_fix():
     k_npu = k.npu()
     d_o_npu = d_o.npu()
     g_npu = g.npu()
-    dv = torch.ops.npu.npu_chunk_bwd_dv_local(q_npu, k_npu, d_o_npu, g_npu, scale=scale, chunk_size=chunk_size, g_gamma=None, A=None, cu_seqlens=None, chunk_indices=None)
+    dv = ascendc_ops.npu_chunk_bwd_dv_local(q_npu, k_npu, d_o_npu, g_npu, scale=scale, chunk_size=chunk_size, g_gamma=None, A=None, cu_seqlens=None, chunk_indices=None)
     ct.single(dv.cpu(), dv_golden)
 
 

--- a/torch_custom/fla_npu/test/test_npu_chunk_bwd_dv_local.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_bwd_dv_local.py
@@ -9,6 +9,8 @@ from utils import generate_cu_seqlens, compare_tensors_by_ratio, create_incremen
 import ct
 import fla_npu
 
+fla_npu.load_legacy_torch_ops()
+
 torch.npu.config.allow_internal_format = False
 torch.npu.set_compile_mode(jit_compile=False)
 torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))

--- a/torch_custom/fla_npu/test/test_npu_chunk_gated_delta_rule_bwd_dhu.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_gated_delta_rule_bwd_dhu.py
@@ -1,10 +1,18 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 import torch
-import torch_npu
 import os
 # import custom_ops
-import fla_npu
+from fla_npu.ops import ascendc as ascendc_ops
 
-fla_npu.load_legacy_torch_ops()
 
 os.environ['TBE_PARALLEL_COMPILE_ENABLE'] = '0'
 os.environ['PARALLEL_COMPILE'] = '0'
@@ -63,7 +71,7 @@ def run_case(
         print("chunk_indices len =", len(chunk_indices))
 
     print("before custom op")
-    dh, dh0, dv2 = torch.ops.npu.npu_chunk_gated_delta_rule_bwd_dhu(
+    dh, dh0, dv2 = ascendc_ops.npu_chunk_gated_delta_rule_bwd_dhu(
         q.npu(),
         k.npu(),
         w.npu(),

--- a/torch_custom/fla_npu/test/test_npu_chunk_gated_delta_rule_bwd_dhu.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_gated_delta_rule_bwd_dhu.py
@@ -4,6 +4,8 @@ import os
 # import custom_ops
 import fla_npu
 
+fla_npu.load_legacy_torch_ops()
+
 os.environ['TBE_PARALLEL_COMPILE_ENABLE'] = '0'
 os.environ['PARALLEL_COMPILE'] = '0'
 

--- a/torch_custom/fla_npu/test/test_npu_fast_gelu_custom.py
+++ b/torch_custom/fla_npu/test/test_npu_fast_gelu_custom.py
@@ -1,36 +1,43 @@
-import numpy as np
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 import os
+import unittest
+
 import torch
 
-import torch_npu
-from torch_npu.testing.testcase import TestCase, run_tests
-from torch_npu.testing.common_utils import create_common_tensor
+from fla_npu.ops import ascendc as ascendc_ops
 
-import fla_npu
-
-fla_npu.load_legacy_torch_ops()
 
 torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
 
 
-class TestFastGelu(TestCase):
+def fast_gelu_ref(x: torch.Tensor) -> torch.Tensor:
+    x_float = x.float()
+    return (x_float / (1 + torch.exp(-1.702 * x_float))).to(x.dtype)
 
-    # compare with npu_fast_gelu
-    def supported_op_exec(self, input1):
-        output = torch.ops.npu.npu_fast_gelu(input1)
-        return output.cpu().detach()
 
-    def custom_op_exec(self, input1):
-        output = torch.ops.npu.npu_fast_gelu_custom(input1)
-        return output.cpu().detach()
+@unittest.skipIf(not torch.npu.is_available(), "NPU is not available")
+class TestFastGelu(unittest.TestCase):
+    def assertTensorClose(self, actual: torch.Tensor, expected: torch.Tensor) -> None:
+        self.assertTrue(
+            torch.allclose(actual.detach().cpu().float(), expected.detach().cpu().float(), rtol=1e-3, atol=1e-3),
+            msg=f"max diff={(actual.detach().cpu().float() - expected.detach().cpu().float()).abs().max().item()}",
+        )
 
-    def test_npu_fast_gelu_custom(self, device="npu"):
-        item = [np.float32, 0, [3, 16, 32]]
-        _, npu_input = create_common_tensor(item, 0, 100)
+    def test_npu_fast_gelu_custom(self):
+        values = torch.linspace(-3, 3, steps=3 * 16 * 32, dtype=torch.float32).reshape(3, 16, 32)
+        npu_input = values.npu()
+        custom_output = ascendc_ops.npu_fast_gelu_custom(npu_input)
+        self.assertTensorClose(custom_output, fast_gelu_ref(values).npu())
 
-        supported_output = self.supported_op_exec(npu_input)
-        custom_output = self.custom_op_exec(npu_input)
-        self.assertRtolEqual(supported_output, custom_output)
 
 if __name__ == "__main__":
-    run_tests()
+    unittest.main()

--- a/torch_custom/fla_npu/test/test_npu_fast_gelu_custom.py
+++ b/torch_custom/fla_npu/test/test_npu_fast_gelu_custom.py
@@ -8,6 +8,8 @@ from torch_npu.testing.common_utils import create_common_tensor
 
 import fla_npu
 
+fla_npu.load_legacy_torch_ops()
+
 torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
 
 

--- a/torch_custom/fla_npu/test/test_npu_prepare_wy_repr_bwd_da.py
+++ b/torch_custom/fla_npu/test/test_npu_prepare_wy_repr_bwd_da.py
@@ -1,12 +1,20 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 import torch
-import torch_npu
 from typing import Optional
 import math
 # import ct
 import random
-import fla_npu
+from fla_npu.ops import ascendc as ascendc_ops
 
-fla_npu.load_legacy_torch_ops()
 import os
 
 torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
@@ -340,7 +348,7 @@ def test_prepare_wy_repr_bwd_da_variable(
     du_npu = du.npu()
     g_npu = g.npu()
 
-    dA_npu = torch.ops.npu.npu_prepare_wy_repr_bwd_da(
+    dA_npu = ascendc_ops.npu_prepare_wy_repr_bwd_da(
         k_npu, v_npu, beta_npu, A_npu, dw_npu, du_npu, g_npu,
         chunk_size=chunk_size, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices
     )
@@ -402,7 +410,7 @@ def test_prepare_wy_repr_bwd_da_fix(
     du_npu = du.npu()
     g_npu = g.npu()
 
-    dA_npu = torch.ops.npu.npu_prepare_wy_repr_bwd_da(
+    dA_npu = ascendc_ops.npu_prepare_wy_repr_bwd_da(
         k_npu, v_npu, beta_npu, A_npu, dw_npu, du_npu, g_npu,
         chunk_size=chunk_size, cu_seqlens=None, chunk_indices=None
     )

--- a/torch_custom/fla_npu/test/test_npu_prepare_wy_repr_bwd_da.py
+++ b/torch_custom/fla_npu/test/test_npu_prepare_wy_repr_bwd_da.py
@@ -5,6 +5,8 @@ import math
 # import ct
 import random
 import fla_npu
+
+fla_npu.load_legacy_torch_ops()
 import os
 
 torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))

--- a/torch_custom/fla_npu/test/test_npu_prepare_wy_repr_bwd_full.py
+++ b/torch_custom/fla_npu/test/test_npu_prepare_wy_repr_bwd_full.py
@@ -1,5 +1,14 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 import torch
-import torch_npu
 import os
 from typing import Optional
 import pickle
@@ -7,10 +16,9 @@ import math
 # import ct
 import random
 torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
-import fla_npu
+from fla_npu.ops import ascendc as ascendc_ops
 # import custom_ops
 
-fla_npu.load_legacy_torch_ops()
 
 torch.npu.config.allow_internal_format = False
 torch.npu.set_compile_mode(jit_compile=False)
@@ -673,7 +681,7 @@ def test_prepare_wy_repr_bwd_full(
 
     if chunk_indices != None:
         print(f"cu_seqlens: {cu_seqlens}")
-        dk, dv, dbeta, dg = torch.ops.npu.npu_prepare_wy_repr_bwd_full(
+        dk, dv, dbeta, dg = ascendc_ops.npu_prepare_wy_repr_bwd_full(
             k.npu(),
             v.npu(),
             beta.npu(),
@@ -687,7 +695,7 @@ def test_prepare_wy_repr_bwd_full(
             chunk_indices=chunk_indices
         )
     else:
-        dk, dv, dbeta, dg = torch.ops.npu.npu_prepare_wy_repr_bwd_full(
+        dk, dv, dbeta, dg = ascendc_ops.npu_prepare_wy_repr_bwd_full(
             k.npu(),
             v.npu(),
             beta.npu(),

--- a/torch_custom/fla_npu/test/test_npu_prepare_wy_repr_bwd_full.py
+++ b/torch_custom/fla_npu/test/test_npu_prepare_wy_repr_bwd_full.py
@@ -10,6 +10,8 @@ torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
 import fla_npu
 # import custom_ops
 
+fla_npu.load_legacy_torch_ops()
+
 torch.npu.config.allow_internal_format = False
 torch.npu.set_compile_mode(jit_compile=False)
 

--- a/torch_custom/fla_npu/test/test_npu_recompute_w_u_fwd.py
+++ b/torch_custom/fla_npu/test/test_npu_recompute_w_u_fwd.py
@@ -1,14 +1,22 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 import torch
-import torch_npu
 import os
 from typing import Optional
 import pickle
 import math
 import ct
 import random
-import fla_npu
+from fla_npu.ops import ascendc as ascendc_ops
 
-fla_npu.load_legacy_torch_ops()
 torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
 
 def get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices):
@@ -279,7 +287,7 @@ def test_recompute_wu_fwd(
 
     # 将张量移到 NPU 并调用反向算子
     if chunk_indices != None:
-        w, u = torch.ops.npu.npu_recompute_w_u_fwd(
+        w, u = ascendc_ops.npu_recompute_w_u_fwd(
             k.npu(),
             v.npu(),
             beta.npu(),
@@ -291,7 +299,7 @@ def test_recompute_wu_fwd(
             chunk_indices=chunk_indices
         )
     else:
-        w, u = torch.ops.npu.npu_recompute_w_u_fwd(
+        w, u = ascendc_ops.npu_recompute_w_u_fwd(
             k.npu(),
             v.npu(),
             beta.npu(),

--- a/torch_custom/fla_npu/test/test_npu_recompute_w_u_fwd.py
+++ b/torch_custom/fla_npu/test/test_npu_recompute_w_u_fwd.py
@@ -7,6 +7,8 @@ import math
 import ct
 import random
 import fla_npu
+
+fla_npu.load_legacy_torch_ops()
 torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
 
 def get_bos_eos(idx, T, chunk_size, cu_seqlens, chunk_indices):

--- a/torch_custom/fla_npu/test/test_npu_solve_tri_ascend950.py
+++ b/torch_custom/fla_npu/test/test_npu_solve_tri_ascend950.py
@@ -1,5 +1,15 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 """
-test_npu_solve_tri_ascend950.py - Test SolveTri custom operator on ascend950 via torch.ops.npu
+test_npu_solve_tri_ascend950.py - Test SolveTri custom operator on ascend950 via fla_npu.ops.ascendc
 
 支持 BSND [B,T,H,BT] 与 TND [total_T,H,BT]（变长）两种布局。
 
@@ -10,13 +20,11 @@ test_npu_solve_tri_ascend950.py - Test SolveTri custom operator on ascend950 via
 """
 import os
 import torch
-import torch_npu
 import numpy as np
-import fla_npu
+from fla_npu.ops import ascendc as ascendc_ops
 
-fla_npu.load_legacy_torch_ops()
 
-torch.npu.utils.set_device(0)
+torch.npu.set_device(0)
 
 # 是否打印每个 (b,h,c)/(seq,h,c) 点位的 OK/FAIL 明细及用例头。
 # 默认 False：每条用例只打印一行 PASS/FAIL 汇总。
@@ -100,7 +108,7 @@ def test_solve_tri(B, H, T, chunk_size, layout="bsnd", dtype=torch.float16):
 
     A_npu = A.npu()
     # 仓2 接口：chunk_size 由 x 末维隐式确定，定长无需 cu_seqlens / chunk_indices
-    out_npu = torch.ops.npu.npu_solve_tri(A_npu, cu_seqlens=None, chunk_indices=None, layout=layout)
+    out_npu = ascendc_ops.npu_solve_tri(A_npu, cu_seqlens=None, chunk_indices=None, layout=layout)
     out_cpu = out_npu.cpu()
 
     num_chunks = (T + chunk_size - 1) // chunk_size
@@ -208,7 +216,7 @@ def test_solve_tri_varlen(seq_lens, H, chunk_size, dtype=torch.float16):
     cu_seqlens_list = cu_seqlens.tolist()
     chunk_indices_flat = chunk_indices.flatten().tolist()
 
-    out_npu = torch.ops.npu.npu_solve_tri(A_npu,
+    out_npu = ascendc_ops.npu_solve_tri(A_npu,
                                           cu_seqlens=cu_seqlens_list,
                                           chunk_indices=chunk_indices_flat,
                                           layout="tnd")
@@ -314,7 +322,7 @@ def run_all_cases(dtype):
 
 if __name__ == "__main__":
     print("=" * 60)
-    print("SolveTri NPU Test (ascend950, torch.ops.npu) — fp16 + bf16")
+    print("SolveTri NPU Test (ascend950, fla_npu.ops.ascendc) — fp16 + bf16")
     print("=" * 60)
 
     results = []

--- a/torch_custom/fla_npu/test/test_npu_solve_tri_ascend950.py
+++ b/torch_custom/fla_npu/test/test_npu_solve_tri_ascend950.py
@@ -14,6 +14,8 @@ import torch_npu
 import numpy as np
 import fla_npu
 
+fla_npu.load_legacy_torch_ops()
+
 torch.npu.utils.set_device(0)
 
 # 是否打印每个 (b,h,c)/(seq,h,c) 点位的 OK/FAIL 明细及用例头。

--- a/torch_custom/fla_npu/test/test_npu_solve_tri_tnd.py
+++ b/torch_custom/fla_npu/test/test_npu_solve_tri_tnd.py
@@ -1,4 +1,14 @@
 # -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 """
 test_npu_solve_tri_tnd_generalized.py - NPU SolveTri TND format generalized test.
 
@@ -12,13 +22,11 @@ Precision compare uses CPU dual-benchmark:
 import random
 import numpy as np
 import torch
-import torch_npu
-import fla_npu
-
-fla_npu.load_legacy_torch_ops()
+from fla_npu.ops import ascendc as ascendc_ops
 
 
-torch.npu.utils.set_device(0)
+
+torch.npu.set_device(0)
 
 
 # ============================================================================
@@ -498,7 +506,7 @@ def run_single_case(seq_lens: list, H: int, chunk_size: int, dtype: torch.dtype 
     cu_seqlens_list = cu_seqlens.tolist()
     chunk_indices_flat = chunk_indices.flatten().tolist()
 
-    out_npu = torch.ops.npu.npu_solve_tri(
+    out_npu = ascendc_ops.npu_solve_tri(
         x_npu,
         cu_seqlens=cu_seqlens_list,
         chunk_indices=chunk_indices_flat,

--- a/torch_custom/fla_npu/test/test_npu_solve_tri_tnd.py
+++ b/torch_custom/fla_npu/test/test_npu_solve_tri_tnd.py
@@ -15,6 +15,8 @@ import torch
 import torch_npu
 import fla_npu
 
+fla_npu.load_legacy_torch_ops()
+
 
 torch.npu.utils.set_device(0)
 

--- a/torch_custom/fla_npu/test/test_npu_solve_tri_triton_bsnd.py
+++ b/torch_custom/fla_npu/test/test_npu_solve_tri_triton_bsnd.py
@@ -1,4 +1,14 @@
 # -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 """
 test_npu_solve_tri_triton_case.py - NPU SolveTri test with Triton-identical parameters.
 
@@ -12,13 +22,11 @@ Precision compare uses CPU dual-benchmark:
 """
 import numpy as np
 import torch
-import torch_npu
-import fla_npu
-
-fla_npu.load_legacy_torch_ops()
+from fla_npu.ops import ascendc as ascendc_ops
 
 
-torch.npu.utils.set_device(0)
+
+torch.npu.set_device(0)
 
 
 # ============================================================================
@@ -445,7 +453,7 @@ def run_single_case(B: int, T: int, H: int, chunk_size: int, dtype: torch.dtype 
 
     # Run NPU operator
     x_npu = x.npu()
-    out_npu = torch.ops.npu.npu_solve_tri(x_npu, layout=LAYOUT)
+    out_npu = ascendc_ops.npu_solve_tri(x_npu, layout=LAYOUT)
     out_cpu = out_npu.cpu()
 
     # Compute metrics

--- a/torch_custom/fla_npu/test/test_npu_solve_tri_triton_bsnd.py
+++ b/torch_custom/fla_npu/test/test_npu_solve_tri_triton_bsnd.py
@@ -15,6 +15,8 @@ import torch
 import torch_npu
 import fla_npu
 
+fla_npu.load_legacy_torch_ops()
+
 
 torch.npu.utils.set_device(0)
 


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。

## 关联 Issue / 背景

- 关联 Issue: #171
- 背景与目标: 降低 `import fla_npu` 对 PyTorch / torch_npu dispatcher ABI 的强绑定，避免导入包时立即加载 legacy 自定义 op 扩展。
- 本 PR 解决的问题:
  - `import fla_npu` 改为轻量导入，不再自动 import `torch` / `torch_npu`，不再自动注册 `torch.ops.npu`。
  - 新增 `fla_npu.load_legacy_torch_ops()`，用于显式启用旧 `torch.ops.npu.*` 兼容路径。
  - 对 `torch.ops.npu.*` legacy 调用增加 `FutureWarning`，明确提示该路径未来版本不再支持。
  - `fla_npu.ops.ascendc` 保留稳定 Python 入口，并在首次调用时懒加载 legacy fallback。
  - 更新 README、packaged wheel API 检查脚本和 legacy 测试入口。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: 不涉及新增或修改算子实现；覆盖现有 `torch_custom/fla_npu/npu_custom.yaml` 中的 legacy torch ops 入口。
- 涉及目录 / 文件:
  - `torch_custom/fla_npu/fla_npu/__init__.py`
  - `torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py`
  - `torch_custom/fla_npu/test`
  - `scripts/check_packaged_wheel_api.py`
  - `README.md`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不变。
- 明确不包含的范围: 不修改算子 schema、aclnn 接口、kernel、tiling、shape/dtype/format 支持范围。
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [x] 是，请说明影响面、兼容策略和回归范围: `import fla_npu` 行为由自动加载 legacy torch ops 改为轻量导入；旧调用通过显式 `fla_npu.load_legacy_torch_ops()` 保留兼容，并在 `torch.ops.npu.*` 调用时给出未来废弃告警。
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 不修改算子 ABI；仅调整 Python 包导入和 legacy 加载策略。

## 兼容性、风险与回退

- 兼容性说明:
  - 新推荐路径为 `fla_npu.ops.ascendc.*`。
  - 旧路径仍可通过 `fla_npu.load_legacy_torch_ops()` 后继续使用 `torch.ops.npu.*`。
  - 旧路径调用会产生 `FutureWarning`，提示未来版本不再支持。
- 风险点:
  - 依赖 `import fla_npu` 自动注册 `torch.ops.npu` 的旧脚本需要补充显式 `fla_npu.load_legacy_torch_ops()`。
- 回退方案:
  - 回退本 PR 后恢复 `import fla_npu` 自动加载 legacy torch ops 的旧行为。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

本地已验证：
- `python -m py_compile` 覆盖本 PR 修改的 Python 文件，通过。
- `import fla_npu` 与 `import fla_npu.ops.ascendc` 在未加载 legacy ops 时不会导入 `torch` / `torch_npu`，通过。
- mock 验证直接调用 `torch.ops.npu.npu_chunk_fwd_o()` 会产生 `FutureWarning`，通过。
- mock 验证通过 `fla_npu.ops.ascendc.npu_chunk_fwd_o()` 调用不会误触发 legacy warning，通过。
- `git diff --check` 通过。

未执行真实 NPU 扩展加载、编译和算子精度测试，原因是本次改动仅调整 Python 包导入与 legacy 兼容入口；真实 NPU 回归建议通过仓库 NPU CI 或具备 Ascend 环境的验证流程补齐。
