### PR TITLE
fix: stabilize A5 GDN BSND backward kernels

### DIFF
--- a/fla/ops/ascendc/common/kernel_utils/block/block_mmad_pingpong_tla.hpp
+++ b/fla/ops/ascendc/common/kernel_utils/block/block_mmad_pingpong_tla.hpp
@@ -933,10 +933,14 @@ public:
                 auto tensorTileL0C = GetTile(tensorL0C,
                                             tla::MakeCoord(rowIdx, 0),
                                             tla::MakeShape(curRowNum, nL1Actual));
+                uint8_t copyUnitFlag = 0;
+                if constexpr (ENABLE_UNIT_FLAG) {
+                    copyUnitFlag = (i == tileNum - 1) ? 0b11 : 0b10;
+                }
                 if (sendVecNum == 2) {
                     AscendC::CrossCoreWaitFlag<0x4, PIPE_FIX>(l0C2UBAIVAICFlag + ubListId);
                     AscendC::CrossCoreWaitFlag<0x4, PIPE_FIX>(l0C2UBAIVAICFlag + FLAG_ID_MAX + ubListId);
-                    copyL0CToDst(tensorCList[ubListId], tensorTileL0C, ubRowNum, beginSubBlockIdx, sendVecNum);
+                    copyL0CToDst(tensorCList[ubListId], tensorTileL0C, ubRowNum, beginSubBlockIdx, sendVecNum, copyUnitFlag);
                     AscendC::CrossCoreSetFlag<0x4, PIPE_FIX>(l0C2UBAICAIVFlag + ubListId);
                     AscendC::CrossCoreSetFlag<0x4, PIPE_FIX>(l0C2UBAICAIVFlag + FLAG_ID_MAX + ubListId);
                     rowIdx += curRowNum;
@@ -949,7 +953,7 @@ public:
                     } else if (beginSubBlockIdx == 1) {
                         AscendC::CrossCoreWaitFlag<0x4, PIPE_FIX>(l0C2UBAIVAICFlag + FLAG_ID_MAX + ubListId);
                     }
-                    copyL0CToDst(tensorCList[ubListId], tensorTileL0C, ubRowNum, beginSubBlockIdx, sendVecNum);
+                    copyL0CToDst(tensorCList[ubListId], tensorTileL0C, ubRowNum, beginSubBlockIdx, sendVecNum, copyUnitFlag);
                     if (beginSubBlockIdx == 0) {
                         AscendC::CrossCoreSetFlag<0x4, PIPE_FIX>(l0C2UBAICAIVFlag + ubListId);
                     } else if (beginSubBlockIdx == 1) {
@@ -973,10 +977,14 @@ public:
                 auto tensorTileL0C = GetTile(tensorL0C,
                                             tla::MakeCoord(rowIdx, 0),
                                             tla::MakeShape(curRowNum, nL1Actual));
+                uint8_t copyUnitFlag = 0;
+                if constexpr (ENABLE_UNIT_FLAG) {
+                    copyUnitFlag = (i == tileNum - 1) ? 0b11 : 0b10;
+                }
                 if (sendVecNum == 2) {
                     AscendC::CrossCoreWaitFlag<0x4, PIPE_FIX>(l0C2UBAIVAICFlag + ubListId);
                     AscendC::CrossCoreWaitFlag<0x4, PIPE_FIX>(l0C2UBAIVAICFlag + FLAG_ID_MAX + ubListId);
-                    copyL0CToDst(tensorCList[ubListId], tensorTileL0C, ubRowNum, beginSubBlockIdx, sendVecNum);
+                    copyL0CToDst(tensorCList[ubListId], tensorTileL0C, ubRowNum, beginSubBlockIdx, sendVecNum, copyUnitFlag);
                     AscendC::CrossCoreSetFlag<0x4, PIPE_FIX>(l0C2UBAICAIVFlag + ubListId);
                     AscendC::CrossCoreSetFlag<0x4, PIPE_FIX>(l0C2UBAICAIVFlag + FLAG_ID_MAX + ubListId);
                     rowIdx += curRowNum;
@@ -989,7 +997,7 @@ public:
                     } else if (beginSubBlockIdx == 1) {
                         AscendC::CrossCoreWaitFlag<0x4, PIPE_FIX>(l0C2UBAIVAICFlag + FLAG_ID_MAX + ubListId);
                     }
-                    copyL0CToDst(tensorCList[ubListId], tensorTileL0C, ubRowNum, beginSubBlockIdx, sendVecNum);
+                    copyL0CToDst(tensorCList[ubListId], tensorTileL0C, ubRowNum, beginSubBlockIdx, sendVecNum, copyUnitFlag);
                     if (beginSubBlockIdx == 0) {
                         AscendC::CrossCoreSetFlag<0x4, PIPE_FIX>(l0C2UBAICAIVFlag + ubListId);
                     } else if (beginSubBlockIdx == 1) {

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
@@ -207,8 +207,8 @@ public:
 
             AscendC::GlobalTensor<HElementOutput> hOutputThisTile = hOutput[rowStart * outputStride];
             AscendC::GlobalTensor<HElementInput> hInputThisTile = hInput[rowStart * outputStride];
+            AscendC::GlobalTensor<float> hUpdateInputThisTile = hUpdateInput[rowStart * nActual];
             AscendC::GlobalTensor<FinalStateElement> finalStateThisTile = finalState[rowStart * outputStride];
-            AscendC::LocalTensor<float> hUpdateUbTensorThisTile = hUpdateUbTensor[(rowStart - rowBegin) * nActual];
 
             if (waitHFromV) {
                 AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
@@ -233,20 +233,26 @@ public:
 
             if (waitUpdateFromMte3) {
                 AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
+            } else {
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
             }
-            AscendC::Add<float>(hUpdateUbTensorThisTile, calcUbTensor, hUpdateUbTensorThisTile, rowsThisTile * nActual);
+            CopyGmToUb(hUpdateUbTensor, hUpdateInputThisTile, rowsThisTile, nActual, nActual);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            AscendC::Add<float>(hUpdateUbTensor, calcUbTensor, hUpdateUbTensor, rowsThisTile * nActual);
             AscendC::PipeBarrier<PIPE_V>();
 
             if constexpr(std::is_same<FinalStateElement, float>::value) {
                 if (storeFinalState && isFinalState) {
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
                     AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-                    CopyUbToGm(finalStateThisTile, hUpdateUbTensorThisTile, rowsThisTile, nActual, outputStride);
+                    CopyUbToGm(finalStateThisTile, hUpdateUbTensor, rowsThisTile, nActual, outputStride);
                     AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
                     waitUpdateFromMte3 = true;
                 } else {
-                    AscendC::Cast(hUbTensor, hUpdateUbTensorThisTile, AscendC::RoundMode::CAST_RINT, rowsThisTile * nActual);
+                    AscendC::Cast(hUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, rowsThisTile * nActual);
                     AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
                     AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
                     CopyUbToGm(hOutputThisTile, hUbTensor, rowsThisTile, nActual, outputStride);
@@ -255,14 +261,16 @@ public:
                 }
             } else {
                 if (storeFinalState && isFinalState) {
-                    AscendC::Cast(finalOutputUbTensor, hUpdateUbTensorThisTile, AscendC::RoundMode::CAST_RINT, rowsThisTile * nActual);
+                    AscendC::Cast(finalOutputUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, rowsThisTile * nActual);
                     AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
                     AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
                     CopyUbToGm(finalStateThisTile, finalOutputUbTensor, rowsThisTile, nActual, outputStride);
                 } else {
-                    AscendC::Cast(hUbTensor, hUpdateUbTensorThisTile, AscendC::RoundMode::CAST_RINT, rowsThisTile * nActual);
+                    AscendC::Cast(hUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, rowsThisTile * nActual);
                     AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
                     AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
                     CopyUbToGm(hOutputThisTile, hUbTensor, rowsThisTile, nActual, outputStride);
@@ -270,6 +278,14 @@ public:
                 AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
                 waitUpdateFromMte3 = false;
             }
+        }
+
+        if (storeFinalState && isFinalState && std::is_same<FinalStateElement, float>::value) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
+        } else {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
         }
 
     }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
@@ -136,12 +136,13 @@ public:
         AscendC::GlobalTensor<FinalStateElement> finalState,
         AscendC::GlobalTensor<GElementInput> gInput,
         AscendC::GlobalTensor<HElementInput> hInput,
-        AscendC::GlobalTensor<float> hUpdateInput,
         uint32_t chunkSize,
         uint32_t kHeadDim,
         uint32_t vBlockDim,
         uint32_t vHeadDim,
         Arch::CrossCoreFlag cube2Done,
+        uint64_t l0c2ubFreeFlag,
+        uint64_t l0c2ubReadyFlag,
         bool isInitialState,
         bool isFinalState,
         bool storeFinalState,
@@ -160,8 +161,12 @@ public:
         if (rowEnd > mActual) {
             rowEnd = mActual;
         }
+        uint32_t ubListId = isPing ? 0 : 1;
+        uint64_t l0c2ubFlagOffset = static_cast<uint64_t>(subBlockIdx) * 16;
         if (rowBegin >= mActual) {
+            AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(l0c2ubReadyFlag + l0c2ubFlagOffset + ubListId);
             Arch::CrossCoreWaitFlag(cube2Done);
+            AscendC::CrossCoreSetFlag<0x4, PIPE_V>(l0c2ubFreeFlag + l0c2ubFlagOffset + ubListId);
             return;
         }
 
@@ -195,10 +200,11 @@ public:
         AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
         AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID3 + pingpongFlag);
 
