### PR TITLE
perf: improve causal_conv1d_bwd arch32

### DIFF
--- a/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_host/causal_conv1d_bwd_tiling.cpp
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_host/causal_conv1d_bwd_tiling.cpp
@@ -47,6 +47,8 @@ namespace {
     constexpr uint32_t DIRECT_FAST_BT_MAX = 224U;
     constexpr uint32_t DIRECT_FAST_BT_MIN = 64U;
     constexpr uint32_t DIRECT_FAST_BT_STEP = 32U;
+    constexpr uint32_t DIRECT_910B_BT_BD64 = 104U;
+    constexpr uint32_t DIRECT_910B_BT_BD128 = 55U;
     constexpr uint32_t ACTIVATION_NONE = 0;
     constexpr uint32_t ACTIVATION_SILU = 1;
     constexpr uint32_t ACTIVATION_SWISH = 2;
@@ -268,11 +270,13 @@ static ge::graphStatus CausalConv1dBwdTilingFunc(gert::TilingContext *context)
     uint64_t ubSize = 0;
     uint64_t sysWorkspaceSize = 0;
     uint32_t coreNum = 0;
+    bool isAscend910B = false;
     bool isAscend950 = false;
     {
         fe::PlatFormInfos *platformInfoPtr = context->GetPlatformInfo();
         OP_CHECK_NULL_WITH_CONTEXT(context, platformInfoPtr);
         auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
+        isAscend910B = (ascendcPlatform.GetCurNpuArch() == NpuArch::DAV_2201);
         isAscend950 = (ascendcPlatform.GetCurNpuArch() == NpuArch::DAV_3510);
         coreNum = ascendcPlatform.GetCoreNumAiv();
         OP_CHECK_IF(coreNum == 0, OP_LOGE(context, "coreNum is 0"), return ge::GRAPH_FAILED);
@@ -288,12 +292,26 @@ static ge::graphStatus CausalConv1dBwdTilingFunc(gert::TilingContext *context)
                 OP_LOGE(context, "%s D %u must be divisible by 16", inputLayoutStr, alignDim),
                 return ge::GRAPH_FAILED);
     uint32_t BD = (D % 64 == 0) ? 64 : 16;
+    bool wideBlockLayoutSupported =
+        (inputLayout != INPUT_LAYOUT_BNSD && inputLayout != INPUT_LAYOUT_NTD) ||
+        (inputHeadDim >= 128 && inputHeadDim % 128 == 0);
+    bool use910BWideBlock = isAscend910B && isB16Input &&
+                            activation == ACTIVATION_SILU &&
+                            !useInitialState && !useFinalState &&
+                            W == 4 && D % 128 == 0 && wideBlockLayoutSupported;
+    if (use910BWideBlock) {
+        BD = 128;
+    }
     uint32_t numBlksD = D / BD;
 
     bool useArch35DirectFast = isAscend950 && isB16Input &&
                                activation == ACTIVATION_SILU &&
                                !useInitialState && !useFinalState &&
                                W == 4 && BD == 64;
+    bool use910BDirectFast = isAscend910B && isB16Input &&
+                             activation == ACTIVATION_SILU &&
+                             !useInitialState && !useFinalState &&
+                             W == 4 && (BD == 64 || BD == 128);
     auto CalcArch35DirectNeed = [BD, W](uint32_t bt) -> uint32_t {
         uint32_t btBdAl = CeilAlign(bt * BD, BLOCK_ALIGN_NUM);
         uint32_t dyBdAl = CeilAlign((bt + W - 1) * BD, BLOCK_ALIGN_NUM);
@@ -304,12 +322,28 @@ static ge::graphStatus CausalConv1dBwdTilingFunc(gert::TilingContext *context)
         need += (btBdAl + dyBdAl + wBdAl + bdAl) * FP32_DTYPE_SIZE;
         return need;
     };
+    auto Calc910BDirectNeed = [BD, W](uint32_t bt) -> uint32_t {
+        uint32_t btBdAl = CeilAlign(bt * BD, BLOCK_ALIGN_NUM);
+        uint32_t dyBdAl = CeilAlign((bt + W - 1) * BD, BLOCK_ALIGN_NUM);
+        uint32_t wBdAl = CeilAlign(W * BD, BLOCK_ALIGN_NUM);
+        uint32_t bdAl = CeilAlign(BD, BLOCK_ALIGN_NUM);
+        uint32_t xRawAl = std::max(btBdAl, wBdAl);
+        uint32_t need = (btBdAl + 3 * dyBdAl + 2 * wBdAl + 2 * bdAl) * FP32_DTYPE_SIZE;
+        need += (xRawAl + 2 * dyBdAl + 2 * btBdAl) * B16_DTYPE_SIZE;
+        return need;
+    };
 
     uint32_t BT = 64;
     if (useArch35DirectFast) {
         BT = std::min(T, DIRECT_FAST_BT_MAX);
         while (BT > DIRECT_FAST_BT_MIN && CalcArch35DirectNeed(BT) > ubSize) {
             BT = (BT > DIRECT_FAST_BT_MIN + DIRECT_FAST_BT_STEP) ? (BT - DIRECT_FAST_BT_STEP) : DIRECT_FAST_BT_MIN;
+        }
+    } else if (use910BDirectFast) {
+        uint32_t maxBt = (BD == 128) ? DIRECT_910B_BT_BD128 : DIRECT_910B_BT_BD64;
+        BT = std::min(T, maxBt);
+        while (BT > 1 && Calc910BDirectNeed(BT) > ubSize) {
+            BT--;
         }
     } else if (T < BT) {
         BT = T;
@@ -337,6 +371,8 @@ static ge::graphStatus CausalConv1dBwdTilingFunc(gert::TilingContext *context)
     uint32_t need = 0;
     if (useArch35DirectFast) {
         need = CalcArch35DirectNeed(BT);
+    } else if (use910BDirectFast) {
+        need = Calc910BDirectNeed(BT);
     } else {
         need += (3 * btBdAl + 2 * calcBdAl) * FP32_DTYPE_SIZE;
         need += (dyBdAl - btBdAl) * FP32_DTYPE_SIZE;

--- a/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_kernel/arch32/causal_conv1d_bwd_vector.h
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_kernel/arch32/causal_conv1d_bwd_vector.h
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ASCENDC_CAUSAL_CONV1D_BWD_ARCH32_VECTOR_H_
+#define ASCENDC_CAUSAL_CONV1D_BWD_ARCH32_VECTOR_H_
+
+#include "kernel_operator.h"
+
+namespace NsCausalConv1dBwdArch32 {
+
+using namespace AscendC;
+
+constexpr uint32_t DIRECT_BD = 64;
+constexpr uint32_t DIRECT_WIDE_BD = 128;
+constexpr uint32_t DIRECT_W = 4;
+constexpr uint32_t FP32_BLOCK_ELEMENTS = 8;
+constexpr uint32_t FP32_VECTOR_ELEMENTS = 64;
+
+__aicore__ inline void ReduceRowsInplace(LocalTensor<float> tensor, uint32_t rows, uint32_t cols)
+{
+    uint32_t remainRows = rows;
+    while (remainRows > 1) {
+        uint32_t upperRows = (remainRows + 1) >> 1;
+        uint32_t pairRows = remainRows >> 1;
+        Add(tensor, tensor, tensor[upperRows * cols], pairRows * cols);
+        PipeBarrier<PIPE_V>();
+        remainRows = upperRows;
+    }
+}
+
+__aicore__ inline void ApplySiluBackward(
+    LocalTensor<float> dy, LocalTensor<float> y, LocalTensor<float> sigmoidScratch,
+    LocalTensor<float> oneBlock, uint32_t count)
+{
+    Muls(sigmoidScratch, y, float(-1.0), count);
+    PipeBarrier<PIPE_V>();
+    Exp(sigmoidScratch, sigmoidScratch, count);
+    PipeBarrier<PIPE_V>();
+    Adds(sigmoidScratch, sigmoidScratch, float(1.0), count);
+    PipeBarrier<PIPE_V>();
+
+    BinaryRepeatParams divParams;
+    divParams.dstBlkStride = 1;
+    divParams.src0BlkStride = 1;
+    divParams.src1BlkStride = 1;
+    divParams.dstRepStride = static_cast<uint16_t>(FP32_VECTOR_ELEMENTS / FP32_BLOCK_ELEMENTS);
+    divParams.src0RepStride = 0;
+    divParams.src1RepStride = static_cast<uint16_t>(FP32_VECTOR_ELEMENTS / FP32_BLOCK_ELEMENTS);
+    Div(sigmoidScratch, oneBlock, sigmoidScratch, static_cast<uint64_t>(FP32_VECTOR_ELEMENTS),
+        static_cast<uint8_t>(count / FP32_VECTOR_ELEMENTS), divParams);
+    PipeBarrier<PIPE_V>();
+
+    Mul(dy, dy, sigmoidScratch, count);
+    PipeBarrier<PIPE_V>();
+    Muls(sigmoidScratch, sigmoidScratch, float(-1.0), count);
+    PipeBarrier<PIPE_V>();
+    Adds(sigmoidScratch, sigmoidScratch, float(1.0), count);
+    PipeBarrier<PIPE_V>();
+    Mul(y, y, sigmoidScratch, count);
+    PipeBarrier<PIPE_V>();
+    Adds(y, y, float(1.0), count);
+    PipeBarrier<PIPE_V>();
+    Mul(dy, dy, y, count);
+    PipeBarrier<PIPE_V>();
+}
+
+__aicore__ inline void ComputeTile(
+    LocalTensor<float> x, LocalTensor<float> dy, LocalTensor<float> y,
+    LocalTensor<float> weight, LocalTensor<float> dx, LocalTensor<float> dw,
+    LocalTensor<float> db, LocalTensor<float> oneBlock,
+    uint32_t bt, uint32_t bd, uint32_t width, uint32_t dyRows, uint32_t hasBias,
+    bool reuseHalo)
+{
+    uint32_t btCount = bt * bd;
+    uint32_t activationOffset = reuseHalo ? (width - 1) * bd : 0;
+    uint32_t activationCount = reuseHalo ? btCount : dyRows * bd;
+    ApplySiluBackward(dy[activationOffset], y[activationOffset], dx, oneBlock, activationCount);
+
+    BinaryRepeatParams repeatParams;
+    repeatParams.dstBlkStride = 1;
+    repeatParams.src0BlkStride = 1;
+    repeatParams.src1BlkStride = 1;
+    repeatParams.dstRepStride = static_cast<uint16_t>(bd / FP32_BLOCK_ELEMENTS);
+    repeatParams.src0RepStride = static_cast<uint16_t>(bd / FP32_BLOCK_ELEMENTS);
+    repeatParams.src1RepStride = 0;
+
+    for (uint32_t iW = 0; iW < width; iW++) {
+        uint32_t wIdx = width - iW - 1;
+        LocalTensor<float> shiftedDy = dy[iW * bd];
+        for (uint32_t dOffset = 0; dOffset < bd; dOffset += FP32_VECTOR_ELEMENTS) {
+            if (iW == 0) {
+                Mul(dx[dOffset], shiftedDy[dOffset], weight[wIdx * bd + dOffset],
+                    static_cast<uint64_t>(FP32_VECTOR_ELEMENTS),
+                    static_cast<uint8_t>(bt), repeatParams);
+            } else {
+                MulAddDst(dx[dOffset], shiftedDy[dOffset], weight[wIdx * bd + dOffset],
+                          static_cast<uint64_t>(FP32_VECTOR_ELEMENTS),
+                          static_cast<uint8_t>(bt), repeatParams);
+            }
+        }
+        PipeBarrier<PIPE_V>();
+
+        Mul(y, shiftedDy, x, btCount);
+        PipeBarrier<PIPE_V>();
+        ReduceRowsInplace(y, bt, bd);
+        Add(dw[wIdx * bd], dw[wIdx * bd], y, bd);
+        PipeBarrier<PIPE_V>();
+    }
+
+    if (hasBias != 0) {
+        ReduceRowsInplace(dy, bt, bd);
+        Add(db, db, dy, bd);
+        PipeBarrier<PIPE_V>();
+    }
+}
+
+} // namespace NsCausalConv1dBwdArch32
+
+#endif // ASCENDC_CAUSAL_CONV1D_BWD_ARCH32_VECTOR_H_

--- a/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_kernel/causal_conv1d_bwd.h
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_kernel/causal_conv1d_bwd.h
@@ -41,6 +41,13 @@
 #include "causal_conv1d_bwd_tiling_data.h"
 #include "causal_conv1d_bwd_tiling_key.h"
 
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 220
+#include "arch32/causal_conv1d_bwd_vector.h"
+#define CAUSAL_CONV1D_BWD_ARCH32_VECTOR 1
+#else
+#define CAUSAL_CONV1D_BWD_ARCH32_VECTOR 0
+#endif
+
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
 #include "arch35/causal_conv1d_bwd_regbase.h"
 #define CAUSAL_CONV1D_BWD_ARCH35_REGBASE 1
@@ -111,9 +118,17 @@ private:
     __aicore__ inline void ComputeDbRowsAccum(uint32_t dyRowOffset);
     __aicore__ inline void FinalizeDbRowsAccum();
     __aicore__ inline void ComputeDh0(uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t i_b, uint32_t seqLen);
+    __aicore__ inline void CopyInDirectVectorTileRawAsync(uint64_t bos, uint32_t i_t, uint32_t i_d,
+                                                          uint32_t seqLen, bool reuseHalo,
+                                                          event_t mte2ToVEvent);
+    __aicore__ inline void CastDirectVectorTile(bool reuseHalo);
     __aicore__ inline void CopyInDirectTileRawAsync(uint64_t bos, uint32_t i_t, uint32_t i_d,
                                                     uint32_t seqLen, uint32_t slot, event_t mte2ToVEvent);
+    __aicore__ inline void ComputeTileDirectVector(bool reuseHalo);
     __aicore__ inline void ComputeTileDirectRegbase(uint32_t i_t, uint32_t seqLen, uint32_t slot);
+    __aicore__ inline void CopyOutDxDirectVectorAsync(uint64_t bos, uint32_t i_t, uint32_t i_d,
+                                                      uint32_t seqLen, uint32_t slot,
+                                                      event_t mte3ToVEvent);
     __aicore__ inline void CopyOutDx(uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen);
     __aicore__ inline void CopyOutDwDb(uint32_t i_d);
     __aicore__ inline void CopyOutPartialDwDb(uint32_t coreIdx, uint32_t i_d);
@@ -121,6 +136,7 @@ private:
     __aicore__ inline void ReduceRowsInplace(LocalTensor<float> tensor, uint32_t rows, uint32_t cols);
     __aicore__ inline bool ResolveChunk(uint32_t chunkIdx, uint32_t &i_b, uint32_t &i_t,
                                         uint64_t &bos, uint32_t &seqLen);
+    __aicore__ inline bool Arch32UseDirectVector() const;
     __aicore__ inline bool Arch35UseDirectRegbase() const;
 
     TPipe *pipe_;
@@ -228,6 +244,25 @@ template <typename inputT, typename calT>
 __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::InitBuffer(TPipe *inputPipe)
 {
     pipe_ = inputPipe;
+    if (Arch32UseDirectVector()) {
+        pipe_->InitBuffer(xBuf_, btBdCount_ * FP32_DTYPE_SIZE);
+        pipe_->InitBuffer(dyBuf_, dyBdCount_ * FP32_DTYPE_SIZE);
+        pipe_->InitBuffer(dxBuf_, dyBdCount_ * FP32_DTYPE_SIZE);
+        pipe_->InitBuffer(yBuf_, dyBdCount_ * FP32_DTYPE_SIZE);
+        uint32_t xRawCount = (btBdCount_ > wBdCount_) ? btBdCount_ : wBdCount_;
+        pipe_->InitBuffer(castBuf_, xRawCount * sizeof(inputT));
+        pipe_->InitBuffer(wdyBuf_, dyBdCount_ * sizeof(inputT));
+        pipe_->InitBuffer(sigmoidBuf_, dyBdCount_ * sizeof(inputT));
+        pipe_->InitBuffer(tempBuf_, 2 * btBdCount_ * sizeof(inputT) + BD_ * FP32_DTYPE_SIZE);
+        if (hasWeight_) {
+            pipe_->InitBuffer(weightBuf_, wBdCount_ * FP32_DTYPE_SIZE);
+            pipe_->InitBuffer(dwBuf_, wBdCount_ * FP32_DTYPE_SIZE);
+        }
+        if (hasBias_) {
+            pipe_->InitBuffer(dbBuf_, BD_ * FP32_DTYPE_SIZE);
+        }
+        return;
+    }
     if (Arch35UseDirectRegbase()) {
         pipe_->InitBuffer(xBuf_, 2 * btBdCount_ * sizeof(inputT));
         pipe_->InitBuffer(dyBuf_, 2 * dyBdCount_ * sizeof(inputT));
@@ -543,6 +578,11 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInInputTileRawAs
     if (useGradLayout &&
         (inputLayout_ == INPUT_LAYOUT_BNSD || inputLayout_ == INPUT_LAYOUT_NTD)) {
         uint32_t channel = i_d * BD_;
+        if (BD_ == inputHeadDim_ && channel % inputHeadDim_ == 0) {
+            uint64_t base = GetInputOffset(bos, startRow, channel);
+            DataCopy(dst, srcGm[base], validRows * BD_);
+            return;
+        }
         uint32_t remain = BD_;
         uint32_t localOffset = 0;
         while (remain > 0) {
@@ -616,7 +656,12 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInWeight(uint32_
         SetFlag<HardEvent::MTE2_V>(ev);
         WaitFlag<HardEvent::MTE2_V>(ev);
     } else {
-        LocalTensor<inputT> wTemp = tempBuf_.Get<inputT>();
+        LocalTensor<inputT> wTemp;
+        if (Arch32UseDirectVector()) {
+            wTemp = castBuf_.Get<inputT>();
+        } else {
+            wTemp = tempBuf_.Get<inputT>();
+        }
         DataCopyPad(wTemp, weightGm_[off], copyParams, padParams);
         event_t ev = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE2_V));
         SetFlag<HardEvent::MTE2_V>(ev);
@@ -1064,6 +1109,75 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::ComputeDh0(
 }
 
 template <typename inputT, typename calT>
+__aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInDirectVectorTileRawAsync(
+    uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen, bool reuseHalo,
+    event_t mte2ToVEvent)
+{
+#if CAUSAL_CONV1D_BWD_ARCH32_VECTOR
+    LocalTensor<inputT> xRaw = castBuf_.Get<inputT>();
+    LocalTensor<inputT> dyRaw = wdyBuf_.Get<inputT>();
+    LocalTensor<inputT> yRaw = sigmoidBuf_.Get<inputT>();
+
+    event_t vMte2Event = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_MTE2));
+    SetFlag<HardEvent::V_MTE2>(vMte2Event);
+    WaitFlag<HardEvent::V_MTE2>(vMte2Event);
+    CopyInInputTileRawAsync(xGm_, xRaw, bos, i_t * BT_, i_d, BT_, seqLen, false);
+    uint32_t haloRows = reuseHalo ? (W_ - 1) : 0;
+    uint32_t copyRows = reuseHalo ? BT_ : dyRows_;
+    uint32_t haloOffset = haloRows * BD_;
+    CopyInInputTileRawAsync(
+        dyGm_, dyRaw[haloOffset], bos, i_t * BT_ + haloRows, i_d, copyRows, seqLen, true);
+    CopyInInputTileRawAsync(
+        yGm_, yRaw[haloOffset], bos, i_t * BT_ + haloRows, i_d, copyRows, seqLen, true);
+    SetFlag<HardEvent::MTE2_V>(mte2ToVEvent);
+#else
+    (void)bos;
+    (void)i_t;
+    (void)i_d;
+    (void)seqLen;
+    (void)reuseHalo;
+    (void)mte2ToVEvent;
+#endif
+}
+
+template <typename inputT, typename calT>
+__aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CastDirectVectorTile(bool reuseHalo)
+{
+#if CAUSAL_CONV1D_BWD_ARCH32_VECTOR
+    Cast(xBuf_.Get<float>(), castBuf_.Get<inputT>(), RoundMode::CAST_NONE, btBdCount_);
+    if (reuseHalo) {
+        uint32_t haloCount = (W_ - 1) * BD_;
+        Adds(dyBuf_.Get<float>(), dyBuf_.Get<float>()[btBdCount_], float(0), haloCount);
+        PipeBarrier<PIPE_V>();
+        Cast(dyBuf_.Get<float>()[haloCount], wdyBuf_.Get<inputT>()[haloCount],
+             RoundMode::CAST_NONE, btBdCount_);
+        Cast(yBuf_.Get<float>()[haloCount], sigmoidBuf_.Get<inputT>()[haloCount],
+             RoundMode::CAST_NONE, btBdCount_);
+    } else {
+        Cast(dyBuf_.Get<float>(), wdyBuf_.Get<inputT>(), RoundMode::CAST_NONE, dyBdCount_);
+        Cast(yBuf_.Get<float>(), sigmoidBuf_.Get<inputT>(), RoundMode::CAST_NONE, dyBdCount_);
+    }
+    PipeBarrier<PIPE_V>();
+#else
+    (void)reuseHalo;
+#endif
+}
+
+template <typename inputT, typename calT>
+__aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::ComputeTileDirectVector(bool reuseHalo)
+{
+#if CAUSAL_CONV1D_BWD_ARCH32_VECTOR
+    NsCausalConv1dBwdArch32::ComputeTile(
+        xBuf_.Get<float>(), dyBuf_.Get<float>(), yBuf_.Get<float>(), weightBuf_.Get<float>(),
+        dxBuf_.Get<float>(), dwBuf_.Get<float>(), dbBuf_.Get<float>(),
+        tempBuf_.Get<float>()[btBdCount_],
+        BT_, BD_, W_, dyRows_, hasBias_, reuseHalo);
+#else
+    (void)reuseHalo;
+#endif
+}
+
+template <typename inputT, typename calT>
 __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyInDirectTileRawAsync(
     uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen, uint32_t slot, event_t mte2ToVEvent)
 {
@@ -1126,6 +1240,45 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::ComputeTileDirectReg
 }
 
 template <typename inputT, typename calT>
+__aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyOutDxDirectVectorAsync(
+    uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen,
+    uint32_t slot, event_t mte3ToVEvent)
+{
+#if CAUSAL_CONV1D_BWD_ARCH32_VECTOR
+    uint64_t startRow = static_cast<uint64_t>(i_t) * BT_;
+    uint32_t validRows = (startRow + BT_ <= seqLen) ? BT_ :
+                         ((startRow < seqLen) ? (seqLen - startRow) : 0);
+    if (validRows == 0) {
+        return;
+    }
+
+    LocalTensor<inputT> output = tempBuf_.Get<inputT>()[slot * btBdCount_];
+    Cast(output, dxBuf_.Get<float>(), RoundMode::CAST_RINT, validRows * BD_);
+    PipeBarrier<PIPE_V>();
+    event_t vMte3Event = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_MTE3));
+    SetFlag<HardEvent::V_MTE3>(vMte3Event);
+    WaitFlag<HardEvent::V_MTE3>(vMte3Event);
+
+    uint64_t offset = bos * D_ + startRow * D_ + static_cast<uint64_t>(i_d) * BD_;
+    DataCopyExtParams outParams{
+        static_cast<uint16_t>(validRows),
+        static_cast<uint32_t>(BD_ * sizeof(inputT)),
+        0,
+        static_cast<uint32_t>((D_ - BD_) * sizeof(inputT)),
+        0};
+    DataCopyPad(dxGm_[offset], output, outParams);
+    SetFlag<HardEvent::MTE3_V>(mte3ToVEvent);
+#else
+    (void)bos;
+    (void)i_t;
+    (void)i_d;
+    (void)seqLen;
+    (void)slot;
+    (void)mte3ToVEvent;
+#endif
+}
+
+template <typename inputT, typename calT>
 __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyOutDx(
     uint64_t bos, uint32_t i_t, uint32_t i_d, uint32_t seqLen)
 {
@@ -1148,7 +1301,12 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyOutDx(
         SetFlag<HardEvent::MTE3_V>(evMte3V);
         WaitFlag<HardEvent::MTE3_V>(evMte3V);
     } else {
-        LocalTensor<inputT> dlIn = castBuf_.Get<inputT>();
+        LocalTensor<inputT> dlIn;
+        if (Arch32UseDirectVector()) {
+            dlIn = yBuf_.Get<inputT>();
+        } else {
+            dlIn = castBuf_.Get<inputT>();
+        }
         DataCopyExtParams outParams{
             static_cast<uint16_t>(validRows),
             static_cast<uint32_t>(BD_ * sizeof(inputT)),
@@ -1201,7 +1359,12 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyOutDwDb(uint32_t
         SetFlag<HardEvent::MTE3_V>(mte3ToV);
         WaitFlag<HardEvent::MTE3_V>(mte3ToV);
     } else {
-        LocalTensor<inputT> outputLocal = castBuf_.Get<inputT>();
+        LocalTensor<inputT> outputLocal;
+        if (Arch32UseDirectVector()) {
+            outputLocal = yBuf_.Get<inputT>();
+        } else {
+            outputLocal = castBuf_.Get<inputT>();
+        }
         if (hasWeight_) {
             Cast(outputLocal, dwBuf_.Get<float>(), RoundMode::CAST_RINT, wBdCount_);
             PipeBarrier<PIPE_V>();
@@ -1267,7 +1430,12 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::CopyOutPartialDwDb(u
 template <typename inputT, typename calT>
 __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::ReducePartialDwDb(uint32_t i_d)
 {
-    LocalTensor<float> tmp = tempBuf_.Get<float>();
+    LocalTensor<float> tmp;
+    if (Arch32UseDirectVector()) {
+        tmp = yBuf_.Get<float>();
+    } else {
+        tmp = tempBuf_.Get<float>();
+    }
     if (hasWeight_) {
         LocalTensor<float> dwLocal = dwBuf_.Get<float>();
         Duplicate(dwLocal, float(0), wBdCount_);
@@ -1347,6 +1515,24 @@ __aicore__ inline bool CausalConv1dBwdKernel<inputT, calT>::ResolveChunk(
 }
 
 template <typename inputT, typename calT>
+__aicore__ inline bool CausalConv1dBwdKernel<inputT, calT>::Arch32UseDirectVector() const
+{
+#if CAUSAL_CONV1D_BWD_ARCH32_VECTOR
+    if constexpr (!IsSameType<inputT, half>::value && !IsSameType<inputT, bfloat16_t>::value) {
+        return false;
+    } else {
+        return hasWeight_ && activation_ == ACTIVATION_SILU &&
+               !useInitialState_ && !useFinalState_ &&
+               (BD_ == NsCausalConv1dBwdArch32::DIRECT_BD ||
+                BD_ == NsCausalConv1dBwdArch32::DIRECT_WIDE_BD) &&
+               W_ == NsCausalConv1dBwdArch32::DIRECT_W;
+    }
+#else
+    return false;
+#endif
+}
+
+template <typename inputT, typename calT>
 __aicore__ inline bool CausalConv1dBwdKernel<inputT, calT>::Arch35UseDirectRegbase() const
 {
 #if CAUSAL_CONV1D_BWD_ARCH35_REGBASE
@@ -1370,10 +1556,24 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::Process()
 {
     uint32_t bIdx = GetBlockIdx();
     uint32_t blockNum = GetBlockNum();
+    bool useDirectVector = Arch32UseDirectVector();
     bool useDirectRegbase = Arch35UseDirectRegbase();
 
     uint32_t loopC = (bIdx < tailChunk_) ? (chunkPerCore_ + 1) : chunkPerCore_;
 
+    event_t directVectorMte2ToVEvent;
+    event_t directVectorMte3ToVEvent[2];
+    bool directVectorOutputPending[2] = {false, false};
+    if (useDirectVector) {
+        directVectorMte2ToVEvent = static_cast<event_t>(GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>());
+        directVectorMte3ToVEvent[0] = static_cast<event_t>(GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>());
+        directVectorMte3ToVEvent[1] = static_cast<event_t>(GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>());
+#if CAUSAL_CONV1D_BWD_ARCH32_VECTOR
+        Duplicate(tempBuf_.Get<float>()[btBdCount_], float(1.0),
+                  NsCausalConv1dBwdArch32::FP32_VECTOR_ELEMENTS);
+#endif
+        PipeBarrier<PIPE_V>();
+    }
     event_t directMte2ToVEvent[2];
     if (useDirectRegbase) {
         directMte2ToVEvent[0] = static_cast<event_t>(GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>());
@@ -1406,6 +1606,8 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::Process()
         }
 
         bool directTilePrefetched = false;
+        bool directVectorTilePrefetched = false;
+        bool directVectorPrefetchedReuseHalo = false;
 
         for (uint32_t loop = 0; loop < loopC; loop++) {
             uint32_t chunkIdx = (bIdx < tailChunk_)
@@ -1451,6 +1653,37 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::Process()
                 }
 
                 ComputeTileDirectRegbase(i_t, seqLen, slot);
+            } else if (useDirectVector) {
+                bool reuseHalo = directVectorTilePrefetched && directVectorPrefetchedReuseHalo;
+                if (!directVectorTilePrefetched) {
+                    CopyInDirectVectorTileRawAsync(
+                        bos, i_t, i_d, seqLen, false, directVectorMte2ToVEvent);
+                }
+                WaitFlag<HardEvent::MTE2_V>(directVectorMte2ToVEvent);
+                CastDirectVectorTile(reuseHalo);
+
+                directVectorTilePrefetched = false;
+                if (loop + 1U < loopC) {
+                    uint32_t nextChunkIdx = (bIdx < tailChunk_)
+                        ? (bIdx * (chunkPerCore_ + 1) + loop + 1U)
+                        : (bIdx * chunkPerCore_ + tailChunk_ + loop + 1U);
+                    if (nextChunkIdx < numChunks_) {
+                        uint32_t nextB = 0;
+                        uint32_t nextT = 0;
+                        uint32_t nextSeqLen = 0;
+                        uint64_t nextBos = 0;
+                        if (ResolveChunk(nextChunkIdx, nextB, nextT, nextBos, nextSeqLen)) {
+                            bool nextReuseHalo = (nextBos == bos && nextT == i_t + 1U);
+                            CopyInDirectVectorTileRawAsync(
+                                nextBos, nextT, i_d, nextSeqLen, nextReuseHalo,
+                                directVectorMte2ToVEvent);
+                            directVectorTilePrefetched = true;
+                            directVectorPrefetchedReuseHalo = nextReuseHalo;
+                        }
+                    }
+                }
+
+                ComputeTileDirectVector(reuseHalo);
             } else {
                 CopyInX(bos, i_t, i_d, seqLen);
 
@@ -1479,7 +1712,17 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::Process()
             }
 
             AccumulateDhtDx(i_t, i_d, i_b, seqLen);
-            CopyOutDx(bos, i_t, i_d, seqLen);
+            if (useDirectVector) {
+                uint32_t outputSlot = loop & 1U;
+                if (directVectorOutputPending[outputSlot]) {
+                    WaitFlag<HardEvent::MTE3_V>(directVectorMte3ToVEvent[outputSlot]);
+                }
+                CopyOutDxDirectVectorAsync(
+                    bos, i_t, i_d, seqLen, outputSlot, directVectorMte3ToVEvent[outputSlot]);
+                directVectorOutputPending[outputSlot] = true;
+            } else {
+                CopyOutDx(bos, i_t, i_d, seqLen);
+            }
         }
         if (!useDirectRegbase && hasWeight_ && activation_ == ACTIVATION_NONE) {
             FinalizeDwRowsAccum();
@@ -1488,6 +1731,14 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::Process()
             FinalizeDbRowsAccum();
         }
         CopyOutPartialDwDb(bIdx, i_d);
+    }
+
+    if (useDirectVector) {
+        for (uint32_t slot = 0; slot < 2; slot++) {
+            if (directVectorOutputPending[slot]) {
+                WaitFlag<HardEvent::MTE3_V>(directVectorMte3ToVEvent[slot]);
+            }
+        }
     }
 
     SyncAll();
@@ -1499,6 +1750,11 @@ __aicore__ inline void CausalConv1dBwdKernel<inputT, calT>::Process()
     if (useDirectRegbase) {
         GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(directMte2ToVEvent[0]);
         GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(directMte2ToVEvent[1]);
+    }
+    if (useDirectVector) {
+        GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(directVectorMte2ToVEvent);
+        GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(directVectorMte3ToVEvent[0]);
+        GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(directVectorMte3ToVEvent[1]);
     }
 }
 


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [x] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @jiang2027
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [x] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [x] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
