### PR TITLE
Cum int

### DIFF
--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/README.md
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/README.md
@@ -59,20 +59,20 @@ aclnnStatus aclnnChunkLocalCumsum(
 
 | 参数 | 数据类型 | 是否必须 | 描述 |
 |------|----------|----------|------|
-| g | FLOAT32 | 是 | 输入张量，shape 为 `[B, H, T]` |
+| g | FLOAT32 / FLOAT16 / BF16 | 是 | 输入张量，shape 为 `[B, H, T]` |
 | cu_seqlens | INT64 | 否 | 变长序列累积长度。固定长度模式传空 tensor |
 | chunk_indices_out | INT64 | 否 | 变长模式下 block 到 `(seq_id, block_id)` 的映射，按二元组连续存储 |
 | chunk_size | int64 | 是 | chunk 长度，必须为 2 的幂 |
 | reverse | bool | 否 | 是否执行反向 chunk 内累加，默认 `false` |
 | scale | double | 否 | 输出缩放系数，默认 `1.0` |
 | head_first | bool | 否 | 当前实现仅支持 `true` |
-| output_dtype | string | 否 | 当前仅支持 `float32`、`torch.float`、`torch.float32` |
+| output_dtype | string | 否 | 默认 `float32`；支持 `float32`/`torch.float32`、`float16`/`half`、`bfloat16`/`bf16`，以及 `same`/`input`/`none` 跟随输入 dtype |
 
 ---
 
 ## 4. 输入约束
 
-1. **数据类型**：输入 `g` 和输出 `out` 仅支持 FLOAT32。
+1. **数据类型**：输入 `g` 和输出 `out` 均支持 FLOAT32、FLOAT16、BF16；输入输出 dtype 可不一致，kernel 内部按 fp32 累加后 cast 到输出 dtype。
 2. **输入维度**：`g` 必须为 rank 3 的 tensor，shape 为 `[B, H, T]`。
 3. **chunk_size**：必须为 2 的幂，且 host tiling 计算得到的 `block_t` 不小于 `chunk_size`。
 4. **数据布局**：当前 AscendC kernel 仅支持 `[B, H, T]`，`head_first=false` 会被显式拒绝。

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/README.md
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/README.md
@@ -6,18 +6,18 @@
 
 ## 1. 算子功能
 
-输入 `g` 的 shape 为 `[B, H, T, *]`。算子按 `chunk_size` 在时间维 `T` 上划分 chunk，并在每个 chunk 内执行局部累加，输出 shape 与输入一致。尾部 `*` 可为空或包含一个及以上维度，kernel 会将其展平为每个 token 的连续计算宽度。
+输入 `g` 的 shape 为 `[B, H, T]`。算子按 `chunk_size` 在时间维 `T` 上划分 chunk，并在每个 chunk 内执行局部累加，输出 shape 与输入一致。
 
 正向模式 `reverse=false`:
 
 ```text
-out[b, h, t, ...] = scale * sum(g[b, h, k, ...]), k = chunk_start ... t
+out[b, h, t] = scale * sum(g[b, h, k]), k = chunk_start ... t
 ```
 
 反向模式 `reverse=true`:
 
 ```text
-out[b, h, t, ...] = scale * sum(g[b, h, k, ...]), k = t ... chunk_end - 1
+out[b, h, t] = scale * sum(g[b, h, k]), k = t ... chunk_end - 1
 ```
 
 其中 `chunk_start = floor(t / chunk_size) * chunk_size`，`chunk_end = min(chunk_start + chunk_size, T)`。
@@ -32,8 +32,8 @@ out[b, h, t, ...] = scale * sum(g[b, h, k, ...]), k = t ... chunk_end - 1
 // 获取执行所需的 workspace 大小
 aclnnStatus aclnnChunkLocalCumsumGetWorkspaceSize(
     const aclTensor *g,
-    const aclTensor *cuSeqlensOptional,
-    const aclTensor *chunkIndicesOutOptional,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOutOptional,
     int64_t chunkSize,
     bool reverse,
     double scale,
@@ -59,7 +59,7 @@ aclnnStatus aclnnChunkLocalCumsum(
 
 | 参数 | 数据类型 | 是否必须 | 描述 |
 |------|----------|----------|------|
-| g | FLOAT32 | 是 | 输入张量，shape 为 `[B, H, T, *]` |
+| g | FLOAT32 | 是 | 输入张量，shape 为 `[B, H, T]` |
 | cu_seqlens | INT64 | 否 | 变长序列累积长度。固定长度模式传空 tensor |
 | chunk_indices_out | INT64 | 否 | 变长模式下 block 到 `(seq_id, block_id)` 的映射，按二元组连续存储 |
 | chunk_size | int64 | 是 | chunk 长度，必须为 2 的幂 |
@@ -73,9 +73,9 @@ aclnnStatus aclnnChunkLocalCumsum(
 ## 4. 输入约束
 
 1. **数据类型**：输入 `g` 和输出 `out` 仅支持 FLOAT32。
-2. **输入维度**：`g` 必须为 rank >= 3 的 tensor，shape 为 `[B, H, T, *]`。
+2. **输入维度**：`g` 必须为 rank 3 的 tensor，shape 为 `[B, H, T]`。
 3. **chunk_size**：必须为 2 的幂，且 host tiling 计算得到的 `block_t` 不小于 `chunk_size`。
-4. **数据布局**：当前 AscendC kernel 仅支持 `[B, H, T, *]`，`head_first=false` 会被显式拒绝。
+4. **数据布局**：当前 AscendC kernel 仅支持 `[B, H, T]`，`head_first=false` 会被显式拒绝。
 5. **变长模式**：当 `cu_seqlens` 非空时，`B` 必须为 1，且 `chunk_indices_out` 必须非空、元素数为偶数。
 
 ---
@@ -92,7 +92,7 @@ aclnnStatus aclnnChunkLocalCumsum(
 
 该算子使用 AIV kernel 实现。
 
-固定长度模式下，kernel 以 `(batch * head, chunk, tail tile)` 为任务粒度分核，每个任务在一个 batch/head 的一个时间 chunk 内对一段尾部连续维度执行正向或反向累加。
+固定长度模式下，kernel 以 `(batch * head, chunk)` 为任务粒度分核，每个任务在一个 batch/head 的一个时间 chunk 内执行正向或反向累加。
 
 变长模式下，kernel 从 `chunk_indices_out` 读取 `(seq_id, block_id)`，结合 `cu_seqlens` 计算当前序列边界，再在序列局部坐标内执行 chunk-local cumsum。
 

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/docs/aclnnChunkLocalCumsum.md
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/docs/aclnnChunkLocalCumsum.md
@@ -62,15 +62,15 @@ aclnnStatus aclnnChunkLocalCumsum(
 
 | 参数名 | 输入/输出 | 描述 |
 |--------|-----------|------|
-| g | 输入 | Device 侧 aclTensor，数据类型仅支持 FLOAT32，shape 为 `[B, H, T]` |
+| g | 输入 | Device 侧 aclTensor，数据类型支持 FLOAT32、FLOAT16、BF16，shape 为 `[B, H, T]` |
 | cuSeqlensOptional | 输入 | 变长序列模式下的累积序列长度，可选参数。数据类型为 INT64 |
 | chunkIndicesOutOptional | 输入 | 变长序列模式下 block 到 `(seq_id, block_id)` 的映射，可选参数。数据类型为 INT64 |
 | chunkSize | 输入 | chunk 长度，必须为 2 的幂 |
 | reverse | 输入 | 是否执行反向 chunk 内累加 |
 | scale | 输入 | 输出缩放系数 |
 | headFirst | 输入 | 数据布局开关。当前仅支持 `true` |
-| outputDtypeOptional | 输入 | 输出 dtype 字符串。当前仅支持 `float32`、`torch.float`、`torch.float32` |
-| out | 输出 | Device 侧 aclTensor，数据类型仅支持 FLOAT32，shape 与 `g` 一致 |
+| outputDtypeOptional | 输入 | 输出 dtype 字符串。默认 `float32`；支持 `float32`/`torch.float32`、`float16`/`half`、`bfloat16`/`bf16`，以及 `same`/`input`/`none` 跟随输入 dtype |
+| out | 输出 | Device 侧 aclTensor，数据类型由 `outputDtypeOptional` 决定，shape 与 `g` 一致 |
 | workspaceSize | 输出 | 返回执行该算子所需的 workspace 大小 |
 | executor | 输出 | 返回算子执行器 |
 
@@ -85,18 +85,18 @@ aclnnStatus aclnnChunkLocalCumsum(
 
 ## 输入约束
 
-1. **数据类型**：输入 `g` 和输出 `out` 仅支持 FLOAT32。
+1. **数据类型**：输入 `g` 和输出 `out` 均支持 FLOAT32、FLOAT16、BF16；输入输出 dtype 可不一致，kernel 内部按 fp32 累加后 cast 到输出 dtype。
 2. **输入维度**：`g` 必须为 rank 3 的 tensor，shape 为 `[B, H, T]`，且各维为正数。
 3. **chunkSize**：必须为 2 的幂。
 4. **数据布局**：当前仅支持 `[B, H, T]`，`headFirst=false` 会返回失败。
-5. **输出 dtype**：`outputDtypeOptional` 仅支持 `float32`、`torch.float`、`torch.float32`。
+5. **输出 dtype**：`outputDtypeOptional` 默认 `float32`；支持 `float32`/`torch.float32`、`float16`/`half`、`bfloat16`/`bf16`，以及 `same`/`input`/`none` 跟随输入 dtype。
 6. **变长模式**：当 `cuSeqlensOptional` 非空时，`B` 必须为 1，`chunkIndicesOutOptional` 必须非空且元素个数为偶数。
 
 ## 输出说明
 
 | 输出 | 数据类型 | 描述 |
 |------|----------|------|
-| out | FLOAT32 | 输出与输入 `g` 同 shape，为 chunk-local cumsum 结果 |
+| out | FLOAT32 / FLOAT16 / BF16 | 输出与输入 `g` 同 shape，为 chunk-local cumsum 结果 |
 
 ## 返回值
 

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/docs/aclnnChunkLocalCumsum.md
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/docs/aclnnChunkLocalCumsum.md
@@ -18,13 +18,13 @@
   正向模式 `reverse=false`：
 
   $$
-  out[b,h,t,...] = scale \times \sum_{k=chunk\_start}^{t} g[b,h,k,...]
+  out[b,h,t] = scale \times \sum_{k=chunk\_start}^{t} g[b,h,k]
   $$
 
   反向模式 `reverse=true`：
 
   $$
-  out[b,h,t,...] = scale \times \sum_{k=t}^{chunk\_end-1} g[b,h,k,...]
+  out[b,h,t] = scale \times \sum_{k=t}^{chunk\_end-1} g[b,h,k]
   $$
 
   其中 `chunk_start = floor(t / chunk_size) * chunk_size`，`chunk_end = min(chunk_start + chunk_size, T)`。
@@ -37,8 +37,8 @@
 // 获取执行所需的 workspace 大小
 aclnnStatus aclnnChunkLocalCumsumGetWorkspaceSize(
     const aclTensor *g,
-    const aclTensor *cuSeqlensOptional,
-    const aclTensor *chunkIndicesOutOptional,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOutOptional,
     int64_t chunkSize,
     bool reverse,
     double scale,
@@ -62,7 +62,7 @@ aclnnStatus aclnnChunkLocalCumsum(
 
 | 参数名 | 输入/输出 | 描述 |
 |--------|-----------|------|
-| g | 输入 | Device 侧 aclTensor，数据类型仅支持 FLOAT32，shape 为 `[B, H, T, *]` |
+| g | 输入 | Device 侧 aclTensor，数据类型仅支持 FLOAT32，shape 为 `[B, H, T]` |
 | cuSeqlensOptional | 输入 | 变长序列模式下的累积序列长度，可选参数。数据类型为 INT64 |
 | chunkIndicesOutOptional | 输入 | 变长序列模式下 block 到 `(seq_id, block_id)` 的映射，可选参数。数据类型为 INT64 |
 | chunkSize | 输入 | chunk 长度，必须为 2 的幂 |
@@ -86,9 +86,9 @@ aclnnStatus aclnnChunkLocalCumsum(
 ## 输入约束
 
 1. **数据类型**：输入 `g` 和输出 `out` 仅支持 FLOAT32。
-2. **输入维度**：`g` 必须为 rank >= 3 的 tensor，shape 为 `[B, H, T, *]`，且各维为正数。
+2. **输入维度**：`g` 必须为 rank 3 的 tensor，shape 为 `[B, H, T]`，且各维为正数。
 3. **chunkSize**：必须为 2 的幂。
-4. **数据布局**：当前仅支持 `[B, H, T, *]`，`headFirst=false` 会返回失败。
+4. **数据布局**：当前仅支持 `[B, H, T]`，`headFirst=false` 会返回失败。
 5. **输出 dtype**：`outputDtypeOptional` 仅支持 `float32`、`torch.float`、`torch.float32`。
 6. **变长模式**：当 `cuSeqlensOptional` 非空时，`B` 必须为 1，`chunkIndicesOutOptional` 必须非空且元素个数为偶数。
 
@@ -156,7 +156,7 @@ bash torch_custom/fla_npu/test/test.sh --device 0 --op chunk_local_cumsum
 
 ## 实现说明
 
-- Host tiling 根据 `g` 的 `[B, H, T, *]`、`chunkSize`、`cuSeqlensOptional` 和 `chunkIndicesOutOptional` 计算任务数与 `blockDim`。
-- 固定长度模式按 `(batch * head, chunk, tail tile)` 划分任务，避免多个 AIV core 写同一段尾部连续维度。
+- Host tiling 根据 `g` 的 `[B, H, T]`、`chunkSize`、`cuSeqlensOptional` 和 `chunkIndicesOutOptional` 计算任务数与 `blockDim`。
+- 固定长度模式按 `(batch * head, chunk)` 划分任务。
 - 变长模式使用 `chunkIndicesOutOptional` 中的 `(seq_id, block_id)` 定位当前序列 chunk，并通过 `cuSeqlensOptional` 获取序列边界。
 - Kernel 仅使用 AIV，输出写回 `out`。

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/chunk_local_cumsum_def.cpp
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/chunk_local_cumsum_def.cpp
@@ -22,37 +22,37 @@ public:
     {
         this->Input("g")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_FLOAT})
-            .Format({ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND})
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
         this->Input("cu_seqlens")
             .ParamType(OPTIONAL)
             .ValueDepend(OPTIONAL)
-            .DataType({ge::DT_INT64})
-            .Format({ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND})
+            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
         this->Input("chunk_indices_out")
             .ParamType(OPTIONAL)
             .ValueDepend(OPTIONAL)
-            .DataType({ge::DT_INT64})
-            .Format({ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND})
+            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
 
         this->Output("out")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_FLOAT})
-            .Format({ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND})
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
 
         this->Attr("chunk_size").AttrType(REQUIRED).Int();
         this->Attr("reverse").AttrType(OPTIONAL).Bool(false);
         this->Attr("scale").AttrType(OPTIONAL).Float(1.0f);
         this->Attr("head_first").AttrType(OPTIONAL).Bool(true);
-        this->Attr("output_dtype").AttrType(OPTIONAL).String("float32");
+        this->Attr("output_dtype").AttrType(OPTIONAL).String("same");
 
         OpAICoreConfig aicoreConfig;
         aicoreConfig.DynamicCompileStaticFlag(true)

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/chunk_local_cumsum_def.cpp
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/chunk_local_cumsum_def.cpp
@@ -28,12 +28,14 @@ public:
             .AutoContiguous();
         this->Input("cu_seqlens")
             .ParamType(OPTIONAL)
+            .ValueDepend(OPTIONAL)
             .DataType({ge::DT_INT64})
             .Format({ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND})
             .AutoContiguous();
         this->Input("chunk_indices_out")
             .ParamType(OPTIONAL)
+            .ValueDepend(OPTIONAL)
             .DataType({ge::DT_INT64})
             .Format({ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND})

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/chunk_local_cumsum_def.cpp
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/chunk_local_cumsum_def.cpp
@@ -16,43 +16,58 @@
 #include "register/op_def_registry.h"
 
 namespace ops {
+namespace {
+constexpr ge::DataType FLOAT = ge::DT_FLOAT;
+constexpr ge::DataType FLOAT16 = ge::DT_FLOAT16;
+constexpr ge::DataType BF16 = ge::DT_BF16;
+constexpr ge::DataType INT64 = ge::DT_INT64;
+} // namespace
+
 class ChunkLocalCumsum : public OpDef {
 public:
     explicit ChunkLocalCumsum(const char *name) : OpDef(name)
     {
         this->Input("g")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_FLOAT, ge::DT_FLOAT16, ge::DT_BF16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .DataType({FLOAT, FLOAT, FLOAT, FLOAT16, FLOAT16, FLOAT16, BF16, BF16, BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND,
+                     ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND,
+                                 ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
         this->Input("cu_seqlens")
             .ParamType(OPTIONAL)
             .ValueDepend(OPTIONAL)
-            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .DataType({INT64, INT64, INT64, INT64, INT64, INT64, INT64, INT64, INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND,
+                     ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND,
+                                 ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
         this->Input("chunk_indices_out")
             .ParamType(OPTIONAL)
             .ValueDepend(OPTIONAL)
-            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .DataType({INT64, INT64, INT64, INT64, INT64, INT64, INT64, INT64, INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND,
+                     ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND,
+                                 ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
 
         this->Output("out")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_FLOAT, ge::DT_FLOAT16, ge::DT_BF16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .DataType({FLOAT, FLOAT16, BF16, FLOAT, FLOAT16, BF16, FLOAT, FLOAT16, BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND,
+                     ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND,
+                                 ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
 
         this->Attr("chunk_size").AttrType(REQUIRED).Int();
         this->Attr("reverse").AttrType(OPTIONAL).Bool(false);
         this->Attr("scale").AttrType(OPTIONAL).Float(1.0f);
         this->Attr("head_first").AttrType(OPTIONAL).Bool(true);
-        this->Attr("output_dtype").AttrType(OPTIONAL).String("same");
+        this->Attr("output_dtype").AttrType(OPTIONAL).String("float32");
 
         OpAICoreConfig aicoreConfig;
         aicoreConfig.DynamicCompileStaticFlag(true)

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/chunk_local_cumsum_infershape.cpp
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/chunk_local_cumsum_infershape.cpp
@@ -13,6 +13,7 @@
  * \brief
  */
 
+#include <cstring>
 #include "register/op_impl_registry.h"
 #include "log/log.h"
 
@@ -22,6 +23,44 @@ namespace ops {
 namespace {
 constexpr int64_t G_INDEX = 0;
 constexpr int64_t OUT_INDEX = 0;
+constexpr int64_t ATTR_OUTPUT_DTYPE_INDEX = 4;
+
+static bool ResolveOutputDataType(const char *outputDtype, ge::DataType inputDtype, ge::DataType &resolvedDtype)
+{
+    if (outputDtype == nullptr || outputDtype[0] == '\0' ||
+        std::strcmp(outputDtype, "float") == 0 ||
+        std::strcmp(outputDtype, "float32") == 0 ||
+        std::strcmp(outputDtype, "fp32") == 0 ||
+        std::strcmp(outputDtype, "torch.float") == 0 ||
+        std::strcmp(outputDtype, "torch.float32") == 0) {
+        resolvedDtype = ge::DT_FLOAT;
+        return true;
+    }
+    if (std::strcmp(outputDtype, "same") == 0 ||
+        std::strcmp(outputDtype, "same_as_input") == 0 ||
+        std::strcmp(outputDtype, "input") == 0 ||
+        std::strcmp(outputDtype, "none") == 0 ||
+        std::strcmp(outputDtype, "None") == 0 ||
+        std::strcmp(outputDtype, "null") == 0) {
+        resolvedDtype = inputDtype;
+        return true;
+    }
+    if (std::strcmp(outputDtype, "float16") == 0 ||
+        std::strcmp(outputDtype, "fp16") == 0 ||
+        std::strcmp(outputDtype, "half") == 0 ||
+        std::strcmp(outputDtype, "torch.float16") == 0 ||
+        std::strcmp(outputDtype, "torch.half") == 0) {
+        resolvedDtype = ge::DT_FLOAT16;
+        return true;
+    }
+    if (std::strcmp(outputDtype, "bfloat16") == 0 ||
+        std::strcmp(outputDtype, "bf16") == 0 ||
+        std::strcmp(outputDtype, "torch.bfloat16") == 0) {
+        resolvedDtype = ge::DT_BF16;
+        return true;
+    }
+    return false;
+}
 } // namespace
 
 static ge::graphStatus InferShapeChunkLocalCumsum(gert::InferShapeContext *context)
@@ -41,7 +80,16 @@ static ge::graphStatus InferShapeChunkLocalCumsum(gert::InferShapeContext *conte
 
 static ge::graphStatus InferDataTypeChunkLocalCumsum(gert::InferDataTypeContext *context)
 {
-    context->SetOutputDataType(OUT_INDEX, ge::DT_FLOAT);
+    ge::DataType inputDtype = context->GetInputDataType(G_INDEX);
+    ge::DataType outputDtype = ge::DT_FLOAT;
+    const char *outputDtypeAttr = nullptr;
+    if (context->GetAttrs() != nullptr) {
+        outputDtypeAttr = context->GetAttrs()->GetAttrPointer<char>(ATTR_OUTPUT_DTYPE_INDEX);
+    }
+    if (!ResolveOutputDataType(outputDtypeAttr, inputDtype, outputDtype)) {
+        return GRAPH_FAILED;
+    }
+    context->SetOutputDataType(OUT_INDEX, outputDtype);
     return GRAPH_SUCCESS;
 }
 

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/chunk_local_cumsum_tiling.cpp
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/chunk_local_cumsum_tiling.cpp
@@ -37,6 +37,9 @@ constexpr size_t ATTR_HEAD_FIRST_INDEX = 3;
 constexpr size_t ATTR_OUTPUT_DTYPE_INDEX = 4;
 constexpr uint32_t SYS_WORKSPACE_SIZE = 16U * 1024U * 1024U;
 constexpr int64_t H_TILE_SIZE = 512;
+constexpr int64_t INPUT_DTYPE_FP32 = 0;
+constexpr int64_t INPUT_DTYPE_FP16 = 1;
+constexpr int64_t INPUT_DTYPE_BF16 = 2;
 
 struct ChunkLocalCumsumCompileInfo {
     int64_t aivNum = 0;
@@ -93,8 +96,13 @@ static ge::graphStatus TilingChunkLocalCumsum(gert::TilingContext *context)
 
     auto inDtype = context->GetInputDesc(G_INDEX)->GetDataType();
     auto outDtype = context->GetOutputDesc(OUT_INDEX)->GetDataType();
-    OP_CHECK_IF(inDtype != ge::DT_FLOAT || outDtype != ge::DT_FLOAT,
-                OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(), "ChunkLocalCumsum currently supports float32 only."),
+    OP_CHECK_IF(inDtype != ge::DT_FLOAT && inDtype != ge::DT_FLOAT16 && inDtype != ge::DT_BF16,
+                OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(),
+                                            "g dtype must be float32, float16, or bfloat16."),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(outDtype != inDtype,
+                OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(),
+                                            "out dtype must be the same as g dtype."),
                 return ge::GRAPH_FAILED);
 
     auto chunkSizePtr = context->GetAttrs()->GetAttrPointer<int64_t>(ATTR_CHUNK_SIZE_INDEX);
@@ -114,10 +122,15 @@ static ge::graphStatus TilingChunkLocalCumsum(gert::TilingContext *context)
                                             "only [B, H, T] layout."),
                 return ge::GRAPH_FAILED);
 
-    OP_CHECK_IF(std::strcmp(outputDtype, "float32") != 0 && std::strcmp(outputDtype, "torch.float") != 0 &&
-                    std::strcmp(outputDtype, "torch.float32") != 0,
+    bool outputDtypeSame = std::strcmp(outputDtype, "same") == 0 ||
+                           std::strcmp(outputDtype, "same_as_input") == 0 ||
+                           std::strcmp(outputDtype, "input") == 0;
+    bool outputDtypeFloat32 = std::strcmp(outputDtype, "float32") == 0 ||
+                              std::strcmp(outputDtype, "torch.float") == 0 ||
+                              std::strcmp(outputDtype, "torch.float32") == 0;
+    OP_CHECK_IF(!outputDtypeSame && !(outputDtypeFloat32 && inDtype == ge::DT_FLOAT),
                 OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(),
-                                            "output_dtype only supports float32, but got %s.", outputDtype),
+                                            "output_dtype must preserve g dtype; got %s.", outputDtype),
                 return ge::GRAPH_FAILED);
 
     int64_t chunkSize = *chunkSizePtr;
@@ -201,6 +214,13 @@ static ge::graphStatus TilingChunkLocalCumsum(gert::TilingContext *context)
     tiling->isVarlen = isVarlen ? 1 : 0;
     tiling->reverse = *reversePtr ? 1 : 0;
     tiling->headFirst = *headFirstPtr ? 1 : 0;
+    if (inDtype == ge::DT_FLOAT16) {
+        tiling->inputDtype = INPUT_DTYPE_FP16;
+    } else if (inDtype == ge::DT_BF16) {
+        tiling->inputDtype = INPUT_DTYPE_BF16;
+    } else {
+        tiling->inputDtype = INPUT_DTYPE_FP32;
+    }
     tiling->scale = *scalePtr;
 
     context->SetBlockDim(static_cast<uint32_t>(blockDim));

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/chunk_local_cumsum_tiling.cpp
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/chunk_local_cumsum_tiling.cpp
@@ -37,9 +37,9 @@ constexpr size_t ATTR_HEAD_FIRST_INDEX = 3;
 constexpr size_t ATTR_OUTPUT_DTYPE_INDEX = 4;
 constexpr uint32_t SYS_WORKSPACE_SIZE = 16U * 1024U * 1024U;
 constexpr int64_t H_TILE_SIZE = 512;
-constexpr int64_t INPUT_DTYPE_FP32 = 0;
-constexpr int64_t INPUT_DTYPE_FP16 = 1;
-constexpr int64_t INPUT_DTYPE_BF16 = 2;
+constexpr int64_t DTYPE_FP32 = 0;
+constexpr int64_t DTYPE_FP16 = 1;
+constexpr int64_t DTYPE_BF16 = 2;
 
 struct ChunkLocalCumsumCompileInfo {
     int64_t aivNum = 0;
@@ -63,6 +63,59 @@ static bool IsPowerOfTwo(int64_t value)
 static int64_t CeilDiv(int64_t a, int64_t b)
 {
     return (a + b - 1) / b;
+}
+
+static bool IsSupportedDataType(ge::DataType dtype)
+{
+    return dtype == ge::DT_FLOAT || dtype == ge::DT_FLOAT16 || dtype == ge::DT_BF16;
+}
+
+static int64_t ToTilingDataType(ge::DataType dtype)
+{
+    if (dtype == ge::DT_FLOAT16) {
+        return DTYPE_FP16;
+    }
+    if (dtype == ge::DT_BF16) {
+        return DTYPE_BF16;
+    }
+    return DTYPE_FP32;
+}
+
+static bool ResolveOutputDataType(const char *outputDtype, ge::DataType inputDtype, ge::DataType &resolvedDtype)
+{
+    if (outputDtype == nullptr || outputDtype[0] == '\0' ||
+        std::strcmp(outputDtype, "float") == 0 ||
+        std::strcmp(outputDtype, "float32") == 0 ||
+        std::strcmp(outputDtype, "fp32") == 0 ||
+        std::strcmp(outputDtype, "torch.float") == 0 ||
+        std::strcmp(outputDtype, "torch.float32") == 0) {
+        resolvedDtype = ge::DT_FLOAT;
+        return true;
+    }
+    if (std::strcmp(outputDtype, "same") == 0 ||
+        std::strcmp(outputDtype, "same_as_input") == 0 ||
+        std::strcmp(outputDtype, "input") == 0 ||
+        std::strcmp(outputDtype, "none") == 0 ||
+        std::strcmp(outputDtype, "None") == 0 ||
+        std::strcmp(outputDtype, "null") == 0) {
+        resolvedDtype = inputDtype;
+        return true;
+    }
+    if (std::strcmp(outputDtype, "float16") == 0 ||
+        std::strcmp(outputDtype, "fp16") == 0 ||
+        std::strcmp(outputDtype, "half") == 0 ||
+        std::strcmp(outputDtype, "torch.float16") == 0 ||
+        std::strcmp(outputDtype, "torch.half") == 0) {
+        resolvedDtype = ge::DT_FLOAT16;
+        return true;
+    }
+    if (std::strcmp(outputDtype, "bfloat16") == 0 ||
+        std::strcmp(outputDtype, "bf16") == 0 ||
+        std::strcmp(outputDtype, "torch.bfloat16") == 0) {
+        resolvedDtype = ge::DT_BF16;
+        return true;
+    }
+    return false;
 }
 } // namespace
 
@@ -96,13 +149,13 @@ static ge::graphStatus TilingChunkLocalCumsum(gert::TilingContext *context)
 
     auto inDtype = context->GetInputDesc(G_INDEX)->GetDataType();
     auto outDtype = context->GetOutputDesc(OUT_INDEX)->GetDataType();
-    OP_CHECK_IF(inDtype != ge::DT_FLOAT && inDtype != ge::DT_FLOAT16 && inDtype != ge::DT_BF16,
+    OP_CHECK_IF(!IsSupportedDataType(inDtype),
                 OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(),
                                             "g dtype must be float32, float16, or bfloat16."),
                 return ge::GRAPH_FAILED);
-    OP_CHECK_IF(outDtype != inDtype,
+    OP_CHECK_IF(!IsSupportedDataType(outDtype),
                 OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(),
-                                            "out dtype must be the same as g dtype."),
+                                            "out dtype must be float32, float16, or bfloat16."),
                 return ge::GRAPH_FAILED);
 
     auto chunkSizePtr = context->GetAttrs()->GetAttrPointer<int64_t>(ATTR_CHUNK_SIZE_INDEX);
@@ -122,15 +175,17 @@ static ge::graphStatus TilingChunkLocalCumsum(gert::TilingContext *context)
                                             "only [B, H, T] layout."),
                 return ge::GRAPH_FAILED);
 
-    bool outputDtypeSame = std::strcmp(outputDtype, "same") == 0 ||
-                           std::strcmp(outputDtype, "same_as_input") == 0 ||
-                           std::strcmp(outputDtype, "input") == 0;
-    bool outputDtypeFloat32 = std::strcmp(outputDtype, "float32") == 0 ||
-                              std::strcmp(outputDtype, "torch.float") == 0 ||
-                              std::strcmp(outputDtype, "torch.float32") == 0;
-    OP_CHECK_IF(!outputDtypeSame && !(outputDtypeFloat32 && inDtype == ge::DT_FLOAT),
+    ge::DataType expectedOutDtype = ge::DT_FLOAT;
+    OP_CHECK_IF(!ResolveOutputDataType(outputDtype, inDtype, expectedOutDtype),
                 OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(),
-                                            "output_dtype must preserve g dtype; got %s.", outputDtype),
+                                            "output_dtype must be float32/float16/bfloat16 or same/input/none, got %s.",
+                                            outputDtype),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(outDtype != expectedOutDtype,
+                OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(),
+                                            "out dtype %d does not match output_dtype=%s expected dtype %d.",
+                                            static_cast<int>(outDtype), outputDtype,
+                                            static_cast<int>(expectedOutDtype)),
                 return ge::GRAPH_FAILED);
 
     int64_t chunkSize = *chunkSizePtr;
@@ -214,13 +269,8 @@ static ge::graphStatus TilingChunkLocalCumsum(gert::TilingContext *context)
     tiling->isVarlen = isVarlen ? 1 : 0;
     tiling->reverse = *reversePtr ? 1 : 0;
     tiling->headFirst = *headFirstPtr ? 1 : 0;
-    if (inDtype == ge::DT_FLOAT16) {
-        tiling->inputDtype = INPUT_DTYPE_FP16;
-    } else if (inDtype == ge::DT_BF16) {
-        tiling->inputDtype = INPUT_DTYPE_BF16;
-    } else {
-        tiling->inputDtype = INPUT_DTYPE_FP32;
-    }
+    tiling->inputDtype = ToTilingDataType(inDtype);
+    tiling->outputDtype = ToTilingDataType(outDtype);
     tiling->scale = *scalePtr;
 
     context->SetBlockDim(static_cast<uint32_t>(blockDim));

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/chunk_local_cumsum_tiling.cpp
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/chunk_local_cumsum_tiling.cpp
@@ -86,8 +86,8 @@ static ge::graphStatus TilingChunkLocalCumsum(gert::TilingContext *context)
     OP_CHECK_NULL_WITH_CONTEXT(context, context->GetAttrs());
 
     const auto &gShape = context->GetInputShape(G_INDEX)->GetStorageShape();
-    OP_CHECK_IF(gShape.GetDimNum() < 3,
-                OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(), "g must be rank >= 3 for [B, H, T, *], but rank is %zu.",
+    OP_CHECK_IF(gShape.GetDimNum() != 3,
+                OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(), "g must be rank 3 for [B, H, T], but rank is %zu.",
                                             gShape.GetDimNum()),
                 return ge::GRAPH_FAILED);
 
@@ -111,7 +111,7 @@ static ge::graphStatus TilingChunkLocalCumsum(gert::TilingContext *context)
     OP_CHECK_IF(!*headFirstPtr,
                 OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(),
                                             "head_first=false is not supported; ChunkLocalCumsum currently supports "
-                                            "only [B, H, T, *] layout."),
+                                            "only [B, H, T] layout."),
                 return ge::GRAPH_FAILED);
 
     OP_CHECK_IF(std::strcmp(outputDtype, "float32") != 0 && std::strcmp(outputDtype, "torch.float") != 0 &&
@@ -130,13 +130,10 @@ static ge::graphStatus TilingChunkLocalCumsum(gert::TilingContext *context)
     int64_t head = gShape.GetDim(1);
     int64_t t = gShape.GetDim(2);
     int64_t tail = 1;
-    for (size_t dimIdx = 3; dimIdx < gShape.GetDimNum(); ++dimIdx) {
-        tail *= gShape.GetDim(dimIdx);
-    }
     OP_CHECK_IF(batch <= 0 || head <= 0 || t <= 0 || tail <= 0,
                 OPS_REPORT_VECTOR_INNER_ERR(context->GetNodeName(),
-                                            "g shape must be positive [B, H, T, *], got B=%ld, H=%ld, T=%ld, tail=%ld.",
-                                            batch, head, t, tail),
+                                            "g shape must be positive [B, H, T], got B=%ld, H=%ld, T=%ld.",
+                                            batch, head, t),
                 return ge::GRAPH_FAILED);
     int64_t outer = batch * head;
 

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/op_api/aclnn_chunk_local_cumsum.cpp
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/op_api/aclnn_chunk_local_cumsum.cpp
@@ -24,8 +24,8 @@ extern "C" {
 
 struct ChunkLocalCumsumParams {
     const aclTensor *g = nullptr;
-    const aclTensor *cuSeqlensOptional = nullptr;
-    const aclTensor *chunkIndicesOutOptional = nullptr;
+    const aclIntArray *cuSeqlensOptional = nullptr;
+    const aclIntArray *chunkIndicesOutOptional = nullptr;
     int64_t chunkSize = 0;
     bool reverse = false;
     double scale = 1.0;
@@ -57,29 +57,17 @@ static aclnnStatus DataContiguous(const aclTensor *&tensor, aclOpExecutor *execu
     return ACLNN_SUCCESS;
 }
 
-static aclnnStatus OptionalDataContiguous(const aclTensor *&tensor, aclOpExecutor *executor)
-{
-    if (tensor == nullptr) {
-        return ACLNN_SUCCESS;
-    }
-    return DataContiguous(tensor, executor);
-}
-
 static aclnnStatus ParamsDataContiguous(ChunkLocalCumsumParams &params, aclOpExecutor *executorPtr)
 {
     CHECK_COND(DataContiguous(params.g, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
                "Contiguous g failed.");
-    CHECK_COND(OptionalDataContiguous(params.cuSeqlensOptional, executorPtr) == ACLNN_SUCCESS,
-               ACLNN_ERR_PARAM_INVALID, "Contiguous cuSeqlensOptional failed.");
-    CHECK_COND(OptionalDataContiguous(params.chunkIndicesOutOptional, executorPtr) == ACLNN_SUCCESS,
-               ACLNN_ERR_PARAM_INVALID, "Contiguous chunkIndicesOutOptional failed.");
     return ACLNN_SUCCESS;
 }
 
 aclnnStatus aclnnChunkLocalCumsumGetWorkspaceSize(
     const aclTensor *g,
-    const aclTensor *cuSeqlensOptional,
-    const aclTensor *chunkIndicesOutOptional,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOutOptional,
     int64_t chunkSize,
     bool reverse,
     double scale,

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/op_api/aclnn_chunk_local_cumsum.h
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/op_api/aclnn_chunk_local_cumsum.h
@@ -17,8 +17,8 @@ extern "C" {
 __attribute__((visibility("default")))
 aclnnStatus aclnnChunkLocalCumsumGetWorkspaceSize(
     const aclTensor *g,
-    const aclTensor *cuSeqlensOptional,
-    const aclTensor *chunkIndicesOutOptional,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOutOptional,
     int64_t chunkSize,
     bool reverse,
     double scale,
@@ -42,8 +42,8 @@ aclnnStatus aclnnChunkLocalCumsum(
 namespace l0op {
 const aclTensor *ChunkLocalCumsum(
     const aclTensor *g,
-    const aclTensor *cuSeqlensOptional,
-    const aclTensor *chunkIndicesOutOptional,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOutOptional,
     int64_t chunkSize,
     bool reverse,
     double scale,

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/op_api/chunk_local_cumsum.cpp
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/op_api/chunk_local_cumsum.cpp
@@ -17,8 +17,8 @@ OP_TYPE_REGISTER(ChunkLocalCumsum);
 
 const aclTensor *ChunkLocalCumsum(
     const aclTensor *g,
-    const aclTensor *cuSeqlensOptional,
-    const aclTensor *chunkIndicesOutOptional,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOutOptional,
     int64_t chunkSize,
     bool reverse,
     double scale,
@@ -30,12 +30,28 @@ const aclTensor *ChunkLocalCumsum(
     L0_DFX(ChunkLocalCumsum, g, cuSeqlensOptional, chunkIndicesOutOptional, chunkSize, reverse, scale, headFirst,
            outputDtypeOptional, out);
 
+    const aclTensor *actualCuSeqlens = nullptr;
+    if (cuSeqlensOptional != nullptr) {
+        actualCuSeqlens = executor->ConvertToTensor(cuSeqlensOptional, DataType::DT_INT64);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetStorageFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetViewFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetOriginalFormat(Format::FORMAT_ND);
+    }
+
+    const aclTensor *actualChunkIndicesOut = nullptr;
+    if (chunkIndicesOutOptional != nullptr) {
+        actualChunkIndicesOut = executor->ConvertToTensor(chunkIndicesOutOptional, DataType::DT_INT64);
+        const_cast<aclTensor *>(actualChunkIndicesOut)->SetStorageFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualChunkIndicesOut)->SetViewFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualChunkIndicesOut)->SetOriginalFormat(Format::FORMAT_ND);
+    }
+
     std::string outputDtypeStr(outputDtypeOptional ? outputDtypeOptional : "float32");
     float scaleFloat = static_cast<float>(scale);
 
     auto ret = ADD_TO_LAUNCHER_LIST_AICORE(
         ChunkLocalCumsum,
-        OP_INPUT(g, cuSeqlensOptional, chunkIndicesOutOptional),
+        OP_INPUT(g, actualCuSeqlens, actualChunkIndicesOut),
         OP_OUTPUT(out),
         OP_ATTR(chunkSize, reverse, scaleFloat, headFirst, outputDtypeStr));
     if (ret != ACLNN_SUCCESS) {

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/op_api/chunk_local_cumsum.cpp
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_host/op_api/chunk_local_cumsum.cpp
@@ -33,6 +33,10 @@ const aclTensor *ChunkLocalCumsum(
     const aclTensor *actualCuSeqlens = nullptr;
     if (cuSeqlensOptional != nullptr) {
         actualCuSeqlens = executor->ConvertToTensor(cuSeqlensOptional, DataType::DT_INT64);
+        if (actualCuSeqlens == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "Convert cu_seqlens int array to tensor failed.");
+            return nullptr;
+        }
         const_cast<aclTensor *>(actualCuSeqlens)->SetStorageFormat(Format::FORMAT_ND);
         const_cast<aclTensor *>(actualCuSeqlens)->SetViewFormat(Format::FORMAT_ND);
         const_cast<aclTensor *>(actualCuSeqlens)->SetOriginalFormat(Format::FORMAT_ND);
@@ -41,6 +45,10 @@ const aclTensor *ChunkLocalCumsum(
     const aclTensor *actualChunkIndicesOut = nullptr;
     if (chunkIndicesOutOptional != nullptr) {
         actualChunkIndicesOut = executor->ConvertToTensor(chunkIndicesOutOptional, DataType::DT_INT64);
+        if (actualChunkIndicesOut == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "Convert chunk_indices_out int array to tensor failed.");
+            return nullptr;
+        }
         const_cast<aclTensor *>(actualChunkIndicesOut)->SetStorageFormat(Format::FORMAT_ND);
         const_cast<aclTensor *>(actualChunkIndicesOut)->SetViewFormat(Format::FORMAT_ND);
         const_cast<aclTensor *>(actualChunkIndicesOut)->SetOriginalFormat(Format::FORMAT_ND);

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_kernel/chunk_local_cumsum.cpp
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_kernel/chunk_local_cumsum.cpp
@@ -28,9 +28,9 @@ constexpr int64_t FAST_CHUNK_SCAN_BUFFER_NUM = 2;
 constexpr int64_t FP32_REPEAT_ELEMS = 64;
 constexpr int64_t VECTOR_MAX_REPEAT_TIMES = 255;
 constexpr int64_t VECTOR_MAX_CALC_ELEMS = FP32_REPEAT_ELEMS * VECTOR_MAX_REPEAT_TIMES;
-constexpr int64_t INPUT_DTYPE_FP32 = 0;
-constexpr int64_t INPUT_DTYPE_FP16 = 1;
-constexpr int64_t INPUT_DTYPE_BF16 = 2;
+constexpr int64_t DTYPE_FP32 = 0;
+constexpr int64_t DTYPE_FP16 = 1;
+constexpr int64_t DTYPE_BF16 = 2;
 constexpr int32_t BUFFER_NUM = 1;
 
 __aicore__ inline int64_t MinInt64(int64_t a, int64_t b)
@@ -53,7 +53,7 @@ __aicore__ inline int64_t AlignDownInt64(int64_t value, int64_t align)
     return (value / align) * align;
 }
 
-template <typename GType>
+template <typename GType, typename OType>
 class ChunkLocalCumsumKernel {
 public:
     __aicore__ inline ChunkLocalCumsumKernel() = default;
@@ -63,7 +63,7 @@ public:
     {
         tiling_ = tiling;
         gGm_.SetGlobalBuffer(reinterpret_cast<__gm__ GType *>(g), tiling_->totalElements);
-        outGm_.SetGlobalBuffer(reinterpret_cast<__gm__ GType *>(out), tiling_->totalElements);
+        outGm_.SetGlobalBuffer(reinterpret_cast<__gm__ OType *>(out), tiling_->totalElements);
         if (tiling_->isVarlen != 0) {
             cuSeqlensGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(cuSeqlens));
             chunkIndicesGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(chunkIndices), tiling_->numBlocks * 2);
@@ -74,7 +74,7 @@ public:
         fastHTileSize_ = AlignDownInt64(MinInt64(MinInt64(H_TILE_SIZE, tiling_->h), maxFastHLen),
                                         FLOAT_ALIGN_ELEMS);
         // The log-step scan needs two chunk buffers; shrink only the fast H tile, not the whole fast path.
-        chunkFastPath_ = std::is_same<GType, float>::value &&
+        chunkFastPath_ = std::is_same<GType, float>::value && std::is_same<OType, float>::value &&
                          ((tiling_->h & (FLOAT_ALIGN_ELEMS - 1)) == 0) &&
                          (fastHTileSize_ >= FLOAT_ALIGN_ELEMS);
         if (chunkFastPath_) {
@@ -91,7 +91,11 @@ public:
                 int64_t inputRowBufferBytes =
                     AlignUpInt64(H_TILE_SIZE * static_cast<int64_t>(sizeof(GType)), UB_ALIGN_BYTES);
                 pipe_.InitBuffer(inputRowQueue_, BUFFER_NUM, inputRowBufferBytes);
-                pipe_.InitBuffer(outCastQueue_, BUFFER_NUM, inputRowBufferBytes);
+            }
+            if constexpr (!std::is_same<OType, float>::value) {
+                int64_t outputRowBufferBytes =
+                    AlignUpInt64(H_TILE_SIZE * static_cast<int64_t>(sizeof(OType)), UB_ALIGN_BYTES);
+                pipe_.InitBuffer(outCastQueue_, BUFFER_NUM, outputRowBufferBytes);
             }
         }
     }
@@ -150,7 +154,7 @@ private:
 
     __aicore__ inline void CopyUbToGm(int64_t gmOffset, LocalTensor<float> srcLocal, int64_t elementCount)
     {
-        if constexpr (std::is_same<GType, float>::value) {
+        if constexpr (std::is_same<OType, float>::value) {
             if ((elementCount & 7) == 0) {
                 DataCopy(outGm_[gmOffset], srcLocal, static_cast<uint32_t>(elementCount));
             } else {
@@ -159,12 +163,12 @@ private:
                 DataCopyPad(outGm_[gmOffset], srcLocal, copyParams);
             }
         } else {
-            LocalTensor<GType> outLocal = outCastQueue_.AllocTensor<GType>();
+            LocalTensor<OType> outLocal = outCastQueue_.AllocTensor<OType>();
             Cast(outLocal, srcLocal, RoundMode::CAST_RINT, static_cast<uint32_t>(elementCount));
             PipeBarrier<PIPE_V>();
             outCastQueue_.EnQue(outLocal);
-            outLocal = outCastQueue_.DeQue<GType>();
-            DataCopyExtParams copyParams{1, static_cast<uint32_t>(elementCount * static_cast<int64_t>(sizeof(GType))),
+            outLocal = outCastQueue_.DeQue<OType>();
+            DataCopyExtParams copyParams{1, static_cast<uint32_t>(elementCount * static_cast<int64_t>(sizeof(OType))),
                                          0, 0, 0};
             DataCopyPad(outGm_[gmOffset], outLocal, copyParams);
             outCastQueue_.FreeTensor(outLocal);
@@ -364,7 +368,7 @@ private:
             int64_t chunkStart = chunkIdx * tiling_->chunkSize;
             int64_t chunkEnd = MinInt64(chunkStart + tiling_->chunkSize, tiling_->t);
             int64_t baseOffset = bIdx * tiling_->t * tiling_->h;
-            if constexpr (std::is_same<GType, float>::value) {
+            if constexpr (std::is_same<GType, float>::value && std::is_same<OType, float>::value) {
                 if (chunkFastPath_) {
                     ProcessSequenceChunkFast(baseOffset, chunkStart, chunkEnd, hStart, hLen);
                 } else {
@@ -400,7 +404,7 @@ private:
             int64_t baseOffset = outerIdx * tiling_->t * tiling_->h + bos * tiling_->h;
             for (int64_t chunkStart = tStart; chunkStart < tEnd; chunkStart += tiling_->chunkSize) {
                 int64_t chunkEnd = MinInt64(chunkStart + tiling_->chunkSize, tEnd);
-                if constexpr (std::is_same<GType, float>::value) {
+                if constexpr (std::is_same<GType, float>::value && std::is_same<OType, float>::value) {
                     if (chunkFastPath_) {
                         ProcessSequenceChunkFast(baseOffset, chunkStart, chunkEnd, hStart, hLen);
                     } else {
@@ -423,7 +427,7 @@ private:
     TBuf<> scanBuf_;
     TBuf<> accBuf_;
     GlobalTensor<GType> gGm_;
-    GlobalTensor<GType> outGm_;
+    GlobalTensor<OType> outGm_;
     GlobalTensor<int64_t> cuSeqlensGm_;
     GlobalTensor<int64_t> chunkIndicesGm_;
     const ChunkLocalCumsumTilingData *tiling_ = nullptr;
@@ -438,16 +442,40 @@ extern "C" __global__ __aicore__ void chunk_local_cumsum(GM_ADDR g, GM_ADDR cuSe
     REGISTER_TILING_DEFAULT(ChunkLocalCumsumTilingData);
     GET_TILING_DATA_WITH_STRUCT(ChunkLocalCumsumTilingData, tilingData, tiling);
     KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_AIV_ONLY);
-    if (tilingData.inputDtype == INPUT_DTYPE_FP16) {
-        ChunkLocalCumsumKernel<half> op;
+    if (tilingData.inputDtype == DTYPE_FP16 && tilingData.outputDtype == DTYPE_FP16) {
+        ChunkLocalCumsumKernel<half, half> op;
         op.Init(g, cuSeqlens, chunkIndices, out, &tilingData);
         op.Process();
-    } else if (tilingData.inputDtype == INPUT_DTYPE_BF16) {
-        ChunkLocalCumsumKernel<bfloat16_t> op;
+    } else if (tilingData.inputDtype == DTYPE_FP16 && tilingData.outputDtype == DTYPE_BF16) {
+        ChunkLocalCumsumKernel<half, bfloat16_t> op;
+        op.Init(g, cuSeqlens, chunkIndices, out, &tilingData);
+        op.Process();
+    } else if (tilingData.inputDtype == DTYPE_FP16) {
+        ChunkLocalCumsumKernel<half, float> op;
+        op.Init(g, cuSeqlens, chunkIndices, out, &tilingData);
+        op.Process();
+    } else if (tilingData.inputDtype == DTYPE_BF16 && tilingData.outputDtype == DTYPE_FP16) {
+        ChunkLocalCumsumKernel<bfloat16_t, half> op;
+        op.Init(g, cuSeqlens, chunkIndices, out, &tilingData);
+        op.Process();
+    } else if (tilingData.inputDtype == DTYPE_BF16 && tilingData.outputDtype == DTYPE_BF16) {
+        ChunkLocalCumsumKernel<bfloat16_t, bfloat16_t> op;
+        op.Init(g, cuSeqlens, chunkIndices, out, &tilingData);
+        op.Process();
+    } else if (tilingData.inputDtype == DTYPE_BF16) {
+        ChunkLocalCumsumKernel<bfloat16_t, float> op;
+        op.Init(g, cuSeqlens, chunkIndices, out, &tilingData);
+        op.Process();
+    } else if (tilingData.outputDtype == DTYPE_FP16) {
+        ChunkLocalCumsumKernel<float, half> op;
+        op.Init(g, cuSeqlens, chunkIndices, out, &tilingData);
+        op.Process();
+    } else if (tilingData.outputDtype == DTYPE_BF16) {
+        ChunkLocalCumsumKernel<float, bfloat16_t> op;
         op.Init(g, cuSeqlens, chunkIndices, out, &tilingData);
         op.Process();
     } else {
-        ChunkLocalCumsumKernel<float> op;
+        ChunkLocalCumsumKernel<float, float> op;
         op.Init(g, cuSeqlens, chunkIndices, out, &tilingData);
         op.Process();
     }

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_kernel/chunk_local_cumsum.cpp
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_kernel/chunk_local_cumsum.cpp
@@ -15,6 +15,7 @@
 
 #include "kernel_operator.h"
 #include "chunk_local_cumsum_tiling_data.h"
+#include <type_traits>
 
 using namespace AscendC;
 
@@ -27,6 +28,9 @@ constexpr int64_t FAST_CHUNK_SCAN_BUFFER_NUM = 2;
 constexpr int64_t FP32_REPEAT_ELEMS = 64;
 constexpr int64_t VECTOR_MAX_REPEAT_TIMES = 255;
 constexpr int64_t VECTOR_MAX_CALC_ELEMS = FP32_REPEAT_ELEMS * VECTOR_MAX_REPEAT_TIMES;
+constexpr int64_t INPUT_DTYPE_FP32 = 0;
+constexpr int64_t INPUT_DTYPE_FP16 = 1;
+constexpr int64_t INPUT_DTYPE_BF16 = 2;
 constexpr int32_t BUFFER_NUM = 1;
 
 __aicore__ inline int64_t MinInt64(int64_t a, int64_t b)
@@ -49,6 +53,7 @@ __aicore__ inline int64_t AlignDownInt64(int64_t value, int64_t align)
     return (value / align) * align;
 }
 
+template <typename GType>
 class ChunkLocalCumsumKernel {
 public:
     __aicore__ inline ChunkLocalCumsumKernel() = default;
@@ -57,8 +62,8 @@ public:
                                 const ChunkLocalCumsumTilingData *tiling)
     {
         tiling_ = tiling;
-        gGm_.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(g), tiling_->totalElements);
-        outGm_.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(out), tiling_->totalElements);
+        gGm_.SetGlobalBuffer(reinterpret_cast<__gm__ GType *>(g), tiling_->totalElements);
+        outGm_.SetGlobalBuffer(reinterpret_cast<__gm__ GType *>(out), tiling_->totalElements);
         if (tiling_->isVarlen != 0) {
             cuSeqlensGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(cuSeqlens));
             chunkIndicesGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(chunkIndices), tiling_->numBlocks * 2);
@@ -69,7 +74,8 @@ public:
         fastHTileSize_ = AlignDownInt64(MinInt64(MinInt64(H_TILE_SIZE, tiling_->h), maxFastHLen),
                                         FLOAT_ALIGN_ELEMS);
         // The log-step scan needs two chunk buffers; shrink only the fast H tile, not the whole fast path.
-        chunkFastPath_ = ((tiling_->h & (FLOAT_ALIGN_ELEMS - 1)) == 0) &&
+        chunkFastPath_ = std::is_same<GType, float>::value &&
+                         ((tiling_->h & (FLOAT_ALIGN_ELEMS - 1)) == 0) &&
                          (fastHTileSize_ >= FLOAT_ALIGN_ELEMS);
         if (chunkFastPath_) {
             int64_t chunkBufferBytes = AlignUpInt64(tiling_->chunkSize * fastHTileSize_ *
@@ -81,6 +87,12 @@ public:
             pipe_.InitBuffer(rowQueue_, BUFFER_NUM, rowBufferBytes);
             pipe_.InitBuffer(outQueue_, BUFFER_NUM, rowBufferBytes);
             pipe_.InitBuffer(accBuf_, rowBufferBytes);
+            if constexpr (!std::is_same<GType, float>::value) {
+                int64_t inputRowBufferBytes =
+                    AlignUpInt64(H_TILE_SIZE * static_cast<int64_t>(sizeof(GType)), UB_ALIGN_BYTES);
+                pipe_.InitBuffer(inputRowQueue_, BUFFER_NUM, inputRowBufferBytes);
+                pipe_.InitBuffer(outCastQueue_, BUFFER_NUM, inputRowBufferBytes);
+            }
         }
     }
 
@@ -111,13 +123,26 @@ private:
     __aicore__ inline LocalTensor<float> LoadRowToUb(int64_t gmOffset, int64_t elementCount)
     {
         LocalTensor<float> rowLocal = rowQueue_.AllocTensor<float>();
-        if ((elementCount & 7) == 0) {
-            DataCopy(rowLocal, gGm_[gmOffset], static_cast<uint32_t>(elementCount));
+        if constexpr (std::is_same<GType, float>::value) {
+            if ((elementCount & 7) == 0) {
+                DataCopy(rowLocal, gGm_[gmOffset], static_cast<uint32_t>(elementCount));
+            } else {
+                DataCopyExtParams copyParams{1, static_cast<uint32_t>(elementCount * static_cast<int64_t>(sizeof(float))),
+                                             0, 0, 0};
+                DataCopyPadExtParams<float> padParams{false, 0, 0, 0.0f};
+                DataCopyPad(rowLocal, gGm_[gmOffset], copyParams, padParams);
+            }
         } else {
-            DataCopyExtParams copyParams{1, static_cast<uint32_t>(elementCount * static_cast<int64_t>(sizeof(float))),
+            LocalTensor<GType> inputLocal = inputRowQueue_.AllocTensor<GType>();
+            DataCopyExtParams copyParams{1, static_cast<uint32_t>(elementCount * static_cast<int64_t>(sizeof(GType))),
                                          0, 0, 0};
-            DataCopyPadExtParams<float> padParams{false, 0, 0, 0.0f};
-            DataCopyPad(rowLocal, gGm_[gmOffset], copyParams, padParams);
+            DataCopyPadExtParams<GType> padParams{false, 0, 0, 0};
+            DataCopyPad(inputLocal, gGm_[gmOffset], copyParams, padParams);
+            inputRowQueue_.EnQue(inputLocal);
+            inputLocal = inputRowQueue_.DeQue<GType>();
+            Cast(rowLocal, inputLocal, RoundMode::CAST_NONE, static_cast<uint32_t>(elementCount));
+            PipeBarrier<PIPE_V>();
+            inputRowQueue_.FreeTensor(inputLocal);
         }
         rowQueue_.EnQue(rowLocal);
         return rowQueue_.DeQue<float>();
@@ -125,12 +150,24 @@ private:
 
     __aicore__ inline void CopyUbToGm(int64_t gmOffset, LocalTensor<float> srcLocal, int64_t elementCount)
     {
-        if ((elementCount & 7) == 0) {
-            DataCopy(outGm_[gmOffset], srcLocal, static_cast<uint32_t>(elementCount));
+        if constexpr (std::is_same<GType, float>::value) {
+            if ((elementCount & 7) == 0) {
+                DataCopy(outGm_[gmOffset], srcLocal, static_cast<uint32_t>(elementCount));
+            } else {
+                DataCopyExtParams copyParams{1, static_cast<uint32_t>(elementCount * static_cast<int64_t>(sizeof(float))),
+                                             0, 0, 0};
+                DataCopyPad(outGm_[gmOffset], srcLocal, copyParams);
+            }
         } else {
-            DataCopyExtParams copyParams{1, static_cast<uint32_t>(elementCount * static_cast<int64_t>(sizeof(float))),
+            LocalTensor<GType> outLocal = outCastQueue_.AllocTensor<GType>();
+            Cast(outLocal, srcLocal, RoundMode::CAST_RINT, static_cast<uint32_t>(elementCount));
+            PipeBarrier<PIPE_V>();
+            outCastQueue_.EnQue(outLocal);
+            outLocal = outCastQueue_.DeQue<GType>();
+            DataCopyExtParams copyParams{1, static_cast<uint32_t>(elementCount * static_cast<int64_t>(sizeof(GType))),
                                          0, 0, 0};
-            DataCopyPad(outGm_[gmOffset], srcLocal, copyParams);
+            DataCopyPad(outGm_[gmOffset], outLocal, copyParams);
+            outCastQueue_.FreeTensor(outLocal);
         }
     }
 
@@ -327,8 +364,12 @@ private:
             int64_t chunkStart = chunkIdx * tiling_->chunkSize;
             int64_t chunkEnd = MinInt64(chunkStart + tiling_->chunkSize, tiling_->t);
             int64_t baseOffset = bIdx * tiling_->t * tiling_->h;
-            if (chunkFastPath_) {
-                ProcessSequenceChunkFast(baseOffset, chunkStart, chunkEnd, hStart, hLen);
+            if constexpr (std::is_same<GType, float>::value) {
+                if (chunkFastPath_) {
+                    ProcessSequenceChunkFast(baseOffset, chunkStart, chunkEnd, hStart, hLen);
+                } else {
+                    ProcessSequenceChunk(baseOffset, chunkStart, chunkEnd, hStart, hLen);
+                }
             } else {
                 ProcessSequenceChunk(baseOffset, chunkStart, chunkEnd, hStart, hLen);
             }
@@ -359,8 +400,12 @@ private:
             int64_t baseOffset = outerIdx * tiling_->t * tiling_->h + bos * tiling_->h;
             for (int64_t chunkStart = tStart; chunkStart < tEnd; chunkStart += tiling_->chunkSize) {
                 int64_t chunkEnd = MinInt64(chunkStart + tiling_->chunkSize, tEnd);
-                if (chunkFastPath_) {
-                    ProcessSequenceChunkFast(baseOffset, chunkStart, chunkEnd, hStart, hLen);
+                if constexpr (std::is_same<GType, float>::value) {
+                    if (chunkFastPath_) {
+                        ProcessSequenceChunkFast(baseOffset, chunkStart, chunkEnd, hStart, hLen);
+                    } else {
+                        ProcessSequenceChunk(baseOffset, chunkStart, chunkEnd, hStart, hLen);
+                    }
                 } else {
                     ProcessSequenceChunk(baseOffset, chunkStart, chunkEnd, hStart, hLen);
                 }
@@ -372,11 +417,13 @@ private:
     TPipe pipe_;
     TQue<QuePosition::VECIN, BUFFER_NUM> chunkQueue_;
     TQue<QuePosition::VECIN, BUFFER_NUM> rowQueue_;
+    TQue<QuePosition::VECIN, BUFFER_NUM> inputRowQueue_;
     TQue<QuePosition::VECOUT, BUFFER_NUM> outQueue_;
+    TQue<QuePosition::VECOUT, BUFFER_NUM> outCastQueue_;
     TBuf<> scanBuf_;
     TBuf<> accBuf_;
-    GlobalTensor<float> gGm_;
-    GlobalTensor<float> outGm_;
+    GlobalTensor<GType> gGm_;
+    GlobalTensor<GType> outGm_;
     GlobalTensor<int64_t> cuSeqlensGm_;
     GlobalTensor<int64_t> chunkIndicesGm_;
     const ChunkLocalCumsumTilingData *tiling_ = nullptr;
@@ -391,7 +438,17 @@ extern "C" __global__ __aicore__ void chunk_local_cumsum(GM_ADDR g, GM_ADDR cuSe
     REGISTER_TILING_DEFAULT(ChunkLocalCumsumTilingData);
     GET_TILING_DATA_WITH_STRUCT(ChunkLocalCumsumTilingData, tilingData, tiling);
     KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_AIV_ONLY);
-    ChunkLocalCumsumKernel op;
-    op.Init(g, cuSeqlens, chunkIndices, out, &tilingData);
-    op.Process();
+    if (tilingData.inputDtype == INPUT_DTYPE_FP16) {
+        ChunkLocalCumsumKernel<half> op;
+        op.Init(g, cuSeqlens, chunkIndices, out, &tilingData);
+        op.Process();
+    } else if (tilingData.inputDtype == INPUT_DTYPE_BF16) {
+        ChunkLocalCumsumKernel<bfloat16_t> op;
+        op.Init(g, cuSeqlens, chunkIndices, out, &tilingData);
+        op.Process();
+    } else {
+        ChunkLocalCumsumKernel<float> op;
+        op.Init(g, cuSeqlens, chunkIndices, out, &tilingData);
+        op.Process();
+    }
 }

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_kernel/chunk_local_cumsum_tiling_data.h
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_kernel/chunk_local_cumsum_tiling_data.h
@@ -30,6 +30,7 @@ struct ChunkLocalCumsumTilingData {
     int64_t reverse;
     int64_t headFirst;
     int64_t inputDtype;
+    int64_t outputDtype;
     float scale;
 };
 

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_kernel/chunk_local_cumsum_tiling_data.h
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/op_kernel/chunk_local_cumsum_tiling_data.h
@@ -29,6 +29,7 @@ struct ChunkLocalCumsumTilingData {
     int64_t isVarlen;
     int64_t reverse;
     int64_t headFirst;
+    int64_t inputDtype;
     float scale;
 };
 

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/test/test.py
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/test/test.py
@@ -20,6 +20,8 @@ DTYPE_LABELS = {
     torch.bfloat16: "bf16",
 }
 
+OUTPUT_DTYPE_SPECS = (None, "float32", "float16", "bfloat16", "same")
+
 
 def _next_power_of_two(value: int) -> int:
     value = max(value, 1)
@@ -48,6 +50,7 @@ def reference_impl(
     reverse: bool,
     scale: float,
     cu_seqlens: Optional[torch.Tensor] = None,
+    output_dtype: torch.dtype = torch.float32,
 ) -> torch.Tensor:
     out = torch.empty_like(g, dtype=torch.float32)
     for batch in range(g.size(0)):
@@ -68,7 +71,19 @@ def reference_impl(
                     else:
                         value = torch.cumsum(segment, dim=0)
                     out[batch, head, start:end] = value * scale
-    return out.to(g.dtype)
+    return out.to(output_dtype)
+
+
+def resolve_output_dtype(input_dtype: torch.dtype, output_dtype: Optional[str]) -> torch.dtype:
+    if output_dtype is None or output_dtype in {"", "float", "float32", "fp32", "torch.float", "torch.float32"}:
+        return torch.float32
+    if output_dtype in {"same", "same_as_input", "input", "none", "None", "null"}:
+        return input_dtype
+    if output_dtype in {"float16", "fp16", "half", "torch.float16", "torch.half"}:
+        return torch.float16
+    if output_dtype in {"bfloat16", "bf16", "torch.bfloat16"}:
+        return torch.bfloat16
+    raise ValueError(f"unsupported output_dtype={output_dtype}")
 
 
 def _tolerances(dtype: torch.dtype) -> Tuple[float, float]:
@@ -87,6 +102,7 @@ def run_case(
     scale: float = 1.0,
     cu_seqlens_values: Optional[List[int]] = None,
     dtype: torch.dtype = torch.float32,
+    output_dtype: Optional[str] = "same",
 ) -> None:
     torch.manual_seed(sum(ord(ch) for ch in name))
     if len(shape) != 3:
@@ -103,31 +119,41 @@ def run_case(
         cu_seqlens_arg = cu_seqlens_cpu.tolist()
         chunk_indices_arg = chunk_indices_cpu.reshape(-1).tolist()
 
-    actual = torch.ops.npu.npu_chunk_local_cumsum(
-        g_cpu.npu(),
-        chunk_size,
-        cu_seqlens=cu_seqlens_arg,
-        chunk_indices_out=chunk_indices_arg,
-        reverse=reverse,
-        scale=scale,
-        head_first=True,
-        output_dtype="same",
-    ).cpu()
-    expected = reference_impl(g_cpu, chunk_size, reverse, scale, cu_seqlens_cpu)
+    kwargs = {
+        "cu_seqlens": cu_seqlens_arg,
+        "chunk_indices_out": chunk_indices_arg,
+        "reverse": reverse,
+        "scale": scale,
+        "head_first": True,
+    }
+    if output_dtype is not None:
+        kwargs["output_dtype"] = output_dtype
+    actual = torch.ops.npu.npu_chunk_local_cumsum(g_cpu.npu(), chunk_size, **kwargs).cpu()
+    expected_dtype = resolve_output_dtype(dtype, output_dtype)
+    expected = reference_impl(g_cpu, chunk_size, reverse, scale, cu_seqlens_cpu, expected_dtype)
 
-    if actual.dtype != dtype:
-        raise AssertionError(f"{name}: expected output dtype {dtype}, got {actual.dtype}")
-    rtol, atol = _tolerances(dtype)
+    if actual.dtype != expected_dtype:
+        raise AssertionError(f"{name}: expected output dtype {expected_dtype}, got {actual.dtype}")
+    rtol, atol = _tolerances(expected_dtype)
     torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol)
     print(
-        f"[PASS] {name}: dtype={DTYPE_LABELS[dtype]}, shape={shape}, "
-        f"chunk_size={chunk_size}, reverse={reverse}, scale={scale}"
+        f"[PASS] {name}: input={DTYPE_LABELS[dtype]}, output={DTYPE_LABELS[expected_dtype]}, "
+        f"output_dtype={output_dtype}, shape={shape}, chunk_size={chunk_size}, reverse={reverse}, scale={scale}"
     )
 
 
 def main() -> int:
     for dtype in (torch.float32, torch.float16, torch.bfloat16):
         suffix = DTYPE_LABELS[dtype]
+        for output_dtype in OUTPUT_DTYPE_SPECS:
+            output_suffix = "default" if output_dtype is None else output_dtype.replace(".", "_")
+            run_case(
+                f"fixed_output_{suffix}_{output_suffix}",
+                (2, 3, 129),
+                chunk_size=64,
+                dtype=dtype,
+                output_dtype=output_dtype,
+            )
         run_case(f"fixed_forward_{suffix}", (9, 2, 128), chunk_size=64, dtype=dtype)
         run_case(
             f"fixed_reverse_scale_{suffix}",

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/test/test.py
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/test/test.py
@@ -80,20 +80,20 @@ def run_case(
     g_cpu = torch.randn(shape, dtype=torch.float32)
 
     cu_seqlens_cpu = None
-    cu_seqlens_npu = None
-    chunk_indices_npu = None
+    cu_seqlens_arg = None
+    chunk_indices_arg = None
     if cu_seqlens_values is not None:
         cu_seqlens_cpu = torch.tensor(cu_seqlens_values, dtype=torch.long)
         block_t = _block_t(shape, chunk_size)
         chunk_indices_cpu = prepare_chunk_indices(cu_seqlens_cpu, block_t)
-        cu_seqlens_npu = cu_seqlens_cpu.npu()
-        chunk_indices_npu = chunk_indices_cpu.npu()
+        cu_seqlens_arg = cu_seqlens_cpu.tolist()
+        chunk_indices_arg = chunk_indices_cpu.reshape(-1).tolist()
 
     actual = torch.ops.npu.npu_chunk_local_cumsum(
         g_cpu.npu(),
         chunk_size,
-        cu_seqlens=cu_seqlens_npu,
-        chunk_indices_out=chunk_indices_npu,
+        cu_seqlens=cu_seqlens_arg,
+        chunk_indices_out=chunk_indices_arg,
         reverse=reverse,
         scale=scale,
         head_first=True,

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/test/test.py
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/test/test.py
@@ -14,6 +14,13 @@ torch.npu.set_compile_mode(jit_compile=False)
 torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
 
 
+DTYPE_LABELS = {
+    torch.float32: "fp32",
+    torch.float16: "fp16",
+    torch.bfloat16: "bf16",
+}
+
+
 def _next_power_of_two(value: int) -> int:
     value = max(value, 1)
     return 1 << (value - 1).bit_length()
@@ -61,7 +68,15 @@ def reference_impl(
                     else:
                         value = torch.cumsum(segment, dim=0)
                     out[batch, head, start:end] = value * scale
-    return out
+    return out.to(g.dtype)
+
+
+def _tolerances(dtype: torch.dtype) -> Tuple[float, float]:
+    if dtype is torch.float32:
+        return 1e-4, 1e-4
+    if dtype is torch.float16:
+        return 1e-3, 2e-3
+    return 2e-2, 5e-2
 
 
 def run_case(
@@ -71,11 +86,12 @@ def run_case(
     reverse: bool = False,
     scale: float = 1.0,
     cu_seqlens_values: Optional[List[int]] = None,
+    dtype: torch.dtype = torch.float32,
 ) -> None:
     torch.manual_seed(sum(ord(ch) for ch in name))
     if len(shape) != 3:
         raise ValueError(f"{name}: chunk_local_cumsum only supports rank-3 [B, H, T], got shape={shape}")
-    g_cpu = torch.randn(shape, dtype=torch.float32)
+    g_cpu = torch.randn(shape, dtype=torch.float32).to(dtype)
 
     cu_seqlens_cpu = None
     cu_seqlens_arg = None
@@ -95,27 +111,49 @@ def run_case(
         reverse=reverse,
         scale=scale,
         head_first=True,
-        output_dtype="float32",
+        output_dtype="same",
     ).cpu()
     expected = reference_impl(g_cpu, chunk_size, reverse, scale, cu_seqlens_cpu)
 
-    torch.testing.assert_close(actual, expected, rtol=1e-4, atol=1e-4)
-    print(f"[PASS] {name}: shape={shape}, chunk_size={chunk_size}, reverse={reverse}, scale={scale}")
+    if actual.dtype != dtype:
+        raise AssertionError(f"{name}: expected output dtype {dtype}, got {actual.dtype}")
+    rtol, atol = _tolerances(dtype)
+    torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol)
+    print(
+        f"[PASS] {name}: dtype={DTYPE_LABELS[dtype]}, shape={shape}, "
+        f"chunk_size={chunk_size}, reverse={reverse}, scale={scale}"
+    )
 
 
 def main() -> int:
-    run_case("fixed_forward", (9, 2, 128), chunk_size=64)
-    run_case("fixed_reverse_scale", (9, 2, 128), chunk_size=64, reverse=True, scale=0.25)
-    run_case("fixed_odd_t_forward", (2, 3, 129), chunk_size=64)
-    run_case("varlen_forward", (1, 8, 3580), chunk_size=64, cu_seqlens_values=[0, 3580])
-    run_case(
-        "varlen_reverse_scale",
-        (1, 8, 3580),
-        chunk_size=64,
-        reverse=True,
-        scale=-0.5,
-        cu_seqlens_values=[0, 1024, 2048, 3580],
-    )
+    for dtype in (torch.float32, torch.float16, torch.bfloat16):
+        suffix = DTYPE_LABELS[dtype]
+        run_case(f"fixed_forward_{suffix}", (9, 2, 128), chunk_size=64, dtype=dtype)
+        run_case(
+            f"fixed_reverse_scale_{suffix}",
+            (9, 2, 128),
+            chunk_size=64,
+            reverse=True,
+            scale=0.25,
+            dtype=dtype,
+        )
+        run_case(f"fixed_odd_t_forward_{suffix}", (2, 3, 129), chunk_size=64, dtype=dtype)
+        run_case(
+            f"varlen_forward_{suffix}",
+            (1, 8, 3580),
+            chunk_size=64,
+            cu_seqlens_values=[0, 3580],
+            dtype=dtype,
+        )
+        run_case(
+            f"varlen_reverse_scale_{suffix}",
+            (1, 8, 3580),
+            chunk_size=64,
+            reverse=True,
+            scale=-0.5,
+            cu_seqlens_values=[0, 1024, 2048, 3580],
+            dtype=dtype,
+        )
     return 0
 
 

--- a/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/test/test.py
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/chunk_local_cumsum/test/test.py
@@ -2,8 +2,6 @@
 
 import math
 import os
-from functools import reduce
-from operator import mul
 from typing import List, Optional, Tuple
 
 import torch
@@ -21,12 +19,10 @@ def _next_power_of_two(value: int) -> int:
     return 1 << (value - 1).bit_length()
 
 
-def _tail_size(shape: Tuple[int, ...]) -> int:
-    return reduce(mul, shape[3:], 1)
-
-
 def _block_t(shape: Tuple[int, ...], chunk_size: int) -> int:
-    return _next_power_of_two((1 << 17) // (_tail_size(shape) * chunk_size))
+    if len(shape) != 3:
+        raise ValueError(f"chunk_local_cumsum only supports rank-3 [B, H, T], got shape={shape}")
+    return _next_power_of_two((1 << 17) // chunk_size)
 
 
 def prepare_chunk_indices(cu_seqlens: torch.Tensor, block_t: int) -> torch.Tensor:
@@ -59,12 +55,12 @@ def reference_impl(
                 for chunk_start in range(0, seq_len, chunk_size):
                     start = seq_start + chunk_start
                     end = min(start + chunk_size, seq_end)
-                    segment = g[batch, head, start:end, ...].to(torch.float32)
+                    segment = g[batch, head, start:end].to(torch.float32)
                     if reverse:
                         value = torch.flip(torch.cumsum(torch.flip(segment, dims=[0]), dim=0), dims=[0])
                     else:
                         value = torch.cumsum(segment, dim=0)
-                    out[batch, head, start:end, ...] = value * scale
+                    out[batch, head, start:end] = value * scale
     return out
 
 
@@ -77,6 +73,8 @@ def run_case(
     cu_seqlens_values: Optional[List[int]] = None,
 ) -> None:
     torch.manual_seed(sum(ord(ch) for ch in name))
+    if len(shape) != 3:
+        raise ValueError(f"{name}: chunk_local_cumsum only supports rank-3 [B, H, T], got shape={shape}")
     g_cpu = torch.randn(shape, dtype=torch.float32)
 
     cu_seqlens_cpu = None
@@ -106,13 +104,13 @@ def run_case(
 
 
 def main() -> int:
-    run_case("fixed_forward_tail1", (9, 2, 128), chunk_size=64)
-    run_case("fixed_reverse_scale_tail1", (9, 2, 128), chunk_size=64, reverse=True, scale=0.25)
-    run_case("fixed_forward_4d", (2, 3, 129, 8), chunk_size=64)
-    run_case("varlen_forward_4d", (1, 8, 3580, 8), chunk_size=64, cu_seqlens_values=[0, 3580])
+    run_case("fixed_forward", (9, 2, 128), chunk_size=64)
+    run_case("fixed_reverse_scale", (9, 2, 128), chunk_size=64, reverse=True, scale=0.25)
+    run_case("fixed_odd_t_forward", (2, 3, 129), chunk_size=64)
+    run_case("varlen_forward", (1, 8, 3580), chunk_size=64, cu_seqlens_values=[0, 3580])
     run_case(
-        "varlen_reverse_scale_4d",
-        (1, 8, 3580, 8),
+        "varlen_reverse_scale",
+        (1, 8, 3580),
         chunk_size=64,
         reverse=True,
         scale=-0.5,

--- a/torch_custom/fla_npu/gen.sh
+++ b/torch_custom/fla_npu/gen.sh
@@ -51,6 +51,15 @@ python3 -m torchnpugen.gen_op_plugin_functions \
   --output_dir="$OUTPUT_DIR/" \
   --source_yaml="$CDIR/$YAML_FILE"
 
+python3 - <<PY
+from pathlib import Path
+
+path = Path("$OUTPUT_DIR") / "op_plugin_functions.yaml"
+lines = path.read_text().splitlines()
+lines = ["supported: []" if line.strip() == "[]" else line for line in lines]
+path.write_text("\\n".join(lines) + "\\n")
+PY
+
 # check if the second parameter is passed
 if [ -n "$DERIVATIVES_YAML_FILE" ]; then
     python3 -m torchnpugen.gen_derivatives \

--- a/torch_custom/fla_npu/gen.sh
+++ b/torch_custom/fla_npu/gen.sh
@@ -51,15 +51,6 @@ python3 -m torchnpugen.gen_op_plugin_functions \
   --output_dir="$OUTPUT_DIR/" \
   --source_yaml="$CDIR/$YAML_FILE"
 
-python3 - <<PY
-from pathlib import Path
-
-path = Path("$OUTPUT_DIR") / "op_plugin_functions.yaml"
-lines = path.read_text().splitlines()
-lines = ["supported: []" if line.strip() == "[]" else line for line in lines]
-path.write_text("\\n".join(lines) + "\\n")
-PY
-
 # check if the second parameter is passed
 if [ -n "$DERIVATIVES_YAML_FILE" ]; then
     python3 -m torchnpugen.gen_derivatives \

--- a/torch_custom/fla_npu/npu_custom.yaml
+++ b/torch_custom/fla_npu/npu_custom.yaml
@@ -37,17 +37,17 @@ custom:
     op_api: all_version
   - func: npu_recompute_w_u_fwd(Tensor k, Tensor v, Tensor beta, Tensor A, int chunk_size, *, Tensor? g=None, Tensor? gk=None, int[]? cu_seqlens=None, int[]? chunk_indices=None) -> (Tensor, Tensor)
     op_api: all_version
-  - func: npu_chunk_local_cumsum(Tensor g, int chunk_size, *, int[]? cu_seqlens=None, int[]? chunk_indices_out=None, bool reverse=False, float scale=1.0, bool head_first=True, str output_dtype="float32") -> Tensor
+  - func: npu_chunk_local_cumsum(Tensor g, int chunk_size, *, int[]? cu_seqlens=None, int[]? chunk_indices_out=None, bool reverse=False, float scale=1.0, bool head_first=True, str output_dtype="same") -> Tensor
     op_api: all_version
   - func: npu_chunk_scaled_dot_kkt(Tensor k, Tensor g, Tensor beta, *, int chunk_size=64) -> Tensor
     op_api: all_version
   - func: npu_solve_tri(Tensor x, *, int[]? cu_seqlens=None, int[]? chunk_indices=None, str layout="bsnd") -> Tensor
     op_api: all_version
 
-autograd:
+autograd: []
 
 
-symint:
+symint: []
 
 
-quant:
+quant: []

--- a/torch_custom/fla_npu/npu_custom.yaml
+++ b/torch_custom/fla_npu/npu_custom.yaml
@@ -44,10 +44,10 @@ custom:
   - func: npu_solve_tri(Tensor x, *, int[]? cu_seqlens=None, int[]? chunk_indices=None, str layout="bsnd") -> Tensor
     op_api: all_version
 
-autograd: []
+autograd:
 
 
-symint: []
+symint:
 
 
-quant: []
+quant:

--- a/torch_custom/fla_npu/npu_custom.yaml
+++ b/torch_custom/fla_npu/npu_custom.yaml
@@ -37,7 +37,7 @@ custom:
     op_api: all_version
   - func: npu_recompute_w_u_fwd(Tensor k, Tensor v, Tensor beta, Tensor A, int chunk_size, *, Tensor? g=None, Tensor? gk=None, int[]? cu_seqlens=None, int[]? chunk_indices=None) -> (Tensor, Tensor)
     op_api: all_version
-  - func: npu_chunk_local_cumsum(Tensor g, int chunk_size, *, Tensor? cu_seqlens=None, Tensor? chunk_indices_out=None, bool reverse=False, float scale=1.0, bool head_first=True, str output_dtype="float32") -> Tensor
+  - func: npu_chunk_local_cumsum(Tensor g, int chunk_size, *, int[]? cu_seqlens=None, int[]? chunk_indices_out=None, bool reverse=False, float scale=1.0, bool head_first=True, str output_dtype="float32") -> Tensor
     op_api: all_version
   - func: npu_chunk_scaled_dot_kkt(Tensor k, Tensor g, Tensor beta, *, int chunk_size=64) -> Tensor
     op_api: all_version

--- a/torch_custom/fla_npu/npu_custom.yaml
+++ b/torch_custom/fla_npu/npu_custom.yaml
@@ -37,7 +37,7 @@ custom:
     op_api: all_version
   - func: npu_recompute_w_u_fwd(Tensor k, Tensor v, Tensor beta, Tensor A, int chunk_size, *, Tensor? g=None, Tensor? gk=None, int[]? cu_seqlens=None, int[]? chunk_indices=None) -> (Tensor, Tensor)
     op_api: all_version
-  - func: npu_chunk_local_cumsum(Tensor g, int chunk_size, *, int[]? cu_seqlens=None, int[]? chunk_indices_out=None, bool reverse=False, float scale=1.0, bool head_first=True, str output_dtype="same") -> Tensor
+  - func: npu_chunk_local_cumsum(Tensor g, int chunk_size, *, int[]? cu_seqlens=None, int[]? chunk_indices_out=None, bool reverse=False, float scale=1.0, bool head_first=True, str output_dtype="float32") -> Tensor
     op_api: all_version
   - func: npu_chunk_scaled_dot_kkt(Tensor k, Tensor g, Tensor beta, *, int chunk_size=64) -> Tensor
     op_api: all_version

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -577,8 +577,8 @@ at::Tensor npu_solve_tri(
 at::Tensor npu_chunk_local_cumsum(
     const at::Tensor &g,
     int64_t chunk_size,
-    const c10::optional<at::Tensor> &cu_seqlens,
-    const c10::optional<at::Tensor> &chunk_indices_out,
+    at::OptionalIntArrayRef cu_seqlens,
+    at::OptionalIntArrayRef chunk_indices_out,
     bool reverse,
     double scale,
     bool head_first,
@@ -600,33 +600,26 @@ at::Tensor npu_chunk_local_cumsum(
 
     at::Tensor g_contig = g.contiguous();
     at::Tensor out = at::empty_like(g_contig);
-    at::Tensor empty_index = at::empty({0}, g_contig.options().dtype(at::kLong));
 
-    at::Tensor cu_seqlens_tensor = empty_index;
-    if (cu_seqlens.has_value() && cu_seqlens->defined()) {
-        cu_seqlens_tensor = cu_seqlens->contiguous();
-        TORCH_CHECK(cu_seqlens_tensor.scalar_type() == at::kLong,
-                    "npu_chunk_local_cumsum: cu_seqlens must be int64.");
-    }
-
-    at::Tensor chunk_indices_tensor = empty_index;
-    if (chunk_indices_out.has_value() && chunk_indices_out->defined()) {
-        chunk_indices_tensor = chunk_indices_out->contiguous();
-        TORCH_CHECK(chunk_indices_tensor.scalar_type() == at::kLong,
-                    "npu_chunk_local_cumsum: chunk_indices_out must be int64.");
-    }
-
-    if (cu_seqlens_tensor.numel() > 0) {
+    const bool has_cu_seqlens = cu_seqlens.has_value() && cu_seqlens->size() > 0;
+    const bool has_chunk_indices = chunk_indices_out.has_value() && chunk_indices_out->size() > 0;
+    TORCH_CHECK(has_cu_seqlens == has_chunk_indices,
+                "npu_chunk_local_cumsum: cu_seqlens and chunk_indices_out must be both provided or both omitted.");
+    if (has_cu_seqlens) {
+        TORCH_CHECK(cu_seqlens->size() >= 2,
+                    "npu_chunk_local_cumsum: cu_seqlens must have at least 2 elements, got ",
+                    cu_seqlens->size());
+        TORCH_CHECK((chunk_indices_out->size() % 2) == 0,
+                    "npu_chunk_local_cumsum: chunk_indices_out element count must be even, got ",
+                    chunk_indices_out->size());
         TORCH_CHECK(g_contig.size(0) == 1,
                     "npu_chunk_local_cumsum: B must be 1 when cu_seqlens is provided, got ", g_contig.size(0));
-        TORCH_CHECK(chunk_indices_tensor.numel() > 0,
-                    "npu_chunk_local_cumsum: chunk_indices_out is required when cu_seqlens is provided.");
     }
 
     char *output_dtype_cstr = const_cast<char *>(output_dtype_str.c_str());
     EXEC_NPU_CMD_EXT(
         aclnnChunkLocalCumsum,
-        g_contig, cu_seqlens_tensor, chunk_indices_tensor,
+        g_contig, cu_seqlens, chunk_indices_out,
         chunk_size, reverse, scale, head_first, output_dtype_cstr,
         out
     );

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -584,11 +584,11 @@ at::Tensor npu_chunk_local_cumsum(
     bool head_first,
     c10::string_view output_dtype)
 {
-    TORCH_CHECK(g.dim() >= 3, "npu_chunk_local_cumsum: g must be [B, H, T, *], got ", g.sizes());
+    TORCH_CHECK(g.dim() == 3, "npu_chunk_local_cumsum: g must be rank-3 [B, H, T], got ", g.sizes());
     TORCH_CHECK(g.scalar_type() == at::kFloat, "npu_chunk_local_cumsum: only float32 g is supported.");
     TORCH_CHECK(chunk_size > 0 && (chunk_size & (chunk_size - 1)) == 0,
                 "npu_chunk_local_cumsum: chunk_size must be a positive power of two, got ", chunk_size);
-    TORCH_CHECK(head_first, "npu_chunk_local_cumsum: only head_first=true / [B, H, T, *] layout is supported.");
+    TORCH_CHECK(head_first, "npu_chunk_local_cumsum: only head_first=true / [B, H, T] layout is supported.");
 
     std::string output_dtype_str(output_dtype.data(), output_dtype.size());
     if (output_dtype_str.empty()) {

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -585,18 +585,25 @@ at::Tensor npu_chunk_local_cumsum(
     c10::string_view output_dtype)
 {
     TORCH_CHECK(g.dim() == 3, "npu_chunk_local_cumsum: g must be rank-3 [B, H, T], got ", g.sizes());
-    TORCH_CHECK(g.scalar_type() == at::kFloat, "npu_chunk_local_cumsum: only float32 g is supported.");
+    TORCH_CHECK(g.scalar_type() == at::kFloat || g.scalar_type() == at::kHalf ||
+                    g.scalar_type() == at::kBFloat16,
+                "npu_chunk_local_cumsum: g dtype must be float32, float16, or bfloat16, got ",
+                g.scalar_type());
     TORCH_CHECK(chunk_size > 0 && (chunk_size & (chunk_size - 1)) == 0,
                 "npu_chunk_local_cumsum: chunk_size must be a positive power of two, got ", chunk_size);
     TORCH_CHECK(head_first, "npu_chunk_local_cumsum: only head_first=true / [B, H, T] layout is supported.");
 
     std::string output_dtype_str(output_dtype.data(), output_dtype.size());
     if (output_dtype_str.empty()) {
-        output_dtype_str = "float32";
+        output_dtype_str = "same";
     }
-    TORCH_CHECK(output_dtype_str == "float32" || output_dtype_str == "torch.float" ||
-                    output_dtype_str == "torch.float32",
-                "npu_chunk_local_cumsum: output_dtype only supports float32, got ", output_dtype_str);
+    const bool output_dtype_same = output_dtype_str == "same" || output_dtype_str == "same_as_input" ||
+                                   output_dtype_str == "input";
+    const bool output_dtype_float32 = output_dtype_str == "float32" || output_dtype_str == "torch.float" ||
+                                      output_dtype_str == "torch.float32";
+    TORCH_CHECK(output_dtype_same || (output_dtype_float32 && g.scalar_type() == at::kFloat),
+                "npu_chunk_local_cumsum: output dtype must preserve g dtype; got ", output_dtype_str,
+                " for g dtype ", g.scalar_type());
 
     at::Tensor g_contig = g.contiguous();
     at::Tensor out = at::empty_like(g_contig);

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -26,6 +26,37 @@ using npu_preparation = at_npu::native::OpPreparation;
 using namespace op_plugin::utils;
 using namespace op_infer;
 
+namespace {
+bool ResolveChunkLocalCumsumOutputDtype(
+    const std::string &output_dtype_str,
+    c10::ScalarType input_dtype,
+    c10::ScalarType &resolved_dtype)
+{
+    if (output_dtype_str.empty() || output_dtype_str == "float" || output_dtype_str == "float32" ||
+        output_dtype_str == "fp32" || output_dtype_str == "torch.float" ||
+        output_dtype_str == "torch.float32") {
+        resolved_dtype = c10::ScalarType::Float;
+        return true;
+    }
+    if (output_dtype_str == "same" || output_dtype_str == "same_as_input" || output_dtype_str == "input" ||
+        output_dtype_str == "none" || output_dtype_str == "None" || output_dtype_str == "null") {
+        resolved_dtype = input_dtype;
+        return true;
+    }
+    if (output_dtype_str == "float16" || output_dtype_str == "fp16" || output_dtype_str == "half" ||
+        output_dtype_str == "torch.float16" || output_dtype_str == "torch.half") {
+        resolved_dtype = c10::ScalarType::Half;
+        return true;
+    }
+    if (output_dtype_str == "bfloat16" || output_dtype_str == "bf16" ||
+        output_dtype_str == "torch.bfloat16") {
+        resolved_dtype = c10::ScalarType::BFloat16;
+        return true;
+    }
+    return false;
+}
+} // namespace
+
 
 ::std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor> npu_prepare_wy_repr_bwd_full(const at::Tensor & k, const at::Tensor & v, const at::Tensor & beta, const at::Tensor & A, const at::Tensor & dA, const at::Tensor & dw, const at::Tensor & du, const at::Tensor & g, int64_t chunk_size, at::OptionalIntArrayRef cu_seqlens, at::OptionalIntArrayRef chunk_indices)
 {
@@ -594,19 +625,13 @@ at::Tensor npu_chunk_local_cumsum(
     TORCH_CHECK(head_first, "npu_chunk_local_cumsum: only head_first=true / [B, H, T] layout is supported.");
 
     std::string output_dtype_str(output_dtype.data(), output_dtype.size());
-    if (output_dtype_str.empty()) {
-        output_dtype_str = "same";
-    }
-    const bool output_dtype_same = output_dtype_str == "same" || output_dtype_str == "same_as_input" ||
-                                   output_dtype_str == "input";
-    const bool output_dtype_float32 = output_dtype_str == "float32" || output_dtype_str == "torch.float" ||
-                                      output_dtype_str == "torch.float32";
-    TORCH_CHECK(output_dtype_same || (output_dtype_float32 && g.scalar_type() == at::kFloat),
-                "npu_chunk_local_cumsum: output dtype must preserve g dtype; got ", output_dtype_str,
-                " for g dtype ", g.scalar_type());
+    c10::ScalarType out_scalar_type = c10::ScalarType::Float;
+    TORCH_CHECK(ResolveChunkLocalCumsumOutputDtype(output_dtype_str, g.scalar_type(), out_scalar_type),
+                "npu_chunk_local_cumsum: output_dtype must be float32/float16/bfloat16 or same/input/none, got ",
+                output_dtype_str);
 
     at::Tensor g_contig = g.contiguous();
-    at::Tensor out = at::empty_like(g_contig);
+    at::Tensor out = at::empty(g_contig.sizes(), g_contig.options().dtype(out_scalar_type));
 
     const bool has_cu_seqlens = cu_seqlens.has_value() && cu_seqlens->size() > 0;
     const bool has_chunk_indices = chunk_indices_out.has_value() && chunk_indices_out->size() > 0;

--- a/torch_custom/fla_npu/test/test.sh
+++ b/torch_custom/fla_npu/test/test.sh
@@ -8,6 +8,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export PYTHONPATH="$(cd "$SCRIPT_DIR/.." && pwd):${PYTHONPATH:-}"
 TEST_DEVICE_ID=""
 SINGLE_OP=""
 DRY_RUN=false

--- a/torch_custom/fla_npu/test/test_npu_chunk_local_cumsum.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_local_cumsum.py
@@ -18,6 +18,8 @@ DTYPE_LABELS = {
     torch.bfloat16: "bf16",
 }
 
+OUTPUT_DTYPE_SPECS = (None, "float32", "float16", "bfloat16", "same")
+
 
 def _next_power_of_two(value: int) -> int:
     value = max(value, 1)
@@ -45,6 +47,7 @@ def reference_impl(
     reverse: bool,
     scale: float,
     cu_seqlens: Optional[torch.Tensor] = None,
+    output_dtype: torch.dtype = torch.float32,
 ) -> torch.Tensor:
     out = torch.empty_like(g, dtype=torch.float32)
     for batch in range(g.size(0)):
@@ -65,7 +68,19 @@ def reference_impl(
                     else:
                         value = torch.cumsum(segment, dim=0)
                     out[batch, head, start:end] = value * scale
-    return out.to(g.dtype)
+    return out.to(output_dtype)
+
+
+def resolve_output_dtype(input_dtype: torch.dtype, output_dtype: Optional[str]) -> torch.dtype:
+    if output_dtype is None or output_dtype in {"", "float", "float32", "fp32", "torch.float", "torch.float32"}:
+        return torch.float32
+    if output_dtype in {"same", "same_as_input", "input", "none", "None", "null"}:
+        return input_dtype
+    if output_dtype in {"float16", "fp16", "half", "torch.float16", "torch.half"}:
+        return torch.float16
+    if output_dtype in {"bfloat16", "bf16", "torch.bfloat16"}:
+        return torch.bfloat16
+    raise ValueError(f"unsupported output_dtype={output_dtype}")
 
 
 def _tolerances(dtype: torch.dtype) -> Tuple[float, float]:
@@ -84,6 +99,7 @@ def run_case(
     scale: float = 1.0,
     cu_seqlens_values: Optional[List[int]] = None,
     dtype: torch.dtype = torch.float32,
+    output_dtype: Optional[str] = "same",
 ) -> None:
     torch.manual_seed(sum(ord(ch) for ch in name))
     if len(shape) != 3:
@@ -101,31 +117,41 @@ def run_case(
         cu_seqlens_arg = cu_seqlens_cpu.tolist()
         chunk_indices_arg = chunk_indices_cpu.reshape(-1).tolist()
 
-    actual = torch.ops.npu.npu_chunk_local_cumsum(
-        g_npu,
-        chunk_size,
-        cu_seqlens=cu_seqlens_arg,
-        chunk_indices_out=chunk_indices_arg,
-        reverse=reverse,
-        scale=scale,
-        head_first=True,
-        output_dtype="same",
-    ).cpu()
-    expected = reference_impl(g_cpu, chunk_size, reverse, scale, cu_seqlens_cpu)
+    kwargs = {
+        "cu_seqlens": cu_seqlens_arg,
+        "chunk_indices_out": chunk_indices_arg,
+        "reverse": reverse,
+        "scale": scale,
+        "head_first": True,
+    }
+    if output_dtype is not None:
+        kwargs["output_dtype"] = output_dtype
+    actual = torch.ops.npu.npu_chunk_local_cumsum(g_npu, chunk_size, **kwargs).cpu()
+    expected_dtype = resolve_output_dtype(dtype, output_dtype)
+    expected = reference_impl(g_cpu, chunk_size, reverse, scale, cu_seqlens_cpu, expected_dtype)
 
-    if actual.dtype != dtype:
-        raise AssertionError(f"{name}: expected output dtype {dtype}, got {actual.dtype}")
-    rtol, atol = _tolerances(dtype)
+    if actual.dtype != expected_dtype:
+        raise AssertionError(f"{name}: expected output dtype {expected_dtype}, got {actual.dtype}")
+    rtol, atol = _tolerances(expected_dtype)
     torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol)
     print(
-        f"[PASS] {name}: dtype={DTYPE_LABELS[dtype]}, shape={shape}, "
-        f"chunk_size={chunk_size}, reverse={reverse}, scale={scale}"
+        f"[PASS] {name}: input={DTYPE_LABELS[dtype]}, output={DTYPE_LABELS[expected_dtype]}, "
+        f"output_dtype={output_dtype}, shape={shape}, chunk_size={chunk_size}, reverse={reverse}, scale={scale}"
     )
 
 
 if __name__ == "__main__":
     for dtype in (torch.float32, torch.float16, torch.bfloat16):
         suffix = DTYPE_LABELS[dtype]
+        for output_dtype in OUTPUT_DTYPE_SPECS:
+            output_suffix = "default" if output_dtype is None else output_dtype.replace(".", "_")
+            run_case(
+                f"fixed_bht_output_{suffix}_{output_suffix}",
+                (2, 3, 129),
+                chunk_size=64,
+                dtype=dtype,
+                output_dtype=output_dtype,
+            )
         run_case(f"fixed_bht_forward_{suffix}", (9, 2, 128), chunk_size=64, dtype=dtype)
         run_case(
             f"fixed_bht_reverse_scale_{suffix}",

--- a/torch_custom/fla_npu/test/test_npu_chunk_local_cumsum.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_local_cumsum.py
@@ -77,21 +77,21 @@ def run_case(
     g_cpu = torch.randn(shape, dtype=torch.float32)
     g_npu = g_cpu.npu()
 
-    cu_seqlens_npu = None
-    chunk_indices_npu = None
+    cu_seqlens_arg = None
+    chunk_indices_arg = None
     cu_seqlens_cpu = None
     if cu_seqlens_values is not None:
         cu_seqlens_cpu = torch.tensor(cu_seqlens_values, dtype=torch.long)
         block_t = _block_t(shape, chunk_size)
         chunk_indices_cpu = prepare_chunk_indices(cu_seqlens_cpu, block_t)
-        cu_seqlens_npu = cu_seqlens_cpu.npu()
-        chunk_indices_npu = chunk_indices_cpu.npu()
+        cu_seqlens_arg = cu_seqlens_cpu.tolist()
+        chunk_indices_arg = chunk_indices_cpu.reshape(-1).tolist()
 
     actual = torch.ops.npu.npu_chunk_local_cumsum(
         g_npu,
         chunk_size,
-        cu_seqlens=cu_seqlens_npu,
-        chunk_indices_out=chunk_indices_npu,
+        cu_seqlens=cu_seqlens_arg,
+        chunk_indices_out=chunk_indices_arg,
         reverse=reverse,
         scale=scale,
         head_first=True,

--- a/torch_custom/fla_npu/test/test_npu_chunk_local_cumsum.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_local_cumsum.py
@@ -12,6 +12,13 @@ torch.npu.set_compile_mode(jit_compile=False)
 torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
 
 
+DTYPE_LABELS = {
+    torch.float32: "fp32",
+    torch.float16: "fp16",
+    torch.bfloat16: "bf16",
+}
+
+
 def _next_power_of_two(value: int) -> int:
     value = max(value, 1)
     return 1 << (value - 1).bit_length()
@@ -58,7 +65,15 @@ def reference_impl(
                     else:
                         value = torch.cumsum(segment, dim=0)
                     out[batch, head, start:end] = value * scale
-    return out
+    return out.to(g.dtype)
+
+
+def _tolerances(dtype: torch.dtype) -> Tuple[float, float]:
+    if dtype is torch.float32:
+        return 1e-4, 1e-4
+    if dtype is torch.float16:
+        return 1e-3, 2e-3
+    return 2e-2, 5e-2
 
 
 def run_case(
@@ -68,11 +83,12 @@ def run_case(
     reverse: bool = False,
     scale: float = 1.0,
     cu_seqlens_values: Optional[List[int]] = None,
+    dtype: torch.dtype = torch.float32,
 ) -> None:
     torch.manual_seed(sum(ord(ch) for ch in name))
     if len(shape) != 3:
         raise ValueError(f"{name}: chunk_local_cumsum only supports rank-3 [B, H, T], got shape={shape}")
-    g_cpu = torch.randn(shape, dtype=torch.float32)
+    g_cpu = torch.randn(shape, dtype=torch.float32).to(dtype)
     g_npu = g_cpu.npu()
 
     cu_seqlens_arg = None
@@ -93,25 +109,53 @@ def run_case(
         reverse=reverse,
         scale=scale,
         head_first=True,
-        output_dtype="float32",
+        output_dtype="same",
     ).cpu()
     expected = reference_impl(g_cpu, chunk_size, reverse, scale, cu_seqlens_cpu)
 
-    torch.testing.assert_close(actual, expected, rtol=1e-4, atol=1e-4)
-    print(f"[PASS] {name}: shape={shape}, chunk_size={chunk_size}, reverse={reverse}, scale={scale}")
+    if actual.dtype != dtype:
+        raise AssertionError(f"{name}: expected output dtype {dtype}, got {actual.dtype}")
+    rtol, atol = _tolerances(dtype)
+    torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol)
+    print(
+        f"[PASS] {name}: dtype={DTYPE_LABELS[dtype]}, shape={shape}, "
+        f"chunk_size={chunk_size}, reverse={reverse}, scale={scale}"
+    )
 
 
 if __name__ == "__main__":
-    run_case("fixed_bht_forward", (9, 2, 128), chunk_size=64)
-    run_case("fixed_bht_reverse_scale", (9, 2, 128), chunk_size=64, reverse=True, scale=0.25)
-    run_case("fixed_bht_odd_t_forward", (2, 3, 129), chunk_size=64)
-    run_case("varlen_bht_forward", (1, 2, 128), chunk_size=64, cu_seqlens_values=[0, 128])
-    run_case("varlen_bht_long_forward", (1, 8, 3580), chunk_size=64, cu_seqlens_values=[0, 3580])
-    run_case(
-        "varlen_bht_reverse_scale",
-        (1, 8, 3580),
-        chunk_size=64,
-        reverse=True,
-        scale=-0.5,
-        cu_seqlens_values=[0, 1024, 2048, 3580],
-    )
+    for dtype in (torch.float32, torch.float16, torch.bfloat16):
+        suffix = DTYPE_LABELS[dtype]
+        run_case(f"fixed_bht_forward_{suffix}", (9, 2, 128), chunk_size=64, dtype=dtype)
+        run_case(
+            f"fixed_bht_reverse_scale_{suffix}",
+            (9, 2, 128),
+            chunk_size=64,
+            reverse=True,
+            scale=0.25,
+            dtype=dtype,
+        )
+        run_case(f"fixed_bht_odd_t_forward_{suffix}", (2, 3, 129), chunk_size=64, dtype=dtype)
+        run_case(
+            f"varlen_bht_forward_{suffix}",
+            (1, 2, 128),
+            chunk_size=64,
+            cu_seqlens_values=[0, 128],
+            dtype=dtype,
+        )
+        run_case(
+            f"varlen_bht_long_forward_{suffix}",
+            (1, 8, 3580),
+            chunk_size=64,
+            cu_seqlens_values=[0, 3580],
+            dtype=dtype,
+        )
+        run_case(
+            f"varlen_bht_reverse_scale_{suffix}",
+            (1, 8, 3580),
+            chunk_size=64,
+            reverse=True,
+            scale=-0.5,
+            cu_seqlens_values=[0, 1024, 2048, 3580],
+            dtype=dtype,
+        )

--- a/torch_custom/fla_npu/test/test_npu_chunk_local_cumsum.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_local_cumsum.py
@@ -1,7 +1,5 @@
 import math
 import os
-from functools import reduce
-from operator import mul
 from typing import List, Optional, Tuple
 
 import torch
@@ -19,12 +17,10 @@ def _next_power_of_two(value: int) -> int:
     return 1 << (value - 1).bit_length()
 
 
-def _tail_size(shape: Tuple[int, ...]) -> int:
-    return reduce(mul, shape[3:], 1)
-
-
 def _block_t(shape: Tuple[int, ...], chunk_size: int) -> int:
-    return _next_power_of_two((1 << 17) // (_tail_size(shape) * chunk_size))
+    if len(shape) != 3:
+        raise ValueError(f"chunk_local_cumsum only supports rank-3 [B, H, T], got shape={shape}")
+    return _next_power_of_two((1 << 17) // chunk_size)
 
 
 def prepare_chunk_indices(cu_seqlens: torch.Tensor, block_t: int) -> torch.Tensor:
@@ -56,12 +52,12 @@ def reference_impl(
                 for chunk_start in range(0, seq_len, chunk_size):
                     start = seq_start + chunk_start
                     end = min(start + chunk_size, seq_end)
-                    segment = g[batch, head, start:end, ...].to(torch.float32)
+                    segment = g[batch, head, start:end].to(torch.float32)
                     if reverse:
                         value = torch.flip(torch.cumsum(torch.flip(segment, dims=[0]), dim=0), dims=[0])
                     else:
                         value = torch.cumsum(segment, dim=0)
-                    out[batch, head, start:end, ...] = value * scale
+                    out[batch, head, start:end] = value * scale
     return out
 
 
@@ -74,6 +70,8 @@ def run_case(
     cu_seqlens_values: Optional[List[int]] = None,
 ) -> None:
     torch.manual_seed(sum(ord(ch) for ch in name))
+    if len(shape) != 3:
+        raise ValueError(f"{name}: chunk_local_cumsum only supports rank-3 [B, H, T], got shape={shape}")
     g_cpu = torch.randn(shape, dtype=torch.float32)
     g_npu = g_cpu.npu()
 
@@ -106,11 +104,12 @@ def run_case(
 if __name__ == "__main__":
     run_case("fixed_bht_forward", (9, 2, 128), chunk_size=64)
     run_case("fixed_bht_reverse_scale", (9, 2, 128), chunk_size=64, reverse=True, scale=0.25)
-    run_case("fixed_bhtd_forward", (2, 3, 129, 8), chunk_size=64)
-    run_case("varlen_bhtd_forward", (1, 8, 3580, 8), chunk_size=64, cu_seqlens_values=[0, 3580])
+    run_case("fixed_bht_odd_t_forward", (2, 3, 129), chunk_size=64)
+    run_case("varlen_bht_forward", (1, 2, 128), chunk_size=64, cu_seqlens_values=[0, 128])
+    run_case("varlen_bht_long_forward", (1, 8, 3580), chunk_size=64, cu_seqlens_values=[0, 3580])
     run_case(
-        "varlen_bhtd_reverse_scale",
-        (1, 8, 3580, 8),
+        "varlen_bht_reverse_scale",
+        (1, 8, 3580),
         chunk_size=64,
         reverse=True,
         scale=-0.5,


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @huoyibingli
- 修改范围:
  - [x] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [x] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