+        AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(l0c2ubReadyFlag + l0c2ubFlagOffset + ubListId);
         Arch::CrossCoreWaitFlag(cube2Done);
 
         bool waitHFromV = storeFinalState && isInitialState && std::is_same<FinalStateElement, float>::value;
-        bool waitUpdateFromMte3 = false;
+        bool waitFinalStateFromMte3 = storeFinalState && isFinalState && std::is_same<FinalStateElement, float>::value;
         for (uint32_t rowStart = rowBegin; rowStart < rowEnd; rowStart += ROW_TILE) {
             uint32_t rowsThisTile = rowEnd - rowStart;
             if (rowsThisTile > ROW_TILE) {
@@ -207,8 +213,9 @@ public:
 
             AscendC::GlobalTensor<HElementOutput> hOutputThisTile = hOutput[rowStart * outputStride];
             AscendC::GlobalTensor<HElementInput> hInputThisTile = hInput[rowStart * outputStride];
-            AscendC::GlobalTensor<float> hUpdateInputThisTile = hUpdateInput[rowStart * nActual];
             AscendC::GlobalTensor<FinalStateElement> finalStateThisTile = finalState[rowStart * outputStride];
+            uint32_t localRowStart = rowStart - rowBegin;
+            AscendC::LocalTensor<float> hUpdateUbTensorThisTile = hUpdateUbTensor[localRowStart * nActual];
 
             if (waitHFromV) {
                 AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
@@ -231,52 +238,42 @@ public:
             AscendC::Muls(calcUbTensor, calcUbTensor, muls, rowsThisTile * nActual);
             AscendC::PipeBarrier<PIPE_V>();
 
-            if (waitUpdateFromMte3) {
-                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
-            } else {
-                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
-            }
-            CopyGmToUb(hUpdateUbTensor, hUpdateInputThisTile, rowsThisTile, nActual, nActual);
-            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
-            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
-            AscendC::Add<float>(hUpdateUbTensor, calcUbTensor, hUpdateUbTensor, rowsThisTile * nActual);
+            AscendC::Add<float>(hUpdateUbTensorThisTile, calcUbTensor, hUpdateUbTensorThisTile, rowsThisTile * nActual);
             AscendC::PipeBarrier<PIPE_V>();
 
             if constexpr(std::is_same<FinalStateElement, float>::value) {
                 if (storeFinalState && isFinalState) {
+                    if (waitFinalStateFromMte3) {
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
+                    }
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
                     AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-                    CopyUbToGm(finalStateThisTile, hUpdateUbTensor, rowsThisTile, nActual, outputStride);
+                    CopyUbToGm(finalStateThisTile, hUpdateUbTensorThisTile, rowsThisTile, nActual, outputStride);
                     AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
-                    waitUpdateFromMte3 = true;
+                    waitFinalStateFromMte3 = true;
                 } else {
-                    AscendC::Cast(hUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, rowsThisTile * nActual);
+                    AscendC::Cast(hUbTensor, hUpdateUbTensorThisTile, AscendC::RoundMode::CAST_RINT, rowsThisTile * nActual);
                     AscendC::PipeBarrier<PIPE_V>();
-                    AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
                     AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
                     CopyUbToGm(hOutputThisTile, hUbTensor, rowsThisTile, nActual, outputStride);
                     AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
-                    waitUpdateFromMte3 = false;
                 }
             } else {
                 if (storeFinalState && isFinalState) {
-                    AscendC::Cast(finalOutputUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, rowsThisTile * nActual);
+                    AscendC::Cast(finalOutputUbTensor, hUpdateUbTensorThisTile, AscendC::RoundMode::CAST_RINT, rowsThisTile * nActual);
                     AscendC::PipeBarrier<PIPE_V>();
-                    AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
                     AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
                     CopyUbToGm(finalStateThisTile, finalOutputUbTensor, rowsThisTile, nActual, outputStride);
                 } else {
-                    AscendC::Cast(hUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, rowsThisTile * nActual);
+                    AscendC::Cast(hUbTensor, hUpdateUbTensorThisTile, AscendC::RoundMode::CAST_RINT, rowsThisTile * nActual);
                     AscendC::PipeBarrier<PIPE_V>();
-                    AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
                     AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2 + pingpongFlag);
                     CopyUbToGm(hOutputThisTile, hUbTensor, rowsThisTile, nActual, outputStride);
                 }
                 AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
-                waitUpdateFromMte3 = false;
             }
         }
 
@@ -287,6 +284,7 @@ public:
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
         }
+        AscendC::CrossCoreSetFlag<0x4, PIPE_V>(l0c2ubFreeFlag + l0c2ubFlagOffset + ubListId);
 
     }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
@@ -246,6 +246,7 @@ public:
 
             AscendC::GlobalTensor<VElementOutput> vnewOutputThisSubBlock = vnewOutput[rowBegin * inputStride];
             AscendC::GlobalTensor<UElementInput> uInputThisSubBlock = uInput[rowBegin * inputStride];
+            AscendC::GlobalTensor<float> wsInputThisSubBlock = wsInput[rowBegin * nvActual];
 
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
             AscendC::DataCopy(uUbTensor, uInputThisSubBlock, mActualThisSubBlock * nvActual);
@@ -258,7 +259,13 @@ public:
 
             if (storeFinalState && isInitialState && std::is_same<FinalStateElement, float>::value) {
                 AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
+            } else {
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
             }
+            AscendC::DataCopy(wsUbTensor, wsInputThisSubBlock, mActualThisSubBlock * nvActual);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+
             AscendC::Sub<float>(wsUbTensor, calcUbTensor, wsUbTensor, mActualThisSubBlock * nvActual);
             AscendC::PipeBarrier<PIPE_V>();
 
@@ -288,7 +295,7 @@ public:
             intriParams.srcGap = 0;
             intriParams.dstGap = mActualPadded - mActualThisSubBlock;
             uint32_t l1Addr = rowBegin * SIZE_16_NUM_PER_C0;
-            AscendC::DataCopy(l1VUpdate[l1Addr], vNewDecayUbTensor, intriParams);
+            AscendC::DataCopy(vnewdecayOutput[l1Addr], vNewDecayUbTensor, intriParams);
             AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1 + pingpongFlag);
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1 + pingpongFlag);
             Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vec1Done);
@@ -296,6 +303,7 @@ public:
             AscendC::Cast(vNewOutputUbTensor, wsUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nvActual);
             AscendC::PipeBarrier<PIPE_V>();
             AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
             AscendC::DataCopy(vnewOutputThisSubBlock, vNewOutputUbTensor, mActualThisSubBlock * nvActual);
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
@@ -322,6 +330,7 @@ public:
 
             AscendC::GlobalTensor<VElementOutput> vnewOutputThisTile = vnewOutput[rowStart * inputStride];
             AscendC::GlobalTensor<UElementInput> uInputThisTile = uInput[rowStart * inputStride];
+            AscendC::GlobalTensor<float> wsInputThisTile = wsInput[rowStart * nvActual];
             AscendC::LocalTensor<float> wsUbTensorThisTile = wsUbTensor[localRowStart * nvActual];
 
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
@@ -333,8 +342,13 @@ public:
 
             if (waitWsFromMte3) {
                 AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
-                waitWsFromMte3 = false;
+            } else {
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
             }
