### PR TITLE
fix: 修复 Ascend950 GDN 反向算子同步状态异常

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/arch35/chunk_bwd_dv_local_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/arch35/chunk_bwd_dv_local_vector.h
@@ -18,6 +18,7 @@
 #include <type_traits>
 #include "chunk_bwd_dv_local_struct.h"
 #include "chunk_bwd_dv_local_common.h"
+#include "catlass/arch/cross_core_sync.hpp"
 #include "kernel_operator.h"
 #include "kernel_utils/vector/regbase.hpp"
 
@@ -30,6 +31,8 @@ template <typename QKVT, typename GT, typename Strategy>
 class ChunkBwdDvLocalVector {
 private:
     Strategy strategy;
+    Catlass::Arch::CrossCoreFlagWithReverse<> aivToAicGatedReadyFlag{
+        SYNC_AIV_AIC_GATED_READY_FLAG, SYNC_AIC_AIV_GATED_FREE_FLAG};
 
 public:
     __aicore__ inline ChunkBwdDvLocalVector(const Strategy &s) : strategy(s)
@@ -162,7 +165,7 @@ __aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessChunk(c
             if (doHead % hRatio == 0) {
                 AscendC::CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_3);
             }
-            AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_1);
+            Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(aivToAicGatedReadyFlag);
             continue;
         }
 
@@ -229,7 +232,7 @@ __aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessChunk(c
             AscendC::DataCopy(workspaceGm[taskOffset], kqOutLocalTensor, taskLineNum * strategy.chunkSize);
             kqTQueOut.FreeTensor(kqOutLocalTensor);
         }
-        AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_1);
+        Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(aivToAicGatedReadyFlag);
     }
 }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/arch35/chunk_bwd_dv_local_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/arch35/chunk_bwd_dv_local_vector.h
@@ -33,6 +33,8 @@ private:
     Strategy strategy;
     Catlass::Arch::CrossCoreFlagWithReverse<> aivToAicGatedReadyFlag{
         SYNC_AIV_AIC_GATED_READY_FLAG, SYNC_AIC_AIV_GATED_FREE_FLAG};
+    Catlass::Arch::CrossCoreFlagWithReverse<> aicToAivQkReadyFlag{
+        SYNC_AIC_AIV_QK_READY_FLAG, SYNC_AIV_AIC_QK_FREE_FLAG};
 
 public:
     __aicore__ inline ChunkBwdDvLocalVector(const Strategy &s) : strategy(s)
@@ -163,7 +165,7 @@ __aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessChunk(c
         taskLineNum = taskEndLine - taskStartLine + 1;
         if (taskLineNum == 0) {
             if (doHead % hRatio == 0) {
-                AscendC::CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_3);
+                Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(aicToAivQkReadyFlag);
             }
             Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(aivToAicGatedReadyFlag);
             continue;
@@ -186,7 +188,7 @@ __aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessChunk(c
         }
 
         if (doHead % hRatio == 0) {
-            AscendC::CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_3);
+            Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(aicToAivQkReadyFlag);
         }
 
         {

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_common.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_common.h
@@ -29,6 +29,8 @@ constexpr uint64_t SYNC_AIC_AIV_FLAG_3 = 3;
 constexpr uint64_t SYNC_AIC_AIV_FLAG_4 = 4;
 constexpr uint64_t SYNC_AIV_AIC_GATED_READY_FLAG = SYNC_AIV_AIC_FLAG_1;
 constexpr uint64_t SYNC_AIC_AIV_GATED_FREE_FLAG = SYNC_AIC_AIV_FLAG_4;
+constexpr uint64_t SYNC_AIC_AIV_QK_READY_FLAG = SYNC_AIC_AIV_FLAG_3;
+constexpr uint64_t SYNC_AIV_AIC_QK_FREE_FLAG = SYNC_AIV_AIC_FLAG_2;
 
 __aicore__ inline int64_t CeilDiv(int64_t dividend, int64_t divisor)
 {

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_cube.h
@@ -57,6 +57,8 @@ private:
     Strategy strategy;
     Catlass::Arch::CrossCoreFlagWithReverse<> aivToAicGatedReadyFlag{
         SYNC_AIV_AIC_GATED_READY_FLAG, SYNC_AIC_AIV_GATED_FREE_FLAG};
+    Catlass::Arch::CrossCoreFlagWithReverse<> aicToAivQkReadyFlag{
+        SYNC_AIC_AIV_QK_READY_FLAG, SYNC_AIV_AIC_QK_FREE_FLAG};
 
 public:
     __aicore__ inline ChunkBwdDvLocalCube(const Strategy &s) : strategy(s)
@@ -212,7 +214,7 @@ __aicore__ inline void ChunkBwdDvLocalCube<QKVT, GT, Strategy, V>::Process()
                 auto tensorBlockC =
                     GetTile(tensorC, tla::MakeCoord(0, 0), tla::MakeShape(actualBlockShapeQK.m(), actualBlockShapeQK.n()));
                 blockMmadQK(tensorBlockA, tensorBlockB, tensorBlockC, actualBlockShapeQK);
-                AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(SYNC_AIC_AIV_FLAG_3);
+                Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(aicToAivQkReadyFlag);
             }
         }
     }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_vector.h
@@ -28,6 +28,8 @@ private:
     Strategy strategy;
     Catlass::Arch::CrossCoreFlagWithReverse<> aivToAicGatedReadyFlag{
         SYNC_AIV_AIC_GATED_READY_FLAG, SYNC_AIC_AIV_GATED_FREE_FLAG};
+    Catlass::Arch::CrossCoreFlagWithReverse<> aicToAivQkReadyFlag{
+        SYNC_AIC_AIV_QK_READY_FLAG, SYNC_AIV_AIC_QK_FREE_FLAG};
 
 public:
     __aicore__ inline ChunkBwdDvLocalVector(const Strategy &s) : strategy(s)
