### PR TITLE
fix: 修复 A5 fwd_h epilogue 确定性问题

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
@@ -60,13 +60,12 @@ public:
         constexpr uint32_t PONG_BUF_1_OFFSET = 112 * 1024;
         constexpr uint32_t PONG_BUF_2_OFFSET = 128 * 1024;
         constexpr uint32_t PONG_BUF_3_OFFSET = 144 * 1024;
-        constexpr uint32_t PING_G_BUF_OFFSET = 160 * 1024;
-        constexpr uint32_t PONG_G_BUF_OFFSET = 161 * 1024;
-        constexpr uint32_t PING_G_SUB_BUF_OFFSET = 162 * 1024;
-        constexpr uint32_t PONG_G_SUB_BUF_OFFSET = 163 * 1024;
-        constexpr uint32_t PING_G_INPUT_BUF_OFFSET = 164 * 1024;
-        constexpr uint32_t PONG_G_INPUT_BUF_OFFSET = 165 * 1024;
-        constexpr uint32_t SHARE_BUF_OFFSET = 166 * 1024;
+        constexpr uint32_t PING_G_BUF_OFFSET = 168 * 1024;
+        constexpr uint32_t PONG_G_BUF_OFFSET = 169 * 1024;
+        constexpr uint32_t PING_G_SUB_BUF_OFFSET = 170 * 1024;
+        constexpr uint32_t PONG_G_SUB_BUF_OFFSET = 171 * 1024;
+        constexpr uint32_t PING_G_INPUT_BUF_OFFSET = 172 * 1024;
+        constexpr uint32_t PONG_G_INPUT_BUF_OFFSET = 173 * 1024;
         constexpr uint32_t UPDATE_SCRATCH_BUF_OFFSET = 160 * 1024;
         constexpr uint32_t UPDATE_G_BUF_OFFSET = 176 * 1024;
 
@@ -88,7 +87,8 @@ public:
             gkLastUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_G_SUB_BUF_OFFSET);
             gkInputUbTensor_ping = resource.ubBuf.template GetBufferByByte<GElementInput>(PING_G_INPUT_BUF_OFFSET);
             gkInputUbTensor_pong = resource.ubBuf.template GetBufferByByte<GElementInput>(PONG_G_INPUT_BUF_OFFSET);
-            shareBufferGk_ = resource.ubBuf.template GetBufferByByte<uint8_t>(SHARE_BUF_OFFSET);
+            gkBrcbUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_G_INPUT_BUF_OFFSET);
+            gkBrcbUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_G_INPUT_BUF_OFFSET);
         }
 
     }
@@ -139,6 +139,32 @@ public:
             static_cast<uint32_t>((dstStride - cols) * sizeof(Element)),
             0};
         AscendC::DataCopyPad(dst, src, copyParams);
+    }
+
+    CATLASS_DEVICE
+    void ApplyRowScale(
+        AscendC::LocalTensor<float> matrix,
+        AscendC::LocalTensor<float> rowScale,
+        AscendC::LocalTensor<float> rowScaleBrcb,
+        uint32_t rows,
+        uint32_t cols)
+    {
+        constexpr uint32_t FP32_PER_BLOCK = 8;
+        constexpr uint32_t FP32_PER_REPEAT = 64;
+        uint8_t rowStride = static_cast<uint8_t>(cols / FP32_PER_BLOCK);
+        AscendC::BinaryRepeatParams params(1, 1, 0, rowStride, rowStride, 1);
+        for (uint32_t row = 0; row < rows; row += FP32_PER_BLOCK) {
+            uint32_t rowsThisBlock = Min(FP32_PER_BLOCK, rows - row);
+            AscendC::Brcb(rowScaleBrcb, rowScale[row], 1, {1, FP32_PER_BLOCK});
+            AscendC::PipeBarrier<PIPE_V>();
+            for (uint32_t col = 0; col < cols; col += FP32_PER_REPEAT) {
+                uint32_t count = Min(FP32_PER_REPEAT, cols - col);
+                uint32_t offset = row * cols + col;
+                AscendC::Mul(matrix[offset], matrix[offset], rowScaleBrcb,
+                             count, rowsThisBlock, params);
+            }
+            AscendC::PipeBarrier<PIPE_V>();
+        }
     }
 
     CATLASS_DEVICE