+            CopyGmToUb(wsUbTensorThisTile, wsInputThisTile, rowsThisTile, nvActual, nvActual);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            waitWsFromMte3 = false;
             AscendC::Sub<float>(wsUbTensorThisTile, calcUbTensor, wsUbTensorThisTile, rowsThisTile * nvActual);
             AscendC::PipeBarrier<PIPE_V>();
 
@@ -361,7 +375,7 @@ public:
             intriParams.srcGap = 0;
             intriParams.dstGap = mActualPadded - rowsThisTile;
             uint32_t l1Addr = rowStart * SIZE_16_NUM_PER_C0;
-            AscendC::DataCopy(l1VUpdate[l1Addr], vNewDecayUbTensor, intriParams);
+            AscendC::DataCopy(vnewdecayOutput[l1Addr], vNewDecayUbTensor, intriParams);
             AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1 + pingpongFlag);
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1 + pingpongFlag);
             if (rowStart + rowsThisTile >= rowEnd) {
@@ -371,6 +385,7 @@ public:
             AscendC::Cast(vNewOutputUbTensor, wsUbTensorThisTile, AscendC::RoundMode::CAST_RINT, rowsThisTile * nvActual);
             AscendC::PipeBarrier<PIPE_V>();
             AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
             CopyUbToGm(vnewOutputThisTile, vNewOutputUbTensor, rowsThisTile, nvActual, inputStride);
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
@@ -191,13 +191,14 @@ public:
         AscendC::LocalTensor<VElementUpdate> l1VUpdate,
         AscendC::GlobalTensor<GElementInput> gInput,
         AscendC::GlobalTensor<UElementInput> uInput,
-        AscendC::GlobalTensor<float> wsInput,
         uint32_t chunkSize,
         uint32_t kHeadDim,
         uint32_t vBlockDim,
         uint32_t vHeadDim,
         Arch::CrossCoreFlag cube1Done,
         Arch::CrossCoreFlag vec1Done,
+        uint64_t l0c2ubFreeFlag,
+        uint64_t l0c2ubReadyFlag,
         bool isInitialState,
         bool isFinalState,
         bool storeFinalState,
@@ -217,7 +218,11 @@ public:
         if (rowEnd > mActual) {
             rowEnd = mActual;
         }
+        uint32_t ubListId = isPing ? 0 : 1;
+        uint64_t l0c2ubFlagOffset = static_cast<uint64_t>(subBlockIdx) * 16;
         if (rowBegin >= mActual) {
+            AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(l0c2ubReadyFlag + l0c2ubFlagOffset + ubListId);
+            AscendC::CrossCoreSetFlag<0x4, PIPE_V>(l0c2ubFreeFlag + l0c2ubFlagOffset + ubListId);
             Arch::CrossCoreWaitFlag(cube1Done);
             Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vec1Done);
             return;
@@ -246,7 +251,6 @@ public:
 
             AscendC::GlobalTensor<VElementOutput> vnewOutputThisSubBlock = vnewOutput[rowBegin * inputStride];
             AscendC::GlobalTensor<UElementInput> uInputThisSubBlock = uInput[rowBegin * inputStride];
-            AscendC::GlobalTensor<float> wsInputThisSubBlock = wsInput[rowBegin * nvActual];
 
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
             AscendC::DataCopy(uUbTensor, uInputThisSubBlock, mActualThisSubBlock * nvActual);
@@ -255,17 +259,13 @@ public:
             AscendC::Cast(calcUbTensor, uUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nvActual);
 
             PrepareG(gUbTensor, gLastUbTensor, gInputUbTensor, gInputThisSubBlock, mActual, pingpongFlag);
-            Arch::CrossCoreWaitFlag(cube1Done);
+            AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(l0c2ubReadyFlag + l0c2ubFlagOffset + ubListId);
 
             if (storeFinalState && isInitialState && std::is_same<FinalStateElement, float>::value) {
                 AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
             } else {
                 AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
             }
-            AscendC::DataCopy(wsUbTensor, wsInputThisSubBlock, mActualThisSubBlock * nvActual);
-            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
-            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
-
             AscendC::Sub<float>(wsUbTensor, calcUbTensor, wsUbTensor, mActualThisSubBlock * nvActual);
             AscendC::PipeBarrier<PIPE_V>();
 
@@ -298,7 +298,6 @@ public:
             AscendC::DataCopy(vnewdecayOutput[l1Addr], vNewDecayUbTensor, intriParams);
             AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1 + pingpongFlag);
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1 + pingpongFlag);
-            Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vec1Done);
 
             AscendC::Cast(vNewOutputUbTensor, wsUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nvActual);
             AscendC::PipeBarrier<PIPE_V>();
@@ -307,11 +306,16 @@ public:
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1 + pingpongFlag);
             AscendC::DataCopy(vnewOutputThisSubBlock, vNewOutputUbTensor, mActualThisSubBlock * nvActual);
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
+            Arch::CrossCoreWaitFlag(cube1Done);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
+            AscendC::CrossCoreSetFlag<0x4, PIPE_V>(l0c2ubFreeFlag + l0c2ubFlagOffset + ubListId);
+            Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vec1Done);
             return;
         }
 
         PrepareG(gUbTensor, gLastUbTensor, gInputUbTensor, gInputThisSubBlock, mActual, pingpongFlag);
-        Arch::CrossCoreWaitFlag(cube1Done);
+        AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(l0c2ubReadyFlag + l0c2ubFlagOffset + ubListId);
 
         uint32_t mActualPadded = (mActual + NZ_BLOCK_SIZE - 1) / NZ_BLOCK_SIZE * NZ_BLOCK_SIZE;
         bool waitWsFromMte3 = storeFinalState && isInitialState && std::is_same<FinalStateElement, float>::value;
@@ -330,7 +334,6 @@ public:
 
             AscendC::GlobalTensor<VElementOutput> vnewOutputThisTile = vnewOutput[rowStart * inputStride];
             AscendC::GlobalTensor<UElementInput> uInputThisTile = uInput[rowStart * inputStride];
-            AscendC::GlobalTensor<float> wsInputThisTile = wsInput[rowStart * nvActual];
             AscendC::LocalTensor<float> wsUbTensorThisTile = wsUbTensor[localRowStart * nvActual];
 
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
@@ -345,9 +348,6 @@ public:
             } else {
                 AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
             }
-            CopyGmToUb(wsUbTensorThisTile, wsInputThisTile, rowsThisTile, nvActual, nvActual);
-            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
-            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
             waitWsFromMte3 = false;
             AscendC::Sub<float>(wsUbTensorThisTile, calcUbTensor, wsUbTensorThisTile, rowsThisTile * nvActual);
             AscendC::PipeBarrier<PIPE_V>();
@@ -378,9 +378,6 @@ public:
             AscendC::DataCopy(vnewdecayOutput[l1Addr], vNewDecayUbTensor, intriParams);
             AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1 + pingpongFlag);
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1 + pingpongFlag);
-            if (rowStart + rowsThisTile >= rowEnd) {
-                Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vec1Done);
-            }
 
             AscendC::Cast(vNewOutputUbTensor, wsUbTensorThisTile, AscendC::RoundMode::CAST_RINT, rowsThisTile * nvActual);
             AscendC::PipeBarrier<PIPE_V>();
@@ -392,11 +389,14 @@ public:
             rowStart += rowsThisTile;
         }
 
+        Arch::CrossCoreWaitFlag(cube1Done);
         if (rowBegin < rowEnd) {
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
         }
         AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
+        AscendC::CrossCoreSetFlag<0x4, PIPE_V>(l0c2ubFreeFlag + l0c2ubFlagOffset + ubListId);
+        Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vec1Done);
 
     }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -97,13 +97,13 @@ public:
     using VUpdateType = Gemm::GemmType<INPUT_TYPE, layout::zN>;
 
     // cube 1
-    using TileCopyWH = Catlass::Gemm::Tile::PackedTileCopyTlaToUB<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor, void, Catlass::Gemm::Tile::CopyL0CToUBMode::SPLIT_M>;
+    using TileCopyWH = Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor>;
     using BlockMmadWH = Gemm::Block::BlockMmadTla<DispatchPolicyTlaMulti, L1TileShapeVTla, L0TileShapeVTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyWH>;
 
     // cube 2
