### PR TITLE
feat(dqkwg): support A5 RegBase vector fusion

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_regbase.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_regbase.h
@@ -1,0 +1,326 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_bwd_dqkwg_regbase.h
+ * \brief A5 (arch35 / __CCE_AICORE__==310, "Ascend950"/"350") RegBase SIMD vector helpers.
+ *
+ * 本文件在命名空间内内联一组 __simd_callee__ 寄存器助手
+ * (CastHalf2Float / CastFloat2Half / *FloatTwoReg / LoadIn / HalfOrFloat2Float / ...)
+ * (而非放到 kernel_utils 公共路径), 以便:
+ *   1) 统一 RegBase 写法、CastTrait 和取整模式 (fp32->half 用 CAST_ROUND);
+ *   2) 保持实现自包含, 不向公共路径引入算子专用依赖。
+ *
+ * 本文件只提供"纯按元素"的融合 VF 入口 (NegCastVF / AddCastVF) —— 这是最安全、收益最高的转换点。
+ * 跨行/多寄存器归约 (列求和、WholeReduceSum 树、Brcb 广播) 与 B stage 就地复用缓冲的
+ * ds*mul1*mm5 暂仍走原 LocalTensor 路径 (见 chunk_bwd_dqkwg_vector.h 说明), 留作后续。
+ *
+ * 调用约定 (与 arch35/ 既有算子一致): VF 入口由 __aicore__ 端在 TQue DeQue 与 EnQue 之间直接调用,
+ * 入参为 LocalTensor::GetPhyAddr() 得到的 __ubuf__ 裸指针; TQue 的 MTE2->V / V->MTE3 同步与 VF
+ * (跑在 V 流水) 自然组合, 无需额外手工同步。
+ *
+ * 整个文件体被 arch35 宏保护: 910B (非 310) 编译时为空, 不影响既有路径。
+ */
+
+#ifndef CHUNK_BWD_DQKWG_REGBASE_H
+#define CHUNK_BWD_DQKWG_REGBASE_H
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+
+#include "kernel_operator.h"
+
+namespace ChunkBwdDqkwgRegBase {
+
+using namespace AscendC::MicroAPI;
+
+// ===== CastTrait =====
+// fp16/bf16 -> fp32: 偶 lane (ZERO) / 奇 lane (ONE)。ZEROING => 掩码外 lane 置 0, fp32 运算可用满掩码。
+constexpr static CastTrait ctHalf2Fp32Zero = {
+    RegLayout::ZERO, SatMode::SAT, MaskMergeMode::ZEROING, AscendC::RoundMode::CAST_NONE,
+};
+constexpr static CastTrait ctHalf2Fp32One = {
+    RegLayout::ONE, SatMode::SAT, MaskMergeMode::ZEROING, AscendC::RoundMode::CAST_NONE,
+};
+// fp32 -> fp16/bf16: 先写奇 lane (ONE, ZEROING 清寄存器), 再写偶 lane (ZERO, MERGING 保留奇 lane)。
+// 取整用 CAST_ROUND (RegBase 路径的 golden 以此为准)。
+constexpr static CastTrait ctFp322HalfZero = {
+    RegLayout::ZERO, SatMode::NO_SAT, MaskMergeMode::MERGING, AscendC::RoundMode::CAST_ROUND,
+};
+constexpr static CastTrait ctFp322HalfOne = {
+    RegLayout::ONE, SatMode::NO_SAT, MaskMergeMode::ZEROING, AscendC::RoundMode::CAST_ROUND,
+};
+
+constexpr uint16_t PRELOAD_NUM = 2;
+
+// ===== 寄存器助手 =====
+
+// 连续读 (DIST_NORM) 或广播读 (DIST_BRC_B16/B32)。
+template <typename TType, bool BroadCast = false>
+__simd_callee__ inline void LoadIn(RegTensor<TType>& dstReg, __ubuf__ TType* srcUb)
+{
+    if constexpr (BroadCast) {
+        if constexpr (!std::is_same<TType, float>()) {
+            LoadAlign<TType, LoadDist::DIST_BRC_B16>(dstReg, srcUb);
+        } else {
+            LoadAlign<TType, LoadDist::DIST_BRC_B32>(dstReg, srcUb);
+        }
+    } else {
+        LoadAlign<TType, LoadDist::DIST_NORM>(dstReg, srcUb);
+    }
+}
+
+// fp16/bf16 -> fp32 偶(ZERO)/奇(ONE) 两寄存器。
+template <typename TType>
+__simd_callee__ inline void CastHalf2Float(RegTensor<float>& dstZeroReg, RegTensor<float>& dstOneReg,
+                                           RegTensor<TType>& srcReg, MaskReg& mask)
+{
+    Cast<float, TType, ctHalf2Fp32Zero>(dstZeroReg, srcReg, mask);
+    Cast<float, TType, ctHalf2Fp32One>(dstOneReg, srcReg, mask);
+}
+
+// fp32 偶/奇 两寄存器 -> fp16/bf16 (先奇后偶, 重新交织)。
+template <typename TType>
+__simd_callee__ inline void CastFloat2Half(RegTensor<TType>& dstReg, RegTensor<float>& srcZeroReg,
+                                           RegTensor<float>& srcOneReg, MaskReg& mask)
+{
+    Cast<TType, float, ctFp322HalfOne>(dstReg, srcOneReg, mask);
+    Cast<TType, float, ctFp322HalfZero>(dstReg, srcZeroReg, mask);
+}
+
+// 源是 fp16/bf16 则 cast 到 fp32 (偶 lane); 源本就是 fp32 则按 lane 广播复制。
+template <typename TType>
+__simd_callee__ inline void HalfOrFloat2Float(RegTensor<float>& dstReg, RegTensor<TType>& srcReg,
+                                              MaskReg& maskHalf, MaskReg& maskFloat)
+{
+    if constexpr (!std::is_same<TType, float>()) {
+        Cast<float, TType, ctHalf2Fp32Zero>(dstReg, srcReg, maskHalf);
+    } else {
+        Duplicate(dstReg, srcReg, maskFloat);
+    }
+}
+
+__simd_callee__ inline void MulFloatTwoReg(RegTensor<float>& dstZeroReg, RegTensor<float>& dstOneReg,
+                                           RegTensor<float>& src1ZeroReg, RegTensor<float>& src1OneReg,
+                                           RegTensor<float>& src2ZeroReg, RegTensor<float>& src2OneReg,
+                                           MaskReg& maskFloat)
+{
+    Mul(dstZeroReg, src1ZeroReg, src2ZeroReg, maskFloat);
+    Mul(dstOneReg, src1OneReg, src2OneReg, maskFloat);
+}
+
+__simd_callee__ inline void MinsFloatTwoReg(RegTensor<float>& dstZeroReg, RegTensor<float>& dstOneReg,
+                                            RegTensor<float>& srcZeroReg, RegTensor<float>& srcOneReg,
+                                            float scalarValue, MaskReg& maskFloat)
+{
+    Mins(dstZeroReg, srcZeroReg, scalarValue, maskFloat);
+    Mins(dstOneReg, srcOneReg, scalarValue, maskFloat);
+}
+
+__simd_callee__ inline void ExpFloatTwoReg(RegTensor<float>& dstZeroReg, RegTensor<float>& dstOneReg,
+                                           RegTensor<float>& srcZeroReg, RegTensor<float>& srcOneReg,
+                                           MaskReg& maskFloat)
+{
+    Exp(dstZeroReg, srcZeroReg, maskFloat);
+    Exp(dstOneReg, srcOneReg, maskFloat);
+}
+
+__simd_callee__ inline void SubFloatTwoReg(RegTensor<float>& dstZeroReg, RegTensor<float>& dstOneReg,
+                                           RegTensor<float>& src1ZeroReg, RegTensor<float>& src1OneReg,
+                                           RegTensor<float>& src2ZeroReg, RegTensor<float>& src2OneReg,
+                                           MaskReg& maskFloat)
+{
+    Sub(dstZeroReg, src1ZeroReg, src2ZeroReg, maskFloat);
+    Sub(dstOneReg, src1OneReg, src2OneReg, maskFloat);
+}
+
+__simd_callee__ inline void AddFloatTwoReg(RegTensor<float>& dstZeroReg, RegTensor<float>& dstOneReg,
+                                           RegTensor<float>& src1ZeroReg, RegTensor<float>& src1OneReg,
+                                           RegTensor<float>& src2ZeroReg, RegTensor<float>& src2OneReg,
+                                           MaskReg& maskFloat)
+{
+    Add(dstZeroReg, src1ZeroReg, src2ZeroReg, maskFloat);
+    Add(dstOneReg, src1OneReg, src2OneReg, maskFloat);
+}
+
+// fp32 标量乘 (取负等)。上游 regbase.hpp 未提供, 这里按 Mins/Muls 同族补一个 (Muls 不可用时可换 Mul + Duplicate(-1))。
+__simd_callee__ inline void MulsFloatTwoReg(RegTensor<float>& dstZeroReg, RegTensor<float>& dstOneReg,
+                                            RegTensor<float>& srcZeroReg, RegTensor<float>& srcOneReg,
+                                            float scalarValue, MaskReg& maskFloat)
+{
+    Muls(dstZeroReg, srcZeroReg, scalarValue, maskFloat);
+    Muls(dstOneReg, srcOneReg, scalarValue, maskFloat);
+}
+
+// ===== VF 入口 (本算子用) =====
+
+/**
+ * out_fp16 = (T)( -in_fp32 )   (按元素)
+ * 用于 A_vector 的 dw = -dw 收尾段 (RefineSmallDw 之后)。in 与 out 必须是不同 UB 缓冲。
+ * count = 元素个数 (BT_sub * K)。in 缓冲需按最大 tile (BT*K) 分配, 以容忍尾块整寄存器读取;
+ * 输出用 fp16 尾掩码 m16 写, 不会越界写。
+ */
+template <typename T>
+__simd_vf__ inline void NegCastVF(__ubuf__ T* out, __ubuf__ float* in, uint32_t count)
+{
+    constexpr uint32_t lanes16 = AscendC::VECTOR_REG_WIDTH / sizeof(T);  // 每寄存器 fp16 元素数 = VL/2
+    MaskReg m32 = CreateMask<float, MaskPattern::ALL>();
+    RegTensor<float> z, o;
+    RegTensor<T> outReg;
+
+    uint32_t cnt = count;
+    uint16_t loops = static_cast<uint16_t>((count + lanes16 - 1) / lanes16);
+    for (uint16_t i = 0; i < loops; ++i) {
+        MaskReg m16 = UpdateMask<T>(cnt);  // fp16 域尾掩码 (递减 cnt); 无尾时退化为满掩码
+        uint32_t off = static_cast<uint32_t>(i) * lanes16;
+        LoadAlign<float, LoadDist::DIST_DINTLV_B32>(z, o, in + off);  // 连续 fp32 -> 偶/奇寄存器对
+        MulsFloatTwoReg(z, o, z, o, static_cast<float>(-1.0f), m32);
+        CastFloat2Half<T>(outReg, z, o, m32);
+        StoreAlign(out + off, outReg, m16);
+    }
+}
+
+/**
+ * out_fp16 = (T)( accFp32 + (float)addHalf )   (按元素)
+ * 用于 C_vector 的 dq += mm6 与 D_vector 的 dk += mm7 收尾段。
+ *   accFp32  : dq_state / dk_state (UB 中连续 fp32, 计算结果仍驻留)
+ *   addHalf  : mm6 / mm7 (刚 DataCopy 进来的 fp16)
+ *   out      : dq / dk 输出 (fp16, 独立 outQue 缓冲)
+ * 三个缓冲互不重叠。count = real_BT * K。acc 缓冲按最大 tile (BT*K) 分配。
+ */
+template <typename T>
+__simd_vf__ inline void AddCastVF(__ubuf__ T* out, __ubuf__ float* accFp32,
+                                  __ubuf__ T* addHalf, uint32_t count)
+{
+    constexpr uint32_t lanes16 = AscendC::VECTOR_REG_WIDTH / sizeof(T);
+    MaskReg m32 = CreateMask<float, MaskPattern::ALL>();
+    RegTensor<float> aZ, aO, bZ, bO;
+    RegTensor<T> addReg, outReg;
+
+    uint32_t cnt = count;
+    uint16_t loops = static_cast<uint16_t>((count + lanes16 - 1) / lanes16);
+    for (uint16_t i = 0; i < loops; ++i) {
+        MaskReg m16 = UpdateMask<T>(cnt);
+        uint32_t off = static_cast<uint32_t>(i) * lanes16;
+        LoadAlign<float, LoadDist::DIST_DINTLV_B32>(aZ, aO, accFp32 + off);  // acc fp32 偶/奇
+        LoadIn<T, false>(addReg, addHalf + off);                            // add fp16 (DIST_NORM)
+        CastHalf2Float<T>(bZ, bO, addReg, m16);                            // add -> fp32 偶/奇
+        AddFloatTwoReg(aZ, aO, aZ, aO, bZ, bO, m32);
+        CastFloat2Half<T>(outReg, aZ, aO, m32);
+        StoreAlign(out + off, outReg, m16);
+    }
+}
+
+/**
+ * B_vector 第 1 段 (全 RegBase): ds_temp = ds*mul1; ds2 = ds_temp*mm5;
+ *                                 dgcScratch[i] = rowsum_i(ds2); colScratch[j] = colsum_j(ds2)。
+ * 使用 ReduceSum 计算行和, 并通过跨行累加计算列和。
+ *
+ * 形状: ds/mul1/mm5/dsTempOut 均为 [real_BT 行, BT 列] fp16 (行 stride = BT)。
+ * 关键: 一行 <= BT <= 128 列 <= 1 个 fp16 寄存器 (A5 VL=256B => 128 fp16 lane), 故按行循环、每行一寄存器。
+ *   - ds_temp 用满 BT 掩码 (mBT) 算 + 存 (保留全部 BT 列, 与原 LocalTensor 路径一致, 含 col>=real_BT 的真实乘积);
+ *   - ds2 把 mm5 用 real_BT 掩码 (mReal, ZEROING) 转换 => col>=real_BT 置 0, 行/列归约只统计有效 real_BT 列;
+ *   - 行和: 偶/奇两寄存器相加后 ReduceSum -> 标量, 逐行写 dgcScratch[i];
+ *   - 列和: 偶/奇寄存器跨行累加 (colZ/colO), 循环后 INTLV 交织写回 colScratch (连续列序)。
+ * scratch 需 >= 2*(VL/4) 个 fp32 (列和 INTLV 会写满一寄存器对)。dgcScratch / colScratch 与本段输出由
+ * 调用方在两段 VF 之间用 PipeBarrier<PIPE_V> 排空 (store -> load 跨段别名)。
+ */
+template <typename DataType>
+__simd_vf__ inline void BdsTempRowColVF(
+    __ubuf__ DataType* dsTempOut, __ubuf__ float* dgcScratch, __ubuf__ float* colScratch,
+    __ubuf__ DataType* ds, __ubuf__ DataType* mul1, __ubuf__ DataType* mm5,
+    uint32_t real_BT, uint32_t BT)
+{
+    MaskReg m32 = CreateMask<float, MaskPattern::ALL>();
+    RegTensor<DataType> dsReg, mul1Reg, mm5Reg, dsTempOutReg;
+    RegTensor<float> dsZ, dsO, mul1Z, mul1O, mm5Z, mm5O, tZ, tO, d2Z, d2O, rowReg, rsReg;
+    RegTensor<float> colZ, colO;
+    UnalignRegForStore uStoreDgc;
+
+    Duplicate(colZ, static_cast<float>(0.0f), m32);
+    Duplicate(colO, static_cast<float>(0.0f), m32);
+
+    for (uint32_t i = 0; i < real_BT; ++i) {
+        uint32_t cntBT = BT;          MaskReg mBT = UpdateMask<DataType>(cntBT);     // 满 BT 列
+        uint32_t cntReal = real_BT;   MaskReg mReal = UpdateMask<DataType>(cntReal); // 有效 real_BT 列
+        uint32_t off = i * BT;
+        LoadIn<DataType, false>(dsReg, ds + off);
+        LoadIn<DataType, false>(mul1Reg, mul1 + off);
+        LoadIn<DataType, false>(mm5Reg, mm5 + off);
+
+        // ds_temp = ds * mul1 (保留全部 BT 列)
+        CastHalf2Float<DataType>(dsZ, dsO, dsReg, mBT);
+        CastHalf2Float<DataType>(mul1Z, mul1O, mul1Reg, mBT);
+        MulFloatTwoReg(tZ, tO, dsZ, dsO, mul1Z, mul1O, m32);
+        CastFloat2Half<DataType>(dsTempOutReg, tZ, tO, m32);
+        StoreAlign(dsTempOut + off, dsTempOutReg, mBT);
+
+        // ds2 = ds_temp * mm5 (mm5 用 real_BT 掩码 => col>=real_BT 置 0)
+        CastHalf2Float<DataType>(mm5Z, mm5O, mm5Reg, mReal);
+        MulFloatTwoReg(d2Z, d2O, tZ, tO, mm5Z, mm5O, m32);
+
+        // 行和 -> dgcScratch[i]
+        Add(rowReg, d2Z, d2O, m32);
+        ReduceSum(rsReg, rowReg, m32);
+        auto dgcOut = dgcScratch + i;
+        StoreUnAlign(dgcOut, rsReg, uStoreDgc, 1);
+        StoreUnAlignPost(dgcOut, uStoreDgc, 0);
+
+        // 列和累加 (偶/奇)
+        AddFloatTwoReg(colZ, colO, colZ, colO, d2Z, d2O, m32);
+    }
+    // 列和交织写回 (连续列序)
+    StoreAlign<float, StoreDist::DIST_INTLV_B32>(colScratch, colZ, colO, m32);
+}
+
+/**
+ * B_vector 第 2 段 (全 RegBase): dg[k] = dgcScratch[k] - colScratch[k], k in [0,real_BT), 按 GType 写出。
+ * 调用方需在第 1 段后插 PipeBarrier<PIPE_V> (dgc/col scratch 是上一段 store、本段 load 的同址别名)。
+ */
+template <typename GType>
+__simd_vf__ inline void BdgFinalizeVF(
+    __ubuf__ GType* dgOut, __ubuf__ float* dgcScratch, __ubuf__ float* colScratch, uint32_t real_BT)
+{
+    MaskReg m32 = CreateMask<float, MaskPattern::ALL>();
+    if constexpr (!std::is_same<GType, float>()) {
+        // dgc/col 是连续 fp32。反交织读成偶/奇两寄存器后分别相减，
+        // 再用两次 Cast 合成连续 fp16/bf16；单独 ZERO cast 会使奇 lane 未定义。
+        RegTensor<float> rcZ, rcO, ccZ, ccO, dgZ, dgO;
+        RegTensor<GType> dgOutReg;
+        UnalignRegForStore uStoreDg;
+        LoadAlign<float, LoadDist::DIST_DINTLV_B32>(rcZ, rcO, dgcScratch);
+        LoadAlign<float, LoadDist::DIST_DINTLV_B32>(ccZ, ccO, colScratch);
+        Sub(dgZ, rcZ, ccZ, m32);
+        Sub(dgO, rcO, ccO, m32);
+        CastFloat2Half<GType>(dgOutReg, dgZ, dgO, m32);
+        auto actDgOut = dgOut;
+        StoreUnAlign(actDgOut, dgOutReg, uStoreDg, real_BT);
+        StoreUnAlignPost(actDgOut, uStoreDg, 0);
+    } else {
+        constexpr uint32_t flanes = AscendC::VECTOR_REG_WIDTH / sizeof(float);
+        uint16_t floops = static_cast<uint16_t>((real_BT + flanes - 1) / flanes);
+        for (uint16_t b = 0; b < floops; ++b) {
+            uint32_t foff = static_cast<uint32_t>(b) * flanes;
+            uint32_t copyNum = min(flanes, real_BT - foff);
+            RegTensor<float> rcReg, ccReg, dgReg;
+            UnalignRegForStore uStoreDg;
+            LoadAlign<float, LoadDist::DIST_NORM>(rcReg, dgcScratch + foff);
+            LoadAlign<float, LoadDist::DIST_NORM>(ccReg, colScratch + foff);
+            Sub(dgReg, rcReg, ccReg, m32);
+            auto actDgOut = dgOut + foff;
+            StoreUnAlign(actDgOut, dgReg, uStoreDg, copyNum);
+            StoreUnAlignPost(actDgOut, uStoreDg, 0);
+        }
+    }
+}
+
+}  // namespace ChunkBwdDqkwgRegBase
+
+#endif  // __CCE_AICORE__ == 310
+
+#endif  // CHUNK_BWD_DQKWG_REGBASE_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
@@ -32,6 +32,7 @@
 
  #include "chunk_bwd_dqkwg_common.h"
  #include "kernel_operator.h"