@@ -253,6 +279,8 @@ public:
                     isPing ? gkLastUbTensor_ping : gkLastUbTensor_pong;
                 AscendC::LocalTensor<GElementInput> gkInputUbTensor =
                     isPing ? gkInputUbTensor_ping : gkInputUbTensor_pong;
+                AscendC::LocalTensor<float> gkBrcbUbTensor =
+                    isPing ? gkBrcbUbTensor_ping : gkBrcbUbTensor_pong;
 
                 if (rowStart == rowBegin) {
                     AscendC::WaitFlag<AscendC::HardEvent::S_MTE2>(EVENT_ID1 + pingpongFlag);
@@ -277,15 +305,8 @@ public:
                 AscendC::Exp(gkLastUbTensor, gkLastUbTensor, rowsThisTile);
                 AscendC::PipeBarrier<PIPE_V>();
 
-                uint32_t gkBrcReptime = (rowsThisTile + 8 - 1) / 8;
-                uint32_t dstShapeGk[2] = {gkBrcReptime * 8, nActual};
-                uint32_t srcShapeGk[2] = {gkBrcReptime * 8, 1};
-                AscendC::Broadcast<float, 2, 1>(hUpdateUbTensor, gkLastUbTensor,
-                                                dstShapeGk, srcShapeGk, shareBufferGk_);
-                AscendC::PipeBarrier<PIPE_V>();
-                AscendC::Mul(calcUbTensor, calcUbTensor, hUpdateUbTensor,
-                             rowsThisTile * nActual);
-                AscendC::PipeBarrier<PIPE_V>();
+                ApplyRowScale(calcUbTensor, gkLastUbTensor, gkBrcbUbTensor,
+                              rowsThisTile, nActual);
                 AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
             }
 
@@ -370,7 +391,8 @@ private:
     AscendC::LocalTensor<float> gkLastUbTensor_pong;
     AscendC::LocalTensor<GElementInput> gkInputUbTensor_ping;
     AscendC::LocalTensor<GElementInput> gkInputUbTensor_pong;
-    AscendC::LocalTensor<uint8_t> shareBufferGk_;
+    AscendC::LocalTensor<float> gkBrcbUbTensor_ping;
+    AscendC::LocalTensor<float> gkBrcbUbTensor_pong;
 };
 }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
@@ -65,6 +65,8 @@ public:
         constexpr uint32_t PONG_BUF_1_OFFSET = 112 * 1024;
         constexpr uint32_t PONG_BUF_2_OFFSET = 128 * 1024;
         constexpr uint32_t PONG_BUF_3_OFFSET = 144 * 1024;
+        constexpr uint32_t PING_WIDE_IO_BUF_OFFSET = 16 * 1024;
+        constexpr uint32_t PONG_WIDE_IO_BUF_OFFSET = 24 * 1024;
         constexpr uint32_t PING_G_BUF_OFFSET = 160 * 1024;
         constexpr uint32_t PONG_G_BUF_OFFSET = 161 * 1024;
         constexpr uint32_t PING_G_SUB_BUF_OFFSET = 162 * 1024;
@@ -82,6 +84,7 @@ public:
         gInputUbTensor_ping = resource.ubBuf.template GetBufferByByte<GElementInput>(PING_G_SUB_BUF_OFFSET);
         vNewOutputUbTensor_ping = resource.ubBuf.template GetBufferByByte<VElementOutput>(PING_BUF_2_OFFSET);
         vNewDecayUbTensor_ping = resource.ubBuf.template GetBufferByByte<VElementOutput>(PING_BUF_2_OFFSET);
+        wideIoUbTensor_ping = resource.ubBuf.template GetBufferByByte<VElementOutput>(PING_WIDE_IO_BUF_OFFSET);
 
         uUbTensor_pong = resource.ubBuf.template GetBufferByByte<UElementInput>(PONG_BUF_2_OFFSET);
         wsUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_BUF_0_OFFSET);
