### PR TITLE
feat: 新增 prepare_wy_repr_bwd 融合算子

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/CMakeLists.txt
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/CMakeLists.txt
@@ -1,0 +1,10 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# Adapted for flash-linear-attention-npu by Tianjin University.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# -----------------------------------------------------------------------------------------------------------
+add_subdirectory(op_host)

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/README.md
@@ -1,0 +1,89 @@
+# PrepareWyReprBwd 算子说明
+
+`PrepareWyReprBwd` 是 Chunk Gated Delta Rule 反向中 WY 表示准备阶段的独立融合入口。公开接口只接收原始输入 `k/v/beta/A/dw/du/g` 以及可选的 `cu_seqlens/chunk_indices`，一次返回 `dk/dv/dbeta/dg`。
+
+本版按照新的算子结构生成：host tiling 直接描述该算子的 chunk、head、tile 和 workspace；kernel 内部构造 chunk 级伴随矩阵缓存，并在同一个 AiCore launch 中写回四个公开梯度输出。内部缓存不暴露给 PyTorch 或 ACLNN 调用方。
+
+## 支持范围
+
+当前只按 A2/A3 生成，OpDef 仅注册：
+
+- `ascend910b`
+- `ascend910_93`
+
+其他架构需要单独评估核类型、workspace 切分与同步策略，不在本次范围内。
+
+## ACLNN 接口
+
+```cpp
+aclnnStatus aclnnPrepareWyReprBwdGetWorkspaceSize(
+    const aclTensor *k,
+    const aclTensor *v,
+    const aclTensor *beta,
+    const aclTensor *A,
+    const aclTensor *dw,
+    const aclTensor *du,
+    const aclTensor *g,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    int64_t chunkSize,
+    const aclTensor *dkOut,
+    const aclTensor *dvOut,
+    const aclTensor *dbetaOut,
+    const aclTensor *dgOut,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor);
+
+aclnnStatus aclnnPrepareWyReprBwd(
+    void *workspace,
+    uint64_t workspaceSize,
+    aclOpExecutor *executor,
+    aclrtStream stream);
+```
+
+PyTorch 侧入口：
+
+```python
+dk, dv, dbeta, dg = torch.ops.npu.npu_prepare_wy_repr_bwd(
+    k, v, beta, A, dw, du, g, chunk_size,
+    cu_seqlens=cu_seqlens,
+    chunk_indices=chunk_indices,
+)
+```
+
+## Kernel 结构
+
+`op_kernel/prepare_wy_repr_bwd.cpp` 是独立 A2/A3 kernel 骨架，按 mixed AIC/AIV 拆分：
+
+1. host tiling 使用 `GET_TPL_TILING_KEY(IS_VARLEN, k_dtype, gate_dtype, V)` 生成模板化 tiling key。
+2. AIV 侧 `prepare_wy_repr_bwd_vector.h` 使用 AscendC 基础 API 生成 `kbg/vb/kbeta`，并处理 mask、exp、reduce 与公开输出写回。
+3. AIC 侧 `prepare_wy_repr_bwd_cube.h` 使用 Catlass tile 层接口显式执行所有矩阵乘，包括 DA 阶段和 full 阶段的 `A.T@*`、`dA@*`、`K@K.T`。
+4. AIC/AIV 之间先用全参与同步表达阶段边界，后续性能化再替换为细粒度 ready/free flag。
+5. 任务粒度按每轮两个 chunk 遍历，并在 chunk 内顺序覆盖全部 value head；`dk` 对同一 key head 的多个 value head 贡献在同一阶段内累加。
+
+这版重点是先在小 shape 上打通实际执行代码与精度验证；后续可在保持 `PrepareWyReprBwdTilingData` 主字段稳定的基础上，把同步策略替换为细粒度 flag 和双 slot 流水。
+
+## Tiling 结构
+
+`PrepareWyReprBwdTilingData` 包含：
+
+- 主维度：`B/HV/HK/T/K/V`
+- chunk 信息：`chunkSize/chunkNum/isVariable/headGroup`
+- AIV 行粒度：`rowTileInput/rowTileDa/rowTileFullK/rowTileFullV/rowTileFullKkt`
+- workspace：`kbg/vb/kbeta/da*/full*` 各阶段 offset、`kWorkspaceBytes/vWorkspaceBytes/aWorkspaceBytes/userWorkspaceBytes`
+
+shape 校验覆盖：
+
+- `k` 为 `[B, HK, T, K]`
+- `v/du` 为 `[B, HV, T, V]`
+- `beta/g` 为 `[B, HV, T]`
+- `A` 为 `[B, HV, T, chunk_size]`
+- `dw` 为 `[B, HV, T, K]`
+- `HV` 必须是 `HK` 的正整数倍
+- `chunk_size` 仅支持 `64/128`
+- `V` 仅支持 `128/256`
+- 可变长模式要求同时提供 `cu_seqlens` 与 `chunk_indices`，并要求 `B=1`
+
+## 验证状态
+
+本次按“只生成，不跑通”的要求提交，未执行 CANN 构建、单算子精度或性能测试。

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/CMakeLists.txt
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/CMakeLists.txt
@@ -1,0 +1,28 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2025 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# -----------------------------------------------------------------------------------------------------------
+add_op_to_compiled_list()
+if (BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnnExc PRIVATE
+        prepare_wy_repr_bwd_def.cpp
+    )
+endif()
+
+add_modules_sources(OPTYPE prepare_wy_repr_bwd ACLNNTYPE aclnn_exclude)
+add_ops_compile_options(
+    OP_NAME PrepareWyReprBwd
+    OPTIONS --cce-auto-sync=off
+            -Wno-deprecated-declarations
+)
+if("${ASCEND_COMPUTE_UNIT}" STREQUAL "ascend950")
+    add_ops_compile_options(
+        OP_NAME PrepareWyReprBwd
+        COMPUTE_UNIT Ascend950PR_9599
+        OPTIONS -mllvm -cce-aicore-dcci-before-kernel-end=false
+    )
+endif()

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/op_api/aclnn_prepare_wy_repr_bwd.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/op_api/aclnn_prepare_wy_repr_bwd.cpp
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+#include "aclnn_prepare_wy_repr_bwd.h"
+#include "prepare_wy_repr_bwd.h"
+#include <dlfcn.h>
+#include <new>
+
+#include "aclnn_kernels/transdata.h"
+#include "aclnn_kernels/contiguous.h"
+#include "acl/acl.h"
+#include "aclnn/aclnn_base.h"
+#include "aclnn_kernels/common/op_error_check.h"
+#include "opdev/common_types.h"
+#include "opdev/data_type_utils.h"
+#include "opdev/format_utils.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_executor.h"
+#include "opdev/op_log.h"
+#include "opdev/platform.h"
+#include "opdev/shape_utils.h"
+#include "opdev/tensor_view_utils.h"
+#include "opdev/make_op_executor.h"
+
+using namespace op;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct PrepareWyReprBwdParams {
+    const aclTensor *k = nullptr;
+    const aclTensor *v = nullptr;
+    const aclTensor *beta = nullptr;
+    const aclTensor *a = nullptr;
+    const aclTensor *dw = nullptr;
+    const aclTensor *du = nullptr;
+    const aclTensor *g = nullptr;
+    const aclIntArray *cuSeqlensOptional = nullptr;
+    const aclIntArray *chunkIndicesOptional = nullptr;
+    int64_t chunkSize = 64;
+    const aclTensor *dkOut = nullptr;
+    const aclTensor *dvOut = nullptr;
+    const aclTensor *dbetaOut = nullptr;
+    const aclTensor *dgOut = nullptr;
+};
+
+static aclnnStatus CheckNotNull(PrepareWyReprBwdParams params)
+{
+    CHECK_COND(params.k != nullptr, ACLNN_ERR_PARAM_NULLPTR, "k must not be nullptr.");
+    CHECK_COND(params.v != nullptr, ACLNN_ERR_PARAM_NULLPTR, "v must not be nullptr.");
+    CHECK_COND(params.beta != nullptr, ACLNN_ERR_PARAM_NULLPTR, "beta must not be nullptr.");
+    CHECK_COND(params.a != nullptr, ACLNN_ERR_PARAM_NULLPTR, "a must not be nullptr.");
+    CHECK_COND(params.dw != nullptr, ACLNN_ERR_PARAM_NULLPTR, "dw must not be nullptr.");
+    CHECK_COND(params.du != nullptr, ACLNN_ERR_PARAM_NULLPTR, "du must not be nullptr.");
+    CHECK_COND(params.g != nullptr, ACLNN_ERR_PARAM_NULLPTR, "g must not be nullptr.");
+
+    CHECK_COND(params.dkOut != nullptr, ACLNN_ERR_PARAM_NULLPTR, "dkOut must not be nullptr.");
+    CHECK_COND(params.dvOut != nullptr, ACLNN_ERR_PARAM_NULLPTR, "dvOut must not be nullptr.");
+    CHECK_COND(params.dbetaOut != nullptr, ACLNN_ERR_PARAM_NULLPTR, "dbetaOut must not be nullptr.");
+    CHECK_COND(params.dgOut != nullptr, ACLNN_ERR_PARAM_NULLPTR, "dgOut must not be nullptr.");
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckFormat(PrepareWyReprBwdParams params)
+{
+    (void)params;
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckShape(PrepareWyReprBwdParams params)
+{
+    (void)params;
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus DataContiguous(const aclTensor *&tensor, aclOpExecutor *executor)
+{
+    tensor = l0op::Contiguous(tensor, executor);
+    CHECK_RET(tensor != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus ParamsDataContiguous(PrepareWyReprBwdParams &params, aclOpExecutor *executorPtr)
+{
+    CHECK_COND(DataContiguous(params.k, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous k failed.");
+    CHECK_COND(DataContiguous(params.v, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous v failed.");
+    CHECK_COND(DataContiguous(params.beta, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous beta failed.");
+    CHECK_COND(DataContiguous(params.a, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous a failed.");
+    CHECK_COND(DataContiguous(params.dw, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous dw failed.");
+    CHECK_COND(DataContiguous(params.du, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous du failed.");
+    CHECK_COND(DataContiguous(params.g, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous g failed.");
+
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckDtype(PrepareWyReprBwdParams params)
+{
+    (void)params;
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckParams(PrepareWyReprBwdParams params)
+{
+    CHECK_RET(CheckNotNull(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(CheckFormat(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(CheckShape(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(CheckDtype(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    return ACLNN_SUCCESS;
+}
+
+aclnnStatus aclnnPrepareWyReprBwdGetWorkspaceSize(
+    const aclTensor *k,
+    const aclTensor *v,
+    const aclTensor *beta,
+    const aclTensor *a,
+    const aclTensor *dw,
+    const aclTensor *du,
+    const aclTensor *g,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    int64_t chunkSize,
+    const aclTensor *dkOut,
+    const aclTensor *dvOut,
+    const aclTensor *dbetaOut,
+    const aclTensor *dgOut,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor)
+{
+    PrepareWyReprBwdParams params{k, v, beta, a, dw, du, g, cuSeqlensOptional, chunkIndicesOptional, chunkSize,
+                                  dkOut, dvOut, dbetaOut, dgOut};
+    // DFX 记录只描述公开入参：内部伴随矩阵由 kernel workspace 承接，不出现在 ACLNN API 中。
+    L2_DFX_PHASE_1(aclnnPrepareWyReprBwd, DFX_IN(k, v, beta, a, dw, du, g, cuSeqlensOptional, chunkIndicesOptional),
+                   DFX_OUT(dkOut, dvOut, dbetaOut, dgOut));
+    auto uniqueExecutor = CREATE_EXECUTOR();
+    CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);
+    auto executorPtr = uniqueExecutor.get();
+
+    auto ret = CheckParams(params);
+    CHECK_RET(ret == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_COND(ParamsDataContiguous(params, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "ParamsDataContiguous failed.");
+
+    // l0op::PrepareWyReprBwd 直接下发一个 AiCore kernel。host tiling 负责分配内部缓存，
+    // kernel 内按 chunk-head 任务构造伴随矩阵并写回 dk/dv/dbeta/dg。
+    auto result = l0op::PrepareWyReprBwd(params.k, params.v, params.beta, params.a, params.dw, params.du, params.g,
+                                         params.cuSeqlensOptional, params.chunkIndicesOptional, params.chunkSize,
+                                         params.dkOut, params.dvOut, params.dbetaOut, params.dgOut, executorPtr);
+    CHECK_RET(result[0] != nullptr, ACLNN_ERR_PARAM_NULLPTR);
+    CHECK_RET(result[1] != nullptr, ACLNN_ERR_PARAM_NULLPTR);
+    CHECK_RET(result[2] != nullptr, ACLNN_ERR_PARAM_NULLPTR);
+    CHECK_RET(result[3] != nullptr, ACLNN_ERR_PARAM_NULLPTR);
+
+    auto viewCopyResult = l0op::ViewCopy(result[0], params.dkOut, executorPtr);
+    CHECK_RET(viewCopyResult != nullptr, ACLNN_ERR_INNER_NULLPTR);
+
+    viewCopyResult = l0op::ViewCopy(result[1], params.dvOut, executorPtr);
+    CHECK_RET(viewCopyResult != nullptr, ACLNN_ERR_INNER_NULLPTR);
+
+    viewCopyResult = l0op::ViewCopy(result[2], params.dbetaOut, executorPtr);
+    CHECK_RET(viewCopyResult != nullptr, ACLNN_ERR_INNER_NULLPTR);
+
+    viewCopyResult = l0op::ViewCopy(result[3], params.dgOut, executorPtr);
+    CHECK_RET(viewCopyResult != nullptr, ACLNN_ERR_INNER_NULLPTR);
+
+    *workspaceSize = uniqueExecutor->GetWorkspaceSize();
+    uniqueExecutor.ReleaseTo(executor);
+    return ACLNN_SUCCESS;
+}
+
+aclnnStatus aclnnPrepareWyReprBwd(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor, aclrtStream stream)
+{
+    L2_DFX_PHASE_2(aclnnPrepareWyReprBwd);
+    CHECK_COND(CommonOpExecutorRun(workspace, workspaceSize, executor, stream) == ACLNN_SUCCESS, ACLNN_ERR_INNER,
+               "This is an error in PrepareWyReprBwd launch aicore.");
+    return ACLNN_SUCCESS;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/op_api/aclnn_prepare_wy_repr_bwd.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/op_api/aclnn_prepare_wy_repr_bwd.h
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+#ifndef OP_API_INC_PREPARE_WY_REPR_BWD_H
+#define OP_API_INC_PREPARE_WY_REPR_BWD_H
+#include "aclnn/aclnn_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* funtion: aclnnPrepareWyReprBwdGetWorkspaceSize
+ * parameters :
+ * k : required
+ * v : required
+ * beta : required
+ * a : required
+ * dw : required
+ * du : required
+ * g : required
+ * cuSeqlensOptional : optional
+ * chunkIndicesOptional : optional
+ * chunkSize : required
+ * dkOut : required
+ * dvOut : required
+ * dbetaOut : required
+ * dgOut : required
+ * workspaceSize : size of workspace(output).
+ * executor : executor context(output).
+ */
+__attribute__((visibility("default")))
+aclnnStatus aclnnPrepareWyReprBwdGetWorkspaceSize(
+    const aclTensor *k,
+    const aclTensor *v,
+    const aclTensor *beta,
+    const aclTensor *a,
+    const aclTensor *dw,
+    const aclTensor *du,
+    const aclTensor *g,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    int64_t chunkSize,
+    const aclTensor *dkOut,
+    const aclTensor *dvOut,
+    const aclTensor *dbetaOut,
+    const aclTensor *dgOut,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor);
+
+/* funtion: aclnnPrepareWyReprBwd
+ * parameters :
+ * workspace : workspace memory addr(input).
+ * workspaceSize : size of workspace(input).
+ * executor : executor context(input).
+ * stream : acl stream.
+ */
+__attribute__((visibility("default")))
+aclnnStatus aclnnPrepareWyReprBwd(
+    void *workspace,
+    uint64_t workspaceSize,
+    aclOpExecutor *executor,
+    aclrtStream stream);
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/op_api/prepare_wy_repr_bwd.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/op_api/prepare_wy_repr_bwd.cpp
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "opdev/op_log.h"
+#include "opdev/op_dfx.h"
+#include "opdev/make_op_executor.h"
+#include "prepare_wy_repr_bwd.h"
+
+using namespace op;
+
+namespace l0op {
+OP_TYPE_REGISTER(PrepareWyReprBwd);
+
+const std::array<const aclTensor *, 4> PrepareWyReprBwd(
+    const aclTensor *k,
+    const aclTensor *v,
+    const aclTensor *beta,
+    const aclTensor *a,
+    const aclTensor *dw,
+    const aclTensor *du,
+    const aclTensor *g,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    int64_t chunkSize,
+    const aclTensor *dkOut,
+    const aclTensor *dvOut,
+    const aclTensor *dbetaOut,
+    const aclTensor *dgOut,
+    aclOpExecutor *executor)
+{
+    L0_DFX(PrepareWyReprBwd, k, v, beta, a, dw, du, g, cuSeqlensOptional, chunkIndicesOptional, chunkSize,
+           dkOut, dvOut, dbetaOut, dgOut);
+
+    // 可变长输入在 OpDef 中是 OPTIONAL + ValueDepend。这里把 aclIntArray 转成 ND tensor，
+    // 让 host tiling 能直接读取序列边界与 chunk 映射。
+    const aclTensor *actualCuSeqLen = nullptr;
+    if (cuSeqlensOptional) {
+        actualCuSeqLen = executor->ConvertToTensor(cuSeqlensOptional, DataType::DT_INT64);
+        const_cast<aclTensor *>(actualCuSeqLen)->SetStorageFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualCuSeqLen)->SetViewFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualCuSeqLen)->SetOriginalFormat(Format::FORMAT_ND);
+    }
+
+    const aclTensor *actualChunkIndices = nullptr;
+    if (chunkIndicesOptional) {
+        actualChunkIndices = executor->ConvertToTensor(chunkIndicesOptional, DataType::DT_INT64);
+        const_cast<aclTensor *>(actualChunkIndices)->SetStorageFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualChunkIndices)->SetViewFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualChunkIndices)->SetOriginalFormat(Format::FORMAT_ND);
+    }
+
+    // 单次 AiCore launch 完成内部伴随矩阵构造和四个公开梯度写回。伴随矩阵只存在于
+    // kernel workspace 中，不作为 executor 临时 tensor 暴露给调用方。
+    auto ret = ADD_TO_LAUNCHER_LIST_AICORE(PrepareWyReprBwd,
+        OP_INPUT(k, v, beta, a, dw, du, g, actualCuSeqLen, actualChunkIndices),
+        OP_OUTPUT(dkOut, dvOut, dbetaOut, dgOut),
+        OP_ATTR(chunkSize));
+    if (ret != ACLNN_SUCCESS) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "ADD_TO_LAUNCHER_LIST_AICORE failed.");
+        return {nullptr, nullptr, nullptr, nullptr};
+    }
+    return {dkOut, dvOut, dbetaOut, dgOut};
+}
+
+} // namespace l0op

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/op_api/prepare_wy_repr_bwd.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/op_api/prepare_wy_repr_bwd.h
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+#ifndef OP_API_INC_LEVEL0_OP_PREPARE_WY_REPR_BWD_OP_H
+#define OP_API_INC_LEVEL0_OP_PREPARE_WY_REPR_BWD_OP_H
+
+#include "opdev/op_executor.h"
+
+namespace l0op {
+const std::array<const aclTensor *, 4> PrepareWyReprBwd(
+    const aclTensor *k,
+    const aclTensor *v,
+    const aclTensor *beta,
+    const aclTensor *a,
+    const aclTensor *dw,
+    const aclTensor *du,
+    const aclTensor *g,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    int64_t chunkSize,
+    const aclTensor *dkOut,
+    const aclTensor *dvOut,
+    const aclTensor *dbetaOut,
+    const aclTensor *dgOut,
+    aclOpExecutor *executor);
+}
+
+#endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/op_tiling/prepare_wy_repr_bwd_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/op_tiling/prepare_wy_repr_bwd_tiling.cpp
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file prepare_wy_repr_bwd_tiling.cpp
+ * \brief Tiling registration for prepare_wy_repr_bwd.
+ */
+
+#include "prepare_wy_repr_bwd_tiling.h"
+#include <register/op_impl_registry.h>
+#include "platform/platform_ascendc.h"
+
+namespace optiling {
+namespace {
+
+int64_t ToPrepareWyReprBwdDtype(ge::DataType dtype)
+{
+    if (dtype == ge::DT_BF16) {
+        return PREPARE_WY_REPR_BWD_DTYPE_BF16;
+    }
+    if (dtype == ge::DT_FLOAT) {
+        return PREPARE_WY_REPR_BWD_DTYPE_FP32;
+    }
+    return PREPARE_WY_REPR_BWD_DTYPE_FP16;
+}
+
+int32_t ToPrepareWyReprBwdTplDtype(ge::DataType dtype)
+{
+    if (dtype == ge::DT_BF16) {
+        return GDN::TPL_BF16;
+    }
+    if (dtype == ge::DT_FLOAT) {
+        return GDN::TPL_FP32;
+    }
+    return GDN::TPL_FP16;
+}
+
+void PrepareWyReprBwdTilingDataPrint(gert::TilingContext *context, const PrepareWyReprBwdTilingData &tiling)
+{
+    auto nodeName = context->GetNodeName();
+    OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Start to print PrepareWyReprBwd tiling data <<<<<<<<<<<<<<<<");
+    OP_LOGD(nodeName, "=== B: %ld", tiling.B);
+    OP_LOGD(nodeName, "=== HV: %ld", tiling.HV);
+    OP_LOGD(nodeName, "=== HK: %ld", tiling.HK);
+    OP_LOGD(nodeName, "=== T: %ld", tiling.T);
+    OP_LOGD(nodeName, "=== K: %ld", tiling.K);
+    OP_LOGD(nodeName, "=== V: %ld", tiling.V);
+    OP_LOGD(nodeName, "=== chunkSize: %ld", tiling.chunkSize);
+    OP_LOGD(nodeName, "=== chunkNum: %ld", tiling.chunkNum);
+    OP_LOGD(nodeName, "=== isVariable: %ld", tiling.isVariable);
+    OP_LOGD(nodeName, "=== headGroup: %ld", tiling.headGroup);
+    OP_LOGD(nodeName, "=== taskPairMode: %ld", tiling.taskPairMode);
+    OP_LOGD(nodeName, "=== ownerUnitNum: %ld", tiling.ownerUnitNum);
+    OP_LOGD(nodeName, "=== rowTileInput: %ld", tiling.rowTileInput);
+    OP_LOGD(nodeName, "=== rowTileDa: %ld", tiling.rowTileDa);
+    OP_LOGD(nodeName, "=== rowTileFullK: %ld", tiling.rowTileFullK);
+    OP_LOGD(nodeName, "=== rowTileFullV: %ld", tiling.rowTileFullV);
+    OP_LOGD(nodeName, "=== rowTileFullKkt: %ld", tiling.rowTileFullKkt);
+    OP_LOGD(nodeName, "=== vectorIoInOffset: %ld", tiling.vectorIoInOffset);
+    OP_LOGD(nodeName, "=== vectorIoOutOffset: %ld", tiling.vectorIoOutOffset);
+    OP_LOGD(nodeName, "=== vectorPersistentOffset: %ld", tiling.vectorPersistentOffset);
+    OP_LOGD(nodeName, "=== vectorGateCacheOffset: %ld", tiling.vectorGateCacheOffset);
+    OP_LOGD(nodeName, "=== vectorTempOffset: %ld", tiling.vectorTempOffset);
+    OP_LOGD(nodeName, "=== vectorMaskOffset: %ld", tiling.vectorMaskOffset);
+    OP_LOGD(nodeName, "=== vectorZeroOffset: %ld", tiling.vectorZeroOffset);
+    OP_LOGD(nodeName, "=== vectorUbBytes: %ld", tiling.vectorUbBytes);
+    OP_LOGD(nodeName, "=== usedCoreNum: %ld", tiling.usedCoreNum);
+    OP_LOGD(nodeName, "=== kbgOffset: %ld", tiling.kbgOffset);
+    OP_LOGD(nodeName, "=== vbOffset: %ld", tiling.vbOffset);
+    OP_LOGD(nodeName, "=== kbetaOffset: %ld", tiling.kbetaOffset);
+    OP_LOGD(nodeName, "=== da1Offset: %ld", tiling.da1Offset);
+    OP_LOGD(nodeName, "=== da2Offset: %ld", tiling.da2Offset);
+    OP_LOGD(nodeName, "=== da4Offset: %ld", tiling.da4Offset);
+    OP_LOGD(nodeName, "=== da5Offset: %ld", tiling.da5Offset);
+    OP_LOGD(nodeName, "=== daOffset: %ld", tiling.daOffset);
+    OP_LOGD(nodeName, "=== fullDkOffset: %ld", tiling.fullDkOffset);
+    OP_LOGD(nodeName, "=== fullDkbOffset: %ld", tiling.fullDkbOffset);
+    OP_LOGD(nodeName, "=== fullDkbgOffset: %ld", tiling.fullDkbgOffset);
+    OP_LOGD(nodeName, "=== fullDvbOffset: %ld", tiling.fullDvbOffset);
+    OP_LOGD(nodeName, "=== fullKktOffset: %ld", tiling.fullKktOffset);
+    OP_LOGD(nodeName, "=== kWorkspaceBytes: %ld", tiling.kWorkspaceBytes);
+    OP_LOGD(nodeName, "=== vWorkspaceBytes: %ld", tiling.vWorkspaceBytes);
+    OP_LOGD(nodeName, "=== aWorkspaceBytes: %ld", tiling.aWorkspaceBytes);
+    OP_LOGD(nodeName, "=== workspaceSlotBytes: %ld", tiling.workspaceSlotBytes);
+    OP_LOGD(nodeName, "=== workspaceBufferCount: %ld", tiling.workspaceBufferCount);
+    OP_LOGD(nodeName, "=== userWorkspaceBytes: %ld", tiling.userWorkspaceBytes);
+    OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Print PrepareWyReprBwd tiling data end <<<<<<<<<<<<<<<<");
+}
+
+} // namespace
+
+ge::graphStatus Tiling4PrepareWyReprBwd(gert::TilingContext *context)
+{
+    OP_LOGD(context->GetNodeName(), "Tiling4PrepareWyReprBwd start.");
+    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
+
+    PrepareWyReprBwdTilingData *tiling = context->GetTilingData<PrepareWyReprBwdTilingData>();
+    OP_CHECK_NULL_WITH_CONTEXT(context, tiling);
+
+    auto attrPtr = context->GetAttrs();
+    OP_CHECK_NULL_WITH_CONTEXT(context, attrPtr);
+
+    auto kDesc = context->GetInputDesc(BWD_INPUT_K_IDX);
+    auto betaDesc = context->GetInputDesc(BWD_INPUT_BETA_IDX);
+    OP_CHECK_NULL_WITH_CONTEXT(context, kDesc);
+    OP_CHECK_NULL_WITH_CONTEXT(context, betaDesc);
+
+    uint64_t ubSize = 0;
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
+    uint32_t aicCoreNum = static_cast<uint32_t>(ascendcPlatform.GetCoreNumAic());
+    if (aicCoreNum == 0) {
+        aicCoreNum = static_cast<uint32_t>(ascendcPlatform.GetCoreNum());
+    }
+
+    auto cuSeqlensTensor = context->GetOptionalInputTensor(BWD_INPUT_SEQLENS_IDX);
+    auto chunkIndicesTensor = context->GetOptionalInputTensor(BWD_INPUT_CHUNK_INDICES_IDX);
+    const int64_t *cuSeqlensData = cuSeqlensTensor == nullptr ? nullptr : cuSeqlensTensor->GetData<int64_t>();
+    const int64_t *chunkIndicesData =
+        chunkIndicesTensor == nullptr ? nullptr : chunkIndicesTensor->GetData<int64_t>();
+
+    PrepareWyReprBwdTilingContext ctx{
+        context->GetNodeName(),
+        context->GetRequiredInputShape(BWD_INPUT_K_IDX),
+        context->GetRequiredInputShape(BWD_INPUT_V_IDX),
+        context->GetRequiredInputShape(BWD_INPUT_BETA_IDX),
+        context->GetRequiredInputShape(BWD_INPUT_A_IDX),
+        context->GetRequiredInputShape(BWD_INPUT_DW_IDX),
+        context->GetRequiredInputShape(BWD_INPUT_DU_IDX),
+        context->GetRequiredInputShape(BWD_INPUT_G_IDX),
+        context->GetOptionalInputShape(BWD_INPUT_SEQLENS_IDX),
+        context->GetOptionalInputShape(BWD_INPUT_CHUNK_INDICES_IDX),
+        cuSeqlensData,
+        chunkIndicesData,
+        static_cast<int64_t>(*(attrPtr->GetAttrPointer<int32_t>(BWD_ATTR_CHUNK_SIZE_IDX))),
+        ToPrepareWyReprBwdDtype(kDesc->GetDataType()),
+        ToPrepareWyReprBwdDtype(betaDesc->GetDataType()),
+        ubSize,
+        aicCoreNum,
+        static_cast<size_t>(ascendcPlatform.GetLibApiWorkSpaceSize()),
+    };
+
+    PrepareWyReprBwdTilingProcessor processor(ctx, *tiling);
+    OP_CHECK_IF(processor.Process() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+
+    const bool isVarLenKey = processor.IsVariableLength();
+    const int32_t kTplDtype = ToPrepareWyReprBwdTplDtype(kDesc->GetDataType());
+    const int32_t gateTplDtype = ToPrepareWyReprBwdTplDtype(betaDesc->GetDataType());
+    const uint64_t cubeTileChunkSize = tiling->V == 128 ? 128 : static_cast<uint64_t>(tiling->chunkSize);
+    const uint64_t tilingKey = GET_TPL_TILING_KEY(isVarLenKey, kTplDtype, gateTplDtype,
+                                                  static_cast<uint64_t>(tiling->V),
+                                                  cubeTileChunkSize);
+    context->SetTilingKey(tilingKey);
+    context->SetBlockDim(processor.GetBlockDim());
+    size_t *currentWorkspace = context->GetWorkspaceSizes(1);
+    currentWorkspace[0] = processor.GetWorkspaceSize();
+    context->SetScheduleMode(1);
+
+    OP_LOGD(context->GetNodeName(), "tilingKey: %lu", static_cast<uint64_t>(context->GetTilingKey()));
+    PrepareWyReprBwdTilingDataPrint(context, *tiling);
+    OP_LOGD(context->GetNodeName(), "Tiling4PrepareWyReprBwd end.");
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus TilingPrepareForPrepareWyReprBwd(gert::TilingParseContext *context)
+{
+    (void)context;
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(PrepareWyReprBwd)
+    .Tiling(Tiling4PrepareWyReprBwd)
+    .TilingParse<PrepareWyReprBwdCompileInfo>(TilingPrepareForPrepareWyReprBwd);
+
+} // namespace optiling

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/op_tiling/prepare_wy_repr_bwd_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/op_tiling/prepare_wy_repr_bwd_tiling.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef PREPARE_WY_REPR_BWD_TILING_H
+#define PREPARE_WY_REPR_BWD_TILING_H
+
+#include <exe_graph/runtime/tiling_context.h>
+#include <graph/utils/type_utils.h>
+
+#include "../prepare_wy_repr_bwd_tiling_processor.h"
+
+namespace optiling {
+
+struct PrepareWyReprBwdCompileInfo {};
+
+} // namespace optiling
+
+#endif // PREPARE_WY_REPR_BWD_TILING_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/prepare_wy_repr_bwd_def.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/prepare_wy_repr_bwd_def.cpp
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file prepare_wy_repr_bwd_def.cpp
+ * \brief OpDef for the prepare_wy_repr_bwd AiCore operator.
+ */
+
+#include "register/op_def_registry.h"
+
+namespace ops {
+class PrepareWyReprBwd : public OpDef {
+public:
+    explicit PrepareWyReprBwd(const char *name) : OpDef(name)
+    {
+        // 公开接口沿用亲和流程图中的原始输入；内部伴随矩阵只由 kernel workspace 管理。
+        this->Input("k")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("v")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("beta")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("A")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("dw")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("du")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("g")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("cu_seqlens")
+            .ParamType(OPTIONAL)
+            .ValueDepend(OPTIONAL)
+            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("chunk_indices")
+            .ParamType(OPTIONAL)
+            .ValueDepend(OPTIONAL)
+            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+
+        this->Output("dk")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Output("dv")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Output("dbeta")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Output("dg")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+
+        this->Attr("chunk_size").AttrType(REQUIRED).Int(64);
+
+        OpAICoreConfig aicoreConfig;
+        aicoreConfig.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .PrecisionReduceFlag(true)
+            .ExtendCfgInfo("prebuildPattern.value", "Opaque")
+            .ExtendCfgInfo("coreType.value", "AiCore")
+            .ExtendCfgInfo("aclnnSupport.value", "support_aclnn");
+
+        this->AICore().AddConfig("ascend910b");
+        this->AICore().AddConfig("ascend910_93");
+        this->AICore().AddConfig("ascend950", aicoreConfig);
+    }
+};
+
+OP_ADD(PrepareWyReprBwd);
+} // namespace ops

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/prepare_wy_repr_bwd_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/prepare_wy_repr_bwd_tiling_processor.h
@@ -1,0 +1,591 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef PREPARE_WY_REPR_BWD_TILING_PROCESSOR_H
+#define PREPARE_WY_REPR_BWD_TILING_PROCESSOR_H
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "../op_kernel/prepare_wy_repr_bwd_struct.h"
+
+#include <exe_graph/runtime/storage_shape.h>
+#include "log/log.h"
+#include <register/op_impl_registry.h>
+
+using GDN::PrepareWyReprBwdTilingData;
+
+namespace optiling {
+
+static constexpr size_t BWD_INPUT_K_IDX = 0;
+static constexpr size_t BWD_INPUT_V_IDX = 1;
+static constexpr size_t BWD_INPUT_BETA_IDX = 2;
+static constexpr size_t BWD_INPUT_A_IDX = 3;
+static constexpr size_t BWD_INPUT_DW_IDX = 4;
+static constexpr size_t BWD_INPUT_DU_IDX = 5;
+static constexpr size_t BWD_INPUT_G_IDX = 6;
+static constexpr size_t BWD_INPUT_SEQLENS_IDX = 7;
+static constexpr size_t BWD_INPUT_CHUNK_INDICES_IDX = 8;
+static constexpr size_t BWD_ATTR_CHUNK_SIZE_IDX = 0;
+
+static constexpr size_t BWD_DIM_NUM_1 = 1;
+static constexpr size_t BWD_DIM_NUM_3 = 3;
+static constexpr size_t BWD_DIM_NUM_4 = 4;
+static constexpr size_t BWD_DIM_0 = 0;
+static constexpr size_t BWD_DIM_1 = 1;
+static constexpr size_t BWD_DIM_2 = 2;
+static constexpr size_t BWD_DIM_3 = 3;
+
+static constexpr int64_t BWD_CHUNK_SIZE_64 = 64;
+static constexpr int64_t BWD_CHUNK_SIZE_128 = 128;
+static constexpr int64_t BWD_K_DIM_128 = 128;
+static constexpr int64_t BWD_V_DIM_128 = 128;
+static constexpr int64_t BWD_V_DIM_256 = 256;
+static constexpr int64_t BWD_VAR_LEN_B_DIM_1 = 1;
+
+static constexpr int64_t PREPARE_WY_REPR_BWD_DTYPE_FP16 = 0;
+static constexpr int64_t PREPARE_WY_REPR_BWD_DTYPE_BF16 = 1;
+static constexpr int64_t PREPARE_WY_REPR_BWD_DTYPE_FP32 = 2;
+
+static constexpr uint64_t BWD_SIZE_HALF = 2;
+static constexpr uint64_t BWD_SIZE_FP32 = 4;
+static constexpr uint64_t BWD_ONE_BLOCK_32 = 32;
+static constexpr uint64_t BWD_TILE_MIN_ROW = 8;
+static constexpr uint64_t BWD_VECTOR_IO_BUFFER_COUNT = 2;
+static constexpr uint64_t BWD_BIT_NUM_FOR_UINT8 = 8;
+static constexpr uint64_t BWD_A5_UB_SIZE = 248 * 1024;
+static constexpr uint64_t BWD_A5_L1_SIZE = 512 * 1024;
+
+struct PrepareWyReprBwdTilingContext {
+    const char *nodeName;
+    const gert::StorageShape *kShape;
+    const gert::StorageShape *vShape;
+    const gert::StorageShape *betaShape;
+    const gert::StorageShape *aShape;
+    const gert::StorageShape *dwShape;
+    const gert::StorageShape *duShape;
+    const gert::StorageShape *gShape;
+    const gert::StorageShape *cuSeqlensShape;
+    const gert::StorageShape *chunkIndicesShape;
+    const int64_t *cuSeqlensData;
+    const int64_t *chunkIndicesData;
+    int64_t chunkSize;
+    int64_t kDataType;
+    int64_t betaDataType;
+    uint64_t ubSize;
+    uint32_t aicCoreNum;
+    size_t sysWorkspaceSize;
+};
+
+class PrepareWyReprBwdTilingProcessor {
+    PrepareWyReprBwdTilingContext &ctx_;
+    PrepareWyReprBwdTilingData &tiling_;
+    size_t workspaceSize_ = 0;
+    uint32_t blockDim_ = 0;
+
+public:
+    explicit PrepareWyReprBwdTilingProcessor(PrepareWyReprBwdTilingContext &ctx, PrepareWyReprBwdTilingData &tiling)
+        : ctx_(ctx), tiling_(tiling)
+    {
+    }
+
+    size_t GetWorkspaceSize() const
+    {
+        return workspaceSize_;
+    }
+
+    uint32_t GetBlockDim() const
+    {
+        return blockDim_;
+    }
+
+    bool IsVariableLength() const
+    {
+        return ctx_.cuSeqlensShape != nullptr || ctx_.chunkIndicesShape != nullptr;
+    }
+
+    ge::graphStatus RequiredInputDimNumCheck(const gert::StorageShape *curShape, size_t validDimNum,
+                                             const char *inputName)
+    {
+        OP_CHECK_IF(curShape == nullptr,
+                    OP_LOGE(ctx_.nodeName, "Input %s is required, but got nullptr.", inputName),
+                    return ge::GRAPH_FAILED);
+        size_t dimNum = curShape->GetStorageShape().GetDimNum();
+        OP_CHECK_IF(dimNum != validDimNum,
+                    OP_LOGE(ctx_.nodeName,
+                            "Check input %s shape failed, dim num should be %zu, but get %zu.", inputName,
+                            validDimNum, dimNum),
+                    return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus PreCheck()
+    {
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.kShape, BWD_DIM_NUM_4, "k") != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.vShape, BWD_DIM_NUM_4, "v") != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.betaShape, BWD_DIM_NUM_3, "beta") != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.aShape, BWD_DIM_NUM_4, "A") != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.dwShape, BWD_DIM_NUM_4, "dw") != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.duShape, BWD_DIM_NUM_4, "du") != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.gShape, BWD_DIM_NUM_3, "g") != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus CompareShape(const gert::Shape &shape1, const gert::Shape &shape2, const char *inputName1,
+                                 const char *inputName2, size_t compareDimNum)
+    {
+        for (size_t dimIndex = 0; dimIndex < compareDimNum; ++dimIndex) {
+            size_t shapeDim1 = shape1.GetDim(dimIndex);
+            size_t shapeDim2 = shape2.GetDim(dimIndex);
+            OP_CHECK_IF(shapeDim1 != shapeDim2,
+                        OP_LOGE(ctx_.nodeName,
+                                "Compare input shape of %s and %s failed, dim %zu should be same, got %zu and %zu.",
+                                inputName1, inputName2, dimIndex, shapeDim1, shapeDim2),
+                        return ge::GRAPH_FAILED);
+        }
+        return ge::GRAPH_SUCCESS;
+    }
+
+    uint64_t AlignUp(uint64_t value, uint64_t align) const
+    {
+        return (value + align - 1) / align * align;
+    }
+
+    int64_t CeilDiv(int64_t a, int64_t b) const
+    {
+        if (b == 0) {
+            return 0;
+        }
+        return (a + b - 1) / b;
+    }
+
+    uint64_t DtypeSize(int64_t dtype) const
+    {
+        return dtype == PREPARE_WY_REPR_BWD_DTYPE_FP32 ? BWD_SIZE_FP32 : BWD_SIZE_HALF;
+    }
+
+    struct VectorUbLayout {
+        uint64_t ioInOffset = 0;
+        uint64_t ioOutOffset = 0;
+        uint64_t persistentOffset = 0;
+        uint64_t gateCacheOffset = 0;
+        uint64_t tempOffset = 0;
+        uint64_t maskOffset = 0;
+        uint64_t zeroOffset = 0;
+        uint64_t totalBytes = 0;
+    };
+
+    uint64_t VectorGateCacheStride() const
+    {
+        return AlignUp(static_cast<uint64_t>(tiling_.chunkSize) * BWD_SIZE_FP32, BWD_ONE_BLOCK_32) /
+               BWD_SIZE_FP32;
+    }
+
+    bool EnableVectorInputCache() const
+    {
+        return tiling_.chunkSize == BWD_CHUNK_SIZE_64 && tiling_.K == BWD_K_DIM_128 &&
+               tiling_.V == BWD_V_DIM_128;
+    }
+
+    uint64_t CalcVectorUbLayout(uint64_t rowNum, uint64_t elemBytes, uint64_t gateBytes,
+                                VectorUbLayout *layout = nullptr) const
+    {
+        uint64_t chunkSize = static_cast<uint64_t>(tiling_.chunkSize);
+        uint64_t kDim = static_cast<uint64_t>(tiling_.K);
+        uint64_t vDim = static_cast<uint64_t>(tiling_.V);
+        uint64_t maxDim = std::max<uint64_t>(static_cast<uint64_t>(tiling_.K), static_cast<uint64_t>(tiling_.V));
+        maxDim = std::max<uint64_t>(maxDim, chunkSize);
+        uint64_t ioBytes = rowNum * maxDim * elemBytes;
+        uint64_t gateIoBytes = chunkSize * gateBytes;
+        ioBytes = std::max<uint64_t>(ioBytes, gateIoBytes);
+
+        uint64_t gateCacheBytes = 4 * VectorGateCacheStride() * BWD_SIZE_FP32;
+        // Two head slots each retain the rows owned by one of the two AIV subblocks.
+        uint64_t finalDaCacheBytes = chunkSize * chunkSize * elemBytes;
+        uint64_t inputCacheBytes = EnableVectorInputCache() ?
+                                   chunkSize * (kDim + vDim) * BWD_SIZE_FP32 : 0;
+        uint64_t persistentBytes = gateCacheBytes + finalDaCacheBytes + inputCacheBytes;
+        uint64_t brcbBytes = rowNum * BWD_ONE_BLOCK_32;
+        uint64_t kbgTileCount = EnableVectorInputCache() ? 2 : 3;
+        uint64_t kbgTempBytes = kbgTileCount * rowNum * maxDim * BWD_SIZE_FP32 +
+                                2 * rowNum * BWD_SIZE_FP32 + 2 * brcbBytes;
+        uint64_t da4TempBytes = 3 * rowNum * chunkSize * BWD_SIZE_FP32;
+        uint64_t finalDaTempBytes = (2 * rowNum * chunkSize + rowNum) * BWD_SIZE_FP32 + brcbBytes;
+        uint64_t outputKTileCount = EnableVectorInputCache() ? 4 : 5;
+        uint64_t outputVTileCount = EnableVectorInputCache() ? 2 : 3;
+        uint64_t outputKTempBytes = outputKTileCount * rowNum * kDim * BWD_SIZE_FP32 + 3 * brcbBytes;
+        uint64_t outputVTempBytes = outputVTileCount * rowNum * vDim * BWD_SIZE_FP32 + 2 * brcbBytes;
+        uint64_t kktTempBytes = chunkSize * chunkSize * BWD_SIZE_FP32 +
+                                rowNum * chunkSize * BWD_SIZE_FP32 +
+                                rowNum * BWD_SIZE_FP32 +
+                                chunkSize * BWD_ONE_BLOCK_32;
+        uint64_t singletonTempBytes = (3 * kDim + 3 * vDim + 2 * (BWD_ONE_BLOCK_32 / BWD_SIZE_FP32) + 1) *
+                                      BWD_SIZE_FP32;
+        uint64_t tempBytes = std::max<uint64_t>(kbgTempBytes, da4TempBytes);
+        tempBytes = std::max<uint64_t>(tempBytes, finalDaTempBytes);
+        tempBytes = std::max<uint64_t>(tempBytes, outputKTempBytes);
+        tempBytes = std::max<uint64_t>(tempBytes, outputVTempBytes);
+        tempBytes = std::max<uint64_t>(tempBytes, kktTempBytes);
+        tempBytes = std::max<uint64_t>(tempBytes, singletonTempBytes);
+        uint64_t maskBlocksPerRow = CeilDiv(chunkSize, BWD_BIT_NUM_FOR_UINT8);
+        uint64_t maskBytes = 2 * chunkSize * maskBlocksPerRow;
+
+        VectorUbLayout localLayout;
+        uint64_t offset = 0;
+        localLayout.ioInOffset = offset;
+        offset += BWD_VECTOR_IO_BUFFER_COUNT * AlignUp(ioBytes, BWD_ONE_BLOCK_32);
+        localLayout.ioOutOffset = offset;
+        offset += BWD_VECTOR_IO_BUFFER_COUNT * AlignUp(ioBytes, BWD_ONE_BLOCK_32);
+        localLayout.persistentOffset = offset;
+        offset += AlignUp(persistentBytes, BWD_ONE_BLOCK_32);
+        localLayout.gateCacheOffset = offset;
+        offset += AlignUp(gateCacheBytes, BWD_ONE_BLOCK_32);
+        localLayout.tempOffset = offset;
+        offset += AlignUp(tempBytes, BWD_ONE_BLOCK_32);
+        localLayout.maskOffset = offset;
+        offset += AlignUp(maskBytes, BWD_ONE_BLOCK_32);
+        localLayout.zeroOffset = offset;
+        offset += BWD_ONE_BLOCK_32;
+        localLayout.totalBytes = offset;
+
+        if (layout != nullptr) {
+            *layout = localLayout;
+        }
+        return localLayout.totalBytes;
+    }
+
+    uint64_t SelectRowTile(uint64_t ubSize) const
+    {
+        uint64_t rowNum = static_cast<uint64_t>(tiling_.chunkSize) / 2;
+        uint64_t elemBytes = DtypeSize(ctx_.kDataType);
+        uint64_t gateBytes = DtypeSize(ctx_.betaDataType);
+        while (rowNum >= BWD_TILE_MIN_ROW) {
+            if (CalcVectorUbLayout(rowNum, elemBytes, gateBytes) <= ubSize) {
+                break;
+            }
+            rowNum = rowNum / 2;
+        }
+        return std::max<uint64_t>(rowNum, BWD_TILE_MIN_ROW);
+    }
+
+    void SetVectorUbLayout(uint64_t rowNum)
+    {
+        VectorUbLayout layout;
+        CalcVectorUbLayout(rowNum, DtypeSize(ctx_.kDataType), DtypeSize(ctx_.betaDataType), &layout);
+        tiling_.vectorIoInOffset = static_cast<int64_t>(layout.ioInOffset);
+        tiling_.vectorIoOutOffset = static_cast<int64_t>(layout.ioOutOffset);
+        tiling_.vectorPersistentOffset = static_cast<int64_t>(layout.persistentOffset);
+        tiling_.vectorGateCacheOffset = static_cast<int64_t>(layout.gateCacheOffset);
+        tiling_.vectorTempOffset = static_cast<int64_t>(layout.tempOffset);
+        tiling_.vectorMaskOffset = static_cast<int64_t>(layout.maskOffset);
+        tiling_.vectorZeroOffset = static_cast<int64_t>(layout.zeroOffset);
+        tiling_.vectorUbBytes = static_cast<int64_t>(layout.totalBytes);
+    }
+
+    uint64_t CalcA5VectorUbBytes(uint64_t workRows, bool useSlotWork, bool useVPrefetch) const
+    {
+        uint64_t chunkSize = static_cast<uint64_t>(tiling_.chunkSize);
+        uint64_t localRows = chunkSize / 2;
+        uint64_t elemBytes = DtypeSize(ctx_.kDataType);
+        uint64_t gateBytes = DtypeSize(ctx_.betaDataType);
+        uint64_t maxWidth = std::max<uint64_t>(static_cast<uint64_t>(tiling_.V),
+                                               static_cast<uint64_t>(BWD_K_DIM_128));
+        uint64_t splitResultBytes = localRows * maxWidth * elemBytes;
+        uint64_t broadcastResultBytes = chunkSize * chunkSize * elemBytes;
+        uint64_t resultSlotBytes = std::max<uint64_t>(splitResultBytes, broadcastResultBytes);
+        uint64_t resultBytes = 2 * resultSlotBytes;
+        uint64_t finalDaBytes = chunkSize * chunkSize * elemBytes;
+        uint64_t workElements = std::max<uint64_t>(workRows * maxWidth,
+                                                   localRows * static_cast<uint64_t>(tiling_.K));
+        uint64_t workSlotBytes = workElements * elemBytes;
+        uint64_t workSlotCount = useSlotWork ? 2 : 1;
+        uint64_t gateStrideBytes = AlignUp(chunkSize * gateBytes, BWD_ONE_BLOCK_32);
+        uint64_t gateSlotBytes = 4 * gateStrideBytes;
+        uint64_t reduceBytes = 2 * chunkSize * BWD_SIZE_FP32;
+        uint64_t ubBytes = resultBytes + 2 * finalDaBytes + 3 * workSlotCount * workSlotBytes +
+                           2 * gateSlotBytes + reduceBytes;
+        if (useVPrefetch) {
+            ubBytes += workRows * static_cast<uint64_t>(tiling_.V) * elemBytes;
+        }
+        return ubBytes;
+    }
+
+    uint64_t SelectA5VectorRowTile() const
+    {
+        uint64_t localRows = static_cast<uint64_t>(tiling_.chunkSize) / 2;
+        uint64_t rowTile = tiling_.chunkSize == BWD_CHUNK_SIZE_128 ? localRows / 2 : localRows;
+        rowTile = std::max<uint64_t>(rowTile, BWD_TILE_MIN_ROW);
+        while (rowTile > BWD_TILE_MIN_ROW) {
+            if (CalcA5VectorUbBytes(rowTile, true, true) <= ctx_.ubSize &&
+                CalcA5VectorUbBytes(rowTile, true, true) <= BWD_A5_UB_SIZE) {
+                return rowTile;
+            }
+            rowTile /= 2;
+        }
+        return BWD_TILE_MIN_ROW;
+    }
+
+    bool CanUseA5L1Resident() const
+    {
+        uint64_t chunkSize = static_cast<uint64_t>(tiling_.chunkSize);
+        uint64_t elemBytes = DtypeSize(ctx_.kDataType);
+        uint64_t kBytes = chunkSize * static_cast<uint64_t>(BWD_K_DIM_128) * elemBytes;
+        uint64_t vBytes = chunkSize * static_cast<uint64_t>(tiling_.V) * elemBytes;
+        uint64_t aBytes = chunkSize * chunkSize * elemBytes;
+        uint64_t scratchBytes = std::max<uint64_t>(3 * kBytes, 2 * vBytes);
+        uint64_t residentBytes = scratchBytes + 2 * aBytes + 2 * kBytes + 2 * vBytes + 2 * aBytes + 2 * kBytes;
+        return residentBytes <= BWD_A5_L1_SIZE;
+    }
+
+    void SetA5PipelinePolicy()
+    {
+        uint64_t a5RowTile = SelectA5VectorRowTile();
+        bool useSlotWork = CalcA5VectorUbBytes(a5RowTile, true, false) <= ctx_.ubSize &&
+                           CalcA5VectorUbBytes(a5RowTile, true, false) <= BWD_A5_UB_SIZE;
+        bool useVPrefetch = useSlotWork &&
+                            CalcA5VectorUbBytes(a5RowTile, true, true) <= ctx_.ubSize &&
+                            CalcA5VectorUbBytes(a5RowTile, true, true) <= BWD_A5_UB_SIZE;
+        tiling_.a5UseSlotWork = useSlotWork ? 1 : 0;
+        tiling_.a5UseVPrefetch = useVPrefetch ? 1 : 0;
+        tiling_.a5UseL1Resident = CanUseA5L1Resident() ? 1 : 0;
+        tiling_.a5VectorRowTile = static_cast<int64_t>(a5RowTile);
+    }
+
+    ge::graphStatus CommonTiling()
+    {
+        const gert::Shape kStorageShape = ctx_.kShape->GetStorageShape();
+        const gert::Shape vStorageShape = ctx_.vShape->GetStorageShape();
+        const gert::Shape betaStorageShape = ctx_.betaShape->GetStorageShape();
+        const gert::Shape aStorageShape = ctx_.aShape->GetStorageShape();
+        const gert::Shape dwStorageShape = ctx_.dwShape->GetStorageShape();
+        const gert::Shape duStorageShape = ctx_.duShape->GetStorageShape();
+        const gert::Shape gStorageShape = ctx_.gShape->GetStorageShape();
+
+        OP_CHECK_IF(CompareShape(vStorageShape, duStorageShape, "v", "du", BWD_DIM_NUM_4) != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(CompareShape(betaStorageShape, gStorageShape, "beta", "g", BWD_DIM_NUM_3) != ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(CompareShape(vStorageShape, betaStorageShape, "v", "beta", BWD_DIM_NUM_3) != ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(CompareShape(vStorageShape, aStorageShape, "v", "A", BWD_DIM_NUM_3) != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(CompareShape(vStorageShape, dwStorageShape, "v", "dw", BWD_DIM_NUM_3) != ge::GRAPH_SUCCESS, ,
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(kStorageShape.GetDim(BWD_DIM_0) != vStorageShape.GetDim(BWD_DIM_0) ||
+                        kStorageShape.GetDim(BWD_DIM_2) != vStorageShape.GetDim(BWD_DIM_2),
+                    OP_LOGE(ctx_.nodeName, "k and v must share batch and time dimensions."),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(dwStorageShape.GetDim(BWD_DIM_3) != kStorageShape.GetDim(BWD_DIM_3),
+                    OP_LOGE(ctx_.nodeName, "dw last dimension must match k last dimension."),
+                    return ge::GRAPH_FAILED);
+
+        tiling_.B = static_cast<int64_t>(vStorageShape.GetDim(BWD_DIM_0));
+        tiling_.HV = static_cast<int64_t>(vStorageShape.GetDim(BWD_DIM_1));
+        tiling_.HK = static_cast<int64_t>(kStorageShape.GetDim(BWD_DIM_1));
+        tiling_.T = static_cast<int64_t>(vStorageShape.GetDim(BWD_DIM_2));
+        tiling_.K = static_cast<int64_t>(kStorageShape.GetDim(BWD_DIM_3));
+        tiling_.V = static_cast<int64_t>(vStorageShape.GetDim(BWD_DIM_3));
+
+        OP_CHECK_IF(tiling_.HK <= 0 || tiling_.HV <= 0 || tiling_.HV % tiling_.HK != 0,
+                    OP_LOGE(ctx_.nodeName, "HV (%ld) must be a positive multiple of HK (%ld).", tiling_.HV,
+                            tiling_.HK),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(tiling_.K != BWD_K_DIM_128,
+                    OP_LOGE(ctx_.nodeName, "Only K=128 is supported, but get %ld.", tiling_.K),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(tiling_.V != BWD_V_DIM_128 && tiling_.V != BWD_V_DIM_256,
+                    OP_LOGE(ctx_.nodeName, "Only V=128 or V=256 is supported, but get %ld.", tiling_.V),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(ctx_.chunkSize != BWD_CHUNK_SIZE_64 && ctx_.chunkSize != BWD_CHUNK_SIZE_128,
+                    OP_LOGE(ctx_.nodeName, "chunk_size should be 64 or 128, but get %ld.", ctx_.chunkSize),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(aStorageShape.GetDim(BWD_DIM_3) != static_cast<size_t>(ctx_.chunkSize),
+                    OP_LOGE(ctx_.nodeName, "A last dimension should equal chunk_size (%ld), but get %zu.",
+                            ctx_.chunkSize, aStorageShape.GetDim(BWD_DIM_3)),
+                    return ge::GRAPH_FAILED);
+
+        tiling_.chunkSize = ctx_.chunkSize;
+        tiling_.headGroup = tiling_.HV / tiling_.HK;
+        tiling_.taskPairMode = tiling_.headGroup == 1 ? GDN::BWD_TASK_PAIR_INDEPENDENT_UNIT :
+                                                        GDN::BWD_TASK_PAIR_SAME_OWNER_HV;
+
+        uint64_t rowTile = SelectRowTile(ctx_.ubSize);
+        uint64_t rowTileInput = rowTile;
+        uint64_t rowTileDa = rowTile;
+        uint64_t rowTileFull = rowTile;
+        tiling_.rowTileInput = static_cast<int64_t>(rowTileInput);
+        tiling_.rowTileDa = static_cast<int64_t>(rowTileDa);
+        tiling_.rowTileFullK = static_cast<int64_t>(rowTileFull);
+        tiling_.rowTileFullV = static_cast<int64_t>(rowTileFull);
+        tiling_.rowTileFullKkt = static_cast<int64_t>(rowTileFull);
+        SetVectorUbLayout(rowTile);
+        SetA5PipelinePolicy();
+        OP_CHECK_IF(tiling_.a5UseSlotWork == 0,
+                    OP_LOGE(ctx_.nodeName, "PrepareWyReprBwd A5 vector slot-work layout does not fit."),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(tiling_.a5UseL1Resident == 0,
+                    OP_LOGE(ctx_.nodeName, "PrepareWyReprBwd A5 L1 resident layout does not fit."),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(static_cast<uint64_t>(tiling_.vectorUbBytes) > ctx_.ubSize,
+                    OP_LOGE(ctx_.nodeName, "PrepareWyReprBwd vector UB requires %ld bytes, but UB size is %lu.",
+                            tiling_.vectorUbBytes, ctx_.ubSize),
+                    return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus FixLenTiling()
+    {
+        tiling_.chunkNum = tiling_.B * CeilDiv(tiling_.T, tiling_.chunkSize);
+        tiling_.seqNum = tiling_.B;
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus VariableLenTiling()
+    {
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.chunkIndicesShape, BWD_DIM_NUM_1, "chunk_indices") !=
+                        ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(RequiredInputDimNumCheck(ctx_.cuSeqlensShape, BWD_DIM_NUM_1, "cu_seqlens") != ge::GRAPH_SUCCESS,
+                    , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(ctx_.cuSeqlensData == nullptr || ctx_.chunkIndicesData == nullptr,
+                    OP_LOGE(ctx_.nodeName,
+                            "Variable-length tiling requires host-visible cu_seqlens and chunk_indices data."),
+                    return ge::GRAPH_FAILED);
+
+        const gert::Shape seqlensStorageShape = ctx_.cuSeqlensShape->GetStorageShape();
+        int64_t seqlensDim0 = static_cast<int64_t>(seqlensStorageShape.GetDim(BWD_DIM_0));
+        OP_CHECK_IF(seqlensDim0 < 2,
+                    OP_LOGE(ctx_.nodeName, "cu_seqlens dim 0 should be larger than 1, but get %ld.", seqlensDim0),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(ctx_.cuSeqlensData[0] != 0,
+                    OP_LOGE(ctx_.nodeName, "cu_seqlens[0] should be 0, but get %ld.", ctx_.cuSeqlensData[0]),
+                    return ge::GRAPH_FAILED);
+
+        std::vector<int64_t> expectChunkIndices;
+        for (int64_t seq = 1; seq < seqlensDim0; ++seq) {
+            int64_t curSeqLen = ctx_.cuSeqlensData[seq] - ctx_.cuSeqlensData[seq - 1];
+            OP_CHECK_IF(curSeqLen <= 0,
+                        OP_LOGE(ctx_.nodeName, "cu_seqlens should be strictly increasing."),
+                        return ge::GRAPH_FAILED);
+            for (int64_t token = 0; token < curSeqLen; token += tiling_.chunkSize) {
+                expectChunkIndices.push_back(seq - 1);
+                expectChunkIndices.push_back(token / tiling_.chunkSize);
+            }
+        }
+
+        const gert::Shape chunkIndicesStorageShape = ctx_.chunkIndicesShape->GetStorageShape();
+        int64_t chunkIndicesDim0 = static_cast<int64_t>(chunkIndicesStorageShape.GetDim(BWD_DIM_0));
+        OP_CHECK_IF(chunkIndicesDim0 != static_cast<int64_t>(expectChunkIndices.size()),
+                    OP_LOGE(ctx_.nodeName,
+                            "chunk_indices length should be %zu, but get %ld.", expectChunkIndices.size(),
+                            chunkIndicesDim0),
+                    return ge::GRAPH_FAILED);
+        for (int64_t i = 0; i < static_cast<int64_t>(expectChunkIndices.size()); ++i) {
+            OP_CHECK_IF(expectChunkIndices[i] != ctx_.chunkIndicesData[i],
+                        OP_LOGE(ctx_.nodeName, "chunk_indices[%ld] should be %ld, but get %ld.", i,
+                                expectChunkIndices[i], ctx_.chunkIndicesData[i]),
+                        return ge::GRAPH_FAILED);
+        }
+        tiling_.chunkNum = chunkIndicesDim0 / 2;
+        tiling_.seqNum = seqlensDim0 - 1;
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus WorkspaceTiling()
+    {
+        OP_CHECK_IF(ctx_.aicCoreNum == 0,
+                    OP_LOGE(ctx_.nodeName, "AIC core num should be larger than 0."),
+                    return ge::GRAPH_FAILED);
+        uint64_t ownerUnitNum = static_cast<uint64_t>(tiling_.chunkNum) * static_cast<uint64_t>(tiling_.HK);
+        blockDim_ = ctx_.aicCoreNum;
+        tiling_.usedCoreNum = static_cast<int64_t>(blockDim_);
+        tiling_.ownerUnitNum = static_cast<int64_t>(ownerUnitNum);
+
+        uint64_t elemBytes = DtypeSize(ctx_.kDataType);
+        uint64_t slotRows = static_cast<uint64_t>(tiling_.HV) * static_cast<uint64_t>(tiling_.chunkSize);
+        uint64_t kBytes = AlignUp(slotRows * static_cast<uint64_t>(tiling_.K) * elemBytes, BWD_ONE_BLOCK_32);
+        uint64_t vBytes = AlignUp(slotRows * static_cast<uint64_t>(tiling_.V) * elemBytes, BWD_ONE_BLOCK_32);
+        uint64_t aBytes = AlignUp(slotRows * static_cast<uint64_t>(tiling_.chunkSize) * elemBytes,
+                                  BWD_ONE_BLOCK_32);
+
+        uint64_t offset = 0;
+        tiling_.kbgOffset = static_cast<int64_t>(offset);
+        offset += kBytes;
+        tiling_.vbOffset = static_cast<int64_t>(offset);
+        offset += vBytes;
+        tiling_.kbetaOffset = static_cast<int64_t>(offset);
+        offset += kBytes;
+        tiling_.da1Offset = static_cast<int64_t>(offset);
+        offset += aBytes;
+        tiling_.da2Offset = static_cast<int64_t>(offset);
+        offset += aBytes;
+        tiling_.da4Offset = static_cast<int64_t>(offset);
+        offset += aBytes;
+        tiling_.da5Offset = static_cast<int64_t>(offset);
+        offset += aBytes;
+        tiling_.daOffset = static_cast<int64_t>(offset);
+        offset += aBytes;
+        tiling_.fullDkOffset = static_cast<int64_t>(offset);
+        offset += kBytes;
+        tiling_.fullDkbOffset = static_cast<int64_t>(offset);
+        offset += kBytes;
+        tiling_.fullDkbgOffset = static_cast<int64_t>(offset);
+        offset += kBytes;
+        tiling_.fullDvbOffset = static_cast<int64_t>(offset);
+        offset += vBytes;
+        tiling_.fullKktOffset = static_cast<int64_t>(offset);
+        offset += aBytes;
+
+        tiling_.kWorkspaceBytes = static_cast<int64_t>(kBytes);
+        tiling_.vWorkspaceBytes = static_cast<int64_t>(vBytes);
+        tiling_.aWorkspaceBytes = static_cast<int64_t>(aBytes);
+        tiling_.workspaceSlotBytes = static_cast<int64_t>(offset);
+        tiling_.workspaceBufferCount = 2;
+        tiling_.userWorkspaceBytes =
+            static_cast<int64_t>(static_cast<uint64_t>(tiling_.usedCoreNum) *
+                                 static_cast<uint64_t>(tiling_.workspaceBufferCount) * offset);
+        workspaceSize_ = ctx_.sysWorkspaceSize + static_cast<size_t>(tiling_.userWorkspaceBytes);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus Process()
+    {
+        OP_CHECK_IF(PreCheck() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+        OP_CHECK_IF(CommonTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+        if (IsVariableLength()) {
+            OP_CHECK_IF(ctx_.cuSeqlensShape == nullptr || ctx_.chunkIndicesShape == nullptr,
+                        OP_LOGE(ctx_.nodeName,
+                                "Variable-length mode requires both cu_seqlens and chunk_indices."),
+                        return ge::GRAPH_FAILED);
+            OP_CHECK_IF(tiling_.B != BWD_VAR_LEN_B_DIM_1,
+                        OP_LOGE(ctx_.nodeName, "Variable-length mode requires B=1, but get %ld.", tiling_.B),
+                        return ge::GRAPH_FAILED);
+            OP_CHECK_IF(VariableLenTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+            tiling_.isVariable = 1;
+        } else {
+            OP_CHECK_IF(FixLenTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+            tiling_.isVariable = 0;
+        }
+        OP_CHECK_IF(WorkspaceTiling() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+};
+
+} // namespace optiling
+
+#endif // PREPARE_WY_REPR_BWD_TILING_PROCESSOR_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/arch35/prepare_wy_repr_bwd_common.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/arch35/prepare_wy_repr_bwd_common.h
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef PREPARE_WY_REPR_BWD_ARCH35_COMMON_H
+#define PREPARE_WY_REPR_BWD_ARCH35_COMMON_H
+
+#include "kernel_operator.h"
+
+namespace GDN::A5Pipeline {
+
+static constexpr uint32_t HEAD_SLOT_COUNT = 2;
+
+struct ChunkTask {
+    uint64_t linear;
+    uint64_t batch;
+    uint64_t chunkBegin;
+    uint32_t chunkLen;
+};
+
+struct HeadTask {
+    ChunkTask chunk;
+    uint64_t headBase;
+};
+
+template <typename T, int V, int CHUNK_SIZE>
+struct BufferLayout {
+    static constexpr uint32_t kMaxWidth = V > 128 ? V : 128;
+    static constexpr uint32_t kSplitResultBytes = (CHUNK_SIZE / 2U) * kMaxWidth * sizeof(T);
+    static constexpr uint32_t kBroadcastResultBytes = CHUNK_SIZE * CHUNK_SIZE * sizeof(T);
+    static constexpr uint32_t kResultSlotBytes =
+        kSplitResultBytes > kBroadcastResultBytes ? kSplitResultBytes : kBroadcastResultBytes;
+    static constexpr uint32_t kResultBytes = 2U * kResultSlotBytes;
+
+    static constexpr uint32_t kL1SlotBytes = CHUNK_SIZE * kMaxWidth * sizeof(T);
+    static constexpr uint32_t kL1Bytes = 2U * kL1SlotBytes;
+    static constexpr uint32_t kL1TileKBytes = CHUNK_SIZE * 128U * sizeof(T);
+    static constexpr uint32_t kL1TileVBytes = CHUNK_SIZE * V * sizeof(T);
+    static constexpr uint32_t kL1TileABytes = CHUNK_SIZE * CHUNK_SIZE * sizeof(T);
+    static constexpr uint32_t kL1ScratchKBytes = 3U * kL1TileKBytes;
+    static constexpr uint32_t kL1ScratchVBytes = 2U * kL1TileVBytes;
+    static constexpr uint32_t kL1ScratchBytes =
+        kL1ScratchKBytes > kL1ScratchVBytes ? kL1ScratchKBytes : kL1ScratchVBytes;
+    static constexpr uint32_t kResidentDaBaseOffset = kL1ScratchBytes;
+    static constexpr uint32_t kResidentDwBaseOffset = kResidentDaBaseOffset + 2U * kL1TileABytes;
+    static constexpr uint32_t kResidentDuBaseOffset = kResidentDwBaseOffset + 2U * kL1TileKBytes;
+    static constexpr uint32_t kResidentATBaseOffset = kResidentDuBaseOffset + 2U * kL1TileVBytes;
+    static constexpr uint32_t kResidentKBaseOffset = kResidentATBaseOffset + 2U * kL1TileABytes;
+    static_assert(kResidentKBaseOffset + 2U * kL1TileKBytes <= 512U * 1024U,
+                  "A5 cube L1 layout exceeds 512 KiB");
+
+    __aicore__ static inline uint32_t ResultOffset(uint32_t slot)
+    {
+        return slot * kResultSlotBytes;
+    }
+
+    __aicore__ static inline uint32_t L1Offset(uint32_t slot)
+    {
+        return slot * kL1SlotBytes;
+    }
+
+    __aicore__ static inline uint32_t ResidentDaOffset(uint32_t slot)
+    {
+        return kResidentDaBaseOffset + slot * kL1TileABytes;
+    }
+};
+
+__aicore__ inline uint32_t LocalRowBegin(uint32_t subBlockIdx, uint32_t chunkSize)
+{
+    return subBlockIdx * (chunkSize / 2U);
+}
+
+__aicore__ inline uint32_t LocalRowCount(uint32_t subBlockIdx, uint32_t chunkLen, uint32_t chunkSize)
+{
+    uint32_t begin = LocalRowBegin(subBlockIdx, chunkSize);
+    if (begin >= chunkLen) {
+        return 0;
+    }
+    uint32_t rows = chunkSize / 2U;
+    return begin + rows > chunkLen ? chunkLen - begin : rows;
+}
+
+} // namespace GDN::A5Pipeline
+
+#endif // PREPARE_WY_REPR_BWD_ARCH35_COMMON_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/arch35/prepare_wy_repr_bwd_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/arch35/prepare_wy_repr_bwd_cube.h
@@ -1,0 +1,1331 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef PREPARE_WY_REPR_BWD_CUBE_H
+#define PREPARE_WY_REPR_BWD_CUBE_H
+
+#define CATLASS_ARCH 3510
+#include "catlass/arch/cross_core_sync.hpp"
+#include "kernel_operator.h"
+#include "catlass/arch/arch.hpp"
+#include "catlass/arch/resource.hpp"
+#include "catlass/catlass.hpp"
+#include "catlass/gemm/dispatch_policy.hpp"
+#include "catlass/gemm/gemm_type.hpp"
+#include "catlass/gemm/tile/tile_copy.hpp"
+#include "catlass/gemm/tile/tile_mmad.hpp"
+#include "catlass/layout/layout.hpp"
+#include "tla/layout.hpp"
+#include "tla/tensor.hpp"
+
+#include "../prepare_wy_repr_bwd_struct.h"
+
+namespace GDN {
+
+using PrepareWyReprBwdInt64Tensor = AscendC::GlobalTensor<uint64_t>;
+template <typename T, bool IS_VARLEN, int V, int CHUNK_SIZE>
+class PrepareWyReprBwdCube {
+    using ArchTag = Catlass::Arch::Ascend950;
+    using L0TileShapeDa1 = tla::Shape<tla::Int<CHUNK_SIZE>, tla::Int<CHUNK_SIZE>, tla::Int<128>>;
+    using L0TileShapeDa2 = tla::Shape<tla::Int<CHUNK_SIZE>, tla::Int<CHUNK_SIZE>, tla::Int<V>>;
+    using L0TileShapeDa5 =
+        tla::Shape<tla::Int<CHUNK_SIZE>, tla::Int<CHUNK_SIZE>, tla::Int<CHUNK_SIZE>>;
+    using L0TileShapeDa6 = L0TileShapeDa5;
+    using L0TileShapeFullK = tla::Shape<tla::Int<CHUNK_SIZE>, tla::Int<128>, tla::Int<CHUNK_SIZE>>;
+    static constexpr int DVB_TILE_M = V == 128 ? 128 : CHUNK_SIZE;
+    static constexpr int DVB_TILE_N = V == 128 ? 256 : V;
+    static constexpr int DVB_TILE_K = V == 128 ? 64 : CHUNK_SIZE;
+    using L0TileShapeDvb = tla::Shape<tla::Int<DVB_TILE_M>, tla::Int<DVB_TILE_N>, tla::Int<DVB_TILE_K>>;
+    using L0TileShapeKkt = L0TileShapeDa1;
+    using RowMajor = Catlass::layout::RowMajor;
+    using ColumnMajor = Catlass::layout::ColumnMajor;
+
+    using TileCopyDa =
+        Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, T, RowMajor, T, ColumnMajor, T, RowMajor>;
+    using TileCopyDa6 =
+        Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, T, ColumnMajor, T, RowMajor, T, RowMajor>;
+    using TileCopyDK =
+        Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, T, RowMajor, T, RowMajor, T, RowMajor>;
+    using TileCopyDkb =
+        Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, T, ColumnMajor, T, RowMajor, T, RowMajor>;
+    using TileCopyDkbg =
+        Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, T, ColumnMajor, T, RowMajor, T, RowMajor>;
+    using TileCopyDvb =
+        Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, T, ColumnMajor, T, RowMajor, T, RowMajor>;
+    using TileCopyKkt =
+        Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, T, RowMajor, T, ColumnMajor, T, RowMajor>;
+
+    using Da1TileCopy = TileCopyDa;
+    using Da1ElementA = typename Da1TileCopy::ElementA;
+    using Da1ElementB = typename Da1TileCopy::ElementB;
+    using Da1ElementAccumulator = typename Da1TileCopy::ElementAccumulator;
+    using Da1LayoutTagL1A = typename Da1TileCopy::LayoutTagL1A;
+    using Da1LayoutTagL1B = typename Da1TileCopy::LayoutTagL1B;
+    using Da1LayoutTagL0A = typename Da1TileCopy::LayoutTagL0A;
+    using Da1LayoutTagL0B = typename Da1TileCopy::LayoutTagL0B;
+    using Da1CopyL1ToL0A = typename Da1TileCopy::CopyL1ToL0A;
+    using Da1CopyL1ToL0B = typename Da1TileCopy::CopyL1ToL0B;
+    using Da1TileMmad = Catlass::Gemm::Tile::TileMmadTla<ArchTag, Da1ElementA, Da1LayoutTagL1A>;
+
+    using Da2TileCopy = TileCopyDa;
+    using Da2ElementA = typename Da2TileCopy::ElementA;
+    using Da2ElementB = typename Da2TileCopy::ElementB;
+    using Da2ElementAccumulator = typename Da2TileCopy::ElementAccumulator;
+    using Da2LayoutTagL1A = typename Da2TileCopy::LayoutTagL1A;
+    using Da2LayoutTagL1B = typename Da2TileCopy::LayoutTagL1B;
+    using Da2LayoutTagL0A = typename Da2TileCopy::LayoutTagL0A;
+    using Da2LayoutTagL0B = typename Da2TileCopy::LayoutTagL0B;
+    using Da2CopyL1ToL0B = typename Da2TileCopy::CopyL1ToL0B;
+    using Da2TileMmad = Catlass::Gemm::Tile::TileMmadTla<ArchTag, Da2ElementA, Da2LayoutTagL1A>;
+    using Da2ResidentLayoutTagL1A = typename TileCopyDa::LayoutTagL1A;
+
+    using Da5TileCopy = TileCopyDa;
+    using Da5ElementA = typename Da5TileCopy::ElementA;
+    using Da5ElementB = typename Da5TileCopy::ElementB;
+    using Da5ElementAccumulator = typename Da5TileCopy::ElementAccumulator;
+    using Da5LayoutTagL1A = typename Da5TileCopy::LayoutTagL1A;
+    using Da5LayoutTagL1B = typename Da5TileCopy::LayoutTagL1B;
+    using Da5LayoutTagL0A = typename Da5TileCopy::LayoutTagL0A;
+    using Da5LayoutTagL0B = typename Da5TileCopy::LayoutTagL0B;
+    using Da5CopyL1ToL0A = typename Da5TileCopy::CopyL1ToL0A;
+    using Da5TileMmad = Catlass::Gemm::Tile::TileMmadTla<ArchTag, Da5ElementA, Da5LayoutTagL1A>;
+    using Da5ResidentLayoutTagL1B = typename TileCopyDa::LayoutTagL1B;
+
+    using Da6TileCopy = TileCopyDa6;
+    using Da6ElementA = typename Da6TileCopy::ElementA;
+    using Da6ElementB = typename Da6TileCopy::ElementB;
+    using Da6ElementAccumulator = typename Da6TileCopy::ElementAccumulator;
+    using Da6LayoutTagL1A = typename Da6TileCopy::LayoutTagL1A;
+    using Da6LayoutTagL1B = typename Da6TileCopy::LayoutTagL1B;
+    using Da6LayoutTagL0A = typename Da6TileCopy::LayoutTagL0A;
+    using Da6LayoutTagL0B = typename Da6TileCopy::LayoutTagL0B;
+    using Da6CopyL1ToL0A = typename Da6TileCopy::CopyL1ToL0A;
+    using Da6CopyL1ToL0B = typename Da6TileCopy::CopyL1ToL0B;
+    using Da6TileMmad = Catlass::Gemm::Tile::TileMmadTla<ArchTag, Da6ElementA, Da6LayoutTagL1A>;
+
+    using FullDkTileCopy = TileCopyDK;
+    using FullDkElementA = typename FullDkTileCopy::ElementA;
+    using FullDkElementB = typename FullDkTileCopy::ElementB;
+    using FullDkElementAccumulator = typename FullDkTileCopy::ElementAccumulator;
+    using FullDkLayoutTagL1A = typename FullDkTileCopy::LayoutTagL1A;
+    using FullDkLayoutTagL1B = typename FullDkTileCopy::LayoutTagL1B;
+    using FullDkLayoutTagL0A = typename FullDkTileCopy::LayoutTagL0A;
+    using FullDkLayoutTagL0B = typename FullDkTileCopy::LayoutTagL0B;
+    using FullDkCopyL1ToL0A = typename FullDkTileCopy::CopyL1ToL0A;
+    using FullDkCopyL1ToL0B = typename FullDkTileCopy::CopyL1ToL0B;
+    using FullDkTileMmad = Catlass::Gemm::Tile::TileMmadTla<ArchTag, FullDkElementA, FullDkLayoutTagL1A>;
+
+    using FullDkbTileCopy = TileCopyDkb;
+    using FullDkbElementA = typename FullDkbTileCopy::ElementA;
+    using FullDkbElementB = typename FullDkbTileCopy::ElementB;
+    using FullDkbElementAccumulator = typename FullDkbTileCopy::ElementAccumulator;
+    using FullDkbLayoutTagL1A = typename FullDkbTileCopy::LayoutTagL1A;
+    using FullDkbLayoutTagL1B = typename FullDkbTileCopy::LayoutTagL1B;
+    using FullDkbLayoutTagL0A = typename FullDkbTileCopy::LayoutTagL0A;
+    using FullDkbLayoutTagL0B = typename FullDkbTileCopy::LayoutTagL0B;
+    using FullDkbTileMmad =
+        Catlass::Gemm::Tile::TileMmadTla<ArchTag, FullDkbElementA, FullDkbLayoutTagL1A>;
+    using FullDkbResidentLayoutTagL1A = typename TileCopyDkb::LayoutTagL1A;
+    using FullDkbResidentLayoutTagL1B = typename TileCopyDkb::LayoutTagL1B;
+
+    using FullDkbgTileCopy = TileCopyDkbg;
+    using FullDkbgElementA = typename FullDkbgTileCopy::ElementA;
+    using FullDkbgElementB = typename FullDkbgTileCopy::ElementB;
+    using FullDkbgElementAccumulator = typename FullDkbgTileCopy::ElementAccumulator;
+    using FullDkbgLayoutTagL1A = typename FullDkbgTileCopy::LayoutTagL1A;
+    using FullDkbgLayoutTagL1B = typename FullDkbgTileCopy::LayoutTagL1B;
+    using FullDkbgLayoutTagL0A = typename FullDkbgTileCopy::LayoutTagL0A;
+    using FullDkbgLayoutTagL0B = typename FullDkbgTileCopy::LayoutTagL0B;
+    using FullDkbgCopyL1ToL0A = typename FullDkbgTileCopy::CopyL1ToL0A;
+    using FullDkbgCopyL1ToL0B = typename FullDkbgTileCopy::CopyL1ToL0B;
+    using FullDkbgTileMmad =
+        Catlass::Gemm::Tile::TileMmadTla<ArchTag, FullDkbgElementA, FullDkbgLayoutTagL1A>;
+
+    using FullDvbTileCopy = TileCopyDvb;
+    using FullDvbElementA = typename FullDvbTileCopy::ElementA;
+    using FullDvbElementB = typename FullDvbTileCopy::ElementB;
+    using FullDvbElementAccumulator = typename FullDvbTileCopy::ElementAccumulator;
+    using FullDvbLayoutTagL1A = typename FullDvbTileCopy::LayoutTagL1A;
+    using FullDvbLayoutTagL1B = typename FullDvbTileCopy::LayoutTagL1B;
+    using FullDvbLayoutTagL0A = typename FullDvbTileCopy::LayoutTagL0A;
+    using FullDvbLayoutTagL0B = typename FullDvbTileCopy::LayoutTagL0B;
+    using FullDvbTileMmad =
+        Catlass::Gemm::Tile::TileMmadTla<ArchTag, FullDvbElementA, FullDvbLayoutTagL1A>;
+    using FullDvbResidentLayoutTagL1A = typename TileCopyDa::LayoutTagL1B;
+    using FullDvbResidentLayoutTagL1B = typename TileCopyDa::LayoutTagL1A;
+
+    using FullKktTileCopy = TileCopyKkt;
+    using FullKktElementA = typename FullKktTileCopy::ElementA;
+    using FullKktElementB = typename FullKktTileCopy::ElementB;
+    using FullKktElementAccumulator = typename FullKktTileCopy::ElementAccumulator;
+    using FullKktLayoutTagL1A = typename FullKktTileCopy::LayoutTagL1A;
+    using FullKktLayoutTagL1B = typename FullKktTileCopy::LayoutTagL1B;
+    using FullKktLayoutTagL0A = typename FullKktTileCopy::LayoutTagL0A;
+    using FullKktLayoutTagL0B = typename FullKktTileCopy::LayoutTagL0B;
+    using FullKktCopyL1ToL0A = typename FullKktTileCopy::CopyL1ToL0A;
+    using FullKktCopyL1ToL0B = typename FullKktTileCopy::CopyL1ToL0B;
+    using FullKktTileMmad =
+        Catlass::Gemm::Tile::TileMmadTla<ArchTag, FullKktElementA, FullKktLayoutTagL1A>;
+
+    static constexpr uint32_t da1TileM = tla::get<0>(L0TileShapeDa1{});
+    static constexpr uint32_t da1TileN = tla::get<1>(L0TileShapeDa1{});
+    static constexpr uint32_t da1TileK = tla::get<2>(L0TileShapeDa1{});
+    static constexpr uint32_t da1L1ATileBytes = da1TileM * da1TileK * sizeof(Da1ElementA);
+    static constexpr uint32_t da1L0ATileBytes = da1TileM * da1TileK * sizeof(Da1ElementA);
+    static constexpr uint32_t da1L0BTileBytes = da1TileK * da1TileN * sizeof(Da1ElementB);
+
+    static constexpr uint32_t da2TileM = tla::get<0>(L0TileShapeDa2{});
+    static constexpr uint32_t da2TileN = tla::get<1>(L0TileShapeDa2{});
+    static constexpr uint32_t da2TileK = tla::get<2>(L0TileShapeDa2{});
+    static constexpr uint32_t da2L1ATileBytes = da2TileM * da2TileK * sizeof(Da2ElementA);
+    static constexpr uint32_t da2L0ATileBytes = da2TileM * da2TileK * sizeof(Da2ElementA);
+    static constexpr uint32_t da2L0BTileBytes = da2TileK * da2TileN * sizeof(Da2ElementB);
+
+    static constexpr uint32_t da5TileM = tla::get<0>(L0TileShapeDa5{});
+    static constexpr uint32_t da5TileN = tla::get<1>(L0TileShapeDa5{});
+    static constexpr uint32_t da5TileK = tla::get<2>(L0TileShapeDa5{});
+    static constexpr uint32_t da5L1ATileBytes = da5TileM * da5TileK * sizeof(Da5ElementA);
+    static constexpr uint32_t da5L0ATileBytes = da5TileM * da5TileK * sizeof(Da5ElementA);
+    static constexpr uint32_t da5L0BTileBytes = da5TileK * da5TileN * sizeof(Da5ElementB);
+
+    static constexpr uint32_t da6TileM = tla::get<0>(L0TileShapeDa6{});
+    static constexpr uint32_t da6TileN = tla::get<1>(L0TileShapeDa6{});
+    static constexpr uint32_t da6TileK = tla::get<2>(L0TileShapeDa6{});
+    static constexpr uint32_t da6L1ATileBytes = da6TileM * da6TileK * sizeof(Da6ElementA);
+    static constexpr uint32_t da6L0ATileBytes = da6TileM * da6TileK * sizeof(Da6ElementA);
+    static constexpr uint32_t da6L0BTileBytes = da6TileK * da6TileN * sizeof(Da6ElementB);
+
+    static constexpr uint32_t fullDkTileM = tla::get<0>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkTileN = tla::get<1>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkTileK = tla::get<2>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkL1ATileBytes = fullDkTileM * fullDkTileK * sizeof(FullDkElementA);
+    static constexpr uint32_t fullDkL0ATileBytes = fullDkTileM * fullDkTileK * sizeof(FullDkElementA);
+    static constexpr uint32_t fullDkL0BTileBytes = fullDkTileK * fullDkTileN * sizeof(FullDkElementB);
+
+    static constexpr uint32_t fullDkbTileM = tla::get<0>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkbTileN = tla::get<1>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkbTileK = tla::get<2>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkbL1ATileBytes = fullDkbTileM * fullDkbTileK * sizeof(FullDkbElementA);
+    static constexpr uint32_t fullDkbL0ATileBytes = fullDkbTileM * fullDkbTileK * sizeof(FullDkbElementA);
+    static constexpr uint32_t fullDkbL0BTileBytes = fullDkbTileK * fullDkbTileN * sizeof(FullDkbElementB);
+
+    static constexpr uint32_t fullDkbgTileM = tla::get<0>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkbgTileN = tla::get<1>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkbgTileK = tla::get<2>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkbgL1ATileBytes =
+        fullDkbgTileM * fullDkbgTileK * sizeof(FullDkbgElementA);
+    static constexpr uint32_t fullDkbgL0ATileBytes =
+        fullDkbgTileM * fullDkbgTileK * sizeof(FullDkbgElementA);
+    static constexpr uint32_t fullDkbgL0BTileBytes =
+        fullDkbgTileK * fullDkbgTileN * sizeof(FullDkbgElementB);
+
+    static constexpr uint32_t fullDvbTileM = tla::get<0>(L0TileShapeDvb{});
+    static constexpr uint32_t fullDvbTileN = tla::get<1>(L0TileShapeDvb{});
+    static constexpr uint32_t fullDvbTileK = tla::get<2>(L0TileShapeDvb{});
+    static constexpr uint32_t fullDvbL1ATileBytes =
+        fullDvbTileM * fullDvbTileK * sizeof(FullDvbElementA);
+    static constexpr uint32_t fullDvbL0ATileBytes =
+        fullDvbTileM * fullDvbTileK * sizeof(FullDvbElementA);
+    static constexpr uint32_t fullDvbL0BTileBytes =
+        fullDvbTileK * static_cast<uint32_t>(V) * sizeof(FullDvbElementB);
+
+    static constexpr uint32_t fullKktTileM = tla::get<0>(L0TileShapeKkt{});
+    static constexpr uint32_t fullKktTileN = tla::get<1>(L0TileShapeKkt{});
+    static constexpr uint32_t fullKktTileK = tla::get<2>(L0TileShapeKkt{});
+    static constexpr uint32_t fullKktL1ATileBytes = fullKktTileM * fullKktTileK * sizeof(FullKktElementA);
+    static constexpr uint32_t fullKktL0ATileBytes = fullKktTileM * fullKktTileK * sizeof(FullKktElementA);
+    static constexpr uint32_t fullKktL0BTileBytes = fullKktTileK * fullKktTileN * sizeof(FullKktElementB);
+
+    static constexpr uint32_t L1_TILE_K_BYTES = static_cast<uint32_t>(CHUNK_SIZE) * 128U * sizeof(T);
+    static constexpr uint32_t L1_TILE_V_BYTES =
+        static_cast<uint32_t>(CHUNK_SIZE) * static_cast<uint32_t>(V) * sizeof(T);
+    static constexpr uint32_t L1_TILE_A_BYTES =
+        static_cast<uint32_t>(CHUNK_SIZE) * static_cast<uint32_t>(CHUNK_SIZE) * sizeof(T);
+    static constexpr uint32_t L1_SCRATCH_K_BYTES = 3U * L1_TILE_K_BYTES;
+    static constexpr uint32_t L1_SCRATCH_V_BYTES = 2U * L1_TILE_V_BYTES;
+    static constexpr uint32_t L1_SCRATCH_BYTES =
+        L1_SCRATCH_K_BYTES > L1_SCRATCH_V_BYTES ? L1_SCRATCH_K_BYTES : L1_SCRATCH_V_BYTES;
+    static constexpr uint32_t RESIDENT_DW_BASE_OFFSET = L1_SCRATCH_BYTES;
+    static constexpr uint32_t RESIDENT_DU_BASE_OFFSET = RESIDENT_DW_BASE_OFFSET + 2U * L1_TILE_K_BYTES;
+    static constexpr uint32_t RESIDENT_AT_BASE_OFFSET = RESIDENT_DU_BASE_OFFSET + 2U * L1_TILE_V_BYTES;
+    static constexpr uint32_t RESIDENT_DA_BASE_OFFSET = RESIDENT_AT_BASE_OFFSET + 2U * L1_TILE_A_BYTES;
+    static constexpr uint32_t RESIDENT_K_BASE_OFFSET = RESIDENT_DA_BASE_OFFSET + 2U * L1_TILE_A_BYTES;
+    static constexpr int32_t PREFETCH_DU_EVENT_BASE = 2;
+    static constexpr int32_t PREFETCH_AT_EVENT_BASE = 4;
+    static constexpr uint32_t L0_STAGE_NUM = 2;
+    static constexpr int32_t L0A_EVENT_BASE = 0;
+    static constexpr int32_t L0B_EVENT_BASE = 2;
+    static constexpr int32_t L0_READY_EVENT_BASE = 0;
+
+    __aicore__ inline int32_t L0AEvent(uint32_t stage) const
+    {
+        return L0A_EVENT_BASE + static_cast<int32_t>(stage);
+    }
+
+    __aicore__ inline int32_t L0BEvent(uint32_t stage) const
+    {
+        return L0B_EVENT_BASE + static_cast<int32_t>(stage);
+    }
+
+    __aicore__ inline int32_t L0ReadyEvent(uint32_t stage) const
+    {
+        return L0_READY_EVENT_BASE + static_cast<int32_t>(stage);
+    }
+
+    __aicore__ inline void MarkL0BuffersFree() const
+    {
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(0));
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(1));
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(0));
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(1));
+    }
+
+    __aicore__ inline void WaitL0BuffersFree() const
+    {
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(0));
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(1));
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(0));
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(1));
+    }
+
+    __aicore__ inline void InitGemmEvents(int32_t eventL1A, int32_t eventL1B, int32_t eventL0C) const
+    {
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+        MarkL0BuffersFree();
+        AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+    }
+
+    __aicore__ inline void DrainGemmEvents(int32_t eventL1A, int32_t eventL1B, int32_t eventL0C) const
+    {
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+        WaitL0BuffersFree();
+        AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+    }
+
+    __aicore__ inline void SignalAicFinishStore()
+    {
+        // Cube-only stage: no AIC/AIV cross-core notification in the full-core MIX prototype.
+    }
+
+    __aicore__ inline void SignalAicFinishFullStore()
+    {
+        // Cube-only stage: no AIC/AIV cross-core notification in the full-core MIX prototype.
+    }
+
+    __aicore__ inline void WaitAivFinishStore()
+    {
+        // Cube-only stage: do not wait for vector credit in the no-cross-core prototype.
+    }
+
+    __aicore__ inline int32_t PrefetchDuEvent(uint64_t slot) const
+    {
+        return PREFETCH_DU_EVENT_BASE + static_cast<int32_t>(slot);
+    }
+
+    __aicore__ inline int32_t PrefetchATEvent(uint64_t slot) const
+    {
+        return PREFETCH_AT_EVENT_BASE + static_cast<int32_t>(slot);
+    }
+
+    __aicore__ inline uint64_t ResidentKSlot(uint64_t headBase, uint64_t slot, uint64_t valueHead) const
+    {
+        uint64_t keyHead = valueHead / static_cast<uint64_t>(tiling_->headGroup);
+        uint64_t firstKeyHead = headBase / static_cast<uint64_t>(tiling_->headGroup);
+        return (slot != 0U && keyHead == firstKeyHead) ? 0U : slot;
+    }
+
+    __aicore__ inline uint32_t ResidentKOffset(uint64_t headBase, uint64_t slot, uint64_t valueHead) const
+    {
+        return RESIDENT_K_BASE_OFFSET +
+               static_cast<uint32_t>(ResidentKSlot(headBase, slot, valueHead)) * L1_TILE_K_BYTES;
+    }
+
+    __aicore__ inline bool IsResidentKOwner(uint64_t headBase, uint64_t slot, uint64_t valueHead) const
+    {
+        return ResidentKSlot(headBase, slot, valueHead) == slot;
+    }
+
+    __aicore__ inline void PrefetchDuResident(uint64_t batch, uint64_t valueHead, uint64_t chunkBegin,
+                                              uint32_t chunkLen, uint32_t residentDuOffset, int32_t eventId)
+    {
+        using TileCopy = TileCopyDa;
+        using ElementA = typename TileCopy::ElementA;
+        using LayoutTagL1A = typename TileCopy::LayoutTagL1A;
+
+        static constexpr uint32_t tileM = tla::get<0>(L0TileShapeDa2{});
+
+        AscendC::GlobalTensor<T> gmDu;
+        gmDu.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(du_) + ValueOffset(batch, valueHead, chunkBegin, 0));
+        auto layoutDu = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->V);
+        auto tensorA = tla::MakeTensor(gmDu, layoutDu, Catlass::Arch::PositionGM{});
+        auto blockA = GetTile(tensorA, tla::MakeCoord(0, 0),
+                              tla::MakeShape(chunkLen, static_cast<uint32_t>(tiling_->V)));
+
+        auto l1ABuf = resource_.l1Buf.template GetBufferByByte<ElementA>(residentDuOffset);
+        auto layoutL1A = tla::MakeLayout<ElementA, LayoutTagL1A>(tla::Int<tileM>{}, tla::Int<V>{});
+        auto tensorL1A = tla::MakeTensor(l1ABuf, layoutL1A, Catlass::Arch::PositionL1{});
+
+        typename TileCopy::template CopyGmToL1A<decltype(blockA)> copyGmToL1A;
+        copyGmToL1A(tensorL1A, blockA);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventId);
+    }
+
+    __aicore__ inline void PrefetchATResident(uint64_t batch, uint64_t valueHead, uint64_t chunkBegin,
+                                              uint32_t chunkLen, uint32_t residentATOffset, int32_t eventId)
+    {
+        using TileCopy = TileCopyDa;
+        using ElementB = typename TileCopy::ElementB;
+        using LayoutTagL1B = typename TileCopy::LayoutTagL1B;
+
+        static constexpr uint32_t tileN = tla::get<1>(L0TileShapeDa5{});
+        static constexpr uint32_t tileK = tla::get<2>(L0TileShapeDa5{});
+
+        AscendC::GlobalTensor<T> gmAT;
+        gmAT.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(a_) + MatrixOffset(batch, valueHead, chunkBegin, 0));
+        auto layoutAT = tla::MakeLayout<T, ColumnMajor>(tiling_->chunkSize, tiling_->chunkSize);
+        auto tensorB = tla::MakeTensor(gmAT, layoutAT, Catlass::Arch::PositionGM{});
+        auto blockB = GetTile(tensorB, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, chunkLen));
+
+        auto l1BBuf = resource_.l1Buf.template GetBufferByByte<ElementB>(residentATOffset);
+        auto layoutL1B = tla::MakeLayout<ElementB, LayoutTagL1B>(tla::Int<tileK>{}, tla::Int<tileN>{});
+        auto tensorL1B = tla::MakeTensor(l1BBuf, layoutL1B, Catlass::Arch::PositionL1{});
+
+        typename TileCopy::template CopyGmToL1B<decltype(blockB)> copyGmToL1B;
+        copyGmToL1B(tensorL1B, blockB);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventId);
+    }
+
+    __aicore__ inline void PrefetchKResident(uint64_t batch, uint64_t keyHead, uint64_t chunkBegin,
+                                             uint32_t chunkLen, uint32_t residentKOffset, int32_t eventId)
+    {
+        using TileCopy = TileCopyDkb;
+        using ElementB = typename TileCopy::ElementB;
+        using LayoutTagL1B = typename TileCopy::LayoutTagL1B;
+
+        static constexpr uint32_t tileN = tla::get<1>(L0TileShapeFullK{});
+        static constexpr uint32_t tileK = tla::get<2>(L0TileShapeFullK{});
+
+        AscendC::GlobalTensor<T> gmK;
+        gmK.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(k_) + KeyOffset(batch, keyHead, chunkBegin, 0));
+        auto layoutK = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->K);
+        auto tensorB = tla::MakeTensor(gmK, layoutK, Catlass::Arch::PositionGM{});
+        auto blockB = GetTile(tensorB, tla::MakeCoord(0, 0),
+                              tla::MakeShape(chunkLen, static_cast<uint32_t>(tiling_->K)));
+
+        auto l1BBuf = resource_.l1Buf.template GetBufferByByte<ElementB>(residentKOffset);
+        auto layoutL1B = tla::MakeLayout<ElementB, LayoutTagL1B>(tla::Int<tileK>{}, tla::Int<tileN>{});
+        auto tensorL1B = tla::MakeTensor(l1BBuf, layoutL1B, Catlass::Arch::PositionL1{});
+
+        typename TileCopy::template CopyGmToL1B<decltype(blockB)> copyGmToL1B;
+        copyGmToL1B(tensorL1B, blockB);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventId);
+    }
+
+public:
+    __aicore__ inline void Init(GM_ADDR k, GM_ADDR v, GM_ADDR A, GM_ADDR dw, GM_ADDR du,
+                                GM_ADDR cuSeqlens, GM_ADDR chunkIndices, GM_ADDR workspace,
+                                const PrepareWyReprBwdTilingData *tiling)
+    {
+        k_ = k;
+        v_ = v;
+        a_ = A;
+        dw_ = dw;
+        du_ = du;
+        workspace_ = workspace;
+        tiling_ = tiling;
+        coreIdx_ = static_cast<uint64_t>(AscendC::GetBlockIdx());
+        if (cuSeqlens != nullptr) {
+            cuSeqlensGm_.SetGlobalBuffer(reinterpret_cast<__gm__ uint64_t *>(cuSeqlens));
+        }
+        if (chunkIndices != nullptr) {
+            chunkIndicesGm_.SetGlobalBuffer(reinterpret_cast<__gm__ uint64_t *>(chunkIndices));
+        }
+    }
+
+    __aicore__ inline void ProcessPipeline()
+    {
+        constexpr int32_t eventL1A = 0;
+        constexpr int32_t eventL1B = 1;
+        constexpr int32_t eventL0C = 0;
+
+        auto layoutDw = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->K);
+        auto layoutKbgT = tla::MakeLayout<T, ColumnMajor>(tiling_->K, tiling_->chunkSize);
+        auto layoutDu = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->V);
+        auto layoutVbT = tla::MakeLayout<T, ColumnMajor>(tiling_->V, tiling_->chunkSize);
+        auto layoutDa = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->chunkSize);
+        auto layoutDaT = tla::MakeLayout<T, ColumnMajor>(tiling_->chunkSize, tiling_->chunkSize);
+        auto layoutA = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->chunkSize);
+        auto layoutAT = tla::MakeLayout<T, ColumnMajor>(tiling_->chunkSize, tiling_->chunkSize);
+        auto layoutK = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->K);
+        auto layoutKT = tla::MakeLayout<T, ColumnMajor>(tiling_->K, tiling_->chunkSize);
+        auto layoutKOut = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->K);
+        auto layoutV = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->V);
+        auto layoutVOut = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->V);
+        constexpr uint64_t slotCount = 2;
+
+        const uint64_t coreLoops = static_cast<uint64_t>(tiling_->chunkNum);
+        for (uint64_t loopIdx = coreIdx_; loopIdx < coreLoops;
+             loopIdx += static_cast<uint64_t>(AscendC::GetBlockNum())) {
+            uint64_t batch = 0;
+            uint64_t chunkBegin = 0;
+            uint64_t chunkEnd = 0;
+            GetChunkOffset(loopIdx, batch, chunkBegin, chunkEnd);
+            if (chunkEnd <= chunkBegin) {
+                continue;
+            }
+            uint32_t chunkLen = static_cast<uint32_t>(chunkEnd - chunkBegin);
+            for (uint64_t headBase = 0; headBase < static_cast<uint64_t>(tiling_->HV); headBase += slotCount) {
+                // Advance both head slots one dependency stage at a time to overlap AIC(slot 1) with AIV(slot 0).
+                for (uint32_t pipelineStage = 0; pipelineStage < 3; ++pipelineStage) {
+                    if (pipelineStage == 2) {
+                        // Return AIV credit for both final-dA slots before either long full stage can block on AIV.
+                        for (uint64_t slot = 0; slot < slotCount; ++slot) {
+                            uint64_t valueHead = 0;
+                            if (ResolvePipelineHeadSlot(headBase, slot, valueHead)) {
+                                WaitAivFinishStore();
+                            }
+                        }
+                    }
+                    for (uint64_t slot = 0; slot < slotCount; ++slot) {
+                    uint64_t valueHead = 0;
+                    if (!ResolvePipelineHeadSlot(headBase, slot, valueHead)) {
+                        continue;
+                    }
+                    InitGemmEvents(eventL1A, eventL1B, eventL0C);
+                    uint32_t residentDwOffset = RESIDENT_DW_BASE_OFFSET + static_cast<uint32_t>(slot) * L1_TILE_K_BYTES;
+                    uint32_t residentDuOffset = RESIDENT_DU_BASE_OFFSET + static_cast<uint32_t>(slot) * L1_TILE_V_BYTES;
+                    uint32_t residentATOffset = RESIDENT_AT_BASE_OFFSET + static_cast<uint32_t>(slot) * L1_TILE_A_BYTES;
+                    if (pipelineStage == 0) {
+                    uint32_t da1L1BOffset = da1L1ATileBytes;
+
+                    AscendC::GlobalTensor<T> da1GmDw;
+                    AscendC::GlobalTensor<T> da1GmKbgT;
+                    AscendC::GlobalTensor<T> da1GmDa1;
+                    da1GmDw.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(dw_) + (ValueKeyLikeOffset(batch, valueHead, chunkBegin, 0)));
+                    da1GmKbgT.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->kbgOffset, SlotValueKeyLikeOffset(valueHead, 0, 0))));
+                    da1GmDa1.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->da1Offset, SlotMatrixOffset(valueHead, 0, 0))));
+
+                    auto da1TensorA = tla::MakeTensor(da1GmDw, layoutDw, Catlass::Arch::PositionGM{});
+                    auto da1TensorB = tla::MakeTensor(da1GmKbgT, layoutKbgT, Catlass::Arch::PositionGM{});
+                    auto da1TensorC = tla::MakeTensor(da1GmDa1, layoutDa, Catlass::Arch::PositionGM{});
+
+                    auto da1L1ABuf = resource_.l1Buf.template GetBufferByByte<Da1ElementA>(residentDwOffset);
+                    auto da1L1BBuf = resource_.l1Buf.template GetBufferByByte<Da1ElementB>(da1L1BOffset);
+
+                    auto da1L0CBuf = resource_.l0CBuf.template GetBufferByByte<Da1ElementAccumulator>(0);
+                    auto da1LayoutL1A = tla::MakeLayout<Da1ElementA, Da1LayoutTagL1A>(tla::Int<da1TileM>{}, tla::Int<da1TileK>{});
+                    auto da1LayoutL1B = tla::MakeLayout<Da1ElementB, Da1LayoutTagL1B>(tla::Int<da1TileK>{}, tla::Int<da1TileN>{});
+                    auto da1TensorL1A = tla::MakeTensor(da1L1ABuf, da1LayoutL1A, Catlass::Arch::PositionL1{});
+                    auto da1TensorL1B = tla::MakeTensor(da1L1BBuf, da1LayoutL1B, Catlass::Arch::PositionL1{});
+
+                    Da1CopyL1ToL0A da1CopyL1ToL0A;
+                    Da1CopyL1ToL0B da1CopyL1ToL0B;
+                    Da1TileMmad da1TileMmad;
+                    uint32_t da1MActual = chunkLen;
+                    if (da1MActual == 1) {
+                        da1MActual = 16;
+                    }
+
+                    auto da1BlockC = GetTile(da1TensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, chunkLen));
+                    auto da1LayoutL0C = tla::MakeLayoutL0C(da1MActual, chunkLen);
+                    auto da1TensorL0C = tla::MakeTensor(da1L0CBuf, da1LayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto da1TileL0C = GetTile(da1TensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(da1MActual, chunkLen));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    WaitAivFinishStore();
+
+                    for (uint32_t da1KOffset = 0; da1KOffset < (static_cast<uint32_t>(tiling_->K)); da1KOffset += da1TileK) {
+                        uint32_t da1CurK = da1KOffset + da1TileK > (static_cast<uint32_t>(tiling_->K)) ? (static_cast<uint32_t>(tiling_->K)) - da1KOffset : da1TileK;
+                        auto da1BlockA = GetTile(da1TensorA, tla::MakeCoord(0, da1KOffset), tla::MakeShape(chunkLen, da1CurK));
+                        auto da1BlockB = GetTile(da1TensorB, tla::MakeCoord(da1KOffset, 0), tla::MakeShape(da1CurK, chunkLen));
+                        typename Da1TileCopy::template CopyGmToL1A<decltype(da1BlockA)> da1CopyGmToL1A;
+                        typename Da1TileCopy::template CopyGmToL1B<decltype(da1BlockB)> da1CopyGmToL1B;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+                        da1CopyGmToL1A(da1TensorL1A, da1BlockA);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+                        da1CopyGmToL1B(da1TensorL1B, da1BlockB);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+                        if (da1KOffset == 0) {
+                            PrefetchDuResident(batch, valueHead, chunkBegin, chunkLen, residentDuOffset,
+                                                   PrefetchDuEvent(slot));
+                            PrefetchATResident(batch, valueHead, chunkBegin, chunkLen, residentATOffset,
+                                                   PrefetchATEvent(slot));
+                        }
+
+                        uint32_t da1L0Stage = (da1KOffset / da1TileK) & 1U;
+                        auto da1L0ABuf = resource_.l0ABuf.template GetBufferByByte<Da1ElementA>(da1L0Stage * da1L0ATileBytes);
+                        auto da1L0BBuf = resource_.l0BBuf.template GetBufferByByte<Da1ElementB>(da1L0Stage * da1L0BTileBytes);
+
+                        auto da1LayoutL0A = tla::MakeLayout<Da1ElementA, Da1LayoutTagL0A>(da1MActual, da1CurK);
+                        auto da1LayoutL0B = tla::MakeLayout<Da1ElementB, Da1LayoutTagL0B>(da1CurK, chunkLen);
+                        auto da1TensorL0A = tla::MakeTensor(da1L0ABuf, da1LayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto da1TensorL0B = tla::MakeTensor(da1L0BBuf, da1LayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto da1TileL1A = GetTile(da1TensorL1A, tla::MakeCoord(0, 0), tla::MakeShape(da1MActual, da1CurK));
+                        auto da1TileL1B = GetTile(da1TensorL1B, tla::MakeCoord(0, 0), tla::MakeShape(da1CurK, chunkLen));
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(da1L0Stage));
+                        da1CopyL1ToL0A(da1TensorL0A, da1TileL1A);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(da1L0Stage));
+                        da1CopyL1ToL0B(da1TensorL0B, da1TileL1B);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(da1L0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(da1L0Stage));
+                        uint8_t da1UnitFlag = (da1KOffset + da1CurK >= (static_cast<uint32_t>(tiling_->K))) ? 0b11 : 0b10;
+                        da1TileMmad(da1TileL0C, da1TensorL0A, da1TensorL0B, da1MActual, chunkLen, da1CurK, da1KOffset == 0, da1UnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(da1L0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(da1L0Stage));
+                    }
+
+                    typename Da1TileCopy::template CopyL0CToGm<decltype(da1BlockC)> da1CopyL0CToGm;
+                    da1CopyL0CToGm(da1BlockC, da1TileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    uint32_t da2L1BOffset = da2L1ATileBytes;
+
+                    AscendC::GlobalTensor<T> da2GmVbT;
+                    AscendC::GlobalTensor<T> da2GmDa2;
+                    da2GmVbT.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->vbOffset, SlotValueOffset(valueHead, 0, 0))));
+                    da2GmDa2.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->da2Offset, SlotMatrixOffset(valueHead, 0, 0))));
+
+                    auto da2TensorB = tla::MakeTensor(da2GmVbT, layoutVbT, Catlass::Arch::PositionGM{});
+                    auto da2TensorC = tla::MakeTensor(da2GmDa2, layoutDa, Catlass::Arch::PositionGM{});
+
+                    auto da2L1ABuf = resource_.l1Buf.template GetBufferByByte<Da2ElementA>(residentDuOffset);
+                    auto da2L1BBuf = resource_.l1Buf.template GetBufferByByte<Da2ElementB>(da2L1BOffset);
+
+                    auto da2L0CBuf = resource_.l0CBuf.template GetBufferByByte<Da2ElementAccumulator>(0);
+                    auto da2LayoutL1B = tla::MakeLayout<Da2ElementB, Da2LayoutTagL1B>(tla::Int<da2TileK>{}, tla::Int<da2TileN>{});
+                    auto da2LayoutResidentL1A =
+                        tla::MakeLayout<Da2ElementA, Da2ResidentLayoutTagL1A>(tla::Int<da2TileM>{}, tla::Int<V>{});
+                    auto da2TensorL1B = tla::MakeTensor(da2L1BBuf, da2LayoutL1B, Catlass::Arch::PositionL1{});
+                    auto da2TensorResidentL1A = tla::MakeTensor(da2L1ABuf, da2LayoutResidentL1A, Catlass::Arch::PositionL1{});
+
+                    Da2CopyL1ToL0B da2CopyL1ToL0B;
+                    Da2TileMmad da2TileMmad;
+                    uint32_t da2MActual = chunkLen;
+                    if (da2MActual == 1) {
+                        da2MActual = 16;
+                    }
+
+                    auto da2BlockC = GetTile(da2TensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, chunkLen));
+                    auto da2LayoutL0C = tla::MakeLayoutL0C(da2MActual, chunkLen);
+                    auto da2TensorL0C = tla::MakeTensor(da2L0CBuf, da2LayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto da2TileL0C = GetTile(da2TensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(da2MActual, chunkLen));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(PrefetchDuEvent(slot));
+
+                    for (uint32_t da2KOffset = 0; da2KOffset < (static_cast<uint32_t>(tiling_->V)); da2KOffset += da2TileK) {
+                        uint32_t da2CurK = da2KOffset + da2TileK > (static_cast<uint32_t>(tiling_->V)) ? (static_cast<uint32_t>(tiling_->V)) - da2KOffset : da2TileK;
+                        auto da2BlockB = GetTile(da2TensorB, tla::MakeCoord(da2KOffset, 0), tla::MakeShape(da2CurK, chunkLen));
+                        typename Da2TileCopy::template CopyGmToL1B<decltype(da2BlockB)> da2CopyGmToL1B;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+                        da2CopyGmToL1B(da2TensorL1B, da2BlockB);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+
+                        uint32_t da2L0Stage = (da2KOffset / da2TileK) & 1U;
+                        auto da2L0ABuf = resource_.l0ABuf.template GetBufferByByte<Da2ElementA>(da2L0Stage * da2L0ATileBytes);
+                        auto da2L0BBuf = resource_.l0BBuf.template GetBufferByByte<Da2ElementB>(da2L0Stage * da2L0BTileBytes);
+
+                        auto da2LayoutL0A = tla::MakeLayout<Da2ElementA, Da2LayoutTagL0A>(da2MActual, da2CurK);
+                        auto da2LayoutL0B = tla::MakeLayout<Da2ElementB, Da2LayoutTagL0B>(da2CurK, chunkLen);
+                        auto da2TensorL0A = tla::MakeTensor(da2L0ABuf, da2LayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto da2TensorL0B = tla::MakeTensor(da2L0BBuf, da2LayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto da2TileL1B = GetTile(da2TensorL1B, tla::MakeCoord(0, 0), tla::MakeShape(da2CurK, chunkLen));
+                        auto da2ResidentShapeA = tla::MakeShape(da2MActual, da2CurK);
+                        auto da2TileResidentL1A =
+                            GetTile(da2TensorResidentL1A, tla::MakeCoord(0, da2KOffset), da2ResidentShapeA);
+                        Catlass::Gemm::Tile::TileCopyTla<ArchTag, decltype(da2TileResidentL1A),
+                                                         decltype(da2TensorL0A)> da2CopyResidentL1ToL0A;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(da2L0Stage));
+                        da2CopyResidentL1ToL0A(da2TensorL0A, da2TileResidentL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(da2L0Stage));
+                        da2CopyL1ToL0B(da2TensorL0B, da2TileL1B);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(da2L0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(da2L0Stage));
+                        uint8_t da2UnitFlag = (da2KOffset + da2CurK >= (static_cast<uint32_t>(tiling_->V))) ? 0b11 : 0b10;
+                        da2TileMmad(da2TileL0C, da2TensorL0A, da2TensorL0B, da2MActual, chunkLen, da2CurK, da2KOffset == 0, da2UnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(da2L0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(da2L0Stage));
+                    }
+
+                    typename Da2TileCopy::template CopyL0CToGm<decltype(da2BlockC)> da2CopyL0CToGm;
+                    da2CopyL0CToGm(da2BlockC, da2TileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    SignalAicFinishStore();
+                    } else if (pipelineStage == 1) {
+                    uint32_t da5L1BOffset = residentATOffset;
+
+                    AscendC::GlobalTensor<T> da5GmDa4;
+                    AscendC::GlobalTensor<T> da5GmDa5;
+                    da5GmDa4.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->da4Offset, SlotMatrixOffset(valueHead, 0, 0))));
+                    da5GmDa5.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->da5Offset, SlotMatrixOffset(valueHead, 0, 0))));
+
+                    auto da5TensorA = tla::MakeTensor(da5GmDa4, layoutDa, Catlass::Arch::PositionGM{});
+                    auto da5TensorC = tla::MakeTensor(da5GmDa5, layoutDa, Catlass::Arch::PositionGM{});
+
+                    auto da5L1ABuf = resource_.l1Buf.template GetBufferByByte<Da5ElementA>(0U);
+                    auto da5L1BBuf = resource_.l1Buf.template GetBufferByByte<Da5ElementB>(da5L1BOffset);
+
+                    auto da5L0CBuf = resource_.l0CBuf.template GetBufferByByte<Da5ElementAccumulator>(0);
+                    auto da5LayoutL1A = tla::MakeLayout<Da5ElementA, Da5LayoutTagL1A>(tla::Int<da5TileM>{}, tla::Int<da5TileK>{});
+                    auto da5LayoutResidentL1B =
+                        tla::MakeLayout<Da5ElementB, Da5ResidentLayoutTagL1B>(tla::Int<da5TileK>{}, tla::Int<da5TileN>{});
+                    auto da5TensorL1A = tla::MakeTensor(da5L1ABuf, da5LayoutL1A, Catlass::Arch::PositionL1{});
+                    auto da5TensorResidentL1B = tla::MakeTensor(da5L1BBuf, da5LayoutResidentL1B, Catlass::Arch::PositionL1{});
+
+                    Da5CopyL1ToL0A da5CopyL1ToL0A;
+                    Da5TileMmad da5TileMmad;
+                    uint32_t da5MActual = chunkLen;
+                    if (da5MActual == 1) {
+                        da5MActual = 16;
+                    }
+
+                    auto da5BlockC = GetTile(da5TensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, chunkLen));
+                    auto da5LayoutL0C = tla::MakeLayoutL0C(da5MActual, chunkLen);
+                    auto da5TensorL0C = tla::MakeTensor(da5L0CBuf, da5LayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto da5TileL0C = GetTile(da5TensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(da5MActual, chunkLen));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(PrefetchATEvent(slot));
+                    WaitAivFinishStore();
+
+                    for (uint32_t da5KOffset = 0; da5KOffset < (chunkLen); da5KOffset += da5TileK) {
+                        uint32_t da5CurK = da5KOffset + da5TileK > (chunkLen) ? (chunkLen) - da5KOffset : da5TileK;
+                        auto da5BlockA = GetTile(da5TensorA, tla::MakeCoord(0, da5KOffset), tla::MakeShape(chunkLen, da5CurK));
+                        typename Da5TileCopy::template CopyGmToL1A<decltype(da5BlockA)> da5CopyGmToL1A;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+                        da5CopyGmToL1A(da5TensorL1A, da5BlockA);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1A);
+
+                        uint32_t da5L0Stage = (da5KOffset / da5TileK) & 1U;
+                        auto da5L0ABuf = resource_.l0ABuf.template GetBufferByByte<Da5ElementA>(da5L0Stage * da5L0ATileBytes);
+                        auto da5L0BBuf = resource_.l0BBuf.template GetBufferByByte<Da5ElementB>(da5L0Stage * da5L0BTileBytes);
+
+                        auto da5LayoutL0A = tla::MakeLayout<Da5ElementA, Da5LayoutTagL0A>(da5MActual, da5CurK);
+                        auto da5LayoutL0B = tla::MakeLayout<Da5ElementB, Da5LayoutTagL0B>(da5CurK, chunkLen);
+                        auto da5TensorL0A = tla::MakeTensor(da5L0ABuf, da5LayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto da5TensorL0B = tla::MakeTensor(da5L0BBuf, da5LayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto da5TileL1A = GetTile(da5TensorL1A, tla::MakeCoord(0, 0), tla::MakeShape(da5MActual, da5CurK));
+                        auto da5ResidentShapeB = tla::MakeShape(da5CurK, chunkLen);
+                        auto da5TileResidentL1B = GetTile(da5TensorResidentL1B, tla::MakeCoord(0, 0), da5ResidentShapeB);
+                        Catlass::Gemm::Tile::TileCopyTla<ArchTag, decltype(da5TileResidentL1B),
+                                                         decltype(da5TensorL0B)> da5CopyResidentL1ToL0B;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(da5L0Stage));
+                        da5CopyL1ToL0A(da5TensorL0A, da5TileL1A);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(da5L0Stage));
+                        da5CopyResidentL1ToL0B(da5TensorL0B, da5TileResidentL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(da5L0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(da5L0Stage));
+                        uint8_t da5UnitFlag = (da5KOffset + da5CurK >= (chunkLen)) ? 0b11 : 0b10;
+                        da5TileMmad(da5TileL0C, da5TensorL0A, da5TensorL0B, da5MActual, chunkLen, da5CurK, da5KOffset == 0, da5UnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(da5L0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(da5L0Stage));
+                    }
+
+                    typename Da5TileCopy::template CopyL0CToGm<decltype(da5BlockC)> da5CopyL0CToGm;
+                    da5CopyL0CToGm(da5BlockC, da5TileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_MTE2>(eventL0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_MTE2>(eventL0C);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    uint32_t da6L1BOffset = da6L1ATileBytes;
+
+                    AscendC::GlobalTensor<T> da6GmDa5;
+                    AscendC::GlobalTensor<T> da6GmA;
+                    AscendC::GlobalTensor<T> da6GmDa;
+                    da6GmDa5.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->da5Offset, SlotMatrixOffset(valueHead, 0, 0))));
+                    da6GmA.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(a_) +
+                                           MatrixOffset(batch, valueHead, chunkBegin, 0));
+                    da6GmDa.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->daOffset, SlotMatrixOffset(valueHead, 0, 0))));
+
+                    auto da6TensorA = tla::MakeTensor(da6GmDa5, layoutDaT, Catlass::Arch::PositionGM{});
+                    auto da6TensorB = tla::MakeTensor(da6GmA, layoutA, Catlass::Arch::PositionGM{});
+                    auto da6TensorC = tla::MakeTensor(da6GmDa, layoutDa, Catlass::Arch::PositionGM{});
+
+                    auto da6L1ABuf = resource_.l1Buf.template GetBufferByByte<Da6ElementA>(0U);
+                    auto da6L1BBuf = resource_.l1Buf.template GetBufferByByte<Da6ElementB>(da6L1BOffset);
+
+                    auto da6L0CBuf = resource_.l0CBuf.template GetBufferByByte<Da6ElementAccumulator>(0);
+                    auto da6LayoutL1A = tla::MakeLayout<Da6ElementA, Da6LayoutTagL1A>(tla::Int<da6TileM>{}, tla::Int<da6TileK>{});
+                    auto da6LayoutL1B = tla::MakeLayout<Da6ElementB, Da6LayoutTagL1B>(
+                        tla::Int<da6TileK>{}, tla::Int<da6TileN>{});
+                    auto da6TensorL1A = tla::MakeTensor(da6L1ABuf, da6LayoutL1A, Catlass::Arch::PositionL1{});
+                    auto da6TensorL1B = tla::MakeTensor(da6L1BBuf, da6LayoutL1B, Catlass::Arch::PositionL1{});
+
+                    Da6CopyL1ToL0A da6CopyL1ToL0A;
+                    Da6CopyL1ToL0B da6CopyL1ToL0B;
+                    Da6TileMmad da6TileMmad;
+                    uint32_t da6MActual = chunkLen;
+                    if (da6MActual == 1) {
+                        da6MActual = 16;
+                    }
+
+                    auto da6BlockC = GetTile(da6TensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, chunkLen));
+                    auto da6LayoutL0C = tla::MakeLayoutL0C(da6MActual, chunkLen);
+                    auto da6TensorL0C = tla::MakeTensor(da6L0CBuf, da6LayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto da6TileL0C = GetTile(da6TensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(da6MActual, chunkLen));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+
+                    for (uint32_t da6KOffset = 0; da6KOffset < (chunkLen); da6KOffset += da6TileK) {
+                        uint32_t da6CurK = da6KOffset + da6TileK > (chunkLen) ? (chunkLen) - da6KOffset : da6TileK;
+                        auto da6BlockA = GetTile(da6TensorA, tla::MakeCoord(0, da6KOffset), tla::MakeShape(chunkLen, da6CurK));
+                        auto da6BlockB = GetTile(da6TensorB, tla::MakeCoord(da6KOffset, 0),
+                                                tla::MakeShape(da6CurK, chunkLen));
+                        typename Da6TileCopy::template CopyGmToL1A<decltype(da6BlockA)> da6CopyGmToL1A;
+                        typename Da6TileCopy::template CopyGmToL1B<decltype(da6BlockB)> da6CopyGmToL1B;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+                        da6CopyGmToL1A(da6TensorL1A, da6BlockA);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+                        da6CopyGmToL1B(da6TensorL1B, da6BlockB);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+
+                        uint32_t da6L0Stage = (da6KOffset / da6TileK) & 1U;
+                        auto da6L0ABuf = resource_.l0ABuf.template GetBufferByByte<Da6ElementA>(da6L0Stage * da6L0ATileBytes);
+                        auto da6L0BBuf = resource_.l0BBuf.template GetBufferByByte<Da6ElementB>(da6L0Stage * da6L0BTileBytes);
+
+                        auto da6LayoutL0A = tla::MakeLayout<Da6ElementA, Da6LayoutTagL0A>(da6MActual, da6CurK);
+                        auto da6LayoutL0B = tla::MakeLayout<Da6ElementB, Da6LayoutTagL0B>(da6CurK, chunkLen);
+                        auto da6TensorL0A = tla::MakeTensor(da6L0ABuf, da6LayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto da6TensorL0B = tla::MakeTensor(da6L0BBuf, da6LayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto da6TileL1A = GetTile(da6TensorL1A, tla::MakeCoord(0, 0), tla::MakeShape(da6MActual, da6CurK));
+                        auto da6TileL1B = GetTile(da6TensorL1B, tla::MakeCoord(0, 0),
+                                                 tla::MakeShape(da6CurK, chunkLen));
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(da6L0Stage));
+                        da6CopyL1ToL0A(da6TensorL0A, da6TileL1A);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(da6L0Stage));
+                        da6CopyL1ToL0B(da6TensorL0B, da6TileL1B);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(da6L0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(da6L0Stage));
+                        uint8_t da6UnitFlag = (da6KOffset + da6CurK >= (chunkLen)) ? 0b11 : 0b10;
+                        da6TileMmad(da6TileL0C, da6TensorL0A, da6TensorL0B, da6MActual, chunkLen, da6CurK, da6KOffset == 0, da6UnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(da6L0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(da6L0Stage));
+                    }
+
+                    typename Da6TileCopy::template CopyL0CToGm<decltype(da6BlockC)> da6CopyL0CToGm;
+                    da6CopyL0CToGm(da6BlockC, da6TileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    SignalAicFinishStore();
+                    } else {
+                    uint64_t keyHead = valueHead / static_cast<uint64_t>(tiling_->headGroup);
+                    uint32_t residentKOffset = ResidentKOffset(headBase, slot, valueHead);
+                    uint32_t residentDaOffset = RESIDENT_DA_BASE_OFFSET + static_cast<uint32_t>(slot) * L1_TILE_A_BYTES;
+                    uint32_t fullDkL1BOffset = fullDkL1ATileBytes;
+
+                    AscendC::GlobalTensor<T> fullDkGmDa;
+                    AscendC::GlobalTensor<T> fullDkGmKBeta;
+                    AscendC::GlobalTensor<T> fullDkGmFullDk;
+                    fullDkGmDa.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->daOffset, SlotMatrixOffset(valueHead, 0, 0))));
+                    fullDkGmKBeta.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->kbetaOffset, SlotValueKeyLikeOffset(valueHead, 0, 0))));
+                    fullDkGmFullDk.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->fullDkOffset, SlotValueKeyLikeOffset(valueHead, 0, 0))));
+
+                    auto fullDkTensorA = tla::MakeTensor(fullDkGmDa, layoutDa, Catlass::Arch::PositionGM{});
+                    auto fullDkTensorB = tla::MakeTensor(fullDkGmKBeta, layoutK, Catlass::Arch::PositionGM{});
+                    auto fullDkTensorC = tla::MakeTensor(fullDkGmFullDk, layoutKOut, Catlass::Arch::PositionGM{});
+
+                    auto fullDkL1ABuf = resource_.l1Buf.template GetBufferByByte<FullDkElementA>(residentDaOffset);
+                    auto fullDkL1BBuf = resource_.l1Buf.template GetBufferByByte<FullDkElementB>(fullDkL1BOffset);
+
+                    auto fullDkL0CBuf = resource_.l0CBuf.template GetBufferByByte<FullDkElementAccumulator>(0);
+                    auto fullDkLayoutL1A = tla::MakeLayout<FullDkElementA, FullDkLayoutTagL1A>(tla::Int<fullDkTileM>{}, tla::Int<fullDkTileK>{});
+                    auto fullDkLayoutL1B = tla::MakeLayout<FullDkElementB, FullDkLayoutTagL1B>(tla::Int<fullDkTileK>{}, tla::Int<fullDkTileN>{});
+                    auto fullDkTensorL1A = tla::MakeTensor(fullDkL1ABuf, fullDkLayoutL1A, Catlass::Arch::PositionL1{});
+                    auto fullDkTensorL1B = tla::MakeTensor(fullDkL1BBuf, fullDkLayoutL1B, Catlass::Arch::PositionL1{});
+
+                    FullDkCopyL1ToL0A fullDkCopyL1ToL0A;
+                    FullDkCopyL1ToL0B fullDkCopyL1ToL0B;
+                    FullDkTileMmad fullDkTileMmad;
+                    uint32_t fullDkMActual = chunkLen;
+                    if (fullDkMActual == 1) {
+                        fullDkMActual = 16;
+                    }
+
+                    auto fullDkBlockC = GetTile(fullDkTensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, static_cast<uint32_t>(tiling_->K)));
+                    auto fullDkLayoutL0C = tla::MakeLayoutL0C(fullDkMActual, static_cast<uint32_t>(tiling_->K));
+                    auto fullDkTensorL0C = tla::MakeTensor(fullDkL0CBuf, fullDkLayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto fullDkTileL0C = GetTile(fullDkTensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(fullDkMActual, static_cast<uint32_t>(tiling_->K)));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+
+                    for (uint32_t fullDkKOffset = 0; fullDkKOffset < (chunkLen); fullDkKOffset += fullDkTileK) {
+                        uint32_t fullDkCurK = fullDkKOffset + fullDkTileK > (chunkLen) ? (chunkLen) - fullDkKOffset : fullDkTileK;
+                        auto fullDkBlockA = GetTile(fullDkTensorA, tla::MakeCoord(0, fullDkKOffset), tla::MakeShape(chunkLen, fullDkCurK));
+                        auto fullDkBlockB = GetTile(fullDkTensorB, tla::MakeCoord(fullDkKOffset, 0), tla::MakeShape(fullDkCurK, static_cast<uint32_t>(tiling_->K)));
+                        typename FullDkTileCopy::template CopyGmToL1A<decltype(fullDkBlockA)> fullDkCopyGmToL1A;
+                        typename FullDkTileCopy::template CopyGmToL1B<decltype(fullDkBlockB)> fullDkCopyGmToL1B;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+                        fullDkCopyGmToL1A(fullDkTensorL1A, fullDkBlockA);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+                        fullDkCopyGmToL1B(fullDkTensorL1B, fullDkBlockB);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+
+                        uint32_t fullDkL0Stage = (fullDkKOffset / fullDkTileK) & 1U;
+                        auto fullDkL0ABuf = resource_.l0ABuf.template GetBufferByByte<FullDkElementA>(fullDkL0Stage * fullDkL0ATileBytes);
+                        auto fullDkL0BBuf = resource_.l0BBuf.template GetBufferByByte<FullDkElementB>(fullDkL0Stage * fullDkL0BTileBytes);
+
+                        auto fullDkLayoutL0A = tla::MakeLayout<FullDkElementA, FullDkLayoutTagL0A>(fullDkMActual, fullDkCurK);
+                        auto fullDkLayoutL0B = tla::MakeLayout<FullDkElementB, FullDkLayoutTagL0B>(fullDkCurK, static_cast<uint32_t>(tiling_->K));
+                        auto fullDkTensorL0A = tla::MakeTensor(fullDkL0ABuf, fullDkLayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto fullDkTensorL0B = tla::MakeTensor(fullDkL0BBuf, fullDkLayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto fullDkTileL1A = GetTile(fullDkTensorL1A, tla::MakeCoord(0, 0), tla::MakeShape(fullDkMActual, fullDkCurK));
+                        auto fullDkTileL1B = GetTile(fullDkTensorL1B, tla::MakeCoord(0, 0), tla::MakeShape(fullDkCurK, static_cast<uint32_t>(tiling_->K)));
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullDkL0Stage));
+                        fullDkCopyL1ToL0A(fullDkTensorL0A, fullDkTileL1A);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullDkL0Stage));
+                        fullDkCopyL1ToL0B(fullDkTensorL0B, fullDkTileL1B);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullDkL0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullDkL0Stage));
+                        uint8_t fullDkUnitFlag = (fullDkKOffset + fullDkCurK >= (chunkLen)) ? 0b11 : 0b10;
+                        fullDkTileMmad(fullDkTileL0C, fullDkTensorL0A, fullDkTensorL0B, fullDkMActual, static_cast<uint32_t>(tiling_->K), fullDkCurK, fullDkKOffset == 0, fullDkUnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullDkL0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullDkL0Stage));
+                    }
+
+                    typename FullDkTileCopy::template CopyL0CToGm<decltype(fullDkBlockC)> fullDkCopyL0CToGm;
+                    fullDkCopyL0CToGm(fullDkBlockC, fullDkTileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    SignalAicFinishFullStore();
+                    uint32_t fullDkbL1BOffset = residentKOffset;
+
+                    AscendC::GlobalTensor<T> fullDkbGmFullDkb;
+                    fullDkbGmFullDkb.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->fullDkbOffset, SlotValueKeyLikeOffset(valueHead, 0, 0))));
+
+                    auto fullDkbTensorC = tla::MakeTensor(fullDkbGmFullDkb, layoutKOut, Catlass::Arch::PositionGM{});
+
+                    auto fullDkbL1ABuf = resource_.l1Buf.template GetBufferByByte<FullDkbElementA>(residentDaOffset);
+                    auto fullDkbL1BBuf = resource_.l1Buf.template GetBufferByByte<FullDkbElementB>(fullDkbL1BOffset);
+
+                    auto fullDkbL0CBuf = resource_.l0CBuf.template GetBufferByByte<FullDkbElementAccumulator>(0);
+                    auto fullDkbLayoutResidentL1A =
+                        tla::MakeLayout<FullDkbElementA, FullDkbResidentLayoutTagL1A>(tla::Int<fullDkbTileM>{}, tla::Int<fullDkbTileK>{});
+                    auto fullDkbLayoutResidentL1B =
+                        tla::MakeLayout<FullDkbElementB, FullDkbResidentLayoutTagL1B>(tla::Int<fullDkbTileK>{}, tla::Int<fullDkbTileN>{});
+                    auto fullDkbTensorResidentL1A = tla::MakeTensor(fullDkbL1ABuf, fullDkbLayoutResidentL1A, Catlass::Arch::PositionL1{});
+                    auto fullDkbTensorResidentL1B = tla::MakeTensor(fullDkbL1BBuf, fullDkbLayoutResidentL1B, Catlass::Arch::PositionL1{});
+
+                    FullDkbTileMmad fullDkbTileMmad;
+                    uint32_t fullDkbMActual = chunkLen;
+                    if (fullDkbMActual == 1) {
+                        fullDkbMActual = 16;
+                    }
+
+                    auto fullDkbBlockC = GetTile(fullDkbTensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, static_cast<uint32_t>(tiling_->K)));
+                    auto fullDkbLayoutL0C = tla::MakeLayoutL0C(fullDkbMActual, static_cast<uint32_t>(tiling_->K));
+                    auto fullDkbTensorL0C = tla::MakeTensor(fullDkbL0CBuf, fullDkbLayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto fullDkbTileL0C = GetTile(fullDkbTensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(fullDkbMActual, static_cast<uint32_t>(tiling_->K)));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    if (IsResidentKOwner(headBase, slot, valueHead)) {
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+                        PrefetchKResident(batch, keyHead, chunkBegin, chunkLen,
+                                          ResidentKOffset(headBase, slot, valueHead),
+                                          eventL1B);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+                    }
+
+                    for (uint32_t fullDkbKOffset = 0; fullDkbKOffset < (chunkLen); fullDkbKOffset += fullDkbTileK) {
+                        uint32_t fullDkbCurK = fullDkbKOffset + fullDkbTileK > (chunkLen) ? (chunkLen) - fullDkbKOffset : fullDkbTileK;
+
+                        uint32_t fullDkbL0Stage = (fullDkbKOffset / fullDkbTileK) & 1U;
+                        auto fullDkbL0ABuf = resource_.l0ABuf.template GetBufferByByte<FullDkbElementA>(fullDkbL0Stage * fullDkbL0ATileBytes);
+                        auto fullDkbL0BBuf = resource_.l0BBuf.template GetBufferByByte<FullDkbElementB>(fullDkbL0Stage * fullDkbL0BTileBytes);
+
+                        auto fullDkbLayoutL0A = tla::MakeLayout<FullDkbElementA, FullDkbLayoutTagL0A>(fullDkbMActual, fullDkbCurK);
+                        auto fullDkbLayoutL0B = tla::MakeLayout<FullDkbElementB, FullDkbLayoutTagL0B>(fullDkbCurK, static_cast<uint32_t>(tiling_->K));
+                        auto fullDkbTensorL0A = tla::MakeTensor(fullDkbL0ABuf, fullDkbLayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto fullDkbTensorL0B = tla::MakeTensor(fullDkbL0BBuf, fullDkbLayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto fullDkbResidentShapeA = tla::MakeShape(fullDkbMActual, fullDkbCurK);
+                        auto fullDkbResidentShapeB = tla::MakeShape(fullDkbCurK, static_cast<uint32_t>(tiling_->K));
+                        auto fullDkbTileResidentL1A = GetTile(fullDkbTensorResidentL1A, tla::MakeCoord(0, 0), fullDkbResidentShapeA);
+                        auto fullDkbTileResidentL1B = GetTile(fullDkbTensorResidentL1B, tla::MakeCoord(0, 0), fullDkbResidentShapeB);
+                        Catlass::Gemm::Tile::TileCopyTla<ArchTag, decltype(fullDkbTileResidentL1A),
+                                                         decltype(fullDkbTensorL0A)> fullDkbCopyResidentL1ToL0A;
+                        Catlass::Gemm::Tile::TileCopyTla<ArchTag, decltype(fullDkbTileResidentL1B),
+                                                         decltype(fullDkbTensorL0B)> fullDkbCopyResidentL1ToL0B;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullDkbL0Stage));
+                        fullDkbCopyResidentL1ToL0A(fullDkbTensorL0A, fullDkbTileResidentL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullDkbL0Stage));
+                        fullDkbCopyResidentL1ToL0B(fullDkbTensorL0B, fullDkbTileResidentL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullDkbL0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullDkbL0Stage));
+                        uint8_t fullDkbUnitFlag = (fullDkbKOffset + fullDkbCurK >= (chunkLen)) ? 0b11 : 0b10;
+                        fullDkbTileMmad(fullDkbTileL0C, fullDkbTensorL0A, fullDkbTensorL0B, fullDkbMActual, static_cast<uint32_t>(tiling_->K), fullDkbCurK, fullDkbKOffset == 0, fullDkbUnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullDkbL0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullDkbL0Stage));
+                    }
+
+                    typename FullDkbTileCopy::template CopyL0CToGm<decltype(fullDkbBlockC)> fullDkbCopyL0CToGm;
+                    fullDkbCopyL0CToGm(fullDkbBlockC, fullDkbTileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    SignalAicFinishFullStore();
+                    uint32_t fullDkbgL1AOffset = residentATOffset;
+                    uint32_t fullDkbgL1BOffset = residentDwOffset;
+
+                    AscendC::GlobalTensor<T> fullDkbgGmFullDkbg;
+                    fullDkbgGmFullDkbg.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->fullDkbgOffset, SlotValueKeyLikeOffset(valueHead, 0, 0))));
+
+                    auto fullDkbgTensorC = tla::MakeTensor(fullDkbgGmFullDkbg, layoutKOut, Catlass::Arch::PositionGM{});
+
+                    auto fullDkbgL1ABuf = resource_.l1Buf.template GetBufferByByte<FullDkbgElementA>(fullDkbgL1AOffset);
+                    auto fullDkbgL1BBuf = resource_.l1Buf.template GetBufferByByte<FullDkbgElementB>(fullDkbgL1BOffset);
+
+                    auto fullDkbgL0CBuf = resource_.l0CBuf.template GetBufferByByte<FullDkbgElementAccumulator>(0);
+                    auto fullDkbgLayoutL1A =
+                        tla::MakeLayout<FullDkbgElementA, FullDkbgLayoutTagL1A>(tla::Int<fullDkbgTileM>{}, tla::Int<fullDkbgTileK>{});
+                    auto fullDkbgLayoutL1B =
+                        tla::MakeLayout<FullDkbgElementB, FullDkbgLayoutTagL1B>(tla::Int<fullDkbgTileK>{}, tla::Int<fullDkbgTileN>{});
+                    auto fullDkbgTensorL1A = tla::MakeTensor(fullDkbgL1ABuf, fullDkbgLayoutL1A, Catlass::Arch::PositionL1{});
+                    auto fullDkbgTensorL1B = tla::MakeTensor(fullDkbgL1BBuf, fullDkbgLayoutL1B, Catlass::Arch::PositionL1{});
+
+                    FullDkbgCopyL1ToL0A fullDkbgCopyL1ToL0A;
+                    FullDkbgCopyL1ToL0B fullDkbgCopyL1ToL0B;
+                    FullDkbgTileMmad fullDkbgTileMmad;
+                    uint32_t fullDkbgMActual = chunkLen;
+                    if (fullDkbgMActual == 1) {
+                        fullDkbgMActual = 16;
+                    }
+
+                    auto fullDkbgBlockC = GetTile(fullDkbgTensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, static_cast<uint32_t>(tiling_->K)));
+                    auto fullDkbgLayoutL0C = tla::MakeLayoutL0C(fullDkbgMActual, static_cast<uint32_t>(tiling_->K));
+                    auto fullDkbgTensorL0C = tla::MakeTensor(fullDkbgL0CBuf, fullDkbgLayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto fullDkbgTileL0C = GetTile(fullDkbgTensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(fullDkbgMActual, static_cast<uint32_t>(tiling_->K)));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+
+                    for (uint32_t fullDkbgKOffset = 0; fullDkbgKOffset < (chunkLen); fullDkbgKOffset += fullDkbgTileK) {
+                        uint32_t fullDkbgCurK = fullDkbgKOffset + fullDkbgTileK > (chunkLen) ? (chunkLen) - fullDkbgKOffset : fullDkbgTileK;
+
+                        uint32_t fullDkbgL0Stage = (fullDkbgKOffset / fullDkbgTileK) & 1U;
+                        auto fullDkbgL0ABuf = resource_.l0ABuf.template GetBufferByByte<FullDkbgElementA>(fullDkbgL0Stage * fullDkbgL0ATileBytes);
+                        auto fullDkbgL0BBuf = resource_.l0BBuf.template GetBufferByByte<FullDkbgElementB>(fullDkbgL0Stage * fullDkbgL0BTileBytes);
+
+                        auto fullDkbgLayoutL0A = tla::MakeLayout<FullDkbgElementA, FullDkbgLayoutTagL0A>(fullDkbgMActual, fullDkbgCurK);
+                        auto fullDkbgLayoutL0B = tla::MakeLayout<FullDkbgElementB, FullDkbgLayoutTagL0B>(fullDkbgCurK, static_cast<uint32_t>(tiling_->K));
+                        auto fullDkbgTensorL0A = tla::MakeTensor(fullDkbgL0ABuf, fullDkbgLayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto fullDkbgTensorL0B = tla::MakeTensor(fullDkbgL0BBuf, fullDkbgLayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto fullDkbgTileL1A = GetTile(fullDkbgTensorL1A, tla::MakeCoord(0, 0),
+                                                      tla::MakeShape(fullDkbgMActual, fullDkbgCurK));
+                        auto fullDkbgTileL1B = GetTile(fullDkbgTensorL1B, tla::MakeCoord(0, 0),
+                                                      tla::MakeShape(fullDkbgCurK, static_cast<uint32_t>(tiling_->K)));
+
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullDkbgL0Stage));
+                        fullDkbgCopyL1ToL0A(fullDkbgTensorL0A, fullDkbgTileL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullDkbgL0Stage));
+                        fullDkbgCopyL1ToL0B(fullDkbgTensorL0B, fullDkbgTileL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullDkbgL0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullDkbgL0Stage));
+                        uint8_t fullDkbgUnitFlag = (fullDkbgKOffset + fullDkbgCurK >= (chunkLen)) ? 0b11 : 0b10;
+                        fullDkbgTileMmad(fullDkbgTileL0C, fullDkbgTensorL0A, fullDkbgTensorL0B, fullDkbgMActual, static_cast<uint32_t>(tiling_->K), fullDkbgCurK, fullDkbgKOffset == 0, fullDkbgUnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullDkbgL0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullDkbgL0Stage));
+                    }
+
+                    typename FullDkbgTileCopy::template CopyL0CToGm<decltype(fullDkbgBlockC)> fullDkbgCopyL0CToGm;
+                    fullDkbgCopyL0CToGm(fullDkbgBlockC, fullDkbgTileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    SignalAicFinishFullStore();
+                    uint32_t fullDvbL1BOffset = residentDuOffset;
+
+                    AscendC::GlobalTensor<T> fullDvbGmFullDvb;
+                    fullDvbGmFullDvb.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->fullDvbOffset, SlotValueOffset(valueHead, 0, 0))));
+
+                    auto fullDvbTensorC = tla::MakeTensor(fullDvbGmFullDvb, layoutVOut, Catlass::Arch::PositionGM{});
+
+                    auto fullDvbL1ABuf = resource_.l1Buf.template GetBufferByByte<FullDvbElementA>(residentATOffset);
+                    auto fullDvbL1BBuf = resource_.l1Buf.template GetBufferByByte<FullDvbElementB>(fullDvbL1BOffset);
+
+                    auto fullDvbL0CBuf = resource_.l0CBuf.template GetBufferByByte<FullDvbElementAccumulator>(0);
+                    auto fullDvbLayoutResidentL1A =
+                        tla::MakeLayout<FullDvbElementA, FullDvbResidentLayoutTagL1A>(
+                            tla::Int<da5TileK>{}, tla::Int<da5TileN>{});
+                    auto fullDvbLayoutResidentL1B =
+                        tla::MakeLayout<FullDvbElementB, FullDvbResidentLayoutTagL1B>(
+                            tla::Int<fullDvbTileM>{}, tla::Int<V>{});
+                    auto fullDvbTensorResidentL1A = tla::MakeTensor(fullDvbL1ABuf, fullDvbLayoutResidentL1A, Catlass::Arch::PositionL1{});
+                    auto fullDvbTensorResidentL1B = tla::MakeTensor(fullDvbL1BBuf, fullDvbLayoutResidentL1B, Catlass::Arch::PositionL1{});
+
+                    FullDvbTileMmad fullDvbTileMmad;
+                    uint32_t fullDvbMActual = chunkLen;
+                    if (fullDvbMActual == 1) {
+                        fullDvbMActual = 16;
+                    }
+
+                    auto fullDvbBlockC = GetTile(fullDvbTensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, static_cast<uint32_t>(tiling_->V)));
+                    auto fullDvbLayoutL0C = tla::MakeLayoutL0C(fullDvbMActual, static_cast<uint32_t>(tiling_->V));
+                    auto fullDvbTensorL0C = tla::MakeTensor(fullDvbL0CBuf, fullDvbLayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto fullDvbTileL0C = GetTile(fullDvbTensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(fullDvbMActual, static_cast<uint32_t>(tiling_->V)));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+
+                    for (uint32_t fullDvbKOffset = 0; fullDvbKOffset < (chunkLen); fullDvbKOffset += fullDvbTileK) {
+                        uint32_t fullDvbCurK = fullDvbKOffset + fullDvbTileK > (chunkLen) ? (chunkLen) - fullDvbKOffset : fullDvbTileK;
+                        // The resident TileCopyTla path aliases its L0 destination; consume K slices serially.
+                        uint32_t fullDvbL0Stage = 0U;
+                        auto fullDvbL0ABuf = resource_.l0ABuf.template GetBufferByByte<FullDvbElementA>(fullDvbL0Stage * fullDvbL0ATileBytes);
+                        auto fullDvbL0BBuf = resource_.l0BBuf.template GetBufferByByte<FullDvbElementB>(fullDvbL0Stage * fullDvbL0BTileBytes);
+
+                        auto fullDvbLayoutL0A = tla::MakeLayout<FullDvbElementA, FullDvbLayoutTagL0A>(fullDvbMActual, fullDvbCurK);
+                        auto fullDvbLayoutL0B = tla::MakeLayout<FullDvbElementB, FullDvbLayoutTagL0B>(fullDvbCurK, static_cast<uint32_t>(tiling_->V));
+                        auto fullDvbTensorL0A = tla::MakeTensor(fullDvbL0ABuf, fullDvbLayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto fullDvbTensorL0B = tla::MakeTensor(fullDvbL0BBuf, fullDvbLayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto fullDvbResidentShapeA = tla::MakeShape(fullDvbMActual, fullDvbCurK);
+                        auto fullDvbResidentShapeB = tla::MakeShape(fullDvbCurK, static_cast<uint32_t>(tiling_->V));
+                        auto fullDvbTileResidentL1A =
+                            GetTile(fullDvbTensorResidentL1A, tla::MakeCoord(0, fullDvbKOffset), fullDvbResidentShapeA);
+                        auto fullDvbTileResidentL1B =
+                            GetTile(fullDvbTensorResidentL1B, tla::MakeCoord(fullDvbKOffset, 0), fullDvbResidentShapeB);
+                        Catlass::Gemm::Tile::TileCopyTla<ArchTag, decltype(fullDvbTileResidentL1A),
+                                                         decltype(fullDvbTensorL0A)> fullDvbCopyResidentL1ToL0A;
+                        Catlass::Gemm::Tile::TileCopyTla<ArchTag, decltype(fullDvbTileResidentL1B),
+                                                         decltype(fullDvbTensorL0B)> fullDvbCopyResidentL1ToL0B;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullDvbL0Stage));
+                        fullDvbCopyResidentL1ToL0A(fullDvbTensorL0A, fullDvbTileResidentL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullDvbL0Stage));
+                        fullDvbCopyResidentL1ToL0B(fullDvbTensorL0B, fullDvbTileResidentL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullDvbL0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullDvbL0Stage));
+                        uint8_t fullDvbUnitFlag = (fullDvbKOffset + fullDvbCurK >= (chunkLen)) ? 0b11 : 0b10;
+                        fullDvbTileMmad(fullDvbTileL0C, fullDvbTensorL0A, fullDvbTensorL0B, fullDvbMActual, static_cast<uint32_t>(tiling_->V), fullDvbCurK, fullDvbKOffset == 0, fullDvbUnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullDvbL0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullDvbL0Stage));
+                    }
+
+                    typename FullDvbTileCopy::template CopyL0CToGm<decltype(fullDvbBlockC)> fullDvbCopyL0CToGm;
+                    fullDvbCopyL0CToGm(fullDvbBlockC, fullDvbTileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    SignalAicFinishFullStore();
+                    uint32_t fullKktL1AOffset = residentKOffset;
+                    uint32_t fullKktL1BOffset = 0;
+
+                    AscendC::GlobalTensor<T> fullKktGmK;
+                    AscendC::GlobalTensor<T> fullKktGmFullKkt;
+                    fullKktGmK.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(k_) +
+                                               KeyOffset(batch, keyHead, chunkBegin, 0));
+                    fullKktGmFullKkt.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->fullKktOffset, SlotMatrixOffset(valueHead, 0, 0))));
+
+                    auto fullKktTensorB = tla::MakeTensor(fullKktGmK, layoutKT, Catlass::Arch::PositionGM{});
+                    auto fullKktTensorC = tla::MakeTensor(fullKktGmFullKkt, layoutDa, Catlass::Arch::PositionGM{});
+
+                    auto fullKktL1ABuf = resource_.l1Buf.template GetBufferByByte<FullKktElementA>(fullKktL1AOffset);
+                    auto fullKktL1BBuf = resource_.l1Buf.template GetBufferByByte<FullKktElementB>(fullKktL1BOffset);
+
+                    auto fullKktL0CBuf = resource_.l0CBuf.template GetBufferByByte<FullKktElementAccumulator>(0);
+                    auto fullKktLayoutL1A =
+                        tla::MakeLayout<FullKktElementA, FullKktLayoutTagL1A>(tla::Int<fullKktTileM>{}, tla::Int<fullKktTileK>{});
+                    auto fullKktLayoutL1B =
+                        tla::MakeLayout<FullKktElementB, FullKktLayoutTagL1B>(tla::Int<fullKktTileK>{}, tla::Int<fullKktTileN>{});
+                    auto fullKktTensorL1A = tla::MakeTensor(fullKktL1ABuf, fullKktLayoutL1A, Catlass::Arch::PositionL1{});
+                    auto fullKktTensorL1B = tla::MakeTensor(fullKktL1BBuf, fullKktLayoutL1B, Catlass::Arch::PositionL1{});
+
+                    auto fullKktBlockB = GetTile(fullKktTensorB, tla::MakeCoord(0, 0),
+                                                 tla::MakeShape(static_cast<uint32_t>(tiling_->K), chunkLen));
+                    typename FullKktTileCopy::template CopyGmToL1B<decltype(fullKktBlockB)> fullKktCopyGmToL1B;
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+                    fullKktCopyGmToL1B(fullKktTensorL1B, fullKktBlockB);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+
+                    FullKktCopyL1ToL0A fullKktCopyL1ToL0A;
+                    FullKktCopyL1ToL0B fullKktCopyL1ToL0B;
+                    FullKktTileMmad fullKktTileMmad;
+                    uint32_t fullKktMActual = chunkLen;
+                    if (fullKktMActual == 1) {
+                        fullKktMActual = 16;
+                    }
+
+                    auto fullKktBlockC = GetTile(fullKktTensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, chunkLen));
+                    auto fullKktLayoutL0C = tla::MakeLayoutL0C(fullKktMActual, chunkLen);
+                    auto fullKktTensorL0C = tla::MakeTensor(fullKktL0CBuf, fullKktLayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto fullKktTileL0C = GetTile(fullKktTensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(fullKktMActual, chunkLen));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+
+                    for (uint32_t fullKktKOffset = 0; fullKktKOffset < (static_cast<uint32_t>(tiling_->K)); fullKktKOffset += fullKktTileK) {
+                        uint32_t fullKktCurK = fullKktKOffset + fullKktTileK > (static_cast<uint32_t>(tiling_->K)) ? (static_cast<uint32_t>(tiling_->K)) - fullKktKOffset : fullKktTileK;
+
+                        uint32_t fullKktL0Stage = (fullKktKOffset / fullKktTileK) & 1U;
+                        auto fullKktL0ABuf = resource_.l0ABuf.template GetBufferByByte<FullKktElementA>(fullKktL0Stage * fullKktL0ATileBytes);
+                        auto fullKktL0BBuf = resource_.l0BBuf.template GetBufferByByte<FullKktElementB>(fullKktL0Stage * fullKktL0BTileBytes);
+
+                        auto fullKktLayoutL0A = tla::MakeLayout<FullKktElementA, FullKktLayoutTagL0A>(fullKktMActual, fullKktCurK);
+                        auto fullKktLayoutL0B = tla::MakeLayout<FullKktElementB, FullKktLayoutTagL0B>(fullKktCurK, chunkLen);
+                        auto fullKktTensorL0A = tla::MakeTensor(fullKktL0ABuf, fullKktLayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto fullKktTensorL0B = tla::MakeTensor(fullKktL0BBuf, fullKktLayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto fullKktTileL1A = GetTile(fullKktTensorL1A, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(fullKktMActual, fullKktCurK));
+                        auto fullKktTileL1B = GetTile(fullKktTensorL1B, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(fullKktCurK, chunkLen));
+
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullKktL0Stage));
+                        fullKktCopyL1ToL0A(fullKktTensorL0A, fullKktTileL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullKktL0Stage));
+                        fullKktCopyL1ToL0B(fullKktTensorL0B, fullKktTileL1B);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullKktL0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullKktL0Stage));
+                        uint8_t fullKktUnitFlag = (fullKktKOffset + fullKktCurK >= (static_cast<uint32_t>(tiling_->K))) ? 0b11 : 0b10;
+                        fullKktTileMmad(fullKktTileL0C, fullKktTensorL0A, fullKktTensorL0B, fullKktMActual, chunkLen, fullKktCurK, fullKktKOffset == 0, fullKktUnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullKktL0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullKktL0Stage));
+                    }
+
+                    typename FullKktTileCopy::template CopyL0CToGm<decltype(fullKktBlockC)> fullKktCopyL0CToGm;
+                    fullKktCopyL0CToGm(fullKktBlockC, fullKktTileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    SignalAicFinishFullStore();
+                    }
+                    DrainGemmEvents(eventL1A, eventL1B, eventL0C);
+                    }
+                }
+                AscendC::PipeBarrier<PIPE_FIX>();
+            }
+        }
+    }
+
+private:
+    __aicore__ inline bool ResolvePipelineHeadSlot(uint64_t headBase, uint64_t slot, uint64_t &valueHead) const
+    {
+        valueHead = headBase + slot;
+        return valueHead < static_cast<uint64_t>(tiling_->HV);
+    }
+
+    __aicore__ inline uint64_t Min(uint64_t lhs, uint64_t rhs) const
+    {
+        return lhs < rhs ? lhs : rhs;
+    }
+
+    __aicore__ inline uint64_t KeyOffset(uint64_t batch, uint64_t head, uint64_t token, uint64_t col) const
+    {
+        return (((batch * static_cast<uint64_t>(tiling_->HK) + head) * static_cast<uint64_t>(tiling_->T) + token) *
+                static_cast<uint64_t>(tiling_->K)) + col;
+    }
+
+    __aicore__ inline uint64_t ValueOffset(uint64_t batch, uint64_t head, uint64_t token, uint64_t col) const
+    {
+        return (((batch * static_cast<uint64_t>(tiling_->HV) + head) * static_cast<uint64_t>(tiling_->T) + token) *
+                static_cast<uint64_t>(tiling_->V)) + col;
+    }
+
+    __aicore__ inline uint64_t ValueKeyLikeOffset(uint64_t batch, uint64_t head, uint64_t token, uint64_t col) const
+    {
+        return (((batch * static_cast<uint64_t>(tiling_->HV) + head) * static_cast<uint64_t>(tiling_->T) + token) *
+                static_cast<uint64_t>(tiling_->K)) + col;
+    }
+
+    __aicore__ inline uint64_t MatrixOffset(uint64_t batch, uint64_t head, uint64_t token, uint64_t localCol) const
+    {
+        return (((batch * static_cast<uint64_t>(tiling_->HV) + head) * static_cast<uint64_t>(tiling_->T) + token) *
+                static_cast<uint64_t>(tiling_->chunkSize)) + localCol;
+    }
+
+    __aicore__ inline uint64_t WorkspaceElem(int64_t byteOffset, uint64_t elemOffset) const
+    {
+        return static_cast<uint64_t>(byteOffset) / sizeof(T) + elemOffset;
+    }
+
+    __aicore__ inline uint64_t SlotBaseElem(uint64_t slot) const
+    {
+        return ((coreIdx_ * static_cast<uint64_t>(tiling_->workspaceBufferCount) + slot) *
+                static_cast<uint64_t>(tiling_->workspaceSlotBytes)) / sizeof(T);
+    }
+
+    __aicore__ inline uint64_t SlotWorkspaceElem(uint64_t slot, int64_t byteOffset, uint64_t elemOffset) const
+    {
+        return SlotBaseElem(slot) + WorkspaceElem(byteOffset, elemOffset);
+    }
+
+    __aicore__ inline uint64_t SlotValueKeyLikeOffset(uint64_t head, uint64_t localRow, uint64_t col) const
+    {
+        return ((head * static_cast<uint64_t>(tiling_->chunkSize) + localRow) *
+                static_cast<uint64_t>(tiling_->K)) + col;
+    }
+
+    __aicore__ inline uint64_t SlotValueOffset(uint64_t head, uint64_t localRow, uint64_t col) const
+    {
+        return ((head * static_cast<uint64_t>(tiling_->chunkSize) + localRow) *
+                static_cast<uint64_t>(tiling_->V)) + col;
+    }
+
+    __aicore__ inline uint64_t SlotMatrixOffset(uint64_t head, uint64_t localRow, uint64_t localCol) const
+    {
+        return ((head * static_cast<uint64_t>(tiling_->chunkSize) + localRow) *
+                static_cast<uint64_t>(tiling_->chunkSize)) + localCol;
+    }
+
+    __aicore__ inline void GetChunkOffset(uint64_t chunkLinear, uint64_t &batch, uint64_t &chunkBegin,
+                                         uint64_t &chunkEnd)
+    {
+        const uint64_t chunkSize = static_cast<uint64_t>(tiling_->chunkSize);
+        if constexpr (IS_VARLEN) {
+            uint64_t seqIdx = static_cast<uint64_t>(chunkIndicesGm_.GetValue(chunkLinear * 2));
+            uint64_t chunkInSeq = static_cast<uint64_t>(chunkIndicesGm_.GetValue(chunkLinear * 2 + 1));
+            uint64_t seqBegin = static_cast<uint64_t>(cuSeqlensGm_.GetValue(seqIdx));
+            uint64_t seqEnd = static_cast<uint64_t>(cuSeqlensGm_.GetValue(seqIdx + 1));
+            batch = 0;
+            chunkBegin = seqBegin + chunkInSeq * chunkSize;
+            chunkEnd = Min(chunkBegin + chunkSize, seqEnd);
+            return;
+        }
+
+        const uint64_t chunksPerBatch = (static_cast<uint64_t>(tiling_->T) + chunkSize - 1) / chunkSize;
+        batch = chunkLinear / chunksPerBatch;
+        uint64_t chunkInBatch = chunkLinear - batch * chunksPerBatch;
+        chunkBegin = chunkInBatch * chunkSize;
+        chunkEnd = Min(chunkBegin + chunkSize, static_cast<uint64_t>(tiling_->T));
+    }
+
+private:
+    const PrepareWyReprBwdTilingData *tiling_ = nullptr;
+    Catlass::Arch::Resource<ArchTag> resource_;
+        uint64_t coreIdx_ = 0;
+    GM_ADDR k_ = nullptr;
+    GM_ADDR v_ = nullptr;
+    GM_ADDR a_ = nullptr;
+    GM_ADDR dw_ = nullptr;
+    GM_ADDR du_ = nullptr;
+    GM_ADDR workspace_ = nullptr;
+    PrepareWyReprBwdInt64Tensor cuSeqlensGm_;
+    PrepareWyReprBwdInt64Tensor chunkIndicesGm_;
+};
+
+} // namespace GDN
+
+#endif // PREPARE_WY_REPR_BWD_CUBE_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/arch35/prepare_wy_repr_bwd_cube_resource.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/arch35/prepare_wy_repr_bwd_cube_resource.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef PREPARE_WY_REPR_BWD_A5_CUBE_RESOURCE_H
+#define PREPARE_WY_REPR_BWD_A5_CUBE_RESOURCE_H
+
+#include "kernel_operator.h"
+
+namespace GDN::A5Pipeline {
+
+template <AscendC::TPosition POSITION, uint32_t SIZE>
+class RawLocalBuffer {
+public:
+    __aicore__ inline RawLocalBuffer()
+    {
+        tensor_ = AscendC::LocalTensor<uint8_t>(POSITION, 0, SIZE);
+    }
+
+    template <typename T>
+    __aicore__ inline AscendC::LocalTensor<T> GetBufferByByte(uint32_t offset) const
+    {
+        return tensor_[offset].template ReinterpretCast<T>();
+    }
+
+private:
+    AscendC::LocalTensor<uint8_t> tensor_;
+};
+
+struct CubeResource {
+    RawLocalBuffer<AscendC::TPosition::A1, 512U * 1024U> l1Buf;
+    RawLocalBuffer<AscendC::TPosition::A2, 64U * 1024U> l0ABuf;
+    RawLocalBuffer<AscendC::TPosition::B2, 64U * 1024U> l0BBuf;
+    RawLocalBuffer<AscendC::TPosition::CO1, 256U * 1024U> l0CBuf;
+    RawLocalBuffer<AscendC::TPosition::VECCALC, 248U * 1024U> ubBuf;
+};
+
+} // namespace GDN::A5Pipeline
+
+#endif // PREPARE_WY_REPR_BWD_A5_CUBE_RESOURCE_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/arch35/prepare_wy_repr_bwd_regbase.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/arch35/prepare_wy_repr_bwd_regbase.h
@@ -1,0 +1,2359 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef PREPARE_WY_REPR_BWD_ARCH35_REGBASE_H
+#define PREPARE_WY_REPR_BWD_ARCH35_REGBASE_H
+
+#include "kernel_operator.h"
+#include "kernel_utils/vector/regbase.hpp"
+
+using namespace AscendC;
+using namespace AscendC::MicroAPI;
+
+template <typename kType, typename betaType>
+class PrepareWyReprBwdRegBase {
+public:
+    constexpr static CastTrait ctHalf2Fp32Zero = {
+        RegLayout::ZERO, SatMode::SAT, MaskMergeMode::ZEROING, AscendC::RoundMode::CAST_NONE,
+    };
+    constexpr static CastTrait ctHalf2Fp32One = {
+        RegLayout::ONE, SatMode::SAT, MaskMergeMode::ZEROING, AscendC::RoundMode::CAST_NONE,
+    };
+    constexpr static CastTrait ctFp322HalfZero = {
+        RegLayout::ZERO, SatMode::NO_SAT, MaskMergeMode::MERGING, AscendC::RoundMode::CAST_ROUND,
+    };
+    constexpr static CastTrait ctFp322HalfOne = {
+        RegLayout::ONE, SatMode::NO_SAT, MaskMergeMode::ZEROING, AscendC::RoundMode::CAST_ROUND,
+    };
+
+    __simd_vf__ inline void ProcessVBetaComputerVFOneLineOneCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ betaType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessVBetaComputerVFMutiLineOneCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ betaType *, uint16_t, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessVBetaComputerVFTwoCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ betaType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessMDuDwComputerVFOneLineOneCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ kType *, uint16_t, uint16_t, uint32_t);
+    __simd_vf__ inline void ProcessMDuDwComputerVFMutiLineOneCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ kType *, uint16_t, uint16_t, uint32_t, uint16_t);
+    __simd_vf__ inline void ProcessKBetaGComputerVFOneLineOneCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ betaType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessKBetaGComputerVFMutiLineOneCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ betaType *,
+        uint16_t, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessKBetaGComputerVFTwoCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ betaType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessKBetaAndKBetaGComputerVFOneLineOneCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ betaType *,
+        uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessKBetaAndKBetaGComputerVFMutiLineOneCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ betaType *,
+        uint16_t, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessGComputerVFOneLineOneCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ betaType *,
+        uint16_t, uint16_t, uint32_t, uint32_t);
+    __simd_vf__ inline void ProcessGComputerVFMutiLineOneCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ betaType *,
+        uint16_t, uint16_t, uint32_t, uint16_t, uint32_t);
+    __simd_vf__ inline void PackFinalDaNz(
+        __ubuf__ kType *, __ubuf__ kType *, uint16_t, uint16_t, uint16_t);
+
+    __simd_vf__ inline void ProcessKBetaComputerVFMutiLineOneCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ betaType *, uint16_t, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessKBetaComputerVFOneLineOneCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ betaType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessKBetaComputerVFTwoCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ betaType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessDkbComputerVFOneLineOneCol(
+        __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ kType *, __ubuf__ betaType *,
+        __ubuf__ kType *, __ubuf__ kType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessDkbComputerVFMutiLineOneCol(
+        __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ kType *, __ubuf__ betaType *,
+        __ubuf__ kType *, __ubuf__ kType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessDkbComputerVFTwoCol(
+        __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ kType *, __ubuf__ betaType *,
+        __ubuf__ kType *, __ubuf__ kType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessDkbgComputerGatherDkVF(
+        __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ betaType *, __ubuf__ kType *,
+        __ubuf__ betaType *, __ubuf__ betaType *, __ubuf__ kType *, __ubuf__ kType *,
+        __ubuf__ betaType *, __ubuf__ kType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessDkbgComputerVF(
+        __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ betaType *, __ubuf__ kType *,
+        __ubuf__ betaType *, __ubuf__ betaType *, __ubuf__ kType *, __ubuf__ betaType *,
+        __ubuf__ kType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessDkbDkbgComputerVF(
+        __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ betaType *, __ubuf__ kType *,
+        __ubuf__ betaType *, __ubuf__ betaType *, __ubuf__ kType *, __ubuf__ kType *,
+        __ubuf__ kType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessDvbComputerVFOneLineOneCol(
+        __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ kType *, __ubuf__ kType *,
+        __ubuf__ betaType *, __ubuf__ betaType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessDvbComputerVFMutiLineOneCol(
+        __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ kType *, __ubuf__ kType *,
+        __ubuf__ betaType *, __ubuf__ betaType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessDvbComputerVFTwoCol(
+        __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ kType *, __ubuf__ kType *,
+        __ubuf__ betaType *, __ubuf__ betaType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessDkGatherComputerVFOneLineOneCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ kType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessDkGatherComputerVFMutiLineOneCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ kType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessDkGatherComputerVFTwoCol(
+        __ubuf__ kType *, __ubuf__ kType *, __ubuf__ kType *, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessKKTComputerVF(
+        __ubuf__ kType *, __ubuf__ betaType *, __ubuf__ kType *, __ubuf__ float *,
+        __ubuf__ float *, uint32_t, uint16_t, uint16_t);
+    __simd_vf__ inline void ProcessKKTComputerVFSub(
+        __ubuf__ betaType *, __ubuf__ betaType *, __ubuf__ float *, __ubuf__ float *, uint16_t);
+};
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessKBetaGComputerVFOneLineOneCol(
+    __ubuf__ kType* kBetaGOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    __ubuf__ betaType* gIn, uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    RegTensor<kType> kInReg;
+    RegTensor<betaType> betaInReg;
+    RegTensor<betaType> gInReg;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg;
+    RegTensor<float> kBetaGFP32ZeroReg, kBetaGFP32OneReg;
+    RegTensor<float> betaFP32Reg, gFP32Reg, betaGFP32Reg;
+    RegTensor<kType> kBetaGOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(gInReg, gIn);
+    LoadIn<kType, false>(kInReg, kIn);
+
+    HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+    HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+    Exp(gFP32Reg, gFP32Reg, maskFull32);
+    Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+
+    CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+    MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaGFP32Reg, betaGFP32Reg, maskFull32);
+    CastFloat2Half<kType>(kBetaGOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+    StoreAlign(kBetaGOut, kBetaGOutReg, maskFull16);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessKBetaGComputerVFMutiLineOneCol(
+    __ubuf__ kType* kBetaGOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    __ubuf__ betaType* gIn, uint16_t mSize, uint16_t nSize, uint16_t lastLoopCnt)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    RegTensor<kType> kInReg, kInReg1;
+    RegTensor<betaType> betaInReg, betaInReg1;
+    RegTensor<betaType> gInReg, gInReg1;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg1, kFP32OneReg1;
+    RegTensor<float> kBetaGFP32ZeroReg, kBetaGFP32OneReg, kBetaGFP32ZeroReg1, kBetaGFP32OneReg1;
+    RegTensor<float> betaFP32Reg, betaFP32Reg1;
+    RegTensor<float> gFP32Reg, gFP32Reg1;
+    RegTensor<float> betaGFP32Reg, betaGFP32Reg1;
+    RegTensor<kType> kBetaGOutReg, kBetaGOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(betaInReg1, betaIn + 1);
+    LoadIn<betaType, true>(gInReg, gIn);
+    LoadIn<betaType, true>(gInReg1, gIn + 1);
+    LoadIn<kType, false>(kInReg, kIn);
+    LoadIn<kType, false>(kInReg1, kIn + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaFP32Reg1, betaInReg1, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1) * PRELOAD_NUM);
+        LoadIn<betaType, true>(betaInReg1, betaIn + (mIdx + 1) * PRELOAD_NUM + 1);
+        HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gFP32Reg1, gInReg1, maskFull16, maskFull32);
+        LoadIn<betaType, true>(gInReg, gIn + (mIdx + 1) * PRELOAD_NUM);
+        LoadIn<betaType, true>(gInReg1, gIn + (mIdx + 1) * PRELOAD_NUM + 1);
+        Exp(gFP32Reg, gFP32Reg, maskFull32);
+        Exp(gFP32Reg1, gFP32Reg1, maskFull32);
+        Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+        Mul(betaGFP32Reg1, betaFP32Reg1, gFP32Reg1, maskFull32);
+
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        LoadIn<kType, false>(kInReg, kIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(kInReg1, kIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaGFP32Reg, betaGFP32Reg, maskFull32);
+        MulFloatTwoReg(kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, betaGFP32Reg1, betaGFP32Reg1, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg1, kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * PRELOAD_NUM), kBetaGOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), kBetaGOutReg1, maskFull16);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaFP32Reg1, betaInReg1, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gFP32Reg1, gInReg1, maskFull16, maskFull32);
+        Exp(gFP32Reg, gFP32Reg, maskFull32);
+        Exp(gFP32Reg1, gFP32Reg1, maskFull32);
+        Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+        Mul(betaGFP32Reg1, betaFP32Reg1, gFP32Reg1, maskFull32);
+
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+
+        MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaGFP32Reg, betaGFP32Reg, maskFull32);
+        MulFloatTwoReg(kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, betaGFP32Reg1, betaGFP32Reg1, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg1, kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * PRELOAD_NUM), kBetaGOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), kBetaGOutReg1, maskFull16);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<betaType, true>(betaInReg, betaIn + mIdx * PRELOAD_NUM);
+            LoadIn<betaType, true>(gInReg, gIn + mIdx * PRELOAD_NUM);
+            LoadIn<kType, false>(kInReg, kIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+            HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+            Exp(gFP32Reg, gFP32Reg, maskFull32);
+            Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaGFP32Reg, betaGFP32Reg, maskFull32);
+            CastFloat2Half<kType>(kBetaGOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * PRELOAD_NUM), kBetaGOutReg, maskFull16);
+        }
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessKBetaGComputerVFTwoCol(
+    __ubuf__ kType* kBetaGOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    __ubuf__ betaType* gIn, uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    uint16_t mLoopCnt = mSize - 1;
+    RegTensor<kType> kInReg, kInReg1;
+    RegTensor<betaType> betaInReg;
+    RegTensor<betaType> gInReg;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg1, kFP32OneReg1;
+    RegTensor<float> kBetaGFP32ZeroReg, kBetaGFP32OneReg, kBetaGFP32ZeroReg1, kBetaGFP32OneReg1;
+    RegTensor<float> betaFP32Reg, gFP32Reg, betaGFP32Reg;
+    RegTensor<kType> kBetaGOutReg, kBetaGOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(gInReg, gIn);
+    LoadIn<kType, false>(kInReg, kIn);
+    LoadIn<kType, false>(kInReg1, kIn + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1));
+        HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+        LoadIn<betaType, true>(gInReg, gIn + (mIdx + 1));
+        Exp(gFP32Reg, gFP32Reg, maskFull32);
+        Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        LoadIn<kType, false>(kInReg, kIn + oneEleNum * ((mIdx + 1) * 2));
+        LoadIn<kType, false>(kInReg1, kIn + oneEleNum * ((mIdx + 1) * 2 + 1));
+
+        MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaGFP32Reg, betaGFP32Reg, maskFull32);
+        MulFloatTwoReg(kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, betaGFP32Reg, betaGFP32Reg, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg1, kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * 2), kBetaGOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * 2 + 1), kBetaGOutReg1, maskFull16);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+        Exp(gFP32Reg, gFP32Reg, maskFull32);
+        Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaGFP32Reg, betaGFP32Reg, maskFull32);
+        MulFloatTwoReg(kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, betaGFP32Reg, betaGFP32Reg, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg1, kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * 2), kBetaGOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * 2 + 1), kBetaGOutReg1, maskFull16);
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessKBetaAndKBetaGComputerVFOneLineOneCol(
+    __ubuf__ kType* kBetaGOut, __ubuf__ kType* kBetaOut, __ubuf__ kType* kIn,
+    __ubuf__ betaType* betaIn, __ubuf__ betaType* gIn, uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    RegTensor<kType> kInReg;
+    RegTensor<betaType> betaInReg;
+    RegTensor<betaType> gInReg;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg;
+    RegTensor<float> kBetaFP32ZeroReg, kBetaFP32OneReg;
+    RegTensor<float> kBetaGFP32ZeroReg, kBetaGFP32OneReg;
+    RegTensor<float> betaFP32Reg, gFP32Reg, betaGFP32Reg;
+    RegTensor<kType> kBetaOutReg, kBetaGOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(gInReg, gIn);
+    LoadIn<kType, false>(kInReg, kIn);
+
+    HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+    HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+    Exp(gFP32Reg, gFP32Reg, maskFull32);
+    Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+
+    CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+    MulFloatTwoReg(kBetaFP32ZeroReg, kBetaFP32OneReg, kFP32ZeroReg, kFP32OneReg,
+                   betaFP32Reg, betaFP32Reg, maskFull32);
+    MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg,
+                   betaGFP32Reg, betaGFP32Reg, maskFull32);
+    CastFloat2Half<kType>(kBetaOutReg, kBetaFP32ZeroReg, kBetaFP32OneReg, maskFull32);
+    CastFloat2Half<kType>(kBetaGOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+    StoreAlign(kBetaOut, kBetaOutReg, maskFull16);
+    StoreAlign(kBetaGOut, kBetaGOutReg, maskFull16);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessKBetaAndKBetaGComputerVFMutiLineOneCol(
+    __ubuf__ kType* kBetaGOut, __ubuf__ kType* kBetaOut, __ubuf__ kType* kIn,
+    __ubuf__ betaType* betaIn, __ubuf__ betaType* gIn, uint16_t mSize, uint16_t nSize,
+    uint16_t lastLoopCnt)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    RegTensor<kType> kInReg, kInReg1;
+    RegTensor<betaType> betaInReg, betaInReg1;
+    RegTensor<betaType> gInReg, gInReg1;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg1, kFP32OneReg1;
+    RegTensor<float> kBetaFP32ZeroReg, kBetaFP32OneReg, kBetaFP32ZeroReg1, kBetaFP32OneReg1;
+    RegTensor<float> kBetaGFP32ZeroReg, kBetaGFP32OneReg, kBetaGFP32ZeroReg1, kBetaGFP32OneReg1;
+    RegTensor<float> betaFP32Reg, betaFP32Reg1;
+    RegTensor<float> gFP32Reg, gFP32Reg1;
+    RegTensor<float> betaGFP32Reg, betaGFP32Reg1;
+    RegTensor<kType> kBetaOutReg, kBetaOutReg1;
+    RegTensor<kType> kBetaGOutReg, kBetaGOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(betaInReg1, betaIn + 1);
+    LoadIn<betaType, true>(gInReg, gIn);
+    LoadIn<betaType, true>(gInReg1, gIn + 1);
+    LoadIn<kType, false>(kInReg, kIn);
+    LoadIn<kType, false>(kInReg1, kIn + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaFP32Reg1, betaInReg1, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1) * PRELOAD_NUM);
+        LoadIn<betaType, true>(betaInReg1, betaIn + (mIdx + 1) * PRELOAD_NUM + 1);
+        HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gFP32Reg1, gInReg1, maskFull16, maskFull32);
+        LoadIn<betaType, true>(gInReg, gIn + (mIdx + 1) * PRELOAD_NUM);
+        LoadIn<betaType, true>(gInReg1, gIn + (mIdx + 1) * PRELOAD_NUM + 1);
+        Exp(gFP32Reg, gFP32Reg, maskFull32);
+        Exp(gFP32Reg1, gFP32Reg1, maskFull32);
+        Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+        Mul(betaGFP32Reg1, betaFP32Reg1, gFP32Reg1, maskFull32);
+
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        LoadIn<kType, false>(kInReg, kIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(kInReg1, kIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        MulFloatTwoReg(kBetaFP32ZeroReg, kBetaFP32OneReg, kFP32ZeroReg, kFP32OneReg,
+                       betaFP32Reg, betaFP32Reg, maskFull32);
+        MulFloatTwoReg(kBetaFP32ZeroReg1, kBetaFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1,
+                       betaFP32Reg1, betaFP32Reg1, maskFull32);
+        MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg,
+                       betaGFP32Reg, betaGFP32Reg, maskFull32);
+        MulFloatTwoReg(kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1,
+                       betaGFP32Reg1, betaGFP32Reg1, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg, kBetaFP32ZeroReg, kBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg1, kBetaFP32ZeroReg1, kBetaFP32OneReg1, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg1, kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * PRELOAD_NUM), kBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), kBetaOutReg1, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * PRELOAD_NUM), kBetaGOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), kBetaGOutReg1, maskFull16);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaFP32Reg1, betaInReg1, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gFP32Reg1, gInReg1, maskFull16, maskFull32);
+        Exp(gFP32Reg, gFP32Reg, maskFull32);
+        Exp(gFP32Reg1, gFP32Reg1, maskFull32);
+        Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+        Mul(betaGFP32Reg1, betaFP32Reg1, gFP32Reg1, maskFull32);
+
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+
+        MulFloatTwoReg(kBetaFP32ZeroReg, kBetaFP32OneReg, kFP32ZeroReg, kFP32OneReg,
+                       betaFP32Reg, betaFP32Reg, maskFull32);
+        MulFloatTwoReg(kBetaFP32ZeroReg1, kBetaFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1,
+                       betaFP32Reg1, betaFP32Reg1, maskFull32);
+        MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg,
+                       betaGFP32Reg, betaGFP32Reg, maskFull32);
+        MulFloatTwoReg(kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1,
+                       betaGFP32Reg1, betaGFP32Reg1, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg, kBetaFP32ZeroReg, kBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg1, kBetaFP32ZeroReg1, kBetaFP32OneReg1, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaGOutReg1, kBetaGFP32ZeroReg1, kBetaGFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * PRELOAD_NUM), kBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), kBetaOutReg1, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * PRELOAD_NUM), kBetaGOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), kBetaGOutReg1, maskFull16);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<betaType, true>(betaInReg, betaIn + mIdx * PRELOAD_NUM);
+            LoadIn<betaType, true>(gInReg, gIn + mIdx * PRELOAD_NUM);
+            LoadIn<kType, false>(kInReg, kIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+            HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+            Exp(gFP32Reg, gFP32Reg, maskFull32);
+            Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            MulFloatTwoReg(kBetaFP32ZeroReg, kBetaFP32OneReg, kFP32ZeroReg, kFP32OneReg,
+                           betaFP32Reg, betaFP32Reg, maskFull32);
+            MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg,
+                           betaGFP32Reg, betaGFP32Reg, maskFull32);
+            CastFloat2Half<kType>(kBetaOutReg, kBetaFP32ZeroReg, kBetaFP32OneReg, maskFull32);
+            CastFloat2Half<kType>(kBetaGOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * PRELOAD_NUM), kBetaOutReg, maskFull16);
+            StoreAlign((__ubuf__ kType*&)kBetaGOut + oneEleNum * (mIdx * PRELOAD_NUM), kBetaGOutReg, maskFull16);
+        }
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessVBetaComputerVFOneLineOneCol(
+    __ubuf__ kType* vBetaOut, __ubuf__ kType* vIn, __ubuf__ betaType* betaIn,
+    uint16_t mSize, uint16_t nSize)
+{
+    RegTensor<kType> vInReg;
+    RegTensor<betaType> betaInReg;
+    RegTensor<float> vFP32ZeroReg, vFP32OneReg;
+    RegTensor<float> vBetaFP32ZeroReg, vBetaFP32OneReg;
+    RegTensor<float> betaBrcbFP32Reg;
+    RegTensor<kType> vBetaOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<kType, false>(vInReg, vIn);
+
+    HalfOrFloat2Float<betaType>(betaBrcbFP32Reg, betaInReg, maskFull16, maskFull32);
+    CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+    MulFloatTwoReg(vBetaFP32ZeroReg, vBetaFP32OneReg, vFP32ZeroReg, vFP32OneReg, betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+    CastFloat2Half<kType>(vBetaOutReg, vBetaFP32ZeroReg, vBetaFP32OneReg, maskFull32);
+    StoreAlign(vBetaOut, vBetaOutReg, maskFull16);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessVBetaComputerVFMutiLineOneCol(
+    __ubuf__ kType* vBetaOut, __ubuf__ kType* vIn, __ubuf__ betaType* betaIn,
+    uint16_t mSize, uint16_t nSize, uint16_t lastLoopCnt)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    RegTensor<kType> vInReg, vInReg1;
+    RegTensor<betaType> betaInReg, betaInReg1;
+    RegTensor<float> vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg1, vFP32OneReg1;
+    RegTensor<float> vBetaFP32ZeroReg, vBetaFP32OneReg, vBetaFP32ZeroReg1, vBetaFP32OneReg1;
+    RegTensor<float> betaBrcbFP32Reg, betaBrcbFP32Reg1;
+    RegTensor<kType> vBetaOutReg, vBetaOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(betaInReg1, betaIn + 1);
+    LoadIn<kType, false>(vInReg, vIn);
+    LoadIn<kType, false>(vInReg1, vIn + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32Reg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32Reg1, betaInReg1, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1) * PRELOAD_NUM);
+        LoadIn<betaType, true>(betaInReg1, betaIn + (mIdx + 1) * PRELOAD_NUM + 1);
+        CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+        CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+        LoadIn<kType, false>(vInReg, vIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(vInReg1, vIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        MulFloatTwoReg(vBetaFP32ZeroReg, vBetaFP32OneReg, vFP32ZeroReg, vFP32OneReg, betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+        MulFloatTwoReg(vBetaFP32ZeroReg1, vBetaFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1, betaBrcbFP32Reg1, betaBrcbFP32Reg1, maskFull32);
+        CastFloat2Half<kType>(vBetaOutReg, vBetaFP32ZeroReg, vBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(vBetaOutReg1, vBetaFP32ZeroReg1, vBetaFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * PRELOAD_NUM), vBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), vBetaOutReg1, maskFull16);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32Reg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32Reg1, betaInReg1, maskFull16, maskFull32);
+        CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+        CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+        MulFloatTwoReg(vBetaFP32ZeroReg, vBetaFP32OneReg, vFP32ZeroReg, vFP32OneReg, betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+        MulFloatTwoReg(vBetaFP32ZeroReg1, vBetaFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1, betaBrcbFP32Reg1, betaBrcbFP32Reg1, maskFull32);
+        CastFloat2Half<kType>(vBetaOutReg, vBetaFP32ZeroReg, vBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(vBetaOutReg1, vBetaFP32ZeroReg1, vBetaFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * PRELOAD_NUM), vBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), vBetaOutReg1, maskFull16);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<betaType, true>(betaInReg, betaIn + mIdx * PRELOAD_NUM);
+            LoadIn<kType, false>(vInReg, vIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            HalfOrFloat2Float<betaType>(betaBrcbFP32Reg, betaInReg, maskFull16, maskFull32);
+            CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+            MulFloatTwoReg(vBetaFP32ZeroReg, vBetaFP32OneReg, vFP32ZeroReg, vFP32OneReg, betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+            CastFloat2Half<kType>(vBetaOutReg, vBetaFP32ZeroReg, vBetaFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * PRELOAD_NUM), vBetaOutReg, maskFull16);
+        }
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessVBetaComputerVFTwoCol(
+    __ubuf__ kType* vBetaOut, __ubuf__ kType* vIn, __ubuf__ betaType* betaIn,
+    uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    uint16_t mLoopCnt = mSize - 1;
+    RegTensor<kType> vInReg, vInReg1;
+    RegTensor<betaType> betaInReg;
+    RegTensor<float> vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg1, vFP32OneReg1;
+    RegTensor<float> vBetaFP32ZeroReg, vBetaFP32OneReg, vBetaFP32ZeroReg1, vBetaFP32OneReg1;
+    RegTensor<float> betaBrcbFP32Reg;
+    RegTensor<kType> vBetaOutReg, vBetaOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<kType, false>(vInReg, vIn);
+    LoadIn<kType, false>(vInReg1, vIn + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32Reg, betaInReg, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1));
+        CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+        CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+        LoadIn<kType, false>(vInReg, vIn + oneEleNum * ((mIdx + 1) * 2));
+        LoadIn<kType, false>(vInReg1, vIn + oneEleNum * ((mIdx + 1) * 2 + 1));
+        MulFloatTwoReg(vBetaFP32ZeroReg, vBetaFP32OneReg, vFP32ZeroReg, vFP32OneReg, betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+        MulFloatTwoReg(vBetaFP32ZeroReg1, vBetaFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1, betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+        CastFloat2Half<kType>(vBetaOutReg, vBetaFP32ZeroReg, vBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(vBetaOutReg1, vBetaFP32ZeroReg1, vBetaFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * 2), vBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * 2 + 1), vBetaOutReg1, maskFull16);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32Reg, betaInReg, maskFull16, maskFull32);
+        CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+        CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+        MulFloatTwoReg(vBetaFP32ZeroReg, vBetaFP32OneReg, vFP32ZeroReg, vFP32OneReg, betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+        MulFloatTwoReg(vBetaFP32ZeroReg1, vBetaFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1, betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+        CastFloat2Half<kType>(vBetaOutReg, vBetaFP32ZeroReg, vBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(vBetaOutReg1, vBetaFP32ZeroReg1, vBetaFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * 2), vBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)vBetaOut + oneEleNum * (mIdx * 2 + 1), vBetaOutReg1, maskFull16);
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessMDuDwComputerVFOneLineOneCol(
+    __ubuf__ kType* mduwOut, __ubuf__ kType* mduIn, __ubuf__ kType* mdwIn,
+    uint16_t mSize, uint16_t nSize, uint32_t startRow)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    RegTensor<kType> mduInReg, mdwInReg;
+    RegTensor<float> mduFP32ZeroReg, mduFP32OneReg;
+    RegTensor<float> mdwFP32ZeroReg, mdwFP32OneReg;
+    RegTensor<half> colIdxReg;
+    RegTensor<float> colIdxFP32ZeroReg, colIdxFP32OneReg;
+    RegTensor<float> resultFP32ZeroReg, resultFP32OneReg, zeroReg, rowIdxReg;
+    RegTensor<kType> mduwOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    MaskReg maskZeroSelect, maskOneSelect;
+    MaskReg maskStore;
+    Duplicate(zeroReg, static_cast<float>(0), maskFull32);
+    Arange(colIdxReg, 0);
+    CastHalf2Float<half>(colIdxFP32ZeroReg, colIdxFP32OneReg, colIdxReg, maskFull16);
+
+    LoadIn<kType, false>(mduInReg, mduIn);
+    LoadIn<kType, false>(mdwInReg, mdwIn);
+    Duplicate(rowIdxReg, static_cast<float>(startRow));
+    CastHalf2Float<kType>(mduFP32ZeroReg, mduFP32OneReg, mduInReg, maskFull16);
+    CastHalf2Float<kType>(mdwFP32ZeroReg, mdwFP32OneReg, mdwInReg, maskFull16);
+    AddFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, mduFP32ZeroReg, mduFP32OneReg, mdwFP32ZeroReg, mdwFP32OneReg, maskFull32);
+
+    CompareTwoReg<float, CMPMODE::GE>(maskZeroSelect, maskOneSelect, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+    SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg, resultFP32ZeroReg, resultFP32OneReg, maskZeroSelect, maskOneSelect);
+
+    CastFloat2Half<kType>(mduwOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+    uint32_t storeLen = oneEleNum;
+    maskStore = UpdateMask<kType>(storeLen);
+    StoreAlign(mduwOut, mduwOutReg, maskStore);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessMDuDwComputerVFMutiLineOneCol(
+    __ubuf__ kType* mduwOut, __ubuf__ kType* mduIn, __ubuf__ kType* mdwIn,
+    uint16_t mSize, uint16_t nSize, uint32_t startRow, uint16_t lastLoopCnt)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    RegTensor<kType> mduInReg, mduInReg1;
+    RegTensor<kType> mdwInReg, mdwInReg1;
+    RegTensor<float> mduFP32ZeroReg, mduFP32OneReg, mduFP32ZeroReg1, mduFP32OneReg1;
+    RegTensor<float> mdwFP32ZeroReg, mdwFP32OneReg, mdwFP32ZeroReg1, mdwFP32OneReg1;
+    RegTensor<half> colIdxReg;
+    RegTensor<float> colIdxFP32ZeroReg, colIdxFP32OneReg;
+    RegTensor<float> resultFP32ZeroReg, resultFP32OneReg, resultFP32ZeroReg1, resultFP32OneReg1, zeroReg, rowIdxReg;
+    RegTensor<kType> mduwOutReg, mduwOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+    MaskReg maskZeroSelect, maskOneSelect;
+    MaskReg maskZeroSelect1, maskOneSelect1;
+    MaskReg maskStore;
+    Duplicate(zeroReg, static_cast<float>(0), maskFull32);
+    Arange(colIdxReg, 0);
+    CastHalf2Float<half>(colIdxFP32ZeroReg, colIdxFP32OneReg, colIdxReg, maskFull16);
+
+    LoadIn<kType, false>(mduInReg, mduIn);
+    LoadIn<kType, false>(mduInReg1, mduIn + oneEleNum);
+    LoadIn<kType, false>(mdwInReg, mdwIn);
+    LoadIn<kType, false>(mdwInReg1, mdwIn + oneEleNum);
+
+    Duplicate(rowIdxReg, static_cast<float>(startRow));
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        CastHalf2Float<kType>(mduFP32ZeroReg, mduFP32OneReg, mduInReg, maskFull16);
+        CastHalf2Float<kType>(mduFP32ZeroReg1, mduFP32OneReg1, mduInReg1, maskFull16);
+        LoadIn<kType, false>(mduInReg, mduIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(mduInReg1, mduIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(mdwFP32ZeroReg, mdwFP32OneReg, mdwInReg, maskFull16);
+        CastHalf2Float<kType>(mdwFP32ZeroReg1, mdwFP32OneReg1, mdwInReg1, maskFull16);
+        LoadIn<kType, false>(mdwInReg, mdwIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(mdwInReg1, mdwIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        AddFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, mduFP32ZeroReg, mduFP32OneReg, mdwFP32ZeroReg, mdwFP32OneReg, maskFull32);
+        AddFloatTwoReg(resultFP32ZeroReg1, resultFP32OneReg1, mduFP32ZeroReg1, mduFP32OneReg1, mdwFP32ZeroReg1, mdwFP32OneReg1, maskFull32);
+
+        CompareTwoReg<float, CMPMODE::GE>(maskZeroSelect, maskOneSelect, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg, resultFP32ZeroReg, resultFP32OneReg, maskZeroSelect, maskOneSelect);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+        CompareTwoReg<float, CMPMODE::GE>(maskZeroSelect1, maskOneSelect1, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg1, resultFP32OneReg1, zeroReg, zeroReg, resultFP32ZeroReg1, resultFP32OneReg1, maskZeroSelect1, maskOneSelect1);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+        CastFloat2Half<kType>(mduwOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(mduwOutReg1, resultFP32ZeroReg1, resultFP32OneReg1, maskFull32);
+        uint32_t storeLen = oneEleNum;
+        maskStore = UpdateMask<kType>(storeLen);
+        StoreAlign((__ubuf__ kType*&)mduwOut + oneEleNum * (mIdx * PRELOAD_NUM), mduwOutReg, maskStore);
+        storeLen = oneEleNum;
+        maskStore = UpdateMask<kType>(storeLen);
+        StoreAlign((__ubuf__ kType*&)mduwOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), mduwOutReg1, maskStore);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        CastHalf2Float<kType>(mduFP32ZeroReg, mduFP32OneReg, mduInReg, maskFull16);
+        CastHalf2Float<kType>(mduFP32ZeroReg1, mduFP32OneReg1, mduInReg1, maskFull16);
+        CastHalf2Float<kType>(mdwFP32ZeroReg, mdwFP32OneReg, mdwInReg, maskFull16);
+        CastHalf2Float<kType>(mdwFP32ZeroReg1, mdwFP32OneReg1, mdwInReg1, maskFull16);
+
+        AddFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, mduFP32ZeroReg, mduFP32OneReg, mdwFP32ZeroReg, mdwFP32OneReg, maskFull32);
+        AddFloatTwoReg(resultFP32ZeroReg1, resultFP32OneReg1, mduFP32ZeroReg1, mduFP32OneReg1, mdwFP32ZeroReg1, mdwFP32OneReg1, maskFull32);
+
+        CompareTwoReg<float, CMPMODE::GE>(maskZeroSelect, maskOneSelect, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg, resultFP32ZeroReg, resultFP32OneReg, maskZeroSelect, maskOneSelect);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+        CompareTwoReg<float, CMPMODE::GE>(maskZeroSelect1, maskOneSelect1, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg1, resultFP32OneReg1, zeroReg, zeroReg, resultFP32ZeroReg1, resultFP32OneReg1, maskZeroSelect1, maskOneSelect1);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+        CastFloat2Half<kType>(mduwOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(mduwOutReg1, resultFP32ZeroReg1, resultFP32OneReg1, maskFull32);
+        uint32_t storeLen = oneEleNum;
+        maskStore = UpdateMask<kType>(storeLen);
+        StoreAlign((__ubuf__ kType*&)mduwOut + oneEleNum * (mIdx * PRELOAD_NUM), mduwOutReg, maskStore);
+        storeLen = oneEleNum;
+        maskStore = UpdateMask<kType>(storeLen);
+        StoreAlign((__ubuf__ kType*&)mduwOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), mduwOutReg1, maskStore);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<kType, false>(mduInReg, mduIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            LoadIn<kType, false>(mdwInReg, mdwIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            CastHalf2Float<kType>(mduFP32ZeroReg, mduFP32OneReg, mduInReg, maskFull16);
+            CastHalf2Float<kType>(mdwFP32ZeroReg, mdwFP32OneReg, mdwInReg, maskFull16);
+            AddFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, mduFP32ZeroReg, mduFP32OneReg, mdwFP32ZeroReg, mdwFP32OneReg, maskFull32);
+
+            CompareTwoReg<float, CMPMODE::GE>(maskZeroSelect, maskOneSelect, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+            SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg, resultFP32ZeroReg, resultFP32OneReg, maskZeroSelect, maskOneSelect);
+
+            CastFloat2Half<kType>(mduwOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+            uint32_t storeLen = oneEleNum;
+            maskStore = UpdateMask<kType>(storeLen);
+            StoreAlign((__ubuf__ kType*&)mduwOut + oneEleNum * (mIdx * PRELOAD_NUM), mduwOutReg, maskStore);
+        }
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessGComputerVFOneLineOneCol(
+    __ubuf__ kType* dAOut, __ubuf__ kType* dA6In, __ubuf__ betaType* gIn, __ubuf__ betaType* gAllIn,
+    uint16_t mSize, uint16_t nSize, uint32_t startRow, uint32_t calcColSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    RegTensor<kType> dA6InReg;
+    RegTensor<betaType> gInReg, gAllInReg;
+    RegTensor<float> dA6FP32ZeroReg, dA6FP32OneReg;
+    RegTensor<float> gFP32ZeroReg;
+    RegTensor<float> gFactorZeroReg, gFactorOneReg;
+    RegTensor<float> gAllFP32ZeroReg, gAllFP32OneReg;
+    RegTensor<float> resultFP32ZeroReg, resultFP32OneReg;
+    RegTensor<half> colIdxReg;
+    RegTensor<float> colIdxFP32ZeroReg, colIdxFP32OneReg;
+    RegTensor<float> zeroReg, negOneReg, rowIdxReg;
+    RegTensor<kType> dAOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+    MaskReg maskZeroSelect, maskOneSelect;
+    MaskReg maskStore;
+    MaskReg castDA6MaskCount16;
+    uint32_t castDA6Count = calcColSize;
+    castDA6MaskCount16 = UpdateMask<kType>(castDA6Count);
+
+    Duplicate(zeroReg, static_cast<float>(0), maskFull32);
+    Duplicate(negOneReg, static_cast<float>(-1), maskFull32);
+    Arange(colIdxReg, 0);
+    CastHalf2Float<half>(colIdxFP32ZeroReg, colIdxFP32OneReg, colIdxReg, maskFull16);
+
+    if constexpr (!std::is_same<betaType, float>()) {
+        LoadAlign(gAllInReg, gAllIn);
+        Cast<float, betaType, ctHalf2Fp32Zero>(gAllFP32ZeroReg, gAllInReg, maskFull16);
+        Cast<float, betaType, ctHalf2Fp32One>(gAllFP32OneReg, gAllInReg, maskFull16);
+    } else {
+        LoadAlign<betaType, LoadDist::DIST_DINTLV_B32>(gAllFP32ZeroReg, gAllFP32OneReg, gAllIn);
+    }
+    LoadIn<kType, false>(dA6InReg, dA6In);
+    LoadIn<betaType, true>(gInReg, gIn);
+
+    Duplicate(rowIdxReg, static_cast<float>(startRow));
+    CastHalf2Float<kType>(dA6FP32ZeroReg, dA6FP32OneReg, dA6InReg, castDA6MaskCount16);
+    HalfOrFloat2Float<betaType>(gFP32ZeroReg, gInReg, maskFull16, maskFull32);
+
+    SubFloatTwoReg(gFactorZeroReg, gFactorOneReg, gAllFP32ZeroReg, gAllFP32OneReg, gFP32ZeroReg, gFP32ZeroReg, maskFull32);
+    MinsFloatTwoReg(gFactorZeroReg, gFactorOneReg, gFactorZeroReg, gFactorOneReg, float(0.0), maskFull32);
+    ExpFloatTwoReg(gFactorZeroReg, gFactorOneReg, gFactorZeroReg, gFactorOneReg, maskFull32);
+
+    // result = -dA6 * gAll
+    MulFloatTwoReg(dA6FP32ZeroReg, dA6FP32OneReg, dA6FP32ZeroReg, dA6FP32OneReg, negOneReg, negOneReg, maskFull32);
+    MulFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, dA6FP32ZeroReg, dA6FP32OneReg, gFactorZeroReg, gFactorOneReg, maskFull32);
+
+    CompareTwoReg<float, CMPMODE::LE>(maskZeroSelect, maskOneSelect, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+    SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg, resultFP32ZeroReg, resultFP32OneReg, maskZeroSelect, maskOneSelect);
+    Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+    CastFloat2Half<kType>(dAOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+    uint32_t storeLen = oneEleNum;
+    maskStore = UpdateMask<kType>(storeLen);
+    StoreAlign((__ubuf__ kType*&)dAOut, dAOutReg, maskStore);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessGComputerVFMutiLineOneCol(
+    __ubuf__ kType* dAOut, __ubuf__ kType* dA6In, __ubuf__ betaType* gIn, __ubuf__ betaType* gAllIn,
+    uint16_t mSize, uint16_t nSize, uint32_t startRow, uint16_t lastLoopCnt, uint32_t calcColSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    RegTensor<kType> dA6InReg, dA6InReg1;
+    RegTensor<betaType> gInReg, gInReg1, gAllInReg;
+    RegTensor<float> dA6FP32ZeroReg, dA6FP32OneReg, dA6FP32ZeroReg1, dA6FP32OneReg1;
+    RegTensor<float> gFP32ZeroReg, gFP32ZeroReg1;
+    RegTensor<float> gFactorZeroReg, gFactorOneReg, gFactorZeroReg1, gFactorOneReg1;
+    RegTensor<float> gAllFP32ZeroReg, gAllFP32OneReg;
+    RegTensor<float> resultFP32ZeroReg, resultFP32OneReg, resultFP32ZeroReg1, resultFP32OneReg1;
+    RegTensor<half> colIdxReg;
+    RegTensor<float> colIdxFP32ZeroReg, colIdxFP32OneReg;
+    RegTensor<float> zeroReg, negOneReg, rowIdxReg;
+    RegTensor<kType> dAOutReg, dAOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+    MaskReg maskZeroSelect, maskOneSelect;
+    MaskReg maskZeroSelect1, maskOneSelect1;
+    MaskReg maskStore;
+    MaskReg castDA6MaskCount16;
+
+    Duplicate(zeroReg, static_cast<float>(0), maskFull32);
+    Duplicate(negOneReg, static_cast<float>(-1), maskFull32);
+    Arange(colIdxReg, 0);
+    CastHalf2Float<half>(colIdxFP32ZeroReg, colIdxFP32OneReg, colIdxReg, maskFull16);
+
+    if constexpr (!std::is_same<betaType, float>()) {
+        LoadAlign(gAllInReg, gAllIn);
+        Cast<float, betaType, ctHalf2Fp32Zero>(gAllFP32ZeroReg, gAllInReg, maskFull16);
+        Cast<float, betaType, ctHalf2Fp32One>(gAllFP32OneReg, gAllInReg, maskFull16);
+    } else {
+        LoadAlign<betaType, LoadDist::DIST_DINTLV_B32>(gAllFP32ZeroReg, gAllFP32OneReg, gAllIn);
+    }
+    LoadIn<kType, false>(dA6InReg, dA6In);
+    LoadIn<kType, false>(dA6InReg1, dA6In + oneEleNum);
+    LoadIn<betaType, true>(gInReg, gIn);
+    LoadIn<betaType, true>(gInReg1, gIn + 1);
+
+    Duplicate(rowIdxReg, static_cast<float>(startRow));
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        uint32_t castDA6Count = calcColSize;
+        castDA6MaskCount16 = UpdateMask<kType>(castDA6Count);
+        CastHalf2Float<kType>(dA6FP32ZeroReg, dA6FP32OneReg, dA6InReg, castDA6MaskCount16);
+        castDA6Count = calcColSize;
+        castDA6MaskCount16 = UpdateMask<kType>(castDA6Count);
+        CastHalf2Float<kType>(dA6FP32ZeroReg1, dA6FP32OneReg1, dA6InReg1, castDA6MaskCount16);
+        LoadIn<kType, false>(dA6InReg, dA6In + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dA6InReg1, dA6In + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        HalfOrFloat2Float<betaType>(gFP32ZeroReg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gFP32ZeroReg1, gInReg1, maskFull16, maskFull32);
+        LoadIn<betaType, true>(gInReg, gIn + (mIdx + 1) * PRELOAD_NUM);
+        LoadIn<betaType, true>(gInReg1, gIn + (mIdx + 1) * PRELOAD_NUM + 1);
+
+        SubFloatTwoReg(gFactorZeroReg, gFactorOneReg, gAllFP32ZeroReg, gAllFP32OneReg, gFP32ZeroReg, gFP32ZeroReg, maskFull32);
+        SubFloatTwoReg(gFactorZeroReg1, gFactorOneReg1, gAllFP32ZeroReg, gAllFP32OneReg, gFP32ZeroReg1, gFP32ZeroReg1, maskFull32);
+        MinsFloatTwoReg(gFactorZeroReg, gFactorOneReg, gFactorZeroReg, gFactorOneReg, float(0.0), maskFull32);
+        MinsFloatTwoReg(gFactorZeroReg1, gFactorOneReg1, gFactorZeroReg1, gFactorOneReg1, float(0.0), maskFull32);
+        ExpFloatTwoReg(gFactorZeroReg, gFactorOneReg, gFactorZeroReg, gFactorOneReg, maskFull32);
+        ExpFloatTwoReg(gFactorZeroReg1, gFactorOneReg1, gFactorZeroReg1, gFactorOneReg1, maskFull32);
+
+        // result = -dA6 * gAll
+        MulFloatTwoReg(dA6FP32ZeroReg, dA6FP32OneReg, dA6FP32ZeroReg, dA6FP32OneReg, negOneReg, negOneReg, maskFull32);
+        MulFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, dA6FP32ZeroReg, dA6FP32OneReg, gFactorZeroReg, gFactorOneReg, maskFull32);
+        MulFloatTwoReg(dA6FP32ZeroReg1, dA6FP32OneReg1, dA6FP32ZeroReg1, dA6FP32OneReg1, negOneReg, negOneReg, maskFull32);
+        MulFloatTwoReg(resultFP32ZeroReg1, resultFP32OneReg1, dA6FP32ZeroReg1, dA6FP32OneReg1, gFactorZeroReg1, gFactorOneReg1, maskFull32);
+
+        CompareTwoReg<float, CMPMODE::LE>(maskZeroSelect, maskOneSelect, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg, resultFP32ZeroReg, resultFP32OneReg, maskZeroSelect, maskOneSelect);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+        CompareTwoReg<float, CMPMODE::LE>(maskZeroSelect1, maskOneSelect1, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg1, resultFP32OneReg1, zeroReg, zeroReg, resultFP32ZeroReg1, resultFP32OneReg1, maskZeroSelect1, maskOneSelect1);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+        CastFloat2Half<kType>(dAOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dAOutReg1, resultFP32ZeroReg1, resultFP32OneReg1, maskFull32);
+
+        uint32_t storeLen = oneEleNum;
+        maskStore = UpdateMask<kType>(storeLen);
+        StoreAlign((__ubuf__ kType*&)dAOut + oneEleNum * (mIdx * PRELOAD_NUM), dAOutReg, maskStore);
+        storeLen = oneEleNum;
+        maskStore = UpdateMask<kType>(storeLen);
+        StoreAlign((__ubuf__ kType*&)dAOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dAOutReg1, maskStore);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        uint32_t castDA6Count = calcColSize;
+        castDA6MaskCount16 = UpdateMask<kType>(castDA6Count);
+        CastHalf2Float<kType>(dA6FP32ZeroReg, dA6FP32OneReg, dA6InReg, castDA6MaskCount16);
+        castDA6Count = calcColSize;
+        castDA6MaskCount16 = UpdateMask<kType>(castDA6Count);
+        CastHalf2Float<kType>(dA6FP32ZeroReg1, dA6FP32OneReg1, dA6InReg1, castDA6MaskCount16);
+        HalfOrFloat2Float<betaType>(gFP32ZeroReg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gFP32ZeroReg1, gInReg1, maskFull16, maskFull32);
+
+        SubFloatTwoReg(gFactorZeroReg, gFactorOneReg, gAllFP32ZeroReg, gAllFP32OneReg, gFP32ZeroReg, gFP32ZeroReg, maskFull32);
+        SubFloatTwoReg(gFactorZeroReg1, gFactorOneReg1, gAllFP32ZeroReg, gAllFP32OneReg, gFP32ZeroReg1, gFP32ZeroReg1, maskFull32);
+        MinsFloatTwoReg(gFactorZeroReg, gFactorOneReg, gFactorZeroReg, gFactorOneReg, float(0.0), maskFull32);
+        MinsFloatTwoReg(gFactorZeroReg1, gFactorOneReg1, gFactorZeroReg1, gFactorOneReg1, float(0.0), maskFull32);
+        ExpFloatTwoReg(gFactorZeroReg, gFactorOneReg, gFactorZeroReg, gFactorOneReg, maskFull32);
+        ExpFloatTwoReg(gFactorZeroReg1, gFactorOneReg1, gFactorZeroReg1, gFactorOneReg1, maskFull32);
+
+        // result = -dA6 * gAll
+        MulFloatTwoReg(dA6FP32ZeroReg, dA6FP32OneReg, dA6FP32ZeroReg, dA6FP32OneReg, negOneReg, negOneReg, maskFull32);
+        MulFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, dA6FP32ZeroReg, dA6FP32OneReg, gFactorZeroReg, gFactorOneReg, maskFull32);
+        MulFloatTwoReg(dA6FP32ZeroReg1, dA6FP32OneReg1, dA6FP32ZeroReg1, dA6FP32OneReg1, negOneReg, negOneReg, maskFull32);
+        MulFloatTwoReg(resultFP32ZeroReg1, resultFP32OneReg1, dA6FP32ZeroReg1, dA6FP32OneReg1, gFactorZeroReg1, gFactorOneReg1, maskFull32);
+
+        CompareTwoReg<float, CMPMODE::LE>(maskZeroSelect, maskOneSelect, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg, resultFP32ZeroReg, resultFP32OneReg, maskZeroSelect, maskOneSelect);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+        CompareTwoReg<float, CMPMODE::LE>(maskZeroSelect1, maskOneSelect1, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+        SelectTwoReg(resultFP32ZeroReg1, resultFP32OneReg1, zeroReg, zeroReg, resultFP32ZeroReg1, resultFP32OneReg1, maskZeroSelect1, maskOneSelect1);
+        Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+        CastFloat2Half<kType>(dAOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dAOutReg1, resultFP32ZeroReg1, resultFP32OneReg1, maskFull32);
+        uint32_t storeLen = oneEleNum;
+        maskStore = UpdateMask<kType>(storeLen);
+        StoreAlign((__ubuf__ kType*&)dAOut + oneEleNum * (mIdx * PRELOAD_NUM), dAOutReg, maskStore);
+        storeLen = oneEleNum;
+        maskStore = UpdateMask<kType>(storeLen);
+        StoreAlign((__ubuf__ kType*&)dAOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dAOutReg1, maskStore);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<kType, false>(dA6InReg, dA6In + oneEleNum * (mIdx * PRELOAD_NUM));
+            LoadIn<betaType, true>(gInReg, gIn + mIdx * PRELOAD_NUM);
+
+            uint32_t castDA6Count = calcColSize;
+            castDA6MaskCount16 = UpdateMask<kType>(castDA6Count);
+            CastHalf2Float<kType>(dA6FP32ZeroReg, dA6FP32OneReg, dA6InReg, castDA6MaskCount16);
+            HalfOrFloat2Float<betaType>(gFP32ZeroReg, gInReg, maskFull16, maskFull32);
+
+            SubFloatTwoReg(gFactorZeroReg, gFactorOneReg, gAllFP32ZeroReg, gAllFP32OneReg, gFP32ZeroReg, gFP32ZeroReg, maskFull32);
+            MinsFloatTwoReg(gFactorZeroReg, gFactorOneReg, gFactorZeroReg, gFactorOneReg, float(0.0), maskFull32);
+            ExpFloatTwoReg(gFactorZeroReg, gFactorOneReg, gFactorZeroReg, gFactorOneReg, maskFull32);
+
+            // result = -dA6 * gAll
+            MulFloatTwoReg(dA6FP32ZeroReg, dA6FP32OneReg, dA6FP32ZeroReg, dA6FP32OneReg, negOneReg, negOneReg, maskFull32);
+            MulFloatTwoReg(resultFP32ZeroReg, resultFP32OneReg, dA6FP32ZeroReg, dA6FP32OneReg, gFactorZeroReg, gFactorOneReg, maskFull32);
+
+            CompareTwoReg<float, CMPMODE::LE>(maskZeroSelect, maskOneSelect, colIdxFP32ZeroReg, colIdxFP32OneReg, rowIdxReg, rowIdxReg, maskFull32);
+            SelectTwoReg(resultFP32ZeroReg, resultFP32OneReg, zeroReg, zeroReg, resultFP32ZeroReg, resultFP32OneReg, maskZeroSelect, maskOneSelect);
+            Adds(rowIdxReg, rowIdxReg, static_cast<float>(1), maskFull32);
+
+            CastFloat2Half<kType>(dAOutReg, resultFP32ZeroReg, resultFP32OneReg, maskFull32);
+            uint32_t storeLen = oneEleNum;
+            maskStore = UpdateMask<kType>(storeLen);
+            StoreAlign((__ubuf__ kType*&)dAOut + oneEleNum * (mIdx * PRELOAD_NUM), dAOutReg, maskStore);
+        }
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::PackFinalDaNz(
+    __ubuf__ kType* dst, __ubuf__ kType* src, uint16_t rows, uint16_t cols, uint16_t srcStride)
+{
+    RegTensor<kType> dataReg;
+    uint32_t dataCount = cols;
+    MaskReg dataMask = UpdateMask<kType>(dataCount);
+    uint16_t alignedRows = (rows + 15U) & ~15U;
+    __ubuf__ kType* dstPtr = dst;
+
+    for (uint16_t row = 0; row < rows; ++row) {
+        LoadAlign(dataReg, src + row * srcStride);
+        StoreAlign<kType, DataCopyMode::DATA_BLOCK_COPY, PostLiteral::POST_MODE_UPDATE>(
+            dstPtr, dataReg, alignedRows, 1U, dataMask);
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessKKTComputerVF(
+    __ubuf__ kType* kktIn, __ubuf__ betaType* betaIn, __ubuf__ kType* daIn,
+    __ubuf__ float* reducesum1, __ubuf__ float* reducesum0,
+    uint32_t calcColSize, uint16_t mSize, uint16_t nSize)
+{
+    RegTensor<betaType> betaInReg;
+    RegTensor<kType> kktInReg;
+    RegTensor<kType> daInReg;
+    RegTensor<float> betaFP32ZeroReg, betaFP32OneReg, kktFP32ZeroReg, kktFP32OneReg, daFP32ZeroReg, daFP32OneReg;
+    RegTensor<float> daaFP32ZeroReg, daaFP32OneReg, daaFP32AddReg, reduceSumReg, Sum1DaaLineFP32Reg;
+    RegTensor<float> dgFP32AddZeroReg, dgFP32AddOneReg;
+    RegTensor<float> reducesum0ZeroReg, reducesum0OneReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    uint32_t calcNNum = calcColSize;
+    UnalignRegForStore uStoreReducesum;
+
+    if constexpr (!std::is_same<betaType, float>()) {
+        LoadAlign(betaInReg, betaIn);
+        Cast<float, betaType, ctHalf2Fp32Zero>(betaFP32ZeroReg, betaInReg, maskFull16);
+        Cast<float, betaType, ctHalf2Fp32One>(betaFP32OneReg, betaInReg, maskFull16);
+    } else {
+        LoadAlign<betaType, LoadDist::DIST_DINTLV_B32>(betaFP32ZeroReg, betaFP32OneReg, betaIn);
+    }
+    Duplicate(dgFP32AddZeroReg, static_cast<float>(0), maskFull32);
+    Duplicate(dgFP32AddOneReg, static_cast<float>(0), maskFull32);
+    uint32_t nextEleOffset = 0;
+    // 先copy第一块数据
+    LoadAlign(kktInReg, kktIn);
+    LoadAlign(daInReg, daIn);
+    // 做前mSize-1行的exe并copy下一个loop需要的数据
+    for (uint16_t mIdx = 0; mIdx < mSize - 1; mIdx++) {
+        Duplicate(reduceSumReg, static_cast<float>(0), maskFull32);
+        uint32_t castKktCountZero = calcNNum;
+        uint32_t castKktCountOne = calcNNum;
+        MaskReg castKktMaskCountZero16, castKktMaskCountOne16, castDaMaskCountZero16, castDaMaskCountOne16;
+        castKktMaskCountZero16 = UpdateMask<half>(castKktCountZero);
+        castKktMaskCountOne16 = UpdateMask<half>(castKktCountOne);
+        uint32_t castDaCountZero = calcNNum;
+        uint32_t castDaCountOne = calcNNum;
+        castDaMaskCountZero16 = UpdateMask<half>(castDaCountZero);
+        castDaMaskCountOne16 = UpdateMask<half>(castDaCountOne);
+        Cast<float, kType, ctHalf2Fp32Zero>(kktFP32ZeroReg, kktInReg, castKktMaskCountZero16);
+        Cast<float, kType, ctHalf2Fp32One>(kktFP32OneReg, kktInReg, castKktMaskCountOne16);
+        Cast<float, kType, ctHalf2Fp32Zero>(daFP32ZeroReg, daInReg, castDaMaskCountZero16);
+        Cast<float, kType, ctHalf2Fp32One>(daFP32OneReg, daInReg, castDaMaskCountOne16);
+        uint32_t nextEleOffset = (mIdx + 1) * nSize;
+        LoadAlign(kktInReg, kktIn + nextEleOffset);
+        LoadAlign(daInReg, daIn + nextEleOffset);
+        Mul(kktFP32ZeroReg, kktFP32ZeroReg, betaFP32ZeroReg, maskFull32);
+        Mul(kktFP32OneReg, kktFP32OneReg, betaFP32OneReg, maskFull32);
+        Mul(daaFP32ZeroReg, daFP32ZeroReg, kktFP32ZeroReg, maskFull32);
+        Mul(daaFP32OneReg, daFP32OneReg, kktFP32OneReg, maskFull32);
+        // 每行相加
+        Add(daaFP32AddReg, daaFP32ZeroReg, daaFP32OneReg, maskFull32);
+        Add(reduceSumReg, reduceSumReg, daaFP32AddReg, maskFull32);
+        // 每列相加
+        Add(dgFP32AddZeroReg, dgFP32AddZeroReg, daaFP32ZeroReg, maskFull32);
+        Add(dgFP32AddOneReg, dgFP32AddOneReg, daaFP32OneReg, maskFull32);
+        ReduceSum(Sum1DaaLineFP32Reg, reduceSumReg, maskFull32);
+        auto actReducesum1 = reducesum1 + mIdx;
+        StoreUnAlign(actReducesum1, Sum1DaaLineFP32Reg, uStoreReducesum, 1);
+        StoreUnAlignPost(actReducesum1, uStoreReducesum, 0);
+    }
+    // 最后一行数据exe
+    uint16_t mIdx = mSize - 1;
+    {
+        Duplicate(reduceSumReg, static_cast<float>(0), maskFull32);
+        uint32_t castKktCountZero = calcNNum;
+        uint32_t castKktCountOne = calcNNum;
+        MaskReg castKktMaskCountZero16, castKktMaskCountOne16, castDaMaskCountZero16, castDaMaskCountOne16;
+        castKktMaskCountZero16 = UpdateMask<half>(castKktCountZero);
+        castKktMaskCountOne16 = UpdateMask<half>(castKktCountOne);
+        uint32_t castDaCountZero = calcNNum;
+        uint32_t castDaCountOne = calcNNum;
+        castDaMaskCountZero16 = UpdateMask<half>(castDaCountZero);
+        castDaMaskCountOne16 = UpdateMask<half>(castDaCountOne);
+        Cast<float, kType, ctHalf2Fp32Zero>(kktFP32ZeroReg, kktInReg, castKktMaskCountZero16);
+        Cast<float, kType, ctHalf2Fp32One>(kktFP32OneReg, kktInReg, castKktMaskCountOne16);
+        Cast<float, kType, ctHalf2Fp32Zero>(daFP32ZeroReg, daInReg, castDaMaskCountZero16);
+        Cast<float, kType, ctHalf2Fp32One>(daFP32OneReg, daInReg, castDaMaskCountOne16);
+        Mul(kktFP32ZeroReg, kktFP32ZeroReg, betaFP32ZeroReg, maskFull32);
+        Mul(kktFP32OneReg, kktFP32OneReg, betaFP32OneReg, maskFull32);
+        Mul(daaFP32ZeroReg, daFP32ZeroReg, kktFP32ZeroReg, maskFull32);
+        Mul(daaFP32OneReg, daFP32OneReg, kktFP32OneReg, maskFull32);
+        // 每行相加
+        Add(daaFP32AddReg, daaFP32ZeroReg, daaFP32OneReg, maskFull32);
+        Add(reduceSumReg, reduceSumReg, daaFP32AddReg, maskFull32);
+        // 每列相加
+        Add(dgFP32AddZeroReg, dgFP32AddZeroReg, daaFP32ZeroReg, maskFull32);
+        Add(dgFP32AddOneReg, dgFP32AddOneReg, daaFP32OneReg, maskFull32);
+        ReduceSum(Sum1DaaLineFP32Reg, reduceSumReg, maskFull32);
+        auto actReducesum1 = reducesum1 + mIdx;
+        StoreUnAlign(actReducesum1, Sum1DaaLineFP32Reg, uStoreReducesum, 1);
+        StoreUnAlignPost(actReducesum1, uStoreReducesum, 0);
+    }
+    LoadAlign<float, LoadDist::DIST_DINTLV_B32>(reducesum0ZeroReg, reducesum0OneReg, reducesum0);
+    Add(reducesum0ZeroReg, reducesum0ZeroReg, dgFP32AddZeroReg, maskFull32);
+    Add(reducesum0OneReg, reducesum0OneReg, dgFP32AddOneReg, maskFull32);
+    StoreAlign<float, StoreDist::DIST_INTLV_B32>(reducesum0, reducesum0ZeroReg, reducesum0OneReg, maskFull32);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessKKTComputerVFSub(
+    __ubuf__ betaType* dgOut, __ubuf__ betaType* dgIn, __ubuf__ float* reducesum1, __ubuf__ float* reducesum0,
+    uint16_t calcSize)
+{
+    uint32_t eleNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(betaType);
+    uint16_t nLoopCnt = (calcSize + eleNumPerVf - 1) / eleNumPerVf;
+
+    RegTensor<betaType> dgInReg;
+    RegTensor<float> sum1DaaLineZeroFP32Reg, sum1DaaLineOneFP32Reg, dgFP32AddZeroReg, dgFP32AddOneReg;
+    RegTensor<float> dgFP32ZeroReg, dgFP32OneReg;
+    RegTensor<betaType> dgOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt; vfBlockIdx++) {
+        uint32_t eleOffset = vfBlockIdx * eleNumPerVf;
+        if constexpr (!std::is_same<betaType, float>()) {
+            LoadAlign<float, LoadDist::DIST_DINTLV_B32>(sum1DaaLineZeroFP32Reg, sum1DaaLineOneFP32Reg, reducesum1 + eleOffset);
+            LoadAlign<float, LoadDist::DIST_DINTLV_B32>(dgFP32AddZeroReg, dgFP32AddOneReg, reducesum0 + eleOffset);
+            LoadAlign(dgInReg, dgIn + eleOffset);
+            Sub(dgFP32AddZeroReg, dgFP32AddZeroReg, sum1DaaLineZeroFP32Reg, maskFull32);
+            Sub(dgFP32AddOneReg, dgFP32AddOneReg, sum1DaaLineOneFP32Reg, maskFull32);
+
+            Cast<float, betaType, ctHalf2Fp32Zero>(dgFP32ZeroReg, dgInReg, maskFull16);
+            Cast<float, betaType, ctHalf2Fp32One>(dgFP32OneReg, dgInReg, maskFull16);
+            Add(dgFP32AddZeroReg, dgFP32AddZeroReg, dgFP32ZeroReg, maskFull32);
+            Add(dgFP32AddOneReg, dgFP32AddOneReg, dgFP32OneReg, maskFull32);
+
+            Cast<betaType, float, ctFp322HalfOne>(dgOutReg, dgFP32AddOneReg, maskFull32);
+            Cast<betaType, float, ctFp322HalfZero>(dgOutReg, dgFP32AddZeroReg, maskFull32);
+            UnalignRegForStore uStoreDg;
+            auto actDgOut = dgOut + eleOffset;
+            uint32_t copyNum = min(eleNumPerVf, static_cast<uint32_t>(calcSize) - eleOffset);
+            StoreUnAlign(actDgOut, dgOutReg, uStoreDg, copyNum);
+            StoreUnAlignPost(actDgOut, uStoreDg, 0);
+        } else {
+            LoadAlign(sum1DaaLineZeroFP32Reg, reducesum1 + eleOffset);
+            LoadAlign(dgFP32AddZeroReg, reducesum0 + eleOffset);
+            LoadAlign(dgFP32ZeroReg, dgIn + eleOffset);
+            Sub(dgFP32AddZeroReg, dgFP32AddZeroReg, sum1DaaLineZeroFP32Reg, maskFull32);
+            Add(dgFP32AddZeroReg, dgFP32AddZeroReg, dgFP32ZeroReg, maskFull32);
+
+            UnalignRegForStore uStoreDg;
+            auto actDgOut = dgOut + eleOffset;
+            uint32_t copyNum = min(eleNumPerVf, static_cast<uint32_t>(calcSize) - eleOffset);
+            StoreUnAlign(actDgOut, dgFP32AddZeroReg, uStoreDg, copyNum);
+            StoreUnAlignPost(actDgOut, uStoreDg, 0);
+        }
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessDvbComputerVFMutiLineOneCol(
+    __ubuf__ kType* dvOut, __ubuf__ betaType* dBetaOut, __ubuf__ kType* dvbIn, __ubuf__ kType* vIn,
+    __ubuf__ betaType* betaIn, __ubuf__ betaType* dbetaIn, uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    uint16_t lastLoopCnt = mSize % PRELOAD_NUM;
+    RegTensor<betaType> betaInReg, betaInReg1;
+    RegTensor<kType> vInReg, vInReg1;
+    RegTensor<kType> dvbInReg, dvbInReg1;
+    RegTensor<float> betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg1;
+    RegTensor<float> vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg1, vFP32OneReg1;
+    RegTensor<float> dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg1, dvbFP32OneReg1;
+    RegTensor<betaType> dbetaInReg;
+    RegTensor<float> dbetaFP32Reg;
+    RegTensor<float> dBetaFP32Reg;
+    RegTensor<kType> dvOutReg, dvOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    UnalignRegForStore uStore;
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(betaInReg1, betaIn + 1);
+    LoadIn<kType, false>(vInReg, vIn);
+    LoadIn<kType, false>(vInReg1, vIn + oneEleNum);
+    LoadIn<kType, false>(dvbInReg, dvbIn);
+    LoadIn<kType, false>(dvbInReg1, dvbIn + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg1, betaInReg1, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1) * PRELOAD_NUM);
+        LoadIn<betaType, true>(betaInReg1, betaIn + (mIdx + 1) * PRELOAD_NUM + 1);
+        CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+        CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+        LoadIn<kType, false>(vInReg, vIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(vInReg1, vIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(dvbFP32ZeroReg, dvbFP32OneReg, dvbInReg, maskFull16);
+        CastHalf2Float<kType>(dvbFP32ZeroReg1, dvbFP32OneReg1, dvbInReg1, maskFull16);
+        LoadIn<kType, false>(dvbInReg, dvbIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dvbInReg1, dvbIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        MulFloatTwoReg(vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg, vFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+        MulFloatTwoReg(dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+
+        MulFloatTwoReg(vFP32ZeroReg1, vFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, maskFull32);
+        MulFloatTwoReg(dvbFP32ZeroReg1, dvbFP32OneReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, betaBrcbFP32ZeroReg1, betaBrcbFP32ZeroReg1, maskFull32);
+
+        CastFloat2Half<kType>(dvOutReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dvOutReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM), dvOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dvOutReg1, maskFull16);
+
+        // Row 0: dBeta = reduceSum(v * dvb) + dbeta
+        Add(vFP32ZeroReg, vFP32ZeroReg, vFP32OneReg, maskFull32);
+        ReduceSum(dBetaFP32Reg, vFP32ZeroReg, maskFull32);
+        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM);
+        HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
+
+        // Row 1
+        Add(vFP32ZeroReg1, vFP32ZeroReg1, vFP32OneReg1, maskFull32);
+        ReduceSum(dBetaFP32Reg, vFP32ZeroReg1, maskFull32);
+        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM + 1);
+        HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM + 1, dBetaFP32Reg, maskFull32, uStore, 1);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg1, betaInReg1, maskFull16, maskFull32);
+        CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+        CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+        CastHalf2Float<kType>(dvbFP32ZeroReg, dvbFP32OneReg, dvbInReg, maskFull16);
+        CastHalf2Float<kType>(dvbFP32ZeroReg1, dvbFP32OneReg1, dvbInReg1, maskFull16);
+
+        MulFloatTwoReg(vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg, vFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+        MulFloatTwoReg(dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        MulFloatTwoReg(vFP32ZeroReg1, vFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, maskFull32);
+        MulFloatTwoReg(dvbFP32ZeroReg1, dvbFP32OneReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, betaBrcbFP32ZeroReg1, betaBrcbFP32ZeroReg1, maskFull32);
+
+        CastFloat2Half<kType>(dvOutReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dvOutReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM), dvOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dvOutReg1, maskFull16);
+
+        Add(vFP32ZeroReg, vFP32ZeroReg, vFP32OneReg, maskFull32);
+        ReduceSum(dBetaFP32Reg, vFP32ZeroReg, maskFull32);
+        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM);
+        HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
+
+        Add(vFP32ZeroReg1, vFP32ZeroReg1, vFP32OneReg1, maskFull32);
+        ReduceSum(dBetaFP32Reg, vFP32ZeroReg1, maskFull32);
+        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM + 1);
+        HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM + 1, dBetaFP32Reg, maskFull32, uStore, 1);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<betaType, true>(betaInReg, betaIn + mIdx * PRELOAD_NUM);
+            LoadIn<kType, false>(vInReg, vIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            LoadIn<kType, false>(dvbInReg, dvbIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+            CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+            CastHalf2Float<kType>(dvbFP32ZeroReg, dvbFP32OneReg, dvbInReg, maskFull16);
+            MulFloatTwoReg(vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg, vFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+            MulFloatTwoReg(dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            CastFloat2Half<kType>(dvOutReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM), dvOutReg, maskFull16);
+
+            Add(vFP32ZeroReg, vFP32ZeroReg, vFP32OneReg, maskFull32);
+            ReduceSum(dBetaFP32Reg, vFP32ZeroReg, maskFull32);
+            LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx * PRELOAD_NUM);
+            HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+            Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+            StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
+        }
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessDvbComputerVFOneLineOneCol(
+    __ubuf__ kType* dvOut, __ubuf__ betaType* dBetaOut, __ubuf__ kType* dvbIn, __ubuf__ kType* vIn,
+    __ubuf__ betaType* betaIn, __ubuf__ betaType* dbetaIn, uint16_t mSize, uint16_t nSize)
+{
+    RegTensor<betaType> betaInReg;
+    RegTensor<kType> vInReg;
+    RegTensor<kType> dvbInReg;
+    RegTensor<float> betaBrcbFP32ZeroReg;
+    RegTensor<float> vFP32ZeroReg, vFP32OneReg;
+    RegTensor<float> dvbFP32ZeroReg, dvbFP32OneReg;
+    RegTensor<betaType> dbetaInReg;
+    RegTensor<float> dbetaFP32Reg;
+    RegTensor<float> dBetaFP32Reg;
+    RegTensor<kType> dvOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    UnalignRegForStore uStore;
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<kType, false>(vInReg, vIn);
+    LoadIn<kType, false>(dvbInReg, dvbIn);
+    HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+    CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+    CastHalf2Float<kType>(dvbFP32ZeroReg, dvbFP32OneReg, dvbInReg, maskFull16);
+    MulFloatTwoReg(vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg, vFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+    MulFloatTwoReg(dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+    CastFloat2Half<kType>(dvOutReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+    StoreAlign((__ubuf__ kType*&)dvOut, dvOutReg, maskFull16);
+
+    Add(vFP32ZeroReg, vFP32ZeroReg, vFP32OneReg, maskFull32);
+    ReduceSum(dBetaFP32Reg, vFP32ZeroReg, maskFull32);
+    LoadIn<betaType, true>(dbetaInReg, dbetaIn);
+    HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+    Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+    StoreUnAlignOut<betaType>(dBetaOut, dBetaFP32Reg, maskFull32, uStore, 1);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessDvbComputerVFTwoCol(
+    __ubuf__ kType* dvOut, __ubuf__ betaType* dBetaOut, __ubuf__ kType* dvbIn, __ubuf__ kType* vIn,
+    __ubuf__ betaType* betaIn, __ubuf__ betaType* dbetaIn, uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    uint16_t mLoopCnt = mSize - 1;
+    RegTensor<betaType> betaInReg;
+    RegTensor<kType> vInReg, vInReg1;
+    RegTensor<kType> dvbInReg, dvbInReg1;
+    RegTensor<float> betaBrcbFP32ZeroReg;
+    RegTensor<float> vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg1, vFP32OneReg1;
+    RegTensor<float> dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg1, dvbFP32OneReg1;
+    RegTensor<betaType> dbetaInReg;
+    RegTensor<float> dbetaFP32Reg;
+    RegTensor<float> dBetaFP32Reg, dBetaFP32Reg1;
+    RegTensor<kType> dvOutReg, dvOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    UnalignRegForStore uStore;
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<kType, false>(vInReg, vIn);
+    LoadIn<kType, false>(vInReg1, vIn + oneEleNum);
+    LoadIn<kType, false>(dvbInReg, dvbIn);
+    LoadIn<kType, false>(dvbInReg1, dvbIn + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + mIdx + 1);
+        CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+        CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+        LoadIn<kType, false>(vInReg, vIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(vInReg1, vIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(dvbFP32ZeroReg, dvbFP32OneReg, dvbInReg, maskFull16);
+        CastHalf2Float<kType>(dvbFP32ZeroReg1, dvbFP32OneReg1, dvbInReg1, maskFull16);
+        LoadIn<kType, false>(dvbInReg, dvbIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dvbInReg1, dvbIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        MulFloatTwoReg(vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg, vFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+        MulFloatTwoReg(dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        MulFloatTwoReg(vFP32ZeroReg1, vFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, maskFull32);
+        MulFloatTwoReg(dvbFP32ZeroReg1, dvbFP32OneReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+
+        CastFloat2Half<kType>(dvOutReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dvOutReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM), dvOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dvOutReg1, maskFull16);
+
+        Add(vFP32ZeroReg, vFP32ZeroReg, vFP32OneReg, maskFull32);
+        ReduceSum(dBetaFP32Reg, vFP32ZeroReg, maskFull32);
+        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx);
+        HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+
+        Add(vFP32ZeroReg1, vFP32ZeroReg1, vFP32OneReg1, maskFull32);
+        ReduceSum(dBetaFP32Reg1, vFP32ZeroReg1, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dBetaFP32Reg1, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaFP32Reg, maskFull32, uStore, 1);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+        CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+        CastHalf2Float<kType>(dvbFP32ZeroReg, dvbFP32OneReg, dvbInReg, maskFull16);
+        CastHalf2Float<kType>(dvbFP32ZeroReg1, dvbFP32OneReg1, dvbInReg1, maskFull16);
+
+        MulFloatTwoReg(vFP32ZeroReg, vFP32OneReg, vFP32ZeroReg, vFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+        MulFloatTwoReg(dvbFP32ZeroReg, dvbFP32OneReg, dvbFP32ZeroReg, dvbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        MulFloatTwoReg(vFP32ZeroReg1, vFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, maskFull32);
+        MulFloatTwoReg(dvbFP32ZeroReg1, dvbFP32OneReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+
+        CastFloat2Half<kType>(dvOutReg, dvbFP32ZeroReg, dvbFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dvOutReg1, dvbFP32ZeroReg1, dvbFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM), dvOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dvOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dvOutReg1, maskFull16);
+
+        Add(vFP32ZeroReg, vFP32ZeroReg, vFP32OneReg, maskFull32);
+        ReduceSum(dBetaFP32Reg, vFP32ZeroReg, maskFull32);
+        LoadIn<betaType, true>(dbetaInReg, dbetaIn + mIdx);
+        HalfOrFloat2Float<betaType>(dbetaFP32Reg, dbetaInReg, maskFull16, maskFull32);
+
+        Add(vFP32ZeroReg1, vFP32ZeroReg1, vFP32OneReg1, maskFull32);
+        ReduceSum(dBetaFP32Reg1, vFP32ZeroReg1, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dBetaFP32Reg1, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dbetaFP32Reg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaFP32Reg, maskFull32, uStore, 1);
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessDkbgComputerGatherDkVF(
+    __ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut, __ubuf__ betaType* dgOut,
+    __ubuf__ kType* kIn, __ubuf__ betaType* betaIn, __ubuf__ betaType* gIn,
+    __ubuf__ kType* dkIn, __ubuf__ kType* dkGatherIn, __ubuf__ betaType* dBetaIn, __ubuf__ kType* dkbgIn,
+    uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint16_t nLoopCnt = (nSize + eleKNumPerVf - 1) / eleKNumPerVf;
+    uint16_t mLoopCnt = mSize - 1;
+    RegTensor<kType> kInReg;
+    RegTensor<betaType> betaInReg;
+    RegTensor<betaType> gInReg;
+    RegTensor<kType> dkInReg, dkGatherInReg;
+    RegTensor<betaType> dbetaInReg;
+    RegTensor<kType> dkbgInReg;
+    RegTensor<float> betaBrcbFP32ZeroReg, dkFP32ZeroReg, dkFP32OneReg, dkGatherFP32ZeroReg, dkGatherFP32OneReg, dgFP32ZeroReg;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, dBetaAddZeroReg, dkbgFP32ZeroReg, dkbgFP32OneReg;
+    RegTensor<float> gBrcbFP32ZeroReg, dbetaFP32ZeroReg, dbetaFP32OneReg;
+    RegTensor<float> kReduceSumReg, dkReduceSumReg;
+    RegTensor<kType> dkOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    UnalignRegForStore uStoreDBeta;
+    UnalignRegForStore uStoreDg;
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(gInReg, gIn);
+    LoadIn<betaType, true>(dbetaInReg, dBetaIn);
+    LoadIn<kType>(kInReg, kIn);
+    LoadIn<kType>(dkbgInReg, dkbgIn);
+    LoadIn<kType>(dkInReg, dkIn);
+    LoadIn<kType>(dkGatherInReg, dkGatherIn);
+    // 前mSize - 1行
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gBrcbFP32ZeroReg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(dbetaFP32ZeroReg, dbetaInReg, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1));
+        LoadIn<betaType, true>(gInReg, gIn + (mIdx + 1));
+        LoadIn<betaType, true>(dbetaInReg, dBetaIn + (mIdx + 1));
+
+        Exp(gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+        Duplicate(kReduceSumReg, static_cast<float>(0), maskFull32);
+        Duplicate(dkReduceSumReg, static_cast<float>(0), maskFull32);
+        for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt; vfBlockIdx++) {
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            CastHalf2Float<kType>(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgInReg, maskFull16);
+            LoadIn<kType>(kInReg, kIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            LoadIn<kType>(dkbgInReg, dkbgIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            MulFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+            Add(kReduceSumReg, kReduceSumReg, kFP32ZeroReg, maskFull32);
+            Add(dkFP32ZeroReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            Add(dkReduceSumReg, dkReduceSumReg, dkFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+
+            CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+            LoadIn<kType>(dkInReg, dkIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            CastHalf2Float<kType>(dkGatherFP32ZeroReg, dkGatherFP32OneReg, dkGatherInReg, maskFull16);
+            LoadIn<kType>(dkGatherInReg, dkGatherIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkGatherFP32ZeroReg, dkGatherFP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + mIdx * nSize + vfBlockIdx * eleKNumPerVf, dkOutReg, maskFull16);
+        }
+        ReduceSum(dBetaAddZeroReg, kReduceSumReg, maskFull32);
+        ReduceSum(dgFP32ZeroReg, dkReduceSumReg, maskFull32);
+        Add(dBetaAddZeroReg, dBetaAddZeroReg, dbetaFP32ZeroReg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaAddZeroReg, maskFull32, uStoreDBeta, 1);
+        StoreUnAlignOut<betaType>(dgOut + mIdx, dgFP32ZeroReg, maskFull32, uStoreDg, 1);
+    }
+    // 最后一行
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gBrcbFP32ZeroReg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(dbetaFP32ZeroReg, dbetaInReg, maskFull16, maskFull32);
+
+        Exp(gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+        Duplicate(kReduceSumReg, static_cast<float>(0), maskFull32);
+        Duplicate(dkReduceSumReg, static_cast<float>(0), maskFull32);
+        // 最后一行的前nLoopCnt - 1
+        for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt - 1; vfBlockIdx++) {
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            CastHalf2Float<kType>(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgInReg, maskFull16);
+            LoadIn<kType>(kInReg, kIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            LoadIn<kType>(dkbgInReg, dkbgIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            MulFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+            Add(kReduceSumReg, kReduceSumReg, kFP32ZeroReg, maskFull32);
+            Add(dkFP32ZeroReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            Add(dkReduceSumReg, dkReduceSumReg, dkFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+
+            CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+            LoadIn<kType>(dkInReg, dkIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            CastHalf2Float<kType>(dkGatherFP32ZeroReg, dkGatherFP32OneReg, dkGatherInReg, maskFull16);
+            LoadIn<kType>(dkGatherInReg, dkGatherIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkGatherFP32ZeroReg, dkGatherFP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + mIdx * nSize + vfBlockIdx * eleKNumPerVf, dkOutReg, maskFull16);
+        }
+        // 最后一行最后一个loop
+        uint16_t vfBlockIdx = nLoopCnt - 1;
+        {
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            CastHalf2Float<kType>(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgInReg, maskFull16);
+
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            MulFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+            Add(kReduceSumReg, kReduceSumReg, kFP32ZeroReg, maskFull32);
+            Add(dkFP32ZeroReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            Add(dkReduceSumReg, dkReduceSumReg, dkFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+
+            CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+            CastHalf2Float<kType>(dkGatherFP32ZeroReg, dkGatherFP32OneReg, dkGatherInReg, maskFull16);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkGatherFP32ZeroReg, dkGatherFP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + mIdx * nSize + vfBlockIdx * eleKNumPerVf, dkOutReg, maskFull16);
+        }
+        ReduceSum(dBetaAddZeroReg, kReduceSumReg, maskFull32);
+        ReduceSum(dgFP32ZeroReg, dkReduceSumReg, maskFull32);
+        Add(dBetaAddZeroReg, dBetaAddZeroReg, dbetaFP32ZeroReg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaAddZeroReg, maskFull32, uStoreDBeta, 1);
+        StoreUnAlignOut<betaType>(dgOut + mIdx, dgFP32ZeroReg, maskFull32, uStoreDg, 1);
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessDkbgComputerVF(
+    __ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut, __ubuf__ betaType* dgOut,
+    __ubuf__ kType* kIn, __ubuf__ betaType* betaIn, __ubuf__ betaType* gIn,
+    __ubuf__ kType* dkIn, __ubuf__ betaType* dBetaIn, __ubuf__ kType* dkbgIn,
+    uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint16_t nLoopCnt = (nSize + eleKNumPerVf - 1) / eleKNumPerVf;
+    uint16_t mLoopCnt = mSize - 1;
+    RegTensor<kType> kInReg;
+    RegTensor<betaType> betaInReg;
+    RegTensor<betaType> gInReg;
+    RegTensor<kType> dkInReg;
+    RegTensor<betaType> dbetaInReg;
+    RegTensor<kType> dkbgInReg;
+    RegTensor<float> betaBrcbFP32ZeroReg, dkFP32ZeroReg, dkFP32OneReg, dgFP32ZeroReg;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, dBetaAddZeroReg, dkbgFP32ZeroReg, dkbgFP32OneReg;
+    RegTensor<float> gBrcbFP32ZeroReg, dbetaFP32ZeroReg, dbetaFP32OneReg;
+    RegTensor<float> kReduceSumReg, dkReduceSumReg;
+    RegTensor<kType> dkOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    UnalignRegForStore uStoreDBeta;
+    UnalignRegForStore uStoreDg;
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(gInReg, gIn);
+    LoadIn<betaType, true>(dbetaInReg, dBetaIn);
+    LoadIn<kType>(kInReg, kIn);
+    LoadIn<kType>(dkbgInReg, dkbgIn);
+    LoadIn<kType>(dkInReg, dkIn);
+    // 前mSize - 1行
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gBrcbFP32ZeroReg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(dbetaFP32ZeroReg, dbetaInReg, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1));
+        LoadIn<betaType, true>(gInReg, gIn + (mIdx + 1));
+        LoadIn<betaType, true>(dbetaInReg, dBetaIn + (mIdx + 1));
+
+        Exp(gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+        Duplicate(kReduceSumReg, static_cast<float>(0), maskFull32);
+        Duplicate(dkReduceSumReg, static_cast<float>(0), maskFull32);
+        for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt; vfBlockIdx++) {
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            CastHalf2Float<kType>(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgInReg, maskFull16);
+            LoadIn<kType>(kInReg, kIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            LoadIn<kType>(dkbgInReg, dkbgIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            MulFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+            Add(kReduceSumReg, kReduceSumReg, kFP32ZeroReg, maskFull32);
+            Add(dkFP32ZeroReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            Add(dkReduceSumReg, dkReduceSumReg, dkFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+
+            CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+            LoadIn<kType>(dkInReg, dkIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + mIdx * nSize + vfBlockIdx * eleKNumPerVf, dkOutReg, maskFull16);
+        }
+        ReduceSum(dBetaAddZeroReg, kReduceSumReg, maskFull32);
+        ReduceSum(dgFP32ZeroReg, dkReduceSumReg, maskFull32);
+        Add(dBetaAddZeroReg, dBetaAddZeroReg, dbetaFP32ZeroReg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaAddZeroReg, maskFull32, uStoreDBeta, 1);
+        StoreUnAlignOut<betaType>(dgOut + mIdx, dgFP32ZeroReg, maskFull32, uStoreDg, 1);
+    }
+    // 最后一行
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gBrcbFP32ZeroReg, gInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(dbetaFP32ZeroReg, dbetaInReg, maskFull16, maskFull32);
+
+        Exp(gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+        Duplicate(kReduceSumReg, static_cast<float>(0), maskFull32);
+        Duplicate(dkReduceSumReg, static_cast<float>(0), maskFull32);
+        // 最后一行的前nLoopCnt - 1
+        for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt - 1; vfBlockIdx++) {
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            CastHalf2Float<kType>(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgInReg, maskFull16);
+            LoadIn<kType>(kInReg, kIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            LoadIn<kType>(dkbgInReg, dkbgIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            MulFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+            Add(kReduceSumReg, kReduceSumReg, kFP32ZeroReg, maskFull32);
+            Add(dkFP32ZeroReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            Add(dkReduceSumReg, dkReduceSumReg, dkFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+
+            CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+            LoadIn<kType>(dkInReg, dkIn + mIdx * nSize + (vfBlockIdx + 1) * eleKNumPerVf);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + mIdx * nSize + vfBlockIdx * eleKNumPerVf, dkOutReg, maskFull16);
+        }
+        // 最后一行最后一个loop
+        uint16_t vfBlockIdx = nLoopCnt - 1;
+        {
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            CastHalf2Float<kType>(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgInReg, maskFull16);
+
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            MulFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+            Add(kReduceSumReg, kReduceSumReg, kFP32ZeroReg, maskFull32);
+            Add(dkFP32ZeroReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            Add(dkReduceSumReg, dkReduceSumReg, dkFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+
+            CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + mIdx * nSize + vfBlockIdx * eleKNumPerVf, dkOutReg, maskFull16);
+        }
+        ReduceSum(dBetaAddZeroReg, kReduceSumReg, maskFull32);
+        ReduceSum(dgFP32ZeroReg, dkReduceSumReg, maskFull32);
+        Add(dBetaAddZeroReg, dBetaAddZeroReg, dbetaFP32ZeroReg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaAddZeroReg, maskFull32, uStoreDBeta, 1);
+        StoreUnAlignOut<betaType>(dgOut + mIdx, dgFP32ZeroReg, maskFull32, uStoreDg, 1);
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessDkbDkbgComputerVF(
+    __ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut, __ubuf__ betaType* dgOut,
+    __ubuf__ kType* kIn, __ubuf__ betaType* betaIn, __ubuf__ betaType* gIn,
+    __ubuf__ kType* dkIn, __ubuf__ kType* dkbIn, __ubuf__ kType* dkbgIn,
+    uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint16_t nLoopCnt = (nSize + eleKNumPerVf - 1) / eleKNumPerVf;
+    RegTensor<betaType> betaInReg;
+    RegTensor<betaType> gInReg;
+    RegTensor<kType> kInReg;
+    RegTensor<kType> dkInReg;
+    RegTensor<kType> dkbInReg;
+    RegTensor<kType> dkbgInReg;
+    RegTensor<float> betaBrcbFP32ZeroReg, gBrcbFP32ZeroReg;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg;
+    RegTensor<float> dkFP32ZeroReg, dkFP32OneReg;
+    RegTensor<float> dkbFP32ZeroReg, dkbFP32OneReg;
+    RegTensor<float> dkbgFP32ZeroReg, dkbgFP32OneReg;
+    RegTensor<float> mulFP32ZeroReg, mulFP32OneReg;
+    RegTensor<float> dBetaReduceReg, dgReduceReg, dBetaOutReg, dgOutReg;
+    RegTensor<kType> dkOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    UnalignRegForStore uStoreDBeta;
+    UnalignRegForStore uStoreDg;
+
+    for (uint16_t mIdx = 0; mIdx < mSize; mIdx++) {
+        LoadIn<betaType, true>(betaInReg, betaIn + mIdx);
+        LoadIn<betaType, true>(gInReg, gIn + mIdx);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gBrcbFP32ZeroReg, gInReg, maskFull16, maskFull32);
+        Exp(gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+        Duplicate(dBetaReduceReg, static_cast<float>(0), maskFull32);
+        Duplicate(dgReduceReg, static_cast<float>(0), maskFull32);
+
+        for (uint16_t vfBlockIdx = 0; vfBlockIdx < nLoopCnt; vfBlockIdx++) {
+            uint32_t offset = mIdx * nSize + vfBlockIdx * eleKNumPerVf;
+            LoadIn<kType>(kInReg, kIn + offset);
+            LoadIn<kType>(dkInReg, dkIn + offset);
+            LoadIn<kType>(dkbInReg, dkbIn + offset);
+            LoadIn<kType>(dkbgInReg, dkbgIn + offset);
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+            CastHalf2Float<kType>(dkbFP32ZeroReg, dkbFP32OneReg, dkbInReg, maskFull16);
+            CastHalf2Float<kType>(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgInReg, maskFull16);
+
+            MulFloatTwoReg(mulFP32ZeroReg, mulFP32OneReg, kFP32ZeroReg, kFP32OneReg,
+                           dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+            Add(mulFP32ZeroReg, mulFP32ZeroReg, mulFP32OneReg, maskFull32);
+            Add(dBetaReduceReg, dBetaReduceReg, mulFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg,
+                           betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg,
+                           dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg,
+                           gBrcbFP32ZeroReg, gBrcbFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(mulFP32ZeroReg, mulFP32OneReg, kFP32ZeroReg, kFP32OneReg,
+                           dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            Add(mulFP32ZeroReg, mulFP32ZeroReg, mulFP32OneReg, maskFull32);
+            Add(dBetaReduceReg, dBetaReduceReg, mulFP32ZeroReg, maskFull32);
+            Mul(mulFP32ZeroReg, mulFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            Add(dgReduceReg, dgReduceReg, mulFP32ZeroReg, maskFull32);
+            MulFloatTwoReg(dkbgFP32ZeroReg, dkbgFP32OneReg, dkbgFP32ZeroReg, dkbgFP32OneReg,
+                           betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg,
+                           dkbgFP32ZeroReg, dkbgFP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + offset, dkOutReg, maskFull16);
+        }
+        ReduceSum(dBetaOutReg, dBetaReduceReg, maskFull32);
+        ReduceSum(dgOutReg, dgReduceReg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaOutReg, maskFull32, uStoreDBeta, 1);
+        StoreUnAlignOut<betaType>(dgOut + mIdx, dgOutReg, maskFull32, uStoreDg, 1);
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessDkGatherComputerVFOneLineOneCol(
+    __ubuf__ kType* dkOut, __ubuf__ kType* dkIn1, __ubuf__ kType* dkIn2,
+    uint16_t mSize, uint16_t nSize)
+{
+    RegTensor<kType> dk1Reg, dk2Reg;
+    RegTensor<float> dk1FP32ZeroReg, dk1FP32OneReg;
+    RegTensor<float> dk2FP32ZeroReg, dk2FP32OneReg;
+    RegTensor<kType> dkOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<kType, false>(dk1Reg, dkIn1);
+    LoadIn<kType, false>(dk2Reg, dkIn2);
+    CastHalf2Float<kType>(dk1FP32ZeroReg, dk1FP32OneReg, dk1Reg, maskFull16);
+    CastHalf2Float<kType>(dk2FP32ZeroReg, dk2FP32OneReg, dk2Reg, maskFull16);
+    AddFloatTwoReg(dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg, dk1FP32OneReg, dk2FP32ZeroReg, dk2FP32OneReg, maskFull32);
+    CastFloat2Half<kType>(dkOutReg, dk1FP32ZeroReg, dk1FP32OneReg, maskFull32);
+    StoreAlign((__ubuf__ kType*&)dkOut, dkOutReg, maskFull16);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessDkGatherComputerVFMutiLineOneCol(
+    __ubuf__ kType* dkOut, __ubuf__ kType* dkIn1, __ubuf__ kType* dkIn2,
+    uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    uint16_t lastLoopCnt = mSize % PRELOAD_NUM;
+    RegTensor<kType> dk1Reg, dk1Reg1;
+    RegTensor<kType> dk2Reg, dk2Reg1;
+    RegTensor<float> dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg1, dk1FP32OneReg1;
+    RegTensor<float> dk2FP32ZeroReg, dk2FP32OneReg, dk2FP32ZeroReg1, dk2FP32OneReg1;
+    RegTensor<kType> dkOutReg, dkOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<kType, false>(dk1Reg, dkIn1);
+    LoadIn<kType, false>(dk1Reg1, dkIn1 + oneEleNum);
+    LoadIn<kType, false>(dk2Reg, dkIn2);
+    LoadIn<kType, false>(dk2Reg1, dkIn2 + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        CastHalf2Float<kType>(dk1FP32ZeroReg, dk1FP32OneReg, dk1Reg, maskFull16);
+        CastHalf2Float<kType>(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1Reg1, maskFull16);
+        LoadIn<kType, false>(dk1Reg, dkIn1 + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dk1Reg1, dkIn1 + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(dk2FP32ZeroReg, dk2FP32OneReg, dk2Reg, maskFull16);
+        CastHalf2Float<kType>(dk2FP32ZeroReg1, dk2FP32OneReg1, dk2Reg1, maskFull16);
+        LoadIn<kType, false>(dk2Reg, dkIn2 + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dk2Reg1, dkIn2 + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        AddFloatTwoReg(dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg, dk1FP32OneReg, dk2FP32ZeroReg, dk2FP32OneReg, maskFull32);
+        AddFloatTwoReg(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, dk2FP32ZeroReg1, dk2FP32OneReg1, maskFull32);
+
+        CastFloat2Half<kType>(dkOutReg, dk1FP32ZeroReg, dk1FP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dkOutReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        CastHalf2Float<kType>(dk1FP32ZeroReg, dk1FP32OneReg, dk1Reg, maskFull16);
+        CastHalf2Float<kType>(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1Reg1, maskFull16);
+        CastHalf2Float<kType>(dk2FP32ZeroReg, dk2FP32OneReg, dk2Reg, maskFull16);
+        CastHalf2Float<kType>(dk2FP32ZeroReg1, dk2FP32OneReg1, dk2Reg1, maskFull16);
+
+        AddFloatTwoReg(dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg, dk1FP32OneReg, dk2FP32ZeroReg, dk2FP32OneReg, maskFull32);
+        AddFloatTwoReg(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, dk2FP32ZeroReg1, dk2FP32OneReg1, maskFull32);
+
+        CastFloat2Half<kType>(dkOutReg, dk1FP32ZeroReg, dk1FP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dkOutReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<kType, false>(dk1Reg, dkIn1 + oneEleNum * (mIdx * PRELOAD_NUM));
+            LoadIn<kType, false>(dk2Reg, dkIn2 + oneEleNum * (mIdx * PRELOAD_NUM));
+            CastHalf2Float<kType>(dk1FP32ZeroReg, dk1FP32OneReg, dk1Reg, maskFull16);
+            CastHalf2Float<kType>(dk2FP32ZeroReg, dk2FP32OneReg, dk2Reg, maskFull16);
+            AddFloatTwoReg(dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg, dk1FP32OneReg, dk2FP32ZeroReg, dk2FP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dk1FP32ZeroReg, dk1FP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        }
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessDkGatherComputerVFTwoCol(
+    __ubuf__ kType* dkOut, __ubuf__ kType* dkIn1, __ubuf__ kType* dkIn2,
+    uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    uint16_t mLoopCnt = mSize - 1;
+    uint16_t lastLoopCnt = mSize % PRELOAD_NUM;
+    RegTensor<kType> dk1Reg, dk1Reg1;
+    RegTensor<kType> dk2Reg, dk2Reg1;
+    RegTensor<float> dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg1, dk1FP32OneReg1;
+    RegTensor<float> dk2FP32ZeroReg, dk2FP32OneReg, dk2FP32ZeroReg1, dk2FP32OneReg1;
+    RegTensor<kType> dkOutReg, dkOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<kType, false>(dk1Reg, dkIn1);
+    LoadIn<kType, false>(dk1Reg1, dkIn1 + oneEleNum);
+    LoadIn<kType, false>(dk2Reg, dkIn2);
+    LoadIn<kType, false>(dk2Reg1, dkIn2 + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        CastHalf2Float<kType>(dk1FP32ZeroReg, dk1FP32OneReg, dk1Reg, maskFull16);
+        CastHalf2Float<kType>(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1Reg1, maskFull16);
+        LoadIn<kType, false>(dk1Reg, dkIn1 + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dk1Reg1, dkIn1 + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(dk2FP32ZeroReg, dk2FP32OneReg, dk2Reg, maskFull16);
+        CastHalf2Float<kType>(dk2FP32ZeroReg1, dk2FP32OneReg1, dk2Reg1, maskFull16);
+        LoadIn<kType, false>(dk2Reg, dkIn2 + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dk2Reg1, dkIn2 + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        AddFloatTwoReg(dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg, dk1FP32OneReg, dk2FP32ZeroReg, dk2FP32OneReg, maskFull32);
+        AddFloatTwoReg(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, dk2FP32ZeroReg1, dk2FP32OneReg1, maskFull32);
+
+        CastFloat2Half<kType>(dkOutReg, dk1FP32ZeroReg, dk1FP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dkOutReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        CastHalf2Float<kType>(dk1FP32ZeroReg, dk1FP32OneReg, dk1Reg, maskFull16);
+        CastHalf2Float<kType>(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1Reg1, maskFull16);
+        CastHalf2Float<kType>(dk2FP32ZeroReg, dk2FP32OneReg, dk2Reg, maskFull16);
+        CastHalf2Float<kType>(dk2FP32ZeroReg1, dk2FP32OneReg1, dk2Reg1, maskFull16);
+
+        AddFloatTwoReg(dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg, dk1FP32OneReg, dk2FP32ZeroReg, dk2FP32OneReg, maskFull32);
+        AddFloatTwoReg(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, dk2FP32ZeroReg1, dk2FP32OneReg1, maskFull32);
+
+        CastFloat2Half<kType>(dkOutReg, dk1FP32ZeroReg, dk1FP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dkOutReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<kType, false>(dk1Reg, dkIn1 + oneEleNum * (mIdx * PRELOAD_NUM));
+            LoadIn<kType, false>(dk1Reg1, dkIn1 + oneEleNum * (mIdx * PRELOAD_NUM + 1));
+            LoadIn<kType, false>(dk2Reg, dkIn2 + oneEleNum * (mIdx * PRELOAD_NUM));
+            LoadIn<kType, false>(dk2Reg1, dkIn2 + oneEleNum * (mIdx * PRELOAD_NUM + 1));
+            CastHalf2Float<kType>(dk1FP32ZeroReg, dk1FP32OneReg, dk1Reg, maskFull16);
+            CastHalf2Float<kType>(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1Reg1, maskFull16);
+            CastHalf2Float<kType>(dk2FP32ZeroReg, dk2FP32OneReg, dk2Reg, maskFull16);
+            CastHalf2Float<kType>(dk2FP32ZeroReg1, dk2FP32OneReg1, dk2Reg1, maskFull16);
+            AddFloatTwoReg(dk1FP32ZeroReg, dk1FP32OneReg, dk1FP32ZeroReg, dk1FP32OneReg, dk2FP32ZeroReg, dk2FP32OneReg, maskFull32);
+            AddFloatTwoReg(dk1FP32ZeroReg1, dk1FP32OneReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, dk2FP32ZeroReg1, dk2FP32OneReg1, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dk1FP32ZeroReg, dk1FP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg1, dk1FP32ZeroReg1, dk1FP32OneReg1, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+            StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+        }
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessDkbComputerVFMutiLineOneCol(
+    __ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    __ubuf__ kType* dkIn, __ubuf__ kType* dkbIn, uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    uint16_t mLoopCnt = mSize / PRELOAD_NUM - 1;
+    uint16_t lastLoopCnt = mSize % PRELOAD_NUM;
+    RegTensor<betaType> betaInReg, betaInReg1;
+    RegTensor<kType> kInReg, kInReg1;
+    RegTensor<kType> dkInReg, dkInReg1;
+    RegTensor<kType> dkbInReg, dkbInReg1;
+    RegTensor<float> betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg1;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg1, kFP32OneReg1;
+    RegTensor<float> dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg1, dkFP32OneReg1;
+    RegTensor<float> dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg1, dkbFP32OneReg1;
+    RegTensor<kType> dkOutReg, dkOutReg1;
+    RegTensor<float> dBetaFP32Reg;
+    RegTensor<betaType> dBetaOutZeroReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    UnalignRegForStore uStore;
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(betaInReg1, betaIn + 1);
+    LoadIn<kType, false>(kInReg, kIn);
+    LoadIn<kType, false>(kInReg1, kIn + oneEleNum);
+    LoadIn<kType, false>(dkInReg, dkIn);
+    LoadIn<kType, false>(dkInReg1, dkIn + oneEleNum);
+    LoadIn<kType, false>(dkbInReg, dkbIn);
+    LoadIn<kType, false>(dkbInReg1, dkbIn + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg1, betaInReg1, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1) * PRELOAD_NUM);
+        LoadIn<betaType, true>(betaInReg1, betaIn + (mIdx + 1) * PRELOAD_NUM + 1);
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        LoadIn<kType, false>(kInReg, kIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(kInReg1, kIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+        CastHalf2Float<kType>(dkFP32ZeroReg1, dkFP32OneReg1, dkInReg1, maskFull16);
+        LoadIn<kType, false>(dkInReg, dkIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dkInReg1, dkIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(dkbFP32ZeroReg, dkbFP32OneReg, dkbInReg, maskFull16);
+        CastHalf2Float<kType>(dkbFP32ZeroReg1, dkbFP32OneReg1, dkbInReg1, maskFull16);
+        LoadIn<kType, false>(dkbInReg, dkbIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dkbInReg1, dkbIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+        MulFloatTwoReg(dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+
+        MulFloatTwoReg(kFP32ZeroReg1, kFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, maskFull32);
+        MulFloatTwoReg(dkbFP32ZeroReg1, dkbFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, betaBrcbFP32ZeroReg1, betaBrcbFP32ZeroReg1, maskFull32);
+        AddFloatTwoReg(dkFP32ZeroReg1, dkFP32OneReg1, dkFP32ZeroReg1, dkFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, maskFull32);
+
+        CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dkOutReg1, dkFP32ZeroReg1, dkFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+
+        Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+        ReduceSum(dBetaFP32Reg, kFP32ZeroReg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
+
+        Add(kFP32ZeroReg1, kFP32ZeroReg1, kFP32OneReg1, maskFull32);
+        ReduceSum(dBetaFP32Reg, kFP32ZeroReg1, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM + 1, dBetaFP32Reg, maskFull32, uStore, 1);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg1, betaInReg1, maskFull16, maskFull32);
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+        CastHalf2Float<kType>(dkFP32ZeroReg1, dkFP32OneReg1, dkInReg1, maskFull16);
+        CastHalf2Float<kType>(dkbFP32ZeroReg, dkbFP32OneReg, dkbInReg, maskFull16);
+        CastHalf2Float<kType>(dkbFP32ZeroReg1, dkbFP32OneReg1, dkbInReg1, maskFull16);
+
+        MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+        MulFloatTwoReg(dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+
+        MulFloatTwoReg(kFP32ZeroReg1, kFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, maskFull32);
+        MulFloatTwoReg(dkbFP32ZeroReg1, dkbFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, betaBrcbFP32ZeroReg1, betaBrcbFP32ZeroReg1, maskFull32);
+        AddFloatTwoReg(dkFP32ZeroReg1, dkFP32OneReg1, dkFP32ZeroReg1, dkFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, maskFull32);
+
+        CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dkOutReg1, dkFP32ZeroReg1, dkFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+
+        Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+        ReduceSum(dBetaFP32Reg, kFP32ZeroReg, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
+
+        Add(kFP32ZeroReg1, kFP32ZeroReg1, kFP32OneReg1, maskFull32);
+        ReduceSum(dBetaFP32Reg, kFP32ZeroReg1, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM + 1, dBetaFP32Reg, maskFull32, uStore, 1);
+
+        mIdx += 1;
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<betaType, true>(betaInReg, betaIn + mIdx * PRELOAD_NUM);
+            LoadIn<kType, false>(kInReg, kIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            LoadIn<kType, false>(dkInReg, dkIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            LoadIn<kType, false>(dkbInReg, dkbIn + oneEleNum * (mIdx * PRELOAD_NUM));
+            HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+            CastHalf2Float<kType>(dkbFP32ZeroReg, dkbFP32OneReg, dkbInReg, maskFull16);
+            MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+            MulFloatTwoReg(dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+            CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+
+            Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+            ReduceSum(dBetaFP32Reg, kFP32ZeroReg, maskFull32);
+            StoreUnAlignOut<betaType>(dBetaOut + mIdx * PRELOAD_NUM, dBetaFP32Reg, maskFull32, uStore, 1);
+        }
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessDkbComputerVFOneLineOneCol(
+    __ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    __ubuf__ kType* dkIn, __ubuf__ kType* dkbIn, uint16_t mSize, uint16_t nSize)
+{
+    RegTensor<betaType> betaInReg;
+    RegTensor<kType> kInReg;
+    RegTensor<kType> dkInReg;
+    RegTensor<kType> dkbInReg;
+    RegTensor<float> betaBrcbFP32ZeroReg;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg;
+    RegTensor<float> dkFP32ZeroReg, dkFP32OneReg;
+    RegTensor<float> dkbFP32ZeroReg, dkbFP32OneReg;
+    RegTensor<kType> dkOutReg;
+    RegTensor<float> dBetaFP32Reg;
+    RegTensor<betaType> dBetaOutZeroReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    UnalignRegForStore uStore;
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<kType, false>(kInReg, kIn);
+    LoadIn<kType, false>(dkInReg, dkIn);
+    LoadIn<kType, false>(dkbInReg, dkbIn);
+    HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+    CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+    CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+    CastHalf2Float<kType>(dkbFP32ZeroReg, dkbFP32OneReg, dkbInReg, maskFull16);
+    MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+    MulFloatTwoReg(dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+    AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+    CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+    StoreAlign((__ubuf__ kType*&)dkOut, dkOutReg, maskFull16);
+
+    Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+    ReduceSum(dBetaFP32Reg, kFP32ZeroReg, maskFull32);
+    StoreUnAlignOut<betaType>(dBetaOut, dBetaFP32Reg, maskFull32, uStore, 1);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessDkbComputerVFTwoCol(
+    __ubuf__ kType* dkOut, __ubuf__ betaType* dBetaOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    __ubuf__ kType* dkIn, __ubuf__ kType* dkbIn, uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    uint16_t mLoopCnt = mSize - 1;
+    uint16_t lastLoopCnt = mSize % PRELOAD_NUM;
+    RegTensor<betaType> betaInReg;
+    RegTensor<kType> kInReg, kInReg1;
+    RegTensor<kType> dkInReg, dkInReg1;
+    RegTensor<kType> dkbInReg, dkbInReg1;
+    RegTensor<float> betaBrcbFP32ZeroReg;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg1, kFP32OneReg1;
+    RegTensor<float> dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg1, dkFP32OneReg1;
+    RegTensor<float> dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg1, dkbFP32OneReg1;
+    RegTensor<kType> dkOutReg, dkOutReg1;
+    RegTensor<float> dBetaFP32Reg, dBetaFP32Reg1;
+    RegTensor<betaType> dBetaOutZeroReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    UnalignRegForStore uStore;
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<kType, false>(kInReg, kIn);
+    LoadIn<kType, false>(kInReg1, kIn + oneEleNum);
+    LoadIn<kType, false>(dkInReg, dkIn);
+    LoadIn<kType, false>(dkInReg1, dkIn + oneEleNum);
+    LoadIn<kType, false>(dkbInReg, dkbIn);
+    LoadIn<kType, false>(dkbInReg1, dkbIn + oneEleNum);
+
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + mIdx + 1);
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        LoadIn<kType, false>(kInReg, kIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(kInReg1, kIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+        CastHalf2Float<kType>(dkFP32ZeroReg1, dkFP32OneReg1, dkInReg1, maskFull16);
+        LoadIn<kType, false>(dkInReg, dkIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dkInReg1, dkIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+        CastHalf2Float<kType>(dkbFP32ZeroReg, dkbFP32OneReg, dkbInReg, maskFull16);
+        CastHalf2Float<kType>(dkbFP32ZeroReg1, dkbFP32OneReg1, dkbInReg1, maskFull16);
+        LoadIn<kType, false>(dkbInReg, dkbIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM));
+        LoadIn<kType, false>(dkbInReg1, dkbIn + oneEleNum * ((mIdx + 1) * PRELOAD_NUM + 1));
+
+        MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+        MulFloatTwoReg(dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+
+        MulFloatTwoReg(kFP32ZeroReg1, kFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, maskFull32);
+        MulFloatTwoReg(dkbFP32ZeroReg1, dkbFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        AddFloatTwoReg(dkFP32ZeroReg1, dkFP32OneReg1, dkFP32ZeroReg1, dkFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, maskFull32);
+
+        CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dkOutReg1, dkFP32ZeroReg1, dkFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+
+        Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+        ReduceSum(dBetaFP32Reg, kFP32ZeroReg, maskFull32);
+
+        Add(kFP32ZeroReg1, kFP32ZeroReg1, kFP32OneReg1, maskFull32);
+        ReduceSum(dBetaFP32Reg1, kFP32ZeroReg1, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dBetaFP32Reg1, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaFP32Reg, maskFull32, uStore, 1);
+    }
+    uint16_t mIdx = mLoopCnt;
+    {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        CastHalf2Float<kType>(dkFP32ZeroReg, dkFP32OneReg, dkInReg, maskFull16);
+        CastHalf2Float<kType>(dkFP32ZeroReg1, dkFP32OneReg1, dkInReg1, maskFull16);
+        CastHalf2Float<kType>(dkbFP32ZeroReg, dkbFP32OneReg, dkbInReg, maskFull16);
+        CastHalf2Float<kType>(dkbFP32ZeroReg1, dkbFP32OneReg1, dkbInReg1, maskFull16);
+
+        MulFloatTwoReg(kFP32ZeroReg, kFP32OneReg, kFP32ZeroReg, kFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+        MulFloatTwoReg(dkbFP32ZeroReg, dkbFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        AddFloatTwoReg(dkFP32ZeroReg, dkFP32OneReg, dkFP32ZeroReg, dkFP32OneReg, dkbFP32ZeroReg, dkbFP32OneReg, maskFull32);
+
+        MulFloatTwoReg(kFP32ZeroReg1, kFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, maskFull32);
+        MulFloatTwoReg(dkbFP32ZeroReg1, dkbFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        AddFloatTwoReg(dkFP32ZeroReg1, dkFP32OneReg1, dkFP32ZeroReg1, dkFP32OneReg1, dkbFP32ZeroReg1, dkbFP32OneReg1, maskFull32);
+
+        CastFloat2Half<kType>(dkOutReg, dkFP32ZeroReg, dkFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(dkOutReg1, dkFP32ZeroReg1, dkFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM), dkOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)dkOut + oneEleNum * (mIdx * PRELOAD_NUM + 1), dkOutReg1, maskFull16);
+
+        Add(kFP32ZeroReg, kFP32ZeroReg, kFP32OneReg, maskFull32);
+        ReduceSum(dBetaFP32Reg, kFP32ZeroReg, maskFull32);
+
+        Add(kFP32ZeroReg1, kFP32ZeroReg1, kFP32OneReg1, maskFull32);
+        ReduceSum(dBetaFP32Reg1, kFP32ZeroReg1, maskFull32);
+        Add(dBetaFP32Reg, dBetaFP32Reg, dBetaFP32Reg1, maskFull32);
+        StoreUnAlignOut<betaType>(dBetaOut + mIdx, dBetaFP32Reg, maskFull32, uStore, 1);
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessKBetaComputerVFMutiLineOneCol(
+    __ubuf__ kType* kBetaOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    uint16_t mSize, uint16_t nSize, uint16_t lastLoopCnt)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint16_t nLoopCnt = (nSize + eleKNumPerVf - 1) / eleKNumPerVf;
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    uint16_t mLoopCnt = mSize / 2 - 1;
+    RegTensor<kType> kInReg, kInReg1;
+    RegTensor<betaType> betaInReg, betaInReg1;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, kBetaFP32ZeroReg, kBetaFP32OneReg;
+    RegTensor<float> kFP32ZeroReg1, kFP32OneReg1, kBetaFP32ZeroReg1, kBetaFP32OneReg1;
+    RegTensor<float> betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg1;
+    RegTensor<kType> kBetaOutReg, kBetaOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<betaType, true>(betaInReg1, betaIn + 1);
+    LoadIn<kType, false>(kInReg, kIn);
+    LoadIn<kType, false>(kInReg1, kIn + oneEleNum);
+    // 前mSize - 3行
+    for (uint16_t mIdx = 0; mIdx < mLoopCnt; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg1, betaInReg1, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1) * 2);
+        LoadIn<betaType, true>(betaInReg1, betaIn + (mIdx + 1) * 2 + 1);
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        LoadIn<kType, false>(kInReg, kIn + oneEleNum * ((mIdx + 1) * 2));
+        LoadIn<kType, false>(kInReg1, kIn + oneEleNum * ((mIdx + 1) * 2 + 1));
+        MulFloatTwoReg(kBetaFP32ZeroReg, kBetaFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        MulFloatTwoReg(kBetaFP32ZeroReg1, kBetaFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, betaBrcbFP32ZeroReg1, betaBrcbFP32ZeroReg1, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg, kBetaFP32ZeroReg, kBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg1, kBetaFP32ZeroReg1, kBetaFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2), kBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2 + 1), kBetaOutReg1, maskFull16);
+    }
+    uint16_t mIdx = mLoopCnt;
+    // 最后三行
+    {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg1, betaInReg1, maskFull16, maskFull32);
+
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+
+        MulFloatTwoReg(kBetaFP32ZeroReg, kBetaFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        MulFloatTwoReg(kBetaFP32ZeroReg1, kBetaFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, betaBrcbFP32ZeroReg1, betaBrcbFP32ZeroReg1, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg, kBetaFP32ZeroReg, kBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg1, kBetaFP32ZeroReg1, kBetaFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2), kBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2 + 1), kBetaOutReg1, maskFull16);
+
+        mIdx += 1;
+        // 最后一行
+        for (uint16_t i = 0; i < lastLoopCnt; i++) {
+            LoadIn<betaType, true>(betaInReg, betaIn + mIdx * 2);
+            LoadIn<kType, false>(kInReg, kIn + oneEleNum * (mIdx * 2));
+            HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            MulFloatTwoReg(kBetaFP32ZeroReg, kBetaFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+            CastFloat2Half<kType>(kBetaOutReg, kBetaFP32ZeroReg, kBetaFP32OneReg, maskFull32);
+            StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2), kBetaOutReg, maskFull16);
+        }
+    }
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessKBetaComputerVFOneLineOneCol(
+    __ubuf__ kType* kBetaOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    RegTensor<kType> kInReg;
+    RegTensor<betaType> betaInReg;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, kBetaFP32ZeroReg, kBetaFP32OneReg;
+    RegTensor<float> betaBrcbFP32ZeroReg;
+    RegTensor<kType> kBetaOutReg;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<kType, false>(kInReg, kIn);
+
+    HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+    CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+    MulFloatTwoReg(kBetaFP32ZeroReg, kBetaFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+    CastFloat2Half<kType>(kBetaOutReg, kBetaFP32ZeroReg, kBetaFP32OneReg, maskFull32);
+    StoreAlign(kBetaOut, kBetaOutReg, maskFull16);
+}
+
+template <typename kType, typename betaType>
+__simd_vf__ inline void PrepareWyReprBwdRegBase<kType, betaType>::ProcessKBetaComputerVFTwoCol(
+    __ubuf__ kType* kBetaOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleKNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint16_t nLoopCnt = (nSize + eleKNumPerVf - 1) / eleKNumPerVf;
+    uint32_t oneEleNum = min(eleKNumPerVf, static_cast<uint32_t>(nSize));
+    RegTensor<kType> kInReg, kInReg1;
+    RegTensor<betaType> betaInReg, betaInReg1;
+    RegTensor<float> kFP32ZeroReg, kFP32OneReg, kBetaFP32ZeroReg, kBetaFP32OneReg;
+    RegTensor<float> kFP32ZeroReg1, kFP32OneReg1, kBetaFP32ZeroReg1, kBetaFP32OneReg1;
+    RegTensor<float> betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg1;
+    RegTensor<kType> kBetaOutReg, kBetaOutReg1;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    LoadIn<betaType, true>(betaInReg, betaIn);
+    LoadIn<kType, false>(kInReg, kIn);
+    LoadIn<kType, false>(kInReg1, kIn + oneEleNum);
+    for (uint16_t mIdx = 0; mIdx < mSize - 1; mIdx++) {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        LoadIn<betaType, true>(betaInReg, betaIn + (mIdx + 1));
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        LoadIn<kType, false>(kInReg, kIn + oneEleNum * (mIdx + 1) * 2);
+        LoadIn<kType, false>(kInReg1, kIn + oneEleNum * (mIdx + 1) * 2 + 1);
+        MulFloatTwoReg(kBetaFP32ZeroReg, kBetaFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        MulFloatTwoReg(kBetaFP32ZeroReg1, kBetaFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg, kBetaFP32ZeroReg, kBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg1, kBetaFP32ZeroReg1, kBetaFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2), kBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2 + 1), kBetaOutReg1, maskFull16);
+    }
+    uint16_t mIdx = mSize - 1;
+    // 最后一行
+    {
+        HalfOrFloat2Float<betaType>(betaBrcbFP32ZeroReg, betaInReg, maskFull16, maskFull32);
+        CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+        CastHalf2Float<kType>(kFP32ZeroReg1, kFP32OneReg1, kInReg1, maskFull16);
+        MulFloatTwoReg(kBetaFP32ZeroReg, kBetaFP32OneReg, kFP32ZeroReg, kFP32OneReg, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        MulFloatTwoReg(kBetaFP32ZeroReg1, kBetaFP32OneReg1, kFP32ZeroReg1, kFP32OneReg1, betaBrcbFP32ZeroReg, betaBrcbFP32ZeroReg, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg, kBetaFP32ZeroReg, kBetaFP32OneReg, maskFull32);
+        CastFloat2Half<kType>(kBetaOutReg1, kBetaFP32ZeroReg1, kBetaFP32OneReg1, maskFull32);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2), kBetaOutReg, maskFull16);
+        StoreAlign((__ubuf__ kType*&)kBetaOut + oneEleNum * (mIdx * 2 + 1), kBetaOutReg1, maskFull16);
+    }
+}
+
+#endif // PREPARE_WY_REPR_BWD_ARCH35_REGBASE_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/arch35/prepare_wy_repr_bwd_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/arch35/prepare_wy_repr_bwd_vector.h
@@ -1,0 +1,731 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef PREPARE_WY_REPR_BWD_ARCH35_VECTOR_H
+#define PREPARE_WY_REPR_BWD_ARCH35_VECTOR_H
+
+#include <type_traits>
+
+#include "../prepare_wy_repr_bwd_struct.h"
+#include "prepare_wy_repr_bwd_cube_resource.h"
+#include "kernel_operator.h"
+
+namespace GDN {
+
+static constexpr uint32_t BWD_A5_SLOT_COUNT = 2;
+static constexpr uint32_t BWD_A5_ONE_BLOCK_BYTES = 32;
+static constexpr uint32_t BWD_A5_FP32_PER_BLOCK = 8;
+static constexpr uint32_t BWD_A5_FP32_PER_REPEAT = 64;
+
+template <typename T, typename GateT, bool IS_VARLEN, int V, int CHUNK_SIZE>
+class PrepareWyReprBwdVector {
+    struct TaskDesc {
+        bool valid = false;
+        uint64_t ownerUnit = 0;
+        uint64_t chunkLinear = 0;
+        uint64_t batch = 0;
+        uint64_t chunkBegin = 0;
+        uint64_t chunkEnd = 0;
+        uint64_t keyHead = 0;
+        uint64_t valueHead = 0;
+        uint64_t hvLocal = 0;
+        bool firstValueHead = true;
+    };
+
+public:
+    /**
+     * @brief 初始化 A5 vector kernel 的 GM tensor、tiling、core 和 subblock 信息。
+     */
+    __aicore__ inline void Init(GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR dw, GM_ADDR du, GM_ADDR g,
+                                GM_ADDR cuSeqlens, GM_ADDR chunkIndices, GM_ADDR dk, GM_ADDR dv, GM_ADDR dbeta,
+                                GM_ADDR dg, GM_ADDR workspace, const PrepareWyReprBwdTilingData *tiling)
+    {
+        (void)A;
+        (void)dw;
+        (void)du;
+        (void)workspace;
+        tiling_ = tiling;
+        coreIdx_ = static_cast<uint64_t>(AscendC::GetBlockIdx() / AscendC::GetSubBlockNum());
+        coreNum_ = static_cast<uint64_t>(tiling_->usedCoreNum) > 0 ? static_cast<uint64_t>(tiling_->usedCoreNum) : 1;
+        subBlockIdx_ = static_cast<uint64_t>(AscendC::GetSubBlockIdx());
+        subBlockNum_ = static_cast<uint64_t>(AscendC::GetSubBlockNum());
+
+        kGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(k));
+        vGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(v));
+        betaGm_.SetGlobalBuffer(reinterpret_cast<__gm__ GateT *>(beta));
+        gGm_.SetGlobalBuffer(reinterpret_cast<__gm__ GateT *>(g));
+        dkGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(dk));
+        dvGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(dv));
+        dbetaGm_.SetGlobalBuffer(reinterpret_cast<__gm__ GateT *>(dbeta));
+        dgGm_.SetGlobalBuffer(reinterpret_cast<__gm__ GateT *>(dg));
+        if (cuSeqlens != nullptr) {
+            cuSeqlensGm_.SetGlobalBuffer(reinterpret_cast<__gm__ uint64_t *>(cuSeqlens));
+        }
+        if (chunkIndices != nullptr) {
+            chunkIndicesGm_.SetGlobalBuffer(reinterpret_cast<__gm__ uint64_t *>(chunkIndices));
+        }
+    }
+
+    /**
+     * @brief 执行 A5 vector 侧双任务流水。
+     *
+     * 非 GVA 使用两个独立 owner unit 填满 task slot；GVA 使用同一 owner 下两个 hv。
+     * 当前 CUBE 侧直接返回，本函数独立跑通 MTE2/VEC/MTE3 双 buffer profile 路径。
+     */
+    __aicore__ inline void ProcessPipeline()
+    {
+        InitUbArena();
+        if (tiling_->taskPairMode == BWD_TASK_PAIR_INDEPENDENT_UNIT) {
+            ProcessIndependentUnitPairs();
+        } else {
+            ProcessSameOwnerHeadPairs();
+        }
+        DrainIoBuffers();
+    }
+
+private:
+    /**
+     * @brief 初始化 UB arena 和输入/输出 buffer 的可复用事件状态。
+     */
+    __aicore__ inline void InitUbArena()
+    {
+        ioInOffset_ = static_cast<uint64_t>(tiling_->vectorIoInOffset);
+        ioOutOffset_ = static_cast<uint64_t>(tiling_->vectorIoOutOffset);
+        persistentOffset_ = static_cast<uint64_t>(tiling_->vectorPersistentOffset);
+        gateCacheOffset_ = static_cast<uint64_t>(tiling_->vectorGateCacheOffset);
+        tempOffset_ = static_cast<uint64_t>(tiling_->vectorTempOffset);
+        ubBytes_ = static_cast<uint64_t>(tiling_->vectorUbBytes);
+        ioInStride_ = (static_cast<uint64_t>(tiling_->vectorIoOutOffset) - ioInOffset_) / BWD_A5_SLOT_COUNT;
+        ioOutStride_ = (static_cast<uint64_t>(tiling_->vectorPersistentOffset) -
+                        static_cast<uint64_t>(tiling_->vectorIoOutOffset)) / BWD_A5_SLOT_COUNT;
+        for (uint32_t slot = 0; slot < BWD_A5_SLOT_COUNT; ++slot) {
+            ReleaseInputSlot(slot);
+            ReleaseOutputSlot(slot);
+        }
+    }
+
+    /**
+     * @brief 非 GVA 调度：两个 task slot 分别消费两个独立 owner unit。
+     */
+    __aicore__ inline void ProcessIndependentUnitPairs()
+    {
+        const uint64_t ownerUnitNum = OwnerUnitNum();
+        const uint64_t step = coreNum_ * BWD_A5_SLOT_COUNT;
+        for (uint64_t baseUnit = coreIdx_; baseUnit < ownerUnitNum; baseUnit += step) {
+            TaskDesc task0 = BuildIndependentTask(baseUnit);
+            TaskDesc task1 = BuildIndependentTask(baseUnit + coreNum_);
+            ProcessTaskPair(task0, task1);
+        }
+    }
+
+    /**
+     * @brief GVA 调度：一个 owner unit 内每轮处理两个相邻 value head。
+     */
+    __aicore__ inline void ProcessSameOwnerHeadPairs()
+    {
+        const uint64_t ownerUnitNum = OwnerUnitNum();
+        const uint64_t headGroup = static_cast<uint64_t>(tiling_->headGroup);
+        for (uint64_t ownerUnit = coreIdx_; ownerUnit < ownerUnitNum; ownerUnit += coreNum_) {
+            for (uint64_t hvLocal = 0; hvLocal < headGroup; hvLocal += BWD_A5_SLOT_COUNT) {
+                TaskDesc task0 = BuildGroupedHeadTask(ownerUnit, hvLocal);
+                TaskDesc task1 = BuildGroupedHeadTask(ownerUnit, hvLocal + 1);
+                ProcessTaskPair(task0, task1);
+            }
+        }
+    }
+
+    /**
+     * @brief 执行一个双 slot 逻辑循环，先缓存两个 task 的 gate，再分别写回公开输出。
+     */
+    __aicore__ inline void ProcessTaskPair(const TaskDesc &task0, const TaskDesc &task1)
+    {
+        LoadTaskGate(0, task0);
+        LoadTaskGate(1, task1);
+        ProcessTaskOutputs(0, task0);
+        ProcessTaskOutputs(1, task1);
+    }
+
+    /**
+     * @brief 从独立 owner unit 解码非 GVA task。
+     */
+    __aicore__ inline TaskDesc BuildIndependentTask(uint64_t ownerUnit)
+    {
+        TaskDesc task;
+        if (ownerUnit >= OwnerUnitNum()) {
+            return task;
+        }
+        DecodeOwnerUnit(ownerUnit, task);
+        task.valueHead = task.keyHead;
+        task.hvLocal = 0;
+        task.firstValueHead = true;
+        task.valid = task.chunkEnd > task.chunkBegin;
+        return task;
+    }
+
+    /**
+     * @brief 从 owner unit 和局部 hv 序号解码 GVA task。
+     */
+    __aicore__ inline TaskDesc BuildGroupedHeadTask(uint64_t ownerUnit, uint64_t hvLocal)
+    {
+        TaskDesc task;
+        const uint64_t headGroup = static_cast<uint64_t>(tiling_->headGroup);
+        if (ownerUnit >= OwnerUnitNum() || hvLocal >= headGroup) {
+            return task;
+        }
+        DecodeOwnerUnit(ownerUnit, task);
+        task.hvLocal = hvLocal;
+        task.valueHead = task.keyHead * headGroup + hvLocal;
+        task.firstValueHead = hvLocal == 0;
+        task.valid = task.valueHead < static_cast<uint64_t>(tiling_->HV) && task.chunkEnd > task.chunkBegin;
+        return task;
+    }
+
+    /**
+     * @brief 将 owner unit 解码成 chunk、batch、token 范围和 key head。
+     */
+    __aicore__ inline void DecodeOwnerUnit(uint64_t ownerUnit, TaskDesc &task)
+    {
+        const uint64_t hk = static_cast<uint64_t>(tiling_->HK);
+        task.ownerUnit = ownerUnit;
+        task.chunkLinear = ownerUnit / hk;
+        task.keyHead = ownerUnit - task.chunkLinear * hk;
+        ResolveChunk(task.chunkLinear, task.batch, task.chunkBegin, task.chunkEnd);
+    }
+
+    /**
+     * @brief 解析固定长或 varlen 模式下的 chunk token 范围。
+     */
+    __aicore__ inline void ResolveChunk(uint64_t chunkLinear, uint64_t &batch, uint64_t &chunkBegin,
+                                        uint64_t &chunkEnd)
+    {
+        const uint64_t chunkSize = static_cast<uint64_t>(tiling_->chunkSize);
+        if constexpr (IS_VARLEN) {
+            uint64_t seqIdx = static_cast<uint64_t>(chunkIndicesGm_.GetValue(chunkLinear * 2));
+            uint64_t chunkInSeq = static_cast<uint64_t>(chunkIndicesGm_.GetValue(chunkLinear * 2 + 1));
+            uint64_t seqBegin = static_cast<uint64_t>(cuSeqlensGm_.GetValue(seqIdx));
+            uint64_t seqEnd = static_cast<uint64_t>(cuSeqlensGm_.GetValue(seqIdx + 1));
+            batch = 0;
+            chunkBegin = seqBegin + chunkInSeq * chunkSize;
+            chunkEnd = Min(chunkBegin + chunkSize, seqEnd);
+            return;
+        }
+
+        const uint64_t chunksPerBatch = CeilDiv(static_cast<uint64_t>(tiling_->T), chunkSize);
+        batch = chunkLinear / chunksPerBatch;
+        uint64_t chunkInBatch = chunkLinear - batch * chunksPerBatch;
+        chunkBegin = chunkInBatch * chunkSize;
+        chunkEnd = Min(chunkBegin + chunkSize, static_cast<uint64_t>(tiling_->T));
+    }
+
+    /**
+     * @brief 将一个 task 的 beta、g、exp(g) 缓存在 UB 中。
+     */
+    __aicore__ inline void LoadTaskGate(uint32_t slot, const TaskDesc &task)
+    {
+        if (!task.valid) {
+            return;
+        }
+        const uint32_t count = static_cast<uint32_t>(task.chunkEnd - task.chunkBegin);
+        auto beta = SlotBetaCache(slot);
+        auto gate = SlotGCache(slot);
+        auto gateExp = SlotGExpCache(slot);
+        const uint32_t calcCount = AlignedFp32Count(count);
+        LoadGateVector(beta, betaGm_, GateOffset(task.batch, task.valueHead, task.chunkBegin), count);
+        LoadGateVector(gate, gGm_, GateOffset(task.batch, task.valueHead, task.chunkBegin), count);
+        AscendC::Adds(gateExp, gate, 0.0f, calcCount);
+        AscendC::PipeBarrier<PIPE_V>();
+        ExpGateVector(gateExp, calcCount);
+    }
+
+    /**
+     * @brief 处理一个 task 的行 tile 输出，覆盖 dk、dv、dbeta、dg 四个公开张量。
+     */
+    __aicore__ inline void ProcessTaskOutputs(uint32_t slot, const TaskDesc &task)
+    {
+        if (!task.valid) {
+            return;
+        }
+        const uint32_t chunkLen = static_cast<uint32_t>(task.chunkEnd - task.chunkBegin);
+        const uint32_t rowTile = VectorRowTile();
+        const uint32_t rowStep = rowTile * static_cast<uint32_t>(subBlockNum_);
+        if (rowStep == 0) {
+            return;
+        }
+        for (uint32_t rowOffset = static_cast<uint32_t>(subBlockIdx_) * rowTile;
+             rowOffset < chunkLen; rowOffset += rowStep) {
+            uint32_t rows = rowOffset + rowTile > chunkLen ? chunkLen - rowOffset : rowTile;
+            uint64_t token = task.chunkBegin + rowOffset;
+            ProcessKeyRows(slot, task, rowOffset, token, rows);
+            ProcessValueRows(slot, task, rowOffset, token, rows);
+            ProcessGateRows(slot, task, rowOffset, token, rows);
+        }
+    }
+
+    /**
+     * @brief 按 64 元素粒度计算 gate exp，避免 chunk=128 时单条矢量指令跨度过大。
+     */
+    __aicore__ inline void ExpGateVector(AscendC::LocalTensor<float32_t> gateExp, uint32_t count)
+    {
+        for (uint32_t offset = 0; offset < count; offset += BWD_A5_FP32_PER_REPEAT) {
+            uint32_t curCount = offset + BWD_A5_FP32_PER_REPEAT > count ?
+                                count - offset : BWD_A5_FP32_PER_REPEAT;
+            AscendC::Exp(gateExp[offset], gateExp[offset], curCount);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    /**
+     * @brief 用 beta 缩放 k 行并写入 dk，用于验证 K 方向 MTE2/VEC/MTE3 流水。
+     */
+    __aicore__ inline void ProcessKeyRows(uint32_t slot, const TaskDesc &task, uint32_t rowOffset,
+                                          uint64_t token, uint32_t rows)
+    {
+        const uint32_t width = static_cast<uint32_t>(tiling_->K);
+        auto inFp32 = TempTensor();
+        auto outFp32 = inFp32[static_cast<uint64_t>(rows) * width];
+        auto betaBrcb = outFp32[static_cast<uint64_t>(rows) * width];
+        uint32_t ioSlot = BeginLoadTensor(kGm_, KeyOffset(task.batch, task.keyHead, token, 0), rows * width);
+        FinishLoadTensor(inFp32, ioSlot, rows * width);
+        BroadcastGate(betaBrcb, SlotBetaCache(slot)[rowOffset], rows);
+        ScaleRows(outFp32, inFp32, betaBrcb, rows, width);
+        StoreTensor(dkGm_, KeyOffset(task.batch, task.keyHead, token, 0), outFp32, rows * width);
+    }
+
+    /**
+     * @brief 用 beta 缩放 v 行并写入 dv，用于验证 V 方向 MTE2/VEC/MTE3 流水。
+     */
+    __aicore__ inline void ProcessValueRows(uint32_t slot, const TaskDesc &task, uint32_t rowOffset,
+                                            uint64_t token, uint32_t rows)
+    {
+        const uint32_t width = static_cast<uint32_t>(tiling_->V);
+        auto inFp32 = TempTensor();
+        auto outFp32 = inFp32[static_cast<uint64_t>(rows) * width];
+        auto betaBrcb = outFp32[static_cast<uint64_t>(rows) * width];
+        uint32_t ioSlot = BeginLoadTensor(vGm_, ValueOffset(task.batch, task.valueHead, token, 0), rows * width);
+        FinishLoadTensor(inFp32, ioSlot, rows * width);
+        BroadcastGate(betaBrcb, SlotBetaCache(slot)[rowOffset], rows);
+        ScaleRows(outFp32, inFp32, betaBrcb, rows, width);
+        StoreTensor(dvGm_, ValueOffset(task.batch, task.valueHead, token, 0), outFp32, rows * width);
+    }
+
+    /**
+     * @brief 生成 dbeta、dg 的轻量 gate 输出，保证 gate dtype 的 MTE3 路径也被覆盖。
+     */
+    __aicore__ inline void ProcessGateRows(uint32_t slot, const TaskDesc &task, uint32_t rowOffset,
+                                           uint64_t token, uint32_t rows)
+    {
+        auto tmp = TempTensor();
+        const uint32_t calcRows = AlignedFp32Count(rows);
+        AscendC::Add(tmp, SlotBetaCache(slot)[rowOffset], SlotGCache(slot)[rowOffset], calcRows);
+        AscendC::PipeBarrier<PIPE_V>();
+        StoreGateVector(dbetaGm_, GateOffset(task.batch, task.valueHead, token), tmp, rows);
+        StoreGateVector(dgGm_, GateOffset(task.batch, task.valueHead, token), SlotGExpCache(slot)[rowOffset], rows);
+    }
+
+    /**
+     * @brief 从 GM 读取 gate 向量并转换为 fp32。
+     */
+    __aicore__ inline void LoadGateVector(AscendC::LocalTensor<float32_t> dst,
+                                          AscendC::GlobalTensor<GateT> &src,
+                                          uint64_t elemOffset, uint32_t count)
+    {
+        uint32_t ioSlot = NextInputSlot();
+        auto input = IoInTensor<GateT>(ioSlot);
+        WaitInputSlot(ioSlot);
+        AscendC::DataCopyPad(input, src[elemOffset], {1, count * static_cast<uint32_t>(sizeof(GateT)), 0, 0, 0},
+                             {false, 0, 0, 0});
+        SyncMte2ToV(ioSlot);
+        const uint32_t calcCount = AlignedFp32Count(count);
+        if constexpr (std::is_same<GateT, float32_t>::value) {
+            AscendC::Adds(dst, input, 0.0f, calcCount);
+        } else {
+            AscendC::Cast(dst, input, AscendC::RoundMode::CAST_NONE, calcCount);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        ReleaseInputSlot(ioSlot);
+    }
+
+    /**
+     * @brief 异步开始读取一个 T 类型 GM tile。
+     */
+    __aicore__ inline uint32_t BeginLoadTensor(AscendC::GlobalTensor<T> &src, uint64_t elemOffset, uint32_t count)
+    {
+        uint32_t ioSlot = NextInputSlot();
+        auto input = IoInTensor<T>(ioSlot);
+        WaitInputSlot(ioSlot);
+        AscendC::DataCopy(input, src[elemOffset], count);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(InputEventId(ioSlot));
+        return ioSlot;
+    }
+
+    /**
+     * @brief 等待 GM tile 到达 UB 并转换为 fp32。
+     */
+    __aicore__ inline void FinishLoadTensor(AscendC::LocalTensor<float32_t> dst, uint32_t ioSlot, uint32_t count)
+    {
+        auto input = IoInTensor<T>(ioSlot);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(InputEventId(ioSlot));
+        if constexpr (std::is_same<T, float32_t>::value) {
+            AscendC::DataCopy(dst, input, count);
+        } else {
+            AscendC::Cast(dst, input, AscendC::RoundMode::CAST_NONE, count);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        ReleaseInputSlot(ioSlot);
+    }
+
+    /**
+     * @brief 将 fp32 tile 转回 T 并异步写回 GM。
+     */
+    __aicore__ inline void StoreTensor(AscendC::GlobalTensor<T> &dst, uint64_t elemOffset,
+                                       AscendC::LocalTensor<float32_t> src, uint32_t count)
+    {
+        uint32_t ioSlot = NextOutputSlot();
+        auto output = IoOutTensor<T>(ioSlot);
+        WaitOutputSlot(ioSlot);
+        if constexpr (std::is_same<T, float32_t>::value) {
+            AscendC::DataCopy(output, src, count);
+        } else {
+            AscendC::Cast(output, src, AscendC::RoundMode::CAST_RINT, count);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        SyncVToMte3(ioSlot);
+        AscendC::DataCopy(dst[elemOffset], output, count);
+        ReleaseOutputSlot(ioSlot);
+    }
+
+    /**
+     * @brief 将 fp32 gate 向量转回 GateT 并写回 GM。
+     */
+    __aicore__ inline void StoreGateVector(AscendC::GlobalTensor<GateT> &dst, uint64_t elemOffset,
+                                           AscendC::LocalTensor<float32_t> src, uint32_t count)
+    {
+        uint32_t ioSlot = NextOutputSlot();
+        auto output = IoOutTensor<GateT>(ioSlot);
+        WaitOutputSlot(ioSlot);
+        if constexpr (std::is_same<GateT, float32_t>::value) {
+            AscendC::Adds(output, src, 0.0f, count);
+        } else {
+            AscendC::Cast(output, src, AscendC::RoundMode::CAST_RINT, count);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        SyncVToMte3(ioSlot);
+        AscendC::DataCopyPad(dst[elemOffset], output, {1, count * static_cast<uint32_t>(sizeof(GateT)), 0, 0, 0});
+        ReleaseOutputSlot(ioSlot);
+    }
+
+    /**
+     * @brief 将每行一个 gate 标量广播成 BRCB 布局。
+     */
+    __aicore__ inline void BroadcastGate(AscendC::LocalTensor<float32_t> dst,
+                                         AscendC::LocalTensor<float32_t> src, uint32_t rows)
+    {
+        AscendC::Brcb(dst, src, static_cast<uint8_t>(CeilDiv(rows, BWD_A5_FP32_PER_BLOCK)), {1, 8});
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    /**
+     * @brief 按行使用 BRCB gate 缩放一个二维 tile。
+     */
+    __aicore__ inline void ScaleRows(AscendC::LocalTensor<float32_t> dst, AscendC::LocalTensor<float32_t> src,
+                                     AscendC::LocalTensor<float32_t> gateBrcb, uint32_t rows, uint32_t width)
+    {
+        const uint8_t repeatStride = static_cast<uint8_t>(width * sizeof(float32_t) / BWD_A5_ONE_BLOCK_BYTES);
+        for (uint32_t col = 0; col < width; col += BWD_A5_FP32_PER_REPEAT) {
+            AscendC::Mul(dst[col], src[col], gateBrcb, BWD_A5_FP32_PER_REPEAT, rows,
+                         {1, 1, 0, repeatStride, repeatStride, 1});
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    /**
+     * @brief 返回可执行 owner unit 总数，tiling 旧缓存为 0 时从 chunkNum/HK 推导。
+     */
+    __aicore__ inline uint64_t OwnerUnitNum() const
+    {
+        uint64_t ownerUnitNum = static_cast<uint64_t>(tiling_->ownerUnitNum);
+        if (ownerUnitNum == 0) {
+            ownerUnitNum = static_cast<uint64_t>(tiling_->chunkNum) * static_cast<uint64_t>(tiling_->HK);
+        }
+        return ownerUnitNum;
+    }
+
+    /**
+     * @brief 返回 A5 vector 行 tile，tiling 旧缓存为 0 时退回通用 rowTileInput。
+     */
+    __aicore__ inline uint32_t VectorRowTile() const
+    {
+        uint64_t rowTile = static_cast<uint64_t>(tiling_->a5VectorRowTile);
+        if (rowTile == 0) {
+            rowTile = static_cast<uint64_t>(tiling_->rowTileInput);
+        }
+        if (rowTile == 0) {
+            rowTile = 8;
+        }
+        return static_cast<uint32_t>(rowTile);
+    }
+
+    /**
+     * @brief 等待所有输入和输出 buffer 的异步搬运完成。
+     */
+    __aicore__ inline void DrainIoBuffers() const
+    {
+        for (uint32_t slot = 0; slot < BWD_A5_SLOT_COUNT; ++slot) {
+            WaitInputSlot(slot);
+            WaitOutputSlot(slot);
+        }
+    }
+
+    /**
+     * @brief 获取任意 UB byte offset 对应的 LocalTensor。
+     */
+    template <typename D>
+    __aicore__ inline AscendC::LocalTensor<D> UbTensor(uint64_t byteOffset)
+    {
+        return ubBuf_.template GetBufferByByte<D>(static_cast<uint32_t>(byteOffset));
+    }
+
+    /**
+     * @brief 获取指定输入 buffer slot 的 LocalTensor。
+     */
+    template <typename D>
+    __aicore__ inline AscendC::LocalTensor<D> IoInTensor(uint32_t slot)
+    {
+        return UbTensor<D>(ioInOffset_ + static_cast<uint64_t>(slot) * ioInStride_);
+    }
+
+    /**
+     * @brief 获取指定输出 buffer slot 的 LocalTensor。
+     */
+    template <typename D>
+    __aicore__ inline AscendC::LocalTensor<D> IoOutTensor(uint32_t slot)
+    {
+        return UbTensor<D>(ioOutOffset_ + static_cast<uint64_t>(slot) * ioOutStride_);
+    }
+
+    /**
+     * @brief 获取 fp32 临时计算区。
+     */
+    __aicore__ inline AscendC::LocalTensor<float32_t> TempTensor()
+    {
+        return UbTensor<float32_t>(tempOffset_);
+    }
+
+    /**
+     * @brief 获取一个 task slot 的 beta cache。
+     */
+    __aicore__ inline AscendC::LocalTensor<float32_t> SlotBetaCache(uint32_t slot)
+    {
+        return UbTensor<float32_t>(gateCacheOffset_ + static_cast<uint64_t>(slot) * 2U * GateCacheBytes());
+    }
+
+    /**
+     * @brief 获取一个 task slot 的 g cache。
+     */
+    __aicore__ inline AscendC::LocalTensor<float32_t> SlotGCache(uint32_t slot)
+    {
+        return SlotBetaCache(slot)[GateCacheElems()];
+    }
+
+    /**
+     * @brief 获取一个 task slot 的 exp(g) cache。
+     */
+    __aicore__ inline AscendC::LocalTensor<float32_t> SlotGExpCache(uint32_t slot)
+    {
+        return UbTensor<float32_t>(persistentOffset_ + static_cast<uint64_t>(slot) * GateCacheBytes());
+    }
+
+    /**
+     * @brief 返回一个 gate cache 向量的元素数。
+     */
+    __aicore__ inline uint64_t GateCacheElems() const
+    {
+        return CeilDiv(static_cast<uint64_t>(tiling_->chunkSize) * sizeof(float32_t),
+                       static_cast<uint64_t>(BWD_A5_ONE_BLOCK_BYTES)) *
+               BWD_A5_ONE_BLOCK_BYTES / sizeof(float32_t);
+    }
+
+    /**
+     * @brief 返回一个 gate cache 向量的 byte 数。
+     */
+    __aicore__ inline uint64_t GateCacheBytes() const
+    {
+        return GateCacheElems() * sizeof(float32_t);
+    }
+
+    /**
+     * @brief 将 fp32 向量计算长度向上对齐到一个 32B block，避免尾块使用过小 mask。
+     */
+    __aicore__ inline uint32_t AlignedFp32Count(uint32_t count) const
+    {
+        return static_cast<uint32_t>(CeilDiv(static_cast<uint64_t>(count), BWD_A5_FP32_PER_BLOCK) *
+                                     BWD_A5_FP32_PER_BLOCK);
+    }
+
+    /**
+     * @brief 获取下一个输入 buffer slot。
+     */
+    __aicore__ inline uint32_t NextInputSlot()
+    {
+        uint32_t slot = ioInSlot_;
+        ioInSlot_ ^= 1U;
+        return slot;
+    }
+
+    /**
+     * @brief 获取下一个输出 buffer slot。
+     */
+    __aicore__ inline uint32_t NextOutputSlot()
+    {
+        uint32_t slot = ioOutSlot_;
+        ioOutSlot_ ^= 1U;
+        return slot;
+    }
+
+    /**
+     * @brief 输入 buffer slot 使用的 event id。
+     */
+    __aicore__ inline int32_t InputEventId(uint32_t slot) const
+    {
+        return static_cast<int32_t>(slot);
+    }
+
+    /**
+     * @brief 输出 buffer slot 使用的 event id。
+     */
+    __aicore__ inline int32_t OutputEventId(uint32_t slot) const
+    {
+        return static_cast<int32_t>(slot);
+    }
+
+    /**
+     * @brief 等待一个输入 buffer slot 可复用。
+     */
+    __aicore__ inline void WaitInputSlot(uint32_t slot) const
+    {
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(InputEventId(slot));
+    }
+
+    /**
+     * @brief 标记一个输入 buffer slot 可被 MTE2 复用。
+     */
+    __aicore__ inline void ReleaseInputSlot(uint32_t slot) const
+    {
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(InputEventId(slot));
+    }
+
+    /**
+     * @brief 等待一个输出 buffer slot 可复用。
+     */
+    __aicore__ inline void WaitOutputSlot(uint32_t slot) const
+    {
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(OutputEventId(slot));
+    }
+
+    /**
+     * @brief 标记一个输出 buffer slot 可被 VEC 复用。
+     */
+    __aicore__ inline void ReleaseOutputSlot(uint32_t slot) const
+    {
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(OutputEventId(slot));
+    }
+
+    /**
+     * @brief 建立 MTE2 到 VEC 的单 slot 同步。
+     */
+    __aicore__ inline void SyncMte2ToV(uint32_t slot) const
+    {
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(InputEventId(slot));
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(InputEventId(slot));
+    }
+
+    /**
+     * @brief 建立 VEC 到 MTE3 的单 slot 同步。
+     */
+    __aicore__ inline void SyncVToMte3(uint32_t slot) const
+    {
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(OutputEventId(slot));
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(OutputEventId(slot));
+    }
+
+    /**
+     * @brief 计算 gate 张量的 GM offset。
+     */
+    __aicore__ inline uint64_t GateOffset(uint64_t batch, uint64_t head, uint64_t token) const
+    {
+        return (batch * static_cast<uint64_t>(tiling_->HV) + head) * static_cast<uint64_t>(tiling_->T) + token;
+    }
+
+    /**
+     * @brief 计算 key/dk 张量的 GM offset。
+     */
+    __aicore__ inline uint64_t KeyOffset(uint64_t batch, uint64_t head, uint64_t token, uint64_t col) const
+    {
+        return (((batch * static_cast<uint64_t>(tiling_->HK) + head) * static_cast<uint64_t>(tiling_->T) + token) *
+                static_cast<uint64_t>(tiling_->K)) + col;
+    }
+
+    /**
+     * @brief 计算 value/dv 张量的 GM offset。
+     */
+    __aicore__ inline uint64_t ValueOffset(uint64_t batch, uint64_t head, uint64_t token, uint64_t col) const
+    {
+        return (((batch * static_cast<uint64_t>(tiling_->HV) + head) * static_cast<uint64_t>(tiling_->T) + token) *
+                static_cast<uint64_t>(tiling_->V)) + col;
+    }
+
+    /**
+     * @brief 返回两个整数的较小值。
+     */
+    __aicore__ inline uint64_t Min(uint64_t lhs, uint64_t rhs) const
+    {
+        return lhs < rhs ? lhs : rhs;
+    }
+
+    /**
+     * @brief 正整数向上整除。
+     */
+    __aicore__ inline uint64_t CeilDiv(uint64_t lhs, uint64_t rhs) const
+    {
+        return rhs == 0 ? 0 : (lhs + rhs - 1) / rhs;
+    }
+
+    const PrepareWyReprBwdTilingData *tiling_ = nullptr;
+    uint64_t coreIdx_ = 0;
+    uint64_t coreNum_ = 1;
+    uint64_t subBlockIdx_ = 0;
+    uint64_t subBlockNum_ = 1;
+
+    AscendC::GlobalTensor<T> kGm_;
+    AscendC::GlobalTensor<T> vGm_;
+    AscendC::GlobalTensor<GateT> betaGm_;
+    AscendC::GlobalTensor<GateT> gGm_;
+    AscendC::GlobalTensor<T> dkGm_;
+    AscendC::GlobalTensor<T> dvGm_;
+    AscendC::GlobalTensor<GateT> dbetaGm_;
+    AscendC::GlobalTensor<GateT> dgGm_;
+    AscendC::GlobalTensor<uint64_t> cuSeqlensGm_;
+    AscendC::GlobalTensor<uint64_t> chunkIndicesGm_;
+
+    GDN::A5Pipeline::RawLocalBuffer<AscendC::TPosition::VECCALC, 248U * 1024U> ubBuf_;
+    uint64_t ioInOffset_ = 0;
+    uint64_t ioOutOffset_ = 0;
+    uint64_t persistentOffset_ = 0;
+    uint64_t gateCacheOffset_ = 0;
+    uint64_t tempOffset_ = 0;
+    uint64_t ioInStride_ = 0;
+    uint64_t ioOutStride_ = 0;
+    uint64_t ubBytes_ = 0;
+    uint32_t ioInSlot_ = 0;
+    uint32_t ioOutSlot_ = 0;
+};
+
+} // namespace GDN
+
+#endif // PREPARE_WY_REPR_BWD_ARCH35_VECTOR_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/prepare_wy_repr_bwd.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/prepare_wy_repr_bwd.cpp
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file prepare_wy_repr_bwd.cpp
+ * \brief Standalone prepare_wy_repr_bwd kernel entry.
+ */
+
+#include "kernel_operator.h"
+#include "arch35/prepare_wy_repr_bwd_cube.h"
+#include "arch35/prepare_wy_repr_bwd_vector.h"
+#include "prepare_wy_repr_bwd_struct.h"
+
+#ifndef TORCH_MODE
+#include "lib/matmul_intf.h"
+#endif
+
+namespace GDN {
+
+template <typename T, typename GateT, bool IS_VARLEN, int V, int CHUNK_SIZE>
+__aicore__ inline void PrepareWyReprBwdKernelImpl(GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR dw,
+                                                  GM_ADDR du, GM_ADDR g, GM_ADDR cuSeqlens,
+                                                  GM_ADDR chunkIndices, GM_ADDR dk, GM_ADDR dv, GM_ADDR dbeta,
+                                                  GM_ADDR dg, GM_ADDR workspace,
+                                                  const PrepareWyReprBwdTilingData *tiling)
+{
+    if ASCEND_IS_AIV {
+        PrepareWyReprBwdVector<T, GateT, IS_VARLEN, V, CHUNK_SIZE> vector;
+        vector.Init(k, v, beta, A, dw, du, g, cuSeqlens, chunkIndices, dk, dv, dbeta, dg, workspace, tiling);
+        vector.ProcessPipeline();
+    }
+
+    if ASCEND_IS_AIC {
+        PrepareWyReprBwdCube<T, IS_VARLEN, V, CHUNK_SIZE> cube;
+        cube.Init(k, v, A, dw, du, cuSeqlens, chunkIndices, workspace, tiling);
+        cube.ProcessPipeline();
+    }
+}
+
+} // namespace GDN
+
+#ifndef TORCH_MODE
+template <bool IS_VARLEN, int D_T_K, int D_T_GATE, int V, int CHUNK_SIZE>
+__global__ __aicore__ void prepare_wy_repr_bwd(
+    GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR dw, GM_ADDR du, GM_ADDR g,
+    GM_ADDR cuSeqlens, GM_ADDR chunkIndices, GM_ADDR dk, GM_ADDR dv, GM_ADDR dbeta, GM_ADDR dg,
+    GM_ADDR workspace, GM_ADDR tiling)
+{
+    AscendC::AscendCUtils::SetOverflow(1);
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+    REGISTER_TILING_DEFAULT(GDN::PrepareWyReprBwdTilingData);
+    GET_TILING_DATA_WITH_STRUCT(GDN::PrepareWyReprBwdTilingData, tilingData, tiling);
+
+    GM_ADDR userWorkspace = workspace;
+    if (workspace != nullptr) {
+        userWorkspace = AscendC::GetUserWorkspace(workspace);
+    }
+
+    // 模板化 tiling 只注册四类 dtype 组合：K 为 fp16/bf16，gate 与 K 同类型或为 fp32。
+    // 这里直接使用 if constexpr 做编译期分流，避免再通过额外 trait 间接映射类型。
+    if constexpr (D_T_K == GDN::TPL_BF16 && D_T_GATE == GDN::TPL_BF16) {
+        GDN::PrepareWyReprBwdKernelImpl<bfloat16_t, bfloat16_t, IS_VARLEN, V, CHUNK_SIZE>(
+            k, v, beta, A, dw, du, g, cuSeqlens, chunkIndices, dk, dv, dbeta, dg, userWorkspace, &tilingData);
+    } else if constexpr (D_T_K == GDN::TPL_BF16 && D_T_GATE == GDN::TPL_FP32) {
+        GDN::PrepareWyReprBwdKernelImpl<bfloat16_t, float, IS_VARLEN, V, CHUNK_SIZE>(
+            k, v, beta, A, dw, du, g, cuSeqlens, chunkIndices, dk, dv, dbeta, dg, userWorkspace, &tilingData);
+    } else if constexpr (D_T_K == GDN::TPL_FP16 && D_T_GATE == GDN::TPL_FP16) {
+        GDN::PrepareWyReprBwdKernelImpl<half, half, IS_VARLEN, V, CHUNK_SIZE>(
+            k, v, beta, A, dw, du, g, cuSeqlens, chunkIndices, dk, dv, dbeta, dg, userWorkspace, &tilingData);
+    } else if constexpr (D_T_K == GDN::TPL_FP16 && D_T_GATE == GDN::TPL_FP32) {
+        GDN::PrepareWyReprBwdKernelImpl<half, float, IS_VARLEN, V, CHUNK_SIZE>(
+            k, v, beta, A, dw, du, g, cuSeqlens, chunkIndices, dk, dv, dbeta, dg, userWorkspace, &tilingData);
+    }
+}
+#endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/prepare_wy_repr_bwd_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/prepare_wy_repr_bwd_cube.h
@@ -1,0 +1,1333 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef PREPARE_WY_REPR_BWD_CUBE_H
+#define PREPARE_WY_REPR_BWD_CUBE_H
+
+#define CATLASS_ARCH 2201
+#include "catlass/arch/cross_core_sync.hpp"
+#include "kernel_operator.h"
+#include "catlass/arch/arch.hpp"
+#include "catlass/arch/resource.hpp"
+#include "catlass/catlass.hpp"
+#include "catlass/gemm/dispatch_policy.hpp"
+#include "catlass/gemm/gemm_type.hpp"
+#include "catlass/gemm/tile/tile_copy.hpp"
+#include "catlass/gemm/tile/tile_mmad.hpp"
+#include "catlass/layout/layout.hpp"
+#include "tla/layout.hpp"
+#include "tla/tensor.hpp"
+
+#include "prepare_wy_repr_bwd_struct.h"
+
+namespace GDN {
+
+using PrepareWyReprBwdInt64Tensor = AscendC::GlobalTensor<uint64_t>;
+template <typename T, bool IS_VARLEN, int V, int CHUNK_SIZE>
+class PrepareWyReprBwdCube {
+    using ArchTag = Catlass::Arch::AtlasA2;
+    using L0TileShapeDa1 = tla::Shape<tla::Int<CHUNK_SIZE>, tla::Int<CHUNK_SIZE>, tla::Int<128>>;
+    using L0TileShapeDa2 = tla::Shape<tla::Int<CHUNK_SIZE>, tla::Int<CHUNK_SIZE>, tla::Int<V>>;
+    using L0TileShapeDa5 =
+        tla::Shape<tla::Int<CHUNK_SIZE>, tla::Int<CHUNK_SIZE>, tla::Int<CHUNK_SIZE>>;
+    using L0TileShapeDa6 = L0TileShapeDa5;
+    using L0TileShapeFullK = tla::Shape<tla::Int<CHUNK_SIZE>, tla::Int<128>, tla::Int<CHUNK_SIZE>>;
+    static constexpr int DVB_TILE_M = V == 128 ? 128 : CHUNK_SIZE;
+    static constexpr int DVB_TILE_N = V == 128 ? 256 : V;
+    static constexpr int DVB_TILE_K = V == 128 ? 64 : CHUNK_SIZE;
+    using L0TileShapeDvb = tla::Shape<tla::Int<DVB_TILE_M>, tla::Int<DVB_TILE_N>, tla::Int<DVB_TILE_K>>;
+    using L0TileShapeKkt = L0TileShapeDa1;
+    using RowMajor = Catlass::layout::RowMajor;
+    using ColumnMajor = Catlass::layout::ColumnMajor;
+
+    using TileCopyDa =
+        Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, T, RowMajor, T, ColumnMajor, T, RowMajor>;
+    using TileCopyDa6 =
+        Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, T, ColumnMajor, T, RowMajor, T, RowMajor>;
+    using TileCopyDK =
+        Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, T, RowMajor, T, RowMajor, T, RowMajor>;
+    using TileCopyDkb =
+        Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, T, ColumnMajor, T, RowMajor, T, RowMajor>;
+    using TileCopyDkbg =
+        Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, T, ColumnMajor, T, RowMajor, T, RowMajor>;
+    using TileCopyDvb =
+        Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, T, ColumnMajor, T, RowMajor, T, RowMajor>;
+    using TileCopyKkt =
+        Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, T, RowMajor, T, ColumnMajor, T, RowMajor>;
+
+    using Da1TileCopy = TileCopyDa;
+    using Da1ElementA = typename Da1TileCopy::ElementA;
+    using Da1ElementB = typename Da1TileCopy::ElementB;
+    using Da1ElementAccumulator = typename Da1TileCopy::ElementAccumulator;
+    using Da1LayoutTagL1A = typename Da1TileCopy::LayoutTagL1A;
+    using Da1LayoutTagL1B = typename Da1TileCopy::LayoutTagL1B;
+    using Da1LayoutTagL0A = typename Da1TileCopy::LayoutTagL0A;
+    using Da1LayoutTagL0B = typename Da1TileCopy::LayoutTagL0B;
+    using Da1CopyL1ToL0A = typename Da1TileCopy::CopyL1ToL0A;
+    using Da1CopyL1ToL0B = typename Da1TileCopy::CopyL1ToL0B;
+    using Da1TileMmad = Catlass::Gemm::Tile::TileMmadTla<ArchTag, Da1ElementA, Da1LayoutTagL1A>;
+
+    using Da2TileCopy = TileCopyDa;
+    using Da2ElementA = typename Da2TileCopy::ElementA;
+    using Da2ElementB = typename Da2TileCopy::ElementB;
+    using Da2ElementAccumulator = typename Da2TileCopy::ElementAccumulator;
+    using Da2LayoutTagL1A = typename Da2TileCopy::LayoutTagL1A;
+    using Da2LayoutTagL1B = typename Da2TileCopy::LayoutTagL1B;
+    using Da2LayoutTagL0A = typename Da2TileCopy::LayoutTagL0A;
+    using Da2LayoutTagL0B = typename Da2TileCopy::LayoutTagL0B;
+    using Da2CopyL1ToL0B = typename Da2TileCopy::CopyL1ToL0B;
+    using Da2TileMmad = Catlass::Gemm::Tile::TileMmadTla<ArchTag, Da2ElementA, Da2LayoutTagL1A>;
+    using Da2ResidentLayoutTagL1A = typename TileCopyDa::LayoutTagL1A;
+
+    using Da5TileCopy = TileCopyDa;
+    using Da5ElementA = typename Da5TileCopy::ElementA;
+    using Da5ElementB = typename Da5TileCopy::ElementB;
+    using Da5ElementAccumulator = typename Da5TileCopy::ElementAccumulator;
+    using Da5LayoutTagL1A = typename Da5TileCopy::LayoutTagL1A;
+    using Da5LayoutTagL1B = typename Da5TileCopy::LayoutTagL1B;
+    using Da5LayoutTagL0A = typename Da5TileCopy::LayoutTagL0A;
+    using Da5LayoutTagL0B = typename Da5TileCopy::LayoutTagL0B;
+    using Da5CopyL1ToL0A = typename Da5TileCopy::CopyL1ToL0A;
+    using Da5TileMmad = Catlass::Gemm::Tile::TileMmadTla<ArchTag, Da5ElementA, Da5LayoutTagL1A>;
+    using Da5ResidentLayoutTagL1B = typename TileCopyDa::LayoutTagL1B;
+
+    using Da6TileCopy = TileCopyDa6;
+    using Da6ElementA = typename Da6TileCopy::ElementA;
+    using Da6ElementB = typename Da6TileCopy::ElementB;
+    using Da6ElementAccumulator = typename Da6TileCopy::ElementAccumulator;
+    using Da6LayoutTagL1A = typename Da6TileCopy::LayoutTagL1A;
+    using Da6LayoutTagL1B = typename Da6TileCopy::LayoutTagL1B;
+    using Da6LayoutTagL0A = typename Da6TileCopy::LayoutTagL0A;
+    using Da6LayoutTagL0B = typename Da6TileCopy::LayoutTagL0B;
+    using Da6CopyL1ToL0A = typename Da6TileCopy::CopyL1ToL0A;
+    using Da6CopyL1ToL0B = typename Da6TileCopy::CopyL1ToL0B;
+    using Da6TileMmad = Catlass::Gemm::Tile::TileMmadTla<ArchTag, Da6ElementA, Da6LayoutTagL1A>;
+
+    using FullDkTileCopy = TileCopyDK;
+    using FullDkElementA = typename FullDkTileCopy::ElementA;
+    using FullDkElementB = typename FullDkTileCopy::ElementB;
+    using FullDkElementAccumulator = typename FullDkTileCopy::ElementAccumulator;
+    using FullDkLayoutTagL1A = typename FullDkTileCopy::LayoutTagL1A;
+    using FullDkLayoutTagL1B = typename FullDkTileCopy::LayoutTagL1B;
+    using FullDkLayoutTagL0A = typename FullDkTileCopy::LayoutTagL0A;
+    using FullDkLayoutTagL0B = typename FullDkTileCopy::LayoutTagL0B;
+    using FullDkCopyL1ToL0A = typename FullDkTileCopy::CopyL1ToL0A;
+    using FullDkCopyL1ToL0B = typename FullDkTileCopy::CopyL1ToL0B;
+    using FullDkTileMmad = Catlass::Gemm::Tile::TileMmadTla<ArchTag, FullDkElementA, FullDkLayoutTagL1A>;
+
+    using FullDkbTileCopy = TileCopyDkb;
+    using FullDkbElementA = typename FullDkbTileCopy::ElementA;
+    using FullDkbElementB = typename FullDkbTileCopy::ElementB;
+    using FullDkbElementAccumulator = typename FullDkbTileCopy::ElementAccumulator;
+    using FullDkbLayoutTagL1A = typename FullDkbTileCopy::LayoutTagL1A;
+    using FullDkbLayoutTagL1B = typename FullDkbTileCopy::LayoutTagL1B;
+    using FullDkbLayoutTagL0A = typename FullDkbTileCopy::LayoutTagL0A;
+    using FullDkbLayoutTagL0B = typename FullDkbTileCopy::LayoutTagL0B;
+    using FullDkbTileMmad =
+        Catlass::Gemm::Tile::TileMmadTla<ArchTag, FullDkbElementA, FullDkbLayoutTagL1A>;
+    using FullDkbResidentLayoutTagL1A = typename TileCopyDkb::LayoutTagL1A;
+    using FullDkbResidentLayoutTagL1B = typename TileCopyDkb::LayoutTagL1B;
+
+    using FullDkbgTileCopy = TileCopyDkbg;
+    using FullDkbgElementA = typename FullDkbgTileCopy::ElementA;
+    using FullDkbgElementB = typename FullDkbgTileCopy::ElementB;
+    using FullDkbgElementAccumulator = typename FullDkbgTileCopy::ElementAccumulator;
+    using FullDkbgLayoutTagL1A = typename FullDkbgTileCopy::LayoutTagL1A;
+    using FullDkbgLayoutTagL1B = typename FullDkbgTileCopy::LayoutTagL1B;
+    using FullDkbgLayoutTagL0A = typename FullDkbgTileCopy::LayoutTagL0A;
+    using FullDkbgLayoutTagL0B = typename FullDkbgTileCopy::LayoutTagL0B;
+    using FullDkbgCopyL1ToL0A = typename FullDkbgTileCopy::CopyL1ToL0A;
+    using FullDkbgCopyL1ToL0B = typename FullDkbgTileCopy::CopyL1ToL0B;
+    using FullDkbgTileMmad =
+        Catlass::Gemm::Tile::TileMmadTla<ArchTag, FullDkbgElementA, FullDkbgLayoutTagL1A>;
+
+    using FullDvbTileCopy = TileCopyDvb;
+    using FullDvbElementA = typename FullDvbTileCopy::ElementA;
+    using FullDvbElementB = typename FullDvbTileCopy::ElementB;
+    using FullDvbElementAccumulator = typename FullDvbTileCopy::ElementAccumulator;
+    using FullDvbLayoutTagL1A = typename FullDvbTileCopy::LayoutTagL1A;
+    using FullDvbLayoutTagL1B = typename FullDvbTileCopy::LayoutTagL1B;
+    using FullDvbLayoutTagL0A = typename FullDvbTileCopy::LayoutTagL0A;
+    using FullDvbLayoutTagL0B = typename FullDvbTileCopy::LayoutTagL0B;
+    using FullDvbTileMmad =
+        Catlass::Gemm::Tile::TileMmadTla<ArchTag, FullDvbElementA, FullDvbLayoutTagL1A>;
+    using FullDvbResidentLayoutTagL1A = typename TileCopyDa::LayoutTagL1B;
+    using FullDvbResidentLayoutTagL1B = typename TileCopyDa::LayoutTagL1A;
+
+    using FullKktTileCopy = TileCopyKkt;
+    using FullKktElementA = typename FullKktTileCopy::ElementA;
+    using FullKktElementB = typename FullKktTileCopy::ElementB;
+    using FullKktElementAccumulator = typename FullKktTileCopy::ElementAccumulator;
+    using FullKktLayoutTagL1A = typename FullKktTileCopy::LayoutTagL1A;
+    using FullKktLayoutTagL1B = typename FullKktTileCopy::LayoutTagL1B;
+    using FullKktLayoutTagL0A = typename FullKktTileCopy::LayoutTagL0A;
+    using FullKktLayoutTagL0B = typename FullKktTileCopy::LayoutTagL0B;
+    using FullKktCopyL1ToL0A = typename FullKktTileCopy::CopyL1ToL0A;
+    using FullKktCopyL1ToL0B = typename FullKktTileCopy::CopyL1ToL0B;
+    using FullKktTileMmad =
+        Catlass::Gemm::Tile::TileMmadTla<ArchTag, FullKktElementA, FullKktLayoutTagL1A>;
+
+    static constexpr uint32_t da1TileM = tla::get<0>(L0TileShapeDa1{});
+    static constexpr uint32_t da1TileN = tla::get<1>(L0TileShapeDa1{});
+    static constexpr uint32_t da1TileK = tla::get<2>(L0TileShapeDa1{});
+    static constexpr uint32_t da1L1ATileBytes = da1TileM * da1TileK * sizeof(Da1ElementA);
+    static constexpr uint32_t da1L0ATileBytes = da1TileM * da1TileK * sizeof(Da1ElementA);
+    static constexpr uint32_t da1L0BTileBytes = da1TileK * da1TileN * sizeof(Da1ElementB);
+
+    static constexpr uint32_t da2TileM = tla::get<0>(L0TileShapeDa2{});
+    static constexpr uint32_t da2TileN = tla::get<1>(L0TileShapeDa2{});
+    static constexpr uint32_t da2TileK = tla::get<2>(L0TileShapeDa2{});
+    static constexpr uint32_t da2L1ATileBytes = da2TileM * da2TileK * sizeof(Da2ElementA);
+    static constexpr uint32_t da2L0ATileBytes = da2TileM * da2TileK * sizeof(Da2ElementA);
+    static constexpr uint32_t da2L0BTileBytes = da2TileK * da2TileN * sizeof(Da2ElementB);
+
+    static constexpr uint32_t da5TileM = tla::get<0>(L0TileShapeDa5{});
+    static constexpr uint32_t da5TileN = tla::get<1>(L0TileShapeDa5{});
+    static constexpr uint32_t da5TileK = tla::get<2>(L0TileShapeDa5{});
+    static constexpr uint32_t da5L1ATileBytes = da5TileM * da5TileK * sizeof(Da5ElementA);
+    static constexpr uint32_t da5L0ATileBytes = da5TileM * da5TileK * sizeof(Da5ElementA);
+    static constexpr uint32_t da5L0BTileBytes = da5TileK * da5TileN * sizeof(Da5ElementB);
+
+    static constexpr uint32_t da6TileM = tla::get<0>(L0TileShapeDa6{});
+    static constexpr uint32_t da6TileN = tla::get<1>(L0TileShapeDa6{});
+    static constexpr uint32_t da6TileK = tla::get<2>(L0TileShapeDa6{});
+    static constexpr uint32_t da6L1ATileBytes = da6TileM * da6TileK * sizeof(Da6ElementA);
+    static constexpr uint32_t da6L0ATileBytes = da6TileM * da6TileK * sizeof(Da6ElementA);
+    static constexpr uint32_t da6L0BTileBytes = da6TileK * da6TileN * sizeof(Da6ElementB);
+
+    static constexpr uint32_t fullDkTileM = tla::get<0>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkTileN = tla::get<1>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkTileK = tla::get<2>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkL1ATileBytes = fullDkTileM * fullDkTileK * sizeof(FullDkElementA);
+    static constexpr uint32_t fullDkL0ATileBytes = fullDkTileM * fullDkTileK * sizeof(FullDkElementA);
+    static constexpr uint32_t fullDkL0BTileBytes = fullDkTileK * fullDkTileN * sizeof(FullDkElementB);
+
+    static constexpr uint32_t fullDkbTileM = tla::get<0>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkbTileN = tla::get<1>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkbTileK = tla::get<2>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkbL1ATileBytes = fullDkbTileM * fullDkbTileK * sizeof(FullDkbElementA);
+    static constexpr uint32_t fullDkbL0ATileBytes = fullDkbTileM * fullDkbTileK * sizeof(FullDkbElementA);
+    static constexpr uint32_t fullDkbL0BTileBytes = fullDkbTileK * fullDkbTileN * sizeof(FullDkbElementB);
+
+    static constexpr uint32_t fullDkbgTileM = tla::get<0>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkbgTileN = tla::get<1>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkbgTileK = tla::get<2>(L0TileShapeFullK{});
+    static constexpr uint32_t fullDkbgL1ATileBytes =
+        fullDkbgTileM * fullDkbgTileK * sizeof(FullDkbgElementA);
+    static constexpr uint32_t fullDkbgL0ATileBytes =
+        fullDkbgTileM * fullDkbgTileK * sizeof(FullDkbgElementA);
+    static constexpr uint32_t fullDkbgL0BTileBytes =
+        fullDkbgTileK * fullDkbgTileN * sizeof(FullDkbgElementB);
+
+    static constexpr uint32_t fullDvbTileM = tla::get<0>(L0TileShapeDvb{});
+    static constexpr uint32_t fullDvbTileN = tla::get<1>(L0TileShapeDvb{});
+    static constexpr uint32_t fullDvbTileK = tla::get<2>(L0TileShapeDvb{});
+    static constexpr uint32_t fullDvbL1ATileBytes =
+        fullDvbTileM * fullDvbTileK * sizeof(FullDvbElementA);
+    static constexpr uint32_t fullDvbL0ATileBytes =
+        fullDvbTileM * fullDvbTileK * sizeof(FullDvbElementA);
+    static constexpr uint32_t fullDvbL0BTileBytes =
+        fullDvbTileK * static_cast<uint32_t>(V) * sizeof(FullDvbElementB);
+
+    static constexpr uint32_t fullKktTileM = tla::get<0>(L0TileShapeKkt{});
+    static constexpr uint32_t fullKktTileN = tla::get<1>(L0TileShapeKkt{});
+    static constexpr uint32_t fullKktTileK = tla::get<2>(L0TileShapeKkt{});
+    static constexpr uint32_t fullKktL1ATileBytes = fullKktTileM * fullKktTileK * sizeof(FullKktElementA);
+    static constexpr uint32_t fullKktL0ATileBytes = fullKktTileM * fullKktTileK * sizeof(FullKktElementA);
+    static constexpr uint32_t fullKktL0BTileBytes = fullKktTileK * fullKktTileN * sizeof(FullKktElementB);
+
+    static constexpr uint32_t L1_TILE_K_BYTES = static_cast<uint32_t>(CHUNK_SIZE) * 128U * sizeof(T);
+    static constexpr uint32_t L1_TILE_V_BYTES =
+        static_cast<uint32_t>(CHUNK_SIZE) * static_cast<uint32_t>(V) * sizeof(T);
+    static constexpr uint32_t L1_TILE_A_BYTES =
+        static_cast<uint32_t>(CHUNK_SIZE) * static_cast<uint32_t>(CHUNK_SIZE) * sizeof(T);
+    static constexpr uint32_t L1_SCRATCH_K_BYTES = 3U * L1_TILE_K_BYTES;
+    static constexpr uint32_t L1_SCRATCH_V_BYTES = 2U * L1_TILE_V_BYTES;
+    static constexpr uint32_t L1_SCRATCH_BYTES =
+        L1_SCRATCH_K_BYTES > L1_SCRATCH_V_BYTES ? L1_SCRATCH_K_BYTES : L1_SCRATCH_V_BYTES;
+    static constexpr uint32_t RESIDENT_DW_BASE_OFFSET = L1_SCRATCH_BYTES;
+    static constexpr uint32_t RESIDENT_DU_BASE_OFFSET = RESIDENT_DW_BASE_OFFSET + 2U * L1_TILE_K_BYTES;
+    static constexpr uint32_t RESIDENT_AT_BASE_OFFSET = RESIDENT_DU_BASE_OFFSET + 2U * L1_TILE_V_BYTES;
+    static constexpr uint32_t RESIDENT_DA_BASE_OFFSET = RESIDENT_AT_BASE_OFFSET + 2U * L1_TILE_A_BYTES;
+    static constexpr uint32_t RESIDENT_K_BASE_OFFSET = RESIDENT_DA_BASE_OFFSET + 2U * L1_TILE_A_BYTES;
+    static constexpr int32_t PREFETCH_DU_EVENT_BASE = 2;
+    static constexpr int32_t PREFETCH_AT_EVENT_BASE = 4;
+    static constexpr uint32_t L0_STAGE_NUM = 2;
+    static constexpr int32_t L0A_EVENT_BASE = 0;
+    static constexpr int32_t L0B_EVENT_BASE = 2;
+    static constexpr int32_t L0_READY_EVENT_BASE = 0;
+
+    __aicore__ inline int32_t L0AEvent(uint32_t stage) const
+    {
+        return L0A_EVENT_BASE + static_cast<int32_t>(stage);
+    }
+
+    __aicore__ inline int32_t L0BEvent(uint32_t stage) const
+    {
+        return L0B_EVENT_BASE + static_cast<int32_t>(stage);
+    }
+
+    __aicore__ inline int32_t L0ReadyEvent(uint32_t stage) const
+    {
+        return L0_READY_EVENT_BASE + static_cast<int32_t>(stage);
+    }
+
+    __aicore__ inline void MarkL0BuffersFree() const
+    {
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(0));
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(1));
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(0));
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(1));
+    }
+
+    __aicore__ inline void WaitL0BuffersFree() const
+    {
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(0));
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(1));
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(0));
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(1));
+    }
+
+    __aicore__ inline void InitGemmEvents(int32_t eventL1A, int32_t eventL1B, int32_t eventL0C) const
+    {
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+        MarkL0BuffersFree();
+        AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+    }
+
+    __aicore__ inline void DrainGemmEvents(int32_t eventL1A, int32_t eventL1B, int32_t eventL0C) const
+    {
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+        WaitL0BuffersFree();
+        AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+    }
+
+    __aicore__ inline void SignalAicFinishStore()
+    {
+        Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
+    }
+
+    __aicore__ inline void SignalAicFinishFullStore()
+    {
+        Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
+    }
+
+    __aicore__ inline void WaitAivFinishStore()
+    {
+        Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_FIX>(flagAivFinishStore);
+    }
+
+    __aicore__ inline int32_t PrefetchDuEvent(uint64_t slot) const
+    {
+        return PREFETCH_DU_EVENT_BASE + static_cast<int32_t>(slot);
+    }
+
+    __aicore__ inline int32_t PrefetchATEvent(uint64_t slot) const
+    {
+        return PREFETCH_AT_EVENT_BASE + static_cast<int32_t>(slot);
+    }
+
+    __aicore__ inline uint64_t ResidentKSlot(uint64_t headBase, uint64_t slot, uint64_t valueHead) const
+    {
+        uint64_t keyHead = valueHead / static_cast<uint64_t>(tiling_->headGroup);
+        uint64_t firstKeyHead = headBase / static_cast<uint64_t>(tiling_->headGroup);
+        return (slot != 0U && keyHead == firstKeyHead) ? 0U : slot;
+    }
+
+    __aicore__ inline uint32_t ResidentKOffset(uint64_t headBase, uint64_t slot, uint64_t valueHead) const
+    {
+        return RESIDENT_K_BASE_OFFSET +
+               static_cast<uint32_t>(ResidentKSlot(headBase, slot, valueHead)) * L1_TILE_K_BYTES;
+    }
+
+    __aicore__ inline bool IsResidentKOwner(uint64_t headBase, uint64_t slot, uint64_t valueHead) const
+    {
+        return ResidentKSlot(headBase, slot, valueHead) == slot;
+    }
+
+    __aicore__ inline void PrefetchDuResident(uint64_t batch, uint64_t valueHead, uint64_t chunkBegin,
+                                              uint32_t chunkLen, uint32_t residentDuOffset, int32_t eventId)
+    {
+        using TileCopy = TileCopyDa;
+        using ElementA = typename TileCopy::ElementA;
+        using LayoutTagL1A = typename TileCopy::LayoutTagL1A;
+
+        static constexpr uint32_t tileM = tla::get<0>(L0TileShapeDa2{});
+
+        AscendC::GlobalTensor<T> gmDu;
+        gmDu.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(du_) + ValueOffset(batch, valueHead, chunkBegin, 0));
+        auto layoutDu = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->V);
+        auto tensorA = tla::MakeTensor(gmDu, layoutDu, Catlass::Arch::PositionGM{});
+        auto blockA = GetTile(tensorA, tla::MakeCoord(0, 0),
+                              tla::MakeShape(chunkLen, static_cast<uint32_t>(tiling_->V)));
+
+        auto l1ABuf = resource_.l1Buf.template GetBufferByByte<ElementA>(residentDuOffset);
+        auto layoutL1A = tla::MakeLayout<ElementA, LayoutTagL1A>(tla::Int<tileM>{}, tla::Int<V>{});
+        auto tensorL1A = tla::MakeTensor(l1ABuf, layoutL1A, Catlass::Arch::PositionL1{});
+
+        typename TileCopy::template CopyGmToL1A<decltype(blockA)> copyGmToL1A;
+        copyGmToL1A(tensorL1A, blockA);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventId);
+    }
+
+    __aicore__ inline void PrefetchATResident(uint64_t batch, uint64_t valueHead, uint64_t chunkBegin,
+                                              uint32_t chunkLen, uint32_t residentATOffset, int32_t eventId)
+    {
+        using TileCopy = TileCopyDa;
+        using ElementB = typename TileCopy::ElementB;
+        using LayoutTagL1B = typename TileCopy::LayoutTagL1B;
+
+        static constexpr uint32_t tileN = tla::get<1>(L0TileShapeDa5{});
+        static constexpr uint32_t tileK = tla::get<2>(L0TileShapeDa5{});
+
+        AscendC::GlobalTensor<T> gmAT;
+        gmAT.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(a_) + MatrixOffset(batch, valueHead, chunkBegin, 0));
+        auto layoutAT = tla::MakeLayout<T, ColumnMajor>(tiling_->chunkSize, tiling_->chunkSize);
+        auto tensorB = tla::MakeTensor(gmAT, layoutAT, Catlass::Arch::PositionGM{});
+        auto blockB = GetTile(tensorB, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, chunkLen));
+
+        auto l1BBuf = resource_.l1Buf.template GetBufferByByte<ElementB>(residentATOffset);
+        auto layoutL1B = tla::MakeLayout<ElementB, LayoutTagL1B>(tla::Int<tileK>{}, tla::Int<tileN>{});
+        auto tensorL1B = tla::MakeTensor(l1BBuf, layoutL1B, Catlass::Arch::PositionL1{});
+
+        typename TileCopy::template CopyGmToL1B<decltype(blockB)> copyGmToL1B;
+        copyGmToL1B(tensorL1B, blockB);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventId);
+    }
+
+    __aicore__ inline void PrefetchKResident(uint64_t batch, uint64_t keyHead, uint64_t chunkBegin,
+                                             uint32_t chunkLen, uint32_t residentKOffset, int32_t eventId)
+    {
+        using TileCopy = TileCopyDkb;
+        using ElementB = typename TileCopy::ElementB;
+        using LayoutTagL1B = typename TileCopy::LayoutTagL1B;
+
+        static constexpr uint32_t tileN = tla::get<1>(L0TileShapeFullK{});
+        static constexpr uint32_t tileK = tla::get<2>(L0TileShapeFullK{});
+
+        AscendC::GlobalTensor<T> gmK;
+        gmK.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(k_) + KeyOffset(batch, keyHead, chunkBegin, 0));
+        auto layoutK = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->K);
+        auto tensorB = tla::MakeTensor(gmK, layoutK, Catlass::Arch::PositionGM{});
+        auto blockB = GetTile(tensorB, tla::MakeCoord(0, 0),
+                              tla::MakeShape(chunkLen, static_cast<uint32_t>(tiling_->K)));
+
+        auto l1BBuf = resource_.l1Buf.template GetBufferByByte<ElementB>(residentKOffset);
+        auto layoutL1B = tla::MakeLayout<ElementB, LayoutTagL1B>(tla::Int<tileK>{}, tla::Int<tileN>{});
+        auto tensorL1B = tla::MakeTensor(l1BBuf, layoutL1B, Catlass::Arch::PositionL1{});
+
+        typename TileCopy::template CopyGmToL1B<decltype(blockB)> copyGmToL1B;
+        copyGmToL1B(tensorL1B, blockB);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventId);
+    }
+
+public:
+    __aicore__ inline void Init(GM_ADDR k, GM_ADDR v, GM_ADDR A, GM_ADDR dw, GM_ADDR du,
+                                GM_ADDR cuSeqlens, GM_ADDR chunkIndices, GM_ADDR workspace,
+                                const PrepareWyReprBwdTilingData *tiling)
+    {
+        k_ = k;
+        v_ = v;
+        a_ = A;
+        dw_ = dw;
+        du_ = du;
+        workspace_ = workspace;
+        tiling_ = tiling;
+        coreIdx_ = static_cast<uint64_t>(AscendC::GetBlockIdx());
+        if (cuSeqlens != nullptr) {
+            cuSeqlensGm_.SetGlobalBuffer(reinterpret_cast<__gm__ uint64_t *>(cuSeqlens));
+        }
+        if (chunkIndices != nullptr) {
+            chunkIndicesGm_.SetGlobalBuffer(reinterpret_cast<__gm__ uint64_t *>(chunkIndices));
+        }
+    }
+
+    __aicore__ inline void ProcessPipeline()
+    {
+        constexpr int32_t eventL1A = 0;
+        constexpr int32_t eventL1B = 1;
+        constexpr int32_t eventL0C = 0;
+
+        auto layoutDw = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->K);
+        auto layoutKbgT = tla::MakeLayout<T, ColumnMajor>(tiling_->K, tiling_->chunkSize);
+        auto layoutDu = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->V);
+        auto layoutVbT = tla::MakeLayout<T, ColumnMajor>(tiling_->V, tiling_->chunkSize);
+        auto layoutDa = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->chunkSize);
+        auto layoutDaT = tla::MakeLayout<T, ColumnMajor>(tiling_->chunkSize, tiling_->chunkSize);
+        auto layoutA = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->chunkSize);
+        auto layoutAT = tla::MakeLayout<T, ColumnMajor>(tiling_->chunkSize, tiling_->chunkSize);
+        auto layoutK = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->K);
+        auto layoutKT = tla::MakeLayout<T, ColumnMajor>(tiling_->K, tiling_->chunkSize);
+        auto layoutKOut = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->K);
+        auto layoutV = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->V);
+        auto layoutVOut = tla::MakeLayout<T, RowMajor>(tiling_->chunkSize, tiling_->V);
+        constexpr uint64_t slotCount = 2;
+
+        const uint64_t coreLoops = static_cast<uint64_t>(tiling_->chunkNum);
+        for (uint64_t loopIdx = coreIdx_; loopIdx < coreLoops;
+             loopIdx += static_cast<uint64_t>(AscendC::GetBlockNum())) {
+            uint64_t batch = 0;
+            uint64_t chunkBegin = 0;
+            uint64_t chunkEnd = 0;
+            GetChunkOffset(loopIdx, batch, chunkBegin, chunkEnd);
+            if (chunkEnd <= chunkBegin) {
+                continue;
+            }
+            uint32_t chunkLen = static_cast<uint32_t>(chunkEnd - chunkBegin);
+            for (uint64_t headBase = 0; headBase < static_cast<uint64_t>(tiling_->HV); headBase += slotCount) {
+                // Advance both head slots one dependency stage at a time to overlap AIC(slot 1) with AIV(slot 0).
+                for (uint32_t pipelineStage = 0; pipelineStage < 3; ++pipelineStage) {
+                    if (pipelineStage == 2) {
+                        // Return AIV credit for both final-dA slots before either long full stage can block on AIV.
+                        for (uint64_t slot = 0; slot < slotCount; ++slot) {
+                            uint64_t valueHead = 0;
+                            if (ResolvePipelineHeadSlot(headBase, slot, valueHead)) {
+                                WaitAivFinishStore();
+                            }
+                        }
+                    }
+                    for (uint64_t slot = 0; slot < slotCount; ++slot) {
+                    uint64_t valueHead = 0;
+                    if (!ResolvePipelineHeadSlot(headBase, slot, valueHead)) {
+                        continue;
+                    }
+                    InitGemmEvents(eventL1A, eventL1B, eventL0C);
+                    uint32_t residentDwOffset = RESIDENT_DW_BASE_OFFSET + static_cast<uint32_t>(slot) * L1_TILE_K_BYTES;
+                    uint32_t residentDuOffset = RESIDENT_DU_BASE_OFFSET + static_cast<uint32_t>(slot) * L1_TILE_V_BYTES;
+                    uint32_t residentATOffset = RESIDENT_AT_BASE_OFFSET + static_cast<uint32_t>(slot) * L1_TILE_A_BYTES;
+                    if (pipelineStage == 0) {
+                    uint32_t da1L1BOffset = da1L1ATileBytes;
+
+                    AscendC::GlobalTensor<T> da1GmDw;
+                    AscendC::GlobalTensor<T> da1GmKbgT;
+                    AscendC::GlobalTensor<T> da1GmDa1;
+                    da1GmDw.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(dw_) + (ValueKeyLikeOffset(batch, valueHead, chunkBegin, 0)));
+                    da1GmKbgT.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->kbgOffset, SlotValueKeyLikeOffset(valueHead, 0, 0))));
+                    da1GmDa1.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->da1Offset, SlotMatrixOffset(valueHead, 0, 0))));
+
+                    auto da1TensorA = tla::MakeTensor(da1GmDw, layoutDw, Catlass::Arch::PositionGM{});
+                    auto da1TensorB = tla::MakeTensor(da1GmKbgT, layoutKbgT, Catlass::Arch::PositionGM{});
+                    auto da1TensorC = tla::MakeTensor(da1GmDa1, layoutDa, Catlass::Arch::PositionGM{});
+
+                    auto da1L1ABuf = resource_.l1Buf.template GetBufferByByte<Da1ElementA>(residentDwOffset);
+                    auto da1L1BBuf = resource_.l1Buf.template GetBufferByByte<Da1ElementB>(da1L1BOffset);
+
+                    auto da1L0CBuf = resource_.l0CBuf.template GetBufferByByte<Da1ElementAccumulator>(0);
+                    auto da1LayoutL1A = tla::MakeLayout<Da1ElementA, Da1LayoutTagL1A>(tla::Int<da1TileM>{}, tla::Int<da1TileK>{});
+                    auto da1LayoutL1B = tla::MakeLayout<Da1ElementB, Da1LayoutTagL1B>(tla::Int<da1TileK>{}, tla::Int<da1TileN>{});
+                    auto da1TensorL1A = tla::MakeTensor(da1L1ABuf, da1LayoutL1A, Catlass::Arch::PositionL1{});
+                    auto da1TensorL1B = tla::MakeTensor(da1L1BBuf, da1LayoutL1B, Catlass::Arch::PositionL1{});
+
+                    Da1CopyL1ToL0A da1CopyL1ToL0A;
+                    Da1CopyL1ToL0B da1CopyL1ToL0B;
+                    Da1TileMmad da1TileMmad;
+                    uint32_t da1MActual = chunkLen;
+                    if (da1MActual == 1) {
+                        da1MActual = 16;
+                    }
+
+                    auto da1BlockC = GetTile(da1TensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, chunkLen));
+                    auto da1LayoutL0C = tla::MakeLayoutL0C(da1MActual, chunkLen);
+                    auto da1TensorL0C = tla::MakeTensor(da1L0CBuf, da1LayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto da1TileL0C = GetTile(da1TensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(da1MActual, chunkLen));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    WaitAivFinishStore();
+
+                    for (uint32_t da1KOffset = 0; da1KOffset < (static_cast<uint32_t>(tiling_->K)); da1KOffset += da1TileK) {
+                        uint32_t da1CurK = da1KOffset + da1TileK > (static_cast<uint32_t>(tiling_->K)) ? (static_cast<uint32_t>(tiling_->K)) - da1KOffset : da1TileK;
+                        auto da1BlockA = GetTile(da1TensorA, tla::MakeCoord(0, da1KOffset), tla::MakeShape(chunkLen, da1CurK));
+                        auto da1BlockB = GetTile(da1TensorB, tla::MakeCoord(da1KOffset, 0), tla::MakeShape(da1CurK, chunkLen));
+                        typename Da1TileCopy::template CopyGmToL1A<decltype(da1BlockA)> da1CopyGmToL1A;
+                        typename Da1TileCopy::template CopyGmToL1B<decltype(da1BlockB)> da1CopyGmToL1B;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+                        da1CopyGmToL1A(da1TensorL1A, da1BlockA);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+                        da1CopyGmToL1B(da1TensorL1B, da1BlockB);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+                        if (da1KOffset == 0) {
+                            PrefetchDuResident(batch, valueHead, chunkBegin, chunkLen, residentDuOffset,
+                                                   PrefetchDuEvent(slot));
+                            PrefetchATResident(batch, valueHead, chunkBegin, chunkLen, residentATOffset,
+                                                   PrefetchATEvent(slot));
+                        }
+
+                        uint32_t da1L0Stage = (da1KOffset / da1TileK) & 1U;
+                        auto da1L0ABuf = resource_.l0ABuf.template GetBufferByByte<Da1ElementA>(da1L0Stage * da1L0ATileBytes);
+                        auto da1L0BBuf = resource_.l0BBuf.template GetBufferByByte<Da1ElementB>(da1L0Stage * da1L0BTileBytes);
+
+                        auto da1LayoutL0A = tla::MakeLayout<Da1ElementA, Da1LayoutTagL0A>(da1MActual, da1CurK);
+                        auto da1LayoutL0B = tla::MakeLayout<Da1ElementB, Da1LayoutTagL0B>(da1CurK, chunkLen);
+                        auto da1TensorL0A = tla::MakeTensor(da1L0ABuf, da1LayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto da1TensorL0B = tla::MakeTensor(da1L0BBuf, da1LayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto da1TileL1A = GetTile(da1TensorL1A, tla::MakeCoord(0, 0), tla::MakeShape(da1MActual, da1CurK));
+                        auto da1TileL1B = GetTile(da1TensorL1B, tla::MakeCoord(0, 0), tla::MakeShape(da1CurK, chunkLen));
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(da1L0Stage));
+                        da1CopyL1ToL0A(da1TensorL0A, da1TileL1A);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(da1L0Stage));
+                        da1CopyL1ToL0B(da1TensorL0B, da1TileL1B);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(da1L0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(da1L0Stage));
+                        uint8_t da1UnitFlag = (da1KOffset + da1CurK >= (static_cast<uint32_t>(tiling_->K))) ? 0b11 : 0b10;
+                        da1TileMmad(da1TileL0C, da1TensorL0A, da1TensorL0B, da1MActual, chunkLen, da1CurK, da1KOffset == 0, da1UnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(da1L0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(da1L0Stage));
+                    }
+
+                    typename Da1TileCopy::template CopyL0CToGm<decltype(da1BlockC)> da1CopyL0CToGm;
+                    da1CopyL0CToGm(da1BlockC, da1TileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    uint32_t da2L1BOffset = da2L1ATileBytes;
+
+                    AscendC::GlobalTensor<T> da2GmVbT;
+                    AscendC::GlobalTensor<T> da2GmDa2;
+                    da2GmVbT.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->vbOffset, SlotValueOffset(valueHead, 0, 0))));
+                    da2GmDa2.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->da2Offset, SlotMatrixOffset(valueHead, 0, 0))));
+
+                    auto da2TensorB = tla::MakeTensor(da2GmVbT, layoutVbT, Catlass::Arch::PositionGM{});
+                    auto da2TensorC = tla::MakeTensor(da2GmDa2, layoutDa, Catlass::Arch::PositionGM{});
+
+                    auto da2L1ABuf = resource_.l1Buf.template GetBufferByByte<Da2ElementA>(residentDuOffset);
+                    auto da2L1BBuf = resource_.l1Buf.template GetBufferByByte<Da2ElementB>(da2L1BOffset);
+
+                    auto da2L0CBuf = resource_.l0CBuf.template GetBufferByByte<Da2ElementAccumulator>(0);
+                    auto da2LayoutL1B = tla::MakeLayout<Da2ElementB, Da2LayoutTagL1B>(tla::Int<da2TileK>{}, tla::Int<da2TileN>{});
+                    auto da2LayoutResidentL1A =
+                        tla::MakeLayout<Da2ElementA, Da2ResidentLayoutTagL1A>(tla::Int<da2TileM>{}, tla::Int<V>{});
+                    auto da2TensorL1B = tla::MakeTensor(da2L1BBuf, da2LayoutL1B, Catlass::Arch::PositionL1{});
+                    auto da2TensorResidentL1A = tla::MakeTensor(da2L1ABuf, da2LayoutResidentL1A, Catlass::Arch::PositionL1{});
+
+                    Da2CopyL1ToL0B da2CopyL1ToL0B;
+                    Da2TileMmad da2TileMmad;
+                    uint32_t da2MActual = chunkLen;
+                    if (da2MActual == 1) {
+                        da2MActual = 16;
+                    }
+
+                    auto da2BlockC = GetTile(da2TensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, chunkLen));
+                    auto da2LayoutL0C = tla::MakeLayoutL0C(da2MActual, chunkLen);
+                    auto da2TensorL0C = tla::MakeTensor(da2L0CBuf, da2LayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto da2TileL0C = GetTile(da2TensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(da2MActual, chunkLen));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(PrefetchDuEvent(slot));
+
+                    for (uint32_t da2KOffset = 0; da2KOffset < (static_cast<uint32_t>(tiling_->V)); da2KOffset += da2TileK) {
+                        uint32_t da2CurK = da2KOffset + da2TileK > (static_cast<uint32_t>(tiling_->V)) ? (static_cast<uint32_t>(tiling_->V)) - da2KOffset : da2TileK;
+                        auto da2BlockB = GetTile(da2TensorB, tla::MakeCoord(da2KOffset, 0), tla::MakeShape(da2CurK, chunkLen));
+                        typename Da2TileCopy::template CopyGmToL1B<decltype(da2BlockB)> da2CopyGmToL1B;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+                        da2CopyGmToL1B(da2TensorL1B, da2BlockB);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+
+                        uint32_t da2L0Stage = (da2KOffset / da2TileK) & 1U;
+                        auto da2L0ABuf = resource_.l0ABuf.template GetBufferByByte<Da2ElementA>(da2L0Stage * da2L0ATileBytes);
+                        auto da2L0BBuf = resource_.l0BBuf.template GetBufferByByte<Da2ElementB>(da2L0Stage * da2L0BTileBytes);
+
+                        auto da2LayoutL0A = tla::MakeLayout<Da2ElementA, Da2LayoutTagL0A>(da2MActual, da2CurK);
+                        auto da2LayoutL0B = tla::MakeLayout<Da2ElementB, Da2LayoutTagL0B>(da2CurK, chunkLen);
+                        auto da2TensorL0A = tla::MakeTensor(da2L0ABuf, da2LayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto da2TensorL0B = tla::MakeTensor(da2L0BBuf, da2LayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto da2TileL1B = GetTile(da2TensorL1B, tla::MakeCoord(0, 0), tla::MakeShape(da2CurK, chunkLen));
+                        auto da2ResidentShapeA = tla::MakeShape(da2MActual, da2CurK);
+                        auto da2TileResidentL1A =
+                            GetTile(da2TensorResidentL1A, tla::MakeCoord(0, da2KOffset), da2ResidentShapeA);
+                        Catlass::Gemm::Tile::TileCopyTla<ArchTag, decltype(da2TileResidentL1A),
+                                                         decltype(da2TensorL0A)> da2CopyResidentL1ToL0A;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(da2L0Stage));
+                        da2CopyResidentL1ToL0A(da2TensorL0A, da2TileResidentL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(da2L0Stage));
+                        da2CopyL1ToL0B(da2TensorL0B, da2TileL1B);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(da2L0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(da2L0Stage));
+                        uint8_t da2UnitFlag = (da2KOffset + da2CurK >= (static_cast<uint32_t>(tiling_->V))) ? 0b11 : 0b10;
+                        da2TileMmad(da2TileL0C, da2TensorL0A, da2TensorL0B, da2MActual, chunkLen, da2CurK, da2KOffset == 0, da2UnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(da2L0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(da2L0Stage));
+                    }
+
+                    typename Da2TileCopy::template CopyL0CToGm<decltype(da2BlockC)> da2CopyL0CToGm;
+                    da2CopyL0CToGm(da2BlockC, da2TileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    SignalAicFinishStore();
+                    } else if (pipelineStage == 1) {
+                    uint32_t da5L1BOffset = residentATOffset;
+
+                    AscendC::GlobalTensor<T> da5GmDa4;
+                    AscendC::GlobalTensor<T> da5GmDa5;
+                    da5GmDa4.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->da4Offset, SlotMatrixOffset(valueHead, 0, 0))));
+                    da5GmDa5.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->da5Offset, SlotMatrixOffset(valueHead, 0, 0))));
+
+                    auto da5TensorA = tla::MakeTensor(da5GmDa4, layoutDa, Catlass::Arch::PositionGM{});
+                    auto da5TensorC = tla::MakeTensor(da5GmDa5, layoutDa, Catlass::Arch::PositionGM{});
+
+                    auto da5L1ABuf = resource_.l1Buf.template GetBufferByByte<Da5ElementA>(0U);
+                    auto da5L1BBuf = resource_.l1Buf.template GetBufferByByte<Da5ElementB>(da5L1BOffset);
+
+                    auto da5L0CBuf = resource_.l0CBuf.template GetBufferByByte<Da5ElementAccumulator>(0);
+                    auto da5LayoutL1A = tla::MakeLayout<Da5ElementA, Da5LayoutTagL1A>(tla::Int<da5TileM>{}, tla::Int<da5TileK>{});
+                    auto da5LayoutResidentL1B =
+                        tla::MakeLayout<Da5ElementB, Da5ResidentLayoutTagL1B>(tla::Int<da5TileK>{}, tla::Int<da5TileN>{});
+                    auto da5TensorL1A = tla::MakeTensor(da5L1ABuf, da5LayoutL1A, Catlass::Arch::PositionL1{});
+                    auto da5TensorResidentL1B = tla::MakeTensor(da5L1BBuf, da5LayoutResidentL1B, Catlass::Arch::PositionL1{});
+
+                    Da5CopyL1ToL0A da5CopyL1ToL0A;
+                    Da5TileMmad da5TileMmad;
+                    uint32_t da5MActual = chunkLen;
+                    if (da5MActual == 1) {
+                        da5MActual = 16;
+                    }
+
+                    auto da5BlockC = GetTile(da5TensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, chunkLen));
+                    auto da5LayoutL0C = tla::MakeLayoutL0C(da5MActual, chunkLen);
+                    auto da5TensorL0C = tla::MakeTensor(da5L0CBuf, da5LayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto da5TileL0C = GetTile(da5TensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(da5MActual, chunkLen));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(PrefetchATEvent(slot));
+                    WaitAivFinishStore();
+
+                    for (uint32_t da5KOffset = 0; da5KOffset < (chunkLen); da5KOffset += da5TileK) {
+                        uint32_t da5CurK = da5KOffset + da5TileK > (chunkLen) ? (chunkLen) - da5KOffset : da5TileK;
+                        auto da5BlockA = GetTile(da5TensorA, tla::MakeCoord(0, da5KOffset), tla::MakeShape(chunkLen, da5CurK));
+                        typename Da5TileCopy::template CopyGmToL1A<decltype(da5BlockA)> da5CopyGmToL1A;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+                        da5CopyGmToL1A(da5TensorL1A, da5BlockA);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1A);
+
+                        uint32_t da5L0Stage = (da5KOffset / da5TileK) & 1U;
+                        auto da5L0ABuf = resource_.l0ABuf.template GetBufferByByte<Da5ElementA>(da5L0Stage * da5L0ATileBytes);
+                        auto da5L0BBuf = resource_.l0BBuf.template GetBufferByByte<Da5ElementB>(da5L0Stage * da5L0BTileBytes);
+
+                        auto da5LayoutL0A = tla::MakeLayout<Da5ElementA, Da5LayoutTagL0A>(da5MActual, da5CurK);
+                        auto da5LayoutL0B = tla::MakeLayout<Da5ElementB, Da5LayoutTagL0B>(da5CurK, chunkLen);
+                        auto da5TensorL0A = tla::MakeTensor(da5L0ABuf, da5LayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto da5TensorL0B = tla::MakeTensor(da5L0BBuf, da5LayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto da5TileL1A = GetTile(da5TensorL1A, tla::MakeCoord(0, 0), tla::MakeShape(da5MActual, da5CurK));
+                        auto da5ResidentShapeB = tla::MakeShape(da5CurK, chunkLen);
+                        auto da5TileResidentL1B = GetTile(da5TensorResidentL1B, tla::MakeCoord(0, 0), da5ResidentShapeB);
+                        Catlass::Gemm::Tile::TileCopyTla<ArchTag, decltype(da5TileResidentL1B),
+                                                         decltype(da5TensorL0B)> da5CopyResidentL1ToL0B;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(da5L0Stage));
+                        da5CopyL1ToL0A(da5TensorL0A, da5TileL1A);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(da5L0Stage));
+                        da5CopyResidentL1ToL0B(da5TensorL0B, da5TileResidentL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(da5L0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(da5L0Stage));
+                        uint8_t da5UnitFlag = (da5KOffset + da5CurK >= (chunkLen)) ? 0b11 : 0b10;
+                        da5TileMmad(da5TileL0C, da5TensorL0A, da5TensorL0B, da5MActual, chunkLen, da5CurK, da5KOffset == 0, da5UnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(da5L0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(da5L0Stage));
+                    }
+
+                    typename Da5TileCopy::template CopyL0CToGm<decltype(da5BlockC)> da5CopyL0CToGm;
+                    da5CopyL0CToGm(da5BlockC, da5TileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_MTE2>(eventL0C);
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_MTE2>(eventL0C);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    uint32_t da6L1BOffset = da6L1ATileBytes;
+
+                    AscendC::GlobalTensor<T> da6GmDa5;
+                    AscendC::GlobalTensor<T> da6GmA;
+                    AscendC::GlobalTensor<T> da6GmDa;
+                    da6GmDa5.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->da5Offset, SlotMatrixOffset(valueHead, 0, 0))));
+                    da6GmA.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(a_) +
+                                           MatrixOffset(batch, valueHead, chunkBegin, 0));
+                    da6GmDa.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->daOffset, SlotMatrixOffset(valueHead, 0, 0))));
+
+                    auto da6TensorA = tla::MakeTensor(da6GmDa5, layoutDaT, Catlass::Arch::PositionGM{});
+                    auto da6TensorB = tla::MakeTensor(da6GmA, layoutA, Catlass::Arch::PositionGM{});
+                    auto da6TensorC = tla::MakeTensor(da6GmDa, layoutDa, Catlass::Arch::PositionGM{});
+
+                    auto da6L1ABuf = resource_.l1Buf.template GetBufferByByte<Da6ElementA>(0U);
+                    auto da6L1BBuf = resource_.l1Buf.template GetBufferByByte<Da6ElementB>(da6L1BOffset);
+
+                    auto da6L0CBuf = resource_.l0CBuf.template GetBufferByByte<Da6ElementAccumulator>(0);
+                    auto da6LayoutL1A = tla::MakeLayout<Da6ElementA, Da6LayoutTagL1A>(tla::Int<da6TileM>{}, tla::Int<da6TileK>{});
+                    auto da6LayoutL1B = tla::MakeLayout<Da6ElementB, Da6LayoutTagL1B>(
+                        tla::Int<da6TileK>{}, tla::Int<da6TileN>{});
+                    auto da6TensorL1A = tla::MakeTensor(da6L1ABuf, da6LayoutL1A, Catlass::Arch::PositionL1{});
+                    auto da6TensorL1B = tla::MakeTensor(da6L1BBuf, da6LayoutL1B, Catlass::Arch::PositionL1{});
+
+                    Da6CopyL1ToL0A da6CopyL1ToL0A;
+                    Da6CopyL1ToL0B da6CopyL1ToL0B;
+                    Da6TileMmad da6TileMmad;
+                    uint32_t da6MActual = chunkLen;
+                    if (da6MActual == 1) {
+                        da6MActual = 16;
+                    }
+
+                    auto da6BlockC = GetTile(da6TensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, chunkLen));
+                    auto da6LayoutL0C = tla::MakeLayoutL0C(da6MActual, chunkLen);
+                    auto da6TensorL0C = tla::MakeTensor(da6L0CBuf, da6LayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto da6TileL0C = GetTile(da6TensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(da6MActual, chunkLen));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+
+                    for (uint32_t da6KOffset = 0; da6KOffset < (chunkLen); da6KOffset += da6TileK) {
+                        uint32_t da6CurK = da6KOffset + da6TileK > (chunkLen) ? (chunkLen) - da6KOffset : da6TileK;
+                        auto da6BlockA = GetTile(da6TensorA, tla::MakeCoord(0, da6KOffset), tla::MakeShape(chunkLen, da6CurK));
+                        auto da6BlockB = GetTile(da6TensorB, tla::MakeCoord(da6KOffset, 0),
+                                                tla::MakeShape(da6CurK, chunkLen));
+                        typename Da6TileCopy::template CopyGmToL1A<decltype(da6BlockA)> da6CopyGmToL1A;
+                        typename Da6TileCopy::template CopyGmToL1B<decltype(da6BlockB)> da6CopyGmToL1B;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+                        da6CopyGmToL1A(da6TensorL1A, da6BlockA);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+                        da6CopyGmToL1B(da6TensorL1B, da6BlockB);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+
+                        uint32_t da6L0Stage = (da6KOffset / da6TileK) & 1U;
+                        auto da6L0ABuf = resource_.l0ABuf.template GetBufferByByte<Da6ElementA>(da6L0Stage * da6L0ATileBytes);
+                        auto da6L0BBuf = resource_.l0BBuf.template GetBufferByByte<Da6ElementB>(da6L0Stage * da6L0BTileBytes);
+
+                        auto da6LayoutL0A = tla::MakeLayout<Da6ElementA, Da6LayoutTagL0A>(da6MActual, da6CurK);
+                        auto da6LayoutL0B = tla::MakeLayout<Da6ElementB, Da6LayoutTagL0B>(da6CurK, chunkLen);
+                        auto da6TensorL0A = tla::MakeTensor(da6L0ABuf, da6LayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto da6TensorL0B = tla::MakeTensor(da6L0BBuf, da6LayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto da6TileL1A = GetTile(da6TensorL1A, tla::MakeCoord(0, 0), tla::MakeShape(da6MActual, da6CurK));
+                        auto da6TileL1B = GetTile(da6TensorL1B, tla::MakeCoord(0, 0),
+                                                 tla::MakeShape(da6CurK, chunkLen));
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(da6L0Stage));
+                        da6CopyL1ToL0A(da6TensorL0A, da6TileL1A);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(da6L0Stage));
+                        da6CopyL1ToL0B(da6TensorL0B, da6TileL1B);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(da6L0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(da6L0Stage));
+                        uint8_t da6UnitFlag = (da6KOffset + da6CurK >= (chunkLen)) ? 0b11 : 0b10;
+                        da6TileMmad(da6TileL0C, da6TensorL0A, da6TensorL0B, da6MActual, chunkLen, da6CurK, da6KOffset == 0, da6UnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(da6L0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(da6L0Stage));
+                    }
+
+                    typename Da6TileCopy::template CopyL0CToGm<decltype(da6BlockC)> da6CopyL0CToGm;
+                    da6CopyL0CToGm(da6BlockC, da6TileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    SignalAicFinishStore();
+                    } else {
+                    uint64_t keyHead = valueHead / static_cast<uint64_t>(tiling_->headGroup);
+                    uint32_t residentKOffset = ResidentKOffset(headBase, slot, valueHead);
+                    uint32_t residentDaOffset = RESIDENT_DA_BASE_OFFSET + static_cast<uint32_t>(slot) * L1_TILE_A_BYTES;
+                    uint32_t fullDkL1BOffset = fullDkL1ATileBytes;
+
+                    AscendC::GlobalTensor<T> fullDkGmDa;
+                    AscendC::GlobalTensor<T> fullDkGmKBeta;
+                    AscendC::GlobalTensor<T> fullDkGmFullDk;
+                    fullDkGmDa.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->daOffset, SlotMatrixOffset(valueHead, 0, 0))));
+                    fullDkGmKBeta.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->kbetaOffset, SlotValueKeyLikeOffset(valueHead, 0, 0))));
+                    fullDkGmFullDk.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->fullDkOffset, SlotValueKeyLikeOffset(valueHead, 0, 0))));
+
+                    auto fullDkTensorA = tla::MakeTensor(fullDkGmDa, layoutDa, Catlass::Arch::PositionGM{});
+                    auto fullDkTensorB = tla::MakeTensor(fullDkGmKBeta, layoutK, Catlass::Arch::PositionGM{});
+                    auto fullDkTensorC = tla::MakeTensor(fullDkGmFullDk, layoutKOut, Catlass::Arch::PositionGM{});
+
+                    auto fullDkL1ABuf = resource_.l1Buf.template GetBufferByByte<FullDkElementA>(residentDaOffset);
+                    auto fullDkL1BBuf = resource_.l1Buf.template GetBufferByByte<FullDkElementB>(fullDkL1BOffset);
+
+                    auto fullDkL0CBuf = resource_.l0CBuf.template GetBufferByByte<FullDkElementAccumulator>(0);
+                    auto fullDkLayoutL1A = tla::MakeLayout<FullDkElementA, FullDkLayoutTagL1A>(tla::Int<fullDkTileM>{}, tla::Int<fullDkTileK>{});
+                    auto fullDkLayoutL1B = tla::MakeLayout<FullDkElementB, FullDkLayoutTagL1B>(tla::Int<fullDkTileK>{}, tla::Int<fullDkTileN>{});
+                    auto fullDkTensorL1A = tla::MakeTensor(fullDkL1ABuf, fullDkLayoutL1A, Catlass::Arch::PositionL1{});
+                    auto fullDkTensorL1B = tla::MakeTensor(fullDkL1BBuf, fullDkLayoutL1B, Catlass::Arch::PositionL1{});
+
+                    FullDkCopyL1ToL0A fullDkCopyL1ToL0A;
+                    FullDkCopyL1ToL0B fullDkCopyL1ToL0B;
+                    FullDkTileMmad fullDkTileMmad;
+                    uint32_t fullDkMActual = chunkLen;
+                    if (fullDkMActual == 1) {
+                        fullDkMActual = 16;
+                    }
+
+                    auto fullDkBlockC = GetTile(fullDkTensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, static_cast<uint32_t>(tiling_->K)));
+                    auto fullDkLayoutL0C = tla::MakeLayoutL0C(fullDkMActual, static_cast<uint32_t>(tiling_->K));
+                    auto fullDkTensorL0C = tla::MakeTensor(fullDkL0CBuf, fullDkLayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto fullDkTileL0C = GetTile(fullDkTensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(fullDkMActual, static_cast<uint32_t>(tiling_->K)));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+
+                    for (uint32_t fullDkKOffset = 0; fullDkKOffset < (chunkLen); fullDkKOffset += fullDkTileK) {
+                        uint32_t fullDkCurK = fullDkKOffset + fullDkTileK > (chunkLen) ? (chunkLen) - fullDkKOffset : fullDkTileK;
+                        auto fullDkBlockA = GetTile(fullDkTensorA, tla::MakeCoord(0, fullDkKOffset), tla::MakeShape(chunkLen, fullDkCurK));
+                        auto fullDkBlockB = GetTile(fullDkTensorB, tla::MakeCoord(fullDkKOffset, 0), tla::MakeShape(fullDkCurK, static_cast<uint32_t>(tiling_->K)));
+                        typename FullDkTileCopy::template CopyGmToL1A<decltype(fullDkBlockA)> fullDkCopyGmToL1A;
+                        typename FullDkTileCopy::template CopyGmToL1B<decltype(fullDkBlockB)> fullDkCopyGmToL1B;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+                        fullDkCopyGmToL1A(fullDkTensorL1A, fullDkBlockA);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+                        fullDkCopyGmToL1B(fullDkTensorL1B, fullDkBlockB);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+
+                        uint32_t fullDkL0Stage = (fullDkKOffset / fullDkTileK) & 1U;
+                        auto fullDkL0ABuf = resource_.l0ABuf.template GetBufferByByte<FullDkElementA>(fullDkL0Stage * fullDkL0ATileBytes);
+                        auto fullDkL0BBuf = resource_.l0BBuf.template GetBufferByByte<FullDkElementB>(fullDkL0Stage * fullDkL0BTileBytes);
+
+                        auto fullDkLayoutL0A = tla::MakeLayout<FullDkElementA, FullDkLayoutTagL0A>(fullDkMActual, fullDkCurK);
+                        auto fullDkLayoutL0B = tla::MakeLayout<FullDkElementB, FullDkLayoutTagL0B>(fullDkCurK, static_cast<uint32_t>(tiling_->K));
+                        auto fullDkTensorL0A = tla::MakeTensor(fullDkL0ABuf, fullDkLayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto fullDkTensorL0B = tla::MakeTensor(fullDkL0BBuf, fullDkLayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto fullDkTileL1A = GetTile(fullDkTensorL1A, tla::MakeCoord(0, 0), tla::MakeShape(fullDkMActual, fullDkCurK));
+                        auto fullDkTileL1B = GetTile(fullDkTensorL1B, tla::MakeCoord(0, 0), tla::MakeShape(fullDkCurK, static_cast<uint32_t>(tiling_->K)));
+
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullDkL0Stage));
+                        fullDkCopyL1ToL0A(fullDkTensorL0A, fullDkTileL1A);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullDkL0Stage));
+                        fullDkCopyL1ToL0B(fullDkTensorL0B, fullDkTileL1B);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullDkL0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullDkL0Stage));
+                        uint8_t fullDkUnitFlag = (fullDkKOffset + fullDkCurK >= (chunkLen)) ? 0b11 : 0b10;
+                        fullDkTileMmad(fullDkTileL0C, fullDkTensorL0A, fullDkTensorL0B, fullDkMActual, static_cast<uint32_t>(tiling_->K), fullDkCurK, fullDkKOffset == 0, fullDkUnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullDkL0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullDkL0Stage));
+                    }
+
+                    typename FullDkTileCopy::template CopyL0CToGm<decltype(fullDkBlockC)> fullDkCopyL0CToGm;
+                    fullDkCopyL0CToGm(fullDkBlockC, fullDkTileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    SignalAicFinishFullStore();
+                    uint32_t fullDkbL1BOffset = residentKOffset;
+
+                    AscendC::GlobalTensor<T> fullDkbGmFullDkb;
+                    fullDkbGmFullDkb.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->fullDkbOffset, SlotValueKeyLikeOffset(valueHead, 0, 0))));
+
+                    auto fullDkbTensorC = tla::MakeTensor(fullDkbGmFullDkb, layoutKOut, Catlass::Arch::PositionGM{});
+
+                    auto fullDkbL1ABuf = resource_.l1Buf.template GetBufferByByte<FullDkbElementA>(residentDaOffset);
+                    auto fullDkbL1BBuf = resource_.l1Buf.template GetBufferByByte<FullDkbElementB>(fullDkbL1BOffset);
+
+                    auto fullDkbL0CBuf = resource_.l0CBuf.template GetBufferByByte<FullDkbElementAccumulator>(0);
+                    auto fullDkbLayoutResidentL1A =
+                        tla::MakeLayout<FullDkbElementA, FullDkbResidentLayoutTagL1A>(tla::Int<fullDkbTileM>{}, tla::Int<fullDkbTileK>{});
+                    auto fullDkbLayoutResidentL1B =
+                        tla::MakeLayout<FullDkbElementB, FullDkbResidentLayoutTagL1B>(tla::Int<fullDkbTileK>{}, tla::Int<fullDkbTileN>{});
+                    auto fullDkbTensorResidentL1A = tla::MakeTensor(fullDkbL1ABuf, fullDkbLayoutResidentL1A, Catlass::Arch::PositionL1{});
+                    auto fullDkbTensorResidentL1B = tla::MakeTensor(fullDkbL1BBuf, fullDkbLayoutResidentL1B, Catlass::Arch::PositionL1{});
+
+                    FullDkbTileMmad fullDkbTileMmad;
+                    uint32_t fullDkbMActual = chunkLen;
+                    if (fullDkbMActual == 1) {
+                        fullDkbMActual = 16;
+                    }
+
+                    auto fullDkbBlockC = GetTile(fullDkbTensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, static_cast<uint32_t>(tiling_->K)));
+                    auto fullDkbLayoutL0C = tla::MakeLayoutL0C(fullDkbMActual, static_cast<uint32_t>(tiling_->K));
+                    auto fullDkbTensorL0C = tla::MakeTensor(fullDkbL0CBuf, fullDkbLayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto fullDkbTileL0C = GetTile(fullDkbTensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(fullDkbMActual, static_cast<uint32_t>(tiling_->K)));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    if (IsResidentKOwner(headBase, slot, valueHead)) {
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+                        PrefetchKResident(batch, keyHead, chunkBegin, chunkLen,
+                                          ResidentKOffset(headBase, slot, valueHead),
+                                          eventL1B);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+                    }
+
+                    for (uint32_t fullDkbKOffset = 0; fullDkbKOffset < (chunkLen); fullDkbKOffset += fullDkbTileK) {
+                        uint32_t fullDkbCurK = fullDkbKOffset + fullDkbTileK > (chunkLen) ? (chunkLen) - fullDkbKOffset : fullDkbTileK;
+
+                        uint32_t fullDkbL0Stage = (fullDkbKOffset / fullDkbTileK) & 1U;
+                        auto fullDkbL0ABuf = resource_.l0ABuf.template GetBufferByByte<FullDkbElementA>(fullDkbL0Stage * fullDkbL0ATileBytes);
+                        auto fullDkbL0BBuf = resource_.l0BBuf.template GetBufferByByte<FullDkbElementB>(fullDkbL0Stage * fullDkbL0BTileBytes);
+
+                        auto fullDkbLayoutL0A = tla::MakeLayout<FullDkbElementA, FullDkbLayoutTagL0A>(fullDkbMActual, fullDkbCurK);
+                        auto fullDkbLayoutL0B = tla::MakeLayout<FullDkbElementB, FullDkbLayoutTagL0B>(fullDkbCurK, static_cast<uint32_t>(tiling_->K));
+                        auto fullDkbTensorL0A = tla::MakeTensor(fullDkbL0ABuf, fullDkbLayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto fullDkbTensorL0B = tla::MakeTensor(fullDkbL0BBuf, fullDkbLayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto fullDkbResidentShapeA = tla::MakeShape(fullDkbMActual, fullDkbCurK);
+                        auto fullDkbResidentShapeB = tla::MakeShape(fullDkbCurK, static_cast<uint32_t>(tiling_->K));
+                        auto fullDkbTileResidentL1A = GetTile(fullDkbTensorResidentL1A, tla::MakeCoord(0, 0), fullDkbResidentShapeA);
+                        auto fullDkbTileResidentL1B = GetTile(fullDkbTensorResidentL1B, tla::MakeCoord(0, 0), fullDkbResidentShapeB);
+                        Catlass::Gemm::Tile::TileCopyTla<ArchTag, decltype(fullDkbTileResidentL1A),
+                                                         decltype(fullDkbTensorL0A)> fullDkbCopyResidentL1ToL0A;
+                        Catlass::Gemm::Tile::TileCopyTla<ArchTag, decltype(fullDkbTileResidentL1B),
+                                                         decltype(fullDkbTensorL0B)> fullDkbCopyResidentL1ToL0B;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullDkbL0Stage));
+                        fullDkbCopyResidentL1ToL0A(fullDkbTensorL0A, fullDkbTileResidentL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullDkbL0Stage));
+                        fullDkbCopyResidentL1ToL0B(fullDkbTensorL0B, fullDkbTileResidentL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullDkbL0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullDkbL0Stage));
+                        uint8_t fullDkbUnitFlag = (fullDkbKOffset + fullDkbCurK >= (chunkLen)) ? 0b11 : 0b10;
+                        fullDkbTileMmad(fullDkbTileL0C, fullDkbTensorL0A, fullDkbTensorL0B, fullDkbMActual, static_cast<uint32_t>(tiling_->K), fullDkbCurK, fullDkbKOffset == 0, fullDkbUnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullDkbL0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullDkbL0Stage));
+                    }
+
+                    typename FullDkbTileCopy::template CopyL0CToGm<decltype(fullDkbBlockC)> fullDkbCopyL0CToGm;
+                    fullDkbCopyL0CToGm(fullDkbBlockC, fullDkbTileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    SignalAicFinishFullStore();
+                    uint32_t fullDkbgL1AOffset = residentATOffset;
+                    uint32_t fullDkbgL1BOffset = residentDwOffset;
+
+                    AscendC::GlobalTensor<T> fullDkbgGmFullDkbg;
+                    fullDkbgGmFullDkbg.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->fullDkbgOffset, SlotValueKeyLikeOffset(valueHead, 0, 0))));
+
+                    auto fullDkbgTensorC = tla::MakeTensor(fullDkbgGmFullDkbg, layoutKOut, Catlass::Arch::PositionGM{});
+
+                    auto fullDkbgL1ABuf = resource_.l1Buf.template GetBufferByByte<FullDkbgElementA>(fullDkbgL1AOffset);
+                    auto fullDkbgL1BBuf = resource_.l1Buf.template GetBufferByByte<FullDkbgElementB>(fullDkbgL1BOffset);
+
+                    auto fullDkbgL0CBuf = resource_.l0CBuf.template GetBufferByByte<FullDkbgElementAccumulator>(0);
+                    auto fullDkbgLayoutL1A =
+                        tla::MakeLayout<FullDkbgElementA, FullDkbgLayoutTagL1A>(tla::Int<fullDkbgTileM>{}, tla::Int<fullDkbgTileK>{});
+                    auto fullDkbgLayoutL1B =
+                        tla::MakeLayout<FullDkbgElementB, FullDkbgLayoutTagL1B>(tla::Int<fullDkbgTileK>{}, tla::Int<fullDkbgTileN>{});
+                    auto fullDkbgTensorL1A = tla::MakeTensor(fullDkbgL1ABuf, fullDkbgLayoutL1A, Catlass::Arch::PositionL1{});
+                    auto fullDkbgTensorL1B = tla::MakeTensor(fullDkbgL1BBuf, fullDkbgLayoutL1B, Catlass::Arch::PositionL1{});
+
+                    FullDkbgCopyL1ToL0A fullDkbgCopyL1ToL0A;
+                    FullDkbgCopyL1ToL0B fullDkbgCopyL1ToL0B;
+                    FullDkbgTileMmad fullDkbgTileMmad;
+                    uint32_t fullDkbgMActual = chunkLen;
+                    if (fullDkbgMActual == 1) {
+                        fullDkbgMActual = 16;
+                    }
+
+                    auto fullDkbgBlockC = GetTile(fullDkbgTensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, static_cast<uint32_t>(tiling_->K)));
+                    auto fullDkbgLayoutL0C = tla::MakeLayoutL0C(fullDkbgMActual, static_cast<uint32_t>(tiling_->K));
+                    auto fullDkbgTensorL0C = tla::MakeTensor(fullDkbgL0CBuf, fullDkbgLayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto fullDkbgTileL0C = GetTile(fullDkbgTensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(fullDkbgMActual, static_cast<uint32_t>(tiling_->K)));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+
+                    for (uint32_t fullDkbgKOffset = 0; fullDkbgKOffset < (chunkLen); fullDkbgKOffset += fullDkbgTileK) {
+                        uint32_t fullDkbgCurK = fullDkbgKOffset + fullDkbgTileK > (chunkLen) ? (chunkLen) - fullDkbgKOffset : fullDkbgTileK;
+
+                        uint32_t fullDkbgL0Stage = (fullDkbgKOffset / fullDkbgTileK) & 1U;
+                        auto fullDkbgL0ABuf = resource_.l0ABuf.template GetBufferByByte<FullDkbgElementA>(fullDkbgL0Stage * fullDkbgL0ATileBytes);
+                        auto fullDkbgL0BBuf = resource_.l0BBuf.template GetBufferByByte<FullDkbgElementB>(fullDkbgL0Stage * fullDkbgL0BTileBytes);
+
+                        auto fullDkbgLayoutL0A = tla::MakeLayout<FullDkbgElementA, FullDkbgLayoutTagL0A>(fullDkbgMActual, fullDkbgCurK);
+                        auto fullDkbgLayoutL0B = tla::MakeLayout<FullDkbgElementB, FullDkbgLayoutTagL0B>(fullDkbgCurK, static_cast<uint32_t>(tiling_->K));
+                        auto fullDkbgTensorL0A = tla::MakeTensor(fullDkbgL0ABuf, fullDkbgLayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto fullDkbgTensorL0B = tla::MakeTensor(fullDkbgL0BBuf, fullDkbgLayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto fullDkbgTileL1A = GetTile(fullDkbgTensorL1A, tla::MakeCoord(0, 0),
+                                                      tla::MakeShape(fullDkbgMActual, fullDkbgCurK));
+                        auto fullDkbgTileL1B = GetTile(fullDkbgTensorL1B, tla::MakeCoord(0, 0),
+                                                      tla::MakeShape(fullDkbgCurK, static_cast<uint32_t>(tiling_->K)));
+
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullDkbgL0Stage));
+                        fullDkbgCopyL1ToL0A(fullDkbgTensorL0A, fullDkbgTileL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullDkbgL0Stage));
+                        fullDkbgCopyL1ToL0B(fullDkbgTensorL0B, fullDkbgTileL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullDkbgL0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullDkbgL0Stage));
+                        uint8_t fullDkbgUnitFlag = (fullDkbgKOffset + fullDkbgCurK >= (chunkLen)) ? 0b11 : 0b10;
+                        fullDkbgTileMmad(fullDkbgTileL0C, fullDkbgTensorL0A, fullDkbgTensorL0B, fullDkbgMActual, static_cast<uint32_t>(tiling_->K), fullDkbgCurK, fullDkbgKOffset == 0, fullDkbgUnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullDkbgL0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullDkbgL0Stage));
+                    }
+
+                    typename FullDkbgTileCopy::template CopyL0CToGm<decltype(fullDkbgBlockC)> fullDkbgCopyL0CToGm;
+                    fullDkbgCopyL0CToGm(fullDkbgBlockC, fullDkbgTileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    SignalAicFinishFullStore();
+                    uint32_t fullDvbL1BOffset = residentDuOffset;
+
+                    AscendC::GlobalTensor<T> fullDvbGmFullDvb;
+                    fullDvbGmFullDvb.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->fullDvbOffset, SlotValueOffset(valueHead, 0, 0))));
+
+                    auto fullDvbTensorC = tla::MakeTensor(fullDvbGmFullDvb, layoutVOut, Catlass::Arch::PositionGM{});
+
+                    auto fullDvbL1ABuf = resource_.l1Buf.template GetBufferByByte<FullDvbElementA>(residentATOffset);
+                    auto fullDvbL1BBuf = resource_.l1Buf.template GetBufferByByte<FullDvbElementB>(fullDvbL1BOffset);
+
+                    auto fullDvbL0CBuf = resource_.l0CBuf.template GetBufferByByte<FullDvbElementAccumulator>(0);
+                    auto fullDvbLayoutResidentL1A =
+                        tla::MakeLayout<FullDvbElementA, FullDvbResidentLayoutTagL1A>(
+                            tla::Int<da5TileK>{}, tla::Int<da5TileN>{});
+                    auto fullDvbLayoutResidentL1B =
+                        tla::MakeLayout<FullDvbElementB, FullDvbResidentLayoutTagL1B>(
+                            tla::Int<fullDvbTileM>{}, tla::Int<V>{});
+                    auto fullDvbTensorResidentL1A = tla::MakeTensor(fullDvbL1ABuf, fullDvbLayoutResidentL1A, Catlass::Arch::PositionL1{});
+                    auto fullDvbTensorResidentL1B = tla::MakeTensor(fullDvbL1BBuf, fullDvbLayoutResidentL1B, Catlass::Arch::PositionL1{});
+
+                    FullDvbTileMmad fullDvbTileMmad;
+                    uint32_t fullDvbMActual = chunkLen;
+                    if (fullDvbMActual == 1) {
+                        fullDvbMActual = 16;
+                    }
+
+                    auto fullDvbBlockC = GetTile(fullDvbTensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, static_cast<uint32_t>(tiling_->V)));
+                    auto fullDvbLayoutL0C = tla::MakeLayoutL0C(fullDvbMActual, static_cast<uint32_t>(tiling_->V));
+                    auto fullDvbTensorL0C = tla::MakeTensor(fullDvbL0CBuf, fullDvbLayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto fullDvbTileL0C = GetTile(fullDvbTensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(fullDvbMActual, static_cast<uint32_t>(tiling_->V)));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+
+                    for (uint32_t fullDvbKOffset = 0; fullDvbKOffset < (chunkLen); fullDvbKOffset += fullDvbTileK) {
+                        uint32_t fullDvbCurK = fullDvbKOffset + fullDvbTileK > (chunkLen) ? (chunkLen) - fullDvbKOffset : fullDvbTileK;
+                        // The resident TileCopyTla path aliases its L0 destination; consume K slices serially.
+                        uint32_t fullDvbL0Stage = 0U;
+                        auto fullDvbL0ABuf = resource_.l0ABuf.template GetBufferByByte<FullDvbElementA>(fullDvbL0Stage * fullDvbL0ATileBytes);
+                        auto fullDvbL0BBuf = resource_.l0BBuf.template GetBufferByByte<FullDvbElementB>(fullDvbL0Stage * fullDvbL0BTileBytes);
+
+                        auto fullDvbLayoutL0A = tla::MakeLayout<FullDvbElementA, FullDvbLayoutTagL0A>(fullDvbMActual, fullDvbCurK);
+                        auto fullDvbLayoutL0B = tla::MakeLayout<FullDvbElementB, FullDvbLayoutTagL0B>(fullDvbCurK, static_cast<uint32_t>(tiling_->V));
+                        auto fullDvbTensorL0A = tla::MakeTensor(fullDvbL0ABuf, fullDvbLayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto fullDvbTensorL0B = tla::MakeTensor(fullDvbL0BBuf, fullDvbLayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto fullDvbResidentShapeA = tla::MakeShape(fullDvbMActual, fullDvbCurK);
+                        auto fullDvbResidentShapeB = tla::MakeShape(fullDvbCurK, static_cast<uint32_t>(tiling_->V));
+                        auto fullDvbTileResidentL1A =
+                            GetTile(fullDvbTensorResidentL1A, tla::MakeCoord(0, fullDvbKOffset), fullDvbResidentShapeA);
+                        auto fullDvbTileResidentL1B =
+                            GetTile(fullDvbTensorResidentL1B, tla::MakeCoord(fullDvbKOffset, 0), fullDvbResidentShapeB);
+                        Catlass::Gemm::Tile::TileCopyTla<ArchTag, decltype(fullDvbTileResidentL1A),
+                                                         decltype(fullDvbTensorL0A)> fullDvbCopyResidentL1ToL0A;
+                        Catlass::Gemm::Tile::TileCopyTla<ArchTag, decltype(fullDvbTileResidentL1B),
+                                                         decltype(fullDvbTensorL0B)> fullDvbCopyResidentL1ToL0B;
+
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullDvbL0Stage));
+                        fullDvbCopyResidentL1ToL0A(fullDvbTensorL0A, fullDvbTileResidentL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullDvbL0Stage));
+                        fullDvbCopyResidentL1ToL0B(fullDvbTensorL0B, fullDvbTileResidentL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullDvbL0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullDvbL0Stage));
+                        uint8_t fullDvbUnitFlag = (fullDvbKOffset + fullDvbCurK >= (chunkLen)) ? 0b11 : 0b10;
+                        fullDvbTileMmad(fullDvbTileL0C, fullDvbTensorL0A, fullDvbTensorL0B, fullDvbMActual, static_cast<uint32_t>(tiling_->V), fullDvbCurK, fullDvbKOffset == 0, fullDvbUnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullDvbL0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullDvbL0Stage));
+                    }
+
+                    typename FullDvbTileCopy::template CopyL0CToGm<decltype(fullDvbBlockC)> fullDvbCopyL0CToGm;
+                    fullDvbCopyL0CToGm(fullDvbBlockC, fullDvbTileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    SignalAicFinishFullStore();
+                    uint32_t fullKktL1AOffset = residentKOffset;
+                    uint32_t fullKktL1BOffset = 0;
+
+                    AscendC::GlobalTensor<T> fullKktGmK;
+                    AscendC::GlobalTensor<T> fullKktGmFullKkt;
+                    fullKktGmK.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(k_) +
+                                               KeyOffset(batch, keyHead, chunkBegin, 0));
+                    fullKktGmFullKkt.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace_) + (SlotWorkspaceElem(slot, tiling_->fullKktOffset, SlotMatrixOffset(valueHead, 0, 0))));
+
+                    auto fullKktTensorB = tla::MakeTensor(fullKktGmK, layoutKT, Catlass::Arch::PositionGM{});
+                    auto fullKktTensorC = tla::MakeTensor(fullKktGmFullKkt, layoutDa, Catlass::Arch::PositionGM{});
+
+                    auto fullKktL1ABuf = resource_.l1Buf.template GetBufferByByte<FullKktElementA>(fullKktL1AOffset);
+                    auto fullKktL1BBuf = resource_.l1Buf.template GetBufferByByte<FullKktElementB>(fullKktL1BOffset);
+
+                    auto fullKktL0CBuf = resource_.l0CBuf.template GetBufferByByte<FullKktElementAccumulator>(0);
+                    auto fullKktLayoutL1A =
+                        tla::MakeLayout<FullKktElementA, FullKktLayoutTagL1A>(tla::Int<fullKktTileM>{}, tla::Int<fullKktTileK>{});
+                    auto fullKktLayoutL1B =
+                        tla::MakeLayout<FullKktElementB, FullKktLayoutTagL1B>(tla::Int<fullKktTileK>{}, tla::Int<fullKktTileN>{});
+                    auto fullKktTensorL1A = tla::MakeTensor(fullKktL1ABuf, fullKktLayoutL1A, Catlass::Arch::PositionL1{});
+                    auto fullKktTensorL1B = tla::MakeTensor(fullKktL1BBuf, fullKktLayoutL1B, Catlass::Arch::PositionL1{});
+
+                    auto fullKktBlockB = GetTile(fullKktTensorB, tla::MakeCoord(0, 0),
+                                                 tla::MakeShape(static_cast<uint32_t>(tiling_->K), chunkLen));
+                    typename FullKktTileCopy::template CopyGmToL1B<decltype(fullKktBlockB)> fullKktCopyGmToL1B;
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+                    fullKktCopyGmToL1B(fullKktTensorL1B, fullKktBlockB);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+
+                    FullKktCopyL1ToL0A fullKktCopyL1ToL0A;
+                    FullKktCopyL1ToL0B fullKktCopyL1ToL0B;
+                    FullKktTileMmad fullKktTileMmad;
+                    uint32_t fullKktMActual = chunkLen;
+                    if (fullKktMActual == 1) {
+                        fullKktMActual = 16;
+                    }
+
+                    auto fullKktBlockC = GetTile(fullKktTensorC, tla::MakeCoord(0, 0), tla::MakeShape(chunkLen, chunkLen));
+                    auto fullKktLayoutL0C = tla::MakeLayoutL0C(fullKktMActual, chunkLen);
+                    auto fullKktTensorL0C = tla::MakeTensor(fullKktL0CBuf, fullKktLayoutL0C, Catlass::Arch::PositionL0C{});
+                    auto fullKktTileL0C = GetTile(fullKktTensorL0C, tla::MakeCoord(0, 0), tla::MakeShape(fullKktMActual, chunkLen));
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+
+                    for (uint32_t fullKktKOffset = 0; fullKktKOffset < (static_cast<uint32_t>(tiling_->K)); fullKktKOffset += fullKktTileK) {
+                        uint32_t fullKktCurK = fullKktKOffset + fullKktTileK > (static_cast<uint32_t>(tiling_->K)) ? (static_cast<uint32_t>(tiling_->K)) - fullKktKOffset : fullKktTileK;
+
+                        uint32_t fullKktL0Stage = (fullKktKOffset / fullKktTileK) & 1U;
+                        auto fullKktL0ABuf = resource_.l0ABuf.template GetBufferByByte<FullKktElementA>(fullKktL0Stage * fullKktL0ATileBytes);
+                        auto fullKktL0BBuf = resource_.l0BBuf.template GetBufferByByte<FullKktElementB>(fullKktL0Stage * fullKktL0BTileBytes);
+
+                        auto fullKktLayoutL0A = tla::MakeLayout<FullKktElementA, FullKktLayoutTagL0A>(fullKktMActual, fullKktCurK);
+                        auto fullKktLayoutL0B = tla::MakeLayout<FullKktElementB, FullKktLayoutTagL0B>(fullKktCurK, chunkLen);
+                        auto fullKktTensorL0A = tla::MakeTensor(fullKktL0ABuf, fullKktLayoutL0A, Catlass::Arch::PositionL0A{});
+                        auto fullKktTensorL0B = tla::MakeTensor(fullKktL0BBuf, fullKktLayoutL0B, Catlass::Arch::PositionL0B{});
+                        auto fullKktTileL1A = GetTile(fullKktTensorL1A, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(fullKktMActual, fullKktCurK));
+                        auto fullKktTileL1B = GetTile(fullKktTensorL1B, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(fullKktCurK, chunkLen));
+
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullKktL0Stage));
+                        fullKktCopyL1ToL0A(fullKktTensorL0A, fullKktTileL1A);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(eventL1B);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullKktL0Stage));
+                        fullKktCopyL1ToL0B(fullKktTensorL0B, fullKktTileL1B);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(eventL1B);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullKktL0Stage));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0ReadyEvent(fullKktL0Stage));
+                        uint8_t fullKktUnitFlag = (fullKktKOffset + fullKktCurK >= (static_cast<uint32_t>(tiling_->K))) ? 0b11 : 0b10;
+                        fullKktTileMmad(fullKktTileL0C, fullKktTensorL0A, fullKktTensorL0B, fullKktMActual, chunkLen, fullKktCurK, fullKktKOffset == 0, fullKktUnitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AEvent(fullKktL0Stage));
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BEvent(fullKktL0Stage));
+                    }
+
+                    typename FullKktTileCopy::template CopyL0CToGm<decltype(fullKktBlockC)> fullKktCopyL0CToGm;
+                    fullKktCopyL0CToGm(fullKktBlockC, fullKktTileL0C, 0b11);
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(eventL0C);
+                    SignalAicFinishFullStore();
+                    }
+                    DrainGemmEvents(eventL1A, eventL1B, eventL0C);
+                    }
+                }
+                AscendC::PipeBarrier<PIPE_FIX>();
+            }
+        }
+    }
+
+private:
+    __aicore__ inline bool ResolvePipelineHeadSlot(uint64_t headBase, uint64_t slot, uint64_t &valueHead) const
+    {
+        valueHead = headBase + slot;
+        return valueHead < static_cast<uint64_t>(tiling_->HV);
+    }
+
+    __aicore__ inline uint64_t Min(uint64_t lhs, uint64_t rhs) const
+    {
+        return lhs < rhs ? lhs : rhs;
+    }
+
+    __aicore__ inline uint64_t KeyOffset(uint64_t batch, uint64_t head, uint64_t token, uint64_t col) const
+    {
+        return (((batch * static_cast<uint64_t>(tiling_->HK) + head) * static_cast<uint64_t>(tiling_->T) + token) *
+                static_cast<uint64_t>(tiling_->K)) + col;
+    }
+
+    __aicore__ inline uint64_t ValueOffset(uint64_t batch, uint64_t head, uint64_t token, uint64_t col) const
+    {
+        return (((batch * static_cast<uint64_t>(tiling_->HV) + head) * static_cast<uint64_t>(tiling_->T) + token) *
+                static_cast<uint64_t>(tiling_->V)) + col;
+    }
+
+    __aicore__ inline uint64_t ValueKeyLikeOffset(uint64_t batch, uint64_t head, uint64_t token, uint64_t col) const
+    {
+        return (((batch * static_cast<uint64_t>(tiling_->HV) + head) * static_cast<uint64_t>(tiling_->T) + token) *
+                static_cast<uint64_t>(tiling_->K)) + col;
+    }
+
+    __aicore__ inline uint64_t MatrixOffset(uint64_t batch, uint64_t head, uint64_t token, uint64_t localCol) const
+    {
+        return (((batch * static_cast<uint64_t>(tiling_->HV) + head) * static_cast<uint64_t>(tiling_->T) + token) *
+                static_cast<uint64_t>(tiling_->chunkSize)) + localCol;
+    }
+
+    __aicore__ inline uint64_t WorkspaceElem(int64_t byteOffset, uint64_t elemOffset) const
+    {
+        return static_cast<uint64_t>(byteOffset) / sizeof(T) + elemOffset;
+    }
+
+    __aicore__ inline uint64_t SlotBaseElem(uint64_t slot) const
+    {
+        return ((coreIdx_ * static_cast<uint64_t>(tiling_->workspaceBufferCount) + slot) *
+                static_cast<uint64_t>(tiling_->workspaceSlotBytes)) / sizeof(T);
+    }
+
+    __aicore__ inline uint64_t SlotWorkspaceElem(uint64_t slot, int64_t byteOffset, uint64_t elemOffset) const
+    {
+        return SlotBaseElem(slot) + WorkspaceElem(byteOffset, elemOffset);
+    }
+
+    __aicore__ inline uint64_t SlotValueKeyLikeOffset(uint64_t head, uint64_t localRow, uint64_t col) const
+    {
+        return ((head * static_cast<uint64_t>(tiling_->chunkSize) + localRow) *
+                static_cast<uint64_t>(tiling_->K)) + col;
+    }
+
+    __aicore__ inline uint64_t SlotValueOffset(uint64_t head, uint64_t localRow, uint64_t col) const
+    {
+        return ((head * static_cast<uint64_t>(tiling_->chunkSize) + localRow) *
+                static_cast<uint64_t>(tiling_->V)) + col;
+    }
+
+    __aicore__ inline uint64_t SlotMatrixOffset(uint64_t head, uint64_t localRow, uint64_t localCol) const
+    {
+        return ((head * static_cast<uint64_t>(tiling_->chunkSize) + localRow) *
+                static_cast<uint64_t>(tiling_->chunkSize)) + localCol;
+    }
+
+    __aicore__ inline void GetChunkOffset(uint64_t chunkLinear, uint64_t &batch, uint64_t &chunkBegin,
+                                         uint64_t &chunkEnd)
+    {
+        const uint64_t chunkSize = static_cast<uint64_t>(tiling_->chunkSize);
+        if constexpr (IS_VARLEN) {
+            uint64_t seqIdx = static_cast<uint64_t>(chunkIndicesGm_.GetValue(chunkLinear * 2));
+            uint64_t chunkInSeq = static_cast<uint64_t>(chunkIndicesGm_.GetValue(chunkLinear * 2 + 1));
+            uint64_t seqBegin = static_cast<uint64_t>(cuSeqlensGm_.GetValue(seqIdx));
+            uint64_t seqEnd = static_cast<uint64_t>(cuSeqlensGm_.GetValue(seqIdx + 1));
+            batch = 0;
+            chunkBegin = seqBegin + chunkInSeq * chunkSize;
+            chunkEnd = Min(chunkBegin + chunkSize, seqEnd);
+            return;
+        }
+
+        const uint64_t chunksPerBatch = (static_cast<uint64_t>(tiling_->T) + chunkSize - 1) / chunkSize;
+        batch = chunkLinear / chunksPerBatch;
+        uint64_t chunkInBatch = chunkLinear - batch * chunksPerBatch;
+        chunkBegin = chunkInBatch * chunkSize;
+        chunkEnd = Min(chunkBegin + chunkSize, static_cast<uint64_t>(tiling_->T));
+    }
+
+private:
+    const PrepareWyReprBwdTilingData *tiling_ = nullptr;
+    Catlass::Arch::Resource<ArchTag> resource_;
+    Catlass::Arch::CrossCoreFlagWithReverse<14> flagAicFinishStore{SYNC_FLAG_2, SYNC_FLAG_3};
+    Catlass::Arch::CrossCoreFlagWithReverse<> flagAivFinishStore{SYNC_FLAG_4, SYNC_FLAG_5};
+    uint64_t coreIdx_ = 0;
+    GM_ADDR k_ = nullptr;
+    GM_ADDR v_ = nullptr;
+    GM_ADDR a_ = nullptr;
+    GM_ADDR dw_ = nullptr;
+    GM_ADDR du_ = nullptr;
+    GM_ADDR workspace_ = nullptr;
+    PrepareWyReprBwdInt64Tensor cuSeqlensGm_;
+    PrepareWyReprBwdInt64Tensor chunkIndicesGm_;
+};
+
+} // namespace GDN
+
+#endif // PREPARE_WY_REPR_BWD_CUBE_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/prepare_wy_repr_bwd_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/prepare_wy_repr_bwd_struct.h
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef PREPARE_WY_REPR_BWD_STRUCT_H
+#define PREPARE_WY_REPR_BWD_STRUCT_H
+
+#include <cstdint>
+#ifndef TORCH_MODE
+#include "ascendc/host_api/tiling/template_argument.h"
+#endif
+
+#define PREPARE_WY_REPR_BWD_TPL_VARLEN_FALSE 0
+#define PREPARE_WY_REPR_BWD_TPL_VARLEN_TRUE 1
+#define PREPARE_WY_REPR_BWD_TPL_BF16 10
+#define PREPARE_WY_REPR_BWD_TPL_FP16 20
+#define PREPARE_WY_REPR_BWD_TPL_FP32 30
+
+namespace GDN {
+
+static constexpr bool IS_VARLEN_FALSE = PREPARE_WY_REPR_BWD_TPL_VARLEN_FALSE;
+static constexpr bool IS_VARLEN_TRUE = PREPARE_WY_REPR_BWD_TPL_VARLEN_TRUE;
+
+static constexpr int32_t TPL_BF16 = PREPARE_WY_REPR_BWD_TPL_BF16;
+static constexpr int32_t TPL_FP16 = PREPARE_WY_REPR_BWD_TPL_FP16;
+static constexpr int32_t TPL_FP32 = PREPARE_WY_REPR_BWD_TPL_FP32;
+static constexpr uint64_t SYNC_FLAG_2 = 2;
+static constexpr uint64_t SYNC_FLAG_3 = 3;
+static constexpr uint64_t SYNC_FLAG_4 = 4;
+static constexpr uint64_t SYNC_FLAG_5 = 5;
+static constexpr uint64_t BWD_TASK_PAIR_SLOT_COUNT = 2;
+static constexpr int64_t BWD_TASK_PAIR_INDEPENDENT_UNIT = 0;
+static constexpr int64_t BWD_TASK_PAIR_SAME_OWNER_HV = 1;
+
+struct PrepareWyReprBwdTilingData {
+    // 张量主维度。k: [B, HK, T, K]，v/du: [B, HV, T, V]，beta/g: [B, HV, T]。
+    int64_t B;
+    int64_t HV;
+    int64_t HK;
+    int64_t T;
+    int64_t K;
+    int64_t V;
+
+    // chunkSize 只支持 64/128；chunkNum 表示 batch 或可变长序列展开后的 chunk 总数。
+    int64_t chunkSize;
+    int64_t chunkNum;
+    int64_t seqNum;
+    int64_t isVariable;
+
+    // 每个 key head 对应的 value head 数。kernel 用它做 GQA 映射与写回归属划分。
+    int64_t headGroup;
+
+    // A5 vector 双任务调度策略。非 GVA(headGroup=1) 时两个 slot 取两个独立 owner unit；
+    // GVA(headGroup>1) 时两个 slot 取同一个 (chunk,hk) owner 下的两个 hv，避免 dk 跨核竞争。
+    int64_t taskPairMode;
+    int64_t ownerUnitNum;
+
+    // AIV 基础 API 的行粒度。AIC 只做矩阵乘，所有逐元素准备、mask、规约和输出写回
+    // 由 AIV 按这些行粒度切片处理。
+    int64_t rowTileInput;
+    int64_t rowTileDa;
+    int64_t rowTileFullK;
+    int64_t rowTileFullV;
+    int64_t rowTileFullKkt;
+
+    // AIV 手工 UB arena 布局，单位 byte。tiling 根据实际 dtype、K/V、chunkSize 和 row tile 计算，
+    // kernel 只按这些 offset 切片复用 UB。
+    int64_t vectorIoInOffset;
+    int64_t vectorIoOutOffset;
+    int64_t vectorPersistentOffset;
+    int64_t vectorGateCacheOffset;
+    int64_t vectorTempOffset;
+    int64_t vectorMaskOffset;
+    int64_t vectorZeroOffset;
+    int64_t vectorUbBytes;
+    int64_t a5UseSlotWork;
+    int64_t a5UseVPrefetch;
+    int64_t a5UseL1Resident;
+    int64_t a5VectorRowTile;
+
+    // 实际下发的 AIC/AIV core 组数。kernel 按 chunk 做 stride 分发，chunk 内每轮处理两个 value head。
+    int64_t usedCoreNum;
+
+    // workspace 使用 GetUserWorkspace 后的 slot 内偏移，单位 byte。每个 core 使用双 buffer slot，
+    // 每个 slot 覆盖一个 chunk 的全部 value heads：
+    //   K 类: [HV, chunkSize, K]
+    //   V 类: [HV, chunkSize, V]
+    //   A 类: [HV, chunkSize, chunkSize]
+    int64_t kbgOffset;
+    int64_t vbOffset;
+    int64_t kbetaOffset;
+    int64_t da1Offset;
+    int64_t da2Offset;
+    int64_t da4Offset;
+    int64_t da5Offset;
+    int64_t daOffset;
+    int64_t fullDkOffset;
+    int64_t fullDkbOffset;
+    int64_t fullDkbgOffset;
+    int64_t fullDvbOffset;
+    int64_t fullKktOffset;
+    int64_t kWorkspaceBytes;
+    int64_t vWorkspaceBytes;
+    int64_t aWorkspaceBytes;
+    int64_t workspaceSlotBytes;
+    int64_t workspaceBufferCount;
+    int64_t userWorkspaceBytes;
+};
+
+} // namespace GDN
+
+using PrepareWyReprBwdTilingData = GDN::PrepareWyReprBwdTilingData;
+
+#ifndef TORCH_MODE
+ASCENDC_TPL_ARGS_DECL(PrepareWyReprBwd,
+    ASCENDC_TPL_BOOL_DECL(IS_VARLEN, PREPARE_WY_REPR_BWD_TPL_VARLEN_FALSE,
+                          PREPARE_WY_REPR_BWD_TPL_VARLEN_TRUE),
+    ASCENDC_TPL_DTYPE_DECL(D_T_K, PREPARE_WY_REPR_BWD_TPL_BF16, PREPARE_WY_REPR_BWD_TPL_FP16),
+    ASCENDC_TPL_DTYPE_DECL(D_T_GATE, PREPARE_WY_REPR_BWD_TPL_BF16,
+                           PREPARE_WY_REPR_BWD_TPL_FP16, PREPARE_WY_REPR_BWD_TPL_FP32),
+    ASCENDC_TPL_UINT_DECL(V, 1, ASCENDC_TPL_UI_LIST, 128, 256),
+    ASCENDC_TPL_UINT_DECL(CHUNK_SIZE, 1, ASCENDC_TPL_UI_LIST, 64, 128),
+);
+
+#define PREPARE_WY_REPR_BWD_SEL_ENTRY_CHUNK(                                                        \
+    IS_VARLEN_VALUE, K_DTYPE, GATE_DTYPE, VALUE_DIM, CHUNK_DIM)                                     \
+    ASCENDC_TPL_ARGS_SEL(ASCENDC_TPL_BOOL_SEL(IS_VARLEN, IS_VARLEN_VALUE),                           \
+                         ASCENDC_TPL_DTYPE_SEL(D_T_K, K_DTYPE),                                      \
+                         ASCENDC_TPL_DTYPE_SEL(D_T_GATE, GATE_DTYPE),                                \
+                         ASCENDC_TPL_UINT_SEL(V, ASCENDC_TPL_UI_LIST, VALUE_DIM),                    \
+                         ASCENDC_TPL_UINT_SEL(CHUNK_SIZE, ASCENDC_TPL_UI_LIST, CHUNK_DIM),           \
+                         ASCENDC_TPL_TILING_STRUCT_SEL(PrepareWyReprBwdTilingData))
+
+#define PREPARE_WY_REPR_BWD_SEL_ENTRY(IS_VARLEN_VALUE, K_DTYPE, GATE_DTYPE, VALUE_DIM)               \
+    PREPARE_WY_REPR_BWD_SEL_ENTRY_CHUNK(IS_VARLEN_VALUE, K_DTYPE, GATE_DTYPE, VALUE_DIM, 64),        \
+    PREPARE_WY_REPR_BWD_SEL_ENTRY_CHUNK(IS_VARLEN_VALUE, K_DTYPE, GATE_DTYPE, VALUE_DIM, 128)
+
+ASCENDC_TPL_SEL(
+    PREPARE_WY_REPR_BWD_SEL_ENTRY(PREPARE_WY_REPR_BWD_TPL_VARLEN_FALSE, PREPARE_WY_REPR_BWD_TPL_FP16,
+                                  PREPARE_WY_REPR_BWD_TPL_FP16, 128),
+    PREPARE_WY_REPR_BWD_SEL_ENTRY(PREPARE_WY_REPR_BWD_TPL_VARLEN_FALSE, PREPARE_WY_REPR_BWD_TPL_FP16,
+                                  PREPARE_WY_REPR_BWD_TPL_FP16, 256),
+    PREPARE_WY_REPR_BWD_SEL_ENTRY(PREPARE_WY_REPR_BWD_TPL_VARLEN_FALSE, PREPARE_WY_REPR_BWD_TPL_BF16,
+                                  PREPARE_WY_REPR_BWD_TPL_BF16, 128),
+    PREPARE_WY_REPR_BWD_SEL_ENTRY(PREPARE_WY_REPR_BWD_TPL_VARLEN_FALSE, PREPARE_WY_REPR_BWD_TPL_BF16,
+                                  PREPARE_WY_REPR_BWD_TPL_BF16, 256),
+    PREPARE_WY_REPR_BWD_SEL_ENTRY(PREPARE_WY_REPR_BWD_TPL_VARLEN_FALSE, PREPARE_WY_REPR_BWD_TPL_FP16,
+                                  PREPARE_WY_REPR_BWD_TPL_FP32, 128),
+    PREPARE_WY_REPR_BWD_SEL_ENTRY(PREPARE_WY_REPR_BWD_TPL_VARLEN_FALSE, PREPARE_WY_REPR_BWD_TPL_FP16,
+                                  PREPARE_WY_REPR_BWD_TPL_FP32, 256),
+    PREPARE_WY_REPR_BWD_SEL_ENTRY(PREPARE_WY_REPR_BWD_TPL_VARLEN_FALSE, PREPARE_WY_REPR_BWD_TPL_BF16,
+                                  PREPARE_WY_REPR_BWD_TPL_FP32, 128),
+    PREPARE_WY_REPR_BWD_SEL_ENTRY(PREPARE_WY_REPR_BWD_TPL_VARLEN_FALSE, PREPARE_WY_REPR_BWD_TPL_BF16,
+                                  PREPARE_WY_REPR_BWD_TPL_FP32, 256),
+    PREPARE_WY_REPR_BWD_SEL_ENTRY(PREPARE_WY_REPR_BWD_TPL_VARLEN_TRUE, PREPARE_WY_REPR_BWD_TPL_FP16,
+                                  PREPARE_WY_REPR_BWD_TPL_FP16, 128),
+    PREPARE_WY_REPR_BWD_SEL_ENTRY(PREPARE_WY_REPR_BWD_TPL_VARLEN_TRUE, PREPARE_WY_REPR_BWD_TPL_FP16,
+                                  PREPARE_WY_REPR_BWD_TPL_FP16, 256),
+    PREPARE_WY_REPR_BWD_SEL_ENTRY(PREPARE_WY_REPR_BWD_TPL_VARLEN_TRUE, PREPARE_WY_REPR_BWD_TPL_BF16,
+                                  PREPARE_WY_REPR_BWD_TPL_BF16, 128),
+    PREPARE_WY_REPR_BWD_SEL_ENTRY(PREPARE_WY_REPR_BWD_TPL_VARLEN_TRUE, PREPARE_WY_REPR_BWD_TPL_BF16,
+                                  PREPARE_WY_REPR_BWD_TPL_BF16, 256),
+    PREPARE_WY_REPR_BWD_SEL_ENTRY(PREPARE_WY_REPR_BWD_TPL_VARLEN_TRUE, PREPARE_WY_REPR_BWD_TPL_FP16,
+                                  PREPARE_WY_REPR_BWD_TPL_FP32, 128),
+    PREPARE_WY_REPR_BWD_SEL_ENTRY(PREPARE_WY_REPR_BWD_TPL_VARLEN_TRUE, PREPARE_WY_REPR_BWD_TPL_FP16,
+                                  PREPARE_WY_REPR_BWD_TPL_FP32, 256),
+    PREPARE_WY_REPR_BWD_SEL_ENTRY(PREPARE_WY_REPR_BWD_TPL_VARLEN_TRUE, PREPARE_WY_REPR_BWD_TPL_BF16,
+                                  PREPARE_WY_REPR_BWD_TPL_FP32, 128),
+    PREPARE_WY_REPR_BWD_SEL_ENTRY(PREPARE_WY_REPR_BWD_TPL_VARLEN_TRUE, PREPARE_WY_REPR_BWD_TPL_BF16,
+                                  PREPARE_WY_REPR_BWD_TPL_FP32, 256),
+);
+
+#undef PREPARE_WY_REPR_BWD_SEL_ENTRY
+#undef PREPARE_WY_REPR_BWD_SEL_ENTRY_CHUNK
+#endif
+
+#endif // PREPARE_WY_REPR_BWD_STRUCT_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/prepare_wy_repr_bwd_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_kernel/prepare_wy_repr_bwd_vector.h
@@ -1,0 +1,1197 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef PREPARE_WY_REPR_BWD_VECTOR_H
+#define PREPARE_WY_REPR_BWD_VECTOR_H
+
+#include <type_traits>
+
+#include "adv_api/index/arithprogression.h"
+#include "catlass/arch/cross_core_sync.hpp"
+#include "kernel_operator.h"
+#include "prepare_wy_repr_bwd_struct.h"
+
+namespace GDN {
+
+static constexpr uint32_t BWD_VEC_ONE_BLOCK_32 = 32;
+static constexpr uint32_t BWD_VEC_FP32_PER_BLOCK_8 = 8;
+static constexpr uint32_t BWD_VEC_FP32_PER_REPEAT_64 = 64;
+static constexpr uint32_t BWD_VEC_BIT_NUM_FOR_UINT8 = 8;
+static constexpr uint32_t BWD_VEC_SIZE_FLOAT = 4;
+static constexpr uint32_t BWD_VEC_CAL_NUM_FLOAT = 64;
+static constexpr uint32_t BWD_VEC_IO_BUFFER_COUNT = 2;
+
+template <typename T, typename GateT, bool IS_VARLEN, int V>
+class PrepareWyReprBwdVector {
+public:
+    __aicore__ inline void Init(GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR dw, GM_ADDR du, GM_ADDR g,
+                                GM_ADDR cuSeqlens, GM_ADDR chunkIndices, GM_ADDR dk, GM_ADDR dv, GM_ADDR dbeta,
+                                GM_ADDR dg, GM_ADDR workspace, const PrepareWyReprBwdTilingData *tiling,
+                                AscendC::TPipe *pipe)
+    {
+        tiling_ = tiling;
+        pipe_ = pipe;
+        coreIdx_ = static_cast<uint64_t>(AscendC::GetBlockIdx() / AscendC::GetSubBlockNum());
+        coreNum_ = static_cast<uint64_t>(tiling_->usedCoreNum);
+        subBlockIdx_ = static_cast<uint64_t>(AscendC::GetSubBlockIdx());
+        subBlockNum_ = static_cast<uint64_t>(AscendC::GetSubBlockNum());
+
+        kGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(k));
+        vGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(v));
+        aGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(A));
+        dwGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(dw));
+        duGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(du));
+        betaGm_.SetGlobalBuffer(reinterpret_cast<__gm__ GateT *>(beta));
+        gGm_.SetGlobalBuffer(reinterpret_cast<__gm__ GateT *>(g));
+        dkGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(dk));
+        dvGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(dv));
+        dbetaGm_.SetGlobalBuffer(reinterpret_cast<__gm__ GateT *>(dbeta));
+        dgGm_.SetGlobalBuffer(reinterpret_cast<__gm__ GateT *>(dg));
+        workspaceGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T *>(workspace));
+        if (cuSeqlens != nullptr) {
+            cuSeqlensGm_.SetGlobalBuffer(reinterpret_cast<__gm__ uint64_t *>(cuSeqlens));
+        }
+        if (chunkIndices != nullptr) {
+            chunkIndicesGm_.SetGlobalBuffer(reinterpret_cast<__gm__ uint64_t *>(chunkIndices));
+        }
+    }
+
+    __aicore__ inline void ProcessPipeline()
+    {
+        constexpr uint64_t slotCount = 2;
+        InitPipelineBuffers();
+        AscendC::Duplicate<float>(ZeroTensor(), 0.0f, BWD_VEC_ONE_BLOCK_32 / BWD_VEC_SIZE_FLOAT);
+        AscendC::PipeBarrier<PIPE_V>();
+        InitTriangleMasks();
+
+        const uint64_t coreLoops = static_cast<uint64_t>(tiling_->chunkNum);
+        for (uint64_t chunkLinear = coreIdx_; chunkLinear < coreLoops; chunkLinear += coreNum_) {
+            uint64_t batch = 0;
+            uint64_t chunkBegin = 0;
+            uint64_t chunkEnd = 0;
+            ResolveChunk(chunkLinear, batch, chunkBegin, chunkEnd);
+            if (chunkEnd <= chunkBegin) {
+                continue;
+            }
+            uint32_t chunkLen = static_cast<uint32_t>(chunkEnd - chunkBegin);
+            for (uint64_t headBase = 0; headBase < static_cast<uint64_t>(tiling_->HV); headBase += slotCount) {
+                // Advance both head slots one dependency stage at a time to overlap AIC(slot 1) with AIV(slot 0).
+                for (uint32_t pipelineStage = 0; pipelineStage < 4; ++pipelineStage) {
+                    for (uint64_t slot = 0; slot < slotCount; ++slot) {
+                    uint64_t valueHead = 0;
+                    uint64_t keyHead = 0;
+                    if (!ResolvePipelineHeadSlot(headBase, slot, valueHead, keyHead)) {
+                        continue;
+                    }
+                    if (pipelineStage == 0) {
+                    uint32_t kbgRowNum = static_cast<uint32_t>(tiling_->rowTileInput);
+                    uint32_t kbgKDim = static_cast<uint32_t>(tiling_->K);
+                    uint32_t kbgVDim = static_cast<uint32_t>(tiling_->V);
+                    uint32_t kbgMaxDim = kbgKDim > kbgVDim ? kbgKDim : kbgVDim;
+                    kbgMaxDim = kbgMaxDim > static_cast<uint32_t>(tiling_->chunkSize) ? kbgMaxDim :
+                                static_cast<uint32_t>(tiling_->chunkSize);
+                    auto kbgBetaCache = SlotBetaCache(slot);
+                    auto kbgGCache = SlotGCache(slot);
+                    auto kbgGExpCache = SlotGExpCache(slot);
+                    LoadGateToFp32(kbgBetaCache, GateOffset(batch, valueHead, chunkBegin), chunkLen);
+                    LoadGToFp32(kbgGCache, GateOffset(batch, valueHead, chunkBegin), chunkLen);
+
+                    auto kbgTemp = TempTensor();
+                    auto kbgKScaled = kbgTemp;
+                    auto kbgVScaled = kbgKScaled[kbgRowNum * kbgMaxDim];
+                    auto kbgInputTile = kbgVScaled[kbgRowNum * kbgMaxDim];
+                    uint32_t kbgTempTileCount = UseInputCache() ? 2U : 3U;
+                    auto kbgBetaExpFp32 = kbgTemp[kbgTempTileCount * kbgRowNum * kbgMaxDim];
+                    auto kbgBetaBrcb = kbgBetaExpFp32[kbgRowNum];
+                    auto kbgBetaExpBrcb = kbgBetaBrcb[kbgRowNum * BWD_VEC_FP32_PER_BLOCK_8];
+
+                    uint32_t kbgRowStep = kbgRowNum * static_cast<uint32_t>(subBlockNum_);
+                    uint32_t rowOffset = static_cast<uint32_t>(subBlockIdx_) * kbgRowNum;
+                    uint32_t kIoSlot = 0;
+                    if (rowOffset < chunkLen) {
+                        uint32_t firstRowNum = rowOffset + kbgRowNum > chunkLen ? chunkLen - rowOffset : kbgRowNum;
+                        kIoSlot = BeginLoadGmTile(
+                            kGm_, KeyOffset(batch, keyHead, chunkBegin + rowOffset, 0), kbgKDim * firstRowNum);
+                    }
+                    for (; rowOffset < chunkLen; rowOffset += kbgRowStep) {
+                        uint32_t curRowNum = rowOffset + kbgRowNum > chunkLen ? chunkLen - rowOffset : kbgRowNum;
+                        uint64_t token = chunkBegin + rowOffset;
+                        AscendC::Adds(kbgGExpCache[rowOffset], kbgGCache[rowOffset], 0.0f, curRowNum);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Exp(kbgGExpCache[rowOffset], kbgGExpCache[rowOffset], curRowNum);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Mul(kbgBetaExpFp32, kbgGExpCache[rowOffset], kbgBetaCache[rowOffset], curRowNum);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Brcb(kbgBetaBrcb, kbgBetaCache[rowOffset],
+                                      static_cast<uint8_t>(CeilDiv(curRowNum, 8)), {1, 8});
+                        AscendC::Brcb(kbgBetaExpBrcb, kbgBetaExpFp32,
+                                      static_cast<uint8_t>(CeilDiv(curRowNum, 8)), {1, 8});
+                        auto kbgKInput = UseInputCache() ?
+                                         SlotKCache(slot)[InputCacheElemOffset(rowOffset, kbgKDim)] :
+                                         kbgInputTile;
+                        FinishLoadTile(kbgKInput, kIoSlot, kbgKDim * curRowNum);
+                        uint32_t vIoSlot = BeginLoadGmTile(
+                            vGm_, ValueOffset(batch, valueHead, token, 0), kbgVDim * curRowNum);
+                        uint64_t perCol = 0;
+                        uint8_t kRepeatStride = kbgKDim * sizeof(float32_t) / BWD_VEC_ONE_BLOCK_32;
+                        while (perCol < kbgKDim) {
+                            AscendC::Mul(kbgKScaled[perCol], kbgKInput[perCol], kbgBetaExpBrcb,
+                                         BWD_VEC_FP32_PER_REPEAT_64, curRowNum,
+                                         {1, 1, 0, kRepeatStride, kRepeatStride, 1});
+                            perCol += BWD_VEC_FP32_PER_REPEAT_64;
+                        }
+                        StoreGmTile(workspaceGm_, SlotWorkspaceElem(
+                                    slot, tiling_->kbgOffset, SlotValueKeyLikeOffset(valueHead, rowOffset, 0)),
+                                    kbgKScaled, kbgKDim * curRowNum);
+                        perCol = 0;
+                        while (perCol < kbgKDim) {
+                            AscendC::Mul(kbgKScaled[perCol], kbgKInput[perCol], kbgBetaBrcb,
+                                         BWD_VEC_FP32_PER_REPEAT_64, curRowNum,
+                                         {1, 1, 0, kRepeatStride, kRepeatStride, 1});
+                            perCol += BWD_VEC_FP32_PER_REPEAT_64;
+                        }
+                        StoreGmTile(workspaceGm_, SlotWorkspaceElem(
+                                    slot, tiling_->kbetaOffset, SlotValueKeyLikeOffset(valueHead, rowOffset, 0)),
+                                    kbgKScaled, kbgKDim * curRowNum);
+                        auto kbgVInput = UseInputCache() ?
+                                         SlotVCache(slot)[InputCacheElemOffset(rowOffset, kbgVDim)] :
+                                         kbgInputTile;
+                        FinishLoadTile(kbgVInput, vIoSlot, kbgVDim * curRowNum);
+                        uint32_t nextKIoSlot = 0;
+                        uint32_t nextRowOffset = rowOffset + kbgRowStep;
+                        if (nextRowOffset < chunkLen) {
+                            uint32_t nextRowNum = nextRowOffset + kbgRowNum > chunkLen ? chunkLen - nextRowOffset :
+                                                  kbgRowNum;
+                            nextKIoSlot = BeginLoadGmTile(
+                                kGm_, KeyOffset(batch, keyHead, chunkBegin + nextRowOffset, 0),
+                                kbgKDim * nextRowNum);
+                        }
+                        perCol = 0;
+                        uint8_t vRepeatStride = kbgVDim * sizeof(float32_t) / BWD_VEC_ONE_BLOCK_32;
+                        while (perCol < kbgVDim) {
+                            AscendC::Mul(kbgVScaled[perCol], kbgVInput[perCol], kbgBetaBrcb,
+                                         BWD_VEC_FP32_PER_REPEAT_64, curRowNum,
+                                         {1, 1, 0, vRepeatStride, vRepeatStride, 1});
+                            perCol += BWD_VEC_FP32_PER_REPEAT_64;
+                        }
+                        StoreGmTile(workspaceGm_, SlotWorkspaceElem(
+                                    slot, tiling_->vbOffset, SlotValueOffset(valueHead, rowOffset, 0)),
+                                    kbgVScaled, kbgVDim * curRowNum);
+                        kIoSlot = nextKIoSlot;
+                    }
+                    AscendC::PipeBarrier<PIPE_MTE3>();
+                    SignalAivFinishStore();
+
+                    } else if (pipelineStage == 1) {
+                    WaitAicFinishStore();
+
+                    uint32_t da4RowNum = static_cast<uint32_t>(tiling_->rowTileDa);
+                    uint32_t da4ChunkSize = static_cast<uint32_t>(tiling_->chunkSize);
+                    auto da4Temp = TempTensor();
+                    auto da4Da1 = da4Temp;
+                    auto da4Da2 = da4Temp[da4RowNum * da4ChunkSize];
+                    auto da4Sum = da4Temp[2 * da4RowNum * da4ChunkSize];
+                    auto da4Mask = LowerMaskTensor();
+                    auto da4Zero = ZeroTensor();
+                    for (uint32_t rowOffset = static_cast<uint32_t>(subBlockIdx_) * da4RowNum; rowOffset < chunkLen;
+                         rowOffset += da4RowNum * static_cast<uint32_t>(subBlockNum_)) {
+                        uint32_t curRowNum = rowOffset + da4RowNum > chunkLen ? chunkLen - rowOffset : da4RowNum;
+                        LoadMatrixTile(da4Da1, slot, tiling_->da1Offset, SlotMatrixOffset(valueHead, rowOffset, 0),
+                                       da4ChunkSize * curRowNum);
+                        LoadMatrixTile(da4Da2, slot, tiling_->da2Offset, SlotMatrixOffset(valueHead, rowOffset, 0),
+                                       da4ChunkSize * curRowNum);
+                        AscendC::Add(da4Sum, da4Da1, da4Da2, da4ChunkSize * curRowNum);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::BinaryRepeatParams repeatParams = {1, 0, 1, 8, 0, 8};
+                        AscendC::Select(da4Sum, da4Mask[rowOffset * da4ChunkSize / BWD_VEC_BIT_NUM_FOR_UINT8],
+                                        da4Zero, da4Sum, AscendC::SELMODE::VSEL_TENSOR_TENSOR_MODE,
+                                        BWD_VEC_CAL_NUM_FLOAT,
+                                        curRowNum * da4ChunkSize / BWD_VEC_CAL_NUM_FLOAT, repeatParams);
+                        StoreGmTile(workspaceGm_, SlotWorkspaceElem(
+                                    slot, tiling_->da4Offset, SlotMatrixOffset(valueHead, rowOffset, 0)),
+                                    da4Sum, da4ChunkSize * curRowNum);
+                    }
+                    AscendC::PipeBarrier<PIPE_MTE3>();
+                    SignalAivFinishStore();
+
+                    } else if (pipelineStage == 2) {
+                    uint32_t finalDaRowNum = static_cast<uint32_t>(tiling_->rowTileDa);
+                    uint32_t finalDaChunkSize = static_cast<uint32_t>(tiling_->chunkSize);
+                    auto finalDaTemp = TempTensor();
+                    auto finalDa = finalDaTemp;
+                    auto finalDaGAll = SlotGCache(slot);
+                    auto finalDaGBrcb = finalDaTemp[finalDaRowNum * finalDaChunkSize];
+                    auto finalDaFactor = finalDaGBrcb[finalDaRowNum * BWD_VEC_FP32_PER_BLOCK_8];
+                    auto finalDaMask = UpperMaskTensor();
+                    auto finalDaZero = ZeroTensor();
+                    WaitAicFinishStore();
+
+                    for (uint32_t rowOffset = static_cast<uint32_t>(subBlockIdx_) * finalDaRowNum;
+                         rowOffset < chunkLen; rowOffset += finalDaRowNum * static_cast<uint32_t>(subBlockNum_)) {
+                        uint32_t curRowNum = rowOffset + finalDaRowNum > chunkLen ? chunkLen - rowOffset :
+                                             finalDaRowNum;
+                        uint32_t finalDaIoSlot = BeginLoadMatrixTile(
+                            slot, tiling_->daOffset, SlotMatrixOffset(valueHead, rowOffset, 0),
+                            finalDaChunkSize * curRowNum);
+
+                        uint64_t perCol = 0;
+                        uint8_t repeatStride = finalDaChunkSize * sizeof(float32_t) / BWD_VEC_ONE_BLOCK_32;
+                        while (perCol < finalDaChunkSize) {
+                            AscendC::Copy(finalDaFactor[perCol], finalDaGAll[perCol],
+                                          BWD_VEC_FP32_PER_REPEAT_64, curRowNum,
+                                          {1, 1, repeatStride, 0});
+                            perCol += BWD_VEC_FP32_PER_REPEAT_64;
+                        }
+                        AscendC::Brcb(finalDaGBrcb, finalDaGAll[rowOffset],
+                                      static_cast<uint8_t>(CeilDiv(curRowNum, 8)), {1, 8});
+                        AscendC::PipeBarrier<PIPE_V>();
+                        perCol = 0;
+                        while (perCol < finalDaChunkSize) {
+                            AscendC::Sub(finalDaFactor[perCol], finalDaFactor[perCol], finalDaGBrcb,
+                                         BWD_VEC_FP32_PER_REPEAT_64, curRowNum,
+                                         {1, 1, 0, repeatStride, repeatStride, 1});
+                            perCol += BWD_VEC_FP32_PER_REPEAT_64;
+                        }
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Mins(finalDaFactor, finalDaFactor, 0.0f, curRowNum * finalDaChunkSize);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Exp(finalDaFactor, finalDaFactor, curRowNum * finalDaChunkSize);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        FinishLoadTile(finalDa, finalDaIoSlot, finalDaChunkSize * curRowNum);
+                        AscendC::Muls(finalDa, finalDa, -1.0f, curRowNum * finalDaChunkSize);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Mul(finalDa, finalDa, finalDaFactor, curRowNum * finalDaChunkSize);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::BinaryRepeatParams repeatParams = {1, 0, 1, 8, 0, 8};
+                        AscendC::Select(finalDa,
+                                        finalDaMask[rowOffset * finalDaChunkSize / BWD_VEC_BIT_NUM_FOR_UINT8],
+                                        finalDaZero, finalDa, AscendC::SELMODE::VSEL_TENSOR_TENSOR_MODE,
+                                        BWD_VEC_CAL_NUM_FLOAT,
+                                        curRowNum * finalDaChunkSize / BWD_VEC_CAL_NUM_FLOAT, repeatParams);
+                        StoreFinalDaTile(slot, rowOffset, workspaceGm_, SlotWorkspaceElem(
+                                         slot, tiling_->daOffset, SlotMatrixOffset(valueHead, rowOffset, 0)),
+                                         finalDa, finalDaChunkSize * curRowNum);
+                    }
+                    AscendC::PipeBarrier<PIPE_MTE3>();
+                    SignalAivFinishStore();
+
+                    } else {
+                    uint32_t outputKDim = static_cast<uint32_t>(tiling_->K);
+                    uint32_t outputVDim = static_cast<uint32_t>(tiling_->V);
+                    uint32_t outputChunkSize = static_cast<uint32_t>(tiling_->chunkSize);
+                    uint32_t outputRowK = static_cast<uint32_t>(tiling_->rowTileFullK);
+                    uint32_t outputRowV = static_cast<uint32_t>(tiling_->rowTileFullV);
+                    uint32_t outputRowKkt = static_cast<uint32_t>(tiling_->rowTileFullKkt);
+                    uint32_t outputRowOwned = outputRowK < outputRowV ? outputRowK : outputRowV;
+                    uint32_t wholeReduceKCnt =
+                        static_cast<uint32_t>(CeilDiv(outputKDim, BWD_VEC_FP32_PER_REPEAT_64));
+                    uint32_t wholeReduceVCnt =
+                        static_cast<uint32_t>(CeilDiv(outputVDim, BWD_VEC_FP32_PER_REPEAT_64));
+                    uint32_t wholeReduceChunkCnt =
+                        static_cast<uint32_t>(CeilDiv(chunkLen, BWD_VEC_FP32_PER_REPEAT_64));
+                    uint64_t persistentStride =
+                        CeilDiv(tiling_->chunkSize * sizeof(float32_t), BWD_VEC_ONE_BLOCK_32) *
+                        BWD_VEC_ONE_BLOCK_32 / sizeof(float32_t);
+                    auto outputPersistent = PersistentTensor();
+                    auto outputBetaFp32 = SlotBetaCache(slot);
+                    auto outputGExpFp32 = SlotGExpCache(slot);
+                    auto outputDbetaAcc = outputPersistent[2 * persistentStride];
+                    auto outputDgAcc = outputPersistent[3 * persistentStride];
+                    WaitAicFinishFullStore();
+
+                    bool waitedFullDkbReady = false;
+                    bool waitedFullDkbgReady = false;
+
+                    auto kOutTemp = TempTensor();
+                    for (uint32_t rowOffset = static_cast<uint32_t>(subBlockIdx_) * outputRowOwned;
+                         rowOffset < chunkLen; rowOffset += outputRowOwned * static_cast<uint32_t>(subBlockNum_)) {
+                        uint32_t curRowNum = rowOffset + outputRowOwned > chunkLen ? chunkLen - rowOffset :
+                                             outputRowOwned;
+                        uint64_t rowElem = outputRowOwned * outputKDim;
+                        auto kOutDkb = kOutTemp;
+                        auto kOutDkbg = kOutTemp[rowElem];
+                        auto kOutProd = kOutTemp[2 * rowElem];
+                        auto kOutDk = kOutTemp[3 * rowElem];
+                        auto kOutK = UseInputCache() ?
+                                     SlotKCache(slot)[InputCacheElemOffset(rowOffset, outputKDim)] :
+                                     kOutTemp[4 * rowElem];
+                        uint32_t kOutTempTileCount = UseInputCache() ? 4U : 5U;
+                        auto kOutBetaBrcb = kOutTemp[kOutTempTileCount * rowElem];
+                        auto kOutGBrcb = kOutBetaBrcb[outputRowOwned * BWD_VEC_FP32_PER_BLOCK_8];
+                        auto kOutReduce = kOutGBrcb[outputRowOwned * BWD_VEC_FP32_PER_BLOCK_8];
+                        uint64_t token = chunkBegin + rowOffset;
+
+                        uint32_t dkIoSlot = BeginLoadMatrixTile(
+                            slot, tiling_->fullDkOffset, SlotValueKeyLikeOffset(valueHead, rowOffset, 0),
+                            outputKDim * curRowNum);
+                        uint32_t kIoSlot = 0;
+                        if (!UseInputCache()) {
+                            kIoSlot = BeginLoadGmTile(
+                                kGm_, KeyOffset(batch, keyHead, token, 0), outputKDim * curRowNum);
+                        }
+                        AscendC::Brcb(kOutBetaBrcb, outputBetaFp32[rowOffset],
+                                      static_cast<uint8_t>(CeilDiv(curRowNum, 8)), {1, 8});
+                        AscendC::Brcb(kOutGBrcb, outputGExpFp32[rowOffset],
+                                      static_cast<uint8_t>(CeilDiv(curRowNum, 8)), {1, 8});
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Mul(kOutGBrcb, kOutGBrcb, kOutBetaBrcb,
+                                     curRowNum * BWD_VEC_FP32_PER_BLOCK_8);
+                        uint32_t dkbIoSlot = 0;
+                        if (UseInputCache()) {
+                            if (!waitedFullDkbReady) {
+                                WaitAicFinishFullStore();
+                                waitedFullDkbReady = true;
+                            }
+                            dkbIoSlot = BeginLoadMatrixTile(
+                                slot, tiling_->fullDkbOffset,
+                                SlotValueKeyLikeOffset(valueHead, rowOffset, 0), outputKDim * curRowNum);
+                        }
+                        FinishLoadTile(kOutDk, dkIoSlot, outputKDim * curRowNum);
+                        if (!UseInputCache()) {
+                            FinishLoadTile(kOutK, kIoSlot, outputKDim * curRowNum);
+                            if (!waitedFullDkbReady) {
+                                WaitAicFinishFullStore();
+                                waitedFullDkbReady = true;
+                            }
+                            dkbIoSlot = BeginLoadMatrixTile(
+                                slot, tiling_->fullDkbOffset,
+                                SlotValueKeyLikeOffset(valueHead, rowOffset, 0), outputKDim * curRowNum);
+                        }
+                        FinishLoadTile(kOutDkb, dkbIoSlot, outputKDim * curRowNum);
+                        AscendC::Mul(kOutProd, kOutDkb, kOutK, outputKDim * curRowNum);
+                        ReduceRowsToVector(kOutProd, kOutReduce, outputKDim, curRowNum, wholeReduceKCnt);
+                        AscendC::Adds(outputDbetaAcc[rowOffset], kOutProd, 0.0f, curRowNum);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        uint64_t perCol = 0;
+                        uint8_t repeatStride = outputKDim * sizeof(float32_t) / BWD_VEC_ONE_BLOCK_32;
+                        while (perCol < outputKDim) {
+                            AscendC::Mul(kOutDkb[perCol], kOutDkb[perCol], kOutBetaBrcb,
+                                         BWD_VEC_FP32_PER_REPEAT_64, curRowNum,
+                                         {1, 1, 0, repeatStride, repeatStride, 1});
+                            perCol += BWD_VEC_FP32_PER_REPEAT_64;
+                        }
+                        if (!waitedFullDkbgReady) {
+                            WaitAicFinishFullStore();
+                            waitedFullDkbgReady = true;
+                        }
+                        uint32_t dkbgIoSlot = BeginLoadMatrixTile(
+                            slot, tiling_->fullDkbgOffset,
+                            SlotValueKeyLikeOffset(valueHead, rowOffset, 0), outputKDim * curRowNum);
+                        FinishLoadTile(kOutDkbg, dkbgIoSlot, outputKDim * curRowNum);
+                        AscendC::Mul(kOutProd, kOutDkbg, kOutK, outputKDim * curRowNum);
+                        ReduceRowsToVector(kOutProd, kOutReduce, outputKDim, curRowNum, wholeReduceKCnt);
+                        AscendC::Mul(kOutProd, kOutProd, outputGExpFp32[rowOffset], curRowNum);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Add(outputDbetaAcc[rowOffset], outputDbetaAcc[rowOffset], kOutProd, curRowNum);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Mul(kOutProd, kOutProd, outputBetaFp32[rowOffset], curRowNum);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Adds(outputDgAcc[rowOffset], kOutProd, 0.0f, curRowNum);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        perCol = 0;
+                        while (perCol < outputKDim) {
+                            AscendC::Mul(kOutDkbg[perCol], kOutDkbg[perCol], kOutGBrcb,
+                                         BWD_VEC_FP32_PER_REPEAT_64, curRowNum,
+                                         {1, 1, 0, repeatStride, repeatStride, 1});
+                            perCol += BWD_VEC_FP32_PER_REPEAT_64;
+                        }
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Add(kOutDkb, kOutDkb, kOutDkbg, outputKDim * curRowNum);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Add(kOutDk, kOutDk, kOutDkb, outputKDim * curRowNum);
+                        if (valueHead % static_cast<uint64_t>(tiling_->headGroup) != 0) {
+                            LoadGmTile(kOutProd, dkGm_, KeyOffset(batch, keyHead, token, 0),
+                                       outputKDim * curRowNum);
+                            AscendC::Add(kOutDk, kOutDk, kOutProd, outputKDim * curRowNum);
+                        }
+                        StoreGmTile(dkGm_, KeyOffset(batch, keyHead, token, 0), kOutDk,
+                                    outputKDim * curRowNum);
+                    }
+                    if (!waitedFullDkbReady) {
+                        WaitAicFinishFullStore();
+                    }
+                    if (!waitedFullDkbgReady) {
+                        WaitAicFinishFullStore();
+                    }
+
+                    WaitAicFinishFullStore();
+                        auto vOutTemp = TempTensor();
+                    for (uint32_t rowOffset = static_cast<uint32_t>(subBlockIdx_) * outputRowOwned;
+                         rowOffset < chunkLen; rowOffset += outputRowOwned * static_cast<uint32_t>(subBlockNum_)) {
+                        uint32_t curRowNum = rowOffset + outputRowOwned > chunkLen ? chunkLen - rowOffset :
+                                             outputRowOwned;
+                        uint64_t rowElem = outputRowOwned * outputVDim;
+                        auto vOutDvb = vOutTemp;
+                        auto vOutProd = vOutTemp[rowElem];
+                        auto vOutV = UseInputCache() ?
+                                     SlotVCache(slot)[InputCacheElemOffset(rowOffset, outputVDim)] :
+                                     vOutTemp[2 * rowElem];
+                        uint32_t vOutTempTileCount = UseInputCache() ? 2U : 3U;
+                        auto vOutBetaBrcb = vOutTemp[vOutTempTileCount * rowElem];
+                        auto vOutReduce = vOutBetaBrcb[outputRowOwned * BWD_VEC_FP32_PER_BLOCK_8];
+                        uint64_t token = chunkBegin + rowOffset;
+                        uint32_t dvbIoSlot = BeginLoadMatrixTile(
+                            slot, tiling_->fullDvbOffset, SlotValueOffset(valueHead, rowOffset, 0),
+                            outputVDim * curRowNum);
+                        uint32_t vIoSlot = 0;
+                        if (!UseInputCache()) {
+                            vIoSlot = BeginLoadGmTile(
+                                vGm_, ValueOffset(batch, valueHead, token, 0), outputVDim * curRowNum);
+                        }
+                        AscendC::Brcb(vOutBetaBrcb, outputBetaFp32[rowOffset],
+                                      static_cast<uint8_t>(CeilDiv(curRowNum, 8)), {1, 8});
+                        FinishLoadTile(vOutDvb, dvbIoSlot, outputVDim * curRowNum);
+                        if (!UseInputCache()) {
+                            FinishLoadTile(vOutV, vIoSlot, outputVDim * curRowNum);
+                        }
+                        AscendC::Mul(vOutProd, vOutV, vOutDvb, outputVDim * curRowNum);
+                        ReduceRowsToVector(vOutProd, vOutReduce, outputVDim, curRowNum, wholeReduceVCnt);
+                        AscendC::Add(outputDbetaAcc[rowOffset], outputDbetaAcc[rowOffset], vOutProd, curRowNum);
+                        uint64_t perCol = 0;
+                        uint8_t repeatStride = outputVDim * sizeof(float32_t) / BWD_VEC_ONE_BLOCK_32;
+                        while (perCol < outputVDim) {
+                            AscendC::Mul(vOutDvb[perCol], vOutDvb[perCol], vOutBetaBrcb,
+                                         BWD_VEC_FP32_PER_REPEAT_64, curRowNum,
+                                         {1, 1, 0, repeatStride, repeatStride, 1});
+                            perCol += BWD_VEC_FP32_PER_REPEAT_64;
+                        }
+                        StoreGmTile(dvGm_, ValueOffset(batch, valueHead, token, 0), vOutDvb,
+                                    outputVDim * curRowNum);
+                    }
+                    WaitAicFinishFullStore();
+                    auto kktTemp = TempTensor();
+                    auto kktAll = kktTemp;
+                    auto kktDa = kktTemp[outputChunkSize * outputChunkSize];
+                    auto kktRowSum = kktDa[outputRowKkt * outputChunkSize];
+                    auto kktReduce = kktRowSum[outputRowKkt];
+                    uint32_t kktRemainCnt = chunkLen % BWD_VEC_FP32_PER_REPEAT_64;
+                    bool hasKktTail = kktRemainCnt > 0;
+                    uint32_t kktTailOffset = wholeReduceChunkCnt * BWD_VEC_FP32_PER_REPEAT_64 -
+                                             BWD_VEC_FP32_PER_REPEAT_64;
+                    uint64_t kktTailMask[1] = {0xffffffffffffffff};
+                    if (hasKktTail) {
+                        kktTailMask[0] <<= kktRemainCnt;
+                    }
+                    uint32_t kktIoSlot = BeginLoadMatrixTile(
+                        slot, tiling_->fullKktOffset, SlotMatrixOffset(valueHead, 0, 0),
+                        outputChunkSize * (outputRowKkt > chunkLen ? chunkLen : outputRowKkt));
+                    bool daFromCache = static_cast<uint32_t>(subBlockIdx_) == 0U;
+                    uint32_t daIoSlot = 0;
+                    if (!daFromCache) {
+                        daIoSlot = BeginLoadMatrixTile(
+                            slot, tiling_->daOffset, SlotMatrixOffset(valueHead, 0, 0),
+                            outputChunkSize * (outputRowKkt > chunkLen ? chunkLen : outputRowKkt));
+                    }
+                    for (uint32_t rowOffset = 0; rowOffset < chunkLen; rowOffset += outputRowKkt) {
+                        uint32_t curRowNum = rowOffset + outputRowKkt > chunkLen ? chunkLen - rowOffset :
+                                             outputRowKkt;
+                        if (daFromCache) {
+                            LoadFinalDaCache(kktDa, slot, rowOffset, outputChunkSize * curRowNum);
+                        } else {
+                            FinishLoadTile(kktDa, daIoSlot, outputChunkSize * curRowNum);
+                        }
+                        FinishLoadTile(kktAll[rowOffset * outputChunkSize], kktIoSlot,
+                                       outputChunkSize * curRowNum);
+                        uint32_t nextRowOffset = rowOffset + outputRowKkt;
+                        uint32_t nextKktIoSlot = 0;
+                        uint32_t nextDaIoSlot = 0;
+                        bool nextDaFromCache = false;
+                        if (nextRowOffset < chunkLen) {
+                            uint32_t nextRowNum = nextRowOffset + outputRowKkt > chunkLen ?
+                                                  chunkLen - nextRowOffset : outputRowKkt;
+                            nextDaFromCache =
+                                (nextRowOffset / static_cast<uint32_t>(tiling_->rowTileDa)) %
+                                    static_cast<uint32_t>(subBlockNum_) ==
+                                static_cast<uint32_t>(subBlockIdx_);
+                            if (!nextDaFromCache) {
+                                nextDaIoSlot = BeginLoadMatrixTile(
+                                    slot, tiling_->daOffset,
+                                    SlotMatrixOffset(valueHead, nextRowOffset, 0),
+                                    outputChunkSize * nextRowNum);
+                            }
+                            nextKktIoSlot = BeginLoadMatrixTile(
+                                slot, tiling_->fullKktOffset,
+                                SlotMatrixOffset(valueHead, nextRowOffset, 0),
+                                outputChunkSize * nextRowNum);
+                        }
+                        uint64_t perCol = 0;
+                        uint8_t repeatStride = outputChunkSize * sizeof(float32_t) / BWD_VEC_ONE_BLOCK_32;
+                        while (perCol < chunkLen) {
+                            AscendC::Mul(kktAll[rowOffset * outputChunkSize + perCol],
+                                         kktAll[rowOffset * outputChunkSize + perCol],
+                                         outputBetaFp32[perCol], BWD_VEC_FP32_PER_REPEAT_64, curRowNum,
+                                         {1, 1, 1, repeatStride, repeatStride, 0});
+                            perCol += BWD_VEC_FP32_PER_REPEAT_64;
+                        }
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Mul(kktAll[rowOffset * outputChunkSize], kktDa,
+                                     kktAll[rowOffset * outputChunkSize], outputChunkSize * curRowNum);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        if (hasKktTail) {
+                            for (uint32_t row = 0; row < curRowNum; ++row) {
+                                AscendC::Duplicate(kktAll[(rowOffset + row) * outputChunkSize + kktTailOffset],
+                                                   0.0f, kktTailMask, 1, 1, 8);
+                            }
+                            AscendC::PipeBarrier<PIPE_V>();
+                        }
+                        kktIoSlot = nextKktIoSlot;
+                        daIoSlot = nextDaIoSlot;
+                        daFromCache = nextDaFromCache;
+                    }
+                    for (uint32_t rowOffset = static_cast<uint32_t>(subBlockIdx_) * outputRowOwned;
+                         rowOffset < chunkLen; rowOffset += outputRowOwned * static_cast<uint32_t>(subBlockNum_)) {
+                        uint32_t curRowNum = rowOffset + outputRowOwned > chunkLen ? chunkLen - rowOffset :
+                                             outputRowOwned;
+                        for (uint32_t row = 0; row < curRowNum; ++row) {
+                            AscendC::WholeReduceSum(kktReduce[(rowOffset + row) * BWD_VEC_FP32_PER_BLOCK_8],
+                                                    kktAll[(rowOffset + row) * outputChunkSize],
+                                                    BWD_VEC_FP32_PER_REPEAT_64, wholeReduceChunkCnt, 1, 1, 8);
+                        }
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::WholeReduceSum(kktRowSum, kktReduce[rowOffset * BWD_VEC_FP32_PER_BLOCK_8],
+                                                wholeReduceChunkCnt, curRowNum, 1, 1, 1);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Muls(kktRowSum, kktRowSum, -1.0f, curRowNum);
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Add(outputDgAcc[rowOffset], outputDgAcc[rowOffset], kktRowSum, curRowNum);
+                        AscendC::PipeBarrier<PIPE_V>();
+                    }
+                    uint32_t remainRow = chunkLen;
+                    while (remainRow > 1) {
+                        uint32_t calcCnt = (remainRow / 2) * outputChunkSize;
+                        remainRow = static_cast<uint32_t>(CeilDiv(remainRow, 2));
+                        uint32_t offset = remainRow * outputChunkSize;
+                        AscendC::Add(kktAll, kktAll, kktAll[offset], calcCnt);
+                        AscendC::PipeBarrier<PIPE_V>();
+                    }
+                    for (uint32_t rowOffset = static_cast<uint32_t>(subBlockIdx_) * outputRowOwned;
+                         rowOffset < chunkLen; rowOffset += outputRowOwned * static_cast<uint32_t>(subBlockNum_)) {
+                        uint32_t curRowNum = rowOffset + outputRowOwned > chunkLen ? chunkLen - rowOffset :
+                                             outputRowOwned;
+                        AscendC::Add(outputDgAcc[rowOffset], outputDgAcc[rowOffset], kktAll[rowOffset], curRowNum);
+                        AscendC::PipeBarrier<PIPE_V>();
+                    }
+                    for (uint32_t rowOffset = static_cast<uint32_t>(subBlockIdx_) * outputRowOwned;
+                         rowOffset < chunkLen; rowOffset += outputRowOwned * static_cast<uint32_t>(subBlockNum_)) {
+                        uint32_t curRowNum = rowOffset + outputRowOwned > chunkLen ? chunkLen - rowOffset :
+                                             outputRowOwned;
+                        StoreGateTile(dbetaGm_, GateOffset(batch, valueHead, chunkBegin + rowOffset),
+                                      outputDbetaAcc[rowOffset], curRowNum);
+                        StoreGateTile(dgGm_, GateOffset(batch, valueHead, chunkBegin + rowOffset),
+                                      outputDgAcc[rowOffset], curRowNum);
+                    }
+                    AscendC::PipeBarrier<PIPE_MTE3>();
+                    }
+                    }
+                }
+            }
+        }
+        DrainPipelineBuffers();
+    }
+
+private:
+    __aicore__ inline bool ResolvePipelineHeadSlot(uint64_t headBase, uint64_t slot,
+                                                   uint64_t &valueHead, uint64_t &keyHead) const
+    {
+        valueHead = headBase + slot;
+        if (valueHead >= static_cast<uint64_t>(tiling_->HV)) {
+            return false;
+        }
+        keyHead = valueHead / static_cast<uint64_t>(tiling_->headGroup);
+        return true;
+    }
+
+    __aicore__ inline uint64_t Min(uint64_t lhs, uint64_t rhs) const
+    {
+        return lhs < rhs ? lhs : rhs;
+    }
+
+    __aicore__ inline int64_t CeilDiv(int64_t lhs, int64_t rhs) const
+    {
+        return rhs == 0 ? 0 : (lhs + rhs - 1) / rhs;
+    }
+
+    template <typename D>
+    __aicore__ inline AscendC::LocalTensor<D> UbTensor(uint64_t byteOffset)
+    {
+        return ubBuf_.Get<D>()[byteOffset / sizeof(D)];
+    }
+
+    template <typename D>
+    __aicore__ inline AscendC::LocalTensor<D> IoInTensor(uint32_t ioSlot)
+    {
+        return UbTensor<D>(ioInOffset_ + static_cast<uint64_t>(ioSlot) * ioInStride_);
+    }
+
+    template <typename D>
+    __aicore__ inline AscendC::LocalTensor<D> IoOutTensor(uint32_t ioSlot)
+    {
+        return UbTensor<D>(ioOutOffset_ + static_cast<uint64_t>(ioSlot) * ioOutStride_);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float32_t> PersistentTensor()
+    {
+        return UbTensor<float32_t>(persistentOffset_);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float32_t> GateCacheTensor()
+    {
+        return UbTensor<float32_t>(gateCacheOffset_);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float32_t> TempTensor()
+    {
+        return UbTensor<float32_t>(tempOffset_);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<uint8_t> MaskTensor()
+    {
+        return UbTensor<uint8_t>(maskOffset_);
+    }
+
+    __aicore__ inline uint32_t MaskBlocksPerRow() const
+    {
+        return (static_cast<uint32_t>(tiling_->chunkSize) + BWD_VEC_BIT_NUM_FOR_UINT8 - 1) /
+               BWD_VEC_BIT_NUM_FOR_UINT8;
+    }
+
+    __aicore__ inline uint32_t MaskElemCount() const
+    {
+        return static_cast<uint32_t>(tiling_->chunkSize) * MaskBlocksPerRow();
+    }
+
+    __aicore__ inline AscendC::LocalTensor<uint8_t> LowerMaskTensor()
+    {
+        return MaskTensor();
+    }
+
+    __aicore__ inline AscendC::LocalTensor<uint8_t> UpperMaskTensor()
+    {
+        return MaskTensor()[MaskElemCount()];
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float32_t> ZeroTensor()
+    {
+        return UbTensor<float32_t>(zeroOffset_);
+    }
+
+    __aicore__ inline uint32_t NextIoInSlot()
+    {
+        uint32_t ioSlot = ioInSlot_;
+        ioInSlot_ ^= 1U;
+        return ioSlot;
+    }
+
+    __aicore__ inline uint32_t NextIoOutSlot()
+    {
+        uint32_t ioSlot = ioOutSlot_;
+        ioOutSlot_ ^= 1U;
+        return ioSlot;
+    }
+
+    __aicore__ inline int32_t IoEventId(uint32_t ioSlot) const
+    {
+        return static_cast<int32_t>(ioSlot);
+    }
+
+    __aicore__ inline void WaitIoInFree(uint32_t ioSlot) const
+    {
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(IoEventId(ioSlot));
+    }
+
+    __aicore__ inline void ReleaseIoIn(uint32_t ioSlot) const
+    {
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(IoEventId(ioSlot));
+    }
+
+    __aicore__ inline void WaitIoOutFree(uint32_t ioSlot) const
+    {
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(IoEventId(ioSlot));
+    }
+
+    __aicore__ inline void ReleaseIoOut(uint32_t ioSlot) const
+    {
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(IoEventId(ioSlot));
+    }
+
+    __aicore__ inline void SyncMte2ToV(uint32_t ioSlot) const
+    {
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoEventId(ioSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoEventId(ioSlot));
+    }
+
+    __aicore__ inline void SyncVToMte3(uint32_t ioSlot) const
+    {
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoEventId(ioSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoEventId(ioSlot));
+    }
+
+    __aicore__ inline uint64_t GateOffset(uint64_t batch, uint64_t head, uint64_t token) const
+    {
+        return (batch * static_cast<uint64_t>(tiling_->HV) + head) * static_cast<uint64_t>(tiling_->T) + token;
+    }
+
+    __aicore__ inline uint64_t KeyOffset(uint64_t batch, uint64_t head, uint64_t token, uint64_t col) const
+    {
+        return (((batch * static_cast<uint64_t>(tiling_->HK) + head) * static_cast<uint64_t>(tiling_->T) + token) *
+                static_cast<uint64_t>(tiling_->K)) + col;
+    }
+
+    __aicore__ inline uint64_t ValueOffset(uint64_t batch, uint64_t head, uint64_t token, uint64_t col) const
+    {
+        return (((batch * static_cast<uint64_t>(tiling_->HV) + head) * static_cast<uint64_t>(tiling_->T) + token) *
+                static_cast<uint64_t>(tiling_->V)) + col;
+    }
+
+    __aicore__ inline uint64_t ValueKeyLikeOffset(uint64_t batch, uint64_t head, uint64_t token, uint64_t col) const
+    {
+        return (((batch * static_cast<uint64_t>(tiling_->HV) + head) * static_cast<uint64_t>(tiling_->T) + token) *
+                static_cast<uint64_t>(tiling_->K)) + col;
+    }
+
+    __aicore__ inline uint64_t MatrixOffset(uint64_t batch, uint64_t head, uint64_t token, uint64_t localCol) const
+    {
+        return (((batch * static_cast<uint64_t>(tiling_->HV) + head) * static_cast<uint64_t>(tiling_->T) + token) *
+                static_cast<uint64_t>(tiling_->chunkSize)) + localCol;
+    }
+
+    __aicore__ inline uint64_t WorkspaceElem(int64_t byteOffset, uint64_t elemOffset) const
+    {
+        return static_cast<uint64_t>(byteOffset) / sizeof(T) + elemOffset;
+    }
+
+    __aicore__ inline uint64_t SlotBaseElem(uint64_t slot) const
+    {
+        return ((coreIdx_ * static_cast<uint64_t>(tiling_->workspaceBufferCount) + slot) *
+                static_cast<uint64_t>(tiling_->workspaceSlotBytes)) / sizeof(T);
+    }
+
+    __aicore__ inline uint64_t SlotWorkspaceElem(uint64_t slot, int64_t byteOffset, uint64_t elemOffset) const
+    {
+        return SlotBaseElem(slot) + WorkspaceElem(byteOffset, elemOffset);
+    }
+
+    __aicore__ inline uint64_t SlotValueKeyLikeOffset(uint64_t head, uint64_t localRow, uint64_t col) const
+    {
+        return ((head * static_cast<uint64_t>(tiling_->chunkSize) + localRow) *
+                static_cast<uint64_t>(tiling_->K)) + col;
+    }
+
+    __aicore__ inline uint64_t SlotValueOffset(uint64_t head, uint64_t localRow, uint64_t col) const
+    {
+        return ((head * static_cast<uint64_t>(tiling_->chunkSize) + localRow) *
+                static_cast<uint64_t>(tiling_->V)) + col;
+    }
+
+    __aicore__ inline uint64_t SlotMatrixOffset(uint64_t head, uint64_t localRow, uint64_t localCol) const
+    {
+        return ((head * static_cast<uint64_t>(tiling_->chunkSize) + localRow) *
+                static_cast<uint64_t>(tiling_->chunkSize)) + localCol;
+    }
+
+    __aicore__ inline void ResolveChunk(uint64_t chunkLinear, uint64_t &batch, uint64_t &chunkBegin,
+                                        uint64_t &chunkEnd)
+    {
+        const uint64_t chunkSize = static_cast<uint64_t>(tiling_->chunkSize);
+        if constexpr (IS_VARLEN) {
+            uint64_t seqIdx = static_cast<uint64_t>(chunkIndicesGm_.GetValue(chunkLinear * 2));
+            uint64_t chunkInSeq = static_cast<uint64_t>(chunkIndicesGm_.GetValue(chunkLinear * 2 + 1));
+            uint64_t seqBegin = static_cast<uint64_t>(cuSeqlensGm_.GetValue(seqIdx));
+            uint64_t seqEnd = static_cast<uint64_t>(cuSeqlensGm_.GetValue(seqIdx + 1));
+            batch = 0;
+            chunkBegin = seqBegin + chunkInSeq * chunkSize;
+            chunkEnd = Min(chunkBegin + chunkSize, seqEnd);
+            return;
+        }
+
+        const uint64_t chunksPerBatch = (static_cast<uint64_t>(tiling_->T) + chunkSize - 1) / chunkSize;
+        batch = chunkLinear / chunksPerBatch;
+        uint64_t chunkInBatch = chunkLinear - batch * chunksPerBatch;
+        chunkBegin = chunkInBatch * chunkSize;
+        chunkEnd = Min(chunkBegin + chunkSize, static_cast<uint64_t>(tiling_->T));
+    }
+
+    __aicore__ inline void InitPipelineBuffers()
+    {
+        ioInOffset_ = static_cast<uint64_t>(tiling_->vectorIoInOffset);
+        ioOutOffset_ = static_cast<uint64_t>(tiling_->vectorIoOutOffset);
+        persistentOffset_ = static_cast<uint64_t>(tiling_->vectorPersistentOffset);
+        gateCacheOffset_ = static_cast<uint64_t>(tiling_->vectorGateCacheOffset);
+        tempOffset_ = static_cast<uint64_t>(tiling_->vectorTempOffset);
+        maskOffset_ = static_cast<uint64_t>(tiling_->vectorMaskOffset);
+        zeroOffset_ = static_cast<uint64_t>(tiling_->vectorZeroOffset);
+        ubBytes_ = static_cast<uint64_t>(tiling_->vectorUbBytes);
+        ioInStride_ = (ioOutOffset_ - ioInOffset_) / BWD_VEC_IO_BUFFER_COUNT;
+        ioOutStride_ = (persistentOffset_ - ioOutOffset_) / BWD_VEC_IO_BUFFER_COUNT;
+        ioInSlot_ = 0;
+        ioOutSlot_ = 0;
+        pipe_->InitBuffer(ubBuf_, ubBytes_);
+        for (uint32_t ioSlot = 0; ioSlot < BWD_VEC_IO_BUFFER_COUNT; ++ioSlot) {
+            ReleaseIoIn(ioSlot);
+            ReleaseIoOut(ioSlot);
+        }
+    }
+
+    __aicore__ inline void DrainPipelineBuffers() const
+    {
+        for (uint32_t ioSlot = 0; ioSlot < BWD_VEC_IO_BUFFER_COUNT; ++ioSlot) {
+            WaitIoInFree(ioSlot);
+            WaitIoOutFree(ioSlot);
+        }
+    }
+
+    __aicore__ inline void InitTriangleMasks()
+    {
+        uint32_t maskChunkSize = static_cast<uint32_t>(tiling_->chunkSize);
+        uint32_t maskBlocksPerRow = MaskBlocksPerRow();
+        auto lowerMask = LowerMaskTensor();
+        auto upperMask = UpperMaskTensor();
+        for (uint32_t row = 0; row < maskChunkSize; ++row) {
+            for (uint32_t block = 0; block < maskBlocksPerRow; ++block) {
+                uint32_t colStart = block * BWD_VEC_BIT_NUM_FOR_UINT8;
+                uint8_t lowerMaskVal = 0;
+                uint8_t upperMaskVal = 0;
+                for (uint32_t bit = 0; bit < BWD_VEC_BIT_NUM_FOR_UINT8 && colStart + bit < maskChunkSize; ++bit) {
+                    uint32_t col = colStart + bit;
+                    if (col >= row) {
+                        lowerMaskVal |= static_cast<uint8_t>(1U << bit);
+                    }
+                    if (col <= row) {
+                        upperMaskVal |= static_cast<uint8_t>(1U << bit);
+                    }
+                }
+                uint32_t maskOffset = row * maskBlocksPerRow + block;
+                lowerMask.SetValue(maskOffset, lowerMaskVal);
+                upperMask.SetValue(maskOffset, upperMaskVal);
+            }
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void SignalAivFinishStore()
+    {
+        Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(flagAivFinishStore);
+    }
+
+    __aicore__ inline void WaitAicFinishStore()
+    {
+        Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
+    }
+
+    __aicore__ inline void WaitAicFinishFullStore()
+    {
+        Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(flagAicFinishStore);
+    }
+
+    __aicore__ inline uint64_t GateCacheStride() const
+    {
+        return CeilDiv(tiling_->chunkSize * sizeof(float32_t), BWD_VEC_ONE_BLOCK_32) *
+               BWD_VEC_ONE_BLOCK_32 / sizeof(float32_t);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float32_t> SlotBetaCache(uint64_t slot)
+    {
+        auto cache = GateCacheTensor();
+        uint64_t stride = GateCacheStride();
+        return cache[slot * 2U * stride];
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float32_t> SlotGCache(uint64_t slot)
+    {
+        auto cache = GateCacheTensor();
+        uint64_t stride = GateCacheStride();
+        return cache[slot * 2U * stride + stride];
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float32_t> SlotGExpCache(uint64_t slot)
+    {
+        return PersistentTensor()[slot * GateCacheStride()];
+    }
+
+    __aicore__ inline bool UseInputCache() const
+    {
+        return tiling_->chunkSize == 64 && tiling_->K == 128 && tiling_->V == 128;
+    }
+
+    __aicore__ inline uint64_t LocalOwnedRowOffset(uint32_t rowOffset) const
+    {
+        uint64_t rowTile = static_cast<uint64_t>(tiling_->rowTileDa);
+        return (static_cast<uint64_t>(rowOffset) / (rowTile * subBlockNum_)) * rowTile;
+    }
+
+    __aicore__ inline AscendC::LocalTensor<T> SlotFinalDaCache(uint64_t slot)
+    {
+        uint64_t gatePersistentBytes = 4U * GateCacheStride() * sizeof(float32_t);
+        uint64_t subBlockMatrixBytes = static_cast<uint64_t>(tiling_->chunkSize) *
+                                       static_cast<uint64_t>(tiling_->chunkSize) * sizeof(T) /
+                                       subBlockNum_;
+        return UbTensor<T>(persistentOffset_ + gatePersistentBytes + slot * subBlockMatrixBytes);
+    }
+
+    __aicore__ inline uint64_t FinalDaCacheElemOffset(uint32_t rowOffset) const
+    {
+        return LocalOwnedRowOffset(rowOffset) * static_cast<uint64_t>(tiling_->chunkSize);
+    }
+
+    __aicore__ inline uint64_t InputCacheElemOffset(uint32_t rowOffset, uint32_t width) const
+    {
+        return LocalOwnedRowOffset(rowOffset) * static_cast<uint64_t>(width);
+    }
+
+    __aicore__ inline uint64_t InputCacheBaseByteOffset() const
+    {
+        uint64_t gatePersistentBytes = 4U * GateCacheStride() * sizeof(float32_t);
+        uint64_t finalDaCacheBytes = static_cast<uint64_t>(tiling_->chunkSize) *
+                                     static_cast<uint64_t>(tiling_->chunkSize) * sizeof(T);
+        return persistentOffset_ + gatePersistentBytes + finalDaCacheBytes;
+    }
+
+    __aicore__ inline uint64_t InputCacheRowsPerSlot() const
+    {
+        return static_cast<uint64_t>(CeilDiv(tiling_->chunkSize, subBlockNum_));
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float32_t> SlotKCache(uint64_t slot)
+    {
+        uint64_t rows = InputCacheRowsPerSlot();
+        uint64_t slotStride = rows * static_cast<uint64_t>(tiling_->K + tiling_->V);
+        return UbTensor<float32_t>(InputCacheBaseByteOffset() + slot * slotStride * sizeof(float32_t));
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float32_t> SlotVCache(uint64_t slot)
+    {
+        uint64_t rows = InputCacheRowsPerSlot();
+        return SlotKCache(slot)[rows * static_cast<uint64_t>(tiling_->K)];
+    }
+
+    __aicore__ inline void LoadGateToFp32(AscendC::LocalTensor<float32_t> dst, uint64_t offset, uint32_t count)
+    {
+        uint32_t ioSlot = NextIoInSlot();
+        auto gate = IoInTensor<GateT>(ioSlot);
+        WaitIoInFree(ioSlot);
+        AscendC::DataCopyPad(gate, betaGm_[offset], {1, count * static_cast<uint32_t>(sizeof(GateT)), 0, 0, 0},
+                             {false, 0, 0, 0});
+        SyncMte2ToV(ioSlot);
+        if constexpr (std::is_same<GateT, float32_t>::value) {
+            AscendC::Adds(dst, gate, 0.0f, count);
+        } else {
+            AscendC::Cast(dst, gate, AscendC::RoundMode::CAST_NONE, count);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        ReleaseIoIn(ioSlot);
+    }
+
+    __aicore__ inline void LoadGToFp32(AscendC::LocalTensor<float32_t> dst, uint64_t offset, uint32_t count)
+    {
+        uint32_t ioSlot = NextIoInSlot();
+        auto gate = IoInTensor<GateT>(ioSlot);
+        WaitIoInFree(ioSlot);
+        AscendC::DataCopyPad(gate, gGm_[offset], {1, count * static_cast<uint32_t>(sizeof(GateT)), 0, 0, 0},
+                             {false, 0, 0, 0});
+        SyncMte2ToV(ioSlot);
+        if constexpr (std::is_same<GateT, float32_t>::value) {
+            AscendC::Adds(dst, gate, 0.0f, count);
+        } else {
+            AscendC::Cast(dst, gate, AscendC::RoundMode::CAST_NONE, count);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        ReleaseIoIn(ioSlot);
+    }
+
+    __aicore__ inline void ReduceRowsToVector(AscendC::LocalTensor<float32_t> matrix,
+                                              AscendC::LocalTensor<float32_t> reduce,
+                                              uint32_t width, uint32_t rows, uint32_t wholeReduceCnt)
+    {
+        AscendC::PipeBarrier<PIPE_V>();
+        for (uint32_t row = 0; row < rows; ++row) {
+            AscendC::WholeReduceSum(reduce[row * BWD_VEC_FP32_PER_BLOCK_8], matrix[row * width],
+                                    BWD_VEC_FP32_PER_REPEAT_64, wholeReduceCnt, 1, 1, 8);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::WholeReduceSum(matrix, reduce, wholeReduceCnt, rows, 1, 1, 1);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void LoadMatrixTile(AscendC::LocalTensor<float32_t> dst, uint64_t slot,
+                                          int64_t baseOffset, uint64_t elemOffset, uint32_t count)
+    {
+        uint32_t ioSlot = NextIoInSlot();
+        auto tensor = IoInTensor<T>(ioSlot);
+        WaitIoInFree(ioSlot);
+        AscendC::DataCopy(tensor, workspaceGm_[SlotWorkspaceElem(slot, baseOffset, elemOffset)], count);
+        SyncMte2ToV(ioSlot);
+        if constexpr (std::is_same<T, float32_t>::value) {
+            AscendC::DataCopy(dst, tensor, count);
+        } else {
+            AscendC::Cast(dst, tensor, AscendC::RoundMode::CAST_NONE, count);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        ReleaseIoIn(ioSlot);
+    }
+
+    __aicore__ inline uint32_t BeginLoadGmTile(AscendC::GlobalTensor<T> &src,
+                                               uint64_t elemOffset, uint32_t count)
+    {
+        uint32_t ioSlot = NextIoInSlot();
+        auto tensor = IoInTensor<T>(ioSlot);
+        WaitIoInFree(ioSlot);
+        AscendC::DataCopy(tensor, src[elemOffset], count);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoEventId(ioSlot));
+        return ioSlot;
+    }
+
+    __aicore__ inline uint32_t BeginLoadMatrixTile(uint64_t slot, int64_t baseOffset,
+                                                   uint64_t elemOffset, uint32_t count)
+    {
+        uint32_t ioSlot = NextIoInSlot();
+        auto tensor = IoInTensor<T>(ioSlot);
+        WaitIoInFree(ioSlot);
+        AscendC::DataCopy(tensor, workspaceGm_[SlotWorkspaceElem(slot, baseOffset, elemOffset)], count);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoEventId(ioSlot));
+        return ioSlot;
+    }
+
+    __aicore__ inline void FinishLoadTile(AscendC::LocalTensor<float32_t> dst,
+                                          uint32_t ioSlot, uint32_t count)
+    {
+        auto tensor = IoInTensor<T>(ioSlot);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoEventId(ioSlot));
+        if constexpr (std::is_same<T, float32_t>::value) {
+            AscendC::DataCopy(dst, tensor, count);
+        } else {
+            AscendC::Cast(dst, tensor, AscendC::RoundMode::CAST_NONE, count);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        ReleaseIoIn(ioSlot);
+    }
+
+    __aicore__ inline void LoadGmTile(AscendC::LocalTensor<float32_t> dst, AscendC::GlobalTensor<T> &src,
+                                      uint64_t elemOffset, uint32_t count)
+    {
+        uint32_t ioSlot = NextIoInSlot();
+        auto tensor = IoInTensor<T>(ioSlot);
+        WaitIoInFree(ioSlot);
+        AscendC::DataCopy(tensor, src[elemOffset], count);
+        SyncMte2ToV(ioSlot);
+        if constexpr (std::is_same<T, float32_t>::value) {
+            AscendC::DataCopy(dst, tensor, count);
+        } else {
+            AscendC::Cast(dst, tensor, AscendC::RoundMode::CAST_NONE, count);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        ReleaseIoIn(ioSlot);
+    }
+
+    __aicore__ inline void StoreGmTile(AscendC::GlobalTensor<T> &dst, uint64_t elemOffset,
+                                       AscendC::LocalTensor<float32_t> src, uint32_t count)
+    {
+        uint32_t ioSlot = NextIoOutSlot();
+        auto tensor = IoOutTensor<T>(ioSlot);
+        WaitIoOutFree(ioSlot);
+        AscendC::PipeBarrier<PIPE_V>();
+        if constexpr (std::is_same<T, float32_t>::value) {
+            AscendC::DataCopy(tensor, src, count);
+        } else {
+            AscendC::Cast(tensor, src, AscendC::RoundMode::CAST_RINT, count);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        SyncVToMte3(ioSlot);
+        AscendC::DataCopy(dst[elemOffset], tensor, count);
+        ReleaseIoOut(ioSlot);
+    }
+
+    __aicore__ inline void StoreFinalDaTile(uint64_t slot, uint32_t rowOffset,
+                                            AscendC::GlobalTensor<T> &dst, uint64_t elemOffset,
+                                            AscendC::LocalTensor<float32_t> src, uint32_t count)
+    {
+        uint32_t ioSlot = NextIoOutSlot();
+        auto cache = SlotFinalDaCache(slot)[FinalDaCacheElemOffset(rowOffset)];
+        WaitIoOutFree(ioSlot);
+        AscendC::PipeBarrier<PIPE_V>();
+        if constexpr (std::is_same<T, float32_t>::value) {
+            AscendC::DataCopy(cache, src, count);
+        } else {
+            AscendC::Cast(cache, src, AscendC::RoundMode::CAST_RINT, count);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        SyncVToMte3(ioSlot);
+        AscendC::DataCopy(dst[elemOffset], cache, count);
+        ReleaseIoOut(ioSlot);
+    }
+
+    __aicore__ inline void LoadFinalDaCache(AscendC::LocalTensor<float32_t> dst, uint64_t slot,
+                                            uint32_t rowOffset, uint32_t count)
+    {
+        auto cache = SlotFinalDaCache(slot)[FinalDaCacheElemOffset(rowOffset)];
+        if constexpr (std::is_same<T, float32_t>::value) {
+            AscendC::DataCopy(dst, cache, count);
+        } else {
+            AscendC::Cast(dst, cache, AscendC::RoundMode::CAST_NONE, count);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void StoreGateTile(AscendC::GlobalTensor<GateT> &dst, uint64_t elemOffset,
+                                         AscendC::LocalTensor<float32_t> src, uint32_t count)
+    {
+        uint32_t ioSlot = NextIoOutSlot();
+        auto out = IoOutTensor<GateT>(ioSlot);
+        WaitIoOutFree(ioSlot);
+        if constexpr (std::is_same<GateT, float32_t>::value) {
+            AscendC::Adds(out, src, 0.0f, count);
+        } else {
+            AscendC::Cast(out, src, AscendC::RoundMode::CAST_RINT, count);
+        }
+        SyncVToMte3(ioSlot);
+        AscendC::DataCopyPad(dst[elemOffset], out, {1, count * static_cast<uint32_t>(sizeof(GateT)), 0, 0, 0});
+        ReleaseIoOut(ioSlot);
+    }
+
+    const PrepareWyReprBwdTilingData *tiling_ = nullptr;
+    AscendC::TPipe *pipe_ = nullptr;
+    uint64_t coreIdx_ = 0;
+    uint64_t coreNum_ = 1;
+    uint64_t subBlockIdx_ = 0;
+    uint64_t subBlockNum_ = 1;
+
+    AscendC::GlobalTensor<T> kGm_;
+    AscendC::GlobalTensor<T> vGm_;
+    AscendC::GlobalTensor<T> aGm_;
+    AscendC::GlobalTensor<T> dwGm_;
+    AscendC::GlobalTensor<T> duGm_;
+    AscendC::GlobalTensor<GateT> betaGm_;
+    AscendC::GlobalTensor<GateT> gGm_;
+    AscendC::GlobalTensor<T> dkGm_;
+    AscendC::GlobalTensor<T> dvGm_;
+    AscendC::GlobalTensor<GateT> dbetaGm_;
+    AscendC::GlobalTensor<GateT> dgGm_;
+    AscendC::GlobalTensor<T> workspaceGm_;
+    AscendC::GlobalTensor<uint64_t> cuSeqlensGm_;
+    AscendC::GlobalTensor<uint64_t> chunkIndicesGm_;
+
+    AscendC::TBuf<AscendC::TPosition::VECCALC> ubBuf_;
+    Catlass::Arch::CrossCoreFlagWithReverse<14> flagAicFinishStore{SYNC_FLAG_2, SYNC_FLAG_3};
+    Catlass::Arch::CrossCoreFlagWithReverse<> flagAivFinishStore{SYNC_FLAG_4, SYNC_FLAG_5};
+    uint64_t ioInOffset_ = 0;
+    uint64_t ioOutOffset_ = 0;
+    uint64_t ioInStride_ = 0;
+    uint64_t ioOutStride_ = 0;
+    uint64_t persistentOffset_ = 0;
+    uint64_t gateCacheOffset_ = 0;
+    uint64_t tempOffset_ = 0;
+    uint64_t maskOffset_ = 0;
+    uint64_t zeroOffset_ = 0;
+    uint64_t ubBytes_ = 0;
+    uint32_t ioInSlot_ = 0;
+    uint32_t ioOutSlot_ = 0;
+};
+
+} // namespace GDN
+
+#endif // PREPARE_WY_REPR_BWD_VECTOR_H

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py
@@ -1,29 +1,15 @@
-# -----------------------------------------------------------------------------------------------------------
-# Copyright (c) 2026 Tianjin University, Ltd.
-# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
-# CANN Open Software License Agreement Version 2.0 (the "License").
-# Please refer to the License for details. You may not use this file except in compliance with the License.
-# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
-# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
-# See LICENSE in the root of the software repository for the full text of the License.
-# -----------------------------------------------------------------------------------------------------------
-
 """Ascend C backed FLA NPU operators.
 
-This module provides stable Python import paths backed by Python ctypes aclnn
-calls.  Compatibility helpers for legacy torch_npu/torch.ops.npu call sites are
-kept opt-in and are not installed during normal import.
+The raw custom operators are registered under ``torch.ops.npu`` by
+``import fla_npu``.  This module provides stable Python import paths and a
+compatibility shim for older ``torch_npu.ops`` call sites.
 """
 
 from __future__ import annotations
 
 import functools
-import inspect
 import types
-import warnings
-from typing import Callable, Optional
-
-from ._aclnn_ctypes import ASCENDC_CTYPES_OPS
+from typing import Callable
 
 _ASCENDC_OPS = (
     "npu_fast_gelu_custom",
@@ -31,6 +17,7 @@ _ASCENDC_OPS = (
     "npu_causal_conv1d",
     "npu_causal_conv1d_bwd",
     "npu_prepare_wy_repr_bwd_full",
+    "npu_prepare_wy_repr_bwd",
     "npu_chunk_gated_delta_rule_bwd_dhu",
     "npu_chunk_bwd_dv_local",
     "npu_prepare_wy_repr_bwd_da",
@@ -38,8 +25,6 @@ _ASCENDC_OPS = (
     "npu_chunk_fwd_o",
     "npu_chunk_gated_delta_rule_fwd_h",
     "npu_recompute_w_u_fwd",
-    "npu_chunk_local_cumsum",
-    "npu_chunk_scaled_dot_kkt",
     "npu_solve_tri",
 )
 
@@ -50,47 +35,6 @@ BACKWARD_OPS = {
     "npu_causal_conv1d": "npu_causal_conv1d_bwd",
 }
 
-# ctypes 直接写 tensor storage 时，PyTorch 无法从 Python 调用自动发现副作用。
-# 这里集中声明被修改的参数，由 direct-op wrapper 负责 grad 限制和版本计数。
-MUTATED_ARGUMENTS = {
-    "causal_conv1d": ("conv_states",),
-    "npu_causal_conv1d": ("conv_states",),
-}
-
-_LEGACY_TORCH_OPS_WARNING = (
-    "torch.ops.npu.{name} is a legacy FLA NPU compatibility API. This call path "
-    "depends on the PyTorch/torch_npu dispatcher ABI and will not be supported "
-    "in a future fla_npu release. Use fla_npu.ops.ascendc.{public_name}(...) "
-    "or the decoupled Ascend C API instead."
-)
-
-_DIRECT_RUNTIME_READY = False
-_DIRECT_RUNTIME_ERROR: Optional[Exception] = None
-
-
-def _prepare_direct_runtime(*, raise_on_error: bool = True) -> None:
-    """Prepare embedded OPP paths and load custom op_api libraries."""
-
-    global _DIRECT_RUNTIME_ERROR, _DIRECT_RUNTIME_READY
-    if _DIRECT_RUNTIME_READY:
-        return
-
-    try:
-        import fla_npu
-
-        fla_npu.load_ascendc_opapi_libraries()
-    except Exception as exc:
-        _DIRECT_RUNTIME_ERROR = exc
-        if raise_on_error:
-            raise RuntimeError(
-                "Unable to initialize fla_npu Ascend C op_api libraries. "
-                "Please source the CANN set_env.sh before importing "
-                "fla_npu.ops.ascendc or calling Ascend C operators."
-            ) from exc
-    else:
-        _DIRECT_RUNTIME_ERROR = None
-        _DIRECT_RUNTIME_READY = True
-
 
 def _torch_npu_namespace():
     import torch
@@ -98,140 +42,24 @@ def _torch_npu_namespace():
     return torch.ops.npu
 
 
-def _ensure_legacy_torch_ops_loaded() -> None:
-    import fla_npu
-
-    is_loaded = getattr(fla_npu, "is_legacy_torch_ops_loaded", lambda: False)
-    if not is_loaded():
-        fla_npu.load_legacy_torch_ops()
-
-
 def _get_torch_op(name: str):
     namespace = _torch_npu_namespace()
     if not hasattr(namespace, name):
-        _ensure_legacy_torch_ops_loaded()
-        namespace = _torch_npu_namespace()
-    if not hasattr(namespace, name):
         raise AttributeError(
-            f"torch.ops.npu.{name} is not registered. Call "
-            "fla_npu.load_legacy_torch_ops() first if you need the legacy "
-            "torch.ops.npu compatibility path."
+            f"torch.ops.npu.{name} is not registered. Import fla_npu first and "
+            "make sure the custom extension loaded successfully."
         )
-    return _unwrap_legacy_torch_op(getattr(namespace, name))
-
-
-@functools.lru_cache(maxsize=None)
-def _get_direct_op(name: str):
-    _prepare_direct_runtime()
-    try:
-        op = ASCENDC_CTYPES_OPS[name]
-    except KeyError as exc:
-        raise AttributeError(f"fla_npu.ops.ascendc has no ctypes Ascend C op {name}.") from exc
-    return _wrap_mutable_direct_op(name, op)
-
-
-def _wrap_mutable_direct_op(name: str, op: Callable) -> Callable:
-    mutated_names = MUTATED_ARGUMENTS.get(name, ())
-    if not mutated_names:
-        return op
-
-    signature = inspect.signature(op)
-
-    @functools.wraps(op)
-    def wrapper(*args, **kwargs):
-        bound = signature.bind(*args, **kwargs)
-        bound.apply_defaults()
-        mutated_tensors = [bound.arguments[arg_name] for arg_name in mutated_names]
-
-        try:
-            import torch
-        except Exception as exc:
-            raise RuntimeError("Mutable Ascend C operators require the torch Python runtime.") from exc
-
-        mutated_tensors = [tensor for tensor in mutated_tensors if isinstance(tensor, torch.Tensor)]
-        requiring_grad = [
-            arg_name for arg_name in mutated_names if getattr(bound.arguments[arg_name], "requires_grad", False)
-        ]
-        if requiring_grad:
-            names = ", ".join(requiring_grad)
-            raise RuntimeError(
-                f"{name} mutates {names} in place through ctypes. Mutable state tensors "
-                "must not require gradients; use a functional state API for training."
-            )
-
-        result = op(*args, **kwargs)
-        if mutated_tensors:
-            torch.autograd.graph.increment_version(mutated_tensors)
-        return result
-
-    return wrapper
-
-
-def _warn_legacy_torch_op(name: str) -> None:
-    warnings.warn(
-        _LEGACY_TORCH_OPS_WARNING.format(
-            name=name,
-            public_name=_strip_npu_prefix(name),
-        ),
-        FutureWarning,
-        stacklevel=3,
-    )
-
-
-def _unwrap_legacy_torch_op(op):
-    return getattr(op, "_fla_npu_original_op", op)
-
-
-class _LegacyTorchOpOverloadWarningWrapper:
-    _fla_npu_legacy_warning_wrapper = True
-
-    def __init__(self, name: str, overload):
-        self._fla_npu_name = name
-        self._fla_npu_original_op = overload
-
-    def __call__(self, *args, **kwargs):
-        _warn_legacy_torch_op(self._fla_npu_name)
-        return self._fla_npu_original_op(*args, **kwargs)
-
-    def __getattr__(self, name: str):
-        return getattr(self._fla_npu_original_op, name)
-
-    def __repr__(self) -> str:
-        return repr(self._fla_npu_original_op)
-
-
-class _LegacyTorchOpWarningWrapper:
-    _fla_npu_legacy_warning_wrapper = True
-
-    def __init__(self, name: str, op):
-        self._fla_npu_name = name
-        self._fla_npu_original_op = op
-        self.__name__ = name
-        self.__qualname__ = name
-        self.__doc__ = getattr(op, "__doc__", None)
-
-    def __call__(self, *args, **kwargs):
-        _warn_legacy_torch_op(self._fla_npu_name)
-        return self._fla_npu_original_op(*args, **kwargs)
-
-    def __getattr__(self, name: str):
-        value = getattr(self._fla_npu_original_op, name)
-        if callable(value):
-            return _LegacyTorchOpOverloadWarningWrapper(self._fla_npu_name, value)
-        return value
-
-    def __repr__(self) -> str:
-        return repr(self._fla_npu_original_op)
+    return getattr(namespace, name)
 
 
 def _make_raw_wrapper(name: str) -> Callable:
-    @functools.wraps(_get_direct_op)
+    @functools.wraps(_get_torch_op)
     def wrapper(*args, **kwargs):
-        return _get_direct_op(name)(*args, **kwargs)
+        return _get_torch_op(name)(*args, **kwargs)
 
     wrapper.__name__ = name
     wrapper.__qualname__ = name
-    wrapper.__doc__ = f"Call the direct Ascend C binding for {name}."
+    wrapper.__doc__ = f"Call torch.ops.npu.{name}."
     return wrapper
 
 
@@ -260,12 +88,12 @@ class _FastGeluCustomFunction:
             @staticmethod
             def forward(ctx, self):
                 ctx.save_for_backward(self)
-                return _get_direct_op("npu_fast_gelu_custom")(self)
+                return _get_torch_op("npu_fast_gelu_custom")(self)
 
             @staticmethod
             def backward(ctx, grad):
                 (self,) = ctx.saved_tensors
-                return _get_direct_op("npu_fast_gelu_custom_backward")(grad, self)
+                return _get_torch_op("npu_fast_gelu_custom_backward")(grad, self)
 
         return Function.apply(input_tensor)
 
@@ -275,7 +103,7 @@ def fast_gelu_custom(input_tensor):
 
     if _has_tensor_requiring_grad(input_tensor):
         return _FastGeluCustomFunction.apply(input_tensor)
-    return _get_direct_op("npu_fast_gelu_custom")(input_tensor)
+    return _get_torch_op("npu_fast_gelu_custom")(input_tensor)
 
 
 def causal_conv1d(
@@ -295,9 +123,7 @@ def causal_conv1d(
 ):
     """Causal conv1d with automatic backward binding for prefill mode.
 
-    ``conv_states`` is mutable state in every mode and must not require gradients.
-    Decode/speculative modes are left on the raw op path; prefill only binds
-    gradients for ``x``, ``weight`` and ``bias``.
+    Decode/speculative modes mutate cache state and are left on the raw op path.
     """
 
     can_bind_backward = (
@@ -310,7 +136,7 @@ def causal_conv1d(
         and _has_tensor_requiring_grad(x, weight, bias)
     )
     if not can_bind_backward:
-        return _get_direct_op("npu_causal_conv1d")(
+        return _get_torch_op("npu_causal_conv1d")(
             x=x,
             weight=weight,
             bias=bias,
@@ -330,7 +156,7 @@ def causal_conv1d(
     class Function(torch.autograd.Function):
         @staticmethod
         def forward(ctx, x_, weight_, bias_, conv_states_):
-            y = _get_direct_op("npu_causal_conv1d")(
+            y = _get_torch_op("npu_causal_conv1d")(
                 x=x_,
                 weight=weight_,
                 bias=bias_,
@@ -348,7 +174,6 @@ def causal_conv1d(
             ctx.has_bias = bias_ is not None
             if bias_ is not None:
                 tensors.append(bias_)
-            ctx.activation_mode = activation_mode
             ctx.save_for_backward(*tensors)
             return y
 
@@ -358,7 +183,7 @@ def causal_conv1d(
             x_ = saved.pop(0)
             weight_ = saved.pop(0)
             bias_ = saved.pop(0) if ctx.has_bias else None
-            dx, dw, db, _ = _get_direct_op("npu_causal_conv1d_bwd")(
+            dx, dw, db, _ = _get_torch_op("npu_causal_conv1d_bwd")(
                 x=x_,
                 y=None if ctx.activation_mode == 0 else None,
                 weight=weight_,
@@ -392,19 +217,6 @@ def install_torch_npu_ops_compat() -> None:
         setattr(ops, _strip_npu_prefix(name), globals()[_strip_npu_prefix(name)])
 
 
-def install_legacy_torch_ops_warning() -> None:
-    """Warn when users call legacy ``torch.ops.npu`` FLA NPU operators."""
-
-    namespace = _torch_npu_namespace()
-    for name in _ASCENDC_OPS:
-        if not hasattr(namespace, name):
-            continue
-        current = getattr(namespace, name)
-        if getattr(current, "_fla_npu_legacy_warning_wrapper", False):
-            continue
-        setattr(namespace, name, _LegacyTorchOpWarningWrapper(name, current))
-
-
 for _name in _ASCENDC_OPS:
     globals()[_name] = _make_raw_wrapper(_name)
     globals()[_strip_npu_prefix(_name)] = globals()[_name]
@@ -412,12 +224,8 @@ for _name in _ASCENDC_OPS:
 globals()["fast_gelu_custom"] = fast_gelu_custom
 globals()["causal_conv1d"] = causal_conv1d
 
-_prepare_direct_runtime(raise_on_error=False)
-
 __all__ = [
     "BACKWARD_OPS",
-    "MUTATED_ARGUMENTS",
-    "install_legacy_torch_ops_warning",
     "install_torch_npu_ops_compat",
     *sorted(set(_ASCENDC_OPS)),
     *sorted({_strip_npu_prefix(name) for name in _ASCENDC_OPS}),

--- a/torch_custom/fla_npu/npu_custom.yaml
+++ b/torch_custom/fla_npu/npu_custom.yaml
@@ -23,6 +23,8 @@ custom:
     op_api: all_version
   - func: npu_prepare_wy_repr_bwd_full(Tensor k, Tensor v, Tensor beta, Tensor A, Tensor dA, Tensor dw, Tensor du, Tensor g, int chunk_size, *, int[]? cu_seqlens=None, int[]? chunk_indices=None) -> (Tensor dk, Tensor dv, Tensor dbeta, Tensor dg)
     op_api: all_version
+  - func: npu_prepare_wy_repr_bwd(Tensor k, Tensor v, Tensor beta, Tensor A, Tensor dw, Tensor du, Tensor g, int chunk_size, *, int[]? cu_seqlens=None, int[]? chunk_indices=None) -> (Tensor dk, Tensor dv, Tensor dbeta, Tensor dg)
+    op_api: all_version
   - func: npu_chunk_gated_delta_rule_bwd_dhu(Tensor q, Tensor k, Tensor w, Tensor d_o, Tensor dv, float scale, int chunk_size, *, Tensor? g=None, Tensor? gK=None, Tensor? h0=None, Tensor? dht=None, int[]? cu_seqlens=None, int[]? chunk_indices=None, bool? use_exp2=False, bool? transpose_state_layout=False) -> (Tensor, Tensor, Tensor)
     op_api: all_version
   - func: npu_chunk_bwd_dv_local(Tensor q, Tensor k, Tensor d_o, Tensor g, float scale, int chunk_size, *, Tensor? g_gamma=None, Tensor? A=None, int[]? cu_seqlens=None, int[]? chunk_indices=None) -> Tensor
@@ -36,10 +38,6 @@ custom:
   - func: npu_chunk_gated_delta_rule_fwd_h(Tensor k, Tensor w, Tensor u, Tensor? g=None, *, Tensor? gk=None, Tensor? initial_state=None, bool? output_final_state=False, int? chunk_size=None, bool? save_new_value=True, int[]? cu_seqlens=None, int[]? chunk_indices=None, bool? use_exp2=False, bool? transpose_state_layout=False) -> (Tensor, Tensor, Tensor)
     op_api: all_version
   - func: npu_recompute_w_u_fwd(Tensor k, Tensor v, Tensor beta, Tensor A, int chunk_size, *, Tensor? g=None, Tensor? gk=None, int[]? cu_seqlens=None, int[]? chunk_indices=None) -> (Tensor, Tensor)
-    op_api: all_version
-  - func: npu_chunk_local_cumsum(Tensor g, int chunk_size, *, Tensor? cu_seqlens=None, Tensor? chunk_indices_out=None, bool reverse=False, float scale=1.0, bool head_first=True, str output_dtype="float32") -> Tensor
-    op_api: all_version
-  - func: npu_chunk_scaled_dot_kkt(Tensor k, Tensor g, Tensor beta, *, int[]? cu_seqlens=None, int[]? chunk_indices=None, int chunk_size=64) -> Tensor
     op_api: all_version
   - func: npu_solve_tri(Tensor x, *, int[]? cu_seqlens=None, int[]? chunk_indices=None, str layout="bsnd") -> Tensor
     op_api: all_version

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -42,6 +42,25 @@ using namespace op_infer;
     return std::make_tuple(std::move(dk), std::move(dv), std::move(dbeta), std::move(dg));
 }
 
+::std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor> npu_prepare_wy_repr_bwd(const at::Tensor & k, const at::Tensor & v, const at::Tensor & beta, const at::Tensor & A, const at::Tensor & dw, const at::Tensor & du, const at::Tensor & g, int64_t chunk_size, at::OptionalIntArrayRef cu_seqlens, at::OptionalIntArrayRef chunk_indices)
+{
+    at::Tensor dk = at::empty_like(k);
+    at::Tensor dv = at::empty_like(v);
+    at::Tensor dbeta = at::empty_like(beta);
+    at::Tensor dg = at::empty_like(g);
+
+    // 这个公开接口对应流程图中的完整反向 DAG：Python 侧不再显式传入 dA。
+    // dA 会在 ACLNN 组合算子内部按 A 的形状申请临时张量，并先由 da 子算子写入，
+    // 再作为 full 子算子的输入继续计算 dk、dv、dbeta 和 dg。
+    EXEC_NPU_CMD_EXT(
+        aclnnPrepareWyReprBwd,
+        k, v, beta, A, dw, du, g,
+        cu_seqlens, chunk_indices, chunk_size,
+        dk, dv, dbeta, dg
+    );
+    return std::make_tuple(std::move(dk), std::move(dv), std::move(dbeta), std::move(dg));
+}
+
 ::std::tuple<at::Tensor,at::Tensor,at::Tensor> npu_chunk_gated_delta_rule_bwd_dhu(
     const at::Tensor & q, 
     const at::Tensor & k, 
@@ -344,67 +363,6 @@ at::Tensor npu_chunk_fwd_o(
     return std::tie(w,u);
 }
 
-at::Tensor npu_chunk_scaled_dot_kkt(
-    const at::Tensor &k,
-    const at::Tensor &g,
-    const at::Tensor &beta,
-    at::OptionalIntArrayRef cu_seqlens,
-    at::OptionalIntArrayRef chunk_indices,
-    int64_t chunk_size)
-{
-    TORCH_CHECK(k.dim() == 4, "npu_chunk_scaled_dot_kkt: k must be [B,Hk,T,K], got ", k.sizes());
-    TORCH_CHECK(g.dim() == 3, "npu_chunk_scaled_dot_kkt: g must be [B,Hv,T], got ", g.sizes());
-    TORCH_CHECK(beta.dim() == 3, "npu_chunk_scaled_dot_kkt: beta must be [B,Hv,T], got ", beta.sizes());
-    TORCH_CHECK(
-        k.scalar_type() == c10::ScalarType::Half || k.scalar_type() == c10::ScalarType::BFloat16,
-        "npu_chunk_scaled_dot_kkt: k dtype must be float16 or bfloat16, got ", k.scalar_type());
-    TORCH_CHECK(g.scalar_type() == c10::ScalarType::Float,
-        "npu_chunk_scaled_dot_kkt: g dtype must be float32, got ", g.scalar_type());
-    TORCH_CHECK(beta.scalar_type() == c10::ScalarType::Float,
-        "npu_chunk_scaled_dot_kkt: beta dtype must be float32, got ", beta.scalar_type());
-    TORCH_CHECK(
-        chunk_size == 16 || chunk_size == 32 || chunk_size == 64 || chunk_size == 128,
-        "npu_chunk_scaled_dot_kkt: chunk_size must be one of 16, 32, 64, 128, got ", chunk_size);
-    TORCH_CHECK(
-        cu_seqlens.has_value() == chunk_indices.has_value(),
-        "npu_chunk_scaled_dot_kkt: cu_seqlens and chunk_indices must be both provided or both omitted.");
-    if (cu_seqlens.has_value()) {
-        const auto cu = cu_seqlens.value();
-        const auto chunks = chunk_indices.value();
-        TORCH_CHECK(cu.size() >= 2,
-            "npu_chunk_scaled_dot_kkt: cu_seqlens must have at least 2 elements, got ", cu.size());
-        TORCH_CHECK(chunks.size() > 0 && chunks.size() % 2 == 0,
-            "npu_chunk_scaled_dot_kkt: chunk_indices must be a non-empty flat [seq, chunk] list, got ",
-            chunks.size(), " elements.");
-    }
-
-    const int64_t B = k.size(0);
-    const int64_t Hk = k.size(1);
-    const int64_t T = k.size(2);
-    const int64_t Hv = g.size(1);
-    TORCH_CHECK(
-        g.size(0) == B && g.size(2) == T,
-        "npu_chunk_scaled_dot_kkt: g must match k B/T and provide value heads [B,Hv,T]; k=", k.sizes(), " g=", g.sizes());
-    TORCH_CHECK(
-        beta.size(0) == B && beta.size(1) == Hv && beta.size(2) == T,
-        "npu_chunk_scaled_dot_kkt: beta must match g as [B,Hv,T]; g=", g.sizes(), " beta=", beta.sizes());
-    TORCH_CHECK(
-        Hk > 0 && Hv > 0 && Hv % Hk == 0,
-        "npu_chunk_scaled_dot_kkt: GVA requires Hv divisible by Hk; Hk=", Hk, " Hv=", Hv);
-
-    at::Tensor k_contig = k.contiguous();
-    at::Tensor g_contig = g.contiguous();
-    at::Tensor beta_contig = beta.contiguous();
-    at::Tensor A = at::empty({B, Hk, T, chunk_size}, k.options().dtype(c10::ScalarType::Float));
-
-    EXEC_NPU_CMD_EXT(
-        aclnnChunkScaledDotKkt,
-        k_contig, g_contig, beta_contig, cu_seqlens, chunk_indices, chunk_size,
-        A
-    );
-    return A;
-}
-
 at::Tensor infer_y_tensor(
     const at::Tensor& x,
     int64_t head_num,
@@ -590,65 +548,6 @@ at::Tensor npu_solve_tri(
         x_out
     );
     return x_out;
-}
-
-at::Tensor npu_chunk_local_cumsum(
-    const at::Tensor &g,
-    int64_t chunk_size,
-    const c10::optional<at::Tensor> &cu_seqlens,
-    const c10::optional<at::Tensor> &chunk_indices_out,
-    bool reverse,
-    double scale,
-    bool head_first,
-    c10::string_view output_dtype)
-{
-    TORCH_CHECK(g.dim() >= 3, "npu_chunk_local_cumsum: g must be [B, H, T, *], got ", g.sizes());
-    TORCH_CHECK(g.scalar_type() == at::kFloat, "npu_chunk_local_cumsum: only float32 g is supported.");
-    TORCH_CHECK(chunk_size > 0 && (chunk_size & (chunk_size - 1)) == 0,
-                "npu_chunk_local_cumsum: chunk_size must be a positive power of two, got ", chunk_size);
-    TORCH_CHECK(head_first, "npu_chunk_local_cumsum: only head_first=true / [B, H, T, *] layout is supported.");
-
-    std::string output_dtype_str(output_dtype.data(), output_dtype.size());
-    if (output_dtype_str.empty()) {
-        output_dtype_str = "float32";
-    }
-    TORCH_CHECK(output_dtype_str == "float32" || output_dtype_str == "torch.float" ||
-                    output_dtype_str == "torch.float32",
-                "npu_chunk_local_cumsum: output_dtype only supports float32, got ", output_dtype_str);
-
-    at::Tensor g_contig = g.contiguous();
-    at::Tensor out = at::empty_like(g_contig);
-    at::Tensor empty_index = at::empty({0}, g_contig.options().dtype(at::kLong));
-
-    at::Tensor cu_seqlens_tensor = empty_index;
-    if (cu_seqlens.has_value() && cu_seqlens->defined()) {
-        cu_seqlens_tensor = cu_seqlens->contiguous();
-        TORCH_CHECK(cu_seqlens_tensor.scalar_type() == at::kLong,
-                    "npu_chunk_local_cumsum: cu_seqlens must be int64.");
-    }
-
-    at::Tensor chunk_indices_tensor = empty_index;
-    if (chunk_indices_out.has_value() && chunk_indices_out->defined()) {
-        chunk_indices_tensor = chunk_indices_out->contiguous();
-        TORCH_CHECK(chunk_indices_tensor.scalar_type() == at::kLong,
-                    "npu_chunk_local_cumsum: chunk_indices_out must be int64.");
-    }
-
-    if (cu_seqlens_tensor.numel() > 0) {
-        TORCH_CHECK(g_contig.size(0) == 1,
-                    "npu_chunk_local_cumsum: B must be 1 when cu_seqlens is provided, got ", g_contig.size(0));
-        TORCH_CHECK(chunk_indices_tensor.numel() > 0,
-                    "npu_chunk_local_cumsum: chunk_indices_out is required when cu_seqlens is provided.");
-    }
-
-    char *output_dtype_cstr = const_cast<char *>(output_dtype_str.c_str());
-    EXEC_NPU_CMD_EXT(
-        aclnnChunkLocalCumsum,
-        g_contig, cu_seqlens_tensor, chunk_indices_tensor,
-        chunk_size, reverse, scale, head_first, output_dtype_cstr,
-        out
-    );
-    return out;
 }
 
 }  // namespace op_api

--- a/torch_custom/fla_npu/test/check_prepare_wy_repr_bwd_golden_parity.py
+++ b/torch_custom/fla_npu/test/check_prepare_wy_repr_bwd_golden_parity.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Check fused prepare_wy_repr_bwd CPU golden against old da + full goldens.
+
+This is a small-shape formula parity check. It imports the existing test
+modules, builds deterministic CPU inputs, computes dA with the old da golden,
+feeds that dA into the old full golden, and compares the stitched result with
+the fused public golden.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import types
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+if "torch_npu" not in sys.modules:
+    sys.modules["torch_npu"] = types.ModuleType("torch_npu")
+if "fla_npu" not in sys.modules:
+    sys.modules["fla_npu"] = types.ModuleType("fla_npu")
+if not hasattr(torch, "npu"):
+    torch.npu = types.SimpleNamespace(  # type: ignore[attr-defined]
+        set_device=lambda *_args, **_kwargs: None,
+        set_compile_mode=lambda *_args, **_kwargs: None,
+        config=types.SimpleNamespace(allow_internal_format=False),
+    )
+
+import test_npu_prepare_wy_repr_bwd as fused
+import test_npu_prepare_wy_repr_bwd_da as da
+import test_npu_prepare_wy_repr_bwd_full as full
+
+
+@dataclass(frozen=True)
+class ParityCase:
+    name: str
+    B: int
+    H: int
+    T: int
+    K: int
+    V: int
+    chunk_size: int
+    seed: int
+    cu_seqlens: Optional[tuple[int, ...]] = None
+
+
+CASES = [
+    ParityCase(
+        name="fixed_one_chunk",
+        B=1,
+        H=1,
+        T=5,
+        K=4,
+        V=6,
+        chunk_size=8,
+        seed=1,
+    ),
+    ParityCase(
+        name="fixed_two_chunks_tail",
+        B=2,
+        H=2,
+        T=9,
+        K=3,
+        V=5,
+        chunk_size=4,
+        seed=2,
+    ),
+    ParityCase(
+        name="varlen_multi_seq_tail",
+        B=1,
+        H=2,
+        T=10,
+        K=3,
+        V=4,
+        chunk_size=4,
+        seed=3,
+        cu_seqlens=(0, 3, 10),
+    ),
+]
+
+
+def make_inputs(case: ParityCase) -> tuple[tuple[torch.Tensor, ...], Optional[list[int]], Optional[list[int]], int]:
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(case.seed)
+
+    def randn(shape: tuple[int, ...], scale: float) -> torch.Tensor:
+        return torch.randn(shape, generator=generator, dtype=torch.float64) * scale
+
+    k = randn((case.B, case.H, case.T, case.K), 0.17)
+    v = randn((case.B, case.H, case.T, case.V), 0.13)
+    beta = randn((case.B, case.H, case.T), 0.11)
+    A = randn((case.B, case.H, case.T, case.chunk_size), 0.07)
+    dw = randn((case.B, case.H, case.T, case.K), 0.19)
+    du = randn((case.B, case.H, case.T, case.V), 0.23)
+    g = randn((case.B, case.H, case.T), 0.05)
+
+    if case.cu_seqlens is None:
+        return (k, v, beta, A, dw, du, g), None, None, (case.T + case.chunk_size - 1) // case.chunk_size
+
+    cu_seqlens = list(case.cu_seqlens)
+    chunk_indices = fused.build_chunk_indices(cu_seqlens, case.chunk_size)
+    return (k, v, beta, A, dw, du, g), cu_seqlens, chunk_indices, len(chunk_indices) // 2
+
+
+def old_split_golden(
+    inputs: tuple[torch.Tensor, ...],
+    chunk_size: int,
+    cu_seqlens: Optional[list[int]],
+    chunk_indices: Optional[list[int]],
+    nt: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    k, v, beta, A, dw, du, g = inputs
+    B, H, T, K = k.shape
+    V = v.shape[-1]
+
+    dA = da.compute_dA_cpu(
+        A,
+        dw,
+        g,
+        beta,
+        k,
+        v,
+        du,
+        chunk_indices,
+        cu_seqlens,
+        B,
+        H,
+        T,
+        K,
+        chunk_size,
+        nt,
+    )
+    dk = full.compute_dk_golden_high_precision(A, dw, g, beta, dA, k, cu_seqlens, chunk_indices, B, H, H, T, K, chunk_size, nt)
+    dv = full.compute_dv_golden_high_precision(A, du, beta, cu_seqlens, chunk_indices, B, H, T, V, chunk_size, nt)
+    dbeta = full.compute_dbeta_golden_high_precision(
+        A,
+        dw,
+        g,
+        beta,
+        dA,
+        k,
+        v,
+        du,
+        cu_seqlens,
+        chunk_indices,
+        B,
+        H,
+        H,
+        T,
+        K,
+        chunk_size,
+        nt,
+    )
+    dg = full.compute_dg_golden_high_precision(A, dw, g, beta, dA, k, cu_seqlens, chunk_indices, B, H, H, T, K, chunk_size, nt)
+    return dk, dv, dbeta, dg
+
+
+def compare_case(case: ParityCase, *, rtol: float, atol: float) -> bool:
+    inputs, cu_seqlens, chunk_indices, nt = make_inputs(case)
+    expected = old_split_golden(inputs, case.chunk_size, cu_seqlens, chunk_indices, nt)
+    actual = fused.prepare_wy_repr_bwd_golden(
+        *inputs,
+        case.chunk_size,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+
+    print(
+        f"CASE {case.name}: B={case.B} H={case.H} T={case.T} K={case.K} "
+        f"V={case.V} chunk={case.chunk_size} cu_seqlens={cu_seqlens}",
+        flush=True,
+    )
+    passed = True
+    for name, got, ref in zip(("dk", "dv", "dbeta", "dg"), actual, expected):
+        got64 = got.to(torch.float64)
+        ref64 = ref.to(torch.float64)
+        diff = (got64 - ref64).abs()
+        flat_idx = int(diff.argmax().item()) if diff.numel() else 0
+        idx = tuple(int(i) for i in torch.unravel_index(torch.tensor(flat_idx), diff.shape)) if diff.numel() else ()
+        close = torch.allclose(got64, ref64, rtol=rtol, atol=atol)
+        max_abs = float(diff[idx].item()) if diff.numel() else 0.0
+        print(f"  {name}: close={close} max_abs={max_abs:.6e} idx={idx}", flush=True)
+        if not close:
+            print(f"    fused={float(got64[idx]):.12e} split={float(ref64[idx]):.12e}", flush=True)
+            passed = False
+    print(f"  RESULT {'PASS' if passed else 'FAIL'}", flush=True)
+    return passed
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="prepare_wy_repr_bwd CPU golden parity check")
+    parser.add_argument("--case", action="append", dest="cases", help="case name to run; repeatable")
+    parser.add_argument("--rtol", type=float, default=1e-10)
+    parser.add_argument("--atol", type=float, default=1e-10)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    selected = CASES
+    if args.cases:
+        names = set(args.cases)
+        selected = [case for case in CASES if case.name in names]
+        missing = names - {case.name for case in selected}
+        if missing:
+            raise ValueError(f"unknown case(s): {sorted(missing)}")
+
+    ok = True
+    for case in selected:
+        ok = compare_case(case, rtol=args.rtol, atol=args.atol) and ok
+    raise SystemExit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/torch_custom/fla_npu/test/compare_prepare_wy_repr_bwd_fused_vs_split.py
+++ b/torch_custom/fla_npu/test/compare_prepare_wy_repr_bwd_fused_vs_split.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Compare fused prepare_wy_repr_bwd with the old da + full path."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+import torch
+import torch_npu  # noqa: F401
+import fla_npu  # noqa: F401
+
+
+@dataclass(frozen=True)
+class CompareResult:
+    name: str
+    passed: bool
+    max_abs: float
+    mean_abs: float
+    rmse: float
+    argmax: tuple[int, ...]
+
+
+def _load_ct():
+    """Load ct from the active Python environment."""
+
+    try:
+        import ct  # type: ignore
+
+        if hasattr(ct, "isclose"):
+            return ct
+    except Exception as exc:
+        print(f"[WARN] import ct failed: {exc!r}")
+        return None
+    return None
+
+
+def prepare_cu_seqlens(T: int, L: int = 33) -> list[int]:
+    """Build balanced varlen cu_seqlens ending at T."""
+
+    if L < 2:
+        raise ValueError("L must be at least 2.")
+    cu_seqlens = [0]
+    num_seq = L - 1
+    for idx in range(1, num_seq + 1):
+        cu_seqlens.append((T * idx) // num_seq)
+    return cu_seqlens
+
+
+def prepare_chunk_indices(cu_seqlens: Sequence[int], chunk_size: int) -> list[int]:
+    """Build flat [seq_idx, chunk_idx, ...] chunk indices."""
+
+    chunk_indices: list[int] = []
+    for seq_idx in range(len(cu_seqlens) - 1):
+        seq_len = int(cu_seqlens[seq_idx + 1] - cu_seqlens[seq_idx])
+        for chunk_idx in range((seq_len + chunk_size - 1) // chunk_size):
+            chunk_indices.extend([seq_idx, chunk_idx])
+    return chunk_indices
+
+
+def _rand(shape: Sequence[int], dtype: torch.dtype, scale: float = 0.08) -> torch.Tensor:
+    return (torch.rand(tuple(shape), dtype=torch.float32) * scale).to(dtype)
+
+
+def _sync() -> None:
+    torch.npu.synchronize()
+
+
+def _to_npu(inputs: Sequence[torch.Tensor]) -> tuple[torch.Tensor, ...]:
+    return tuple(t.npu() for t in inputs)
+
+
+def _error_stats(actual: torch.Tensor, expected: torch.Tensor) -> tuple[float, float, float, tuple[int, ...]]:
+    diff = (actual.float() - expected.float()).abs()
+    max_abs = float(diff.max().item()) if diff.numel() else 0.0
+    mean_abs = float(diff.mean().item()) if diff.numel() else 0.0
+    rmse = float(torch.sqrt(torch.mean(diff * diff)).item()) if diff.numel() else 0.0
+    flat_idx = int(diff.argmax().item()) if diff.numel() else 0
+    argmax = tuple(int(x) for x in torch.unravel_index(torch.tensor(flat_idx), diff.shape))
+    return max_abs, mean_abs, rmse, argmax
+
+
+def _compare_one(
+    name: str,
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    *,
+    diff_thd: float,
+    pct_thd: float,
+    ct_module,
+) -> CompareResult:
+    actual_cpu = actual.detach().cpu()
+    expected_cpu = expected.detach().cpu()
+    max_abs, mean_abs, rmse, argmax = _error_stats(actual_cpu, expected_cpu)
+
+    passed = max_abs <= diff_thd
+    if ct_module is not None:
+        try:
+            ct_ret = ct_module.isclose(actual_cpu, expected_cpu, diff_thd=diff_thd, pct_thd=pct_thd)
+            if isinstance(ct_ret, bool):
+                passed = ct_ret
+        except Exception as exc:
+            print(f"[WARN] ct.isclose failed for {name}: {exc!r}")
+
+    print(
+        f"[{name}] max_abs={max_abs:.6e}, mean_abs={mean_abs:.6e}, "
+        f"rmse={rmse:.6e}, argmax={argmax}, passed={passed}"
+    )
+    if actual_cpu.numel():
+        print(
+            f"    fused={actual_cpu[argmax].item():.8e}, "
+            f"split={expected_cpu[argmax].item():.8e}"
+        )
+    return CompareResult(name, passed, max_abs, mean_abs, rmse, argmax)
+
+
+def test_prepare_wy_repr_bwd(
+    B: int,
+    HK: int,
+    HV: int,
+    T: int,
+    K: int,
+    V: int,
+    chunk_size: int,
+    ktype,
+    btype,
+    cu_seqlens=None,
+    chunk_indices=None,
+    seed: int = 0,
+    diff_thd: float = 1e-2,
+    pct_thd: float = 1e-2,
+) -> dict[str, CompareResult]:
+    """Run fused op and old da + full path, then compare four public outputs."""
+
+    if HV % HK != 0:
+        raise ValueError(f"HV ({HV}) must be a positive multiple of HK ({HK}).")
+
+    torch.manual_seed(seed)
+    torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", "0")))
+    torch.npu.config.allow_internal_format = False
+    torch.npu.set_compile_mode(jit_compile=False)
+
+    if cu_seqlens is not None and chunk_indices is None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+
+    k = _rand((B, HK, T, K), ktype)
+    v = _rand((B, HV, T, V), ktype)
+    beta = _rand((B, HV, T), btype, scale=0.05)
+    A = _rand((B, HV, T, chunk_size), ktype, scale=0.04)
+    dw = _rand((B, HV, T, K), ktype)
+    du = _rand((B, HV, T, V), ktype)
+    g = _rand((B, HV, T), btype, scale=0.03)
+
+    k_n, v_n, beta_n, A_n, dw_n, du_n, g_n = _to_npu((k, v, beta, A, dw, du, g))
+
+    print(
+        "case:",
+        f"B={B}, HK={HK}, HV={HV}, T={T}, K={K}, V={V}, chunk_size={chunk_size},",
+        f"ktype={ktype}, btype={btype}, varlen={cu_seqlens is not None}",
+    )
+    if cu_seqlens is not None:
+        print(f"varlen: seq_num={len(cu_seqlens) - 1}, chunk_num={len(chunk_indices) // 2}")
+
+    fused = torch.ops.npu.npu_prepare_wy_repr_bwd(
+        k_n,
+        v_n,
+        beta_n,
+        A_n,
+        dw_n,
+        du_n,
+        g_n,
+        chunk_size,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    _sync()
+
+    dA_split = torch.ops.npu.npu_prepare_wy_repr_bwd_da(
+        k_n,
+        v_n,
+        beta_n,
+        A_n,
+        dw_n,
+        du_n,
+        g_n,
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    split = torch.ops.npu.npu_prepare_wy_repr_bwd_full(
+        k_n,
+        v_n,
+        beta_n,
+        A_n,
+        dA_split,
+        dw_n,
+        du_n,
+        g_n,
+        chunk_size,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    _sync()
+
+    ct_module = _load_ct()
+    if ct_module is None:
+        print("[WARN] ct.isclose is unavailable; using built-in error statistics only.")
+    else:
+        print(f"ct loaded from: {getattr(ct_module, '__file__', '<unknown>')}")
+
+    results = {}
+    for name, actual, expected in zip(("dk", "dv", "dbeta", "dg"), fused, split):
+        results[name] = _compare_one(
+            name,
+            actual,
+            expected,
+            diff_thd=diff_thd,
+            pct_thd=pct_thd,
+            ct_module=ct_module,
+        )
+
+    failed = [name for name, result in results.items() if not result.passed]
+    if failed:
+        raise AssertionError(f"fused vs split mismatch: {failed}")
+    print("[PASS] fused outputs match da + full outputs.")
+    return results
+
+
+def _dtype(name: str) -> torch.dtype:
+    mapping = {
+        "fp16": torch.float16,
+        "float16": torch.float16,
+        "bf16": torch.bfloat16,
+        "bfloat16": torch.bfloat16,
+        "fp32": torch.float32,
+        "float32": torch.float32,
+    }
+    try:
+        return mapping[name.lower()]
+    except KeyError as exc:
+        raise ValueError(f"unsupported dtype: {name}") from exc
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare fused prepare_wy_repr_bwd with da + full.")
+    parser.add_argument("--B", type=int, default=1)
+    parser.add_argument("--HK", type=int, default=32)
+    parser.add_argument("--HV", type=int, default=32)
+    parser.add_argument("--T", type=int, default=65536)
+    parser.add_argument("--K", type=int, default=128)
+    parser.add_argument("--V", type=int, default=128)
+    parser.add_argument("--chunk-size", type=int, default=64)
+    parser.add_argument("--ktype", default="fp16")
+    parser.add_argument("--btype", default="fp16")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--varlen", action="store_true")
+    parser.add_argument("--seq-num", type=int, default=32)
+    parser.add_argument("--diff-thd", type=float, default=1e-2)
+    parser.add_argument("--pct-thd", type=float, default=1e-2)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    cu_seqlens = None
+    chunk_indices = None
+    if args.varlen:
+        cu_seqlens = prepare_cu_seqlens(args.T, args.seq_num + 1)
+        chunk_indices = prepare_chunk_indices(cu_seqlens, args.chunk_size)
+
+    test_prepare_wy_repr_bwd(
+        B=args.B,
+        HK=args.HK,
+        HV=args.HV,
+        T=args.T,
+        K=args.K,
+        V=args.V,
+        chunk_size=args.chunk_size,
+        ktype=_dtype(args.ktype),
+        btype=_dtype(args.btype),
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        seed=args.seed,
+        diff_thd=args.diff_thd,
+        pct_thd=args.pct_thd,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/torch_custom/fla_npu/test/test_npu_prepare_wy_repr_bwd.py
+++ b/torch_custom/fla_npu/test/test_npu_prepare_wy_repr_bwd.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+"""prepare_wy_repr_bwd 新算子测试入口。
+
+本脚本依据 `docs/prepare_wy_repr_bwd_design.md` 和
+`prepare_wy_repr_bwd_flow_npu_affinity.drawio` 中的总 DAG 公式生成 CPU
+golden，并通过 `torch.ops.npu.npu_prepare_wy_repr_bwd` 调用新算子做对比。
+
+说明：
+1. 当前阶段只要求生成测试脚本，不要求算子已经跑通；因此提供
+   `--golden-only` 模式，便于先检查参考公式和用例构造。
+2. 这里不再沿用旧 `da/full` 拆分脚本的命名与中间接口，而是直接
+   面向新算子的四个公开输出：dk、dv、dbeta、dg。
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence
+
+import torch
+
+
+try:
+    import torch_npu  # noqa: F401
+    import fla_npu  # noqa: F401
+
+    HAS_NPU_RUNTIME = hasattr(torch, "npu")
+except Exception:
+    HAS_NPU_RUNTIME = False
+
+
+@dataclass(frozen=True)
+class PrepareWyReprBwdCase:
+    """单条测试用例配置。
+
+    设计文档当前限定 A2/A3，V 只覆盖 128/256，chunk_size 只覆盖 64/128。
+    `seq_lens=None` 表示固定长度场景；否则表示 varlen 场景，此时 B 必须为 1。
+    """
+
+    name: str
+    B: int
+    HK: int
+    HV: int
+    T: int
+    K: int
+    V: int
+    chunk_size: int
+    data_dtype: torch.dtype
+    gate_dtype: torch.dtype
+    seq_lens: Optional[tuple[int, ...]] = None
+    seed: int = 20260711
+
+
+def _configure_npu() -> None:
+    """配置 NPU 测试环境。
+
+    旧测试脚本统一使用 TEST_DEVICE_ID 环境变量，这里保持一致。
+    若本地没有 torch_npu/fla_npu，仅允许 `--golden-only` 路径继续运行。
+    """
+
+    if not HAS_NPU_RUNTIME:
+        return
+    torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
+    torch.npu.config.allow_internal_format = False
+    torch.npu.set_compile_mode(jit_compile=False)
+
+
+def _ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+def build_cu_seqlens(seq_lens: Sequence[int]) -> list[int]:
+    """根据每段真实长度生成 Python list 形式的 cu_seqlens。
+
+    新算子的 Python 绑定使用 `int[]?`，因此这里直接返回 list[int]，
+    避免 Tensor 与 OptionalIntArrayRef 之间的类型歧义。
+    """
+
+    cu_seqlens = [0]
+    for seq_len in seq_lens:
+        if seq_len <= 0:
+            raise ValueError(f"seq_len must be positive, got {seq_len}")
+        cu_seqlens.append(cu_seqlens[-1] + int(seq_len))
+    return cu_seqlens
+
+
+def build_chunk_indices(cu_seqlens: Sequence[int], chunk_size: int) -> list[int]:
+    """生成扁平化 chunk_indices。
+
+    varlen 场景中每个 chunk 用 `(seq_idx, chunk_idx_in_seq)` 定位。
+    算子接口期望扁平 list，所以返回格式为：
+    `[seq0, chunk0, seq0, chunk1, seq1, chunk0, ...]`。
+    """
+
+    chunk_indices: list[int] = []
+    for seq_idx in range(len(cu_seqlens) - 1):
+        seq_len = int(cu_seqlens[seq_idx + 1] - cu_seqlens[seq_idx])
+        for chunk_idx in range(_ceil_div(seq_len, chunk_size)):
+            chunk_indices.extend([seq_idx, chunk_idx])
+    return chunk_indices
+
+
+def iter_chunk_ranges(
+    B: int,
+    T: int,
+    chunk_size: int,
+    cu_seqlens: Optional[Sequence[int]],
+    chunk_indices: Optional[Sequence[int]],
+) -> Iterable[tuple[int, int, int]]:
+    """按设计文档中的 chunk 规则枚举 `(batch, bos, eos)`。
+
+    固定长度：每个 batch 直接按 `T/chunk_size` 切分。
+    变长：当前设计要求 B=1，通过 `cu_seqlens + chunk_indices` 找到
+    全局 token 范围。
+    """
+
+    if cu_seqlens is None:
+        for batch in range(B):
+            for chunk_idx in range(_ceil_div(T, chunk_size)):
+                bos = chunk_idx * chunk_size
+                eos = min(bos + chunk_size, T)
+                yield batch, bos, eos
+        return
+
+    if B != 1:
+        raise ValueError("varlen prepare_wy_repr_bwd requires B == 1")
+    if chunk_indices is None or len(chunk_indices) % 2 != 0:
+        raise ValueError("varlen prepare_wy_repr_bwd requires flat chunk_indices")
+
+    for pair_idx in range(len(chunk_indices) // 2):
+        seq_idx = int(chunk_indices[pair_idx * 2])
+        local_chunk_idx = int(chunk_indices[pair_idx * 2 + 1])
+        seq_bos = int(cu_seqlens[seq_idx])
+        seq_eos = int(cu_seqlens[seq_idx + 1])
+        bos = seq_bos + local_chunk_idx * chunk_size
+        eos = min(bos + chunk_size, seq_eos)
+        yield 0, bos, eos
+
+
+def validate_case(case: PrepareWyReprBwdCase) -> None:
+    """检查测试用例是否落在当前算子设计约束内。"""
+
+    if case.HV % case.HK != 0:
+        raise ValueError(f"{case.name}: HV must be divisible by HK")
+    if case.V not in (128, 256):
+        raise ValueError(f"{case.name}: V must be 128 or 256")
+    if case.chunk_size not in (64, 128):
+        raise ValueError(f"{case.name}: chunk_size must be 64 or 128")
+    if case.seq_lens is not None:
+        if case.B != 1:
+            raise ValueError(f"{case.name}: varlen case requires B == 1")
+        if sum(case.seq_lens) != case.T:
+            raise ValueError(f"{case.name}: sum(seq_lens) must equal T")
+
+
+def make_inputs(
+    case: PrepareWyReprBwdCase,
+) -> tuple[tuple[torch.Tensor, ...], Optional[list[int]], Optional[list[int]]]:
+    """构造一组稳定、数值范围较小的输入。
+
+    g 会参与 exp 计算，随机范围刻意压小，避免 golden 中指数放大后
+    淹没真实公式错误。A/dw/du/k/v/beta 也使用小尺度随机数，便于后续
+    精度定位时观察输出差异。
+    """
+
+    validate_case(case)
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(case.seed)
+
+    def randn(shape: Sequence[int], dtype: torch.dtype, scale: float) -> torch.Tensor:
+        data = torch.randn(shape, generator=generator, dtype=torch.float32) * scale
+        return data.to(dtype)
+
+    k = randn((case.B, case.HK, case.T, case.K), case.data_dtype, 0.08)
+    v = randn((case.B, case.HV, case.T, case.V), case.data_dtype, 0.08)
+    beta = randn((case.B, case.HV, case.T), case.gate_dtype, 0.05)
+    A = randn((case.B, case.HV, case.T, case.chunk_size), case.data_dtype, 0.04)
+    dw = randn((case.B, case.HV, case.T, case.K), case.data_dtype, 0.08)
+    du = randn((case.B, case.HV, case.T, case.V), case.data_dtype, 0.08)
+    g = randn((case.B, case.HV, case.T), case.gate_dtype, 0.03)
+
+    if case.seq_lens is None:
+        return (k, v, beta, A, dw, du, g), None, None
+
+    cu_seqlens = build_cu_seqlens(case.seq_lens)
+    chunk_indices = build_chunk_indices(cu_seqlens, case.chunk_size)
+    return (k, v, beta, A, dw, du, g), cu_seqlens, chunk_indices
+
+
+def prepare_wy_repr_bwd_golden(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    dw: torch.Tensor,
+    du: torch.Tensor,
+    g: torch.Tensor,
+    chunk_size: int,
+    *,
+    cu_seqlens: Optional[Sequence[int]] = None,
+    chunk_indices: Optional[Sequence[int]] = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """按设计文档公式计算 `dk/dv/dbeta/dg`。
+
+    关键约定：
+    - 每个 value head `hv` 读取 `hk = hv // (HV // HK)` 对应的 k head。
+    - `dk` 对同一个 hk 的多个 value-head 贡献累加。
+    - `dv/dbeta/dg` 按 value head 独立写回。
+    - golden 全部转为 float64 计算，最后再 cast 到各输出约定 dtype。
+    """
+
+    B, HK, T, K = k.shape
+    _, HV, _, V = v.shape
+    heads_per_k = HV // HK
+
+    k64 = k.cpu().to(torch.float64)
+    v64 = v.cpu().to(torch.float64)
+    beta64 = beta.cpu().to(torch.float64)
+    A64 = A.cpu().to(torch.float64)
+    dw64 = dw.cpu().to(torch.float64)
+    du64 = du.cpu().to(torch.float64)
+    g64 = g.cpu().to(torch.float64)
+
+    dk_acc = torch.zeros((B, HK, T, K), dtype=torch.float64)
+    dv_acc = torch.zeros((B, HV, T, V), dtype=torch.float64)
+    dbeta_acc = torch.zeros((B, HV, T), dtype=torch.float64)
+    dg_acc = torch.zeros((B, HV, T), dtype=torch.float64)
+
+    for batch, bos, eos in iter_chunk_ranges(B, T, chunk_size, cu_seqlens, chunk_indices):
+        C = eos - bos
+        if C <= 0:
+            continue
+
+        # 严格下三角 causal mask，对应流程图中的 lower-triangular where。
+        causal_mask = torch.tril(torch.ones((C, C), dtype=torch.bool), diagonal=-1)
+
+        for hv in range(HV):
+            hk = hv // heads_per_k
+
+            b_k = k64[batch, hk, bos:eos, :]
+            b_v = v64[batch, hv, bos:eos, :]
+            b_b = beta64[batch, hv, bos:eos]
+            b_A = A64[batch, hv, bos:eos, :C]
+            b_dw = dw64[batch, hv, bos:eos, :]
+            b_du = du64[batch, hv, bos:eos, :]
+            b_g = g64[batch, hv, bos:eos]
+
+            b_g_exp = torch.exp(b_g)
+            b_bg = b_b * b_g_exp
+            b_kbg = b_k * b_bg[:, None]
+            b_vb = b_v * b_b[:, None]
+
+            b_dA0 = b_dw @ b_kbg.T
+            b_dA1 = b_du @ b_vb.T
+            b_dA2 = b_dA0 + b_dA1
+            b_dA3 = torch.where(causal_mask, b_dA2, torch.zeros_like(b_dA2))
+            b_dA4 = b_dA3 @ b_A.T
+            b_dA5 = b_A.T @ b_dA4
+            b_g_sub_exp = torch.exp(b_g[:, None] - b_g[None, :])
+            b_dA6 = -b_dA5 * b_g_sub_exp
+            b_dA = torch.where(causal_mask, b_dA6, torch.zeros_like(b_dA6))
+
+            b_dvb = b_A.T @ b_du
+            b_dv = b_dvb * b_b[:, None]
+
+            b_dkb = b_dA @ b_k
+            b_kb = b_k * b_b[:, None]
+            b_dkbg = b_A.T @ b_dw
+            b_dkbgk = b_dkbg * b_k
+
+            b_dk = b_dA.T @ b_kb
+            b_dk = b_dk + b_dkb * b_b[:, None]
+            b_dk = b_dk + b_dkbg * b_bg[:, None]
+
+            b_db = (b_dkb * b_k).sum(dim=1)
+            b_db = b_db + (b_dkbgk * b_g_exp[:, None]).sum(dim=1)
+            b_db = b_db + (b_dvb * b_v).sum(dim=1)
+
+            b_kk = b_k @ b_k.T
+            b_A_beta = b_kk * b_b[:, None]
+            b_AdA = b_dA * b_A_beta
+            b_dg = (b_dkbgk * b_bg[:, None]).sum(dim=1)
+            b_dg = b_dg + b_AdA.sum(dim=1) - b_AdA.sum(dim=0)
+
+            dk_acc[batch, hk, bos:eos, :] += b_dk
+            dv_acc[batch, hv, bos:eos, :] = b_dv
+            dbeta_acc[batch, hv, bos:eos] = b_db
+            dg_acc[batch, hv, bos:eos] = b_dg
+
+    return (
+        dk_acc.to(dtype=k.dtype),
+        dv_acc.to(dtype=v.dtype),
+        dbeta_acc.to(dtype=beta.dtype),
+        dg_acc.to(dtype=g.dtype),
+    )
+
+
+def run_npu_operator(
+    inputs: tuple[torch.Tensor, ...],
+    chunk_size: int,
+    *,
+    cu_seqlens: Optional[Sequence[int]] = None,
+    chunk_indices: Optional[Sequence[int]] = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """调用新公开接口，并把结果搬回 CPU 便于和 golden 对比。"""
+
+    if not HAS_NPU_RUNTIME:
+        raise RuntimeError("torch_npu/fla_npu is not available; use --golden-only")
+
+    k, v, beta, A, dw, du, g = (tensor.npu() for tensor in inputs)
+    dk, dv, dbeta, dg = torch.ops.npu.npu_prepare_wy_repr_bwd(
+        k,
+        v,
+        beta,
+        A,
+        dw,
+        du,
+        g,
+        chunk_size,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    torch.npu.synchronize()
+    return dk.cpu(), dv.cpu(), dbeta.cpu(), dg.cpu()
+
+
+def _tolerance(dtype: torch.dtype) -> tuple[float, float]:
+    """给不同输出 dtype 选择较宽松的初始阈值。
+
+    当前算子还处于生成阶段，阈值只作为脚本默认值；后续跑通后可结合
+    ATK 双标杆统计结果再收紧。
+    """
+
+    if dtype == torch.float32:
+        return 2e-3, 2e-3
+    if dtype == torch.bfloat16:
+        return 8e-2, 8e-2
+    return 5e-2, 5e-2
+
+
+def assert_close_outputs(
+    actual: tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+    expected: tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+) -> None:
+    """逐输出比较，并在失败时打印最大误差位置。"""
+
+    for name, got, ref in zip(("dk", "dv", "dbeta", "dg"), actual, expected):
+        rtol, atol = _tolerance(ref.dtype)
+        try:
+            torch.testing.assert_close(
+                got.to(torch.float32),
+                ref.to(torch.float32),
+                rtol=rtol,
+                atol=atol,
+                check_dtype=False,
+            )
+        except AssertionError:
+            diff = (got.to(torch.float32) - ref.to(torch.float32)).abs()
+            flat_idx = int(diff.argmax().item())
+            idx = tuple(int(i) for i in torch.unravel_index(torch.tensor(flat_idx), diff.shape))
+            print(f"[FAIL] {name}: max_abs_diff={diff[idx].item():.6e}, idx={idx}")
+            print(f"       actual={got[idx].item():.6e}, expected={ref[idx].item():.6e}")
+            raise
+
+
+def default_cases() -> list[PrepareWyReprBwdCase]:
+    """覆盖当前设计文档中的主要路径。
+
+    - fixed_fp16_gqa_v128: 固定长度 + GQA 分组 + V=128。
+    - fixed_bf16_gate_fp32_v256: bf16 数据 + fp32 beta/g + V=256。
+    - fixed_fp16_chunk128: chunk_size=128 尾块路径。
+    - varlen_fp16_multi_seq: B=1 变长，多段序列、多 chunk。
+    """
+
+    return [
+        PrepareWyReprBwdCase(
+            name="fixed_fp16_gqa_v128",
+            B=1,
+            HK=2,
+            HV=4,
+            T=96,
+            K=128,
+            V=128,
+            chunk_size=64,
+            data_dtype=torch.float16,
+            gate_dtype=torch.float16,
+            seed=11,
+        ),
+        PrepareWyReprBwdCase(
+            name="fixed_bf16_gate_fp32_v256",
+            B=1,
+            HK=1,
+            HV=2,
+            T=80,
+            K=128,
+            V=256,
+            chunk_size=64,
+            data_dtype=torch.bfloat16,
+            gate_dtype=torch.float32,
+            seed=22,
+        ),
+        PrepareWyReprBwdCase(
+            name="fixed_fp16_chunk128",
+            B=1,
+            HK=2,
+            HV=2,
+            T=129,
+            K=128,
+            V=256,
+            chunk_size=128,
+            data_dtype=torch.float16,
+            gate_dtype=torch.float16,
+            seed=33,
+        ),
+        PrepareWyReprBwdCase(
+            name="varlen_fp16_multi_seq",
+            B=1,
+            HK=2,
+            HV=4,
+            T=185,
+            K=128,
+            V=128,
+            chunk_size=64,
+            data_dtype=torch.float16,
+            gate_dtype=torch.float16,
+            seq_lens=(31, 65, 89),
+            seed=44,
+        ),
+    ]
+
+
+def select_cases(names: Optional[Sequence[str]]) -> list[PrepareWyReprBwdCase]:
+    cases = default_cases()
+    if not names:
+        return cases
+    selected = []
+    name_set = set(names)
+    for case in cases:
+        if case.name in name_set:
+            selected.append(case)
+    missing = name_set - {case.name for case in selected}
+    if missing:
+        raise ValueError(f"unknown case(s): {sorted(missing)}")
+    return selected
+
+
+def run_case(case: PrepareWyReprBwdCase, golden_only: bool) -> None:
+    inputs, cu_seqlens, chunk_indices = make_inputs(case)
+    expected = prepare_wy_repr_bwd_golden(
+        *inputs,
+        case.chunk_size,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+
+    print(
+        f"[GOLDEN] {case.name}: "
+        f"B={case.B}, HK={case.HK}, HV={case.HV}, T={case.T}, "
+        f"K={case.K}, V={case.V}, chunk_size={case.chunk_size}, "
+        f"data_dtype={case.data_dtype}, gate_dtype={case.gate_dtype}"
+    )
+
+    if golden_only:
+        for name, tensor in zip(("dk", "dv", "dbeta", "dg"), expected):
+            print(f"         {name}: shape={tuple(tensor.shape)}, dtype={tensor.dtype}")
+        return
+
+    actual = run_npu_operator(
+        inputs,
+        case.chunk_size,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    assert_close_outputs(actual, expected)
+    print(f"[PASS]   {case.name}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="prepare_wy_repr_bwd generated tests")
+    parser.add_argument(
+        "--case",
+        action="append",
+        dest="cases",
+        help="只运行指定用例名，可重复传入；默认运行全部用例。",
+    )
+    parser.add_argument(
+        "--golden-only",
+        action="store_true",
+        help="只生成 CPU golden，不调用 NPU 算子。",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    _configure_npu()
+    if not args.golden_only and not HAS_NPU_RUNTIME:
+        raise RuntimeError("torch_npu/fla_npu is not available; rerun with --golden-only")
+
+    for case in select_cases(args.cases):
+        run_case(case, args.golden_only)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: Fixes #223
- 背景与目标: 补充 GDN chunk backward 中 WY 表示准备阶段的独立融合入口，减少拆分链路调用成本，并为后续精度、性能与端到端验证提供统一入口。
- 本 PR 解决的问题: 新增 `prepare_wy_repr_bwd` 算子实现、ACLNN / Torch 调用入口及对应测试脚本。

## 变更类型

- [ ] Bug 修复
- [x] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: `prepare_wy_repr_bwd`
- 涉及目录 / 文件: `fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/`、`torch_custom/fla_npu/`
- 责任人 / 提交人: @zhangshuolei-hfut
- 修改范围:
  - [x] `op_host` / 算子定义
  - [x] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [x] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 支持 `k [B, HK, T, K]`、`v/du [B, HV, T, V]`、`beta/g [B, HV, T]`、`A [B, HV, T, chunk_size]`、`dw [B, HV, T, K]`，输出 `dk/dv/dbeta/dg`；`HV` 为 `HK` 的正整数倍；`chunk_size` 支持 `64/128`；`V` 支持 `128/256`；可变长模式需同时提供 `cu_seqlens` 与 `chunk_indices`，且 `B=1`。
- 明确不包含的范围: 不包含 A5 产品编译适配、性能调优、NPU CI 触发和端到端 Example ST 验证。
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [x] 是，请说明影响面、兼容策略和回归范围: 新增 Torch 自定义 op 注册和 Python 入口，修改范围集中在 `torch_custom/fla_npu` 的注册与封装路径；已有算子接口保持兼容。
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [x] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 本 PR 新增 `prepare_wy_repr_bwd` 的 OpDef、ACLNN 接口和 Torch 自定义 op 入口，不修改已有公开算子接口；新增接口仍需按仓库 ABI 敏感路径要求完成检视。

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本: 未执行
- 产品 / 芯片类型: 未执行
- 机器或 CI 链接: 未执行

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=prepare_wy_repr_bwd --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=prepare_wy_repr_bwd --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=prepare_wy_repr_bwd --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=prepare_wy_repr_bwd --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=prepare_wy_repr_bwd --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_prepare_wy_repr_bwd.py
python3 check_prepare_wy_repr_bwd_golden_parity.py
python3 compare_prepare_wy_repr_bwd_fused_vs_split.py
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh prepare_wy_repr_bwd
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | `bash build.sh --pkg --soc=ascend910b --ops=prepare_wy_repr_bwd --vendor_name=fla_npu` | 未执行 | 待补充编译验证 |
| A3 | `ascend910_93` | 未执行 | `bash build.sh --pkg --soc=ascend910_93 --ops=prepare_wy_repr_bwd --vendor_name=fla_npu` | 未执行 | 待补充编译验证 |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | `bash build.sh --pkg --soc=ascend910b --ops=prepare_wy_repr_bwd --vendor_name=fla_npu` | 未执行 | 待补充编译验证 |
| A3 | `ascend910_93` | 未执行 | `bash build.sh --pkg --soc=ascend910_93 --ops=prepare_wy_repr_bwd --vendor_name=fla_npu` | 未执行 | 待补充编译验证 |
| A5 | `ascend950` | 未执行 | `bash build.sh --pkg --soc=ascend950 --ops=prepare_wy_repr_bwd --vendor_name=fla_npu` | 未执行 | 本 PR 不包含 A5 产品编译适配 |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 test_npu_prepare_wy_repr_bwd.py` | 未执行 | 待补充 NPU 精度验证 |
| A3 | `ascend910_93` | `python3 test_npu_prepare_wy_repr_bwd.py` | 未执行 | 待补充 NPU 精度验证 |
| A5 | `ascend950` | `python3 test_npu_prepare_wy_repr_bwd.py` | 未执行 | 本 PR 不包含 A5 产品编译适配 |

- 精度对比: 未执行 NPU 精度对比；已新增 CPU golden 和融合/拆分链路对比脚本。
- 性能对比: 未执行性能对比。
- 边界 / 异常场景: 测试脚本覆盖固定长度、可变长、`chunk_size=64/128`、`V=128/256`、GQA/MQA head 映射配置。
- 未覆盖风险: 仍需在对应产品环境补充编译、安装命中、NPU 精度和端到端 ST 验证。

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待补充 ST 验证 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待补充 ST 验证 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 本 PR 不包含 A5 产品编译适配 |

- 端到端场景说明: 待 NPU CI 或对应产品环境补充验证。
- 与本 PR 修改算子的关联: 本 PR 新增 GDN backward WY 表示准备阶段融合入口，应通过 Example ST 确认不影响 GDN 端到端链路。
- 未覆盖原因及补充计划: 当前仅完成代码提交和基础静态检查，后续由 NPU CI 或对应产品环境补充覆盖。

</details>

## 兼容性、风险与回退

- 兼容性说明: 新增算子接口和 Torch 自定义 op 入口，不修改已有算子的公开调用方式。
- 风险点: 新增 ACLNN / Torch 接口属于 ABI 敏感路径；kernel、tiling、workspace 和 varlen 分支仍需在目标产品环境补充编译与 NPU 精度验证。
- 回退方案: 如编译、精度或端到端验证不满足要求，可回退本 PR 新增的 `prepare_wy_repr_bwd` 目录和 `torch_custom` 注册改动。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

本地提交前已执行：

```sh
git diff --check upstream/main...HEAD
python -m compileall -q torch_custom/fla_npu/test/check_prepare_wy_repr_bwd_golden_parity.py torch_custom/fla_npu/test/compare_prepare_wy_repr_bwd_fused_vs_split.py torch_custom/fla_npu/test/test_npu_prepare_wy_repr_bwd.py
```

结果均通过。