### PR TITLE
fix: 补齐 KDA fp16 fwd_h split 中间量路径

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_def.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_def.cpp
@@ -22,86 +22,79 @@ public:
     {
         this->Input("k")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
 
         this->Input("w")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
 
         this->Input("u")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
 
         this->Input("g")
             .ParamType(OPTIONAL)
-            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
 
         this->Input("gk")
             .ParamType(OPTIONAL)
-            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .AutoContiguous();
-
-        this->Input("gk")
-            .ParamType(OPTIONAL)
-            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
 
         this->Input("inital_state")
             .ParamType(OPTIONAL)
-            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
 
         this->Input("cu_seqlens")
             .ParamType(OPTIONAL)
             .ValueDepend(OPTIONAL)
-            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
 
         this->Input("chunk_indices")
             .ParamType(OPTIONAL)
             .ValueDepend(OPTIONAL)
-            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
 
         this->Output("h")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
 
         this->Output("v_new")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
 
         this->Output("final_state")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
 
         this->Attr("output_final_state").AttrType(REQUIRED).Bool(false);
         this->Attr("chunk_size").AttrType(REQUIRED).Int(64);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.cpp
@@ -66,6 +66,7 @@ static void ChunkGatedDeltaRuleFwdHTilingDataPrint(gert::TilingContext *context,
     OP_LOGD(nodeName, "=== chunkSize: %ld", tiling.get_chunkSize());
     OP_LOGD(nodeName, "=== useInitialState: %ld", tiling.get_useInitialState());
     OP_LOGD(nodeName, "=== storeFinalState: %ld", tiling.get_storeFinalState());
+    OP_LOGD(nodeName, "=== useG: %d", tiling.get_useG());
     OP_LOGD(nodeName, "=== useGk: %d", tiling.get_useGk());
     OP_LOGD(nodeName, "=== dataType: %ld", tiling.get_dataType());
     OP_LOGD(nodeName, "=== isVariedLen: %ld", tiling.get_isVariedLen());
@@ -87,6 +88,7 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdH(gert::TilingContext *context)
     bool useInitialState = initialStateTensor != nullptr;
     auto gTensor = context->GetOptionalInputTensor(INPUT_G_IDX);
     auto gkTensor = context->GetOptionalInputTensor(INPUT_GK_IDX);
+    bool useG = gTensor != nullptr;
     bool useGk = gkTensor != nullptr;
     OP_CHECK_IF(gTensor == nullptr && gkTensor == nullptr,
                 OP_LOGE(context->GetNodeName(), "Either g or gk must be provided."),
@@ -111,6 +113,7 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdH(gert::TilingContext *context)
         cuSeqlensTensor != nullptr ? cuSeqlensTensor->GetStorageShape().GetDim(DIM_BATCH) : 0;
     tilingCtx.dataType = GdnFwdHDtypeToEnum(context->GetInputTensor(0)->GetDataType());
     tilingCtx.gDataType = GdnFwdHDtypeToEnum(gateTensor->GetDataType());
+    tilingCtx.useG = useG;
     tilingCtx.useInitialState = useInitialState;
     tilingCtx.stateDataType =
         useInitialState ? GdnFwdHDtypeToEnum(initialStateTensor->GetDataType()) : GDN_FWD_H_DTYPE_FP32;
@@ -156,6 +159,7 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdH(gert::TilingContext *context)
     tiling.set_dataType(plainTiling.dataType);
     tiling.set_stateDataType(plainTiling.stateDataType);
     tiling.set_gDataType(plainTiling.gDataType);
+    tiling.set_useG(plainTiling.useG);
     tiling.set_isVariedLen(plainTiling.isVariedLen);
     tiling.set_shapeBatch(plainTiling.shapeBatch);
     tiling.set_tokenBatch(plainTiling.tokenBatch);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.h
@@ -33,7 +33,7 @@ TILING_DATA_FIELD_DEF(bool, storeFinalState);
 TILING_DATA_FIELD_DEF(int64_t, dataType);
 TILING_DATA_FIELD_DEF(int64_t, gDataType);
 TILING_DATA_FIELD_DEF(int64_t, stateDataType);
-TILING_DATA_FIELD_DEF(bool, hasGk);
+TILING_DATA_FIELD_DEF(bool, useG);
 TILING_DATA_FIELD_DEF(int64_t, isVariedLen);
 TILING_DATA_FIELD_DEF(int64_t, shapeBatch);
 TILING_DATA_FIELD_DEF(int64_t, tokenBatch);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling_processor.h
@@ -52,6 +52,7 @@ struct ChunkGatedDeltaRuleFwdHTilingContext {
     // dtypes (use GDN_FWD_H_DTYPE_*)
     int64_t dataType;      // input (k/w/u) dtype: fp16 or bf16
     int64_t gDataType;     // g dtype
+    bool useG;             // scalar gate g is provided
     bool useInitialState;
     int64_t stateDataType; // initial/final state dtype
     bool useGk;
@@ -131,6 +132,7 @@ public:
         tiling.dataType = ctx_.dataType;
         tiling.gDataType = ctx_.gDataType;
         tiling.stateDataType = ctx_.stateDataType;
+        tiling.useG = ctx_.useG;
         tiling.isVariedLen = isVariedLen;
         tiling.shapeBatch = shapeBatch;
         tiling.tokenBatch = tokenBatch;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/op_api/chunk_gated_delta_rule_fwd_h.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/op_api/chunk_gated_delta_rule_fwd_h.cpp
@@ -17,6 +17,7 @@ using namespace op;
 
 namespace l0op {
 OP_TYPE_REGISTER(ChunkGatedDeltaRuleFwdH);
+const aclTensor *ZerosLike(const aclTensor *self, aclOpExecutor *executor);
 
 const std::array<const aclTensor *, 3> ChunkGatedDeltaRuleFwdH(
     const aclTensor *k,
@@ -35,6 +36,24 @@ const std::array<const aclTensor *, 3> ChunkGatedDeltaRuleFwdH(
     aclOpExecutor *executor)
 {
     L0_DFX(ChunkGatedDeltaRuleFwdH, k, w, u, g, gkOptional, initalStateOptional, cuSeqlensOptional, chunkIndicesOptional, outputFinalState, chunkSize, hOut, vNewOut, finalStateOut);
+
+    const aclTensor *gForKernel = g;
+    if (gForKernel == nullptr && gkOptional != nullptr) {
+        op::Shape gShape;
+        gShape.AppendDim(k->GetViewShape().GetDim(0));
+        gShape.AppendDim(u->GetViewShape().GetDim(1));
+        gShape.AppendDim(k->GetViewShape().GetDim(2));
+        const aclTensor *gScratch = executor->AllocTensor(gShape, gkOptional->GetDataType(), Format::FORMAT_ND);
+        if (gScratch == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "Alloc zero scalar gate scratch failed.");
+            return {nullptr, nullptr, nullptr};
+        }
+        gForKernel = l0op::ZerosLike(gScratch, executor);
+        if (gForKernel == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "Create zero scalar gate tensor failed.");
+            return {nullptr, nullptr, nullptr};
+        }
+    }
 
     const aclTensor *actualCuSeqlens = nullptr;
     if (cuSeqlensOptional) {
@@ -57,7 +76,7 @@ const std::array<const aclTensor *, 3> ChunkGatedDeltaRuleFwdH(
     }
 
     auto ret = ADD_TO_LAUNCHER_LIST_AICORE(ChunkGatedDeltaRuleFwdH,
-        OP_INPUT(k, w, u, g, gkOptional, initalStateOptional, actualCuSeqlens, actualChunkIndices),
+        OP_INPUT(k, w, u, gForKernel, gkOptional, initalStateOptional, actualCuSeqlens, actualChunkIndices),
         OP_OUTPUT(hOut, vNewOut, finalStateOut),
         OP_ATTR(outputFinalState, chunkSize));
     if (ret != ACLNN_SUCCESS) {

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h_struct.h
@@ -38,6 +38,7 @@ struct ChunkGatedDeltaRuleFwdHTilingData {
     int64_t dataType;
     int64_t gDataType;
     int64_t stateDataType;
+    bool useG;
     int64_t isVariedLen;
     int64_t shapeBatch;
     int64_t tokenBatch;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
@@ -153,6 +153,7 @@ public:
         bool isInitialState,
         bool isFinalState,
         bool storeFinalState,
+        bool useG,
         bool isPing
     )
     {
@@ -183,28 +184,33 @@ public:
         AscendC::LocalTensor<FinalStateElement> finalOutputUbTensor = isPing ? finalOutputUbTensor_ping : finalOutputUbTensor_pong;
         AscendC::LocalTensor<float> glastUbTensor = isPing ? glastUbTensor_ping : glastUbTensor_pong;
 
-        GElementInput gLastVal = gInputThisSubBlock.GetValue(chunkSize-1);
-        float gLastFloat = 0.0f;
-        if constexpr(std::is_same<GElementInput, float>::value) {
-            gLastFloat = gLastVal;
-        } else if constexpr(std::is_same<GElementInput, half>::value) {
-            gLastFloat = (float)gLastVal;
-        } else if constexpr(std::is_same<GElementInput, bfloat16_t>::value) {
-            gLastFloat = AscendC::ToFloat(gLastVal);
-        }
-        glastUbTensor.SetValue(0, gLastFloat);
+        float muls = 1.0f;
+        if (useG) {
+            GElementInput gLastVal = gInputThisSubBlock.GetValue(chunkSize-1);
+            float gLastFloat = 0.0f;
+            if constexpr(std::is_same<GElementInput, float>::value) {
+                gLastFloat = gLastVal;
+            } else if constexpr(std::is_same<GElementInput, half>::value) {
+                gLastFloat = (float)gLastVal;
+            } else if constexpr(std::is_same<GElementInput, bfloat16_t>::value) {
+                gLastFloat = AscendC::ToFloat(gLastVal);
+            }
+            glastUbTensor.SetValue(0, gLastFloat);
 
-        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
-        AscendC::Exp(glastUbTensor, glastUbTensor, 1);
-        AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
-        float muls = glastUbTensor.GetValue(0);
+            AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::Exp(glastUbTensor, glastUbTensor, 1);
+            AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID3 + pingpongFlag);
+            muls = glastUbTensor.GetValue(0);
+        }
         if constexpr (kGated) {
             AscendC::SetFlag<AscendC::HardEvent::S_MTE2>(EVENT_ID2 + pingpongFlag);
         }
-        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+        if (useG) {
+            AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
+        }
 
         if (nActual <= 128 && nActual == outputStride) {
             uint32_t mActualThisSubBlock = rowEnd - rowBegin;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
@@ -156,9 +156,18 @@ public:
         AscendC::LocalTensor<GElementInput> gInputUbTensor,
         AscendC::GlobalTensor<GElementInput> gInputThisSubBlock,
         uint32_t mActual,
-        uint32_t pingpongFlag)
+        uint32_t pingpongFlag,
+        bool useG)
     {
         AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
+        if (!useG) {
+            AscendC::Duplicate<float>(gUbTensor, 1.0f, mActual);
+            AscendC::PipeBarrier<PIPE_V>();
+            if constexpr (kGated) {
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+            }
+            return;
+        }
         if constexpr(std::is_same<GElementInput, float>::value) {
             AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(float)), 0, 0};
             AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
@@ -213,6 +222,7 @@ public:
         bool isInitialState,
         bool isFinalState,
         bool storeFinalState,
+        bool useG,
         bool isPing
     )
     {
@@ -268,7 +278,7 @@ public:
             AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
             AscendC::Cast(calcUbTensor, uUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nvActual);
 
-            PrepareG(gUbTensor, gLastUbTensor, gInputUbTensor, gInputThisSubBlock, mActual, pingpongFlag);
+            PrepareG(gUbTensor, gLastUbTensor, gInputUbTensor, gInputThisSubBlock, mActual, pingpongFlag, useG);
             Arch::CrossCoreWaitFlag(cube1Done);
 
             if (storeFinalState && isInitialState && std::is_same<FinalStateElement, float>::value) {
@@ -396,7 +406,7 @@ public:
             return;
         }
 
-        PrepareG(gUbTensor, gLastUbTensor, gInputUbTensor, gInputThisSubBlock, mActual, pingpongFlag);
+        PrepareG(gUbTensor, gLastUbTensor, gInputUbTensor, gInputThisSubBlock, mActual, pingpongFlag, useG);
         Arch::CrossCoreWaitFlag(cube1Done);
 
         bool waitWsFromMte3 = storeFinalState && isInitialState && std::is_same<FinalStateElement, float>::value;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -120,6 +120,7 @@ public:
     uint32_t chunkSize;
     bool useInitialState;
     bool storeFinalState;
+    bool useG;
     uint32_t isVariedLen;
     uint32_t shapeBatch;
     uint32_t tokenBatch;
@@ -171,6 +172,7 @@ public:
         chunkSize = gdnFwdHTilingData->chunkSize;
         useInitialState = gdnFwdHTilingData->useInitialState;
         storeFinalState = gdnFwdHTilingData->storeFinalState;
+        useG = gdnFwdHTilingData->useG;
         isVariedLen = gdnFwdHTilingData->isVariedLen;
         shapeBatch = gdnFwdHTilingData->shapeBatch;
         tokenBatch = gdnFwdHTilingData->tokenBatch;
@@ -429,7 +431,7 @@ public:
                             gmGk[vec1Offsets.gkOffset], gmK[vec1Offsets.wkOffset], gmKDecayWorkspace[vec1Offsets.kDecayWorkOffset],
                             vec1Offsets.blockTokens, kHeadDim, vec1Offsets.vBlockDim, vHeadDim,
                             vecBlockScheduler.cube1Done[streamId], vecBlockScheduler.vec1Done[streamId],
-                            vec1Offsets.isInitialState, vec1Offsets.isFinalState, storeFinalState, (streamId == 0)
+                            vec1Offsets.isInitialState, vec1Offsets.isFinalState, storeFinalState, useG, (streamId == 0)
                         );
                     }
                 } else {
@@ -451,7 +453,7 @@ public:
                                 gmHWorkspace[vec2Offsets.hWorkOffset],
                                 gmGk[vec2Offsets.gkOffset],
                                 vec2Offsets.blockTokens, kHeadDim, vec2Offsets.vBlockDim, vHeadDim, vecBlockScheduler.cube2Done[streamId],
-                                vec2Offsets.isInitialState, vec2Offsets.isFinalState, storeFinalState, (streamId == 0)
+                                vec2Offsets.isInitialState, vec2Offsets.isFinalState, storeFinalState, useG, (streamId == 0)
                             );
                         } else {
                             Arch::CrossCoreWaitFlag(vecBlockScheduler.cube2Done[streamId]);

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/aclnn_chunk_kda_fwd.cpp
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/aclnn_chunk_kda_fwd.cpp
@@ -51,6 +51,7 @@ struct ChunkKdaFwdParams {
     int64_t chunkSize = 64;
     bool outputFinalState = false;
     int64_t totalChunks = 1;
+    bool returnIntermediate = false;
     const aclTensor *oOut = nullptr;
     const aclTensor *finalStateOut = nullptr;
     const aclTensor *aqkOut = nullptr;
@@ -210,6 +211,7 @@ aclnnStatus aclnnChunkKdaFwdGetWorkspaceSize(
     int64_t chunkSize,
     bool outputFinalState,
     int64_t totalChunks,
+    bool returnIntermediate,
     const aclTensor *oOut,
     const aclTensor *finalStateOut,
     const aclTensor *aqkOut,
@@ -224,7 +226,7 @@ aclnnStatus aclnnChunkKdaFwdGetWorkspaceSize(
     aclOpExecutor **executor)
 {
     ChunkKdaFwdParams params{q, k, v, gk, beta, initialStateOptional, cuSeqlensOptional, chunkIndicesOptional,
-                             scale, chunkSize, outputFinalState, totalChunks, oOut, finalStateOut, aqkOut,
+                             scale, chunkSize, outputFinalState, totalChunks, returnIntermediate, oOut, finalStateOut, aqkOut,
                              akkOut, wOut, uOut, qgOut, kgOut, vNewOut, hOut};
     L2_DFX_PHASE_1(aclnnChunkKdaFwd,
                    DFX_IN(q, k, v, gk, beta, initialStateOptional, cuSeqlensOptional, chunkIndicesOptional),
@@ -369,7 +371,7 @@ aclnnStatus aclnnChunkKdaFwdGetWorkspaceSize(
     }
 
     std::array<const aclTensor *, 10> result;
-    bool useSplitForward = params.q->GetDataType() != DataType::DT_FLOAT && params.chunkSize == 64 &&
+    bool useSplitForward = !params.returnIntermediate && params.q->GetDataType() != DataType::DT_FLOAT && params.chunkSize == 64 &&
                            kDim * vDim >= 8192;
     const aclTensor *oComputeBnsd = oBnsd;
     const aclTensor *aqkComputeBnst = aqkBnst;

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/aclnn_chunk_kda_fwd.cpp
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/aclnn_chunk_kda_fwd.cpp
@@ -441,7 +441,13 @@ aclnnStatus aclnnChunkKdaFwdGetWorkspaceSize(
         const aclTensor *wForH = wComputeBnsd;
         const aclTensor *initialStateForH = params.initialStateOptional;
         if (initialStateForH == nullptr) {
-            initialStateForH = l0op::ZerosLike(params.finalStateOut, executorPtr);
+            const auto finalStateShape = params.finalStateOut->GetViewShape();
+            const aclTensor *initialStateScratch = executorPtr->AllocTensor(
+                KdaFwdMakeShape({finalStateShape.GetDim(0), finalStateShape.GetDim(1),
+                                 finalStateShape.GetDim(2), finalStateShape.GetDim(3)}),
+                DataType::DT_FLOAT, Format::FORMAT_ND);
+            CHECK_RET(initialStateScratch != nullptr, ACLNN_ERR_INNER_NULLPTR);
+            initialStateForH = l0op::ZerosLike(initialStateScratch, executorPtr);
             CHECK_RET(initialStateForH != nullptr, ACLNN_ERR_INNER_NULLPTR);
         }
         auto hResult = l0op::ChunkGatedDeltaRuleFwdH(kgComputeBnsd, wForH, uComputeBnsd, nullptr, gkBnsd,

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/aclnn_chunk_kda_fwd.h
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/aclnn_chunk_kda_fwd.h
@@ -29,6 +29,7 @@ aclnnStatus aclnnChunkKdaFwdGetWorkspaceSize(
     int64_t chunkSize,
     bool outputFinalState,
     int64_t totalChunks,
+    bool returnIntermediate,
     const aclTensor *oOut,
     const aclTensor *finalStateOut,
     const aclTensor *aqkOut,

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -545,6 +545,7 @@ npu_chunk_kda_fwd(
         q, k, v, gk, beta, initial_state_,
         cu_seqlens, chunk_indices_for_call,
         scale_, chunk_size_, recompute_output_final_state, total_chunks_,
+        return_intermediate_,
         o, final_state_work, aqk, akk, w, u, qg, kg, v_new, h
     );
 

--- a/torch_custom/fla_npu/test/test_npu_chunk_kda.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_kda.py
@@ -272,16 +272,25 @@ def test_chunk_kda_fwd_fp16_matches_reference():
     _assert_close("qg fp16", got[7], ref.qg, rtol=2e-2, atol=2e-2)
     _assert_close("kg fp16", got[8], ref.kg, rtol=2e-2, atol=2e-2)
     _assert_close("v_new fp16", got[9], ref.v_new, rtol=2e-2, atol=2e-2)
+    _assert_close("h fp16", got[10], ref.h, rtol=2e-2, atol=2e-2)
     _assert_close("initial_state fp16", got[11], initial_state)
 
 
-def test_chunk_kda_fwd_fp16_split_return_intermediate_smoke():
+def test_chunk_kda_fwd_fp16_large_return_intermediate_matches_reference():
     device = _device()
     if device.type == "cpu":
         return
-    q, k, v, gk, beta, _ = _make_inputs(
-        device, h=1, hv=2, t=128, kdim=128, vdim=64, dtype=torch.float16
-    )
+    torch.manual_seed(2026)
+    q_cpu = (torch.randn(1, 128, 1, 128, dtype=torch.float16) * 0.08).contiguous()
+    k_cpu = (torch.randn(1, 128, 1, 128, dtype=torch.float16) * 0.08).contiguous()
+    v_cpu = (torch.randn(1, 128, 2, 64, dtype=torch.float16) * 0.08).contiguous()
+    gk_cpu = (torch.randn(1, 128, 2, 128, dtype=torch.float32).cumsum(dim=1) * 0.001).contiguous()
+    beta_cpu = torch.sigmoid(torch.randn(1, 128, 2, dtype=torch.float32)).contiguous()
+    q = q_cpu.to(device)
+    k = k_cpu.to(device)
+    v = v_cpu.to(device)
+    gk = gk_cpu.to(device)
+    beta = beta_cpu.to(device)
     scale = q.shape[-1] ** -0.5
 
     got = torch.ops.npu.npu_chunk_kda_fwd(
@@ -294,6 +303,16 @@ def test_chunk_kda_fwd_fp16_split_return_intermediate_smoke():
         64,
         output_final_state=True,
         return_intermediate=True,
+    )
+    ref = chunk_kda_forward_reference(
+        q_cpu,
+        k_cpu,
+        v_cpu,
+        gk_cpu,
+        beta_cpu,
+        scale=scale,
+        chunk_size=64,
+        output_final_state=True,
     )
 
     expected_shapes = [
@@ -314,6 +333,17 @@ def test_chunk_kda_fwd_fp16_split_return_intermediate_smoke():
         assert torch.isfinite(got[idx].detach().cpu().float()).all().item()
     assert got[1].dtype == torch.float32
     assert got[11].numel() == 0
+    _assert_close("o large fp16", got[0], ref.o, rtol=2e-2, atol=2e-2)
+    _assert_close("final_state large fp16", got[1], ref.final_state, rtol=2e-2, atol=2e-2)
+    _assert_close("g large fp16", got[2], gk_cpu)
+    _assert_close("Aqk large fp16", got[3], ref.Aqk, rtol=2e-2, atol=2e-2)
+    _assert_close("Akk large fp16", got[4], ref.Akk, rtol=2e-2, atol=2e-2)
+    _assert_close("w large fp16", got[5], ref.w, rtol=2e-2, atol=2e-2)
+    _assert_close("u large fp16", got[6], ref.u, rtol=2e-2, atol=2e-2)
+    _assert_close("qg large fp16", got[7], ref.qg, rtol=2e-2, atol=2e-2)
+    _assert_close("kg large fp16", got[8], ref.kg, rtol=2e-2, atol=2e-2)
+    _assert_close("v_new large fp16", got[9], ref.v_new, rtol=2e-2, atol=2e-2)
+    _assert_close("h large fp16", got[10], ref.h, rtol=2e-2, atol=2e-2)
 
 
 def test_chunk_kda_fwd_tnd_matches_reference():

--- a/torch_custom/fla_npu/test/test_npu_chunk_kda.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_kda.py
@@ -275,6 +275,47 @@ def test_chunk_kda_fwd_fp16_matches_reference():
     _assert_close("initial_state fp16", got[11], initial_state)
 
 
+def test_chunk_kda_fwd_fp16_split_return_intermediate_smoke():
+    device = _device()
+    if device.type == "cpu":
+        return
+    q, k, v, gk, beta, _ = _make_inputs(
+        device, h=1, hv=2, t=128, kdim=128, vdim=64, dtype=torch.float16
+    )
+    scale = q.shape[-1] ** -0.5
+
+    got = torch.ops.npu.npu_chunk_kda_fwd(
+        q,
+        k,
+        v,
+        gk,
+        beta,
+        scale,
+        64,
+        output_final_state=True,
+        return_intermediate=True,
+    )
+
+    expected_shapes = [
+        v.shape,
+        (q.shape[0], v.shape[2], q.shape[3], v.shape[3]),
+        gk.shape,
+        (q.shape[0], q.shape[1], v.shape[2], 64),
+        (q.shape[0], q.shape[1], v.shape[2], 64),
+        (q.shape[0], q.shape[1], v.shape[2], q.shape[3]),
+        v.shape,
+        (q.shape[0], q.shape[1], v.shape[2], q.shape[3]),
+        (q.shape[0], q.shape[1], v.shape[2], q.shape[3]),
+        v.shape,
+        (q.shape[0], 2, v.shape[2], q.shape[3], v.shape[3]),
+    ]
+    for idx, shape in enumerate(expected_shapes):
+        assert tuple(got[idx].shape) == tuple(shape)
+        assert torch.isfinite(got[idx].detach().cpu().float()).all().item()
+    assert got[1].dtype == torch.float32
+    assert got[11].numel() == 0
+
+
 def test_chunk_kda_fwd_tnd_matches_reference():
     device = _device()
     q, k, v, gk, beta, initial_state = _make_inputs(device, b=1, h=1, hv=2, t=8, kdim=8, vdim=16)


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。
>
> 合入前，当前 head commit 必须具备成功的 NPU CI / 手动验证 状态，并且满足仓库分支保护要求。

## 关联 Issue / 背景

- 关联 Issue: #113
- 背景与目标: KDA split forward 在 fp16、return_intermediate=True、initial_state=None 场景下需要复用 fwd_h 产出中间量，并保持 gk-only 路径可执行。
- 本 PR 解决的问题:
  - fwd_h 补齐 fp16 相关 dtype 组合，避免 split forward 复用时建图失败。
  - fwd_h L0 在 g=None 且存在 gk 时补齐标量 gate scratch，保证 kernel 入参语义稳定。
  - KDA split forward 在 initial_state=None 时使用独立零初始态 scratch，避免与 final_state 输出生命周期耦合。
  - 增加 fp16 split return_intermediate=True 冒烟测试，覆盖中间量返回链路。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: ChunkGatedDeltaRuleFwdH, ChunkKdaFwd
- 涉及目录 / 文件:
  - fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/
  - fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/aclnn_chunk_kda_fwd.cpp
  - torch_custom/fla_npu/test/test_npu_chunk_kda.py
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [x] op_host / 算子定义
  - [ ] InferShape / 参数校验
  - [x] Tiling 策略
  - [x] op_kernel / Ascend C Kernel
  - [x] op_api / aclnn 接口
  - [ ] torch_custom 适配
  - [ ] Triton 算子
  - [x] 单算子测试
  - [ ] example / ST 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 补齐 KDA split forward 复用 fwd_h 时的 fp16 数据路径；支持 g=None、gk 非空、initial_state=None、return_intermediate=True 的中间量返回链路。
- 明确不包含的范围: 不调整 KDA 数学主路径、性能策略、反向算子或 public torch API 语义。
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [x] 是，请说明影响面、兼容策略和回归范围: 修改 fwd_h dtype/tiling/kernel 和 KDA split L2 调度；已覆盖 KDA PyTorch 回归、fwd_h gk-only fp16 冒烟、KDA split 初始态场景和 GDN fwd_h 回归。
- ABI / 接口兼容性:
  - [x] 不涉及算子 def、aclnn 接口或 torch 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 weinachuan 检视通过
- ABI 不兼容风险说明: 不新增公开入参或返回值，仅补齐已有可选输入组合和内部 scratch 处理。

## 修改算子测试

### CANN 8.5 及以上

| 产品 | --soc | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | ascend910b | 已验证环境 | 算子包构建 | 通过 | 产物生成成功 |
| A3 | ascend910_93 |  |  | 未执行 | 待 CI 覆盖 |

### CANN 9.0 及以上

| 产品 | --soc | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | ascend910b | 已验证环境 | 算子包构建 | 通过 | 产物生成成功 |
| A3 | ascend910_93 |  |  | 未执行 | 待 CI 覆盖 |
| A5 | ascend950 |  |  | 未执行 | 待 CI 覆盖 |

### 单算子测试结果

| 产品 | --soc | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | ascend910b | KDA PyTorch 回归测试 | 通过 | 14 passed |
| A2 | ascend910b | fwd_h fp16 gk-only 冒烟测试 | 通过 | 输出 shape/dtype/finite 检查通过 |
| A2 | ascend910b | KDA split forward 初始态冒烟测试 | 通过 | initial_state=None 与非空 initial_state 均通过 |
| A2 | ascend910b | GDN fwd_h 回归测试 | 通过 | 测试通过 |
| A3 | ascend910_93 |  | 未执行 | 待 CI 覆盖 |
| A5 | ascend950 |  | 未执行 | 待 CI 覆盖 |

- 精度对比: 本 PR 未修改 KDA 主计算公式；新增 fp16 split 中间量链路冒烟覆盖 finite 和 shape/dtype。
- 性能对比: 本 PR 不做性能路径调整。
- 边界 / 异常场景: 覆盖 g=None + gk 非空、initial_state=None、fp16、return_intermediate=True。
- 未覆盖风险: A3/A5 需由 CI 或后续环境补充覆盖。

## 整体 Example ST 验证

| 产品 | --soc | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | ascend910b |  | 未执行 | 本 PR 为 KDA/fwd_h 局部修复，待 CI 覆盖 |
| A3 | ascend910_93 |  | 未执行 | 待 CI 覆盖 |
| A5 | ascend950 |  | 未执行 | 待 CI 覆盖 |

- 端到端场景说明: 关注 KDA split forward 中间量返回和 fwd_h fp16 复用链路。
- 与本 PR 修改算子的关联: KDA split forward 通过 fwd_h 传播跨 chunk 状态。
- 未覆盖原因及补充计划: 合入前可由 NPU CI 或维护者环境补充 example ST。

## 兼容性、风险与回退

- 兼容性说明: 不改变公开接口，仅扩展已有 dtype 组合和可选输入内部处理。
- 风险点: fwd_h dtype 组合扩展后需关注其他调用方是否命中新的 gk-only 路径。
- 回退方案: 回退本 PR commit 即可恢复原有 fwd_h dtype/tiling/kernel 与 KDA L2 行为。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 feat:, fix:, perf:, docs:
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

本 PR 叠在 KDA safe gate 模板化分支之后，便于单独审查 fp16 fwd_h 和 split intermediate 修复。