-    using TileCopyKV = Catlass::Gemm::Tile::PackedTileCopyTlaToUB<ArchTag, INPUT_TYPE, layout::ColumnMajor, INPUT_TYPE, layout::zN, WORKSPACE_TYPE, layout::RowMajor, void, Catlass::Gemm::Tile::CopyL0CToUBMode::SPLIT_M>;
+    using TileCopyKV = Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, INPUT_TYPE, layout::ColumnMajor, INPUT_TYPE, layout::zN, WORKSPACE_TYPE, layout::RowMajor>;
     using TileMmadKV = Gemm::Tile::TileMmadTla<ArchTag, INPUT_TYPE, typename TileCopyKV::LayoutTagL1A>;
-    using BlockMmadKV = Gemm::Block::BlockMmadTla<DispatchPolicyTlaPreloadAL1B, L1TileShapeVTla, L0TileShapeVTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyKV, TileMmadKV>;
+    using BlockMmadKV = Gemm::Block::BlockMmadTla<DispatchPolicyTlaMulti, L1TileShapeVTla, L0TileShapeVTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyKV>;
 
     // vec 1
     using DispatchPolicyGDNFwdHVnew = Epilogue::EpilogueAtlasGDNFwdHVnew;
@@ -276,16 +276,17 @@ public:
                         auto vLayout = tla::MakeLayout<ElementVWork, LayoutV>(cube1Offsets.blockTokens, cube1Offsets.vBlockDim);
                         int64_t cube1OffsetW = cube1Offsets.wOffset;
                         int64_t cube1OffsetH = cube1Offsets.hSrcOffset;
+                        int64_t cube1OffsetVwork = cube1Offsets.vWorkOffset;
                         auto tensorW = tla::MakeTensor(gmW[cube1OffsetW], wLayout, Catlass::Arch::PositionGM{});
                         auto tensorH = tla::MakeTensor(gmH[cube1OffsetH], hLayout, Catlass::Arch::PositionGM{});
-                        AscendC::LocalTensor<ElementVWork> ubVWork = (i == 0) ? ubVWorkPing : ubVWorkPong;
-                        auto tensorV = tla::MakeTensor(ubVWork, vLayout, Catlass::Arch::PositionUB{});
+                        auto tensorV = tla::MakeTensor(gmVWorkspace[cube1OffsetVwork], vLayout, Catlass::Arch::PositionGM{});
                         GemmCoord cube1Shape {cube1Offsets.blockTokens, cube1Offsets.vBlockDim, kHeadDim};
                         auto tensorBlockW = GetTile(tensorW, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.k()));
                         auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.k(), cube1Shape.n()));
+                        auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.n()));
 
                         blockMmadWH.preSetFlags();
-                        blockMmadWH(tensorBlockW, tensorBlockH, tensorV, cube1Shape);
+                        blockMmadWH(tensorBlockW, tensorBlockH, tensorBlockV, cube1Shape);
                         blockMmadWH.finalWaitFlags();
                         Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done[streamId]);
                     }
@@ -303,17 +304,18 @@ public:
                         if (cubeBlockScheduler.NeedProcessStage2(stream)) {
                             // step 3: h[i+1] = k.T @ v_work
                             int64_t cube2OffsetK = cube2Offsets.wkOffset;
+                            int64_t cube2OffsetVwork = cube2Offsets.vWorkOffset;
                             auto tensorK = tla::MakeTensor(gmK[cube2OffsetK], kLayout, Catlass::Arch::PositionGM{});
                             auto vUpdateLayout = tla::MakeLayout<ElementVUpdate, LayoutVUpdate>(cube2Offsets.blockTokens, cube2Offsets.vBlockDim);
-                            AscendC::LocalTensor<ElementHWork> ubHUpdate = (i == 0) ? ubHUpdatePing : ubHUpdatePong;
-                            auto tensorHwork = tla::MakeTensor(ubHUpdate, hworkLayout, Catlass::Arch::PositionUB{});
-                            AscendC::LocalTensor<ElementV> l1VUpdate = (i == 0) ? l1VUpdatePing : l1VUpdatePong;
-                            auto tensorVwork = tla::MakeTensor(l1VUpdate, vUpdateLayout, Catlass::Arch::PositionL1{});
+                            auto tensorVwork = tla::MakeTensor(gmVUpdateWorkspace[cube2OffsetVwork], vUpdateLayout, Catlass::Arch::PositionGM{});
+                            auto tensorHwork = tla::MakeTensor(gmHWorkspace[cube2Offsets.hWorkOffset], hworkLayout, Catlass::Arch::PositionGM{});
                             GemmCoord cube2Shape{kHeadDim, cube2Offsets.vBlockDim, cube2Offsets.blockTokens};
                             auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.k()));
+                            auto tensorBlockVwork = GetTile(tensorVwork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.k(), cube2Shape.n()));
+                            auto tensorBlockHwork = GetTile(tensorHwork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.n()));
 
                             blockMmadKV.preSetFlags();
-                            blockMmadKV(tensorBlockK, tensorVwork, tensorHwork, cube2Shape);
+                            blockMmadKV(tensorBlockK, tensorBlockVwork, tensorBlockHwork, cube2Shape);
                             blockMmadKV.finalWaitFlags();
                         }
                         Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube2Done[streamId]);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -19,8 +19,7 @@
 #include "../../epilogue/block/block_epilogue_gdn_fwdh_update.hpp"
 #include "../../epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp"
 #include "catlass/gemm/block/block_mmad.hpp"
-#include "kernel_utils/block/block_mmad_pingpong_tla_multi.hpp"
-#include "kernel_utils/block/block_mmad_pingpong_tla_preloadA_l1B.hpp"
+#include "kernel_utils/block/block_mmad_pingpong_tla.hpp"
 #include "catlass/gemm/block/block_swizzle.hpp"
 #include "catlass/gemm/dispatch_policy.hpp"
 #include "catlass/gemm/gemm_type.hpp"
@@ -80,8 +79,7 @@ public:
     using CubeScheduler = typename Catlass::Gemm::Block::BlockSchedulerGdnFwdHCube;
     using VecScheduler = typename Catlass::Gemm::Block::BlockSchedulerGdnFwdHVec;
 
-    using DispatchPolicyTlaMulti = Gemm::MmadPingpongTlaMulti<ArchTag, true, false>;
-    using DispatchPolicyTlaPreloadAL1B = Gemm::MmadPingpongTlaPreloadAL1B<ArchTag, true>;
+    using DispatchPolicyTla = Common::MmadPingpong<ArchTag, false, false>;
     using L1TileShapeVTla = typename TileShapes::L1TileShape;
     using L0TileShapeVTla = typename TileShapes::L0TileShape;
 
@@ -97,13 +95,12 @@ public:
     using VUpdateType = Gemm::GemmType<INPUT_TYPE, layout::zN>;
 
     // cube 1
-    using TileCopyWH = Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor>;
-    using BlockMmadWH = Gemm::Block::BlockMmadTla<DispatchPolicyTlaMulti, L1TileShapeVTla, L0TileShapeVTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyWH>;
+    using TileCopyWH = Common::Tile::PackedTileCopyTlaToUB<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor, void, Catlass::Gemm::Tile::CopyL0CToUBMode::NO_SPLIT>;
+    using BlockMmadWH = Common::BlockMmadTla<DispatchPolicyTla, L1TileShapeVTla, L0TileShapeVTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyWH>;
 
     // cube 2
-    using TileCopyKV = Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, INPUT_TYPE, layout::ColumnMajor, INPUT_TYPE, layout::zN, WORKSPACE_TYPE, layout::RowMajor>;
-    using TileMmadKV = Gemm::Tile::TileMmadTla<ArchTag, INPUT_TYPE, typename TileCopyKV::LayoutTagL1A>;
-    using BlockMmadKV = Gemm::Block::BlockMmadTla<DispatchPolicyTlaMulti, L1TileShapeVTla, L0TileShapeVTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyKV>;
+    using TileCopyKV = Common::Tile::PackedTileCopyTlaToUB<ArchTag, INPUT_TYPE, layout::ColumnMajor, INPUT_TYPE, layout::zN, WORKSPACE_TYPE, layout::RowMajor, void, Catlass::Gemm::Tile::CopyL0CToUBMode::NO_SPLIT>;
+    using BlockMmadKV = Common::BlockMmadTla<DispatchPolicyTla, L1TileShapeVTla, L0TileShapeVTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyKV>;
 
     // vec 1
     using DispatchPolicyGDNFwdHVnew = Epilogue::EpilogueAtlasGDNFwdHVnew;
@@ -126,6 +123,13 @@ public:
     using ElementHWork = WORKSPACE_TYPE;
     using ElementInitialState = STATE_TYPE;
     using ElementFinalState = STATE_TYPE;
