### PR TITLE
feat(example): use AscendC chunk_local_cumsum and chunk_scaled_dot_kkt

### DIFF
--- a/examples/flash_gated_delta_rule.py
+++ b/examples/flash_gated_delta_rule.py
@@ -34,6 +34,7 @@ from fla_npu.ops.ascendc import (
     prepare_wy_repr_bwd_da as ascendc_prepare_wy_repr_bwd_da,
     prepare_wy_repr_bwd_full as ascendc_prepare_wy_repr_bwd_full,
     recompute_w_u_fwd as ascendc_recompute_w_u_fwd,
+    npu_chunk_scaled_dot_kkt as ascendc_chunk_scaled_dot_kkt,
     solve_tri as ascendc_solve_tri,
 )
 from fla_npu.ops.triton import (
@@ -458,9 +459,124 @@ def _as_chunk_list_dict(
     return {str(chunk_size): _as_int_list(value)}
 
 
+def _next_power_of_2(value: int) -> int:
+    value = max(value, 1)
+    return 1 << (value - 1).bit_length()
+
+
 def _cumsum_block_t(g: torch.Tensor, chunk_size: int) -> int:
-    # Keep this aligned with fla_npu.ops.triton.chunk_local_cumsum_scalar.
-    return int(chunk_size)
+    # AscendC chunk_local_cumsum consumes [B, T, H] gates as [B, H, T] (tail=1).
+    del g
+    return _next_power_of_2((1 << 17) // int(chunk_size))
+
+
+def _chunk_tensor_for_block_t(
+    chunk_indices: Optional[Dict[str, Optional[torch.LongTensor]] | torch.LongTensor],
+    block_t: int,
+) -> Optional[torch.LongTensor]:
+    if chunk_indices is None:
+        return None
+    if isinstance(chunk_indices, dict):
+        return chunk_indices.get(str(block_t))
+    return chunk_indices
+
+
+def _has_npu_op(name: str) -> bool:
+    return hasattr(torch.ops.npu, name)
+
+
+def _chunk_local_cumsum_ascendc(
+    g: torch.Tensor,
+    chunk_size: int,
+    reverse: bool = False,
+    scale: Optional[float] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    chunk_indices_out: Optional[Dict[str, Optional[torch.LongTensor]] | torch.LongTensor] = None,
+) -> torch.Tensor:
+    if g.ndim != 3:
+        raise ValueError(f"npu_chunk_local_cumsum wrapper expects [B, T, H], got {tuple(g.shape)}.")
+
+    block_t = _cumsum_block_t(g, chunk_size)
+    chunk_indices_tensor = _chunk_tensor_for_block_t(chunk_indices_out, block_t)
+    if cu_seqlens is not None and chunk_indices_tensor is None:
+        chunk_indices_tensor = prepare_chunk_indices(cu_seqlens, block_t)
+
+    out = torch.ops.npu.npu_chunk_local_cumsum(
+        g.transpose(1, 2).contiguous().float(),
+        chunk_size,
+        cu_seqlens=cu_seqlens,
+        chunk_indices_out=chunk_indices_tensor,
+        reverse=reverse,
+        scale=1.0 if scale is None else float(scale),
+        head_first=True,
+        output_dtype="float32",
+    )
+    return out.transpose(1, 2).contiguous()
+
+
+def _chunk_scaled_dot_kkt_ascendc(
+    k: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    chunk_size: int,
+) -> torch.Tensor:
+    # AscendC op uses head-first [B, H, T, K] / [B, H, T]; example keeps [B, T, H] / [B, T, H, BT].
+    g_hf = g.transpose(1, 2).contiguous().float()
+    beta_hf = beta.transpose(1, 2).contiguous().float()
+    a_hf = ascendc_chunk_scaled_dot_kkt(k, g_hf, beta_hf, chunk_size=chunk_size)
+    return a_hf.transpose(1, 2).contiguous()
+
+
+def chunk_local_cumsum_auto(
+    g: torch.Tensor,
+    chunk_size: int,
+    reverse: bool = False,
+    scale: Optional[float] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    chunk_indices_out: Optional[Dict[str, Optional[torch.LongTensor]] | torch.LongTensor] = None,
+) -> torch.Tensor:
+    if _has_npu_op("npu_chunk_local_cumsum"):
+        return _chunk_local_cumsum_ascendc(
+            g,
+            chunk_size=chunk_size,
+            reverse=reverse,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_indices_out=chunk_indices_out,
+        )
+    return chunk_local_cumsum(
+        g,
+        chunk_size=chunk_size,
+        reverse=reverse,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices_out=chunk_indices_out,
+        head_first=False,
+    )
+
+
+def chunk_scaled_dot_kkt_auto(
+    k: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    chunk_indices: Optional[torch.LongTensor] = None,
+    chunk_size: int = 64,
+    output_dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    if cu_seqlens is None and _has_npu_op("npu_chunk_scaled_dot_kkt"):
+        return _chunk_scaled_dot_kkt_ascendc(k, g, beta, chunk_size=chunk_size)
+    return chunk_scaled_dot_kkt_fwd(
+        k=k,
+        g=g,
+        beta=beta,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+        output_dtype=output_dtype,
+    )
 
 
 def _ensure_varlen_metadata(
@@ -559,16 +675,15 @@ def flash_chunk_gated_delta_rule_fwd(
     chunk_indices_list: Optional[Dict[str, Optional[list[int]]]] = None,
     chunk_size: int = 64,
 ):
-    g = chunk_local_cumsum(
+    g = chunk_local_cumsum_auto(
         g,
         chunk_size=chunk_size,
         cu_seqlens=cu_seqlens,
         chunk_indices_out=chunk_indices,
-        head_first=False,
     )
 
     # A is the WY lower-triangular representation before inversion.
-    A = chunk_scaled_dot_kkt_fwd(
+    A = chunk_scaled_dot_kkt_auto(
         k=k,
         g=g,
         beta=beta,
@@ -775,13 +890,12 @@ def flash_chunk_gated_delta_rule_bwd(
     if dg.dtype != torch.float32:
         raise ValueError(f"dg current type is {dg.dtype}, should be float32")
 
-    dg = chunk_local_cumsum(
+    dg = chunk_local_cumsum_auto(
         dg,
         chunk_size=chunk_size,
         reverse=True,
         cu_seqlens=cu_seqlens,
         chunk_indices_out=chunk_indices,
-        head_first=False,
     )
 
     return dq, dk, dv, db, dg, dh0


### PR DESCRIPTION
## Summary

Switch `examples/flash_gated_delta_rule.py` to the hand-written AscendC ops for GDN preprocess:

- `npu_chunk_local_cumsum` replaces Triton `chunk_local_cumsum` in forward/backward.
- `npu_chunk_scaled_dot_kkt` replaces Triton `chunk_scaled_dot_kkt_fwd` for fixed-length BSND paths.

Layout handling:
- Example keeps `g`/`beta` in `[B, T, H]`; AscendC expects head-first `[B, H, T]`, so wrappers transpose in/out.
- AscendC `A` is `[B, H, T, BT]` and is transposed back to the example's `[B, T, H, BT]` before `solve_tri`.

Fallbacks:
- Triton `chunk_scaled_dot_kkt_fwd` remains for varlen (`cu_seqlens`) because the AscendC op is fixed-length only.
- Both ops fall back to Triton when the custom op is not registered.

## Test plan

- [ ] Fixed-length BSND: `python examples/flash_gated_delta_rule.py --batch 4 --heads 32 --tokens 8192 --dim 128 --value-dim 128 --chunk-size 64 --dtype bf16 --no-varlen --gate-function logsigmoid --initial-state none`
- [ ] Varlen path still uses Triton for `chunk_scaled_dot_kkt_fwd`
- [ ] `python3 torch_custom/fla_npu/test/test_npu_chunk_local_cumsum.py`
- [ ] `python3 torch_custom/fla_npu/test/test_npu_chunk_scaled_dot_kkt.py`


Made with [Cursor](https://cursor.com)