+ #include "chunk_bwd_dqkwg_regbase.h"   // A5 (arch35/310) RegBase VF 按元素融合算子 (910B 编译时为空)
 
  using namespace AscendC;
 
@@ -477,8 +478,13 @@
      const uint32_t dwSize = BT * K;
      const uint32_t gSize = BT;
      // 诊断 (同 ProcessBVector): 大 case 缩小 mul1 GM 写, 配合 B 端缩小读, 把 mul1 整个往返流量去掉 (~3.2GB), 看 perf。
+ #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+     // RegBase B 阶段仍从独立环形 workspace 读取 mul1，A5 必须保留 Part2 的计算和写回。
+     const bool largeMemBound_diag = false;
+ #else
      const bool largeMemBound_diag =
          ((uint64_t)B * HV * T * K * 2 + (uint64_t)B * HV * T * BT * 2 + (uint64_t)B * HV * numChunks * 4) > (512ULL * 1024 * 1024);
+ #endif
      const uint32_t maxSize = (2 * hDhSize) > dwSize ? (2 * hDhSize) : dwSize;
 
      // ----- Part1 buffers (h/dh, dw) -----
@@ -616,9 +622,17 @@
                      }
                      Cast(tensorHFp32, tensorDwOut, RoundMode::CAST_NONE, dwSize_sub);
                      PipeBarrier<PIPE_V>();