@@ -202,7 +204,7 @@ __aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessChunk(c
         taskLineNum = taskEndLine - taskStartLine + 1;
         if (taskLineNum == 0) {
             if (doHead % hRatio == 0) {
-                AscendC::CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_3);
+                Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(aicToAivQkReadyFlag);
             }
             Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(aivToAicGatedReadyFlag);
             continue;
@@ -294,7 +296,7 @@ __aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessChunk(c
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::Muls(gFactorLocalTensor, gFactorLocalTensor, scale, taskLineNum * strategy.chunkSize);
         if (doHead % hRatio == 0) {
-            AscendC::CrossCoreWaitFlag(SYNC_AIC_AIV_FLAG_3);
+            Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(aicToAivQkReadyFlag);
         }
 
         // 搬入 (k@q^T)

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/tests/test.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/tests/test.py
@@ -545,6 +545,8 @@ if __name__ == "__main__":
     test_chunk_bwd_dv_local_fix(B=16, H_qk=32, T=4096, K=128, V=128, chunk_size=64, scale=0.0442, ktype=torch.float16, gtype=torch.float16, case_name="C3")
     # C4
     test_chunk_bwd_dv_local_fix(B=8, H_qk=32, T=8192, K=128, V=128, chunk_size=64, scale=0.03125, ktype=torch.bfloat16, gtype=torch.bfloat16, case_name="C4")
+    # A5 reverse-sync regression: the ready/free handshake exceeds one hardware counter window.
+    test_chunk_bwd_dv_local_fix(B=2, H_qk=32, T=8192, K=128, V=128, chunk_size=64, scale=0.03125, ktype=torch.bfloat16, gtype=torch.float32, case_name="A5_SYNC_B2")
     # C5
     test_chunk_bwd_dv_local_fix(B=128, H_qk=4, T=1024, K=128, V=128, chunk_size=64, scale=0.088, ktype=torch.float16, gtype=torch.float16, case_name="C5")
     # C6

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/tests/test.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/tests/test.py
@@ -545,7 +545,7 @@ if __name__ == "__main__":
     test_chunk_bwd_dv_local_fix(B=16, H_qk=32, T=4096, K=128, V=128, chunk_size=64, scale=0.0442, ktype=torch.float16, gtype=torch.float16, case_name="C3")
     # C4
     test_chunk_bwd_dv_local_fix(B=8, H_qk=32, T=8192, K=128, V=128, chunk_size=64, scale=0.03125, ktype=torch.bfloat16, gtype=torch.bfloat16, case_name="C4")
-    # A5 reverse-sync regression: the ready/free handshake exceeds one hardware counter window.
+    # A5 bidirectional reverse-sync regression: both handshakes exceed one hardware counter window.
     test_chunk_bwd_dv_local_fix(B=2, H_qk=32, T=8192, K=128, V=128, chunk_size=64, scale=0.03125, ktype=torch.bfloat16, gtype=torch.float32, case_name="A5_SYNC_B2")
     # C5
     test_chunk_bwd_dv_local_fix(B=128, H_qk=4, T=1024, K=128, V=128, chunk_size=64, scale=0.088, ktype=torch.float16, gtype=torch.float16, case_name="C5")

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
@@ -45,7 +45,6 @@ static constexpr uint32_t CHUNK_GDR_BWD_DHU_NUM_128 = 128;
 static constexpr uint32_t CHUNK_GDR_BWD_DHU_NUM_2 = 2;
 static constexpr uint32_t CHUNK_GDR_BWD_DHU_NUM_3 = 3;
 static constexpr uint32_t CHUNK_GDR_BWD_DHU_BLOCK_SIZE = 32;
-static constexpr uint32_t CHUNK_GDR_BWD_DHU_GATE_STATE_SIZE = 2 * CHUNK_GDR_BWD_DHU_BLOCK_SIZE;
 
 static constexpr uint32_t CHUNK_GDR_BWD_DHU_HALF_DTYPE_SIZE = 2;
 static constexpr uint32_t CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE = 4;
@@ -277,8 +276,7 @@ public:
                                         CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE +
                                     dqkBufByte + dqkCastBufByte + gBrcbBufByte;
         const uint32_t dhPeak = CHUNK_GDR_BWD_DHU_NUM_2 * dhCastBufByte;
-        const uint32_t tBufByte =
-            std::max(dhPeak, std::max(dvPeak, gatedQPeak)) + CHUNK_GDR_BWD_DHU_GATE_STATE_SIZE;
+        const uint32_t tBufByte = std::max(dhPeak, std::max(dvPeak, gatedQPeak));
 
         OP_CHECK_IF(tBufByte > ctx_.ubSize,
                     OP_LOGE(ctx_.nodeName, "K/V is too large, K should less than 128 and V should less than 256."),

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
@@ -45,6 +45,7 @@ static constexpr uint32_t CHUNK_GDR_BWD_DHU_NUM_128 = 128;
 static constexpr uint32_t CHUNK_GDR_BWD_DHU_NUM_2 = 2;
 static constexpr uint32_t CHUNK_GDR_BWD_DHU_NUM_3 = 3;
 static constexpr uint32_t CHUNK_GDR_BWD_DHU_BLOCK_SIZE = 32;
+static constexpr uint32_t CHUNK_GDR_BWD_DHU_GATE_STATE_SIZE = 2 * CHUNK_GDR_BWD_DHU_BLOCK_SIZE;
 
 static constexpr uint32_t CHUNK_GDR_BWD_DHU_HALF_DTYPE_SIZE = 2;
 static constexpr uint32_t CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE = 4;
@@ -276,7 +277,8 @@ public:
                                         CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE +
                                     dqkBufByte + dqkCastBufByte + gBrcbBufByte;
         const uint32_t dhPeak = CHUNK_GDR_BWD_DHU_NUM_2 * dhCastBufByte;
-        const uint32_t tBufByte = std::max(dhPeak, std::max(dvPeak, gatedQPeak));
+        const uint32_t tBufByte =
+            std::max(dhPeak, std::max(dvPeak, gatedQPeak)) + CHUNK_GDR_BWD_DHU_GATE_STATE_SIZE;
 
         OP_CHECK_IF(tBufByte > ctx_.ubSize,
                     OP_LOGE(ctx_.nodeName, "K/V is too large, K should less than 128 and V should less than 256."),

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
@@ -74,7 +74,6 @@ protected:
     LocalTensor<DT> qLocal; // [BT/2,K]
     LocalTensor<float> qCastLocal;
     LocalTensor<GT> gLocal; // [BT/2,]
-    LocalTensor<GT> gLastLocal;
     LocalTensor<float> gCastLocal;
     LocalTensor<float> gLastCastLocal;
     LocalTensor<float> gBCLocal;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
@@ -75,12 +75,10 @@ protected:
     LocalTensor<float> qCastLocal;
     LocalTensor<GT> gLocal; // [BT/2,]
     LocalTensor<float> gCastLocal;
-    LocalTensor<float> gLastCastLocal;
     LocalTensor<float> gBCLocal;
     LocalTensor<float> gBrcbLocal;
 
     LocalTensor<float> gExpLocal;
-    LocalTensor<float> gFatorLocal;
     
     // update dv2
     LocalTensor<DT> vInLocal; // [BT/2,V]

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
@@ -35,12 +35,9 @@ private:
     __aicore__ inline void InitGlobalTensor(GM_ADDR q, GM_ADDR dv, GM_ADDR g, GM_ADDR cu_seqlens, 
                                             GM_ADDR dv2, GM_ADDR dh, GM_ADDR workspace);
     __aicore__ inline void CaclOffset(const uint32_t coarseTaskIdx, const uint32_t h, uint64_t& tailChunkLen);
-    __aicore__ inline void CalcGatedQ(const bool isLastChunk);
-    __aicore__ inline void CalcDv2(uint64_t& curGmOffsetV, const bool isLastChunk);
-    __aicore__ inline void UpdateDh(uint64_t& curGmOffsetH, const bool isLastChunk);
-    __aicore__ inline void SaveGateState(const uint32_t validGateCount);
-    __aicore__ inline void MulByGateState(const LocalTensor<float>& dstLocal, const LocalTensor<float>& srcLocal,
-                                         const LocalTensor<float>& gateStateLocal, const uint64_t count);
+    __aicore__ inline void CalcGatedQ(float& gLast, float& gLastExp, const bool isLastChunk);
+    __aicore__ inline void CalcDv2(const float gLast, uint64_t& curGmOffsetV, const bool isLastChunk);
+    __aicore__ inline void UpdateDh(const float gLastExp, uint64_t& curGmOffsetH, const bool isLastChunk);
 
 
 protected:
@@ -76,10 +73,6 @@ __aicore__ inline void GDRVec<DT, GT>::InitUB()
 
     // | gCastLocal | gExpLocal | qLocal | q
     this->pipe.InitBuffer(this->vecTbuf, this->totalTbufByte);
-    const uint64_t gateStateOffset = this->totalTbufByte - 2 * BLOCK_SIZE;
-    this->gLastCastLocal = this->vecTbuf.template GetWithOffset<float>(FP32_PER_BLOCK, gateStateOffset);
-    this->gFatorLocal =
-        this->vecTbuf.template GetWithOffset<float>(FP32_PER_BLOCK, gateStateOffset + BLOCK_SIZE);
     uint32_t offset = 0;
     // gLast and g
     // 申请chunkSize大小，subCore1只用前一半，sub0要用后一半拿gLast
@@ -162,6 +155,8 @@ __aicore__ inline void GDRVec<DT, GT>::Process( )
         for (uint32_t h = hq * static_cast<uint32_t>(this->hvPerHk); h < hGroupEnd; h++) {
             uint64_t tailChunkLen = 0;
             CaclOffset(i, h, tailChunkLen);
+            float gLast = 0.0;
+            float gLastExp = 0.0;
             uint64_t curGmOffsetV = 0;
             uint64_t curGmOffsetH = 0;
             bool isLastChunk = false;
@@ -182,9 +177,9 @@ __aicore__ inline void GDRVec<DT, GT>::Process( )
                 isLastChunk = chunkIdx_ == curChunkNum_ - 1 ? true : false;
                 bos_ = chunkIdx_ * this->chunkSize;
                 // gatedQ = q * gExp
-                CalcGatedQ(isLastChunk);
+                CalcGatedQ(gLast, gLastExp, isLastChunk);
                 // 計算dv2 dv2 = bdv * exp(bg_last - bg) + dv[B,H,T,V]
-                CalcDv2(curGmOffsetV, isLastChunk);
+                CalcDv2(gLast, curGmOffsetV, isLastChunk);
                 if (chunkIdx_ > 0) {
                     CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_DV2); // 计算完一个chunk的dv2,通知cube可以开始计算w @ dv2 
                 }
@@ -193,7 +188,7 @@ __aicore__ inline void GDRVec<DT, GT>::Process( )
                     // 每個chunk更新bdh給下個chunk用，chunkIdx=0作爲最後一個chunk，所有的chunk都已經更新完了，無需更新bdh。
                     continue;
                 }
-                UpdateDh(curGmOffsetH, isLastChunk);
+                UpdateDh(gLastExp, curGmOffsetH, isLastChunk);
             }
         }
     }
@@ -202,6 +197,8 @@ __aicore__ inline void GDRVec<DT, GT>::Process( )
 template <typename DT, typename GT>
 __aicore__ inline void GDRVec<DT, GT>::TailChunkProcess(uint32_t tailChunkLen) 
 {
+    float gLast = 0.0;
+    float gLastExp = 0.0;
     uint64_t curGmOffsetV = 0;
     uint64_t curGmOffsetH = 0;
     // 尾chunk大于halfBT时，0做halfBT， 1做剩下的； 只让0做
@@ -216,14 +213,14 @@ __aicore__ inline void GDRVec<DT, GT>::TailChunkProcess(uint32_t tailChunkLen)
     chunkIdx_ = curChunkNum_ - 1;
     bos_ = chunkIdx_ * this->chunkSize;
     // gatedQ = q * gExp
-    CalcGatedQ(true);
+    CalcGatedQ(gLast, gLastExp, true);
     // 計算dv2 dv2 = bdv * exp(bg_last - bg) + dv[B,H,T,V]
-    CalcDv2(curGmOffsetV, true);
+    CalcDv2(gLast, curGmOffsetV, true);
     if (chunkIdx_ > 0) {
         CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_DV2); // 计算完一个chunk的dv2,通知cube可以开始计算w @ dv2 
     }
     // updated dh
-    UpdateDh(curGmOffsetH, true);
+    UpdateDh(gLastExp, curGmOffsetH, true);
 }
 
 template <typename DT, typename GT>
@@ -282,46 +279,7 @@ __aicore__ inline void GDRVec<DT, GT>::CaclOffset(const uint32_t coarseTaskIdx, 
 }
 
 template <typename DT, typename GT>
