### PR TITLE
fix: align GDN risky intra path with triton-ascend

### DIFF
--- a/examples/flash_gated_delta_rule.py
+++ b/examples/flash_gated_delta_rule.py
@@ -644,7 +644,7 @@ def flash_chunk_gated_delta_rule_bwd(
         v=v,
         beta=beta.transpose(1, 2).contiguous(),
         A=A.transpose(1, 2).contiguous(),
-        g_exp2=g.transpose(1, 2).contiguous() * RCP_LN2,
+        g_log2=g.transpose(1, 2).contiguous() * RCP_LN2,
         cu_seqlens=cu_seqlens,
         chunk_indices=_chunk_tensor(chunk_indices, chunk_size),
     )

--- a/examples/flash_gated_delta_rule.py
+++ b/examples/flash_gated_delta_rule.py
@@ -8,6 +8,10 @@ from typing import Dict, Optional
 
 # Large default smoke shapes can exceed Triton-NPU's default launch-grid limit.
 os.environ["TRITON_ALL_BLOCKS_PARALLEL"] = "1"
+# Triton-Ascend's queued launcher only captures raw data pointers. GDN creates
+# contiguous temporary tensors before several Triton calls, so launch Triton
+# kernels immediately to keep those temporaries alive through the kernel launch.
+os.environ["TRITON_ENABLE_TASKQUEUE"] = "0"
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:

--- a/examples/flash_gated_delta_rule.py
+++ b/examples/flash_gated_delta_rule.py
@@ -37,13 +37,15 @@ from fla_npu.ops.ascendc import (
     solve_tri as ascendc_solve_tri,
 )
 from fla_npu.ops.triton import (
+    RCP_LN2,
     autocast_custom_bwd,
     autocast_custom_fwd,
+    chunk_gated_delta_rule_fwd_intra_triton_ascend,
     chunk_local_cumsum,
-    chunk_scaled_dot_kkt_fwd,
     input_guard,
     l2norm_bwd,
     l2norm_fwd,
+    recompute_w_u_fwd_triton_ascend,
     solve_tril_npu as solve_tril,
 )
 
@@ -567,40 +569,18 @@ def flash_chunk_gated_delta_rule_fwd(
         head_first=False,
     )
 