@@ -90,8 +93,9 @@ public:
         gInputUbTensor_pong = resource.ubBuf.template GetBufferByByte<GElementInput>(PONG_G_SUB_BUF_OFFSET);
         vNewOutputUbTensor_pong = resource.ubBuf.template GetBufferByByte<VElementOutput>(PONG_BUF_2_OFFSET);
         vNewDecayUbTensor_pong = resource.ubBuf.template GetBufferByByte<VElementOutput>(PONG_BUF_2_OFFSET);
+        wideIoUbTensor_pong = resource.ubBuf.template GetBufferByByte<VElementOutput>(PONG_WIDE_IO_BUF_OFFSET);
 
-        shareBuffer_ = resource.ubBuf.template GetBufferByByte<uint8_t>(SHARE_BUF_OFFSET);
+        gBrcbUbTensor_ = resource.ubBuf.template GetBufferByByte<float>(SHARE_BUF_OFFSET);
 
     }
 
@@ -191,6 +195,38 @@ public:
     }
 
     CATLASS_DEVICE
+    void ApplyRowScale(
+        AscendC::LocalTensor<float> matrix,
+        AscendC::LocalTensor<float> rowScale,
+        uint32_t rowScaleOffset,
+        uint32_t rows,
+        uint32_t cols)
+    {
+        constexpr uint32_t FP32_PER_BLOCK = 8;
+        constexpr uint32_t FP32_PER_REPEAT = 64;
+        uint8_t rowStride = static_cast<uint8_t>(cols / FP32_PER_BLOCK);
+        AscendC::BinaryRepeatParams params(1, 1, 0, rowStride, rowStride, 1);
+        uint32_t localRow = 0;
+        while (localRow < rows) {
+            uint32_t scaleRow = rowScaleOffset + localRow;
+            uint32_t alignedScaleRow = scaleRow & ~(FP32_PER_BLOCK - 1);
+            uint32_t firstScaleLane = scaleRow - alignedScaleRow;
+            uint32_t rowsThisBlock = Min(FP32_PER_BLOCK - firstScaleLane, rows - localRow);
+            AscendC::Brcb(gBrcbUbTensor_, rowScale[alignedScaleRow], 1, {1, FP32_PER_BLOCK});
+            AscendC::PipeBarrier<PIPE_V>();
+            for (uint32_t col = 0; col < cols; col += FP32_PER_REPEAT) {
+                uint32_t count = Min(FP32_PER_REPEAT, cols - col);
+                uint32_t matrixOffset = localRow * cols + col;
+                AscendC::Mul(matrix[matrixOffset], matrix[matrixOffset],
+                             gBrcbUbTensor_[firstScaleLane * FP32_PER_BLOCK], count,
+                             rowsThisBlock, params);
+            }
+            AscendC::PipeBarrier<PIPE_V>();
+            localRow += rowsThisBlock;
+        }
+    }
+
+    CATLASS_DEVICE
     void operator()(
         AscendC::GlobalTensor<VElementOutput> vnewOutput,
         AscendC::GlobalTensor<VElementOutput> vnewdecayOutput,
@@ -245,15 +281,14 @@ public:
         AscendC::LocalTensor<GElementInput> gInputUbTensor = isPing ? gInputUbTensor_ping : gInputUbTensor_pong;
         AscendC::LocalTensor<VElementOutput> vNewOutputUbTensor = isPing ? vNewOutputUbTensor_ping : vNewOutputUbTensor_pong;
         AscendC::LocalTensor<VElementOutput> vNewDecayUbTensor = isPing ? vNewDecayUbTensor_ping : vNewDecayUbTensor_pong;
+        if (nvActual > 128) {
+            uUbTensor = isPing ? wideIoUbTensor_ping : wideIoUbTensor_pong;
+            vNewOutputUbTensor = isPing ? wideIoUbTensor_ping : wideIoUbTensor_pong;
+            vNewDecayUbTensor = isPing ? wideIoUbTensor_ping : wideIoUbTensor_pong;
+        }
 
         if (rowBegin < rowEnd && nvActual <= 128 && nvActual == inputStride) {
             uint32_t mActualThisSubBlock = rowEnd - rowBegin;
-            uint32_t gbrcRealStart = rowBegin & ~7;
-            uint32_t gbrcEffStart = rowBegin - gbrcRealStart;
-            uint32_t gbrcRealProcess = gbrcEffStart + mActualThisSubBlock;
-            uint32_t dstShape_[2] = {gbrcRealProcess, nvActual};
-            uint32_t srcShape_[2] = {gbrcRealProcess, 1};
-
             AscendC::GlobalTensor<VElementOutput> vnewOutputThisSubBlock = vnewOutput[rowBegin * inputStride];
             AscendC::GlobalTensor<UElementInput> uInputThisSubBlock = uInput[rowBegin * inputStride];
             AscendC::GlobalTensor<float> wsInputThisSubBlock = wsInput[rowBegin * nvActual];
@@ -279,16 +314,14 @@ public:
             AscendC::Sub<float>(wsUbTensor, calcUbTensor, wsUbTensor, mActualThisSubBlock * nvActual);
             AscendC::PipeBarrier<PIPE_V>();
 
-            AscendC::Broadcast<float, 2, 1>(calcUbTensor, gUbTensor[gbrcRealStart], dstShape_, srcShape_, shareBuffer_);
+            AscendC::Copy(calcUbTensor, wsUbTensor, mActualThisSubBlock * nvActual);
             AscendC::PipeBarrier<PIPE_V>();
+            ApplyRowScale(calcUbTensor, gUbTensor, rowBegin, mActualThisSubBlock, nvActual);
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
-
-            AscendC::Mul(calcUbTensor[gbrcEffStart * nvActual], wsUbTensor, calcUbTensor[gbrcEffStart * nvActual], mActualThisSubBlock * nvActual);
-            AscendC::PipeBarrier<PIPE_V>();
 
             uint32_t nvLoops = nvActual / FLOAT_NUM_PER_REPEAT;
             for (uint32_t nLoop = 0; nLoop < nvLoops; nLoop++) {
-                uint32_t castSrcOffset = gbrcEffStart * nvActual + nLoop * FLOAT_NUM_PER_REPEAT;
+                uint32_t castSrcOffset = nLoop * FLOAT_NUM_PER_REPEAT;
                 uint32_t castDstOffset = nLoop * mActualThisSubBlock * FLOAT_NUM_PER_REPEAT;
                 AscendC::Cast(vNewDecayUbTensor[castDstOffset], calcUbTensor[castSrcOffset], AscendC::RoundMode::CAST_RINT, FLOAT_NUM_PER_REPEAT, mActualThisSubBlock, {(uint16_t)mActualThisSubBlock, 1, 1, (uint8_t)(nvLoops * 8)});
             }
@@ -350,10 +383,6 @@ public:
             if (rowsThisTile > maxRowsThisTile) {
                 rowsThisTile = maxRowsThisTile;
             }
-            uint32_t gbrcRealStart = rowStart & ~7;
-            uint32_t gbrcRealProcess = alignExtra + rowsThisTile;
-            uint32_t dstShape_[2] = {gbrcRealProcess, nvActual};
-            uint32_t srcShape_[2] = {gbrcRealProcess, 1};
             uint32_t localRowStart = rowStart - rowBegin;
 
             AscendC::GlobalTensor<VElementOutput> vnewOutputThisTile = vnewOutput[rowStart * inputStride];
@@ -380,16 +409,15 @@ public:
             AscendC::Sub<float>(wsUbTensorThisTile, calcUbTensor, wsUbTensorThisTile, rowsThisTile * nvActual);
             AscendC::PipeBarrier<PIPE_V>();
 
-            AscendC::Broadcast<float, 2, 1>(calcUbTensor, gUbTensor[gbrcRealStart], dstShape_, srcShape_, shareBuffer_);
+            AscendC::Copy(calcUbTensor, wsUbTensorThisTile, rowsThisTile * nvActual);
             AscendC::PipeBarrier<PIPE_V>();
-            AscendC::Mul(calcUbTensor[alignExtra * nvActual], wsUbTensorThisTile, calcUbTensor[alignExtra * nvActual], rowsThisTile * nvActual);
-            AscendC::PipeBarrier<PIPE_V>();
+            ApplyRowScale(calcUbTensor, gUbTensor, rowStart, rowsThisTile, nvActual);
 
             uint32_t nvLoops = nvActual / FLOAT_NUM_PER_REPEAT;
             for (uint32_t nLoop = 0; nLoop < nvLoops; nLoop++) {
                 uint32_t castSrcOffset = nLoop * FLOAT_NUM_PER_REPEAT;
                 uint32_t castDstOffset = nLoop * rowsThisTile * FLOAT_NUM_PER_REPEAT;
-                AscendC::Cast(vNewDecayUbTensor[castDstOffset], calcUbTensor[alignExtra * nvActual + castSrcOffset], AscendC::RoundMode::CAST_RINT, FLOAT_NUM_PER_REPEAT, rowsThisTile, {(uint16_t)rowsThisTile, 1, 1, (uint8_t)(nvLoops * 8)});
+                AscendC::Cast(vNewDecayUbTensor[castDstOffset], calcUbTensor[castSrcOffset], AscendC::RoundMode::CAST_RINT, FLOAT_NUM_PER_REPEAT, rowsThisTile, {(uint16_t)rowsThisTile, 1, 1, (uint8_t)(nvLoops * 8)});
             }
 
             AscendC::PipeBarrier<PIPE_V>();
@@ -424,18 +452,20 @@ public:
 
         if constexpr (kGated) {
             uint32_t mActualThisSubBlock = rowEnd - rowBegin;
-            AscendC::GlobalTensor<VElementOutput> kInputThisSubBlock =
-                kInput[rowBegin * nkActual];
-            AscendC::GlobalTensor<VElementOutput> kDecayWorkspaceThisSubBlock =
-                kDecayWorkspace[rowBegin * nkActual];
-            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
-            CopyGmToUb(vNewOutputUbTensor, kInputThisSubBlock, mActualThisSubBlock,
-                       nkActual, nkActual);
-            AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(EVENT_ID1 + pingpongFlag);
-            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(EVENT_ID1 + pingpongFlag);
-            CopyUbToGm(kDecayWorkspaceThisSubBlock, vNewOutputUbTensor,
-                       mActualThisSubBlock, nkActual, nkActual);
-            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
+            for (uint32_t rowOffset = 0; rowOffset < mActualThisSubBlock; rowOffset += ROW_TILE) {
+                uint32_t rowsThisTile = Min(ROW_TILE, mActualThisSubBlock - rowOffset);
+                uint32_t row = rowBegin + rowOffset;
+                AscendC::GlobalTensor<VElementOutput> kInputThisTile = kInput[row * nkActual];
+                AscendC::GlobalTensor<VElementOutput> kDecayWorkspaceThisTile =
+                    kDecayWorkspace[row * nkActual];
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
+                CopyGmToUb(vNewOutputUbTensor, kInputThisTile, rowsThisTile, nkActual, nkActual);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(EVENT_ID1 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(EVENT_ID1 + pingpongFlag);
+                CopyUbToGm(kDecayWorkspaceThisTile, vNewOutputUbTensor,
+                           rowsThisTile, nkActual, nkActual);
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pingpongFlag);
+            }
             Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vec1Done);
         }
 
@@ -467,8 +497,10 @@ private:
     AscendC::LocalTensor<GElementInput> gInputUbTensor_pong;
     AscendC::LocalTensor<VElementOutput> vNewOutputUbTensor_pong;
     AscendC::LocalTensor<VElementOutput> vNewDecayUbTensor_pong;
+    AscendC::LocalTensor<VElementOutput> wideIoUbTensor_ping;
+    AscendC::LocalTensor<VElementOutput> wideIoUbTensor_pong;
 
-    AscendC::LocalTensor<uint8_t> shareBuffer_;
+    AscendC::LocalTensor<float> gBrcbUbTensor_;
 
 };
 }