+ #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+                     // RegBase: dw = (DataType)(-dw_fp32), 融合 Muls(-1)+Cast(RINT) 进寄存器 (省 1 次 UB 往返 + 1 个 PIPE_V)
+                     ChunkBwdDqkwgRegBase::NegCastVF<DataType>(
+                         (__ubuf__ DataType*)tensorDwOut.GetPhyAddr(),
+                         (__ubuf__ float*)tensorHFp32.GetPhyAddr(),
+                         dwSize_sub);
+ #else
                      Muls(tensorHFp32, tensorHFp32, -1.0f, dwSize_sub);
                      PipeBarrier<PIPE_V>();
                      Cast(tensorDwOut, tensorHFp32, RoundMode::CAST_RINT, dwSize_sub);
+ #endif
                      PipeBarrier<PIPE_V>();
                      auto tensorRepairWork = calcBuf3.Get<float>();
                      auto tensorRepairScratch = calcBuf2.Get<float>();
@@ -758,11 +772,23 @@
      uint32_t dsSize_full = BT * BT;
      const uint32_t gSize = BT;
 
+ #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+     // RegBase: ds/mul1/mm5 各一独立 fp16 缓冲 (融合 VF 需三者同时在 UB), ds_temp fp16 输出, dg 输出;
+     //          gBuf/dgBuf 复用为 col/dgc scratch (>=2*VL/4 fp32, 列和 INTLV 写满寄存器对)。
+     // 按行循环时每行整寄存器读取 (BT<lanes 时尾行会越读), +512B 余量保证越读仍落在缓冲内 (被掩码丢弃)。
+     constexpr uint32_t kRegbaseRowPad = 512;
+     pipe->InitBuffer(inQue1, BUFFER_NUM, dsSize_full * sizeof(DataType) + kRegbaseRowPad);    // ds (fp16)
+     pipe->InitBuffer(inQue2, BUFFER_NUM, dsSize_full * sizeof(DataType) + kRegbaseRowPad);    // mul1 (fp16)
+     pipe->InitBuffer(inQue3, BUFFER_NUM, dsSize_full * sizeof(DataType) + kRegbaseRowPad);    // mm5 (fp16)
+     pipe->InitBuffer(outQue1, BUFFER_NUM, dsSize_full * sizeof(DataType));   // ds_temp output
+     pipe->InitBuffer(outQue2, BUFFER_NUM, gSize * sizeof(float));            // dg output
+     pipe->InitBuffer(gBuf, 256 * sizeof(float));                            // colScratch
+     pipe->InitBuffer(dgBuf, 256 * sizeof(float));                           // dgcScratch
+ #else
      // 大 memory-bound case: mul1 不走 GM, 改在 vector B 从输入 g 现读现算 (= A Part2 内核 ComputeMul1HalfFp32),
      // 省掉 mul1 的 [BT,BT] GM 往返 (~3.2GB for step2_12)。判据与 host tiling / vector A 同公式; 小 case 仍读 GM。
      const bool largeMemBound_diag =
          ((uint64_t)B * HV * T * K * 2 + (uint64_t)B * HV * T * BT * 2 + (uint64_t)B * HV * numChunks * 4) > (512ULL * 1024 * 1024);