-__aicore__ inline void GDRVec<DT, GT>::SaveGateState(const uint32_t validGateCount)
-{
-    const uint32_t lastBlockStart = (validGateCount - 1) / FP32_PER_BLOCK * FP32_PER_BLOCK;
-    const uint32_t lastBlockIndex = validGateCount - 1 - lastBlockStart;
-    Brcb(this->gBCLocal, this->gCastLocal[lastBlockStart], 1, {1, FP32_PER_BLOCK});
-    PipeBarrier<PIPE_V>();
-    DataCopy(this->gLastCastLocal, this->gBCLocal[lastBlockIndex * FP32_PER_BLOCK], FP32_PER_BLOCK);
-    PipeBarrier<PIPE_V>();
-    Brcb(this->gBCLocal, this->gExpLocal[lastBlockStart], 1, {1, FP32_PER_BLOCK});
-    PipeBarrier<PIPE_V>();
-    DataCopy(this->gFatorLocal, this->gBCLocal[lastBlockIndex * FP32_PER_BLOCK], FP32_PER_BLOCK);
-    PipeBarrier<PIPE_V>();
-}
-
-template <typename DT, typename GT>
-__aicore__ inline void GDRVec<DT, GT>::MulByGateState(const LocalTensor<float>& dstLocal,
-                                                      const LocalTensor<float>& srcLocal,
-                                                      const LocalTensor<float>& gateStateLocal,
-                                                      const uint64_t count)
-{
-    constexpr uint32_t maxRepeatTimes = 255;
-    uint64_t offset = 0;
-    uint64_t repeatTimes = count / FP32_PER_REPEAT;
-    while (repeatTimes > 0) {
-        const uint8_t currentRepeatTimes =
-            static_cast<uint8_t>(repeatTimes > maxRepeatTimes ? maxRepeatTimes : repeatTimes);
-        AscendC::Mul(dstLocal[offset], srcLocal[offset], gateStateLocal, FP32_PER_REPEAT, currentRepeatTimes,
-                     {1, 1, 0, 8, 8, 0});
-        offset += static_cast<uint64_t>(currentRepeatTimes) * FP32_PER_REPEAT;
-        repeatTimes -= currentRepeatTimes;
-    }
-    const uint32_t tailCount = static_cast<uint32_t>(count - offset);
-    if (tailCount > 0) {
-        AscendC::Mul(dstLocal[offset], srcLocal[offset], gateStateLocal, tailCount, 1, {1, 1, 0, 8, 8, 0});
-    }
-    PipeBarrier<PIPE_V>();
-}
-
-template <typename DT, typename GT>
-__aicore__ inline void GDRVec<DT, GT>::CalcGatedQ(const bool isLastChunk)
+__aicore__ inline void GDRVec<DT, GT>::CalcGatedQ(float& gLast, float& gLastExp, const bool isLastChunk)
 {
     if (this->curCalcBT == 0) {
         if (chunkIdx_ != 0) {
@@ -329,29 +287,30 @@ __aicore__ inline void GDRVec<DT, GT>::CalcGatedQ(const bool isLastChunk)
         }
         return;
     }
+    // GetValue emits the required vector/scalar dependency without expanding the gate state to a full vector.
     if constexpr (std::is_same<GT, float>::value) {
         if (this->subBlockIdx == 0) {
             CopyIn(this->gCastLocal, this->gCastLocal, this->gGm[gmOffsetG_ + bos_], this->curBT, false);
             Exp(this->gExpLocal, this->gCastLocal, this->curBT);
-            PipeBarrier<PIPE_V>();
-            SaveGateState(this->curBT);
+            gLast = this->gCastLocal.GetValue(static_cast<uint64_t>(this->curBT - 1));
+            gLastExp = this->gExpLocal.GetValue(static_cast<uint64_t>(this->curBT - 1));
         } else {
             CopyIn(this->gCastLocal, this->gCastLocal, this->gGm[gmOffsetG_ + bos_], this->curCalcBT, false);
             Exp(this->gExpLocal, this->gCastLocal, this->curCalcBT);
-            PipeBarrier<PIPE_V>();
-            SaveGateState(this->curCalcBT);
+            gLast = this->gCastLocal.GetValue(this->curCalcBT - 1);
+            gLastExp = this->gExpLocal.GetValue(this->curCalcBT - 1);
         }
     } else {
         if (this->subBlockIdx == 0) {
             CopyIn(this->gCastLocal, this->gLocal, this->gGm[gmOffsetG_ + bos_], this->curBT);
             Exp(this->gExpLocal, this->gCastLocal, this->curBT);
-            PipeBarrier<PIPE_V>();
-            SaveGateState(this->curBT);
+            gLast = this->gCastLocal.GetValue(static_cast<uint64_t>(this->curBT - 1));
+            gLastExp = this->gExpLocal.GetValue(static_cast<uint64_t>(this->curBT - 1));
         } else {
             CopyIn(this->gCastLocal, this->gLocal, this->gGm[gmOffsetG_ + bos_], this->curCalcBT);
             Exp(this->gExpLocal, this->gCastLocal, this->curCalcBT);
-            PipeBarrier<PIPE_V>();
-            SaveGateState(this->curCalcBT);
+            gLast = this->gCastLocal.GetValue(this->curCalcBT - 1);
+            gLastExp = this->gExpLocal.GetValue(this->curCalcBT - 1);
         }
     }
     if (chunkIdx_ == 0) {
@@ -369,7 +328,7 @@ __aicore__ inline void GDRVec<DT, GT>::CalcGatedQ(const bool isLastChunk)
 }
 
 template <typename DT, typename GT>
-__aicore__ inline void GDRVec<DT, GT>::CalcDv2(uint64_t& curGmOffsetV, const bool isLastChunk)
+__aicore__ inline void GDRVec<DT, GT>::CalcDv2(const float gLast, uint64_t& curGmOffsetV, const bool isLastChunk)
 {
     curGmOffsetV = gmOffsetV_ + bos_ * this->V;
     if (isLastChunk) {
@@ -381,12 +340,8 @@ __aicore__ inline void GDRVec<DT, GT>::CalcDv2(uint64_t& curGmOffsetV, const boo
     } else {
         CopyIn(this->dvCastLocal, this->vInLocal, this->dvGm[curGmOffsetV], this->dvBufSize);
         Muls(this->gCastLocal, this->gCastLocal, static_cast<float>(-1.0), this->halfBT);
-        PipeBarrier<PIPE_V>();
-        AscendC::Add(this->gCastLocal, this->gCastLocal, this->gLastCastLocal, this->halfBT, 1,
-                     {1, 1, 0, 8, 8, 0});
-        PipeBarrier<PIPE_V>();
+        Adds(this->gCastLocal, this->gCastLocal, gLast, this->halfBT);
         Exp(this->gCastLocal, this->gCastLocal, this->halfBT);
-        PipeBarrier<PIPE_V>();
         uint8_t repeatTimes = Ceil(this->halfBT, FP32_PER_BLOCK); // halfBT is 32 or 64
         Brcb(this->gBrcbLocal, this->gCastLocal, repeatTimes, {1,FP32_PER_BLOCK});
         // halfBT * 32
@@ -399,7 +354,8 @@ __aicore__ inline void GDRVec<DT, GT>::CalcDv2(uint64_t& curGmOffsetV, const boo
 }
 
 template <typename DT, typename GT>
-__aicore__ inline void GDRVec<DT, GT>::UpdateDh(uint64_t& curGmOffsetH, const bool isLastChunk)
+__aicore__ inline void GDRVec<DT, GT>::UpdateDh(const float gLastExp, uint64_t& curGmOffsetH,
+                                                const bool isLastChunk)
 {
     curGmOffsetH = gmOffsetH_ + chunkIdx_ * dhBlockSize_;
     if (isLastChunk) {
@@ -407,7 +363,7 @@ __aicore__ inline void GDRVec<DT, GT>::UpdateDh(uint64_t& curGmOffsetH, const bo
         InitOutput<DT>(this->dhGm[curGmOffsetH], this->dhBufSize, 0); // 兩個vec核各初始化一半
     } else {
         CopyIn(this->bdhCastLocal, this->bdhLocal, this->dhGm[curGmOffsetH], this->dhBufSize);
-        MulByGateState(this->bdhCastLocal, this->bdhCastLocal, this->gFatorLocal, this->dhBufSize);
+        Muls(this->bdhCastLocal, this->bdhCastLocal, gLastExp, this->dhBufSize);
     }
     if (chunkIdx_ == 0) {
         return;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
@@ -13,9 +13,8 @@
  */
 #ifndef CHUNK_GATED_DELTA_RULE_BWD_DHU_VEC_H
 #define CHUNK_GATED_DELTA_RULE_BWD_DHU_VEC_H
-#endif
 
-#include <cmath>
+#include <type_traits>
 #include "kernel_operator.h"
 #include "chunk_gated_delta_rule_bwd_dhu_base.h"
 
@@ -36,9 +35,12 @@ private:
     __aicore__ inline void InitGlobalTensor(GM_ADDR q, GM_ADDR dv, GM_ADDR g, GM_ADDR cu_seqlens, 
                                             GM_ADDR dv2, GM_ADDR dh, GM_ADDR workspace);
     __aicore__ inline void CaclOffset(const uint32_t coarseTaskIdx, const uint32_t h, uint64_t& tailChunkLen);
-    __aicore__ inline void CalcGatedQ(float& gLast, float& gLastExp, const bool isLastChunk); 
-    __aicore__ inline void CalcDv2(const float gLast, uint64_t& curGmOffsetV, const bool isLastChunk); 
-    __aicore__ inline void UpdateDh(const float gLastExp, uint64_t& curGmOffsetH, const bool isLastChunk); 
+    __aicore__ inline void CalcGatedQ(const bool isLastChunk);
+    __aicore__ inline void CalcDv2(uint64_t& curGmOffsetV, const bool isLastChunk);
+    __aicore__ inline void UpdateDh(uint64_t& curGmOffsetH, const bool isLastChunk);
+    __aicore__ inline void SaveGateState(const uint32_t validGateCount);
+    __aicore__ inline void MulByGateState(const LocalTensor<float>& dstLocal, const LocalTensor<float>& srcLocal,
+                                         const LocalTensor<float>& gateStateLocal, const uint64_t count);
 
 
 protected:
@@ -74,6 +76,10 @@ __aicore__ inline void GDRVec<DT, GT>::InitUB()
 
     // | gCastLocal | gExpLocal | qLocal | q
     this->pipe.InitBuffer(this->vecTbuf, this->totalTbufByte);
+    const uint64_t gateStateOffset = this->totalTbufByte - 2 * BLOCK_SIZE;
+    this->gLastCastLocal = this->vecTbuf.template GetWithOffset<float>(FP32_PER_BLOCK, gateStateOffset);
+    this->gFatorLocal =
+        this->vecTbuf.template GetWithOffset<float>(FP32_PER_BLOCK, gateStateOffset + BLOCK_SIZE);
     uint32_t offset = 0;
     // gLast and g
     // 申请chunkSize大小，subCore1只用前一半，sub0要用后一半拿gLast
@@ -156,8 +162,6 @@ __aicore__ inline void GDRVec<DT, GT>::Process( )
         for (uint32_t h = hq * static_cast<uint32_t>(this->hvPerHk); h < hGroupEnd; h++) {
             uint64_t tailChunkLen = 0;
             CaclOffset(i, h, tailChunkLen);
-            float gLast = 0.0;
-            float gLastExp = 0.0;
             uint64_t curGmOffsetV = 0;
             uint64_t curGmOffsetH = 0;
             bool isLastChunk = false;
@@ -178,9 +182,9 @@ __aicore__ inline void GDRVec<DT, GT>::Process( )
                 isLastChunk = chunkIdx_ == curChunkNum_ - 1 ? true : false;
                 bos_ = chunkIdx_ * this->chunkSize;
                 // gatedQ = q * gExp
-                CalcGatedQ(gLast, gLastExp, isLastChunk);
+                CalcGatedQ(isLastChunk);
                 // 計算dv2 dv2 = bdv * exp(bg_last - bg) + dv[B,H,T,V]
-                CalcDv2(gLast, curGmOffsetV, isLastChunk);
+                CalcDv2(curGmOffsetV, isLastChunk);
                 if (chunkIdx_ > 0) {
                     CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_DV2); // 计算完一个chunk的dv2,通知cube可以开始计算w @ dv2 
                 }
@@ -189,7 +193,7 @@ __aicore__ inline void GDRVec<DT, GT>::Process( )
                     // 每個chunk更新bdh給下個chunk用，chunkIdx=0作爲最後一個chunk，所有的chunk都已經更新完了，無需更新bdh。
                     continue;
                 }
-                UpdateDh(gLastExp, curGmOffsetH, isLastChunk);
+                UpdateDh(curGmOffsetH, isLastChunk);
             }
         }
     }
@@ -198,8 +202,6 @@ __aicore__ inline void GDRVec<DT, GT>::Process( )
 template <typename DT, typename GT>
 __aicore__ inline void GDRVec<DT, GT>::TailChunkProcess(uint32_t tailChunkLen) 
 {
-    float gLast = 0.0;
-    float gLastExp = 0.0;
     uint64_t curGmOffsetV = 0;
     uint64_t curGmOffsetH = 0;
     // 尾chunk大于halfBT时，0做halfBT， 1做剩下的； 只让0做
@@ -214,14 +216,14 @@ __aicore__ inline void GDRVec<DT, GT>::TailChunkProcess(uint32_t tailChunkLen)
     chunkIdx_ = curChunkNum_ - 1;
     bos_ = chunkIdx_ * this->chunkSize;
     // gatedQ = q * gExp
-    CalcGatedQ(gLast, gLastExp, true);
+    CalcGatedQ(true);
     // 計算dv2 dv2 = bdv * exp(bg_last - bg) + dv[B,H,T,V]
-    CalcDv2(gLast, curGmOffsetV, true);
+    CalcDv2(curGmOffsetV, true);
     if (chunkIdx_ > 0) {
         CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_DV2); // 计算完一个chunk的dv2,通知cube可以开始计算w @ dv2 
     }
     // updated dh
-    UpdateDh(gLastExp, curGmOffsetH, true); 
+    UpdateDh(curGmOffsetH, true);
 }
 
 template <typename DT, typename GT>
@@ -280,7 +282,46 @@ __aicore__ inline void GDRVec<DT, GT>::CaclOffset(const uint32_t coarseTaskIdx, 
 }
 
 template <typename DT, typename GT>
-__aicore__ inline void GDRVec<DT, GT>::CalcGatedQ(float& gLast, float& gLastExp, const bool isLastChunk) 
+__aicore__ inline void GDRVec<DT, GT>::SaveGateState(const uint32_t validGateCount)
+{
+    const uint32_t lastBlockStart = (validGateCount - 1) / FP32_PER_BLOCK * FP32_PER_BLOCK;
+    const uint32_t lastBlockIndex = validGateCount - 1 - lastBlockStart;
+    Brcb(this->gBCLocal, this->gCastLocal[lastBlockStart], 1, {1, FP32_PER_BLOCK});
+    PipeBarrier<PIPE_V>();
+    DataCopy(this->gLastCastLocal, this->gBCLocal[lastBlockIndex * FP32_PER_BLOCK], FP32_PER_BLOCK);
+    PipeBarrier<PIPE_V>();
+    Brcb(this->gBCLocal, this->gExpLocal[lastBlockStart], 1, {1, FP32_PER_BLOCK});
+    PipeBarrier<PIPE_V>();
+    DataCopy(this->gFatorLocal, this->gBCLocal[lastBlockIndex * FP32_PER_BLOCK], FP32_PER_BLOCK);
+    PipeBarrier<PIPE_V>();
+}
+
+template <typename DT, typename GT>
+__aicore__ inline void GDRVec<DT, GT>::MulByGateState(const LocalTensor<float>& dstLocal,
+                                                      const LocalTensor<float>& srcLocal,
+                                                      const LocalTensor<float>& gateStateLocal,
+                                                      const uint64_t count)
+{
+    constexpr uint32_t maxRepeatTimes = 255;
+    uint64_t offset = 0;
+    uint64_t repeatTimes = count / FP32_PER_REPEAT;
+    while (repeatTimes > 0) {
+        const uint8_t currentRepeatTimes =
+            static_cast<uint8_t>(repeatTimes > maxRepeatTimes ? maxRepeatTimes : repeatTimes);
+        AscendC::Mul(dstLocal[offset], srcLocal[offset], gateStateLocal, FP32_PER_REPEAT, currentRepeatTimes,
+                     {1, 1, 0, 8, 8, 0});
+        offset += static_cast<uint64_t>(currentRepeatTimes) * FP32_PER_REPEAT;
+        repeatTimes -= currentRepeatTimes;
+    }
+    const uint32_t tailCount = static_cast<uint32_t>(count - offset);
+    if (tailCount > 0) {
+        AscendC::Mul(dstLocal[offset], srcLocal[offset], gateStateLocal, tailCount, 1, {1, 1, 0, 8, 8, 0});
+    }
+    PipeBarrier<PIPE_V>();
+}
+
+template <typename DT, typename GT>
+__aicore__ inline void GDRVec<DT, GT>::CalcGatedQ(const bool isLastChunk)
 {
     if (this->curCalcBT == 0) {
         if (chunkIdx_ != 0) {
@@ -292,25 +333,25 @@ __aicore__ inline void GDRVec<DT, GT>::CalcGatedQ(float& gLast, float& gLastExp,
         if (this->subBlockIdx == 0) {
             CopyIn(this->gCastLocal, this->gCastLocal, this->gGm[gmOffsetG_ + bos_], this->curBT, false);
             Exp(this->gExpLocal, this->gCastLocal, this->curBT);
-            gLast = this->gCastLocal.GetValue(static_cast<uint64_t>(this->curBT - 1));
-            gLastExp = this->gExpLocal.GetValue(static_cast<uint64_t>(this->curBT - 1));
+            PipeBarrier<PIPE_V>();
+            SaveGateState(this->curBT);
         } else {
             CopyIn(this->gCastLocal, this->gCastLocal, this->gGm[gmOffsetG_ + bos_], this->curCalcBT, false);
             Exp(this->gExpLocal, this->gCastLocal, this->curCalcBT);
-            gLast = this->gCastLocal.GetValue(this->curCalcBT - 1);
-            gLastExp = this->gExpLocal.GetValue(this->curCalcBT - 1);
+            PipeBarrier<PIPE_V>();
+            SaveGateState(this->curCalcBT);
         }
     } else {
         if (this->subBlockIdx == 0) {
             CopyIn(this->gCastLocal, this->gLocal, this->gGm[gmOffsetG_ + bos_], this->curBT);
             Exp(this->gExpLocal, this->gCastLocal, this->curBT);
-            gLast = this->gCastLocal.GetValue(static_cast<uint64_t>(this->curBT - 1));
-            gLastExp = this->gExpLocal.GetValue(static_cast<uint64_t>(this->curBT - 1));
+            PipeBarrier<PIPE_V>();
+            SaveGateState(this->curBT);
         } else {
             CopyIn(this->gCastLocal, this->gLocal, this->gGm[gmOffsetG_ + bos_], this->curCalcBT);
             Exp(this->gExpLocal, this->gCastLocal, this->curCalcBT);
-            gLast = this->gCastLocal.GetValue(this->curCalcBT - 1);
-            gLastExp = this->gExpLocal.GetValue(this->curCalcBT - 1);
+            PipeBarrier<PIPE_V>();
+            SaveGateState(this->curCalcBT);
         }
     }
     if (chunkIdx_ == 0) {
@@ -328,7 +369,7 @@ __aicore__ inline void GDRVec<DT, GT>::CalcGatedQ(float& gLast, float& gLastExp,
 }
 
 template <typename DT, typename GT>
-__aicore__ inline void GDRVec<DT, GT>::CalcDv2(const float gLast, uint64_t& curGmOffsetV, const bool isLastChunk) 
+__aicore__ inline void GDRVec<DT, GT>::CalcDv2(uint64_t& curGmOffsetV, const bool isLastChunk)
 {
     curGmOffsetV = gmOffsetV_ + bos_ * this->V;
     if (isLastChunk) {
@@ -340,8 +381,12 @@ __aicore__ inline void GDRVec<DT, GT>::CalcDv2(const float gLast, uint64_t& curG
     } else {
         CopyIn(this->dvCastLocal, this->vInLocal, this->dvGm[curGmOffsetV], this->dvBufSize);
         Muls(this->gCastLocal, this->gCastLocal, static_cast<float>(-1.0), this->halfBT);
-        Adds(this->gCastLocal, this->gCastLocal, gLast, this->halfBT);
+        PipeBarrier<PIPE_V>();
+        AscendC::Add(this->gCastLocal, this->gCastLocal, this->gLastCastLocal, this->halfBT, 1,
+                     {1, 1, 0, 8, 8, 0});
+        PipeBarrier<PIPE_V>();
         Exp(this->gCastLocal, this->gCastLocal, this->halfBT);
+        PipeBarrier<PIPE_V>();
         uint8_t repeatTimes = Ceil(this->halfBT, FP32_PER_BLOCK); // halfBT is 32 or 64
         Brcb(this->gBrcbLocal, this->gCastLocal, repeatTimes, {1,FP32_PER_BLOCK});
         // halfBT * 32
@@ -354,7 +399,7 @@ __aicore__ inline void GDRVec<DT, GT>::CalcDv2(const float gLast, uint64_t& curG
 }
 
 template <typename DT, typename GT>
-__aicore__ inline void GDRVec<DT, GT>::UpdateDh(const float gLastExp, uint64_t& curGmOffsetH, const bool isLastChunk) 
+__aicore__ inline void GDRVec<DT, GT>::UpdateDh(uint64_t& curGmOffsetH, const bool isLastChunk)
 {
     curGmOffsetH = gmOffsetH_ + chunkIdx_ * dhBlockSize_;
     if (isLastChunk) {
@@ -362,7 +407,7 @@ __aicore__ inline void GDRVec<DT, GT>::UpdateDh(const float gLastExp, uint64_t& 
         InitOutput<DT>(this->dhGm[curGmOffsetH], this->dhBufSize, 0); // 兩個vec核各初始化一半
     } else {
         CopyIn(this->bdhCastLocal, this->bdhLocal, this->dhGm[curGmOffsetH], this->dhBufSize);
-        Muls(this->bdhCastLocal, this->bdhCastLocal, gLastExp, this->dhBufSize);
+        MulByGateState(this->bdhCastLocal, this->bdhCastLocal, this->gFatorLocal, this->dhBufSize);
     }
     if (chunkIdx_ == 0) {
         return;
@@ -389,3 +434,5 @@ __aicore__ inline void GDRVec<DT, GT>::UpdateDh(const float gLastExp, uint64_t& 
 }
 
 } // namespace ChunkGDRBwdDhu
+
+#endif // CHUNK_GATED_DELTA_RULE_BWD_DHU_VEC_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/test/test_chunk_gated_delta_rule_bwd_dhu.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/test/test_chunk_gated_delta_rule_bwd_dhu.py
@@ -589,6 +589,9 @@ if __name__ == "__main__":
 
     # GVA smoke: Hk=2, Hv=4
     test_fix(B=1, Hk=2, Hv=4, T=256, K=128, V=128, chunk_size=64, scale=0.088, ktype=torch.bfloat16, gtype=torch.bfloat16)
+    # Gate state stays in the vector pipeline for both chunk sizes and g dtypes.
+    test_fix(B=2, Hk=2, Hv=4, T=256, K=128, V=128, chunk_size=64, scale=0.088, ktype=torch.bfloat16, gtype=torch.float32)
+    test_fix(B=1, Hk=2, Hv=4, T=320, K=128, V=128, chunk_size=128, scale=0.088, ktype=torch.bfloat16, gtype=torch.bfloat16)
     # MHA smoke: Hk=Hv
     test_fix(B=1, Hk=4, Hv=4, T=128, K=128, V=128, chunk_size=64, scale=0.088, ktype=torch.bfloat16, gtype=torch.bfloat16)
     # GVA varlen smoke

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full_cube.h
@@ -168,9 +168,12 @@ public:
     //   3. DK   = dA @ Kbeta
     //   4. Dvb  = A^T @ du
     //   5. KKT  = K @ K^T
-    // AIV -> AIC has one event: Kbeta = K * beta[:, None] is ready.
-    Arch::CrossCoreFlagWithReverse<5> flagAicFinishStore{SYNC_FLAG_2, SYNC_FLAG_3};
+    // AIV -> AIC has one event: Kbeta = K * beta[:, None] is ready.  The
+    // per-slot free flags prevent AIC from reusing a workspace slot before
+    // both AIV sub-blocks have copied its final KKT payload into UB.
+    Arch::CrossCoreFlag flagAicFinishStore{SYNC_FLAG_2};
     Arch::CrossCoreFlagWithReverse<> flagAivFinishStore{SYNC_FLAG_4, SYNC_FLAG_5};
+    Arch::CrossCoreFlag flagWorkspaceFree[2] = {6, 7};
     /// Parameters structure
     struct Params {
         // Data members
@@ -381,6 +384,7 @@ public:
                 //   slotKbetaDvb  : first Kbeta, later reused as Dvb = A^T @ du
                 //   slotKKT       : KKT  = K @ K^T
                 uint64_t workspaceBufferIdx = taskIdx % params.workspaceBufferCount;
+                Arch::CrossCoreWaitFlag(flagWorkspaceFree[workspaceBufferIdx]);
                 uint64_t slotBaseBytes =
                     (coreIdx * params.workspaceBufferCount + workspaceBufferIdx) * params.workspaceSlotSize;
                 uint64_t slotDK = slotBaseBytes / sizeof(ElementK);
@@ -547,7 +551,7 @@ public:
                     AscendC::SetFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
                     // Ready event #1: AIV can start Dkb-related dbeta and
                     // keep Dkb*beta in UB while AIC computes Dkbg.
-                    Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
+                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(flagAicFinishStore);
                     auto layoutL0C = tla::MakeLayoutL0C(mActual, shapeK.n());
                     auto tensorL0C = tla::MakeTensor(l0CBuf, layoutL0C, Arch::PositionL0C{});
                     auto tensorTileL0C = GetTile(tensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(mActual, shapeK.n()));
@@ -562,7 +566,7 @@ public:
                     AscendC::SetFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
                     // Ready event #2: AIV can now consume Dkbg and finish the
                     // Dkbg-related dk/dbeta/dg partials.
-                    Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
+                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(flagAicFinishStore);
                 }
 
                 // Wait for AIV to produce Kbeta = K * beta[:, None] into
@@ -646,7 +650,7 @@ public:
                 }
 
                 // Ready event #3: DK is available; AIV can finish dk writeback.
-                Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
+                Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(flagAicFinishStore);
 
                 auto tensorBlockKForKKT = GetTile(tensorK, tla::MakeCoord(0, 0),
                                                  tla::MakeShape(shapeKKT.m(), shapeKKT.k()));
@@ -746,7 +750,7 @@ public:
                     copyL0CToGm_Dvb(tensorBlockDvb, tensorL0C_Dvb, 0b11);
                     AscendC::SetFlag<AscendC::HardEvent::FIX_M>(EVENT_L0C);
                     // Ready event #4: Dvb is available.
-                    Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
+                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(flagAicFinishStore);
                     auto layoutL0C = tla::MakeLayoutL0C(mActual, shapeKKT.n());
                     auto tensorL0C = tla::MakeTensor(l0CBuf, layoutL0C, Arch::PositionL0C{});
                     auto tensorTileL0C = GetTile(tensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(mActual, shapeKKT.n()));
@@ -764,9 +768,11 @@ public:
                 }
 
                 // Ready event #5: KKT is available; AIV can finish dg.
-                Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
+                Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(flagAicFinishStore);
             }
         }
+        Arch::CrossCoreWaitFlag(flagWorkspaceFree[0]);
+        Arch::CrossCoreWaitFlag(flagWorkspaceFree[1]);
         AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1A);
         AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_L1B);
         AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_L0A);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_kernel/prepare_wy_repr_bwd_full_vector.h
@@ -78,8 +78,9 @@ private:
     GlobalTensor<betaType> dgTensor;
     GlobalTensor<kType> dATensor;
     GlobalTensor<kType> workSpaceTensor;
-    Arch::CrossCoreFlagWithReverse<5> flagAicFinishStore{SYNC_FLAG_2, SYNC_FLAG_3};
+    Arch::CrossCoreFlag flagAicFinishStore{SYNC_FLAG_2};
     Arch::CrossCoreFlagWithReverse<> flagAivFinishStore{SYNC_FLAG_4, SYNC_FLAG_5};
+    Arch::CrossCoreFlag flagWorkspaceFree[2] = {6, 7};
 
     TQue<AscendC::TPosition::VECIN, 1> oneInQue;
     TQue<AscendC::TPosition::VECOUT, 1> oneOutQue;
@@ -197,6 +198,9 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
     auto tensorGExpFP32 = persistent[persistentStride];
     auto tensorDbetaAccFP32 = persistent[2 * persistentStride];
     auto tensorDgAccFP32 = persistent[3 * persistentStride];
+
+    Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(flagWorkspaceFree[0]);
+    Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(flagWorkspaceFree[1]);
 
     // Outer loop distributes chunks across AIC/AIV core groups; inner loop
     // iterates heads for the same chunk.  For each (chunk, head), AIV performs
@@ -323,7 +327,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
             // DK = dA @ Kbeta.  Then wait for AIC's first ready event:
             // Dkb = dA^T @ K.
             Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(flagAivFinishStore);
-            Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
+            Arch::CrossCoreWaitFlag(flagAicFinishStore);
 
             bool waitedDkbgReady = false;
             bool waitedDKReady = false;
@@ -396,7 +400,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
 
                 if (!waitedDkbgReady) {
                     // Second AIC ready event: Dkbg = A^T @ dw is available.
-                    Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
+                    Arch::CrossCoreWaitFlag(flagAicFinishStore);
                     waitedDkbgReady = true;
                 }
                 tensorIn = oneInQue.AllocTensor<kType>();
@@ -448,7 +452,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
                 PipeBarrier<PIPE_V>();
                 if (!waitedDKReady) {
                     // Third AIC ready event: DK = dA @ Kbeta is available.
-                    Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
+                    Arch::CrossCoreWaitFlag(flagAicFinishStore);
                     waitedDKReady = true;
                 }
 
@@ -485,14 +489,14 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
                 oneOutQue.FreeTensor(tensorDkOut);
             }
             if (!waitedDkbgReady) {
-                Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
+                Arch::CrossCoreWaitFlag(flagAicFinishStore);
             }
             if (!waitedDKReady) {
-                Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
+                Arch::CrossCoreWaitFlag(flagAicFinishStore);
             }
 
             // Fourth AIC ready event: Dvb = A^T @ du is available.
-            Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
+            Arch::CrossCoreWaitFlag(flagAicFinishStore);
 
             // Stage V2: consume Dvb and V to compute:
             //   dbeta += reduce(Dvb * V)
@@ -553,7 +557,7 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
             }
 
             // Fifth AIC ready event: KKT = K @ K^T is available.
-            Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
+            Arch::CrossCoreWaitFlag(flagAicFinishStore);
 
             {
                 uint64_t kktOffset = 0;
@@ -620,6 +624,11 @@ __aicore__ void inline PrepareWyReprBwdFullVectorProcess<kType, betaType>::Proce
                         PipeBarrier<PIPE_V>();
                     }
                 }
+
+                // All GM reads from this workspace slot are complete.  The
+                // remaining reductions use UB only, so AIC can safely reuse
+                // the slot after both AIV sub-blocks reach this point.
+                Arch::CrossCoreSetFlag<0x2, PIPE_MTE2>(flagWorkspaceFree[workspaceBufferIdx]);
 
                 // row_reduce(DAA): only reduce rows owned by this AIV sub-block.
                 // Each sub-block writes disjoint dg rows later, so reducing all

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/gemm/block/block_scheduler_gdn_fwd_o.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/gemm/block/block_scheduler_gdn_fwd_o.hpp
@@ -95,11 +95,10 @@ struct BlockSchedulerGdnFwdO {
     AscendC::GlobalTensor<int64_t> gmSeqlen;
     AscendC::GlobalTensor<int64_t> gmChunkOffsets;
 
-    Arch::CrossCoreFlag cube1Done{3};
-    Arch::CrossCoreFlag vec1Done{4};
-    Arch::CrossCoreFlag cube2Done{5};
-    Arch::CrossCoreFlag cube3Done{6};
-    Arch::CrossCoreFlag vec2Done{7};
+    Arch::CrossCoreFlag cube1Done[PING_PONG_STAGES] = {0, 1};
+    Arch::CrossCoreFlag vec1Done[PING_PONG_STAGES] = {2, 3};
+    Arch::CrossCoreFlag cube3Done[PING_PONG_STAGES] = {4, 5};
+    Arch::CrossCoreFlag vec2Done[PING_PONG_STAGES] = {6, 7};
 
     CATLASS_DEVICE
     BlockSchedulerGdnFwdO() {}

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/gemm/kernel/gdn_fwd_o_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/gemm/kernel/gdn_fwd_o_kernel.hpp
@@ -268,7 +268,6 @@ public:
 
                 if (cubeBlockScheduler.isRunning && coreIdx < coreNum) {
                     uint32_t streamId = cubeBlockScheduler.GetCurStageId();
-                    Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[streamId]);
 
                     GDNFwdOOffsets& cube1Offsets = cubeBlockScheduler.GetCube1Offsets();
                     int64_t cube1OffsetQ = cube1Offsets.qkOffset;
@@ -293,6 +292,8 @@ public:
                 if (needRun && coreIdx < coreNum) {
                     uint32_t streamId = cubeBlockScheduler.GetPrevStageId();
                     Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done[streamId]);
+                    // vec2Done protects the H/V workspace consumed by Cube2/3; Cube1 uses a separate slot.
+                    Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[streamId]);
                     GDNFwdOOffsets& cube2Offsets = cubeBlockScheduler.GetCube23Offsets();
                     int64_t cube2OffsetQ = cube2Offsets.qkOffset;
                     int64_t cube2OffsetH = cube2Offsets.hOffset;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/gemm/kernel/gdn_fwd_o_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/gemm/kernel/gdn_fwd_o_kernel.hpp
@@ -267,6 +267,8 @@ public:
                 cubeBlockScheduler.InitTask();
 
                 if (cubeBlockScheduler.isRunning && coreIdx < coreNum) {
+                    uint32_t streamId = cubeBlockScheduler.GetCurStageId();
+                    Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[streamId]);
 
                     GDNFwdOOffsets& cube1Offsets = cubeBlockScheduler.GetCube1Offsets();
                     int64_t cube1OffsetQ = cube1Offsets.qkOffset;
@@ -283,13 +285,14 @@ public:
                     blockMmadQK.preSetFlags();
                     blockMmadQK(tensorBlockQ, tensorBlockK, tensorBlockAttn, cube1Shape);
                     blockMmadQK.finalWaitFlags();
-                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done);
+                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done[streamId]);
 
                 }
                 // AscendC::PipeBarrier<PIPE_ALL>();
 
                 if (needRun && coreIdx < coreNum) {
-                    Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done);
+                    uint32_t streamId = cubeBlockScheduler.GetPrevStageId();
+                    Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done[streamId]);
                     GDNFwdOOffsets& cube2Offsets = cubeBlockScheduler.GetCube23Offsets();
                     int64_t cube2OffsetQ = cube2Offsets.qkOffset;
                     int64_t cube2OffsetH = cube2Offsets.hOffset;
