### PR TITLE
fix: 修复 solve_tri TND 尾块越界读取

### DIFF
--- a/fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/op_kernel/solve_tri_cube.h
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/op_kernel/solve_tri_cube.h
@@ -773,15 +773,39 @@ __aicore__ inline void SolveTriCube<MATRIX_SIZE, T>::LoadInputTile(int64_t gmOff
 {
     // MCH 路径：批量搬运所有对角 fractals
     // 使用 Nd2Nz 的 ndNum + srcNdMatrixStride 一次性搬运所有对角块
-    // validSize < MATRIX_SIZE 时为尾块，最后一个对角块如果不足 16x16，硬件自动补零
     ClearSlot(SLOT_INPUT);
     PipeBarrier<PIPE_MTE2>();
 
-    int32_t numDiagFracs = (static_cast<int32_t>(validSize) + FRAC - 1) / FRAC;
+    int32_t fullDiagFracs = static_cast<int32_t>(validSize) / FRAC;
+    int32_t tailSize = static_cast<int32_t>(validSize) % FRAC;
 
-    // 使用预计算的参数模板，只修改变化的字段
-    diagLoadParams_.ndNum = numDiagFracs;
-    DataCopy(l1_[SLOT_INPUT * L1_SLOT_ELEMS], inputGM_[gmOffset], diagLoadParams_);
+    if (fullDiagFracs > 0) {
+        // 使用预计算的参数模板批量搬运完整的 16x16 对角块。
+        diagLoadParams_.ndNum = fullDiagFracs;
+        DataCopy(l1_[SLOT_INPUT * L1_SLOT_ELEMS], inputGM_[gmOffset], diagLoadParams_);
+    }
+
+    if (tailSize > 0) {
+        // 尾部对角块只搬运实际有效区域。若仍按 16x16 搬运，最后一个
+        // TND 序列会越过输入末尾读取，并把相邻显存中的 NaN 带入矩阵求逆。
+        Nd2NzParams tailParams;
+        tailParams.ndNum = 1;
+        tailParams.nValue = tailSize;
+        tailParams.dValue = tailSize;
+        tailParams.srcDValue = static_cast<uint32_t>(rowStride_);
+        tailParams.srcNdMatrixStride = 0;
+        tailParams.dstNzNStride = 1;
+        tailParams.dstNzC0Stride = FRAC;
+        tailParams.dstNzMatrixStride = 0;
+
+        int32_t tailSrcOffset = fullDiagFracs * (FRAC * static_cast<int32_t>(rowStride_) + FRAC);
+        int32_t tailDstOffset = fullDiagFracs * (NUM_FRACS + 1) * FRAC_LEN;
+        DataCopy(
+            l1_[SLOT_INPUT * L1_SLOT_ELEMS + tailDstOffset],
+            inputGM_[gmOffset + tailSrcOffset],
+            tailParams);
+    }
+
     SetFlag<HardEvent::MTE2_MTE1>(EVT_MTE2_MTE1);
     WaitFlag<HardEvent::MTE2_MTE1>(EVT_MTE2_MTE1);
 }
@@ -1038,4 +1062,3 @@ __aicore__ inline void SolveTriCube<MATRIX_SIZE, T>::ProcessPartialTile(int64_t 
 }  // namespace NsSolveTri
 
 #endif  // SOLVE_TRI_CUBE_H
- 

--- a/fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/test/test.py
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/test/test.py
@@ -8,6 +8,7 @@ import torch
 import torch_npu
 import numpy as np
 import fla_npu
+from fla_npu.ops.ascendc import solve_tri
 
 torch.npu.utils.set_device(0)
 
@@ -93,6 +94,88 @@ def test_solve_tri(B, H, T, BT, dtype=torch.float16):
     return passed
 
 
+def generate_tnd_input(seq_lens, heads, chunk_size, dtype):
+    """Generate packed TND input and a float32 inverse reference."""
+    total_tokens = sum(seq_lens)
+    x = torch.zeros(total_tokens, heads, chunk_size, dtype=dtype)
+    golden = torch.zeros(total_tokens, heads, chunk_size, dtype=torch.float32)
+    cu_seqlens = [0]
+    chunk_indices = []
+
+    bos = 0
+    for seq_idx, seq_len in enumerate(seq_lens):
+        for chunk_idx, chunk_start in enumerate(range(0, seq_len, chunk_size)):
+            valid_size = min(chunk_size, seq_len - chunk_start)
+            chunk_indices.extend([seq_idx, chunk_idx])
+            for head_idx in range(heads):
+                block = torch.tril(
+                    torch.randn(valid_size, valid_size, dtype=torch.float32) * 0.01,
+                    diagonal=-1,
+                )
+                row_start = bos + chunk_start
+                x[row_start:row_start + valid_size, head_idx, :valid_size] = block.to(dtype)
+                golden[row_start:row_start + valid_size, head_idx, :valid_size] = torch.linalg.inv(
+                    torch.eye(valid_size, dtype=torch.float32) + block
+                )
+        bos += seq_len
+        cu_seqlens.append(bos)
+
+    return x, golden, cu_seqlens, chunk_indices
+
+
+def test_solve_tri_tnd_tail(chunk_size, tail_size, dtype):
+    """Verify a non-16-aligned final TND chunk without reading past the input."""
+    seq_lens = [chunk_size, tail_size]
+    heads = 2
+    x, golden, cu_seqlens, chunk_indices = generate_tnd_input(
+        seq_lens,
+        heads,
+        chunk_size,
+        dtype,
+    )
+
+    # Keep NaNs immediately after the logical input. A tail loader that rounds the
+    # final diagonal block up to 16x16 will read these guard rows and poison output.
+    backing = torch.full(
+        (x.shape[0] + 16, heads, chunk_size),
+        float("nan"),
+        dtype=dtype,
+        device="npu",
+    )
+    x_npu = backing[:x.shape[0]]
+    x_npu.copy_(x.npu())
+    assert x_npu.is_contiguous()
+
+    out = solve_tri(
+        x_npu,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        layout="tnd",
+    ).float().cpu()
+
+    max_diff = 0.0
+    all_finite = True
+    bos = 0
+    for seq_len in seq_lens:
+        for chunk_start in range(0, seq_len, chunk_size):
+            valid_size = min(chunk_size, seq_len - chunk_start)
+            row_start = bos + chunk_start
+            actual_block = out[row_start:row_start + valid_size, :, :valid_size]
+            golden_block = golden[row_start:row_start + valid_size, :, :valid_size]
+            all_finite = all_finite and bool(torch.isfinite(actual_block).all().item())
+            max_diff = max(max_diff, float((actual_block - golden_block).abs().max().item()))
+        bos += seq_len
+
+    tolerance = 5e-3 if dtype == torch.float16 else 2e-2
+    passed = all_finite and max_diff <= tolerance
+    status = "PASS" if passed else "FAIL"
+    print(
+        f"  [{status}] TND chunk_size={chunk_size}, tail_size={tail_size}, dtype={dtype}, "
+        f"finite={all_finite}, max_diff={max_diff:.6f}, tolerance={tolerance:.6f}"
+    )
+    return passed
+
+
 def main():
     print("=" * 60)
     print("SolveTri NPU Test")
@@ -112,6 +195,16 @@ def main():
     results = []
     for B, H, T, BT in test_cases:
         passed = test_solve_tri(B, H, T, BT)
+        results.append(passed)
+
+    tnd_tail_cases = [
+        (64, 39, torch.bfloat16),
+        (64, 63, torch.float16),
+        (128, 95, torch.bfloat16),
+        (128, 127, torch.float16),
+    ]
+    for chunk_size, tail_size, dtype in tnd_tail_cases:
+        passed = test_solve_tri_tnd_tail(chunk_size, tail_size, dtype)
         results.append(passed)
 
     print("\n" + "=" * 60)


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

已知悉：当前 head commit 需要重新触发 NPU CI，并在合入前满足分支保护要求。

## 关联 Issue / 背景

- 关联 Issue: resolves #242
- 背景与目标: 修复 TND 非 16 对齐尾块在矩阵求逆阶段偶发产生 NaN 的问题。
- 本 PR 解决的问题: `solve_tri` 尾部对角块按完整 16×16 区域搬运，可能读取有效输入范围之外的数据。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `solve_tri`
- 涉及目录 / 文件:
  - `fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/op_kernel/solve_tri_cube.h`
  - `fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/test/test.py`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [x] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 支持范围不变；覆盖 TND、FP16/BF16、chunk size 64/128 以及非 16 对齐尾块。
- 明确不包含的范围: 不修改公共接口、Tiling、InferShape、Triton 实现或调用语义。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要对应 owner 检视通过
- ABI 不兼容风险说明: 无。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | - | - | 未执行 | 本次验证环境为 CANN 9.1.0-beta.1 |
| A3 | `ascend910_93` | - | - | 未执行 | 待 NPU CI 补充 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0-beta.1 | `FLA_NPU_SOC=ascend910b python3 -m pip wheel --no-build-isolation --no-deps . -w dist` | 通过 | 当前 v26.6.0 源码全量编译成功 |
| A3 | `ascend910_93` | - | - | 未执行 | 待 NPU CI 补充 |
| A5 | `ascend950` | - | - | 未执行 | 待 NPU CI 补充 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 fla/ops/ascendc/gdn/recurrent_gdn/solve_tri/test/test.py` | 通过 | 11/11 通过 |
| A3 | `ascend910_93` | - | 未执行 | 待 NPU CI 补充 |
| A5 | `ascend950` | - | 未执行 | 待 NPU CI 补充 |

- 精度对比: FP16/BF16 尾块均满足既有测试阈值。
- 性能对比: 未单独执行性能测试；16 对齐路径保持原批量搬运，非对齐路径仅增加一次尾块有效区域搬运。
- 边界 / 异常场景: 使用 NaN guard 覆盖非 16 对齐的最终 TND 尾块；补充多种 chunk size 和 dtype。
- 未覆盖风险: A3、A5 待 NPU CI 补充。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 2 --cases-file ci/example_st_cases.json` | 通过 | 4/4 用例精度通过，退出码 0 |
| A3 | `ascend910_93` | - | 未执行 | 待 NPU CI 补充 |
| A5 | `ascend950` | - | 未执行 | 待 NPU CI 补充 |

- 端到端场景说明: 覆盖 dense、TND、FP16/BF16、输出与梯度精度。
- 与本 PR 修改算子的关联: GDR 前向矩阵求逆阶段调用 `solve_tri`。
- 未覆盖原因及补充计划: 当前仅完成 A2 验证，A3/A5 由 NPU CI 补充。

</details>

## 兼容性、风险与回退

- 兼容性说明: 公共接口和支持范围不变。
- 风险点: 非对齐尾块采用单独的有效区域搬运参数，需要关注不同 chunk size 下的 NZ 目标偏移。
- 回退方案: 回退本 PR 对应提交。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、稳定性和回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已检查相关 README 和算子说明，本次不改变公开接口或支持约束，无需更新
- [x] PR 标题已使用合适类型标签
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

原问题参数追加执行 200 轮，200 次前向输出和 1000 份梯度结果均保持有限；结合此前验证累计执行 250 轮，无 fallback 或运行时异常，输出及梯度 MD5 全程一致。

使用实际加载了 sanitizer 版本 `SolveTri` kernel 的 memcheck 验证，未发现 GM、L1 或 UB 越界访问。