-
      pipe->InitBuffer(inQue1, BUFFER_NUM, dsSize_full * sizeof(float));    // ds from Cube (含 reinterpret)
      pipe->InitBuffer(inQue2, BUFFER_NUM, dsSize_full * sizeof(float));    // mm5/mul1 from workspace (或大 case 内联算 mul1)
      pipe->InitBuffer(outQue1, BUFFER_NUM, dsSize_full * sizeof(DataType));   // ds_temp output
@@ -784,6 +810,7 @@
          }
          PipeBarrier<PIPE_V>();
      }
+ #endif
 
      uint32_t bos = 0;
      uint32_t eos = 0;
@@ -806,6 +833,65 @@
                                                           (uint32_t)wsBtxKSyncSlotsPerHead);
              uint64_t dgOffset = gOffset;
 
+ #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+             // ---- RegBase: ds_temp=ds*mul1, ds2=ds_temp*mm5, dg=rowsum(ds2)-colsum(ds2) ----
+             {  // copy-in: ds / mul1 / mm5 (fp16, 各独立缓冲)
+                 auto tDs = inQue1.AllocTensor<DataType>();
+                 auto tMul1 = inQue2.AllocTensor<DataType>();
+                 auto tMm5 = inQue3.AllocTensor<DataType>();
+                 DataCopy(tDs, gmDsTemp[dsOffset], dsSize_sub);
+                 DataCopy(tMul1, gmMul1[mul1Offset], dsSize_sub);
+                 DataCopy(tMm5, gmMm5[mm5Offset], dsSize_sub);
+                 inQue1.EnQue(tDs);
+                 inQue2.EnQue(tMul1);
+                 inQue3.EnQue(tMm5);
+             }
+             {  // compute: 两段 VF, 中间 PIPE_V 排空 scratch (VF1 store -> VF2 load 同址别名)
+                 auto tDs = inQue1.DeQue<DataType>();
+                 auto tMul1 = inQue2.DeQue<DataType>();
+                 auto tMm5 = inQue3.DeQue<DataType>();
+                 auto tDsTempOut = outQue1.AllocTensor<DataType>();
+                 auto tDgOut = outQue2.AllocTensor<float>();
+                 auto colScratch = gBuf.Get<float>();
+                 auto dgcScratch = dgBuf.Get<float>();
+                 ChunkBwdDqkwgRegBase::BdsTempRowColVF<DataType>(
+                     (__ubuf__ DataType*)tDsTempOut.GetPhyAddr(),
+                     (__ubuf__ float*)dgcScratch.GetPhyAddr(),
+                     (__ubuf__ float*)colScratch.GetPhyAddr(),
+                     (__ubuf__ DataType*)tDs.GetPhyAddr(),
+                     (__ubuf__ DataType*)tMul1.GetPhyAddr(),
+                     (__ubuf__ DataType*)tMm5.GetPhyAddr(),
+                     real_BT, BT);
+                 PipeBarrier<PIPE_V>();
+                 ChunkBwdDqkwgRegBase::BdgFinalizeVF<GType>(
+                     (__ubuf__ GType*)tDgOut.GetPhyAddr(),
+                     (__ubuf__ float*)dgcScratch.GetPhyAddr(),
+                     (__ubuf__ float*)colScratch.GetPhyAddr(),
+                     real_BT);
+                 inQue1.FreeTensor(tDs);
+                 inQue2.FreeTensor(tMul1);
+                 inQue3.FreeTensor(tMm5);
+                 outQue1.EnQue(tDsTempOut);
+                 outQue2.EnQue(tDgOut);
+             }
+             {  // copy-out: ds_temp -> gmDsTemp, dg -> gmDg
+                 auto tDsTempOut = outQue1.DeQue<DataType>();
+                 auto tDgOut = outQue2.DeQue<float>();
+                 DataCopy(gmDsTemp[dsOffset], tDsTempOut, dsSize_sub);
+                 DataCopyParams dataCopyParams;
+                 dataCopyParams.blockCount = 1;
+                 dataCopyParams.blockLen = real_BT * sizeof(GType);
+                 dataCopyParams.srcStride = 0;
+                 dataCopyParams.dstStride = 0;
+                 if constexpr (std::is_same<GType, float>::value) {
+                     DataCopyPad(gmDg[dgOffset], tDgOut, dataCopyParams);
+                 } else {
+                     DataCopyPad(gmDg[dgOffset], tDgOut.template ReinterpretCast<GType>(), dataCopyParams);
+                 }
+                 outQue1.FreeTensor(tDsTempOut);
+                 outQue2.FreeTensor(tDgOut);
+             }
+ #else
              {
                  auto tensorDsIn = inQue1.AllocTensor<DataType>();
                  DataCopy(tensorDsIn[BT * BT], gmDsTemp[dsOffset], dsSize_sub);
@@ -922,6 +1008,7 @@
                  outQue1.FreeTensor(tensorDsTempOut);
                  outQue2.FreeTensor(tensorDgOut);
              }