@@ -316,6 +319,7 @@ public:
                 AscendC::PipeBarrier<PIPE_FIX>();
 
                 if (needRun && coreIdx < coreNum) {
+                    uint32_t streamId = cubeBlockScheduler.GetPrevStageId();
                     GDNFwdOOffsets& cube3Offsets = cubeBlockScheduler.GetCube23Offsets();
                     int64_t cube3OffsetAttnMask = cube3Offsets.attnWorkOffset;
                     int64_t cube3OffsetV = cube3Offsets.ovOffset;
@@ -337,11 +341,13 @@ public:
                         blockMmadAttenVNEW256(tensorBlockAttnMask, tensorBlockV, tensorBlockVWork, cube3Shape);
                         blockMmadAttenVNEW256.finalWaitFlags();
                     }
-                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube3Done);
+                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube3Done[streamId]);
                 }
                 needRun = true;
                 // AscendC::PipeBarrier<PIPE_ALL>();
             }
+            Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[0]);
+            Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[1]);
         }
 
         if ASCEND_IS_AIV {
@@ -350,6 +356,9 @@ public:
             uint32_t coreNum = AscendC::GetBlockNum();
             uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
             uint32_t subBlockNum = AscendC::GetSubBlockNum();
+
+            Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done[0]);
+            Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done[1]);
 
             AscendC::LocalTensor<float> maskUbTensor = resource.ubBuf.template GetBufferByByte<float>(0);
             AscendC::Duplicate<float>(maskUbTensor, (float)0.0, 64*64);
