### PR TITLE
perf: improve causal_conv1d_bwd op

### DIFF
--- a/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_host/causal_conv1d_bwd_tiling.cpp
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_host/causal_conv1d_bwd_tiling.cpp
@@ -41,8 +41,12 @@ namespace {
     constexpr uint32_t ATTR_ACTIVATION_INDEX = 0;
     constexpr uint32_t ATTR_INPUT_LAYOUT_INDEX = 1;
     constexpr uint32_t RESERVED_UB = 16 * 1024;
+    constexpr uint32_t B16_DTYPE_SIZE = 2U;
     constexpr uint32_t FP32_DTYPE_SIZE = 4U;
     constexpr uint32_t BLOCK_ALIGN_NUM = 8U;
+    constexpr uint32_t DIRECT_FAST_BT_MAX = 224U;
+    constexpr uint32_t DIRECT_FAST_BT_MIN = 64U;
+    constexpr uint32_t DIRECT_FAST_BT_STEP = 32U;
     constexpr uint32_t ACTIVATION_NONE = 0;
     constexpr uint32_t ACTIVATION_SILU = 1;
     constexpr uint32_t ACTIVATION_SWISH = 2;
@@ -67,6 +71,10 @@ static ge::graphStatus CausalConv1dBwdTilingFunc(gert::TilingContext *context)
     auto xShape = context->GetInputShape(X_INPUT_INDEX)->GetStorageShape();
     auto dyShape = context->GetInputShape(DY_INPUT_INDEX)->GetStorageShape();
     auto wShape = context->GetInputShape(WEIGHT_INPUT_INDEX)->GetStorageShape();
+    auto xDesc = context->GetInputDesc(X_INPUT_INDEX);
+    OP_CHECK_NULL_WITH_CONTEXT(context, xDesc);
+    auto xDtype = xDesc->GetDataType();
+    bool isB16Input = (xDtype == ge::DT_BF16 || xDtype == ge::DT_FLOAT16);
     uint32_t B = 0;
     uint32_t T = 0;
     uint32_t D = 0;
@@ -260,10 +268,12 @@ static ge::graphStatus CausalConv1dBwdTilingFunc(gert::TilingContext *context)
     uint64_t ubSize = 0;
     uint64_t sysWorkspaceSize = 0;
     uint32_t coreNum = 0;
+    bool isAscend950 = false;
     {
         fe::PlatFormInfos *platformInfoPtr = context->GetPlatformInfo();
         OP_CHECK_NULL_WITH_CONTEXT(context, platformInfoPtr);
         auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
+        isAscend950 = (ascendcPlatform.GetCurNpuArch() == NpuArch::DAV_3510);
         coreNum = ascendcPlatform.GetCoreNumAiv();
         OP_CHECK_IF(coreNum == 0, OP_LOGE(context, "coreNum is 0"), return ge::GRAPH_FAILED);
         ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
@@ -280,8 +290,28 @@ static ge::graphStatus CausalConv1dBwdTilingFunc(gert::TilingContext *context)
     uint32_t BD = (D % 64 == 0) ? 64 : 16;
     uint32_t numBlksD = D / BD;
 
+    bool useArch35DirectFast = isAscend950 && isB16Input &&
+                               activation == ACTIVATION_SILU &&
+                               !useInitialState && !useFinalState &&
+                               W == 4 && BD == 64;
+    auto CalcArch35DirectNeed = [BD, W](uint32_t bt) -> uint32_t {
+        uint32_t btBdAl = CeilAlign(bt * BD, BLOCK_ALIGN_NUM);
+        uint32_t dyBdAl = CeilAlign((bt + W - 1) * BD, BLOCK_ALIGN_NUM);
+        uint32_t wBdAl = CeilAlign(W * BD, BLOCK_ALIGN_NUM);
+        uint32_t bdAl = CeilAlign(BD, BLOCK_ALIGN_NUM);
+        uint32_t need = 0;
+        need += (3 * btBdAl + 4 * dyBdAl + wBdAl) * B16_DTYPE_SIZE;
+        need += (btBdAl + dyBdAl + wBdAl + bdAl) * FP32_DTYPE_SIZE;
+        return need;
+    };
+
     uint32_t BT = 64;
-    if (T < BT) {
+    if (useArch35DirectFast) {
+        BT = std::min(T, DIRECT_FAST_BT_MAX);
+        while (BT > DIRECT_FAST_BT_MIN && CalcArch35DirectNeed(BT) > ubSize) {
+            BT = (BT > DIRECT_FAST_BT_MIN + DIRECT_FAST_BT_STEP) ? (BT - DIRECT_FAST_BT_STEP) : DIRECT_FAST_BT_MIN;
+        }
+    } else if (T < BT) {
         BT = T;
     }
     OP_CHECK_IF(BT == 0 || totalTokens == 0,
@@ -305,18 +335,22 @@ static ge::graphStatus CausalConv1dBwdTilingFunc(gert::TilingContext *context)
     uint32_t wBtBdAl = CeilAlign(W * BT * BD, BLOCK_ALIGN_NUM);
     uint32_t bdAl = CeilAlign(BD, BLOCK_ALIGN_NUM);
     uint32_t need = 0;
-    need += (3 * btBdAl + 2 * calcBdAl) * FP32_DTYPE_SIZE;
-    need += (dyBdAl - btBdAl) * FP32_DTYPE_SIZE;
-    const bool hasWeight = true;
-    const bool hasBias = true;
-    if (hasWeight) need += 2 * wBdAl * FP32_DTYPE_SIZE;
-    if (hasWeight && activation == ACTIVATION_NONE) need += wBtBdAl * FP32_DTYPE_SIZE;
-    if (hasBias)   need += bdAl * FP32_DTYPE_SIZE;
-    if (hasBias && activation == ACTIVATION_NONE) need += btBdAl * FP32_DTYPE_SIZE;
-    if (activation == ACTIVATION_SILU || activation == ACTIVATION_SWISH)
-        need += 2 * dyBdAl * FP32_DTYPE_SIZE;
-    if (useInitialState || useFinalState) {
-        need += bdAl * FP32_DTYPE_SIZE;
+    if (useArch35DirectFast) {
+        need = CalcArch35DirectNeed(BT);
+    } else {
+        need += (3 * btBdAl + 2 * calcBdAl) * FP32_DTYPE_SIZE;
+        need += (dyBdAl - btBdAl) * FP32_DTYPE_SIZE;
+        const bool hasWeight = true;
+        const bool hasBias = true;
+        if (hasWeight) need += 2 * wBdAl * FP32_DTYPE_SIZE;
+        if (hasWeight && activation == ACTIVATION_NONE) need += wBtBdAl * FP32_DTYPE_SIZE;
+        if (hasBias)   need += bdAl * FP32_DTYPE_SIZE;
+        if (hasBias && activation == ACTIVATION_NONE) need += btBdAl * FP32_DTYPE_SIZE;
+        if (activation == ACTIVATION_SILU || activation == ACTIVATION_SWISH)
+            need += 2 * dyBdAl * FP32_DTYPE_SIZE;
+        if (useInitialState || useFinalState) {
+            need += bdAl * FP32_DTYPE_SIZE;
+        }
     }
 
     OP_CHECK_IF(need > ubSize,

--- a/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_kernel/arch35/causal_conv1d_bwd_regbase.h
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_kernel/arch35/causal_conv1d_bwd_regbase.h
@@ -1,0 +1,521 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ASCENDC_CAUSAL_CONV1D_BWD_REGBASE_H_
+#define ASCENDC_CAUSAL_CONV1D_BWD_REGBASE_H_
+
+#include "kernel_utils/vector/regbase.hpp"
+
+namespace NsCausalConv1dBwd {
+using namespace AscendC;
+using namespace AscendC::MicroAPI;
+
+constexpr uint32_t BWD_DIRECT_BD = 64;
+constexpr uint32_t BWD_DIRECT_W_MAX = 4;
+
+constexpr CastTrait B16_TO_F32_ZERO = {
+    RegLayout::ZERO,
+    SatMode::UNKNOWN,
+    MaskMergeMode::ZEROING,
+    RoundMode::UNKNOWN,
+};
+
+template <typename T>
+__simd_callee__ inline void LoadAsFloatPair(
+    RegTensor<float> &zero, RegTensor<float> &one, __ubuf__ T *src, MaskReg &maskB16)
+{
+    if constexpr (std::is_same<T, float>()) {
+        LoadAlign<float, LoadDist::DIST_DINTLV_B32>(zero, one, reinterpret_cast<__ubuf__ float *>(src));
+    } else if constexpr (std::is_same<T, half>()) {
+        RegTensor<half> raw;
+        LoadIn<T, false>(raw, src);
+        CastHalf2Float<half>(zero, one, raw, maskB16);
+    } else {
+        static_assert(!std::is_same<T, T>::value, "LoadAsFloatPair supports float/half only");
+    }
+}
+
+__simd_callee__ inline void LoadFloatPair(
+    RegTensor<float> &zero, RegTensor<float> &one, __ubuf__ float *src)
+{
+    LoadAlign<float, LoadDist::DIST_DINTLV_B32>(zero, one, src);
+}
+
+__simd_callee__ inline void StoreFloatPair(
+    __ubuf__ float *dst, RegTensor<float> &zero, RegTensor<float> &one, MaskReg &maskF32)
+{
+    StoreAlign<float, StoreDist::DIST_INTLV_B32>(dst, zero, one, maskF32);
+}
+
+__simd_callee__ inline void AddPair(
+    RegTensor<float> &dstZero, RegTensor<float> &dstOne,
+    RegTensor<float> &srcZero, RegTensor<float> &srcOne, MaskReg &maskF32)
+{
+    Add(dstZero, dstZero, srcZero, maskF32);
+    Add(dstOne, dstOne, srcOne, maskF32);
+}
+
+__simd_callee__ inline void MulPair(
+    RegTensor<float> &dstZero, RegTensor<float> &dstOne,
+    RegTensor<float> &lhsZero, RegTensor<float> &lhsOne,
+    RegTensor<float> &rhsZero, RegTensor<float> &rhsOne, MaskReg &maskF32)
+{
+    Mul(dstZero, lhsZero, rhsZero, maskF32);
+    Mul(dstOne, lhsOne, rhsOne, maskF32);
+}
+
+__simd_callee__ inline void ApplySiluBackwardOne(
+    RegTensor<float> &dy, RegTensor<float> &y, MaskReg &maskF32)
+{
+    RegTensor<float> sigmoid;
+    RegTensor<float> one;
+    Muls(sigmoid, y, -1.0f, maskF32);
+    Exp(sigmoid, sigmoid, maskF32);
+    Adds(sigmoid, sigmoid, 1.0f, maskF32);
+    Duplicate(one, 1.0f, maskF32);
+    Div(sigmoid, one, sigmoid, maskF32);
+
+    Sub(one, one, sigmoid, maskF32);
+    Mul(one, one, y, maskF32);
+    Adds(one, one, 1.0f, maskF32);
+    Mul(dy, dy, sigmoid, maskF32);
+    Mul(dy, dy, one, maskF32);
+}
+
+__simd_callee__ inline void ApplySiluBackwardPair(
+    RegTensor<float> &dyZero, RegTensor<float> &dyOne,
+    RegTensor<float> &yZero, RegTensor<float> &yOne, MaskReg &maskF32)
+{
+    ApplySiluBackwardOne(dyZero, yZero, maskF32);
+    ApplySiluBackwardOne(dyOne, yOne, maskF32);
+}
+
+__simd_callee__ inline void StoreDwSum(
+    __ubuf__ float *dwAddr, RegTensor<float> &sumZero, RegTensor<float> &sumOne,
+    uint32_t wIdx, MaskReg &maskF32)
+{
+    RegTensor<float> oldZero;
+    RegTensor<float> oldOne;
+    LoadFloatPair(oldZero, oldOne, dwAddr + wIdx * BWD_DIRECT_BD);
+    AddPair(oldZero, oldOne, sumZero, sumOne, maskF32);
+    StoreFloatPair(dwAddr + wIdx * BWD_DIRECT_BD, oldZero, oldOne, maskF32);
+}
+
+template <typename T>
+__simd_callee__ inline void LoadB16AsFloat(
+    RegTensor<float> &dst, __ubuf__ T *src, MaskReg &maskF32)
+{
+    if constexpr (std::is_same<T, half>() || std::is_same<T, bfloat16_t>()) {
+        RegTensor<T> raw;
+        DataCopy<T, LoadDist::DIST_UNPACK_B16>(raw, src);
+        Cast<float, T, B16_TO_F32_ZERO>(dst, raw, maskF32);
+    } else {
+        static_assert(!std::is_same<T, T>::value, "LoadB16AsFloat supports half/bfloat16_t only");
+    }
+}
+
+__simd_callee__ inline void LoadFloatOne(RegTensor<float> &dst, __ubuf__ float *src)
+{
+    DataCopy<float, LoadDist::DIST_NORM>(dst, src);
+}
+
+__simd_callee__ inline void StoreFloatOne(
+    __ubuf__ float *dst, RegTensor<float> &src, MaskReg &maskF32)
+{
+    DataCopy<float, StoreDist::DIST_NORM_B32>(dst, src, maskF32);
+}
+
+__simd_callee__ inline void StoreDwSumOne(
+    __ubuf__ float *dwAddr, RegTensor<float> &sum, uint32_t wIdx, MaskReg &maskF32)
+{
+    RegTensor<float> old;
+    LoadFloatOne(old, dwAddr + wIdx * BWD_DIRECT_BD);
+    Add(old, old, sum, maskF32);
+    StoreFloatOne(dwAddr + wIdx * BWD_DIRECT_BD, old, maskF32);
+}
+
+template <typename T>
+static __simd_vf__ inline void ComputeActivatedDyB16Vf(
+    __ubuf__ T *dyAddr, __ubuf__ T *yAddr, __ubuf__ float *dyActAddr, uint32_t rows)
+{
+    MaskReg maskF32 = CreateMask<float, MaskPattern::ALL>();
+
+    RegTensor<float> dy;
+    RegTensor<float> y;
+
+    for (uint32_t row = 0; row < rows; row++) {
+        LoadB16AsFloat<T>(dy, dyAddr + row * BWD_DIRECT_BD, maskF32);
+        LoadB16AsFloat<T>(y, yAddr + row * BWD_DIRECT_BD, maskF32);
+        ApplySiluBackwardOne(dy, y, maskF32);
+        StoreFloatOne(dyActAddr + row * BWD_DIRECT_BD, dy, maskF32);
+    }
+}
+
+template <typename T>
+static __simd_vf__ inline void ComputeDxActivatedB16Vf(
+    __ubuf__ float *dyActAddr, __ubuf__ T *weightAddr, __ubuf__ float *dxAddr,
+    uint32_t rows, uint32_t width)
+{
+    MaskReg maskF32 = CreateMask<float, MaskPattern::ALL>();
+
+    RegTensor<float> dy;
+    RegTensor<float> weight;
+    RegTensor<float> dx;
+    RegTensor<float> prod;
+
+    for (uint32_t row = 0; row < rows; row++) {
+        Duplicate(dx, 0.0f, maskF32);
+        for (uint32_t iW = 0; iW < width; iW++) {
+            uint32_t wIdx = width - iW - 1;
+            LoadFloatOne(dy, dyActAddr + (row + iW) * BWD_DIRECT_BD);
+            LoadB16AsFloat<T>(weight, weightAddr + wIdx * BWD_DIRECT_BD, maskF32);
+            Mul(prod, dy, weight, maskF32);
+            Add(dx, dx, prod, maskF32);
+        }
+        StoreFloatOne(dxAddr + row * BWD_DIRECT_BD, dx, maskF32);
+    }
+}
+
+template <typename T>
+static __simd_vf__ inline void ComputeDwOneActivatedB16Vf(
+    __ubuf__ T *xAddr, __ubuf__ float *dyActAddr, __ubuf__ float *dwAddr,
+    uint32_t rows, uint32_t width, uint32_t wIdx)
+{
+    MaskReg maskF32 = CreateMask<float, MaskPattern::ALL>();
+
+    RegTensor<float> sum;
+    RegTensor<float> x;
+    RegTensor<float> dy;
+    RegTensor<float> prod;
+
+    Duplicate(sum, 0.0f, maskF32);
+
+    uint32_t iW = width - wIdx - 1U;
+    for (uint32_t row = 0; row < rows; row++) {
+        LoadB16AsFloat<T>(x, xAddr + row * BWD_DIRECT_BD, maskF32);
+        LoadFloatOne(dy, dyActAddr + (row + iW) * BWD_DIRECT_BD);
+        Mul(prod, dy, x, maskF32);
+        Add(sum, sum, prod, maskF32);
+    }
+
+    StoreDwSumOne(dwAddr, sum, wIdx, maskF32);
+}
+
+static __simd_vf__ inline void ComputeDbActivatedB16Vf(
+    __ubuf__ float *dyActAddr, __ubuf__ float *dbAddr, uint32_t rows)
+{
+    MaskReg maskF32 = CreateMask<float, MaskPattern::ALL>();
+
+    RegTensor<float> sum;
+    RegTensor<float> dy;
+    RegTensor<float> old;
+
+    Duplicate(sum, 0.0f, maskF32);
+    for (uint32_t row = 0; row < rows; row++) {
+        LoadFloatOne(dy, dyActAddr + row * BWD_DIRECT_BD);
+        Add(sum, sum, dy, maskF32);
+    }
+
+    LoadFloatOne(old, dbAddr);
+    Add(old, old, sum, maskF32);
+    StoreFloatOne(dbAddr, old, maskF32);
+}
+
+template <typename T>
+static __simd_vf__ inline void ComputeDxDirectVf(
+    __ubuf__ T *dyAddr, __ubuf__ T *weightAddr, __ubuf__ float *dxAddr,
+    uint32_t rows, uint32_t width)
+{
+    MaskReg maskB16 = CreateMask<half, MaskPattern::ALL>();
+    MaskReg maskF32 = CreateMask<float, MaskPattern::ALL>();
+
+    RegTensor<float> dyZero;
+    RegTensor<float> dyOne;
+    RegTensor<float> weightZero;
+    RegTensor<float> weightOne;
+    RegTensor<float> dxZero;
+    RegTensor<float> dxOne;
+    RegTensor<float> prodZero;
+    RegTensor<float> prodOne;
+
+    for (uint32_t row = 0; row < rows; row++) {
+        Duplicate(dxZero, 0.0f, maskF32);
+        Duplicate(dxOne, 0.0f, maskF32);
+        for (uint32_t iW = 0; iW < width; iW++) {
+            uint32_t wIdx = width - iW - 1;
+            LoadAsFloatPair<T>(dyZero, dyOne, dyAddr + (row + iW) * BWD_DIRECT_BD, maskB16);
+            LoadAsFloatPair<T>(weightZero, weightOne, weightAddr + wIdx * BWD_DIRECT_BD, maskB16);
+            MulPair(prodZero, prodOne, dyZero, dyOne, weightZero, weightOne, maskF32);
+            AddPair(dxZero, dxOne, prodZero, prodOne, maskF32);
+        }
+        StoreFloatPair(dxAddr + row * BWD_DIRECT_BD, dxZero, dxOne, maskF32);
+    }
+}
+
+template <typename T>
+static __simd_vf__ inline void ComputeActivatedDyVf(
+    __ubuf__ T *dyAddr, __ubuf__ T *yAddr, __ubuf__ float *dyActAddr, uint32_t rows)
+{
+    MaskReg maskB16 = CreateMask<half, MaskPattern::ALL>();
+    MaskReg maskF32 = CreateMask<float, MaskPattern::ALL>();
+
+    RegTensor<float> dyZero;
+    RegTensor<float> dyOne;
+    RegTensor<float> yZero;
+    RegTensor<float> yOne;
+
+    for (uint32_t row = 0; row < rows; row++) {
+        LoadAsFloatPair<T>(dyZero, dyOne, dyAddr + row * BWD_DIRECT_BD, maskB16);
+        LoadAsFloatPair<T>(yZero, yOne, yAddr + row * BWD_DIRECT_BD, maskB16);
+        ApplySiluBackwardPair(dyZero, dyOne, yZero, yOne, maskF32);
+        StoreFloatPair(dyActAddr + row * BWD_DIRECT_BD, dyZero, dyOne, maskF32);
+    }
+}
+
+template <typename T>
+static __simd_vf__ inline void ComputeDxActivatedVf(
+    __ubuf__ float *dyActAddr, __ubuf__ T *weightAddr, __ubuf__ float *dxAddr,
+    uint32_t rows, uint32_t width)
+{
+    MaskReg maskB16 = CreateMask<half, MaskPattern::ALL>();
+    MaskReg maskF32 = CreateMask<float, MaskPattern::ALL>();
+
+    RegTensor<float> dyZero;
+    RegTensor<float> dyOne;
+    RegTensor<float> weightZero;
+    RegTensor<float> weightOne;
+    RegTensor<float> dxZero;
+    RegTensor<float> dxOne;
+    RegTensor<float> prodZero;
+    RegTensor<float> prodOne;
+
+    for (uint32_t row = 0; row < rows; row++) {
+        Duplicate(dxZero, 0.0f, maskF32);
+        Duplicate(dxOne, 0.0f, maskF32);
+        for (uint32_t iW = 0; iW < width; iW++) {
+            uint32_t wIdx = width - iW - 1;
+            LoadFloatPair(dyZero, dyOne, dyActAddr + (row + iW) * BWD_DIRECT_BD);
+            LoadAsFloatPair<T>(weightZero, weightOne, weightAddr + wIdx * BWD_DIRECT_BD, maskB16);
+            MulPair(prodZero, prodOne, dyZero, dyOne, weightZero, weightOne, maskF32);
+            AddPair(dxZero, dxOne, prodZero, prodOne, maskF32);
+        }
+        StoreFloatPair(dxAddr + row * BWD_DIRECT_BD, dxZero, dxOne, maskF32);
+    }
+}
+
+template <typename T>
+static __simd_vf__ inline void ComputeDwOneDirectVf(
+    __ubuf__ T *xAddr, __ubuf__ T *dyAddr, __ubuf__ float *dwAddr,
+    uint32_t rows, uint32_t width, uint32_t wIdx)
+{
+    MaskReg maskB16 = CreateMask<half, MaskPattern::ALL>();
+    MaskReg maskF32 = CreateMask<float, MaskPattern::ALL>();
+
+    RegTensor<float> sumZero;
+    RegTensor<float> sumOne;
+    RegTensor<float> xZero;
+    RegTensor<float> xOne;
+    RegTensor<float> dyZero;
+    RegTensor<float> dyOne;
+    RegTensor<float> prodZero;
+    RegTensor<float> prodOne;
+
+    Duplicate(sumZero, 0.0f, maskF32);
+    Duplicate(sumOne, 0.0f, maskF32);
+
+    uint32_t iW = width - wIdx - 1U;
+    for (uint32_t row = 0; row < rows; row++) {
+        LoadAsFloatPair<T>(xZero, xOne, xAddr + row * BWD_DIRECT_BD, maskB16);
+        LoadAsFloatPair<T>(dyZero, dyOne, dyAddr + (row + iW) * BWD_DIRECT_BD, maskB16);
+        MulPair(prodZero, prodOne, dyZero, dyOne, xZero, xOne, maskF32);
+        AddPair(sumZero, sumOne, prodZero, prodOne, maskF32);
+    }
+
+    StoreDwSum(dwAddr, sumZero, sumOne, wIdx, maskF32);
+}
+
+template <typename T>
+static __simd_vf__ inline void ComputeDwOneActivatedVf(
+    __ubuf__ T *xAddr, __ubuf__ float *dyActAddr, __ubuf__ float *dwAddr,
+    uint32_t rows, uint32_t width, uint32_t wIdx)
+{
+    MaskReg maskB16 = CreateMask<half, MaskPattern::ALL>();
+    MaskReg maskF32 = CreateMask<float, MaskPattern::ALL>();
+
+    RegTensor<float> sumZero;
+    RegTensor<float> sumOne;
+    RegTensor<float> xZero;
+    RegTensor<float> xOne;
+    RegTensor<float> dyZero;
+    RegTensor<float> dyOne;
+    RegTensor<float> prodZero;
+    RegTensor<float> prodOne;
+
+    Duplicate(sumZero, 0.0f, maskF32);
+    Duplicate(sumOne, 0.0f, maskF32);
+
+    uint32_t iW = width - wIdx - 1U;
+    for (uint32_t row = 0; row < rows; row++) {
+        LoadAsFloatPair<T>(xZero, xOne, xAddr + row * BWD_DIRECT_BD, maskB16);
+        LoadFloatPair(dyZero, dyOne, dyActAddr + (row + iW) * BWD_DIRECT_BD);
+        MulPair(prodZero, prodOne, dyZero, dyOne, xZero, xOne, maskF32);
+        AddPair(sumZero, sumOne, prodZero, prodOne, maskF32);
+    }
+
+    StoreDwSum(dwAddr, sumZero, sumOne, wIdx, maskF32);
+}
+
+template <typename T>
+static __simd_vf__ inline void ComputeDbDirectVf(
+    __ubuf__ T *dyAddr, __ubuf__ float *dbAddr, uint32_t rows)
+{
+    MaskReg maskB16 = CreateMask<half, MaskPattern::ALL>();
+    MaskReg maskF32 = CreateMask<float, MaskPattern::ALL>();
+
+    RegTensor<float> sumZero;
+    RegTensor<float> sumOne;
+    RegTensor<float> dyZero;
+    RegTensor<float> dyOne;
+    RegTensor<float> oldZero;
+    RegTensor<float> oldOne;
+
+    Duplicate(sumZero, 0.0f, maskF32);
+    Duplicate(sumOne, 0.0f, maskF32);
+    for (uint32_t row = 0; row < rows; row++) {
+        LoadAsFloatPair<T>(dyZero, dyOne, dyAddr + row * BWD_DIRECT_BD, maskB16);
+        AddPair(sumZero, sumOne, dyZero, dyOne, maskF32);
+    }
+
+    LoadFloatPair(oldZero, oldOne, dbAddr);
+    AddPair(oldZero, oldOne, sumZero, sumOne, maskF32);
+    StoreFloatPair(dbAddr, oldZero, oldOne, maskF32);
+}
+
+static __simd_vf__ inline void ComputeDbActivatedVf(
+    __ubuf__ float *dyActAddr, __ubuf__ float *dbAddr, uint32_t rows)
+{
+    MaskReg maskF32 = CreateMask<float, MaskPattern::ALL>();
+
+    RegTensor<float> sumZero;
+    RegTensor<float> sumOne;
+    RegTensor<float> dyZero;
+    RegTensor<float> dyOne;
+    RegTensor<float> oldZero;
+    RegTensor<float> oldOne;
+
+    Duplicate(sumZero, 0.0f, maskF32);
+    Duplicate(sumOne, 0.0f, maskF32);
+    for (uint32_t row = 0; row < rows; row++) {
+        LoadFloatPair(dyZero, dyOne, dyActAddr + row * BWD_DIRECT_BD);
+        AddPair(sumZero, sumOne, dyZero, dyOne, maskF32);
+    }
+
+    LoadFloatPair(oldZero, oldOne, dbAddr);
+    AddPair(oldZero, oldOne, sumZero, sumOne, maskF32);
+    StoreFloatPair(dbAddr, oldZero, oldOne, maskF32);
+}
+
+template <typename T>
+__aicore__ inline void ComputeTileDirectRegbase(
+    LocalTensor<T> xRaw, LocalTensor<T> dyRaw, LocalTensor<T> yRaw, LocalTensor<T> weightRaw,
+    LocalTensor<float> stateLocal, LocalTensor<float> dxLocal, LocalTensor<float> dwLocal,
+    LocalTensor<float> dbLocal, LocalTensor<float> dh0Local,
+    uint32_t rows, uint32_t width, uint32_t dyRows, uint32_t activation,
+    uint32_t validRows, uint32_t useInitialState, uint32_t computeDh0, uint32_t hasBias)
+{
+    auto xAddr = reinterpret_cast<__ubuf__ T *>(xRaw.GetPhyAddr());
+    auto dyAddr = reinterpret_cast<__ubuf__ T *>(dyRaw.GetPhyAddr());
+    auto yAddr = reinterpret_cast<__ubuf__ T *>(yRaw.GetPhyAddr());
+    auto weightAddr = reinterpret_cast<__ubuf__ T *>(weightRaw.GetPhyAddr());
+    auto dyActAddr = reinterpret_cast<__ubuf__ float *>(stateLocal.GetPhyAddr());
+    auto dxAddr = reinterpret_cast<__ubuf__ float *>(dxLocal.GetPhyAddr());
+    auto dwAddr = reinterpret_cast<__ubuf__ float *>(dwLocal.GetPhyAddr());
+    auto dbAddr = reinterpret_cast<__ubuf__ float *>(dbLocal.GetPhyAddr());
+    (void)dh0Local;
+    (void)validRows;
+    (void)useInitialState;
+    (void)computeDh0;
+    if constexpr (std::is_same<T, half>() || std::is_same<T, bfloat16_t>()) {
+        if (activation == 1U) {
+            AscendC::VF_CALL<ComputeActivatedDyB16Vf<T>>(dyAddr, yAddr, dyActAddr, dyRows);
+            AscendC::VF_CALL<ComputeDxActivatedB16Vf<T>>(dyActAddr, weightAddr, dxAddr, rows, width);
+            if (width > 0U) {
+                AscendC::VF_CALL<ComputeDwOneActivatedB16Vf<T>>(
+                    xAddr, dyActAddr, dwAddr, rows, width, 0U);
+            }
+            if (width > 1U) {
+                AscendC::VF_CALL<ComputeDwOneActivatedB16Vf<T>>(
+                    xAddr, dyActAddr, dwAddr, rows, width, 1U);
+            }
+            if (width > 2U) {
+                AscendC::VF_CALL<ComputeDwOneActivatedB16Vf<T>>(
+                    xAddr, dyActAddr, dwAddr, rows, width, 2U);
+            }
+            if (width > 3U) {
+                AscendC::VF_CALL<ComputeDwOneActivatedB16Vf<T>>(
+                    xAddr, dyActAddr, dwAddr, rows, width, 3U);
+            }
+            if (hasBias != 0U) {
+                AscendC::VF_CALL<ComputeDbActivatedB16Vf>(dyActAddr, dbAddr, rows);
+            }
+            return;
+        }
+        return;
+    } else {
+        if (activation == 1U) {
+            AscendC::VF_CALL<ComputeActivatedDyVf<T>>(dyAddr, yAddr, dyActAddr, dyRows);
+            AscendC::VF_CALL<ComputeDxActivatedVf<T>>(dyActAddr, weightAddr, dxAddr, rows, width);
+            if (width > 0U) {
+                AscendC::VF_CALL<ComputeDwOneActivatedVf<T>>(
+                    xAddr, dyActAddr, dwAddr, rows, width, 0U);
+            }
+            if (width > 1U) {
+                AscendC::VF_CALL<ComputeDwOneActivatedVf<T>>(
+                    xAddr, dyActAddr, dwAddr, rows, width, 1U);
+            }
+            if (width > 2U) {
+                AscendC::VF_CALL<ComputeDwOneActivatedVf<T>>(
+                    xAddr, dyActAddr, dwAddr, rows, width, 2U);
+            }
+            if (width > 3U) {
+                AscendC::VF_CALL<ComputeDwOneActivatedVf<T>>(
+                    xAddr, dyActAddr, dwAddr, rows, width, 3U);
+            }
+            if (hasBias != 0U) {
+                AscendC::VF_CALL<ComputeDbActivatedVf>(dyActAddr, dbAddr, rows);
+            }
+            return;
+        }
+
+        AscendC::VF_CALL<ComputeDxDirectVf<T>>(dyAddr, weightAddr, dxAddr, rows, width);
+        if (width > 0U) {
+            AscendC::VF_CALL<ComputeDwOneDirectVf<T>>(
+                xAddr, dyAddr, dwAddr, rows, width, 0U);
+        }
+        if (width > 1U) {
+            AscendC::VF_CALL<ComputeDwOneDirectVf<T>>(
+                xAddr, dyAddr, dwAddr, rows, width, 1U);
+        }
+        if (width > 2U) {
+            AscendC::VF_CALL<ComputeDwOneDirectVf<T>>(
+                xAddr, dyAddr, dwAddr, rows, width, 2U);
+        }
+        if (width > 3U) {
+            AscendC::VF_CALL<ComputeDwOneDirectVf<T>>(
+                xAddr, dyAddr, dwAddr, rows, width, 3U);
+        }
+        if (hasBias != 0U) {
+            AscendC::VF_CALL<ComputeDbDirectVf<T>>(dyAddr, dbAddr, rows);
+        }
+    }
+}
+
+} // namespace NsCausalConv1dBwd
+
+#endif // ASCENDC_CAUSAL_CONV1D_BWD_REGBASE_H_

--- a/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_kernel/causal_conv1d_bwd.h
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_kernel/causal_conv1d_bwd.h
@@ -308,48 +308,46 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInInputTile(
     if (useGradLayout &&
         (inputLayout_ == INPUT_LAYOUT_BNSD || inputLayout_ == INPUT_LAYOUT_NTD)) {
         if constexpr (IsSameType<inputT, float>::value) {
-            for (uint32_t row = 0; row < validRows; row++) {
-                uint32_t channel = i_d * BD_;
-                uint32_t remain = BD_;
-                uint32_t localOffset = row * BD_;
-                while (remain > 0) {
-                    uint32_t segLen = GetInputSegmentLen(channel, remain);
-                    DataCopyExtParams copyParams{
-                        1,
-                        static_cast<uint32_t>(segLen * sizeof(inputT)),
-                        0,
-                        0,
-                        0};
-                    uint64_t base = GetInputOffset(bos, startRow + row, channel);
-                    DataCopyPad(dst[localOffset], srcGm[base], copyParams, padParams);
-                    channel += segLen;
-                    localOffset += segLen;
-                    remain -= segLen;
-                }
+            uint32_t channel = i_d * BD_;
+            uint32_t remain = BD_;
+            uint32_t localOffset = 0;
+            while (remain > 0) {
+                uint32_t segLen = GetInputSegmentLen(channel, remain);
+                uint32_t dstGapBytes = (BD_ - segLen) * sizeof(float);
+                DataCopyExtParams copyParams{
+                    static_cast<uint16_t>(validRows),
+                    static_cast<uint32_t>(segLen * sizeof(inputT)),
+                    static_cast<uint32_t>((inputHeadDim_ - segLen) * sizeof(inputT)),
+                    static_cast<uint32_t>(dstGapBytes / 32U),
+                    0};
+                uint64_t base = GetInputOffset(bos, startRow, channel);
+                DataCopyPad(dst[localOffset], srcGm[base], copyParams, padParams);
+                channel += segLen;
+                localOffset += segLen;
+                remain -= segLen;
             }
             event_t ev = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE2_V));
             SetFlag<HardEvent::MTE2_V>(ev);
             WaitFlag<HardEvent::MTE2_V>(ev);
         } else {
             LocalTensor<inputT> srcTemp = tempBuf_.Get<inputT>();
-            for (uint32_t row = 0; row < validRows; row++) {
-                uint32_t channel = i_d * BD_;
-                uint32_t remain = BD_;
-                uint32_t localOffset = row * BD_;
-                while (remain > 0) {
-                    uint32_t segLen = GetInputSegmentLen(channel, remain);
-                    DataCopyExtParams copyParams{
-                        1,
-                        static_cast<uint32_t>(segLen * sizeof(inputT)),
-                        0,
-                        0,
-                        0};
-                    uint64_t base = GetInputOffset(bos, startRow + row, channel);
-                    DataCopyPad(srcTemp[localOffset], srcGm[base], copyParams, padParams);
-                    channel += segLen;
-                    localOffset += segLen;
-                    remain -= segLen;
-                }
+            uint32_t channel = i_d * BD_;
+            uint32_t remain = BD_;
+            uint32_t localOffset = 0;
+            while (remain > 0) {
+                uint32_t segLen = GetInputSegmentLen(channel, remain);
+                uint32_t dstGapBytes = (BD_ - segLen) * sizeof(inputT);
+                DataCopyExtParams copyParams{
+                    static_cast<uint16_t>(validRows),
+                    static_cast<uint32_t>(segLen * sizeof(inputT)),
+                    static_cast<uint32_t>((inputHeadDim_ - segLen) * sizeof(inputT)),
+                    static_cast<uint32_t>(dstGapBytes / 32U),
+                    0};
+                uint64_t base = GetInputOffset(bos, startRow, channel);
+                DataCopyPad(srcTemp[localOffset], srcGm[base], copyParams, padParams);
+                channel += segLen;
+                localOffset += segLen;
+                remain -= segLen;
             }
             event_t ev = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE2_V));
             SetFlag<HardEvent::MTE2_V>(ev);

--- a/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_kernel/causal_conv1d_bwd.h
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_kernel/causal_conv1d_bwd.h
@@ -41,6 +41,13 @@
 #include "causal_conv1d_bwd_tiling_data.h"
 #include "causal_conv1d_bwd_tiling_key.h"
 
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#include "arch35/causal_conv1d_bwd_regbase.h"
+#define CAUSAL_CONV1D_BWD_ARCH35_REGBASE 1
+#else
+#define CAUSAL_CONV1D_BWD_ARCH35_REGBASE 0
+#endif
+
 using namespace AscendC;
 
 constexpr uint32_t FP32_DTYPE_SIZE = 4;
@@ -76,11 +83,21 @@ private:
     __aicore__ inline void CopyInInputTile(GlobalTensor<inputT> &srcGm, LocalTensor<float> dst,
                                            uint64_t bos, uint32_t startRow, uint32_t i_d,
                                            uint32_t totalRows, uint32_t seqLen, bool useGradLayout);
+    __aicore__ inline void CopyInInputTileRaw(GlobalTensor<inputT> &srcGm, LocalTensor<inputT> dst,
+                                              uint64_t bos, uint32_t startRow, uint32_t i_d,
+                                              uint32_t totalRows, uint32_t seqLen, bool useGradLayout);
+    __aicore__ inline void CopyInInputTileRawAsync(GlobalTensor<inputT> &srcGm, LocalTensor<inputT> dst,
+                                                   uint64_t bos, uint32_t startRow, uint32_t i_d,
+                                                   uint32_t totalRows, uint32_t seqLen, bool useGradLayout);
     __aicore__ inline void CopyInX(uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen);
+    __aicore__ inline void CopyInXRaw(uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen);
     __aicore__ inline void CopyInWeight(uint32_t i_d);
+    __aicore__ inline void CopyInWeightRaw(uint32_t i_d);
     __aicore__ inline void CopyInDy(uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t i_w, uint32_t seqLen);
     __aicore__ inline void CopyInDyWindow(uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen);
+    __aicore__ inline void CopyInDyWindowRaw(uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen);
     __aicore__ inline void CopyInYWindow(uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen);
+    __aicore__ inline void CopyInYWindowRaw(uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen);
     __aicore__ inline void CopyInInitialStateBlock(uint32_t i_b, uint32_t i_d);
     __aicore__ inline void CopyInDhtBlock(uint32_t i_b, uint32_t i_d);
     __aicore__ inline void ApplySiluBackward(LocalTensor<float> dyLocal, LocalTensor<float> yLocal, uint32_t count);
@@ -94,6 +111,9 @@ private:
     __aicore__ inline void ComputeDbRowsAccum(uint32_t dyRowOffset);
     __aicore__ inline void FinalizeDbRowsAccum();
     __aicore__ inline void ComputeDh0(uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t i_b, uint32_t seqLen);
+    __aicore__ inline void CopyInDirectTileRawAsync(uint64_t bos, uint32_t i_t, uint32_t i_d,
+                                                    uint32_t seqLen, uint32_t slot, event_t mte2ToVEvent);
+    __aicore__ inline void ComputeTileDirectRegbase(uint32_t i_t, uint32_t seqLen, uint32_t slot);
     __aicore__ inline void CopyOutDx(uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen);
     __aicore__ inline void CopyOutDwDb(uint32_t i_d);
     __aicore__ inline void CopyOutPartialDwDb(uint32_t coreIdx, uint32_t i_d);
@@ -101,6 +121,7 @@ private:
     __aicore__ inline void ReduceRowsInplace(LocalTensor<float> tensor, uint32_t rows, uint32_t cols);
     __aicore__ inline bool ResolveChunk(uint32_t chunkIdx, uint32_t &i_b, uint32_t &i_t,
                                         uint64_t &bos, uint32_t &seqLen);
+    __aicore__ inline bool Arch35UseDirectRegbase() const;
 
     TPipe *pipe_;
     TBuf<TPosition::VECIN> xBuf_;
@@ -207,6 +228,25 @@ template <typename inputT, typename calT>
 __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::InitBuffer(TPipe *inputPipe)
 {
     pipe_ = inputPipe;
+    if (Arch35UseDirectRegbase()) {
+        pipe_->InitBuffer(xBuf_, 2 * btBdCount_ * sizeof(inputT));
+        pipe_->InitBuffer(dyBuf_, 2 * dyBdCount_ * sizeof(inputT));
+        pipe_->InitBuffer(dxBuf_, btBdCount_ * FP32_DTYPE_SIZE);
+        if constexpr (!IsSameType<inputT, float>::value) {
+            pipe_->InitBuffer(castBuf_, btBdCount_ * sizeof(inputT));
+        }
+        pipe_->InitBuffer(tempBuf_, dyBdCount_ * FP32_DTYPE_SIZE);
+        pipe_->InitBuffer(yBuf_, 2 * dyBdCount_ * sizeof(inputT));
+        if (hasWeight_) {
+            pipe_->InitBuffer(weightBuf_, wBdCount_ * sizeof(inputT));
+            pipe_->InitBuffer(dwBuf_, wBdCount_ * FP32_DTYPE_SIZE);
+        }
+        if (hasBias_) {
+            pipe_->InitBuffer(dbBuf_, BD_ * FP32_DTYPE_SIZE);
+        }
+        return;
+    }
+
     pipe_->InitBuffer(xBuf_, btBdCount_ * FP32_DTYPE_SIZE);
     pipe_->InitBuffer(dyBuf_, dyBdCount_ * FP32_DTYPE_SIZE);
     pipe_->InitBuffer(dxBuf_, btBdCount_ * FP32_DTYPE_SIZE);
@@ -408,10 +448,154 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInInputTile(
 }
 
 template <typename inputT, typename calT>
+__aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInInputTileRaw(
+    GlobalTensor<inputT> &srcGm, LocalTensor<inputT> dst, uint64_t bos, uint32_t startRow,
+    uint32_t i_d, uint32_t totalRows, uint32_t seqLen, bool useGradLayout)
+{
+    uint32_t validRows = (startRow + totalRows <= seqLen) ? totalRows :
+                         ((startRow < seqLen) ? (seqLen - startRow) : 0);
+    bool fullTile = (validRows == totalRows);
+    uint32_t totalCount = totalRows * BD_;
+    if (!fullTile) {
+        Duplicate(dst, static_cast<inputT>(0), totalCount);
+        PipeBarrier<PIPE_V>();
+    }
+    if (validRows == 0) {
+        return;
+    }
+
+    event_t vMte2Ev = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_MTE2));
+    SetFlag<HardEvent::V_MTE2>(vMte2Ev);
+    WaitFlag<HardEvent::V_MTE2>(vMte2Ev);
+
+    DataCopyPadExtParams<inputT> padParams{false, 0, 0, static_cast<inputT>(0)};
+    if (useGradLayout &&
+        (inputLayout_ == INPUT_LAYOUT_BNSD || inputLayout_ == INPUT_LAYOUT_NTD)) {
+        uint32_t channel = i_d * BD_;
+        uint32_t remain = BD_;
+        uint32_t localOffset = 0;
+        while (remain > 0) {
+            uint32_t segLen = GetInputSegmentLen(channel, remain);
+            uint32_t dstGapBytes = (BD_ - segLen) * sizeof(inputT);
+            DataCopyExtParams copyParams{
+                static_cast<uint16_t>(validRows),
+                static_cast<uint32_t>(segLen * sizeof(inputT)),
+                static_cast<uint32_t>((inputHeadDim_ - segLen) * sizeof(inputT)),
+                static_cast<uint32_t>(dstGapBytes / 32U),
+                0};
+            uint64_t base = GetInputOffset(bos, startRow, channel);
+            DataCopyPad(dst[localOffset], srcGm[base], copyParams, padParams);
+            channel += segLen;
+            localOffset += segLen;
+            remain -= segLen;
+        }
+        event_t ev = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE2_V));
+        SetFlag<HardEvent::MTE2_V>(ev);
+        WaitFlag<HardEvent::MTE2_V>(ev);
+        return;
+    }
+
+    uint32_t channel = i_d * BD_;
+    uint32_t remain = BD_;
+    uint32_t localOffset = 0;
+    while (remain > 0) {
+        uint32_t segLen = useGradLayout ? GetInputSegmentLen(channel, remain) : remain;
+        uint32_t rowStride = useGradLayout ? GetInputRowStride(channel) : D_;
+        DataCopyExtParams copyParams{
+            static_cast<uint16_t>(validRows),
+            static_cast<uint32_t>(segLen * sizeof(inputT)),
+            static_cast<uint32_t>((rowStride - segLen) * sizeof(inputT)),
+            static_cast<uint32_t>((BD_ - segLen) * sizeof(inputT)),
+            0};
+        uint64_t base = useGradLayout ? GetInputOffset(bos, startRow, channel)
+                                      : (bos + startRow) * D_ + channel;
+        DataCopyPad(dst[localOffset], srcGm[base], copyParams, padParams);
+        channel += segLen;
+        localOffset += segLen;
+        remain -= segLen;
+    }
+    event_t ev = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE2_V));
+    SetFlag<HardEvent::MTE2_V>(ev);
+    WaitFlag<HardEvent::MTE2_V>(ev);
+}
+
+template <typename inputT, typename calT>
+__aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInInputTileRawAsync(
+    GlobalTensor<inputT> &srcGm, LocalTensor<inputT> dst, uint64_t bos, uint32_t startRow,
+    uint32_t i_d, uint32_t totalRows, uint32_t seqLen, bool useGradLayout)
+{
+    uint32_t validRows = (startRow + totalRows <= seqLen) ? totalRows :
+                         ((startRow < seqLen) ? (seqLen - startRow) : 0);
+    bool fullTile = (validRows == totalRows);
+    uint32_t totalCount = totalRows * BD_;
+    if (!fullTile) {
+        Duplicate(dst, static_cast<inputT>(0), totalCount);
+        PipeBarrier<PIPE_V>();
+        event_t vMte2Ev = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_MTE2));
+        SetFlag<HardEvent::V_MTE2>(vMte2Ev);
+        WaitFlag<HardEvent::V_MTE2>(vMte2Ev);
+    }
+    if (validRows == 0) {
+        return;
+    }
+
+    DataCopyPadExtParams<inputT> padParams{false, 0, 0, static_cast<inputT>(0)};
+    if (useGradLayout &&
+        (inputLayout_ == INPUT_LAYOUT_BNSD || inputLayout_ == INPUT_LAYOUT_NTD)) {
+        uint32_t channel = i_d * BD_;
+        uint32_t remain = BD_;
+        uint32_t localOffset = 0;
+        while (remain > 0) {
+            uint32_t segLen = GetInputSegmentLen(channel, remain);
+            uint32_t dstGapBytes = (BD_ - segLen) * sizeof(inputT);
+            DataCopyExtParams copyParams{
+                static_cast<uint16_t>(validRows),
+                static_cast<uint32_t>(segLen * sizeof(inputT)),
+                static_cast<uint32_t>((inputHeadDim_ - segLen) * sizeof(inputT)),
+                static_cast<uint32_t>(dstGapBytes / 32U),
+                0};
+            uint64_t base = GetInputOffset(bos, startRow, channel);
+            DataCopyPad(dst[localOffset], srcGm[base], copyParams, padParams);
+            channel += segLen;
+            localOffset += segLen;
+            remain -= segLen;
+        }
+        return;
+    }
+
+    uint32_t channel = i_d * BD_;
+    uint32_t remain = BD_;
+    uint32_t localOffset = 0;
+    while (remain > 0) {
+        uint32_t segLen = useGradLayout ? GetInputSegmentLen(channel, remain) : remain;
+        uint32_t rowStride = useGradLayout ? GetInputRowStride(channel) : D_;
+        DataCopyExtParams copyParams{
+            static_cast<uint16_t>(validRows),
+            static_cast<uint32_t>(segLen * sizeof(inputT)),
+            static_cast<uint32_t>((rowStride - segLen) * sizeof(inputT)),
+            static_cast<uint32_t>((BD_ - segLen) * sizeof(inputT)),
+            0};
+        uint64_t base = useGradLayout ? GetInputOffset(bos, startRow, channel)
+                                      : (bos + startRow) * D_ + channel;
+        DataCopyPad(dst[localOffset], srcGm[base], copyParams, padParams);
+        channel += segLen;
+        localOffset += segLen;
+        remain -= segLen;
+    }
+}
+
+template <typename inputT, typename calT>
 __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInX(
     uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen)
 {
     CopyInInputTile(xGm_, xBuf_.Get<float>(), bos, i_t * BT_, i_d, BT_, seqLen, false);
+}
+
+template <typename inputT, typename calT>
+__aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInXRaw(
+    uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen)
+{
+    CopyInInputTileRaw(xGm_, xBuf_.Get<inputT>(), bos, i_t * BT_, i_d, BT_, seqLen, false);
 }
 
 template <typename inputT, typename calT>