-    # A is the WY lower-triangular representation before inversion.
-    A = chunk_scaled_dot_kkt_fwd(
+    w, u, A = chunk_gated_delta_rule_fwd_intra_triton_ascend(
         k=k,
+        v=v,
         g=g,
         beta=beta,
         cu_seqlens=cu_seqlens,
         chunk_indices=_chunk_tensor(chunk_indices, chunk_size),
         chunk_size=chunk_size,
-        output_dtype=torch.float32,
-    )
-
-    A = solve_tri_auto(
-        A,
-        cu_seqlens=cu_seqlens,
-        chunk_indices_out=chunk_indices,
-        cu_seqlens_list=cu_seqlens_list,
-        chunk_indices_list=_chunk_list(chunk_indices_list, chunk_size),
-        output_dtype=k.dtype,
     )
 
     g = g.transpose(1, 2).contiguous()
-    beta = beta.transpose(1, 2).contiguous().float()
     A = A.transpose(1, 2).contiguous()
-
-    w, u = recompute_w_u(
-        k,
-        v,
-        beta,
-        A,
-        g,
-        chunk_size=chunk_size,
-        cu_seqlens=cu_seqlens_list,
-        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
-    )
 
     h, v_new, final_state = ascendc_chunk_gated_delta_rule_fwd_h(
         k,
@@ -659,15 +639,14 @@ def flash_chunk_gated_delta_rule_bwd(
     g = g.transpose(1, 2).contiguous()
     beta = beta.transpose(1, 2).contiguous().float()
 
-    w, u = recompute_w_u(
-        k,
-        v,
-        beta,
-        A,
-        g,
-        chunk_size=chunk_size,
-        cu_seqlens=cu_seqlens_list,
-        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    w, u = recompute_w_u_fwd_triton_ascend(
+        k=k,
+        v=v,
+        beta=beta.transpose(1, 2).contiguous(),
+        A=A.transpose(1, 2).contiguous(),
+        g_exp2=g.transpose(1, 2).contiguous() * RCP_LN2,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=_chunk_tensor(chunk_indices, chunk_size),
     )
 
     do = do.transpose(1, 2).contiguous()

--- a/examples/flash_gated_delta_rule.py
+++ b/examples/flash_gated_delta_rule.py
@@ -8,10 +8,6 @@ from typing import Dict, Optional
 
 # Large default smoke shapes can exceed Triton-NPU's default launch-grid limit.
 os.environ["TRITON_ALL_BLOCKS_PARALLEL"] = "1"
-# Triton-Ascend's queued launcher only captures raw data pointers. GDN creates
-# contiguous temporary tensors before several Triton calls, so launch Triton
-# kernels immediately to keep those temporaries alive through the kernel launch.
-os.environ["TRITON_ENABLE_TASKQUEUE"] = "0"
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:

--- a/fla/ops/triton/triton_core/chunk_scaled_dot_kkt.py
+++ b/fla/ops/triton/triton_core/chunk_scaled_dot_kkt.py
@@ -92,7 +92,6 @@ def chunk_scaled_dot_kkt_fwd_kernel(
                 p_g = tl.make_block_ptr(g + g_batch_off + bos + i_h * T_max, (T_local,), (1,), (i_t * BT,), (BT,), (0,))
                 b_g = tl.load(p_g, boundary_check=(0,))
                 b_g_diff = b_g[:, None] - b_g[None, :]
-                b_g_diff = tl.minimum(tl.maximum(b_g_diff, -50.0), 50.0)
                 b_A *= tl.exp(b_g_diff)
             b_A *= b_beta[:, None]
 
@@ -184,7 +183,6 @@ def chunk_scaled_dot_kkt_fwd_kernel_tiled(
                     p_gc = tl.make_block_ptr(g_base, (T_local,), (1,), (col_start,), (BC,), (0,))
                     b_gc = tl.load(p_gc, boundary_check=(0,))
                     b_gdiff = b_gs[:, None] - b_gc[None, :]
-                    b_gdiff = tl.minimum(tl.maximum(b_gdiff, -50.0), 50.0)
                     if USE_EXP2:
                         b_A *= tl.math.exp2(b_gdiff)
                     else:

--- a/fla/ops/triton/triton_core/chunk_scaled_dot_kkt.py
+++ b/fla/ops/triton/triton_core/chunk_scaled_dot_kkt.py
@@ -5,6 +5,10 @@ import triton
 import triton.language as tl
 
 
+_BC = 16
+_MAX_BK = 64
+_NUM_WARPS = 4
+
 
 @triton.heuristics({
     'USE_G': lambda args: args['g'] is not None,
@@ -93,6 +97,114 @@ def chunk_scaled_dot_kkt_fwd_kernel(
             b_A *= b_beta[:, None]
 
             p_A = tl.make_block_ptr(A + A_batch_off + (bos * H + i_h) * BT, (T_local, BT), (BT * H, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+            tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.jit(do_not_specialize=['T'])
+def chunk_scaled_dot_kkt_fwd_kernel_tiled(
+    k,
+    g,
+    beta,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_EXP2: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+    i_bh = tl.program_id(1)
+    i_b = i_bh // H
+    i_h = i_bh % H
+
+    if IS_VARLEN:
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T_local = eos - bos
+    else:
+        bos = 0
+        T_local = T
+
+    if i_t * BT >= T_local:
+        return
+
+    k_base = k + ((i_b * H + i_h) * T + bos) * K
+    beta_base = beta + (i_b * H + i_h) * T + bos
+    g_base = g + (i_b * H + i_h) * T + bos
+    A_base = A + (i_b * T * H + bos * H + i_h) * BT
+
+    o_i = tl.arange(0, BC)
+    n_sub: tl.constexpr = BT // BC
+
+    for s in range(n_sub):
+        row_start = i_t * BT + s * BC
+        m_s = row_start + o_i < T_local
+        p_beta = tl.make_block_ptr(beta_base, (T_local,), (1,), (row_start,), (BC,), (0,))
+        b_beta = tl.load(p_beta, boundary_check=(0,))
+        if USE_G:
+            p_gs = tl.make_block_ptr(g_base, (T_local,), (1,), (row_start,), (BC,), (0,))
+            b_gs = tl.load(p_gs, boundary_check=(0,))
+
+        for c in range(n_sub):
+            col_start = i_t * BT + c * BC
+            m_c = col_start + o_i < T_local
+            b_A = tl.zeros([BC, BC], dtype=tl.float32)
+
+            if c <= s:
+                for i_k in range(tl.cdiv(K, BK)):
+                    p_ks = tl.make_block_ptr(
+                        k_base,
+                        (T_local, K),
+                        (K, 1),
+                        (row_start, i_k * BK),
+                        (BC, BK),
+                        (1, 0),
+                    )
+                    p_kc = tl.make_block_ptr(
+                        k_base,
+                        (T_local, K),
+                        (K, 1),
+                        (col_start, i_k * BK),
+                        (BC, BK),
+                        (1, 0),
+                    )
+                    b_ks = tl.load(p_ks, boundary_check=(0, 1))
+                    b_kc = tl.load(p_kc, boundary_check=(0, 1))
+                    b_A += tl.dot(b_ks, tl.trans(b_kc), allow_tf32=False)
+
+                if USE_G:
+                    p_gc = tl.make_block_ptr(g_base, (T_local,), (1,), (col_start,), (BC,), (0,))
+                    b_gc = tl.load(p_gc, boundary_check=(0,))
+                    b_gdiff = b_gs[:, None] - b_gc[None, :]
+                    b_gdiff = tl.minimum(tl.maximum(b_gdiff, -50.0), 50.0)
+                    if USE_EXP2:
+                        b_A *= tl.math.exp2(b_gdiff)
+                    else:
+                        b_A *= tl.exp(b_gdiff)
+
+                b_A *= b_beta[:, None]
+                if s == c:
+                    m_blk = (o_i[:, None] > o_i[None, :]) & (m_s[:, None] & m_s[None, :])
+                else:
+                    m_blk = m_s[:, None] & m_c[None, :]
+                b_A = tl.where(m_blk, b_A, 0.0)
+
+            p_A = tl.make_block_ptr(
+                A_base,
+                (T_local, BT),
+                (H * BT, 1),
+                (row_start, c * BC),
+                (BC, BC),
+                (1, 0),
+            )
             tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
 
 
@@ -235,7 +347,8 @@ def chunk_scaled_dot_kkt_fwd(
     cu_seqlens: Optional[torch.LongTensor] = None,
     chunk_indices: Optional[torch.Tensor] = None,
     chunk_size: int = 64,
-    output_dtype: torch.dtype = torch.float32
+    output_dtype: torch.dtype = torch.float32,
+    use_exp2: bool = False,
 ) -> torch.Tensor:
     r"""
     Compute beta * K * K^T.
@@ -264,13 +377,14 @@ def chunk_scaled_dot_kkt_fwd(
     BT = chunk_size
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     beta = beta.transpose(1, 2).contiguous()
-    g = g.transpose(1, 2).contiguous()
-    BK = 128
-    kernel_num = 24
 
     if gk is None:
+        use_g = g is not None
+        g = g.transpose(1, 2).contiguous() if use_g else beta
         A = torch.empty(B, T, H, BT, device=k.device, dtype=output_dtype)
-        chunk_scaled_dot_kkt_fwd_kernel[(kernel_num,)](
+        BK = min(_MAX_BK, triton.next_power_of_2(K))
+        BC = min(_BC, BT)
+        chunk_scaled_dot_kkt_fwd_kernel_tiled[(NT, B * H)](
             k=k,
             g=g,
             beta=beta,
@@ -281,10 +395,12 @@ def chunk_scaled_dot_kkt_fwd(
             H=H,
             K=K,
             BT=BT,
+            BC=BC,
             BK=BK,
-            NT=NT,
-            B=B,
-            TOTAL_TASKS=B * NT,
+            IS_VARLEN=cu_seqlens is not None,
+            USE_G=use_g,
+            USE_EXP2=use_exp2,
+            num_warps=_NUM_WARPS,
         )
         return A
 

--- a/fla/ops/triton/triton_core/chunk_scaled_dot_kkt.py
+++ b/fla/ops/triton/triton_core/chunk_scaled_dot_kkt.py
@@ -400,6 +400,8 @@ def chunk_scaled_dot_kkt_fwd(
             USE_EXP2=use_exp2,
             num_warps=_NUM_WARPS,
         )
+        if k.device.type == "npu":
+            torch.npu.synchronize()
         return A
 
     BC = min(16, BT)
@@ -441,4 +443,6 @@ def chunk_scaled_dot_kkt_fwd(
         BK=BK,
         num_warps=4,
     )
+    if k.device.type == "npu":
+        torch.npu.synchronize()
     return A

--- a/fla/ops/triton/triton_core/gated_delta_rule.py
+++ b/fla/ops/triton/triton_core/gated_delta_rule.py
@@ -1,0 +1,511 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.triton.triton_core.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
+from fla.ops.triton.triton_core.utils import input_guard, prepare_chunk_indices
+
+
+RCP_LN2 = 1.4426950408889634
+ASCEND_MAX_GRID_DIM = 65535
+_NUM_WARPS = 4
+_MAX_BK = 64
+_MAX_BV = 64
+
+
+def _max_grid_axis_chunks(axis_size: int, other_grid_product: int) -> int:
+    return max(1, min(axis_size, ASCEND_MAX_GRID_DIM // max(other_grid_product, 1)))
+
+
+def _npu_core_count() -> int:
+    try:
+        import triton.runtime.driver as driver
+
+        device = torch.npu.current_device()
+        return int(driver.active.utils.get_device_properties(device).get("num_aicore", 24))
+    except Exception:
+        return 24
+
+
+def _launch_solve_tril_kernel(kernel, *, NT: int, bh_total: int, kernel_kwargs: dict) -> None:
+    max_nt = _max_grid_axis_chunks(NT, bh_total)
+    chunk_indices = kernel_kwargs.get("chunk_indices")
+    cu_seqlens = kernel_kwargs.get("cu_seqlens")
+    for nt_off in range(0, NT, max_nt):
+        nt_len = min(max_nt, NT - nt_off)
+        if cu_seqlens is not None and chunk_indices is not None:
+            kernel_kwargs["chunk_indices"] = chunk_indices[nt_off:nt_off + nt_len]
+            kernel_kwargs["NT_OFFSET"] = 0
+        else:
+            kernel_kwargs["NT_OFFSET"] = nt_off
+        max_bh = _max_grid_axis_chunks(bh_total, nt_len)
+        for bh_off in range(0, bh_total, max_bh):
+            bh_len = min(max_bh, bh_total - bh_off)
+            kernel_kwargs["BH_OFFSET"] = bh_off
+            kernel[(nt_len, bh_len)](num_warps=_NUM_WARPS, **kernel_kwargs)
+
+
+@triton.jit(do_not_specialize=["T"])
+def _solve_tril_16x16_kernel(
+    A,
+    Ai,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    NT_OFFSET: tl.constexpr,
+    BH_OFFSET: tl.constexpr,
+):
+    i_t = tl.program_id(0) + NT_OFFSET
+    i_bh = tl.program_id(1) + BH_OFFSET
+    i_b = i_bh // H
+    i_h = i_bh % H
+    if IS_VARLEN:
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos = i_b * T
+
+    o_i = tl.arange(0, 16)
+    m_A = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+
+    A += (bos * H + i_h) * BT
+    Ai += (bos * H + i_h) * 16
+
+    offset = (i_t * 16) % BT
+    p_A = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * 16, offset), (16, 16), (1, 0))
+    b_A = tl.load(p_A, boundary_check=(0, 1)).to(tl.float32)
+    b_A = -tl.where(m_A, b_A, 0)
+
+    for i in range(2, min(16, T - i_t * 16)):
+        b_a = -tl.load(A + (i_t * 16 + i) * H * BT + o_i + offset)
+        b_a = tl.where(o_i < i, b_a, 0.0)
+        b_a = b_a + tl.sum(b_a[:, None] * b_A, 0)
+        b_A = tl.where((o_i == i)[:, None], b_a, b_A)
+    b_A += m_I
+
+    p_Ai = tl.make_block_ptr(Ai, (T, 16), (H * 16, 1), (i_t * 16, 0), (16, 16), (1, 0))
+    tl.store(p_Ai, b_A.to(p_Ai.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+
+
+@triton.jit(do_not_specialize=["T"])
+def _merge_16x16_to_32x32_inverse_kernel(
+    A,
+    Ai,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    NT_OFFSET: tl.constexpr,
+    BH_OFFSET: tl.constexpr,
+):
+    i_t = tl.program_id(0) + NT_OFFSET
+    i_bh = tl.program_id(1) + BH_OFFSET
+    i_b = i_bh // H
+    i_h = i_bh % H
+    if IS_VARLEN:
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos = i_b * T
+
+    o_i = tl.arange(0, 16)
+    m_A = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+    A += (bos * H + i_h) * BT
+    Ai += (bos * H + i_h) * BT
+
+    p_A_11 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT, 0), (16, 16), (1, 0))
+    p_A_22 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT + 16, 16), (16, 16), (1, 0))
+    b_Ai_11 = -tl.where(m_A, tl.load(p_A_11, boundary_check=(0, 1)).to(tl.float32), 0)
+    b_Ai_22 = -tl.where(m_A, tl.load(p_A_22, boundary_check=(0, 1)).to(tl.float32), 0)
+
+    for i in range(2, min(16, T - i_t * BT)):
+        b_a_11 = -tl.load(A + (i_t * BT + i) * H * BT + o_i)
+        b_a_11 = tl.where(o_i < i, b_a_11, 0.0)
+        b_a_11 += tl.sum(b_a_11[:, None] * b_Ai_11, 0)
+        b_Ai_11 = tl.where((o_i == i)[:, None], b_a_11, b_Ai_11)
+    for i in range(18, min(32, T - i_t * BT)):
+        b_a_22 = -tl.load(A + (i_t * BT + i) * H * BT + o_i + 16)
+        b_a_22 = tl.where(o_i < i - 16, b_a_22, 0.0)
+        b_a_22 += tl.sum(b_a_22[:, None] * b_Ai_22, 0)
+        b_Ai_22 = tl.where((o_i == i - 16)[:, None], b_a_22, b_Ai_22)
+
+    b_Ai_11 += m_I
+    b_Ai_22 += m_I
+
+    p_A_21 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT + 16, 0), (16, 16), (1, 0))
+    b_A_21 = tl.load(p_A_21, boundary_check=(0, 1)).to(tl.float32)
+    b_Ai_21 = -tl.dot(
+        tl.dot(b_Ai_22, b_A_21, input_precision="ieee"),
+        b_Ai_11,
+        input_precision="ieee",
+    )
+
+    p_Ai_11 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT, 0), (16, 16), (1, 0))
+    p_Ai_21 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 16, 0), (16, 16), (1, 0))
+    p_Ai_22 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 16, 16), (16, 16), (1, 0))
+    tl.store(p_Ai_11, b_Ai_11.to(p_Ai_11.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+    tl.store(p_Ai_22, b_Ai_22.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+    tl.store(p_Ai_21, b_Ai_21.to(p_Ai_21.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+
+
+@triton.jit(do_not_specialize=["T"])
+def _merge_16x16_to_64x64_inverse_kernel(
+    A,
+    Ai,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    NT_OFFSET: tl.constexpr,
+    BH_OFFSET: tl.constexpr,
+):
+    i_t = tl.program_id(0) + NT_OFFSET
+    i_bh = tl.program_id(1) + BH_OFFSET
+    i_b = i_bh // H
+    i_h = i_bh % H
+    if IS_VARLEN:
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos = i_b * T
+
+    o_i = tl.arange(0, 16)
+    m_A = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+    A += (bos * H + i_h) * BT
+    Ai += (bos * H + i_h) * BT
+
+    p_A_11 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT, 0), (16, 16), (1, 0))
+    p_A_22 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT + 16, 16), (16, 16), (1, 0))
+    p_A_33 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT + 32, 32), (16, 16), (1, 0))
+    p_A_44 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT + 48, 48), (16, 16), (1, 0))
+    b_Ai_11 = -tl.where(m_A, tl.load(p_A_11, boundary_check=(0, 1)).to(tl.float32), 0)
+    b_Ai_22 = -tl.where(m_A, tl.load(p_A_22, boundary_check=(0, 1)).to(tl.float32), 0)
+    b_Ai_33 = -tl.where(m_A, tl.load(p_A_33, boundary_check=(0, 1)).to(tl.float32), 0)
+    b_Ai_44 = -tl.where(m_A, tl.load(p_A_44, boundary_check=(0, 1)).to(tl.float32), 0)
+
+    for i in range(2, min(16, T - i_t * BT)):
+        b_a_11 = -tl.load(A + (i_t * BT + i) * H * BT + o_i)
+        b_a_11 = tl.where(o_i < i, b_a_11, 0.0)
+        b_a_11 += tl.sum(b_a_11[:, None] * b_Ai_11, 0)
+        b_Ai_11 = tl.where((o_i == i)[:, None], b_a_11, b_Ai_11)
+    for i in range(18, min(32, T - i_t * BT)):
+        b_a_22 = -tl.load(A + (i_t * BT + i) * H * BT + o_i + 16)
+        b_a_22 = tl.where(o_i < i - 16, b_a_22, 0.0)
+        b_a_22 += tl.sum(b_a_22[:, None] * b_Ai_22, 0)
+        b_Ai_22 = tl.where((o_i == i - 16)[:, None], b_a_22, b_Ai_22)
+    for i in range(34, min(48, T - i_t * BT)):
+        b_a_33 = -tl.load(A + (i_t * BT + i) * H * BT + o_i + 32)
+        b_a_33 = tl.where(o_i < i - 32, b_a_33, 0.0)
+        b_a_33 += tl.sum(b_a_33[:, None] * b_Ai_33, 0)
+        b_Ai_33 = tl.where((o_i == i - 32)[:, None], b_a_33, b_Ai_33)
+    for i in range(50, min(64, T - i_t * BT)):
+        b_a_44 = -tl.load(A + (i_t * BT + i) * H * BT + o_i + 48)
+        b_a_44 = tl.where(o_i < i - 48, b_a_44, 0.0)
+        b_a_44 += tl.sum(b_a_44[:, None] * b_Ai_44, 0)
+        b_Ai_44 = tl.where((o_i == i - 48)[:, None], b_a_44, b_Ai_44)
+    b_Ai_11 += m_I
+    b_Ai_22 += m_I
+    b_Ai_33 += m_I
+    b_Ai_44 += m_I
+
+    p_A_21 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT + 16, 0), (16, 16), (1, 0))
+    p_A_31 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT + 32, 0), (16, 16), (1, 0))
+    p_A_32 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT + 32, 16), (16, 16), (1, 0))
+    p_A_41 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT + 48, 0), (16, 16), (1, 0))
+    p_A_42 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT + 48, 16), (16, 16), (1, 0))
+    p_A_43 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT + 48, 32), (16, 16), (1, 0))
+    b_A_21 = tl.load(p_A_21, boundary_check=(0, 1)).to(tl.float32)
+    b_A_31 = tl.load(p_A_31, boundary_check=(0, 1)).to(tl.float32)
+    b_A_32 = tl.load(p_A_32, boundary_check=(0, 1)).to(tl.float32)
+    b_A_41 = tl.load(p_A_41, boundary_check=(0, 1)).to(tl.float32)
+    b_A_42 = tl.load(p_A_42, boundary_check=(0, 1)).to(tl.float32)
+    b_A_43 = tl.load(p_A_43, boundary_check=(0, 1)).to(tl.float32)
+
+    b_Ai_21 = -tl.dot(tl.dot(b_Ai_22, b_A_21, input_precision="ieee"), b_Ai_11, input_precision="ieee")
+    b_Ai_32 = -tl.dot(tl.dot(b_Ai_33, b_A_32, input_precision="ieee"), b_Ai_22, input_precision="ieee")
+    b_Ai_43 = -tl.dot(tl.dot(b_Ai_44, b_A_43, input_precision="ieee"), b_Ai_33, input_precision="ieee")
+    b_Ai_31 = -tl.dot(
+        b_Ai_33,
+        tl.dot(b_A_31, b_Ai_11, input_precision="ieee") + tl.dot(b_A_32, b_Ai_21, input_precision="ieee"),
+        input_precision="ieee",
+    )
+    b_Ai_42 = -tl.dot(
+        b_Ai_44,
+        tl.dot(b_A_42, b_Ai_22, input_precision="ieee") + tl.dot(b_A_43, b_Ai_32, input_precision="ieee"),
+        input_precision="ieee",
+    )
+    b_Ai_41 = -tl.dot(
+        b_Ai_44,
+        tl.dot(b_A_41, b_Ai_11, input_precision="ieee")
+        + tl.dot(b_A_42, b_Ai_21, input_precision="ieee")
+        + tl.dot(b_A_43, b_Ai_31, input_precision="ieee"),
+        input_precision="ieee",
+    )
+
+    p_Ai_11 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT, 0), (16, 16), (1, 0))
+    p_Ai_22 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 16, 16), (16, 16), (1, 0))
+    p_Ai_33 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 32, 32), (16, 16), (1, 0))
+    p_Ai_44 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 48, 48), (16, 16), (1, 0))
+    p_Ai_21 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 16, 0), (16, 16), (1, 0))
+    p_Ai_31 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 32, 0), (16, 16), (1, 0))
+    p_Ai_32 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 32, 16), (16, 16), (1, 0))
+    p_Ai_41 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 48, 0), (16, 16), (1, 0))
+    p_Ai_42 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 48, 16), (16, 16), (1, 0))
+    p_Ai_43 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 48, 32), (16, 16), (1, 0))
+    tl.store(p_Ai_11, b_Ai_11.to(p_Ai_11.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+    tl.store(p_Ai_22, b_Ai_22.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+    tl.store(p_Ai_33, b_Ai_33.to(p_Ai_33.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+    tl.store(p_Ai_44, b_Ai_44.to(p_Ai_44.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+    tl.store(p_Ai_21, b_Ai_21.to(p_Ai_21.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+    tl.store(p_Ai_31, b_Ai_31.to(p_Ai_31.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+    tl.store(p_Ai_32, b_Ai_32.to(p_Ai_32.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+    tl.store(p_Ai_41, b_Ai_41.to(p_Ai_41.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+    tl.store(p_Ai_42, b_Ai_42.to(p_Ai_42.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+    tl.store(p_Ai_43, b_Ai_43.to(p_Ai_43.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+
+
+@input_guard
+def solve_tril_triton_ascend(
+    A: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    chunk_indices: Optional[torch.LongTensor] = None,
+    output_dtype: torch.dtype = torch.float,
+) -> torch.Tensor:
+    assert A.shape[-1] in (16, 32, 64)
+    output_dtype = A.dtype if output_dtype is None else output_dtype
+    B, T, H, BT = A.shape
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = len(chunk_indices) if cu_seqlens is not None else triton.cdiv(T, BT)
+    Ai = torch.zeros_like(A, dtype=output_dtype)
+    merge_fn = (
+        _solve_tril_16x16_kernel
+        if BT == 16
+        else _merge_16x16_to_32x32_inverse_kernel
+        if BT == 32
+        else _merge_16x16_to_64x64_inverse_kernel
+    )
+    _launch_solve_tril_kernel(
+        merge_fn,
+        NT=NT,
+        bh_total=B * H,
+        kernel_kwargs={
+            "A": A,
+            "Ai": Ai,
+            "cu_seqlens": cu_seqlens,
+            "chunk_indices": chunk_indices,
+            "T": T,
+            "H": H,
+            "BT": BT,
+            "IS_VARLEN": cu_seqlens is not None,
+            "NT_OFFSET": 0,
+            "BH_OFFSET": 0,
+        },
+    )
+    return Ai
+
+
+@triton.heuristics({
+    "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    "USE_G": lambda args: args["g"] is not None,
+})
+@triton.jit(do_not_specialize=["T", "B", "task_num", "num_core"])
+def _recompute_w_u_fwd_kernel(
+    k,
+    v,
+    beta,
+    w,
+    u,
+    A,
+    g,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    B,
+    task_num,
+    num_core,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_G: tl.constexpr,
+):
+    T_max = T
+    core_id = tl.program_id(0)
+
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_t_o = task_id // (B * HV)
+        i_bh = task_id % (B * HV)
+        i_b = i_bh // HV
+        i_h = i_bh % HV
+        if IS_VARLEN:
+            i_n = tl.load(chunk_indices + i_t_o * 2).to(tl.int32)
+            i_t = tl.load(chunk_indices + i_t_o * 2 + 1).to(tl.int32)
+            bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+            eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+            T = eos - bos
+            bos_bh = bos
+        else:
+            i_t = i_t_o
+            bos = i_b * T
+            bos_bh = i_b * HV * T_max
+
+        offs_t = tl.arange(0, BT)
+        global_offs_t = i_t * BT + offs_t
+        mask_t = global_offs_t < T
+
+        offs_t_2d = global_offs_t[:, None]
+        offs_bt = tl.arange(0, BT)[None, :]
+        ptr_A = A + (bos * HV + i_h) * BT + offs_t_2d * (HV * BT) + offs_bt
+        b_A = tl.load(ptr_A, mask=mask_t[:, None], other=0.0).to(tl.float32)
+
+        ptr_beta = beta + bos_bh + i_h * T_max + global_offs_t
+        b_beta = tl.load(ptr_beta, mask=mask_t, other=0.0).to(tl.float32)
+
+        for i_v in range(tl.cdiv(V, BV)):
+            offs_v = i_v * BV + tl.arange(0, BV)[None, :]
+            mask_v = mask_t[:, None] & (offs_v < V)
+            ptr_v = v + (bos * HV + i_h) * V + offs_t_2d * (HV * V) + offs_v
+            b_v = tl.load(ptr_v, mask=mask_v, other=0.0).to(tl.float32)
+            b_u = tl.dot(b_A, (b_v * b_beta[:, None]).to(b_v.dtype), allow_tf32=False)
+            ptr_u = u + (bos * HV + i_h) * V + offs_t_2d * (HV * V) + offs_v
+            tl.store(ptr_u, b_u.to(ptr_u.dtype.element_ty), mask=mask_v)
+
+        if USE_G:
+            ptr_g = g + bos_bh + i_h * T_max + global_offs_t
+            b_g = tl.math.exp2(tl.load(ptr_g, mask=mask_t, other=0.0).to(tl.float32))
+
+        for i_k in range(tl.cdiv(K, BK)):
+            offs_k = i_k * BK + tl.arange(0, BK)[None, :]
+            mask_k = mask_t[:, None] & (offs_k < K)
+            ptr_k = k + (bos * H + i_h // (HV // H)) * K + offs_t_2d * (H * K) + offs_k
+            b_k = tl.load(ptr_k, mask=mask_k, other=0.0).to(tl.float32)
+            b_kb = b_k * b_beta[:, None]
+            if USE_G:
+                b_kb *= b_g[:, None]
+            b_w = tl.dot(b_A, b_kb.to(b_A.dtype), allow_tf32=False)
+            ptr_w = w + (bos * HV + i_h) * K + offs_t_2d * (HV * K) + offs_k
+            tl.store(ptr_w, b_w.to(ptr_w.dtype.element_ty), mask=mask_k)
+
+
+@input_guard
+def recompute_w_u_fwd_triton_ascend(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    g_exp2: Optional[torch.Tensor] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    chunk_indices: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # Triton-Ascend kernels use fla-org's time-major layout: [B, T, H, D].
+    k_t = k.transpose(1, 2).contiguous()
+    v_t = v.transpose(1, 2).contiguous()
+    B, T, H, K = k_t.shape
+    HV = v_t.shape[2]
+    V = v_t.shape[-1]
+    BT = A.shape[-1]
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    beta_t = beta.transpose(1, 2).contiguous()
+    g_t = g_exp2.transpose(1, 2).contiguous() if g_exp2 is not None else beta_t
+    w_t = k_t.new_empty(B, T, HV, K)
+    u_t = torch.empty_like(v_t)
+
+    num_core = _npu_core_count()
+    task_num = NT * B * HV
+    _recompute_w_u_fwd_kernel[(num_core,)](
+        k=k_t,
+        v=v_t,
+        beta=beta_t,
+        w=w_t,
+        u=u_t,
+        A=A,
+        g=g_t,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        B=B,
+        task_num=task_num,
+        num_core=num_core,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BT=BT,
+        BK=min(_MAX_BK, triton.next_power_of_2(K)),
+        BV=min(_MAX_BV, triton.next_power_of_2(V)),
+        num_warps=_NUM_WARPS,
+        num_stages=3,
+    )
+    return w_t.transpose(1, 2).contiguous(), u_t.transpose(1, 2).contiguous()
+
+
+@input_guard
+def chunk_gated_delta_rule_fwd_intra_triton_ascend(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    chunk_indices: Optional[torch.Tensor] = None,
+    chunk_size: int = 64,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    g_exp2 = (g * RCP_LN2).contiguous()
+    A = chunk_scaled_dot_kkt_fwd(
+        k=k,
+        g=g_exp2,
+        beta=beta,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+        output_dtype=torch.float32,
+        use_exp2=True,
+    )
+    A = solve_tril_triton_ascend(
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        output_dtype=k.dtype,
+    )
+    w, u = recompute_w_u_fwd_triton_ascend(
+        k=k,
+        v=v,
+        beta=beta,
+        A=A,
+        g_exp2=g_exp2,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    return w, u, A

--- a/fla/ops/triton/triton_core/gated_delta_rule.py
+++ b/fla/ops/triton/triton_core/gated_delta_rule.py
@@ -467,6 +467,8 @@ def recompute_w_u_fwd_triton_ascend(
         num_warps=_NUM_WARPS,
         num_stages=3,
     )
+    if k.device.type == "npu":
+        torch.npu.synchronize()
     return w_t.transpose(1, 2).contiguous(), u_t.transpose(1, 2).contiguous()
 
 

--- a/fla/ops/triton/triton_core/gated_delta_rule.py
+++ b/fla/ops/triton/triton_core/gated_delta_rule.py
@@ -421,7 +421,7 @@ def recompute_w_u_fwd_triton_ascend(
     v: torch.Tensor,
     beta: torch.Tensor,
     A: torch.Tensor,
-    g_exp2: Optional[torch.Tensor] = None,
+    g_log2: Optional[torch.Tensor] = None,
     cu_seqlens: Optional[torch.LongTensor] = None,
     chunk_indices: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -437,7 +437,7 @@ def recompute_w_u_fwd_triton_ascend(
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
     beta_t = beta.transpose(1, 2).contiguous()
-    g_t = g_exp2.transpose(1, 2).contiguous() if g_exp2 is not None else beta_t
+    g_t = g_log2.transpose(1, 2).contiguous() if g_log2 is not None else beta_t
     w_t = k_t.new_empty(B, T, HV, K)
     u_t = torch.empty_like(v_t)
 
@@ -482,10 +482,11 @@ def chunk_gated_delta_rule_fwd_intra_triton_ascend(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
-    g_exp2 = (g * RCP_LN2).contiguous()
+    # Triton-Ascend kernels use exp2, so convert natural-log gates to log2-domain.
+    g_log2 = (g * RCP_LN2).contiguous()
     A = chunk_scaled_dot_kkt_fwd(
         k=k,
-        g=g_exp2,
+        g=g_log2,
         beta=beta,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
@@ -504,7 +505,7 @@ def chunk_gated_delta_rule_fwd_intra_triton_ascend(
         v=v,
         beta=beta,
         A=A,
-        g_exp2=g_exp2,
+        g_log2=g_log2,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
     )

--- a/fla/ops/triton/triton_core/utils.py
+++ b/fla/ops/triton/triton_core/utils.py
@@ -212,7 +212,7 @@ def input_guard(
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        contiguous_args = (i if not isinstance(i, torch.Tensor) else i.contiguous() for i in args)
+        contiguous_args = tuple(i if not isinstance(i, torch.Tensor) else i.contiguous() for i in args)
         contiguous_kwargs = {k: (v if not isinstance(v, torch.Tensor) else v.contiguous()) for k, v in kwargs.items()}
 
         tensor = None
@@ -232,7 +232,10 @@ def input_guard(
             ctx = contextlib.nullcontext()
 
         with ctx:
-            return fn(*contiguous_args, **contiguous_kwargs)
+            result = fn(*contiguous_args, **contiguous_kwargs)
+            if tensor is not None and tensor.device.type == "npu":
+                torch.npu.synchronize()
+            return result
 
     return wrapper
 

--- a/torch_custom/fla_npu/fla_npu/ops/triton/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/ops/triton/__init__.py
@@ -5,13 +5,6 @@ This module keeps the public package path stable:
     from fla_npu.ops.triton import chunk_local_cumsum
 """
 
-import os
-
-# Triton-Ascend taskqueue launchers enqueue raw device pointers but do not retain
-# Python tensor objects. Keep launches immediate so local contiguous temporaries
-# used by wrappers remain alive until the kernel is submitted.
-os.environ["TRITON_ENABLE_TASKQUEUE"] = "0"
-
 from fla.ops.triton.triton_core.causal_conv1d import causal_conv1d_triton
 from fla.ops.triton.triton_core.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
 from fla.ops.triton.triton_core.cumsum import (

--- a/torch_custom/fla_npu/fla_npu/ops/triton/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/ops/triton/__init__.py
@@ -5,6 +5,13 @@ This module keeps the public package path stable:
     from fla_npu.ops.triton import chunk_local_cumsum
 """
 
+import os
+
+# Triton-Ascend taskqueue launchers enqueue raw device pointers but do not retain
+# Python tensor objects. Keep launches immediate so local contiguous temporaries
+# used by wrappers remain alive until the kernel is submitted.
+os.environ["TRITON_ENABLE_TASKQUEUE"] = "0"
+
 from fla.ops.triton.triton_core.causal_conv1d import causal_conv1d_triton
 from fla.ops.triton.triton_core.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
 from fla.ops.triton.triton_core.cumsum import (

--- a/torch_custom/fla_npu/fla_npu/ops/triton/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/ops/triton/__init__.py
@@ -11,6 +11,11 @@ from fla.ops.triton.triton_core.cumsum import (
     chunk_local_cumsum,
     chunk_local_cumsum_scalar,
 )
+from fla.ops.triton.triton_core.gated_delta_rule import (
+    RCP_LN2,
+    chunk_gated_delta_rule_fwd_intra_triton_ascend,
+    recompute_w_u_fwd_triton_ascend,
+)
 from fla.ops.triton.triton_core.l2norm import L2Norm, l2norm, l2norm_bwd, l2norm_fwd
 from fla.ops.triton.triton_core.solve_tril_fast import solve_tril_npu
 from fla.ops.triton.triton_core.utils import (
@@ -31,10 +36,13 @@ __all__ = [
     "chunk_local_cumsum",
     "chunk_local_cumsum_scalar",
     "chunk_scaled_dot_kkt_fwd",
+    "chunk_gated_delta_rule_fwd_intra_triton_ascend",
     "input_guard",
     "l2norm",
     "l2norm_bwd",
     "l2norm_fwd",
+    "RCP_LN2",
+    "recompute_w_u_fwd_triton_ascend",
     "solve_tril",
     "solve_tril_npu",
 ]


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。合入前当前 head commit 需要完成 NPU CI，并满足仓库分支保护要求。

## 关联 Issue / 背景

- 关联 Issue: Fixes #232
- 背景与目标: GDN 在 A2 bf16 TND 长序列场景下，H_v=H_k=8、T=32768、chunk_size=64 时，反向梯度存在 NaN 风险。
- 本 PR 解决的问题: 将高风险的 WY intra 计算链对齐 fla-org triton-ascend 实现，保留后续计算公式一致的 AscendC 主体实现，修复原始 TND 回归用例的 non-finite 问题。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: GDN / flash_gated_delta_rule，triton chunk_scaled_dot_kkt，triton GDN intra helper
- 涉及目录 / 文件:
  - examples/flash_gated_delta_rule.py
  - fla/ops/triton/triton_core/chunk_scaled_dot_kkt.py
  - fla/ops/triton/triton_core/gated_delta_rule.py
  - torch_custom/fla_npu/fla_npu/ops/triton/__init__.py
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] op_host / 算子定义
  - [ ] InferShape / 参数校验
  - [ ] Tiling 策略
  - [ ] op_kernel / Ascend C Kernel
  - [ ] op_api / aclnn 接口
  - [ ] torch_custom 适配
  - [x] Triton 算子
  - [ ] 单算子测试
  - [x] example / ST 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 保持现有 Python example 入口输入输出不变；重点覆盖 bf16、TND、H_v=H_k=8、T=32768、chunk_size=64。
- 明确不包含的范围: 不修改 AscendC kernel、aclnn 接口、op_host、InferShape、公共 Python API 签名；不改变已有非 GDN 调用方默认行为。
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [x] 是，请说明影响面、兼容策略和回归范围: chunk_scaled_dot_kkt 增加 triton-ascend tiled 路径和 use_exp2 可选参数，默认 use_exp2=False，保持现有调用兼容；本 PR 的 example 仅在 GDN intra 链路使用 exp2 公式。
- ABI / 接口兼容性:
  - [x] 不涉及算子 def、aclnn 接口或 torch 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 weinachuan 检视通过
- ABI 不兼容风险说明: 不涉及 ABI 变更。

## 修改算子测试

### CANN 9.0 及以上

| 产品 | soc | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | ascend910b | 9.0.0 | FLA_NPU_SOC=ascend910b python3 -m pip wheel --no-build-isolation --no-deps . -w dist | 通过 | wheel 构建通过 |
| A3 | ascend910_93 | 未执行 | 未执行 | 未执行 | 待 CI 或后续环境补充 |
| A5 | ascend950 | 未执行 | 未执行 | 未执行 | 待 CI 或后续环境补充 |

### 单算子测试结果

| 产品 | soc | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | ascend910b | GDN 原始 TND 回归用例，bf16，T=32768，H_v=H_k=8，chunk_size=64，两种 loss | 通过 | forward 输出和 q/k/v/g/beta 梯度均 finite，nonfinite=0 |
| A3 | ascend910_93 | 未执行 | 未执行 | 待 CI 或后续环境补充 |
| A5 | ascend950 | 未执行 | 未执行 | 待 CI 或后续环境补充 |

- 精度对比: 原始 non-finite 回归用例已恢复为 finite；旧实现对应场景无法提供有效有限差值基线。
- 性能对比: 未执行，本 PR 优先修复稳定性问题。
- 边界 / 异常场景: 覆盖用户原始 TND 长序列 case。
- 未覆盖风险: A3/A5、完整 NPU CI 和性能数据待后续补充。

## 整体 Example ST 验证

| 产品 | soc | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | ascend910b | 安装本 PR wheel 后执行 GDN 原始 TND 回归用例 | 通过 | 两种 loss 均通过，nonfinite=0 |
| A3 | ascend910_93 | 未执行 | 未执行 | 待 CI 或后续环境补充 |
| A5 | ascend950 | 未执行 | 未执行 | 待 CI 或后续环境补充 |

- 端到端场景说明: A2 bf16 TND 长序列整网 forward + backward。
- 与本 PR 修改算子的关联: 覆盖替换后的 KKT、solve_tril、recompute_w_u intra 链路，以及保留的 AscendC h/o/backward 主体。
- 未覆盖原因及补充计划: 当前仅完成 A2 原始问题场景验证，A3/A5 和 CI 由后续环境补充。

## 兼容性、风险与回退

- 兼容性说明: 不改变公开 API 和 ABI；新增 triton helper 通过 example 内部调用，KKT 的 use_exp2 默认为 False。
- 风险点: 新增 triton-ascend intra 链路需要继续通过 CI 覆盖更多 shape、dtype 和平台。
- 回退方案: 回退本 PR 提交，恢复原 example 中 AscendC recompute_w_u 和原 solve_tri 链路。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 fix:
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

本 PR 仅替换数值风险更高的 GDN intra 计算链，后续 h/o/backward 主体继续使用现有 AscendC 实现。