@@ -364,7 +373,8 @@ public:
                 vecBlockScheduler.InitTask();
 
                 if (vecBlockScheduler.isRunning && coreIdx < coreNum * subBlockNum) {
-                    Arch::CrossCoreWaitFlag(vecBlockScheduler.cube1Done);
+                    uint32_t streamId = vecBlockScheduler.GetCurStageId();
+                    Arch::CrossCoreWaitFlag(vecBlockScheduler.cube1Done[streamId]);
                     GDNFwdOOffsets& vec1Offsets = vecBlockScheduler.GetVec1Offsets();
                     int64_t vec1OffsetAttnMask = vec1Offsets.attnWorkOffset;
                     int64_t vec1OffsetG = vec1Offsets.gOffset;
@@ -375,13 +385,14 @@ public:
                         gmG[vec1OffsetG], gmAttnWorkspace[vec1OffsetAttn], gmMask,
                         chunkSize, vec1Offsets.blockTokens, kHeadDim, vHeadDim, pingpongFlag, vec1Offsets.batchIdx, vec1Offsets.headIdx, vec1Offsets.chunkIdx
                     );
-                    Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec1Done);
+                    Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec1Done[streamId]);
                 }
 
                 // AscendC::PipeBarrier<PIPE_ALL>();
 
                 if (needRun && coreIdx < coreNum * subBlockNum) {
-                    Arch::CrossCoreWaitFlag(vecBlockScheduler.cube3Done);
+                    uint32_t streamId = vecBlockScheduler.GetPrevStageId();
+                    Arch::CrossCoreWaitFlag(vecBlockScheduler.cube3Done[streamId]);
                     GDNFwdOOffsets& vec2Offsets = vecBlockScheduler.GetVec2Offsets();
                     int64_t vec2OffsetO = vec2Offsets.ovOffset;
                     int64_t vec2OffsetG = vec2Offsets.gOffset;
@@ -393,6 +404,7 @@ public:
                         gmG[vec2OffsetG], gmVWorkspace[vec2OffsetVWork], gmHWorkspace[vec2OffsetHWork],
                         scale, vec2Offsets.blockTokens, kHeadDim, vec2Offsets.vBlockDim, vHeadDim, pingpongFlag, vec2Offsets.batchIdx, vec2Offsets.headIdx, vec2Offsets.chunkIdx
                     );