@@ -443,6 +627,24 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInWeight(uint32_
 }
 
 template <typename inputT, typename calT>
+__aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInWeightRaw(uint32_t i_d)
+{
+    if (!hasWeight_) return;
+    LocalTensor<inputT> wLocal = weightBuf_.Get<inputT>();
+    DataCopyExtParams copyParams{static_cast<uint16_t>(W_), blockBytesSrc_,
+        static_cast<uint32_t>((D_ - BD_) * sizeof(inputT)), 0, 0};
+    DataCopyPadExtParams<inputT> padParams{false, 0, 0, static_cast<inputT>(0)};
+    uint64_t off = static_cast<uint64_t>(i_d) * BD_;
+    event_t vMte2Ev = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_MTE2));
+    SetFlag<HardEvent::V_MTE2>(vMte2Ev);
+    WaitFlag<HardEvent::V_MTE2>(vMte2Ev);
+    DataCopyPad(wLocal, weightGm_[off], copyParams, padParams);
+    event_t ev = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE2_V));
+    SetFlag<HardEvent::MTE2_V>(ev);
+    WaitFlag<HardEvent::MTE2_V>(ev);
+}
+
+template <typename inputT, typename calT>
 __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInDy(
     uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t i_w, uint32_t seqLen)
 {
@@ -457,10 +659,24 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInDyWindow(
 }
 
 template <typename inputT, typename calT>
+__aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInDyWindowRaw(
+    uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen)
+{
+    CopyInInputTileRaw(dyGm_, dyBuf_.Get<inputT>(), bos, i_t * BT_, i_d, dyRows_, seqLen, true);
+}
+
+template <typename inputT, typename calT>
 __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInYWindow(
     uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen)
 {
     CopyInInputTile(yGm_, yBuf_.Get<float>(), bos, i_t * BT_, i_d, dyRows_, seqLen, true);
+}
+
+template <typename inputT, typename calT>
+__aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInYWindowRaw(
+    uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen)
+{
+    CopyInInputTileRaw(yGm_, yBuf_.Get<inputT>(), bos, i_t * BT_, i_d, dyRows_, seqLen, true);
 }
 
 template <typename inputT, typename calT>
@@ -848,6 +1064,68 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::ComputeDh0(
 }
 
 template <typename inputT, typename calT>
+__aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInDirectTileRawAsync(
+    uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen, uint32_t slot, event_t mte2ToVEvent)
+{
+#if CAUSAL_CONV1D_BWD_ARCH35_REGBASE
+    LocalTensor<inputT> xSlot = xBuf_.Get<inputT>()[slot * btBdCount_];
+    LocalTensor<inputT> dySlot = dyBuf_.Get<inputT>()[slot * dyBdCount_];
+    LocalTensor<inputT> ySlot = yBuf_.Get<inputT>()[slot * dyBdCount_];
+
+    event_t vMte2Ev = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_MTE2));
+    SetFlag<HardEvent::V_MTE2>(vMte2Ev);
+    WaitFlag<HardEvent::V_MTE2>(vMte2Ev);
+
+    CopyInInputTileRawAsync(xGm_, xSlot, bos, i_t * BT_, i_d, BT_, seqLen, false);
+    CopyInInputTileRawAsync(dyGm_, dySlot, bos, i_t * BT_, i_d, dyRows_, seqLen, true);
+    if (activation_ == ACTIVATION_SILU || activation_ == ACTIVATION_SWISH) {
+        CopyInInputTileRawAsync(yGm_, ySlot, bos, i_t * BT_, i_d, dyRows_, seqLen, true);
+    }
+    SetFlag<HardEvent::MTE2_V>(mte2ToVEvent);
+#else
+    (void)bos;
+    (void)i_t;
+    (void)i_d;
+    (void)seqLen;
+    (void)slot;
+    (void)mte2ToVEvent;
+#endif
+}
+
+template <typename inputT, typename calT>
+__aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::ComputeTileDirectRegbase(
+    uint32_t i_t, uint32_t seqLen, uint32_t slot)
+{
+#if CAUSAL_CONV1D_BWD_ARCH35_REGBASE
+    if constexpr (!IsSameType<inputT, half>::value && !IsSameType<inputT, bfloat16_t>::value) {
+        (void)i_t;
+        (void)seqLen;
+        (void)slot;
+        return;
+    }
+    uint32_t startRow = i_t * BT_;
+    uint32_t validRows = (startRow + BT_ <= seqLen) ? BT_ :
+                         ((startRow < seqLen) ? (seqLen - startRow) : 0);
+    uint32_t useInit = (useInitialState_ && startRow == 0 && validRows > 0) ? 1U : 0U;
+    uint32_t computeDh0 = (hasDh0_ && useInit) ? 1U : 0U;
+    LocalTensor<inputT> xRaw = xBuf_.Get<inputT>()[slot * btBdCount_];
+    LocalTensor<inputT> dyRaw = dyBuf_.Get<inputT>()[slot * dyBdCount_];
+    LocalTensor<inputT> yRaw = (activation_ == ACTIVATION_SILU || activation_ == ACTIVATION_SWISH)
+        ? yBuf_.Get<inputT>()[slot * dyBdCount_] : dyRaw;
+    LocalTensor<float> dh0Local = computeDh0 ? dh0Buf_.Get<float>() : tempBuf_.Get<float>();
+    NsCausalConv1dBwd::ComputeTileDirectRegbase<inputT>(
+        xRaw, dyRaw, yRaw, weightBuf_.Get<inputT>(),
+        tempBuf_.Get<float>(), dxBuf_.Get<float>(), dwBuf_.Get<float>(), dbBuf_.Get<float>(), dh0Local,
+        BT_, W_, dyRows_, activation_, validRows, useInit, computeDh0, hasBias_);
+    PipeBarrier<PIPE_V>();
+#else
+    (void)i_t;
+    (void)seqLen;
+    (void)slot;
+#endif
+}
+
+template <typename inputT, typename calT>
 __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyOutDx(
     uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen)
 {
@@ -1069,31 +1347,65 @@ __aicore__ inline bool CausalConv1dBwdKernel<inputT, calT>::ResolveChunk(
 }
 
 template <typename inputT, typename calT>
+__aicore__ inline bool CausalConv1dBwdKernel<inputT, calT>::Arch35UseDirectRegbase() const
+{
+#if CAUSAL_CONV1D_BWD_ARCH35_REGBASE
+    if constexpr (!IsSameType<inputT, half>::value && !IsSameType<inputT, bfloat16_t>::value) {
+        return false;
+    } else {
+        bool supportActivation = (activation_ == ACTIVATION_SILU &&
+                                  !useInitialState_ && !useFinalState_);
+        return hasWeight_ &&
+               supportActivation &&
+               BD_ == NsCausalConv1dBwd::BWD_DIRECT_BD &&
+               W_ > 0 && W_ <= NsCausalConv1dBwd::BWD_DIRECT_W_MAX;
+    }
+#else
+    return false;
+#endif
+}
+
+template <typename inputT, typename calT>
 __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::Process()
 {
     uint32_t bIdx = GetBlockIdx();
     uint32_t blockNum = GetBlockNum();
+    bool useDirectRegbase = Arch35UseDirectRegbase();
 
     uint32_t loopC = (bIdx < tailChunk_) ? (chunkPerCore_ + 1) : chunkPerCore_;
 
+    event_t directMte2ToVEvent[2];
+    if (useDirectRegbase) {
+        directMte2ToVEvent[0] = static_cast<event_t>(GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>());
+        directMte2ToVEvent[1] = static_cast<event_t>(GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>());
+    }
     for (uint32_t i_d = 0; i_d < numBlksD_; i_d++) {
         if (hasWeight_) {
-            CopyInWeight(i_d);
-            if (activation_ == ACTIVATION_NONE) {
-                Duplicate(dwRowsBuf_.Get<float>(), float(0), W_ * btBdCount_);
-            } else {
+            if (useDirectRegbase) {
+                CopyInWeightRaw(i_d);
                 Duplicate(dwBuf_.Get<float>(), float(0), wBdCount_);
+            } else {
+                CopyInWeight(i_d);
+                if (activation_ == ACTIVATION_NONE) {
+                    Duplicate(dwRowsBuf_.Get<float>(), float(0), W_ * btBdCount_);
+                } else {
+                    Duplicate(dwBuf_.Get<float>(), float(0), wBdCount_);
+                }
             }
             PipeBarrier<PIPE_V>();
         }
         if (hasBias_) {
-            if (activation_ == ACTIVATION_NONE) {
+            if (useDirectRegbase) {
+                Duplicate(dbBuf_.Get<float>(), float(0), BD_);
+            } else if (activation_ == ACTIVATION_NONE) {
                 Duplicate(dbRowsBuf_.Get<float>(), float(0), btBdCount_);
             } else {
                 Duplicate(dbBuf_.Get<float>(), float(0), BD_);
             }
             PipeBarrier<PIPE_V>();
         }
+
+        bool directTilePrefetched = false;
 
         for (uint32_t loop = 0; loop < loopC; loop++) {
             uint32_t chunkIdx = (bIdx < tailChunk_)
@@ -1112,37 +1424,67 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::Process()
                 continue;
             }
 
-            CopyInX(bos, i_t, i_d, seqLen);
-
-            Duplicate(dxBuf_.Get<float>(), float(0), btBdCount_);
-            PipeBarrier<PIPE_V>();
-
-            if (activation_ == ACTIVATION_SILU || activation_ == ACTIVATION_SWISH) {
-                CopyInDyWindow(bos, i_t, i_d, seqLen);
-                CopyInYWindow(bos, i_t, i_d, seqLen);
-                ApplySiluBackward(dyBuf_.Get<float>(), yBuf_.Get<float>(), dyBdCount_);
-                for (uint32_t i_w = 0; i_w < W_; i_w++) {
-                    ComputeWdyAndAcc(i_w, i_w);
-                    ComputeDwPartial(i_w, i_w);
-                    if (hasBias_ && i_w == 0) ComputeDbPartial(0);
+            if (useDirectRegbase) {
+                uint32_t slot = loop & 1U;
+                if (!directTilePrefetched) {
+                    CopyInDirectTileRawAsync(bos, i_t, i_d, seqLen, slot, directMte2ToVEvent[slot]);
                 }
+                WaitFlag<HardEvent::MTE2_V>(directMte2ToVEvent[slot]);
+
+                directTilePrefetched = false;
+                if (loop + 1U < loopC) {
+                    uint32_t nextChunkIdx = (bIdx < tailChunk_)
+                        ? (bIdx * (chunkPerCore_ + 1) + loop + 1U)
+                        : (bIdx * chunkPerCore_ + tailChunk_ + loop + 1U);
+                    if (nextChunkIdx < numChunks_) {
+                        uint32_t nextB = 0;
+                        uint32_t nextT = 0;
+                        uint32_t nextSeqLen = 0;
+                        uint64_t nextBos = 0;
+                        if (ResolveChunk(nextChunkIdx, nextB, nextT, nextBos, nextSeqLen)) {
+                            uint32_t nextSlot = slot ^ 1U;
+                            CopyInDirectTileRawAsync(nextBos, nextT, i_d, nextSeqLen, nextSlot,
+                                                     directMte2ToVEvent[nextSlot]);
+                            directTilePrefetched = true;
+                        }
+                    }
+                }
+
+                ComputeTileDirectRegbase(i_t, seqLen, slot);
             } else {
-                CopyInDyWindow(bos, i_t, i_d, seqLen);
-                for (uint32_t i_w = 0; i_w < W_; i_w++) {
-                    ComputeWdyAndAcc(i_w, i_w);
-                    ComputeDwRowsAccum(i_w, i_w);
+                CopyInX(bos, i_t, i_d, seqLen);
+
+                Duplicate(dxBuf_.Get<float>(), float(0), btBdCount_);
+                PipeBarrier<PIPE_V>();
+
+                if (activation_ == ACTIVATION_SILU || activation_ == ACTIVATION_SWISH) {
+                    CopyInDyWindow(bos, i_t, i_d, seqLen);
+                    CopyInYWindow(bos, i_t, i_d, seqLen);
+                    ApplySiluBackward(dyBuf_.Get<float>(), yBuf_.Get<float>(), dyBdCount_);
+                    for (uint32_t i_w = 0; i_w < W_; i_w++) {
+                        ComputeWdyAndAcc(i_w, i_w);
+                        ComputeDwPartial(i_w, i_w);
+                        if (hasBias_ && i_w == 0) ComputeDbPartial(0);
+                    }
+                } else {
+                    CopyInDyWindow(bos, i_t, i_d, seqLen);
+                    for (uint32_t i_w = 0; i_w < W_; i_w++) {
+                        ComputeWdyAndAcc(i_w, i_w);
+                        ComputeDwRowsAccum(i_w, i_w);
+                    }
+                    if (hasBias_) ComputeDbRowsAccum(0);
                 }
-                if (hasBias_) ComputeDbRowsAccum(0);
+
+                ComputeDh0(bos, i_t, i_d, i_b, seqLen);
             }
 
-            ComputeDh0(bos, i_t, i_d, i_b, seqLen);
             AccumulateDhtDx(i_t, i_d, i_b, seqLen);
             CopyOutDx(bos, i_t, i_d, seqLen);
         }
-        if (hasWeight_ && activation_ == ACTIVATION_NONE) {
+        if (!useDirectRegbase && hasWeight_ && activation_ == ACTIVATION_NONE) {
             FinalizeDwRowsAccum();
         }
-        if (hasBias_ && activation_ == ACTIVATION_NONE) {
+        if (!useDirectRegbase && hasBias_ && activation_ == ACTIVATION_NONE) {
             FinalizeDbRowsAccum();
         }
         CopyOutPartialDwDb(bIdx, i_d);
@@ -1152,6 +1494,11 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::Process()
 
     for (uint32_t i_d = bIdx; i_d < numBlksD_; i_d += blockNum) {
         ReducePartialDwDb(i_d);
+    }
+
+    if (useDirectRegbase) {
+        GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(directMte2ToVEvent[0]);
+        GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(directMte2ToVEvent[1]);
     }
 }
 

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -474,13 +474,14 @@ at::Tensor npu_causal_conv1d(
     c10::string_view input_layout)
 {
     const std::string input_layout_str(input_layout);
-    const char *input_layout_cstr = input_layout_str.c_str();
+    const char *input_layout_cstr = nullptr;
     const int64_t width = weight.size(0);
     const int64_t dim = weight.size(1);
 
     std::vector<int64_t> dx_shape;
     int64_t batch = 0;
     if (input_layout_str == "BNSD") {
+        input_layout_cstr = "BNSD";
         TORCH_CHECK(x.dim() == 3, "BNSD x must be logical [B, T, D]");
         TORCH_CHECK(dy.dim() == 4, "BNSD dy must be [B, N, T, Dh]");
         batch = x.size(0);
@@ -491,6 +492,7 @@ at::Tensor npu_causal_conv1d(
             "BNSD dy must be [B, N, T, Dh] with D=N*Dh for x [B, T, D]");
         dx_shape = x.sizes().vec();
     } else if (input_layout_str == "NTD") {
+        input_layout_cstr = "NTD";
         TORCH_CHECK(x.dim() == 2, "NTD x must be logical [total_tokens, D]");
         TORCH_CHECK(dy.dim() == 3, "NTD dy must be [N, total_tokens, Dh]");
         TORCH_CHECK(query_start_loc.has_value(), "query_start_loc is required for NTD input");
@@ -501,6 +503,7 @@ at::Tensor npu_causal_conv1d(
         batch = static_cast<int64_t>(query_start_loc.value().size()) - 1;
         dx_shape = x.sizes().vec();
     } else if (input_layout_str == "TND") {
+        input_layout_cstr = "TND";
         TORCH_CHECK(x.dim() == 2, "TND input must be [total_tokens, D]");
         TORCH_CHECK(dy.sizes() == x.sizes(), "TND dy shape must match x");
         TORCH_CHECK(query_start_loc.has_value(), "query_start_loc is required for TND input");
@@ -510,6 +513,7 @@ at::Tensor npu_causal_conv1d(
         TORCH_CHECK(
             input_layout_str == "BSND" || input_layout_str == "BSH",
             "input_layout must be one of BSND, BSH, TND, BNSD, or NTD");
+        input_layout_cstr = "BSND";
         TORCH_CHECK(x.dim() == 3, "BSND/BSH input must be [B, T, D]");
         TORCH_CHECK(dy.sizes() == x.sizes(), "BSND/BSH dy shape must match x");
         batch = x.size(0);


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [x] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @jiang2027
- 修改范围:
  - [x] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [x] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [x] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