+
+    static constexpr uint64_t C1_L0C2UB_FREE_FLAG = 8;
+    static constexpr uint64_t C1_L0C2UB_READY_FLAG = 10;
+    static constexpr uint64_t C2_L0C2UB_FREE_FLAG = 12;
+    static constexpr uint64_t C2_L0C2UB_READY_FLAG = 14;
+    static constexpr uint32_t L0C2UB_UB_NUM = PING_PONG_STAGES;
+    static constexpr uint32_t AIV_SUBBLOCK_NUM = 2;
 
     using LayoutW = Catlass::layout::RowMajor;
     using LayoutH = Catlass::layout::RowMajor;
@@ -246,12 +250,6 @@ public:
         }
 
         if ASCEND_IS_AIC {
-            uint32_t coreIdx = AscendC::GetBlockIdx();
-            uint32_t coreNum = AscendC::GetBlockNum();
-
-            BlockMmadWH blockMmadWH(resource, chunkSize * cubeBlockScheduler.vBlockSize * sizeof(ElementV) * PING_PONG_STAGES);
-            BlockMmadKV blockMmadKV(resource, chunkSize * cubeBlockScheduler.vBlockSize * sizeof(ElementV) * PING_PONG_STAGES);
-
             auto wLayout = tla::MakeLayout<ElementW, LayoutW>(shapeBatch * kNumHead * cubeBlockScheduler.totalTokens, kHeadDim);
             auto hLayout = tla::MakeLayout<ElementH, LayoutH>(shapeBatch * vNumHead * cubeBlockScheduler.totalChunks * kHeadDim, vHeadDim);
 
@@ -263,6 +261,7 @@ public:
             while (cubeBlockScheduler.isRunning) {
                 if (currStage == 0) {
                     /* C1: v_work = w @ h[i] */
+                    BlockMmadWH blockMmadWH(resource, chunkSize * cubeBlockScheduler.vBlockSize * sizeof(ElementV) * PING_PONG_STAGES);
                     cubeBlockScheduler.InitTasks();
                     for (uint32_t i = 0; i < PING_PONG_STAGES; ++i) {
                         uint32_t streamId = cubeBlockScheduler.GetStreamId(i);
@@ -276,22 +275,30 @@ public:
                         auto vLayout = tla::MakeLayout<ElementVWork, LayoutV>(cube1Offsets.blockTokens, cube1Offsets.vBlockDim);
                         int64_t cube1OffsetW = cube1Offsets.wOffset;
                         int64_t cube1OffsetH = cube1Offsets.hSrcOffset;
-                        int64_t cube1OffsetVwork = cube1Offsets.vWorkOffset;
                         auto tensorW = tla::MakeTensor(gmW[cube1OffsetW], wLayout, Catlass::Arch::PositionGM{});
                         auto tensorH = tla::MakeTensor(gmH[cube1OffsetH], hLayout, Catlass::Arch::PositionGM{});
-                        auto tensorV = tla::MakeTensor(gmVWorkspace[cube1OffsetVwork], vLayout, Catlass::Arch::PositionGM{});
+                        uint32_t ubListId = (streamId + cube1Offsets.chunkIdx) % L0C2UB_UB_NUM;
+                        auto tensorVPing = tla::MakeTensor(ubVWorkPing, vLayout, Catlass::Arch::PositionUB{});
+                        auto tensorVPong = tla::MakeTensor(ubVWorkPong, vLayout, Catlass::Arch::PositionUB{});
                         GemmCoord cube1Shape {cube1Offsets.blockTokens, cube1Offsets.vBlockDim, kHeadDim};
                         auto tensorBlockW = GetTile(tensorW, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.k()));
                         auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.k(), cube1Shape.n()));
-                        auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.n()));
+                        auto tensorBlockVPing = GetTile(tensorVPing, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.n()));
+                        auto tensorBlockVPong = GetTile(tensorVPong, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.n()));
+                        using TensorVBlock = decltype(tensorBlockVPing);
+                        TensorVBlock tensorVList[BlockMmadWH::MAX_CUBE_VEC_SYNC_NUM];
+                        tensorVList[0] = tensorBlockVPing;
+                        tensorVList[1] = tensorBlockVPong;
 
-                        blockMmadWH.preSetFlags();
-                        blockMmadWH(tensorBlockW, tensorBlockH, tensorBlockV, cube1Shape);
-                        blockMmadWH.finalWaitFlags();
+                        uint32_t ubRowNum = (cube1Shape.m() + AIV_SUBBLOCK_NUM - 1) / AIV_SUBBLOCK_NUM;
+                        blockMmadWH(tensorBlockW, tensorBlockH, tensorVList, cube1Shape, ubRowNum, 0,
+                            C1_L0C2UB_FREE_FLAG, C1_L0C2UB_READY_FLAG, ubListId, AIV_SUBBLOCK_NUM,
+                            L0C2UB_UB_NUM);
                         Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done[streamId]);
                     }
                 } else {
                     /* C2: h[i+1] = k.T @ v_work */
+                    BlockMmadKV blockMmadKV(resource, chunkSize * cubeBlockScheduler.vBlockSize * sizeof(ElementV) * PING_PONG_STAGES);
                     for (uint32_t i = 0; i < PING_PONG_STAGES; ++i) {
                         uint32_t streamId = cubeBlockScheduler.GetStreamId(i);
                         const auto& stream = cubeBlockScheduler.GetStream(i);
@@ -308,15 +315,35 @@ public:
                             auto tensorK = tla::MakeTensor(gmK[cube2OffsetK], kLayout, Catlass::Arch::PositionGM{});
                             auto vUpdateLayout = tla::MakeLayout<ElementVUpdate, LayoutVUpdate>(cube2Offsets.blockTokens, cube2Offsets.vBlockDim);
                             auto tensorVwork = tla::MakeTensor(gmVUpdateWorkspace[cube2OffsetVwork], vUpdateLayout, Catlass::Arch::PositionGM{});
-                            auto tensorHwork = tla::MakeTensor(gmHWorkspace[cube2Offsets.hWorkOffset], hworkLayout, Catlass::Arch::PositionGM{});
-                            GemmCoord cube2Shape{kHeadDim, cube2Offsets.vBlockDim, cube2Offsets.blockTokens};
-                            auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.k()));
-                            auto tensorBlockVwork = GetTile(tensorVwork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.k(), cube2Shape.n()));
-                            auto tensorBlockHwork = GetTile(tensorHwork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.n()));
+                            auto tensorHUpdatePing = tla::MakeTensor(ubHUpdatePing, hworkLayout, Catlass::Arch::PositionUB{});
+                            auto tensorHUpdatePong = tla::MakeTensor(ubHUpdatePong, hworkLayout, Catlass::Arch::PositionUB{});
+                            GemmCoord cube2Shape { kHeadDim, cube2Offsets.vBlockDim, cube2Offsets.blockTokens };
+                            auto tensorBlockK = GetTile(
+                                tensorK,
+                                tla::MakeCoord(0, 0),
+                                tla::MakeShape(cube2Shape.m(), cube2Shape.k()));
+                            auto tensorBlockVwork = GetTile(
+                                tensorVwork,
+                                tla::MakeCoord(0, 0),
+                                tla::MakeShape(cube2Shape.k(), cube2Shape.n()));
+                            auto tensorBlockHUpdatePing = GetTile(
+                                tensorHUpdatePing,
+                                tla::MakeCoord(0, 0),
+                                tla::MakeShape(cube2Shape.m(), cube2Shape.n()));
+                            auto tensorBlockHUpdatePong = GetTile(
+                                tensorHUpdatePong,
+                                tla::MakeCoord(0, 0),
+                                tla::MakeShape(cube2Shape.m(), cube2Shape.n()));
+                            using TensorHUpdateBlock = decltype(tensorBlockHUpdatePing);
+                            TensorHUpdateBlock tensorHUpdateList[BlockMmadKV::MAX_CUBE_VEC_SYNC_NUM];
+                            tensorHUpdateList[0] = tensorBlockHUpdatePing;
+                            tensorHUpdateList[1] = tensorBlockHUpdatePong;
 