+                    Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done[streamId]);
                 }
                 needRun = true;
             }

--- a/torch_custom/fla_npu/test/test_npu_bwd_dhu_gva.py
+++ b/torch_custom/fla_npu/test/test_npu_bwd_dhu_gva.py
@@ -64,13 +64,26 @@ class BwdDhuCase:
         return torch.float32
 
 
-# 与 fwd_h 12 项矩阵对齐，Vdim=256；按规模从小到大排列（去掉与 smoke_fixed 重复的 fixed_t4096）
+# 覆盖泛化表中的 fixed/varlen、V=128/256、chunk=64/128 和 MHA/GVA 组合。
 CASES = [
     BwdDhuCase("smoke_varlen_t256_v256", 1, 16, 32, 256, chunk_size=64, cu_seqlens_len=5),
+    BwdDhuCase("smoke_fixed_mha_t257_v128", 1, 4, 4, 257, v_dim=128, chunk_size=128,
+               varlen=False),
+    BwdDhuCase("general_fixed_b2_h32_t8192_v128", 2, 32, 32, 8192, v_dim=128, chunk_size=64,
+               varlen=False),
     BwdDhuCase("fixed_b176_t24_v256", 176, 2, 64, 24, chunk_size=64, varlen=False),
-    BwdDhuCase("fixed_b711_t196_v256", 711, 4, 32, 196, chunk_size=128, varlen=False),
+    BwdDhuCase("general_fixed_b711_t196_v128", 711, 4, 32, 196, v_dim=128, chunk_size=128,
+               varlen=False),
     BwdDhuCase("fixed_b16_t2048_v256", 16, 21, 63, 2048, chunk_size=64, varlen=False),
     BwdDhuCase("smoke_fixed_t4096_v256", 1, 16, 32, 4096, chunk_size=64, varlen=False),
+    BwdDhuCase("general_varlen_t7178_v128_cu17", 1, 4, 32, 7178, v_dim=128, chunk_size=128,
+               cu_seqlens_len=17),
+    BwdDhuCase("general_varlen_t8999_v256_cu13", 1, 16, 48, 8999, chunk_size=128,
+               cu_seqlens_len=13),
+    BwdDhuCase("general_varlen_t16387_v256_cu667", 1, 16, 48, 16387, chunk_size=64,
+               cu_seqlens_len=667),
+    BwdDhuCase("general_varlen_t36621_v128_cu668", 1, 16, 32, 36621, v_dim=128, chunk_size=64,
+               cu_seqlens_len=668),
     BwdDhuCase("varlen_t16384_v256_cu2", 1, 21, 63, 16384, chunk_size=64, cu_seqlens_len=2),
     BwdDhuCase("varlen_t16384_v256_cu128", 1, 16, 32, 16384, chunk_size=64, cu_seqlens_len=128),
     BwdDhuCase("varlen_t65536_v256_cu17", 1, 4, 32, 65536, chunk_size=128, cu_seqlens_len=17),
@@ -105,7 +118,9 @@ def _build_inputs(case: BwdDhuCase, seed: int = 0):
     cu_seqlens = None
     chunk_indices = None
     if case.varlen:
-        cu_seqlens = generate_cu_seqlens(case.cu_seqlens_len, case.tokens)
+        sequence_count = case.cu_seqlens_len - 1
+        segment_max = max(128, math.ceil(case.tokens / sequence_count))
+        cu_seqlens = generate_cu_seqlens(case.cu_seqlens_len, case.tokens, seg_min=1, seg_max=segment_max)
         chunk_indices = prepare_chunk_indices(cu_seqlens, case.chunk_size)
     scale = scale_for_compute_dtype(effective_scale(1.0 / math.sqrt(case.k_dim), case.k_dim), ktype)
     return q, k, w, do, dv, g, cu_seqlens, chunk_indices, scale
@@ -179,7 +194,7 @@ def main():
             raise SystemExit(f"unknown BWD_HU_CASE={only}")
 
     print(f"[MODE] random input + dual(fp64 gt / npu-aligned bench), no example dump", flush=True)
-    print(f"device={device} out_root={out_root} cases={len(cases)} Vdim=256", flush=True)
+    print(f"device={device} out_root={out_root} cases={len(cases)}", flush=True)
 
     results = []
     for case in cases:

--- a/torch_custom/fla_npu/test/test_npu_fwd_o_generalization.py
+++ b/torch_custom/fla_npu/test/test_npu_fwd_o_generalization.py
@@ -1,0 +1,154 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""ChunkFwdO workspace 流水回归，覆盖 fixed/varlen、MHA/GVA、chunk 64/128 和尾块。"""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+import ct
+import torch
+
+from fla_npu.ops import ascendc as ascendc_ops
+
+
+torch.npu.config.allow_internal_format = False
+torch.npu.set_compile_mode(jit_compile=False)
+
+
+@dataclass(frozen=True)
+class FwdOCase:
+    name: str
+    batch: int
+    k_heads: int
+    v_heads: int
+    tokens: int
+    v_dim: int
+    chunk_size: int
+    cu_seqlens: Optional[tuple[int, ...]] = None
+    k_dim: int = 128
+
+
+CASES = (
+    FwdOCase("fixed_mha_chunk64_tail", 2, 4, 4, 129, 128, 64),
+    FwdOCase("fixed_gva_chunk128_tail_v256", 1, 2, 4, 257, 256, 128),
+    FwdOCase("varlen_gva_chunk64_tail", 1, 2, 4, 321, 128, 64, (0, 65, 193, 321)),
+)
+
+
+def _chunk_indices(cu_seqlens: tuple[int, ...], chunk_size: int) -> list[int]:
+    indices = []
+    for sequence, (begin, end) in enumerate(zip(cu_seqlens, cu_seqlens[1:])):
+        for chunk in range(math.ceil((end - begin) / chunk_size)):
+            indices.extend((sequence, chunk))
+    return indices
+
+
+def _reference(
+    case: FwdOCase,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    h: torch.Tensor,
+    g: torch.Tensor,
+    scale: float,
+    npu_aligned: bool,
+) -> torch.Tensor:
+    compute_dtype = torch.float32 if npu_aligned else torch.float64
+    output = torch.zeros((case.batch, case.v_heads, case.tokens, case.v_dim), dtype=compute_dtype)
+    head_ratio = case.v_heads // case.k_heads
+    sequences = case.cu_seqlens or tuple(range(case.batch + 1))
+    state_offset = 0
+
+    for sequence, (begin, end) in enumerate(zip(sequences, sequences[1:])):
+        batch_index = 0 if case.cu_seqlens is not None else sequence
+        sequence_begin = begin if case.cu_seqlens is not None else 0
+        sequence_end = end if case.cu_seqlens is not None else case.tokens
+        chunk_count = math.ceil((sequence_end - sequence_begin) / case.chunk_size)
+        for head in range(case.v_heads):
+            key_head = head // head_ratio
+            for chunk in range(chunk_count):
+                chunk_begin = sequence_begin + chunk * case.chunk_size
+                chunk_end = min(chunk_begin + case.chunk_size, sequence_end)
+                q_chunk = q[batch_index, key_head, chunk_begin:chunk_end].to(compute_dtype)
+                k_chunk = k[batch_index, key_head, chunk_begin:chunk_end].to(compute_dtype)
+                v_chunk = v[batch_index, head, chunk_begin:chunk_end].to(compute_dtype)
+                g_chunk = g[batch_index, head, chunk_begin:chunk_end].to(compute_dtype)
+                state_index = state_offset + chunk if case.cu_seqlens is not None else chunk
+                state = h[batch_index, head, state_index].to(compute_dtype)
+
+                attention = q_chunk @ k_chunk.transpose(0, 1)
+                attention *= torch.exp(g_chunk[:, None] - g_chunk[None, :])
+                attention = torch.tril(attention)
+                if npu_aligned:
+                    attention = attention.to(q.dtype).float()
+                state_output = (q_chunk @ state) * torch.exp(g_chunk)[:, None]
+                output[batch_index, head, chunk_begin:chunk_end] = (
+                    state_output + attention @ v_chunk
+                ) * scale
+        state_offset += chunk_count
+    return output.to(q.dtype).float() if npu_aligned else output
+
+
+def _run_case(case: FwdOCase) -> None:
+    torch.manual_seed(20260717)
+    dtype = torch.bfloat16
+    scale = 1.0 / math.sqrt(case.k_dim)
+    chunk_count = (
+        sum(math.ceil((end - begin) / case.chunk_size)
+            for begin, end in zip(case.cu_seqlens, case.cu_seqlens[1:]))
+        if case.cu_seqlens is not None
+        else math.ceil(case.tokens / case.chunk_size)
+    )
+    q = torch.randn(case.batch, case.k_heads, case.tokens, case.k_dim, dtype=dtype) * 0.1
+    k = torch.randn_like(q) * 0.1
+    v = torch.randn(case.batch, case.v_heads, case.tokens, case.v_dim, dtype=dtype) * 0.1
+    h = torch.randn(case.batch, case.v_heads, chunk_count, case.k_dim, case.v_dim, dtype=dtype) * 0.1
+    # g=0 隔离 QK/AttnV 和 QH 两条 workspace 流水，避免设备 Exp 近似影响 CPU 双标杆。
+    g = torch.zeros(case.batch, case.v_heads, case.tokens, dtype=torch.float32)
+
+    reference_fp64 = _reference(case, q, k, v, h, g, scale, npu_aligned=False)
+    reference_npu = _reference(case, q, k, v, h, g, scale, npu_aligned=True)
+    chunk_indices = _chunk_indices(case.cu_seqlens, case.chunk_size) if case.cu_seqlens is not None else None
+    output = ascendc_ops.npu_chunk_fwd_o(
+        q.npu(),
+        k.npu(),
+        v.npu(),
+        h.npu(),
+        scale,
+        g=g.npu(),
+        g_gamma=None,
+        cu_seqlens=list(case.cu_seqlens) if case.cu_seqlens is not None else None,
+        chunk_indices=chunk_indices,
+        chunk_size=case.chunk_size,
+        transpose_state_layout=False,
+    )
+    result = ct.dual(output.cpu().float(), reference_fp64.float(), reference_npu.float(), level="L1")
+    if not bool(result.get("success")):
+        raise AssertionError(f"{case.name} dual benchmark failed: {result}")
+    print(f"{case.name}: PASS")
+
+
+def main() -> None:
+    torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
+    selected = os.environ.get("FWD_O_CASE", "").strip()
+    cases = [case for case in CASES if not selected or case.name == selected]
+    if not cases:
+        raise SystemExit(f"unknown FWD_O_CASE={selected}")
+    for case in cases:
+        _run_case(case)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，需要仓库管理员在当前 head commit 上触发 NPU CI，并满足分支保护要求。

## 关联 Issue / 背景

- 关联 Issue: https://github.com/flashserve/flash-linear-attention-npu/issues/207
- 背景与目标: 修复 Ascend950 上 GDN 同步协议不完整、DHU 重复 S/V 同步以及多级/双缓冲 workspace 提前复用问题。
- 本 PR 解决的问题:
  - `chunk_bwd_dv_local` 的 Ascend950 Vector/Cube 路径使用 ready/free 双向握手，防止生产者连续发送 ready 导致计数器累积、任务超时及同步状态残留。
  - `chunk_gated_delta_rule_bwd_dhu` 将 `g_last` 与 `exp(g_last)` 保留为 LocalTensor 广播块，移除 Vector→Scalar→Vector 往返及其重复同步事件。
  - `chunk_fwd_o` 为各流水 stage 的 ping-pong slot 配置独立 free flag，复用 workspace 前等待消费者释放。
  - `prepare_wy_repr_bwd_full` 为 KKT 双缓冲增加按 slot 的 ready/free 握手，避免 AIC 提前覆盖 AIV 尚未搬入 UB 的 workspace。
  - 补充原始 B2 shape、B4 对照、异步 burst 及跨算子交替回归场景。
- 目标分支: `main`

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `chunk_bwd_dv_local`、`chunk_gated_delta_rule_bwd_dhu`、`chunk_fwd_o`、`prepare_wy_repr_bwd_full`
- 涉及目录 / 文件: 四个算子的 Ascend950 Kernel、DHU Tiling 和单算子测试
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 接口支持范围不变；新增回归覆盖 BSND、B2/B4、T=8192、K=V=128、chunk_size=64、BF16 输入和 FP32 Gate。
- 明确不包含的范围: 不修改公共接口、Triton 路径、模型适配和非 Ascend950 专用同步协议。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无 ABI 变化。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

- 编译验证:

```sh
bash build.sh --pkg --soc=ascend950 --vendor_name=fla_npu --ops=chunk_bwd_dv_local,chunk_gated_delta_rule_bwd_dhu,chunk_fwd_o,prepare_wy_repr_bwd_full -j2
```

- DHU 单算子测试:

```sh
python fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/test/test_chunk_gated_delta_rule_bwd_dhu.py
```

- 同步与稳定性验证:
  - `chunk_bwd_dv_local` 使用原始 shape 执行 `B2 → B2 → B4 → B2` synccheck 序列。
  - BF16 输入 + FP32 Gate 原始 B2 shape 执行 10 轮、共 2000 次；B4 对照执行 3 轮、共 600 次。
  - `chunk_gated_delta_rule_bwd_dhu`、`prepare_wy_repr_bwd_full`、`chunk_fwd_o` 分别执行 1000 次同步调用和 32 次 burst。
  - 三个相关算子执行 200 轮交替调用，共 600 次，并在每个目标 kernel 后单独同步。
  - 上述压力测试合计 6296 次调用，全部完成；测试结束后设备 Health 正常、Fault 为 0，且无残留进程。

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=chunk_bwd_dv_local,chunk_gated_delta_rule_bwd_dhu,chunk_fwd_o,prepare_wy_repr_bwd_full --vendor_name=fla_npu` | 未执行 | 当前验证环境不具备对应产品 |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_bwd_dv_local,chunk_gated_delta_rule_bwd_dhu,chunk_fwd_o,prepare_wy_repr_bwd_full --vendor_name=fla_npu` | 未执行 | 当前验证环境不具备对应产品 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 同上 | 未执行 | 当前验证环境不具备对应产品 |
| A3 | `ascend910_93` |  | 同上 | 未执行 | 当前验证环境不具备对应产品 |
| A5 | `ascend950` | CANN 9.1.0 beta | `bash build.sh --pkg --soc=ascend950 --ops=chunk_bwd_dv_local,chunk_gated_delta_rule_bwd_dhu,chunk_fwd_o,prepare_wy_repr_bwd_full --vendor_name=fla_npu -j2` | 通过 | 四个目标算子生成 A5 run 包 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 未执行 | 当前验证环境不具备对应产品 |
| A3 | `ascend910_93` |  | 未执行 | 当前验证环境不具备对应产品 |
| A5 | `ascend950` | 单算子测试、synccheck、循环压力和跨算子交替调用 | 通过（稳定性） | 共执行 6296 次调用；连续执行、burst 和交替调用均完成，设备无 Fault 或残留进程 |

- 精度对比: DHU 五组用例的最大绝对误差、最大相对误差及 CT 统计与修改前基线逐项一致。既有脚本按当前 CT 默认相对误差阈值仍判定为 FAIL，因此本 PR 不将该项描述为精度通过。
- 性能对比: 未执行正式性能 profiling；未使用 Python wall time 作为性能结论。
- 边界 / 异常场景: 覆盖 B2/B4 切换、下一次执行、chunk 64/128、尾块、BF16 输入、FP32 Gate、异步 burst、双缓冲 slot 复用和跨算子交替调用。
- 未覆盖风险:
  - 仍需在可稳定复现问题的目标 CANN 包和 DT 卡上验证原始超时消失。
  - A5 当前 sanitizer 编译链未生成可抽查的 sanitizer 符号；synccheck 中 Cube/Matmul 路径仍有与修改前一致的 `PIPE_M→PIPE_MTE1` 保守报告。
  - DHU 目标 kernel 不再产生 S/V synccheck 诊断，但当前 A5 sanitizer 运行链在插桩后仍可能发生工具侧设备异常；原生压力测试正常。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 当前验证环境不具备对应产品 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 当前验证环境不具备对应产品 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 本轮聚焦两个单算子同步问题，待 NPU CI 补充 |

- 端到端场景说明: 待 NPU CI 和目标 DT 环境补充。
- 与本 PR 修改算子的关联: Qwen3.5 GDN 前反向链路会调用本 PR 修改的四个算子。
- 未覆盖原因及补充计划: PR 创建后触发 NPU CI，并在目标 CANN 包上复测原始模型 shape。

</details>

## 兼容性、风险与回退

- 兼容性说明: 公共接口、shape、dtype、layout 和返回值保持不变；Ascend950 Vector/Cube 同步协议统一。
- 风险点: ready/free 握手会使过快的生产者等待消费者释放；多级/双缓冲路径增加按 slot 的跨核同步；DHU 增加 64 字节 UB Gate 状态及少量 Vector 指令。
- 回退方案: 回退本 PR 的四个独立提交。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- PR 保持 Ready；A5 原始 shape 和相关算子压力验证已完成，目标 DT 卡上的整网复测仍需补充。
- `main` 和 `v26.6.0` 两个 PR 已关联同一公开 Issue。