--- a/torch_custom/fla_npu/test/test_npu_chunk_kda.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_kda.py
@@ -36,6 +36,7 @@ MODEL_SHAPE_CASE = {
 MODEL_SHAPE_DUMP = pathlib.Path(os.environ.get("KDA_MODEL_SHAPE_DUMP", "/tmp/kda_model_shape_case.pt"))
 STAT_SAMPLE_COUNT = int(os.environ.get("KDA_STAT_SAMPLE_COUNT", "262144"))
 REFERENCE_NUM_THREADS = int(os.environ.get("KDA_REFERENCE_NUM_THREADS", "16"))
+FWD_H_DETERMINISM_REPEATS = int(os.environ.get("FWD_H_DETERMINISM_REPEATS", "50"))
 
 
 def _device(device_id=None):
@@ -167,6 +168,28 @@ def _make_inputs(device, b=1, h=2, hv=2, t=64, kdim=128, vdim=128, dtype=torch.b
 
 def _assert_close(name, actual, expected, rtol=2e-3, atol=2e-3):
     torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=rtol, atol=atol, msg=name)
+
+
+def _snapshot_fwd_h_outputs(outputs):
+    torch.npu.synchronize()
+    snapshots = tuple(output.detach().cpu().contiguous() for output in outputs)
+    for name, output in zip(("h", "v_new", "final_state"), snapshots):
+        assert torch.isfinite(output.float()).all().item(), f"{name} contains NaN or Inf"
+    return snapshots
+
+
+def _assert_fwd_h_outputs_bitwise_equal(expected, actual, repeat):
+    for name, expected_output, actual_output in zip(
+        ("h", "v_new", "final_state"), expected, actual
+    ):
+        same_metadata = (
+            expected_output.shape == actual_output.shape
+            and expected_output.dtype == actual_output.dtype
+        )
+        same_bits = same_metadata and torch.equal(
+            expected_output.view(torch.uint8), actual_output.view(torch.uint8)
+        )
+        assert same_bits, f"repeat={repeat} output={name} is not bitwise deterministic"
 
 
 def _kda_gate_cumsum_reference(g, chunk_size, A_log=None, dt_bias=None, cu_seqlens=None,
@@ -1424,6 +1447,76 @@ def test_chunk_gdn_fwd_h_gk_only_matches_neutral_g():
     _assert_close("gk final_state formula", gk_only[2], state, rtol=2e-2, atol=2e-3)
 
 
+def test_chunk_gdn_fwd_h_a5_model_shape_is_bitwise_deterministic():
+    device = _device()
+    if device.type == "cpu":
+        return
+
+    torch.manual_seed(20260722)
+    batch, heads, seqlen, kdim, vdim = 1, 12, 4096, 128, 128
+    chunk_size = 64
+    cu_seqlens = (0, seqlen // 3, seqlen)
+    chunk_indices = []
+    for seq_idx, (seq_start, seq_end) in enumerate(
+        zip(cu_seqlens[:-1], cu_seqlens[1:])
+    ):
+        chunk_count = (seq_end - seq_start + chunk_size - 1) // chunk_size
+        for chunk_idx in range(chunk_count):
+            chunk_indices.extend((seq_idx, chunk_idx))
+    chunk_indices = tuple(chunk_indices)
+    assert len(cu_seqlens) == 3
+    assert len(chunk_indices) == 130
+
+    dtype = torch.bfloat16
+    k = (torch.randn(batch, heads, seqlen, kdim, dtype=dtype) * 0.04).to(device)
+    w = (torch.randn(batch, heads, seqlen, kdim, dtype=dtype) * 0.04).to(device)
+    u = (torch.randn(batch, heads, seqlen, vdim, dtype=dtype) * 0.04).to(device)
+    g = torch.zeros(batch, heads, seqlen, dtype=torch.float32, device=device)
+    raw_gk = -torch.rand(
+        batch, heads, seqlen, kdim, dtype=torch.float32
+    ) * 0.04
+    gk = torch.empty_like(raw_gk)
+    rcp_ln2 = 1.4426950408889634
+    for seq_start, seq_end in zip(cu_seqlens[:-1], cu_seqlens[1:]):
+        for chunk_start in range(seq_start, seq_end, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, seq_end)
+            gk[:, :, chunk_start:chunk_end] = torch.cumsum(
+                raw_gk[:, :, chunk_start:chunk_end] * rcp_ln2,
+                dim=2,
+            )
+    gk = gk.to(device)
+    initial_state = (
+        torch.randn(2, heads, kdim, vdim, dtype=torch.float32) * 0.01
+    ).to(device)
+
+    def run_fwd_h():
+        return fla_ascendc.chunk_gated_delta_rule_fwd_h(
+            k,
+            w,
+            u,
+            g=g,
+            gk=gk,
+            initial_state=initial_state,
+            output_final_state=True,
+            chunk_size=chunk_size,
+            save_new_value=True,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+
+    run_fwd_h()
+    torch.npu.synchronize()
+    expected = _snapshot_fwd_h_outputs(run_fwd_h())
+    assert [tuple(output.shape) for output in expected] == [
+        (1, 12, 65, 128, 128),
+        (1, 12, 4096, 128),
+        (2, 12, 128, 128),
+    ]
+    for repeat in range(1, FWD_H_DETERMINISM_REPEATS):
+        actual = _snapshot_fwd_h_outputs(run_fwd_h())
+        _assert_fwd_h_outputs_bitwise_equal(expected, actual, repeat)
+
+
 def _run_single_test_in_subprocess(name):
     subprocess.run([sys.executable, __file__, "--single-test", name], check=True)
 
@@ -1450,6 +1543,7 @@ if __name__ == "__main__":
     test_chunk_kda_fwd_varlen_sequence_count_capacity_rejected()
     test_chunk_kda_fwd_varlen_large_chunk_indices_not_prechecked()
     test_chunk_gdn_fwd_h_gk_only_matches_neutral_g()
+    test_chunk_gdn_fwd_h_a5_model_shape_is_bitwise_deterministic()
     test_chunk_kda_fwd_upper_triangle_dirty_zero()
     test_chunk_kda_fwd_vdim256_matches_reference()
     test_chunk_kda_fwd_chunk128_matches_reference()


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。
> - push 新 commit 后，旧 commit 的 CI 结果失效，需要重新触发。

## 关联 Issue / 背景

- 关联 Issue: Fixes #236
- 背景与目标: A5 上 `chunk_gated_delta_rule_fwd_h` 使用固定输入重复执行时，输出可能出现 NaN/Inf 或逐 bit 不一致；A3 未观察到相同问题。
- 本 PR 解决的问题: 修复 A5 arch35 epilogue 的 UB 地址重叠、宽 IO buffer 复用和行缩放流水问题，保证固定输入输出稳定。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: `chunk_gated_delta_rule_fwd_h`
- 涉及目录 / 文件:
  - `fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/epilogue/block/`
  - `torch_custom/fla_npu/test/test_npu_chunk_kda.py`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 无变化。
- 明确不包含的范围: 不包含 `chunk_kda_fwd`、PR228 的其他改动、op_host、tiling、op_api 和公共接口调整。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 不涉及 ABI 变化。

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

### 1. 编译验证

```sh
bash build.sh --pkg --soc=ascend910b \
  --vendor_name=fla_npu \
  --ops=chunk_gated_delta_rule_fwd_h -j1

bash build.sh --pkg --soc=ascend950 \
  --vendor_name=fla_npu \
  --ops=chunk_gated_delta_rule_fwd_h -j1
```

### 2. 修改算子 test 验证

```sh
python3 -m pytest -s -vv \
  torch_custom/fla_npu/test/test_npu_chunk_kda.py::test_chunk_gdn_fwd_h_gk_only_matches_neutral_g

FWD_H_DETERMINISM_REPEATS=50 python3 -m pytest -s -vv \
  torch_custom/fla_npu/test/test_npu_chunk_kda.py::test_chunk_gdn_fwd_h_a5_model_shape_is_bitwise_deterministic
```

通过标准:

- 小 shape 公式回归通过。
- 原始模型 shape 连续运行 50 次，三个输出均为 finite 且逐 bit 一致。

### 3. 整体 example ST 验证

A2 / A3 / A5 整体 Example ST 尚未执行；本次依据 A2 / A5 单算子原问题与跨平台回归结果合入。

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | `bash build.sh --pkg --soc=ascend910b --ops=chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu` | 未执行 | 改动仅涉及 arch35，待 CI 补齐 |
| A3 | `ascend910_93` | 未执行 | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu` | 未执行 | 改动仅涉及 arch35，待 CI 补齐 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0-beta.1 | `bash build.sh --pkg --soc=ascend910b --ops=chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu -j1` | 通过 | 四个 kernel 目标编译通过并成功生成 run 包 |
| A3 | `ascend910_93` | 未执行 | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu` | 未执行 | 改动仅涉及 arch35，待 CI 补齐 |
| A5 | `ascend950` | 9.1.0-beta.1 | `bash build.sh --pkg --soc=ascend950 --vendor_name=fla_npu --ops=chunk_gated_delta_rule_fwd_h -j1` | 通过 | 成功生成 run 包，日志无 ERROR / FAILED |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 -m pytest -s -vv ...::test_chunk_gdn_fwd_h_gk_only_matches_neutral_g` | 通过 | 小 shape 公式回归通过 |
| A2 | `ascend910b` | `FWD_H_DETERMINISM_REPEATS=50 python3 -m pytest -s -vv ...::test_chunk_gdn_fwd_h_a5_model_shape_is_bitwise_deterministic` | 通过 | 50 次输出 finite 且逐 bit 一致 |
| A3 | `ascend910_93` | 未执行 | 未执行 | 待 CI 补齐 |
| A5 | `ascend950` | `python3 -m pytest -s -vv ...::test_chunk_gdn_fwd_h_gk_only_matches_neutral_g` | 通过 | 小 shape 公式回归通过 |
| A5 | `ascend950` | `FWD_H_DETERMINISM_REPEATS=50 python3 -m pytest -s -vv ...::test_chunk_gdn_fwd_h_a5_model_shape_is_bitwise_deterministic` | 通过 | 50 次输出 finite 且逐 bit 一致 |

- 精度对比: 未修复 A5 产物使用相同固定输入复现 `h contains NaN or Inf`；修复后 50 次运行均通过。
- 性能对比: 未执行，本 PR 不提供性能结论。
- 边界 / 异常场景: 覆盖两条变长序列、65 个 chunk、BF16 输入、FP32 gate/state。
- 未覆盖风险: CANN 8.5 下的 A2、A3 和整体 Example ST 待 NPU CI 补齐。

模型 shape:

```text
[1,12,4096,128];
[1,12,4096,128];
[1,12,4096,128];
[1,12,4096];
[1,12,4096,128];
[2,12,128,128];
[3];
[130]
```

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐 |

- 端到端场景说明: GDN Example/ST。
- 与本 PR 修改算子的关联: 覆盖 `chunk_gated_delta_rule_fwd_h` 所在 GDN 调用链。
- 未覆盖原因及补充计划: 当前已完成 A2 / A5 单算子验证；A3 和整体 Example ST 待 NPU CI 补齐。

</details>

## 兼容性、风险与回退

- 兼容性说明: 不修改接口、shape、dtype、format 或返回值。
- 风险点: 修改仅作用于 A5 arch35 epilogue；需通过 NPU CI 补齐其他平台编译和端到端回归。
- 回退方案: 回退本 PR 提交即可恢复原实现。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 本 PR 只包含两个 A5 epilogue 文件和一个现有单算子测试文件。
- 公共接口与行为约束未变化，因此无需更新算子文档。
- A2 单算子编译、公式回归和 50 轮固定输入确定性测试已通过；A3 与整体 Example ST 仍待补齐。