-                            blockMmadKV.preSetFlags();
-                            blockMmadKV(tensorBlockK, tensorBlockVwork, tensorBlockHwork, cube2Shape);
-                            blockMmadKV.finalWaitFlags();
+                            uint32_t ubListId = (streamId + cube2Offsets.chunkIdx) % L0C2UB_UB_NUM;
+                            uint32_t ubRowNum = (cube2Shape.m() + AIV_SUBBLOCK_NUM - 1) / AIV_SUBBLOCK_NUM;
+                            blockMmadKV(tensorBlockK, tensorBlockVwork, tensorHUpdateList, cube2Shape, ubRowNum, 0,
+                                C2_L0C2UB_FREE_FLAG, C2_L0C2UB_READY_FLAG, ubListId, AIV_SUBBLOCK_NUM,
+                                L0C2UB_UB_NUM);
                         }
                         Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube2Done[streamId]);
                     }
@@ -437,6 +464,11 @@ public:
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pongBaseEvent);
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3); // preset g
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pongBaseEvent);
+            uint64_t l0c2ubFlagOffset = static_cast<uint64_t>(AscendC::GetSubBlockIdx()) * BlockMmadWH::FLAG_ID_MAX;
+            for (uint32_t i = 0; i < L0C2UB_UB_NUM; ++i) {
+                AscendC::CrossCoreSetFlag<0x4, PIPE_V>(C1_L0C2UB_FREE_FLAG + l0c2ubFlagOffset + i);
+                AscendC::CrossCoreSetFlag<0x4, PIPE_V>(C2_L0C2UB_FREE_FLAG + l0c2ubFlagOffset + i);
+            }
 
             uint32_t currStage = 0; // 0: V1, 1: V2
             while (vecBlockScheduler.isRunning) {
@@ -455,13 +487,15 @@ public:
                             continue;
                         }
                         const GDNFwdHOffsets& vec1Offsets = vecBlockScheduler.GetCurTaskOffsets(stream);
-                        AscendC::LocalTensor<ElementV> l1VUpdate = (i == 0) ? l1VUpdatePing : l1VUpdatePong;
+                        uint32_t ubListId = (streamId + vec1Offsets.chunkIdx) % L0C2UB_UB_NUM;
+                        AscendC::LocalTensor<ElementV> l1VUpdate = (ubListId == 0) ? l1VUpdatePing : l1VUpdatePong;
                         epilogueGDNFwdHVnew(
                             gmV[vec1Offsets.uvOffset], gmVUpdateWorkspace[vec1Offsets.vWorkOffset], l1VUpdate,
-                            gmG[vec1Offsets.gOffset], gmU[vec1Offsets.uvOffset], gmVWorkspace[vec1Offsets.vWorkOffset],
+                            gmG[vec1Offsets.gOffset], gmU[vec1Offsets.uvOffset],
                             vec1Offsets.blockTokens, kHeadDim, vec1Offsets.vBlockDim, vHeadDim,
                             vecBlockScheduler.cube1Done[streamId], vecBlockScheduler.vec1Done[streamId],
-                            vec1Offsets.isInitialState, vec1Offsets.isFinalState, storeFinalState, (i == 0)
+                            C1_L0C2UB_FREE_FLAG, C1_L0C2UB_READY_FLAG,
+                            vec1Offsets.isInitialState, vec1Offsets.isFinalState, storeFinalState, (ubListId == 0)
                         );
                     }
                 } else {
@@ -473,6 +507,7 @@ public:
                             continue;
                         }
                         const GDNFwdHOffsets& vec2Offsets = vecBlockScheduler.GetCurTaskOffsets(stream);
+                        uint32_t ubListId = (streamId + vec2Offsets.chunkIdx) % L0C2UB_UB_NUM;
 
                         if (vecBlockScheduler.NeedProcessStage2(stream)) {
                             // step 4:  h[i+1] += h_work if i < num_chunks - 1 else None
@@ -480,9 +515,9 @@ public:
                                 gmH[vec2Offsets.hDstOffset], gmFinalState[vec2Offsets.finalStateOffset],
                                 gmG[vec2Offsets.gOffset],
                                 gmH[vec2Offsets.hSrcOffset],
-                                gmHWorkspace[vec2Offsets.hWorkOffset],
                                 vec2Offsets.blockTokens, kHeadDim, vec2Offsets.vBlockDim, vHeadDim, vecBlockScheduler.cube2Done[streamId],
-                                vec2Offsets.isInitialState, vec2Offsets.isFinalState, storeFinalState, (i == 0)
+                                C2_L0C2UB_FREE_FLAG, C2_L0C2UB_READY_FLAG,
+                                vec2Offsets.isInitialState, vec2Offsets.isFinalState, storeFinalState, (ubListId == 0)
                             );
                         } else {
                             Arch::CrossCoreWaitFlag(vecBlockScheduler.cube2Done[streamId]);

--- a/fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/op_host/solve_tri_def.cpp
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/op_host/solve_tri_def.cpp
@@ -49,8 +49,8 @@
  
         this->AICore().AddConfig("ascend910b", aicore_config);
         this->AICore().AddConfig("ascend910_93", aicore_config);
+        this->AICore().AddConfig("ascend950", aicore_config);
     }
 };
  OP_ADD(SolveTri);
  }  // namespace ops
- 

--- a/fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/op_kernel/solve_tri.cpp
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/op_kernel/solve_tri.cpp
@@ -71,42 +71,41 @@
                  // fp16
                  if (ms == 16) {
                      NsSolveTri::SolveTriVector<16, half> op;
-                     op.Init(workspace, totalTiles, ms);
+                     op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
                      op.Process();
                  } else if (ms == 32) {
                      NsSolveTri::SolveTriVector<32, half> op;
-                     op.Init(workspace, totalTiles, ms);
+                     op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
                      op.Process();
                  } else if (ms == 64) {
                      NsSolveTri::SolveTriVector<64, half> op;
-                     op.Init(workspace, totalTiles, ms);
+                     op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
                      op.Process();
                  } else if (ms == 128) {
                      NsSolveTri::SolveTriVector<128, half> op;
-                     op.Init(workspace, totalTiles, ms);
+                     op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
                      op.Process();
                  }
              } else {
                  // bf16
                  if (ms == 16) {
                      NsSolveTri::SolveTriVector<16, bfloat16_t> op;
-                     op.Init(workspace, totalTiles, ms);
+                     op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
                      op.Process();
                  } else if (ms == 32) {
                      NsSolveTri::SolveTriVector<32, bfloat16_t> op;
-                     op.Init(workspace, totalTiles, ms);
+                     op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
                      op.Process();
                  } else if (ms == 64) {
                      NsSolveTri::SolveTriVector<64, bfloat16_t> op;
-                     op.Init(workspace, totalTiles, ms);
+                     op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
                      op.Process();
                  } else if (ms == 128) {
                      NsSolveTri::SolveTriVector<128, bfloat16_t> op;
-                     op.Init(workspace, totalTiles, ms);
+                     op.Init(x, cu_seqlens, chunk_indices, x_out, workspace, &tilingData);
                      op.Process();
                  }
              }
          }
      }
  }
- 

--- a/fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/op_kernel/solve_tri_cube.h
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/op_kernel/solve_tri_cube.h
@@ -7,7 +7,6 @@
  */
  #ifndef SOLVE_TRI_CUBE_H
  #define SOLVE_TRI_CUBE_H
- 
  #include "kernel_operator.h"
  #include "lib/matmul_intf.h"
  #include "catlass/arch/cross_core_sync.hpp"
@@ -90,6 +89,7 @@ class SolveTriCube {
  
 private:
    __aicore__ inline void ProcessOneTile(int64_t tileIdx);
+   __aicore__ inline void ProcessOriginalTile(int64_t gmOffset, int64_t validSize);
    __aicore__ inline int64_t GetTileGMOffset(int64_t tileIdx);
    __aicore__ inline int64_t GetTileValidSize(int64_t tileIdx);
    __aicore__ inline void PrepareConstants();
@@ -204,7 +204,11 @@ __aicore__ inline void SolveTriCube<MATRIX_SIZE, T>::Init(
     // AIC 的核索引
     aicIdx_ = GetBlockIdx();
 
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+     inputGM_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(x_out));
+#else
      inputGM_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(x));
+#endif
      outputGM_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(x_out));
      workspaceGM_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(workspace));
 