+ #endif
              PipeBarrier<PIPE_MTE3>();
          }
          PipeBarrier<PIPE_MTE3>();
@@ -1084,6 +1171,20 @@
                  }
                  {
                      auto tensorMm6InFp16 = inQue2.DeQue<DataType>();
+                     auto tensorDqOut = outQue1.AllocTensor<DataType>();
+ #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+                     if (!gvaMode || (h % n_ratio == 0)) {
+                         // RegBase: dq = (DataType)(dq_state_fp32 + (float)mm6), 融合 Cast+Add+Cast 进寄存器
+                         // (省 mm6 的 fp32 中转 UB + 2 个 PIPE_V)。三个缓冲互不重叠。
+                         ChunkBwdDqkwgRegBase::AddCastVF<DataType>(
+                             (__ubuf__ DataType*)tensorDqOut.GetPhyAddr(),
+                             (__ubuf__ float*)tensorDqInFp32.GetPhyAddr(),
+                             (__ubuf__ DataType*)tensorMm6InFp16[dqSize_sub].GetPhyAddr(),
+                             dqSize_sub);
+                         inQue2.FreeTensor(tensorMm6InFp16);
+                     } else
+ #endif
+                     {
                      auto tensorMm6Fp32 = tensorMm6InFp16.template ReinterpretCast<float>();
                      Cast(tensorMm6Fp32, tensorMm6InFp16[dqSize_sub], RoundMode::CAST_NONE, dqSize_sub);
                      PipeBarrier<PIPE_V>();
@@ -1103,8 +1204,8 @@
                          PipeBarrier<PIPE_V>();
                          inQue2.FreeTensor(tensorDqAccumInFp16);
                      }