@@ -370,13 +374,19 @@ __aicore__ inline void SolveTriCube<MATRIX_SIZE, T>::ProcessOneTile(int64_t tile
     int64_t gmOffset = GetTileGMOffset(tileIdx);
     int64_t validSize = GetTileValidSize(tileIdx);
 
+    ProcessOriginalTile(gmOffset, validSize);
+}
+
+template <int MATRIX_SIZE, typename T>
+__aicore__ inline void SolveTriCube<MATRIX_SIZE, T>::ProcessOriginalTile(int64_t gmOffset, int64_t validSize)
+{
     if (validSize < matrixSize_) {
         // 非对齐尾块：特殊路径
         ProcessPartialTile(gmOffset, validSize);
     } else {
         // 正常 chunk：原有逻辑
         LoadInputTile(gmOffset);
-        
+
         MCHInvertDiagonal(gmOffset);
 
         if constexpr (MATRIX_SIZE > FRAC) {
@@ -391,7 +401,7 @@ __aicore__ inline void SolveTriCube<MATRIX_SIZE, T>::ProcessOneTile(int64_t tile
         StoreFinalResult(gmOffset);
     }
 }
- 
+
  // Load slotA->L0A(A2), slotB->L0B(B2), Mmad, result in L0C(CO1)
  // L1(NZ): 分形内行主序(小Z)，分形间列主序(大N) -> (0,0),(1,0),(0,1),(1,1)
  // L0A(ZZ): 分形内行主序(小Z)，分形间行主序(大Z) -> (0,0),(0,1),(1,0),(1,1)
@@ -1038,4 +1048,3 @@ __aicore__ inline void SolveTriCube<MATRIX_SIZE, T>::ProcessPartialTile(int64_t 
 }  // namespace NsSolveTri
 
 #endif  // SOLVE_TRI_CUBE_H
- 

--- a/fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/op_kernel/solve_tri_vector.h
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/op_kernel/solve_tri_vector.h
@@ -29,33 +29,61 @@ class SolveTriVector {
  public:
      __aicore__ inline SolveTriVector() {}
      
-     __aicore__ inline void Init(GM_ADDR workspace,
-                                  int64_t totalTiles,
-                                  int64_t matrixSize);
+     __aicore__ inline void Init(GM_ADDR x, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
+                                  GM_ADDR x_out, GM_ADDR workspace,
+                                  const SolveTriTilingData* tilingData);
      __aicore__ inline void Process();
  
  private:
      __aicore__ inline void GenerateAuxMatrices();
+     __aicore__ inline void MaskInputToOutput();
+     __aicore__ inline int64_t GetTileGMOffset(int64_t tileIdx);
+     __aicore__ inline int64_t GetTileValidSize(int64_t tileIdx);
  
      TPipe pipe_;
+    GlobalTensor<T> inputGM_;
+    GlobalTensor<T> outputGM_;
     GlobalTensor<T> workspaceGM_;
+    GlobalTensor<int64_t> cuSeqlensGM_;
+    GlobalTensor<int64_t> chunkIndicesGM_;
     TBuf<TPosition::VECCALC> ubBuf_;
     LocalTensor<T> ub_;
  
      int64_t totalTiles_;
      int64_t matrixSize_;
+     int64_t numHeads_;
+     int64_t seqLen_;
+     int64_t numChunks_;
+     int64_t lastChunkValidSize_;
+     int64_t rowStride_;
+     int64_t layoutMode_;
+     int64_t isVarlen_;
  
      Catlass::Arch::CrossCoreFlagWithReverse<> flagAivFinish_{SYNC_AIV_AIC_FLAG_SOLVE, SYNC_AIC_AIV_FLAG_SOLVE};
  };
  
 template <int MATRIX_SIZE, typename T>
 __aicore__ inline void SolveTriVector<MATRIX_SIZE, T>::Init(
-    GM_ADDR workspace, int64_t totalTiles, int64_t matrixSize)
+    GM_ADDR x, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
+    GM_ADDR x_out, GM_ADDR workspace, const SolveTriTilingData* tilingData)
 {
-    totalTiles_ = totalTiles;
-    matrixSize_ = matrixSize;
+    totalTiles_ = tilingData->totalTiles;
+    matrixSize_ = tilingData->matrixSize;
+    numHeads_ = tilingData->numHeads;
+    seqLen_ = tilingData->seqLen;
+    numChunks_ = tilingData->numChunks;
+    lastChunkValidSize_ = tilingData->lastChunkValidSize;
+    layoutMode_ = tilingData->layoutMode;
+    isVarlen_ = tilingData->isVarlen;
+    rowStride_ = (layoutMode_ == 0) ? matrixSize_ : numHeads_ * matrixSize_;
 
+    inputGM_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(x));
+    outputGM_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(x_out));
     workspaceGM_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(workspace));
+    if (isVarlen_) {
+        cuSeqlensGM_.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t*>(cu_seqlens));
+        chunkIndicesGM_.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t*>(chunk_indices));
+    }
 
     pipe_.InitBuffer(ubBuf_, UB_AIV_ELEMS * sizeof(T));
     ub_ = ubBuf_.Get<T>();
@@ -66,6 +94,13 @@ __aicore__ inline void SolveTriVector<MATRIX_SIZE, T>::Process()
  {
      int32_t subIdx = static_cast<int32_t>(GetSubBlockIdx());
      int32_t blockIdx = static_cast<int32_t>(GetBlockIdx());
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+     if (subIdx == 0 && blockIdx == 0) {
+         GenerateAuxMatrices();
+     }
+     MaskInputToOutput();
+     SyncAll<false>();
+#else
      // 只让核组 0 的 AIV 子核 0 生成辅助矩阵，其他核直接参与全核同步
      if (subIdx != 0 || blockIdx != 0) {
          SyncAll<false>();
@@ -75,7 +110,99 @@ __aicore__ inline void SolveTriVector<MATRIX_SIZE, T>::Process()
      GenerateAuxMatrices();
  
      SyncAll<false>();
+#endif
  }
+
+template <int MATRIX_SIZE, typename T>
+__aicore__ inline int64_t SolveTriVector<MATRIX_SIZE, T>::GetTileGMOffset(int64_t tileIdx)
+{
+    int64_t H = numHeads_;
+    int64_t BT = matrixSize_;
+    if (layoutMode_ == 2) {
+        int64_t chunkGlobalIdx = tileIdx / H;
+        int64_t h = tileIdx % H;
+        int64_t seqIdx = chunkIndicesGM_.GetValue(chunkGlobalIdx * 2);
+        int64_t chunkInSeq = chunkIndicesGM_.GetValue(chunkGlobalIdx * 2 + 1);
+        int64_t bos = cuSeqlensGM_.GetValue(seqIdx);
+        return (bos + chunkInSeq * BT) * H * BT + h * BT;
+    }
+    if (layoutMode_ == 1) {
+        int64_t h = tileIdx % H;
+        int64_t chunk = (tileIdx / H) % numChunks_;
+        int64_t b = tileIdx / (H * numChunks_);
+        return b * seqLen_ * H * BT + chunk * BT * H * BT + h * BT;
+    }
+    int64_t chunk = tileIdx % numChunks_;
+    int64_t h = (tileIdx / numChunks_) % H;
+    int64_t b = tileIdx / (numChunks_ * H);
+    return b * H * seqLen_ * BT + h * seqLen_ * BT + chunk * BT * BT;
+}
+
+template <int MATRIX_SIZE, typename T>
+__aicore__ inline int64_t SolveTriVector<MATRIX_SIZE, T>::GetTileValidSize(int64_t tileIdx)
+{
+    if (layoutMode_ == 2) {
+        int64_t H = numHeads_;
+        int64_t BT = matrixSize_;
+        int64_t chunkGlobalIdx = tileIdx / H;
+        int64_t seqIdx = chunkIndicesGM_.GetValue(chunkGlobalIdx * 2);
+        int64_t chunkInSeq = chunkIndicesGM_.GetValue(chunkGlobalIdx * 2 + 1);
+        int64_t bos = cuSeqlensGM_.GetValue(seqIdx);
+        int64_t eos = cuSeqlensGM_.GetValue(seqIdx + 1);
+        int64_t remaining = (eos - bos) - chunkInSeq * BT;
+        return (remaining >= BT) ? BT : remaining;
+    }
+    int64_t chunk = (layoutMode_ == 1) ? ((tileIdx / numHeads_) % numChunks_) : (tileIdx % numChunks_);
+    return (chunk == numChunks_ - 1) ? lastChunkValidSize_ : matrixSize_;
+}
+
+template <int MATRIX_SIZE, typename T>
+__aicore__ inline void SolveTriVector<MATRIX_SIZE, T>::MaskInputToOutput()
+{
+    int64_t workerIdx = static_cast<int64_t>(GetBlockIdx()) * static_cast<int64_t>(GetSubBlockNum()) +
+                        static_cast<int64_t>(GetSubBlockIdx());
+    int64_t workerNum = static_cast<int64_t>(GetBlockNum()) * static_cast<int64_t>(GetSubBlockNum());
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    if (workerIdx != 0) {
+        return;
+    }
+    workerNum = 1;
+#endif
+    int64_t totalRows = totalTiles_ * MATRIX_SIZE;
+
+    for (int64_t rowTask = workerIdx; rowTask < totalRows; rowTask += workerNum) {
+        int64_t tileIdx = rowTask / MATRIX_SIZE;
+        int64_t row = rowTask - tileIdx * MATRIX_SIZE;
+        int64_t validSize = GetTileValidSize(tileIdx);
+        int64_t gmOffset = GetTileGMOffset(tileIdx);
+
+        Duplicate(ub_, T(0.0f), MATRIX_SIZE);
+        SetFlag<HardEvent::V_MTE2>(0);
+        WaitFlag<HardEvent::V_MTE2>(0);
+
+        if (row < validSize) {
+            DataCopy(ub_, inputGM_[gmOffset + row * rowStride_], MATRIX_SIZE);
+            SetFlag<HardEvent::MTE2_V>(0);
+            WaitFlag<HardEvent::MTE2_V>(0);
+
+            uint64_t upperMask[2] = {0, 0};
+            if (row < 64) {
+                upperMask[0] = 0xffffffffffffffffULL << row;
+                upperMask[1] = (MATRIX_SIZE > 64) ? 0xffffffffffffffffULL : 0;
+            } else {
+                upperMask[1] = 0xffffffffffffffffULL << (row - 64);
+            }
+            Duplicate(ub_, T(0.0f), upperMask, 1, 1, 8);
+            PipeBarrier<PIPE_V>();
+        }
+
+        SetFlag<HardEvent::V_MTE3>(0);
+        WaitFlag<HardEvent::V_MTE3>(0);
+        DataCopy(outputGM_[gmOffset + row * rowStride_], ub_, MATRIX_SIZE);
+        SetFlag<HardEvent::MTE3_V>(0);
+        WaitFlag<HardEvent::MTE3_V>(0);
+    }
+}
  
 template <int MATRIX_SIZE, typename T>
 __aicore__ inline void SolveTriVector<MATRIX_SIZE, T>::GenerateAuxMatrices()
@@ -133,4 +260,3 @@ __aicore__ inline void SolveTriVector<MATRIX_SIZE, T>::GenerateAuxMatrices()
  }  // namespace NsSolveTri
  
  #endif  // SOLVE_TRI_VECTOR_H