-                     auto tensorDqOut = outQue1.AllocTensor<DataType>();
                      Cast(tensorDqOut, tensorDqInFp32, RoundMode::CAST_RINT, dqSize_sub);
+                     }
                      inQue1.FreeTensor(tensorDqInFp16);
                      outQue1.EnQue(tensorDqOut);
                  }
@@ -1337,6 +1438,19 @@
                  }
                  {
                      auto tensorMm7In = inQue2.DeQue<DataType>();
+                     auto tensorDkOut = outQue1.AllocTensor<DataType>();
+ #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+                     if (!gvaMode || (h % n_ratio == 0)) {
+                         // RegBase: dk = (DataType)(dk_state_fp32 + (float)mm7), 融合 Cast+Add+Cast 进寄存器。
+                         ChunkBwdDqkwgRegBase::AddCastVF<DataType>(
+                             (__ubuf__ DataType*)tensorDkOut.GetPhyAddr(),
+                             (__ubuf__ float*)tensorDkFp32.GetPhyAddr(),
+                             (__ubuf__ DataType*)tensorMm7In[dkSize].GetPhyAddr(),
+                             dkSize);
+                         inQue2.FreeTensor(tensorMm7In);
+                     } else
+ #endif
+                     {
                      auto tensorMm7Fp32 = tensorMm7In.template ReinterpretCast<float>();
                      Cast(tensorMm7Fp32, tensorMm7In[dkSize], RoundMode::CAST_NONE, dkSize);
                      PipeBarrier<PIPE_V>();
@@ -1356,8 +1470,8 @@
                          PipeBarrier<PIPE_V>();
                          inQue2.FreeTensor(tensorDkAccumInFp16);
                      }
-                     auto tensorDkOut = outQue1.AllocTensor<DataType>();
                      Cast(tensorDkOut, tensorDkFp32, RoundMode::CAST_RINT, dkSize);
+                     }
                      inQue1.FreeTensor(tensorDkIn);
                      outQue1.EnQue(tensorDkOut);
                  }


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @ZhangYi2026
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [x] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [x] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