- 


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: Fixes #188
- 背景与目标: 修复 A5 上 GDN BSND fixed-length 原问题场景反向出现 non-finite 的问题。
- 本 PR 解决的问题: 修复 A5 solve_tri 注册和输入语义处理问题，并保留 fwd_h arch35 workspace/同步生命周期修复，避免 non-finite 传递到反向梯度。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
  - solve_tri
  - chunk_gated_delta_rule_fwd_h
- 涉及目录 / 文件:
  - `fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/op_host/solve_tri_def.cpp`
  - `fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/op_kernel/solve_tri.cpp`
  - `fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/op_kernel/solve_tri_cube.h`
  - `fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/op_kernel/solve_tri_vector.h`
  - `fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/kernel/gdn_fwd_h_kernel.hpp`
  - `fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp`
  - `fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_update.hpp`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [x] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [x] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 聚焦 A5/arch35、GDN BSND fixed-length 原问题场景，B=4，Hk=Hv=32，T=8192，Kdim=Vdim=128，bf16，chunk_size=64；同时补充验证 TND/varlen 原调用链。不改变公开 API、torch schema、tiling schema 或 dtype/layout 公开约束。
- 明确不包含的范围: 不调整 aclnn/torch 接口、tiling schema 和文档约束；不修改非 arch35 fwd_h 路径；A2/A3 回归由 CI 补充。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 不涉及 aclnn/torch ABI 变更；solve_tri 仅补充 A5 目标配置。

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未记录 | `bash build.sh --pkg --soc=ascend910b --ops=solve_tri,chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu` | 未执行 | 待 CI 或维护者补充 |
| A3 | `ascend910_93` | 未记录 | `bash build.sh --pkg --soc=ascend910_93 --ops=solve_tri,chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu` | 未执行 | 待 CI 或维护者补充 |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未记录 | `bash build.sh --pkg --soc=ascend910b --ops=solve_tri,chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu` | 未执行 | 待 CI 或维护者补充 |
| A3 | `ascend910_93` | 未记录 | `bash build.sh --pkg --soc=ascend910_93 --ops=solve_tri,chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu` | 未执行 | 待 CI 或维护者补充 |
| A5 | `ascend950` | CANN 9.x | `FLA_NPU_SOC=ascend950 python -m pip wheel --no-build-isolation --no-deps . -w dist`；安装 wheel 后执行 `python scripts/check_packaged_wheel_api.py` | 通过 | wheel 构建、安装和 packaged API check 通过 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | 未执行 | 待 CI 或维护者补充 |
| A3 | `ascend910_93` | 未执行 | 未执行 | 待 CI 或维护者补充 |
| A5 | `ascend950` | solve_tri TND 检查；GDN BSND staged probe | 通过 | solve_tri 输出 finite；BSND 链路各阶段输出 finite，无 first non-finite |

- 精度对比: 本 PR 重点验证 non-finite 修复；原问题端到端场景 forward/backward 均 finite。
- 性能对比: 未执行专项性能测试。
- 边界 / 异常场景: A5 上补充验证 TND/varlen 原调用链；BSND staged probe 覆盖 solve_tri、fwd_h/v_new、o 和反向梯度 finite 状态。
- 未覆盖风险: A2/A3 编译和完整回归未在本次手工验证覆盖，需 CI 补充。

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 CI 或维护者补充 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 CI 或维护者补充 |
| A5 | `ascend950` | `python examples/flash_gated_delta_rule.py --batch 4 --heads 32 --tokens 8192 --dim 128 --value-dim 128 --chunk-size 64 --dtype bf16 --no-varlen --gate-function logsigmoid --initial-state none` | 通过 | BSND fixed-length 原问题用例：forward 输出 finite；backward 完成；q/k/v/g/beta 梯度均 finite |
| A5 | `ascend950` | `python examples/flash_gated_delta_rule.py --batch 1 --heads 32 --tokens 8192 --dim 128 --value-dim 128 --chunk-size 64 --dtype bf16 --varlen --gate-function logsigmoid --initial-state none` | 通过 | TND/varlen 原调用链：forward 输出 finite；backward 完成；q/k/v/g/beta 梯度均 finite |

- 端到端场景说明: BSND fixed-length 覆盖原问题 shape；TND/varlen 覆盖同一 GDN 原调用链的变长布局路径。
- 与本 PR 修改算子的关联: 覆盖 solve_tri、fwd_h 以及 GDN 反向链路。
- 未覆盖原因及补充计划: A2/A3 和完整 CI 由后续 NPU CI 补齐。

</details>

## 兼容性、风险与回退

- 兼容性说明: 不修改公开 API、shape/dtype/layout 校验、aclnn/torch schema。solve_tri 仅补充 ascend950 目标配置并在 A5 kernel 内处理输入语义；fwd_h 变更限定在 arch35 实现。
- 风险点: A5 solve_tri 的 AIV 输入预处理当前以正确性为优先，后续可继续优化 AIV 并行分片；A2/A3 需由 CI 补充回归。
- 回退方案: 回退本 PR 提交即可恢复原 kernel 路径。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

根因定位摘要：

- solve_tri 原 op_host 未注册 `ascend950`，A5 目标 kernel 没有被正确纳入构建/加载。
- 注册 `ascend950` 后，A5 cube 路径暴露真实问题：输入 raw A 的上三角/对角区域不具备 solve_tri 有效语义，原 cube 路径直接读取 raw A，导致 MCH/MBH 中间计算被无效值污染并出现 non-finite。
- 修复方式是在 A5 kernel 内由 AIV 按 tile/row 写出严格下三角输入，再让 AIC cube 求解路径消费该输入；这是 kernel 内语义修复，不是 Python fallback 或绕开算子。
- fwd_h arch35 的 C1/V1、C2/V2 交接补齐 GM workspace 生命周期和写回同步，避免后续链路传播 non-finite。
