### PR TITLE
GDN AscendC 优化

### DIFF
--- a/fla/ops/ascendc/common/kernel_utils/block/block_mmad_pingpong_tla_multi.hpp
+++ b/fla/ops/ascendc/common/kernel_utils/block/block_mmad_pingpong_tla_multi.hpp
@@ -199,6 +199,20 @@ public:
         }
     }
 
+    CATLASS_DEVICE
+    void SkipNextADataCopy()
+    {
+        skipNextADataCopy = true;
+    }
+
+    CATLASS_DEVICE
+    void UseExternalL1ATensor(AscendC::LocalTensor<ElementA> l1ATensor)
+    {
+        externalL1ATensor = l1ATensor;
+        useExternalL1ATensor = true;
+        skipNextADataCopy = true;
+    }
+
     /// Construct
     CATLASS_DEVICE
     BlockMmadTla(Arch::Resource<ArchTag> &resource, uint32_t l1BufAddrStart = 0)
@@ -356,6 +370,11 @@ public:
         uint32_t mBlockActual = actualShape.m();
         uint32_t kBlockActual = actualShape.k();
         uint32_t nBlockActual = actualShape.n();
+        bool useExternalL1AThisCall = useExternalL1ATensor && kBlockActual <= L1_TILE_K;
+        if (useExternalL1ATensor && !useExternalL1AThisCall) {
+            useExternalL1ATensor = false;
+            skipNextADataCopy = false;
+        }
 
         uint32_t mL1Actual = mBlockActual;
         if constexpr (std::is_same_v<ArchTag, Arch::AtlasA2>) {
@@ -373,9 +392,13 @@ public:
         uint32_t kL1Actual = min(kBlockActual, L1_TILE_K);
         // load first matrix A tile from GM to L1
         AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEventList[l1AListId]);
-        auto tensorL1A = tla::MakeTensor(l1ATensorList[l1AListId], L1A_LAYOUT, Arch::PositionL1{});
+        auto tensorL1A = tla::MakeTensor(
+            useExternalL1AThisCall ? externalL1ATensor : l1ATensorList[l1AListId],
+            L1A_LAYOUT, Arch::PositionL1{});
         auto tensorTileA = GetTileA(tensorA, 0, 0, mBlockActual, kL1Actual);
-        if constexpr (ENABLE_L1_RESIDENT) {
+        if (skipNextADataCopy) {
+            skipNextADataCopy = false;
+        } else if constexpr (ENABLE_L1_RESIDENT) {
             // If the currently loaded GM pointer and block coordinates are the same as the last loaded ones,
             // skip this loading.
             if (lastAddrA[l1AListId] != tensorTileA.data().GetPhyAddr()
@@ -431,7 +454,8 @@ public:
         // main loop
         uint32_t kL1Loop = CeilDiv<L1_TILE_K>(kBlockActual);
         for (uint32_t kL1Idx = 0; kL1Idx < kL1Loop; kL1Idx++) {
-            uint32_t l1AListIdNext = (l1AListId + 1 < L1A_STAGES) ? (l1AListId + 1) : 0;
+            uint32_t l1AListIdNext = useExternalL1AThisCall ? l1AListId :
+                ((l1AListId + 1 < L1A_STAGES) ? (l1AListId + 1) : 0);
             uint32_t l1BListIdNext = (l1BListId + 1 < L1B_STAGES) ? (l1BListId + 1) : 0;
             uint32_t kL1ActualNext{0};
             // preload next tile from GM to L1
@@ -489,7 +513,7 @@ public:
             }
 
             // Get L1 tensor for current stage
-            auto l1ATensor = l1ATensorList[l1AListId];
+            auto l1ATensor = useExternalL1AThisCall ? externalL1ATensor : l1ATensorList[l1AListId];
             auto l1BTensor = l1BTensorList[l1BListId];
             tensorL1A = tla::MakeTensor(l1ATensor, L1A_LAYOUT, Arch::PositionL1{});
             tensorL1B = tla::MakeTensor(l1BTensor, L1B_LAYOUT, Arch::PositionL1{});
@@ -613,10 +637,13 @@ public:
                     l0AListId = (l0AListId + 1 < L0A_STAGES) ? (l0AListId + 1) : 0;
                 }
             }
-            l1AListId = l1AListIdNext;
+            if (!useExternalL1AThisCall) {
+                l1AListId = l1AListIdNext;
+            }
             l1BListId = l1BListIdNext;
             kL1Actual = kL1ActualNext;
         }
+        useExternalL1ATensor = false;
 
         // copy block out
         if constexpr (!ENABLE_UNIT_FLAG) {
@@ -668,6 +695,9 @@ protected:
     uint32_t l0AListId{0};
     uint32_t l0BListId{0};
     uint32_t l0CListId{0};
+    bool skipNextADataCopy{false};
+    bool useExternalL1ATensor{false};
+    AscendC::LocalTensor<ElementA> externalL1ATensor;
 
     TileMmad tileMmad;
     CopyL1ToL0A copyL1ToL0A;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdo_output.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdo_output.hpp
@@ -1,0 +1,457 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDO_OUTPUT_HPP
+#define CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDO_OUTPUT_HPP
+
+#include "kernel_operator.h"
+#include "catlass/catlass.hpp"
+#include "catlass/arch/resource.hpp"
+#include "../gdn_fwd_o_epilogue_policies.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/matrix_coord.hpp"
+#include "catlass/epilogue/tile/tile_copy.hpp"
+
+namespace Catlass::Epilogue::Block {
+
+static __simd_vf__ inline void GdnFwdoOutputMulAddScaleVf(
+    __ubuf__ float* dst,
+    __ubuf__ float* attn,
+    __ubuf__ float* hidden,
+    __ubuf__ float* gate,
+    float scale,
+    uint32_t elementCount)
+{
+    AscendC::Reg::RegTensor<float> attnReg0;
+    AscendC::Reg::RegTensor<float> attnReg1;
+    AscendC::Reg::RegTensor<float> hiddenReg0;
+    AscendC::Reg::RegTensor<float> hiddenReg1;
+    AscendC::Reg::RegTensor<float> gateReg0;
+    AscendC::Reg::RegTensor<float> gateReg1;
+    AscendC::Reg::RegTensor<float> dstReg0;
+    AscendC::Reg::RegTensor<float> dstReg1;
+    constexpr uint32_t ELEMS_PER_REG = AscendC::VECTOR_REG_WIDTH / sizeof(float);
+    constexpr uint32_t ELEMS_PER_DUAL = ELEMS_PER_REG * 2;
+    auto maskFull = AscendC::Reg::CreateMask<float, AscendC::Reg::MaskPattern::ALL>();
+    uint16_t dualRepeats = static_cast<uint16_t>(elementCount / ELEMS_PER_DUAL);
+
+    for (uint16_t i = 0; i < dualRepeats; ++i) {
+        uint32_t offset = static_cast<uint32_t>(i) * ELEMS_PER_DUAL;
+        AscendC::Reg::LoadAlign<float, AscendC::Reg::LoadDist::DIST_DINTLV_B32>(attnReg0, attnReg1, attn + offset);
+        AscendC::Reg::LoadAlign<float, AscendC::Reg::LoadDist::DIST_DINTLV_B32>(hiddenReg0, hiddenReg1, hidden + offset);
+        AscendC::Reg::LoadAlign<float, AscendC::Reg::LoadDist::DIST_DINTLV_B32>(gateReg0, gateReg1, gate + offset);
+        AscendC::Reg::Mul(dstReg0, hiddenReg0, gateReg0, maskFull);
+        AscendC::Reg::Mul(dstReg1, hiddenReg1, gateReg1, maskFull);
+        AscendC::Reg::Add(dstReg0, attnReg0, dstReg0, maskFull);
+        AscendC::Reg::Add(dstReg1, attnReg1, dstReg1, maskFull);
+        AscendC::Reg::Muls(dstReg0, dstReg0, scale, maskFull);
+        AscendC::Reg::Muls(dstReg1, dstReg1, scale, maskFull);
+        AscendC::Reg::StoreAlign<float, AscendC::Reg::StoreDist::DIST_INTLV_B32>(
+            dst + offset, dstReg0, dstReg1, maskFull);
+    }
+
+}
+
+template <
+    class HOutputType_,
+    class GInputType_,
+    class AInputType_,
+    class HInputType_
+>
+class BlockEpilogue <
+    EpilogueAtlasGDNFwdOOutput,
+    HOutputType_,
+    GInputType_,
+    AInputType_,
+    HInputType_
+> {
+public:
+    // Type aliases
+    using DispatchPolicy = EpilogueAtlasGDNFwdOOutput;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+
+    using HElementOutput = typename HOutputType_::Element;
+    using GElementInput = typename GInputType_::Element;
+    using AElementInput = typename AInputType_::Element;
+    using HElementInput = typename HInputType_::Element;
+
+    // using CopyGmToUbInput = Tile::CopyGm2Ub<ArchTag, InputType_>;
+    // using CopyUbToGmOutput = Tile::CopyUb2Gm<ArchTag, OutputType_>;
+
+    static constexpr uint32_t HALF_ELENUM_PER_BLK = 16;
+    static constexpr uint32_t FLOAT_ELENUM_PER_BLK = 8;
+    static constexpr uint32_t HALF_ELENUM_PER_VECCALC = 128;
+    static constexpr uint32_t FLOAT_ELENUM_PER_VECCALC = 64;
+    static constexpr uint32_t UB_TILE_SIZE = 16384;  // 64 * 128 * 2B
+    static constexpr uint32_t UB_LINE_SIZE = 512;   // 128 * 2 * 2B
+    static constexpr uint32_t HALF_ELENUM_PER_LINE = 256;    // 128 * 2
+    static constexpr uint32_t FLOAT_ELENUM_PER_LINE = 128;   // 128
+    static constexpr uint32_t MULTIPLIER = 2;
+
+    CATLASS_DEVICE
+    BlockEpilogue(Arch::Resource<ArchTag> &resource)
+    {
+        constexpr uint32_t BASE = 0;
+        constexpr uint32_t MASK_UB_TENSOR_SIZE = 32 * UB_LINE_SIZE;
+        constexpr uint32_t GBRCLEFTCAST_UB_TENSOR_SIZE = 40 * UB_LINE_SIZE;
+        constexpr uint32_t GBRCUP_UB_TENSOR_SIZE = 32 * UB_LINE_SIZE;
+        constexpr uint32_t FLOAT_UB_TENSOR_SIZE = 32 * UB_LINE_SIZE;
+        constexpr uint32_t HALF_UB_TENSOR_SIZE = 16 * UB_LINE_SIZE;
+        constexpr uint32_t G_HALF_UB_TENSOR_SIZE = 2 * UB_LINE_SIZE;
+        constexpr uint32_t G_FLOAT_UB_TENSOR_SIZE = 2 * UB_LINE_SIZE;
+        constexpr uint32_t UB_WORK_SLOT_BYTES = 64 * 128 * sizeof(float);
+
+        constexpr uint32_t MASK_UB_TENSOR_OFFSET = BASE;
+        constexpr uint32_t GBRCLEFTCAST_UB_TENSOR_OFFSET = MASK_UB_TENSOR_OFFSET + MASK_UB_TENSOR_SIZE;
+        constexpr uint32_t GBRCUP_UB_TENSOR_OFFSET = GBRCLEFTCAST_UB_TENSOR_OFFSET + GBRCLEFTCAST_UB_TENSOR_SIZE;
+        constexpr uint32_t GCOMP_UB_TENSOR_OFFSET = GBRCUP_UB_TENSOR_OFFSET + GBRCUP_UB_TENSOR_SIZE;
+        constexpr uint32_t SHARE_UB_TENSOR_OFFSET = GCOMP_UB_TENSOR_OFFSET + G_FLOAT_UB_TENSOR_SIZE;
+
+        maskUbTensor = resource.ubBuf.template GetBufferByByte<float>(MASK_UB_TENSOR_OFFSET);
+        gbrcLeftcastUbTensor = resource.ubBuf.template GetBufferByByte<float>(GBRCLEFTCAST_UB_TENSOR_OFFSET);
+        gbrcUpUbTensor = resource.ubBuf.template GetBufferByByte<float>(GBRCUP_UB_TENSOR_OFFSET);
+        gcompUbTensor = resource.ubBuf.template GetBufferByByte<float>(GCOMP_UB_TENSOR_OFFSET);
+        shareUbTensor = resource.ubBuf.template GetBufferByByte<uint8_t>(SHARE_UB_TENSOR_OFFSET);
+
+        constexpr uint32_t G_UB_TENSOR_OFFSET_PING = SHARE_UB_TENSOR_OFFSET + FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t G_HALF_UB_TENSOR_OFFSET_PING = G_UB_TENSOR_OFFSET_PING + G_FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t A_UB_TENSOR_OFFSET_PING = 71 * 1024;
+        constexpr uint32_t H_UB_TENSOR_OFFSET_PING = A_UB_TENSOR_OFFSET_PING + UB_WORK_SLOT_BYTES;
+        constexpr uint32_t A_UB_TENSOR_OFFSET_PONG = H_UB_TENSOR_OFFSET_PING + UB_WORK_SLOT_BYTES;
+        constexpr uint32_t H_UB_TENSOR_OFFSET_PONG = A_UB_TENSOR_OFFSET_PONG + UB_WORK_SLOT_BYTES;
+        constexpr uint32_t OUT_UB_TENSOR_OFFSET_PING = H_UB_TENSOR_OFFSET_PONG + UB_WORK_SLOT_BYTES;
+        constexpr uint32_t OUT_HALF_UB_TENSOR_OFFSET_PING = OUT_UB_TENSOR_OFFSET_PING + FLOAT_UB_TENSOR_SIZE;
+
+        gUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(G_UB_TENSOR_OFFSET_PING);
+        gUbFPTensorPing = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PING);
+        gUbBFTensorPing = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PING);
+        aUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(A_UB_TENSOR_OFFSET_PING);
+        hUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(H_UB_TENSOR_OFFSET_PING);
+        outUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(OUT_UB_TENSOR_OFFSET_PING);
+        outUbFPTensorPing = resource.ubBuf.template GetBufferByByte<HElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PING);
+        outUbBFTensorPing = resource.ubBuf.template GetBufferByByte<HElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PING);
+
+        constexpr uint32_t G_UB_TENSOR_OFFSET_PONG = G_UB_TENSOR_OFFSET_PING;
+        constexpr uint32_t G_HALF_UB_TENSOR_OFFSET_PONG = G_UB_TENSOR_OFFSET_PONG + G_FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t OUT_UB_TENSOR_OFFSET_PONG = OUT_UB_TENSOR_OFFSET_PING;
+        constexpr uint32_t OUT_HALF_UB_TENSOR_OFFSET_PONG = OUT_UB_TENSOR_OFFSET_PONG + FLOAT_UB_TENSOR_SIZE;
+
+        gUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(G_UB_TENSOR_OFFSET_PONG);
+        gUbFPTensorPong = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PONG);
+        gUbBFTensorPong = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PONG);
+        aUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(A_UB_TENSOR_OFFSET_PONG);
+        hUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(H_UB_TENSOR_OFFSET_PONG);
+        outUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(OUT_UB_TENSOR_OFFSET_PONG);
+        outUbFPTensorPong = resource.ubBuf.template GetBufferByByte<HElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PONG);
+        outUbBFTensorPong = resource.ubBuf.template GetBufferByByte<HElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PONG);
+    }
+    CATLASS_DEVICE
+    ~BlockEpilogue()
+    {}
+
+    CATLASS_DEVICE
+    void CopyOutputToGm(
+        AscendC::GlobalTensor<HElementOutput> output,
+        AscendC::LocalTensor<HElementOutput> outputUb,
+        uint32_t rows,
+        uint32_t cols,
+        uint32_t outputStride)
+    {
+        if (cols == outputStride) {
+            AscendC::DataCopy(output, outputUb, rows * cols);
+            return;
+        }
+        AscendC::DataCopyExtParams outputParams{
+            static_cast<uint16_t>(rows),
+            static_cast<uint32_t>(cols * sizeof(HElementOutput)),
+            0,
+            static_cast<uint32_t>((outputStride - cols) * sizeof(HElementOutput)),
+            0};
+        AscendC::DataCopyPad(output, outputUb, outputParams);
+    }
+
+    CATLASS_DEVICE
+    void operator()(
+        AscendC::GlobalTensor<HElementOutput> hOutput,
+        AscendC::GlobalTensor<GElementInput> gInput,
+        AscendC::LocalTensor<AElementInput> attnInput,
+        AscendC::LocalTensor<HElementInput> hInput,
+        float scale,
+        uint32_t chunkSize,
+        uint32_t kHeadDim,
+        uint32_t vBlockDim,
+        uint32_t vHeadDim,
+        uint32_t &pingpongFlag,
+        uint32_t batchIdx, uint32_t headIdx, uint32_t chunkIdx
+        )
+    {
+        uint32_t mActual = chunkSize;
+        uint32_t nActual = vBlockDim;
+        uint32_t outputStride = vHeadDim;
+        uint32_t alignedM = CeilDiv(nActual, 8) * 8;
+        uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
+        uint32_t subBlockNum = AscendC::GetSubBlockNum();
+        uint32_t blockIdx = AscendC::GetBlockIdx();
+        uint32_t mActualPerSubBlock = CeilDiv(mActual, subBlockNum);
+        uint32_t mActualThisSubBlock = (subBlockIdx == 0) ? mActualPerSubBlock : (mActual - mActualPerSubBlock);
+        uint32_t mOffset = subBlockIdx * mActualPerSubBlock;
+        uint32_t nOffset = 0;
+        int64_t offsetA = mOffset * nActual + nOffset;
+
+        uint32_t gbrcStart, gbrcRealStart, gbrcRealEnd, gbrcRealProcess, gbrcEffStart, gbrcEffEnd, mulsRemain, mulsRemainIdx;
+        if(mActualThisSubBlock <= 32)
+        {
+            if(subBlockIdx == 0)
+            {
+                gbrcStart = 0;
+                gbrcRealStart = 0;
+                gbrcRealProcess = mActualThisSubBlock;
+            }
+            else
+            {
+                gbrcStart = mActualPerSubBlock;
+                gbrcRealStart = gbrcStart & ~7;
+                gbrcRealProcess = mActual - gbrcRealStart;
+            }
+            gbrcEffStart = gbrcStart - gbrcRealStart;
+            uint32_t dstShape_[2] = {gbrcRealProcess, nActual};
+            uint32_t srcShape_[2] = {gbrcRealProcess, 1};
+
+            AscendC::ResetMask();
+            AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
+            AscendC::GlobalTensor<HElementOutput> hOutputThisSubBlock = hOutput[gbrcStart * outputStride];
+
+            AscendC::DataCopyParams gfloatUbParams{1, (uint16_t)(mActual*sizeof(float)), 0, 0};
+            AscendC::DataCopyParams ghalfUbParams{1, (uint16_t)(mActual*sizeof(half)), 0, 0};
+            AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
+
+            AscendC::LocalTensor<float> aUbTensor = (pingpongFlag == 0) ? aUbTensorPing : aUbTensorPong;
+            AscendC::LocalTensor<float> hUbTensor = (pingpongFlag == 0) ? hUbTensorPing : hUbTensorPong;
+            AscendC::LocalTensor<float> outUbTensor = (pingpongFlag == 0) ? outUbTensorPing : outUbTensorPong;
+            AscendC::LocalTensor<HElementOutput> outUbFPTensor = (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
+            AscendC::LocalTensor<HElementOutput> outUbBFTensor = (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
+            AscendC::LocalTensor<float> gUbTensor = (pingpongFlag == 0) ? gUbTensorPing : gUbTensorPong;
+            AscendC::LocalTensor<GElementInput> gUbFPTensor = (pingpongFlag == 0) ? gUbFPTensorPing : gUbFPTensorPong;
+            AscendC::LocalTensor<GElementInput> gUbBFTensor = (pingpongFlag == 0) ? gUbBFTensorPing : gUbBFTensorPong;
+
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+            if constexpr(std::is_same<GElementInput, float>::value) {
+                AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gfloatUbParams, gUbPadParams);
+            } else {
+                AscendC::DataCopyPad(gUbFPTensor, gInputThisSubBlock, ghalfUbParams, gUbPadParams);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            if constexpr(!std::is_same<GElementInput, float>::value) {
+                AscendC::Cast(gUbTensor, gUbFPTensor, AscendC::RoundMode::CAST_NONE, mActual);
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+            AscendC::Copy(gcompUbTensor, gUbTensor, 64, 2, {1, 1, 8, 8});
+            AscendC::PipeBarrier<PIPE_V>();
+
+
+            AscendC::Exp(gcompUbTensor, gcompUbTensor, mActual);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gcompUbTensor[gbrcRealStart], dstShape_, srcShape_, shareUbTensor);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            __ubuf__ float* outAddr = (__ubuf__ float*)outUbTensor.GetPhyAddr();
+            __ubuf__ float* attnAddr = (__ubuf__ float*)aUbTensor.GetPhyAddr();
+            __ubuf__ float* hiddenAddr = (__ubuf__ float*)hUbTensor.GetPhyAddr();
+            __ubuf__ float* gateAddr =
+                (__ubuf__ float*)gbrcLeftcastUbTensor[gbrcEffStart * nActual].GetPhyAddr();
+            constexpr uint32_t VF_DUAL_ELEMENTS = 2 * AscendC::VECTOR_REG_WIDTH / sizeof(float);
+            uint32_t totalElements = mActualThisSubBlock * nActual;
+            uint32_t vfElements = totalElements / VF_DUAL_ELEMENTS * VF_DUAL_ELEMENTS;
+            if (vfElements != 0) {
+                AscendC::VF_CALL<GdnFwdoOutputMulAddScaleVf>(
+                    outAddr, attnAddr, hiddenAddr, gateAddr, (float)scale, vfElements);
+            }
+            uint32_t tailElements = totalElements - vfElements;
+            if (tailElements != 0) {
+                AscendC::Mul(outUbTensor[vfElements], hUbTensor[vfElements],
+                    gbrcLeftcastUbTensor[gbrcEffStart * nActual + vfElements], tailElements);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Add(outUbTensor[vfElements], aUbTensor[vfElements],
+                    outUbTensor[vfElements], tailElements);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Muls(outUbTensor[vfElements], outUbTensor[vfElements], (float)scale, tailElements);
+            }
+            AscendC::PipeBarrier<PIPE_V>();
+            if(std::is_same<HElementOutput, half>::value)
+            {
+                AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nActual);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                CopyOutputToGm(hOutputThisSubBlock, outUbFPTensor, mActualThisSubBlock, nActual, outputStride);
+            }
+            else
+            {
+                AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                CopyOutputToGm(hOutputThisSubBlock, outUbBFTensor, mActualThisSubBlock, nActual, outputStride);
+            }
+        }
+        else
+        {
+            AscendC::ResetMask();
+            AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
+
+            AscendC::DataCopyParams gfloatUbParams{1, (uint16_t)(mActual*sizeof(float)), 0, 0};
+            AscendC::DataCopyParams ghalfUbParams{1, (uint16_t)(mActual*sizeof(half)), 0, 0};
+            AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
+
+            AscendC::LocalTensor<float> gUbTensor = (pingpongFlag == 0) ? gUbTensorPing : gUbTensorPong;
+            AscendC::LocalTensor<GElementInput> gUbFPTensor = (pingpongFlag == 0) ? gUbFPTensorPing : gUbFPTensorPong;
+            AscendC::LocalTensor<GElementInput> gUbBFTensor = (pingpongFlag == 0) ? gUbBFTensorPing : gUbBFTensorPong;
+
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+            if constexpr(std::is_same<GElementInput, float>::value) {
+                AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gfloatUbParams, gUbPadParams);
+            } else {
+                AscendC::DataCopyPad(gUbFPTensor, gInputThisSubBlock, ghalfUbParams, gUbPadParams);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            if constexpr(!std::is_same<GElementInput, float>::value) {
+                AscendC::Cast(gUbTensor, gUbFPTensor, AscendC::RoundMode::CAST_NONE, mActual);
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+            AscendC::Copy(gcompUbTensor, gUbTensor, 64, 2, {1, 1, 8, 8});
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Exp(gcompUbTensor, gcompUbTensor, mActual);
+            AscendC::PipeBarrier<PIPE_V>();
+            uint32_t mActualPerStage = CeilDiv(mActualThisSubBlock, 2);
+            uint32_t mActualThisStage = 0;
+            for(uint32_t stage = 0; stage < 2; stage++)
+            {
+                if(stage == 0) mActualThisStage = mActualPerStage;
+                else mActualThisStage = mActualThisSubBlock - mActualPerStage;
+
+                if(subBlockIdx == 0 && stage == 0)
+                {
+                    gbrcStart = 0;
+                    gbrcRealStart = 0;
+                    gbrcRealProcess = mActualThisStage;
+                }
+                else if(subBlockIdx == 0 && stage == 1)
+                {
+                    gbrcStart = mActualPerStage;
+                    gbrcRealStart = gbrcStart & ~7;
+                    gbrcRealProcess = mActualThisSubBlock - gbrcRealStart;
+                }
+                else if(subBlockIdx == 1 && stage == 0)
+                {
+                    gbrcStart = mActualPerSubBlock;
+                    gbrcRealStart = gbrcStart & ~7;
+                    gbrcRealProcess = mActualPerSubBlock + mActualThisStage - gbrcRealStart;
+                }
+                else if(subBlockIdx == 1 && stage == 1)
+                {
+                    gbrcStart = mActualPerSubBlock + mActualPerStage;
+                    gbrcRealStart = gbrcStart & ~7;
+                    gbrcRealProcess = mActual - gbrcRealStart;
+                }
+                gbrcEffStart = gbrcStart - gbrcRealStart;
+                uint32_t ubStageOffset = stage * mActualPerStage * nActual;
+                uint32_t dstShape_[2] = {gbrcRealProcess, nActual};
+                uint32_t srcShape_[2] = {gbrcRealProcess, 1};
+
+                AscendC::GlobalTensor<HElementOutput> hOutputThisSubBlock = hOutput[gbrcStart * outputStride];
+                AscendC::LocalTensor<float> aUbTensor = (pingpongFlag == 0) ? aUbTensorPing : aUbTensorPong;
+                AscendC::LocalTensor<float> hUbTensor = (pingpongFlag == 0) ? hUbTensorPing : hUbTensorPong;
+                AscendC::LocalTensor<float> outUbTensor = (pingpongFlag == 0) ? outUbTensorPing : outUbTensorPong;
+                AscendC::LocalTensor<HElementOutput> outUbFPTensor = (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
+                AscendC::LocalTensor<HElementOutput> outUbBFTensor = (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
+
+                AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gcompUbTensor[gbrcRealStart], dstShape_, srcShape_, shareUbTensor);
+                AscendC::PipeBarrier<PIPE_V>();
+
+                __ubuf__ float* outAddr = (__ubuf__ float*)outUbTensor.GetPhyAddr();
+                __ubuf__ float* attnAddr = (__ubuf__ float*)aUbTensor[ubStageOffset].GetPhyAddr();
+                __ubuf__ float* hiddenAddr = (__ubuf__ float*)hUbTensor[ubStageOffset].GetPhyAddr();
+                __ubuf__ float* gateAddr =
+                    (__ubuf__ float*)gbrcLeftcastUbTensor[gbrcEffStart * nActual].GetPhyAddr();
+                constexpr uint32_t VF_DUAL_ELEMENTS = 2 * AscendC::VECTOR_REG_WIDTH / sizeof(float);
+                uint32_t totalElements = mActualThisStage * nActual;
+                uint32_t vfElements = totalElements / VF_DUAL_ELEMENTS * VF_DUAL_ELEMENTS;
+                if (vfElements != 0) {
+                    AscendC::VF_CALL<GdnFwdoOutputMulAddScaleVf>(
+                        outAddr, attnAddr, hiddenAddr, gateAddr, (float)scale, vfElements);
+                }
+                uint32_t tailElements = totalElements - vfElements;
+                if (tailElements != 0) {
+                    AscendC::Mul(outUbTensor[vfElements], hUbTensor[ubStageOffset + vfElements],
+                        gbrcLeftcastUbTensor[gbrcEffStart * nActual + vfElements], tailElements);
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Add(outUbTensor[vfElements], aUbTensor[ubStageOffset + vfElements],
+                        outUbTensor[vfElements], tailElements);
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Muls(outUbTensor[vfElements], outUbTensor[vfElements], (float)scale, tailElements);
+                }
+                AscendC::PipeBarrier<PIPE_V>();
+
+                if(std::is_same<HElementOutput, half>::value)
+                {
+                    AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisStage * nActual);
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    CopyOutputToGm(hOutputThisSubBlock, outUbFPTensor, mActualThisStage, nActual, outputStride);
+                }
+                else
+                {
+                    AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisStage * nActual);
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    CopyOutputToGm(hOutputThisSubBlock, outUbBFTensor, mActualThisStage, nActual, outputStride);
+                }
+            }
+        }
+    }
+
+private:
+    AscendC::LocalTensor<float> maskUbTensor;
+    AscendC::LocalTensor<float> gbrcLeftcastUbTensor;
+    AscendC::LocalTensor<float> gbrcUpUbTensor;
+    AscendC::LocalTensor<float> gcompUbTensor;
+    AscendC::LocalTensor<uint8_t> shareUbTensor;
+
+    AscendC::LocalTensor<float> gUbTensorPing;
+    AscendC::LocalTensor<GElementInput> gUbFPTensorPing;
+    AscendC::LocalTensor<GElementInput> gUbBFTensorPing;
+    AscendC::LocalTensor<float> aUbTensorPing;
+    AscendC::LocalTensor<float> hUbTensorPing;
+    AscendC::LocalTensor<float> outUbTensorPing;
+    AscendC::LocalTensor<HElementOutput> outUbFPTensorPing;
+    AscendC::LocalTensor<HElementOutput> outUbBFTensorPing;
+
+    AscendC::LocalTensor<float> gUbTensorPong;
+    AscendC::LocalTensor<GElementInput> gUbFPTensorPong;
+    AscendC::LocalTensor<GElementInput> gUbBFTensorPong;
+    AscendC::LocalTensor<float> aUbTensorPong;
+    AscendC::LocalTensor<float> hUbTensorPong;
+    AscendC::LocalTensor<float> outUbTensorPong;
+    AscendC::LocalTensor<HElementOutput> outUbFPTensorPong;
+    AscendC::LocalTensor<HElementOutput> outUbBFTensorPong;
+
+
+};
+}
+
+#endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdo_qkmask.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdo_qkmask.hpp
@@ -1,0 +1,540 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDO_QKMASK_HPP
+#define CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDO_QKMASK_HPP
+
+#include "kernel_operator.h"
+#include "catlass/catlass.hpp"
+#include "catlass/arch/resource.hpp"
+#include "../gdn_fwd_o_epilogue_policies.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/matrix_coord.hpp"
+#include "catlass/epilogue/tile/tile_copy.hpp"
+
+namespace Catlass::Epilogue::Block {
+
+static __simd_vf__ inline void GdnFwdoQKMaskSubMinsExpVf(
+    __ubuf__ float* dst,
+    __ubuf__ float* left,
+    __ubuf__ float* up,
+    uint32_t elementCount)
+{
+    AscendC::Reg::RegTensor<float> leftReg0;
+    AscendC::Reg::RegTensor<float> leftReg1;
+    AscendC::Reg::RegTensor<float> upReg0;
+    AscendC::Reg::RegTensor<float> upReg1;
+    AscendC::Reg::RegTensor<float> dstReg0;
+    AscendC::Reg::RegTensor<float> dstReg1;
+    constexpr uint32_t ELEMS_PER_REG = AscendC::VECTOR_REG_WIDTH / sizeof(float);
+    constexpr uint32_t ELEMS_PER_DUAL = ELEMS_PER_REG * 2;
+    auto maskFull = AscendC::Reg::CreateMask<float, AscendC::Reg::MaskPattern::ALL>();
+    uint16_t dualRepeats = static_cast<uint16_t>(elementCount / ELEMS_PER_DUAL);
+
+    for (uint16_t i = 0; i < dualRepeats; ++i) {
+        uint32_t offset = static_cast<uint32_t>(i) * ELEMS_PER_DUAL;
+        AscendC::Reg::LoadAlign<float, AscendC::Reg::LoadDist::DIST_DINTLV_B32>(leftReg0, leftReg1, left + offset);
+        AscendC::Reg::LoadAlign<float, AscendC::Reg::LoadDist::DIST_DINTLV_B32>(upReg0, upReg1, up + offset);
+        AscendC::Reg::Sub(dstReg0, leftReg0, upReg0, maskFull);
+        AscendC::Reg::Sub(dstReg1, leftReg1, upReg1, maskFull);
+        AscendC::Reg::Mins(dstReg0, dstReg0, 0.0f, maskFull);
+        AscendC::Reg::Mins(dstReg1, dstReg1, 0.0f, maskFull);
+        AscendC::Reg::Exp(dstReg0, dstReg0, maskFull);
+        AscendC::Reg::Exp(dstReg1, dstReg1, maskFull);
+        AscendC::Reg::StoreAlign<float, AscendC::Reg::StoreDist::DIST_INTLV_B32>(
+            dst + offset, dstReg0, dstReg1, maskFull);
+    }
+
+}
+
+template <
+    class AOutputType_,
+    class GInputType_,
+    class AInputType_,
+    class MaskInputType_
+>
+class BlockEpilogue <
+    EpilogueAtlasGDNFwdOQkmask,
+    AOutputType_,
+    GInputType_,
+    AInputType_,
+    MaskInputType_
+> {
+public:
+    // Type aliases
+    using DispatchPolicy = EpilogueAtlasGDNFwdOQkmask;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+
+    using AElementOutput = typename AOutputType_::Element;
+    using GElementInput = typename GInputType_::Element;
+    using AElementInput = typename AInputType_::Element;
+    using MaskElementInput = typename MaskInputType_::Element;
+
+    static constexpr uint32_t HALF_ELENUM_PER_BLK = 16;
+    static constexpr uint32_t FLOAT_ELENUM_PER_BLK = 8;
+    static constexpr uint32_t HALF_ELENUM_PER_VECCALC = 128;
+    static constexpr uint32_t FLOAT_ELENUM_PER_VECCALC = 64;
+    static constexpr uint32_t UB_TILE_SIZE = 16384;  // 64 * 128 * 2B
+    static constexpr uint32_t UB_LINE_SIZE = 512;   // 128 * 2 * 2B
+    static constexpr uint32_t HALF_ELENUM_PER_LINE = 256;    // 128 * 2
+    static constexpr uint32_t FLOAT_ELENUM_PER_LINE = 128;   // 128
+    static constexpr uint32_t MULTIPLIER = 2;
+    static constexpr uint32_t VEC_TILE_ROWS = 32;
+    using LayoutL1MaskOutput = Catlass::layout::zN;
+
+    CATLASS_DEVICE
+    BlockEpilogue(Arch::Resource<ArchTag> &resource)
+    {
+        constexpr uint32_t BASE = 0;
+        constexpr uint32_t MASK_UB_TENSOR_SIZE = 32 * UB_LINE_SIZE;
+        constexpr uint32_t GBRCLEFTCAST_UB_TENSOR_SIZE = 40 * UB_LINE_SIZE;
+        constexpr uint32_t GBRCUP_UB_TENSOR_SIZE = 32 * UB_LINE_SIZE;
+        constexpr uint32_t TILE_FLOAT_UB_TENSOR_SIZE = VEC_TILE_ROWS * FLOAT_ELENUM_PER_LINE * sizeof(float);
+        constexpr uint32_t TILE_HALF_UB_TENSOR_SIZE = VEC_TILE_ROWS * FLOAT_ELENUM_PER_LINE * sizeof(AElementOutput);
+        constexpr uint32_t G_HALF_UB_TENSOR_SIZE = 2 * UB_LINE_SIZE;
+        constexpr uint32_t G_FLOAT_UB_TENSOR_SIZE = 2 * UB_LINE_SIZE;
+
+        constexpr uint32_t MASK_UB_TENSOR_OFFSET = BASE;
+        constexpr uint32_t GBRCLEFTCAST_UB_TENSOR_OFFSET = MASK_UB_TENSOR_OFFSET + MASK_UB_TENSOR_SIZE;
+        constexpr uint32_t GBRCUP_UB_TENSOR_OFFSET = GBRCLEFTCAST_UB_TENSOR_OFFSET + GBRCLEFTCAST_UB_TENSOR_SIZE;
+        constexpr uint32_t GCOMP_UB_TENSOR_OFFSET = GBRCUP_UB_TENSOR_OFFSET + GBRCUP_UB_TENSOR_SIZE;
+        constexpr uint32_t SHARE_UB_TENSOR_OFFSET = GCOMP_UB_TENSOR_OFFSET + G_FLOAT_UB_TENSOR_SIZE;
+
+        maskUbTensor = resource.ubBuf.template GetBufferByByte<float>(MASK_UB_TENSOR_OFFSET);
+        gbrcLeftcastUbTensor = resource.ubBuf.template GetBufferByByte<float>(GBRCLEFTCAST_UB_TENSOR_OFFSET);
+        gbrcUpUbTensor = resource.ubBuf.template GetBufferByByte<float>(GBRCUP_UB_TENSOR_OFFSET);
+        gcompUbTensor = resource.ubBuf.template GetBufferByByte<float>(GCOMP_UB_TENSOR_OFFSET);
+        shareUbTensor = resource.ubBuf.template GetBufferByByte<uint8_t>(SHARE_UB_TENSOR_OFFSET);
+
+        constexpr uint32_t VEC1_SCRATCH_BASE = 203776;
+        constexpr uint32_t G_UB_TENSOR_OFFSET_PING = SHARE_UB_TENSOR_OFFSET + TILE_FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t G_HALF_UB_TENSOR_OFFSET_PING = G_UB_TENSOR_OFFSET_PING + G_FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t A_UB_TENSOR_OFFSET_PING = VEC1_SCRATCH_BASE;
+        constexpr uint32_t OUT_UB_TENSOR_OFFSET_PING = A_UB_TENSOR_OFFSET_PING;
+        constexpr uint32_t OUT_HALF_UB_TENSOR_OFFSET_PING = OUT_UB_TENSOR_OFFSET_PING + TILE_FLOAT_UB_TENSOR_SIZE;
+
+        gUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(G_UB_TENSOR_OFFSET_PING);
+        gUbFPTensorPing = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PING);
+        gUbBFTensorPing = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PING);
+        aUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(A_UB_TENSOR_OFFSET_PING);
+        outUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(OUT_UB_TENSOR_OFFSET_PING);
+        outUbFPTensorPing = resource.ubBuf.template GetBufferByByte<AElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PING);
+        outUbBFTensorPing = resource.ubBuf.template GetBufferByByte<AElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PING);
+
+        constexpr uint32_t G_UB_TENSOR_OFFSET_PONG = G_UB_TENSOR_OFFSET_PING;
+        constexpr uint32_t G_HALF_UB_TENSOR_OFFSET_PONG = G_UB_TENSOR_OFFSET_PONG + G_FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t A_UB_TENSOR_OFFSET_PONG = OUT_HALF_UB_TENSOR_OFFSET_PING + TILE_HALF_UB_TENSOR_SIZE;
+        constexpr uint32_t OUT_UB_TENSOR_OFFSET_PONG = A_UB_TENSOR_OFFSET_PONG;
+        constexpr uint32_t OUT_HALF_UB_TENSOR_OFFSET_PONG = OUT_UB_TENSOR_OFFSET_PONG + TILE_FLOAT_UB_TENSOR_SIZE;
+
+        gUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(G_UB_TENSOR_OFFSET_PONG);
+        gUbFPTensorPong = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PONG);
+        gUbBFTensorPong = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PONG);
+        aUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(A_UB_TENSOR_OFFSET_PONG);
+        outUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(OUT_UB_TENSOR_OFFSET_PONG);
+        outUbFPTensorPong = resource.ubBuf.template GetBufferByByte<AElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PONG);
+        outUbBFTensorPong = resource.ubBuf.template GetBufferByByte<AElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PONG);
+    }
+
+    CATLASS_DEVICE
+    ~BlockEpilogue()
+    {}
+
+    CATLASS_DEVICE
+    void EnableL1Output(AscendC::LocalTensor<AElementOutput> l1OutputTensor)
+    {
+        l1Output = l1OutputTensor;
+        enableL1Output = true;
+    }
+
+    CATLASS_DEVICE
+    void operator()(
+        AscendC::GlobalTensor<AElementOutput> maskOutput,
+        AscendC::GlobalTensor<GElementInput> gInput,
+        AscendC::GlobalTensor<AElementInput> attnInput,
+        AscendC::GlobalTensor<MaskElementInput> boolInput,
+        uint32_t fullChunkSize,
+        uint32_t chunkSize,
+        uint32_t kHeadDim,
+        uint32_t vHeadDim,
+        uint32_t &pingpongFlag
+        , uint32_t batchIdx, uint32_t headIdx, uint32_t chunkIdx
+        )
+    {
+        uint32_t mActual = chunkSize;
+        uint32_t nActual = chunkSize;
+        uint32_t alignedNActual = CeilDiv(nActual, 16) * 16;
+        uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
+        uint32_t subBlockNum = AscendC::GetSubBlockNum();
+        uint32_t blockIdx = AscendC::GetBlockIdx();
+        uint32_t mActualPerSubBlock = CeilDiv(mActual, subBlockNum);
+        uint32_t mActualThisSubBlock = (subBlockIdx == 0) ? mActualPerSubBlock : (mActual - mActualPerSubBlock);
+        uint32_t mOffset = subBlockIdx * mActualPerSubBlock;
+        uint32_t nOffset = 0;
+        int64_t offsetA = mOffset * nActual + nOffset;
+        uint16_t aInputDstStride;
+        if((nActual - 1) % 16 <= 7) aInputDstStride = 1;
+        else aInputDstStride = 0;
+
+        uint32_t gbrcStart, gbrcRealStart, gbrcRealEnd, gbrcRealProcess, gbrcEffStart, gbrcEffEnd, mulsRemain, mulsRemainIdx;
+        if(mActualThisSubBlock <= VEC_TILE_ROWS)
+        {   if(subBlockIdx == 0)
+            {
+                gbrcStart = 0;
+                gbrcRealStart = 0;
+                gbrcRealProcess = mActualThisSubBlock;
+            }
+            else
+            {
+                gbrcStart = mActualPerSubBlock;
+                gbrcRealStart = gbrcStart & ~7;
+                gbrcRealProcess = mActual - gbrcRealStart;
+            }
+
+            gbrcEffStart = gbrcStart - gbrcRealStart;
+            gbrcEffEnd = gbrcEffStart + mActualThisSubBlock;
+
+            uint32_t dstUpShape_[2] = {mActualThisSubBlock, alignedNActual};
+            uint32_t srcUpShape_[2] = {1, alignedNActual};
+            uint32_t dstLeftShape_[2] = {gbrcRealProcess, alignedNActual};
+            uint32_t srcLeftShape_[2] = {gbrcRealProcess, 1};
+
+            AscendC::ResetMask();
+            AscendC::GlobalTensor<AElementOutput> maskOutputThisSubBlock = maskOutput[gbrcStart * nActual];
+            AscendC::GlobalTensor<AElementInput> attnInputThisSubBlock = attnInput[gbrcStart * nActual];
+            AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
+
+
+            AscendC::DataCopyParams aInputUbParams{(uint16_t)mActualThisSubBlock, (uint16_t)(nActual*sizeof(float)), 0, aInputDstStride};
+            AscendC::DataCopyPadParams aInputUbPadParams{false, 0, 0, 0};
+            AscendC::DataCopyExtParams aOutputUbParams{(uint16_t)mActualThisSubBlock, (uint32_t)(nActual*sizeof(half)), 0, 0, 0};
+
+            AscendC::DataCopyParams gfloatUbParams{1, (uint16_t)(mActual*sizeof(float)), 0, 0};
+            AscendC::DataCopyParams ghalfUbParams{1, (uint16_t)(mActual*sizeof(half)), 0, 0};
+            AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
+
+            AscendC::LocalTensor<float> aUbTensor = (pingpongFlag == 0) ? aUbTensorPing : aUbTensorPong;
+            AscendC::LocalTensor<float> outUbTensor = (pingpongFlag == 0) ? outUbTensorPing : outUbTensorPong;
+            AscendC::LocalTensor<AElementOutput> outUbFPTensor = (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
+            AscendC::LocalTensor<AElementOutput> outUbBFTensor = (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
+            AscendC::LocalTensor<float> gUbTensor = (pingpongFlag == 0) ? gUbTensorPing : gUbTensorPong;
+            AscendC::LocalTensor<GElementInput> gUbFPTensor = (pingpongFlag == 0) ? gUbFPTensorPing : gUbFPTensorPong;
+            AscendC::LocalTensor<GElementInput> gUbBFTensor = (pingpongFlag == 0) ? gUbBFTensorPing : gUbBFTensorPong;
+
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+            if constexpr(std::is_same<GElementInput, float>::value) {
+                AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gfloatUbParams, gUbPadParams);
+            } else {
+                AscendC::DataCopyPad(gUbFPTensor, gInputThisSubBlock, ghalfUbParams, gUbPadParams);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            if constexpr(!std::is_same<GElementInput, float>::value) {
+                AscendC::Cast(gUbTensor, gUbFPTensor, AscendC::RoundMode::CAST_NONE, mActual);
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+            AscendC::Copy(gcompUbTensor, gUbTensor, 64, 2, {1, 1, 8, 8});
+            AscendC::PipeBarrier<PIPE_V>();
+
+            AscendC::Broadcast<float, 2, 0>(gbrcUpUbTensor, gcompUbTensor, dstUpShape_, srcUpShape_, shareUbTensor);
+            AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gcompUbTensor[gbrcRealStart], dstLeftShape_, srcLeftShape_, shareUbTensor);
+            AscendC::PipeBarrier<PIPE_V>();
+            __ubuf__ float* gbrcUpAddr = (__ubuf__ float*)gbrcUpUbTensor.GetPhyAddr();
+            __ubuf__ float* gbrcLeftAddr =
+                (__ubuf__ float*)gbrcLeftcastUbTensor[gbrcEffStart * alignedNActual].GetPhyAddr();
+            constexpr uint32_t VF_DUAL_ELEMENTS = 2 * AscendC::VECTOR_REG_WIDTH / sizeof(float);
+            uint32_t totalElements = mActualThisSubBlock * alignedNActual;
+            uint32_t vfElements = totalElements / VF_DUAL_ELEMENTS * VF_DUAL_ELEMENTS;
+            if (vfElements != 0) {
+                AscendC::VF_CALL<GdnFwdoQKMaskSubMinsExpVf>(
+                    gbrcUpAddr, gbrcLeftAddr, gbrcUpAddr, vfElements);
+            }
+            uint32_t tailElements = totalElements - vfElements;
+            if (tailElements != 0) {
+                AscendC::Sub(gbrcUpUbTensor[vfElements],
+                    gbrcLeftcastUbTensor[gbrcEffStart * alignedNActual + vfElements],
+                    gbrcUpUbTensor[vfElements], tailElements);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Mins(gbrcUpUbTensor[vfElements], gbrcUpUbTensor[vfElements], 0.0f, tailElements);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Exp(gbrcUpUbTensor[vfElements], gbrcUpUbTensor[vfElements], tailElements);
+            }
+            AscendC::PipeBarrier<PIPE_V>();
+
+            gbrcRealEnd = CeilDiv(gbrcStart + mActualThisSubBlock, 8) * 8;
+            AscendC::Mul(gbrcUpUbTensor[gbrcRealStart], gbrcUpUbTensor[gbrcRealStart], maskUbTensor[gbrcEffStart * 64], gbrcRealEnd - gbrcRealStart, mActualThisSubBlock,
+            {1, 1, 1, static_cast<uint8_t>(alignedNActual/8), static_cast<uint8_t>(alignedNActual/8), static_cast<uint8_t>(64/8)});
+            AscendC::PipeBarrier<PIPE_V>();
+
+            mulsRemain = alignedNActual - gbrcRealEnd;
+            mulsRemainIdx = gbrcRealEnd;
+            while(mulsRemain > 64)
+            {
+                AscendC::Muls(gbrcUpUbTensor[mulsRemainIdx], gbrcUpUbTensor[mulsRemainIdx], (float)0.0, 64, mActualThisSubBlock,
+                {1, 1, static_cast<uint8_t>(alignedNActual/8), static_cast<uint8_t>(alignedNActual/8)});
+                mulsRemain -= 64;
+                mulsRemainIdx += 64;
+            }
+            AscendC::Muls(gbrcUpUbTensor[mulsRemainIdx], gbrcUpUbTensor[mulsRemainIdx], (float)0.0, mulsRemain, mActualThisSubBlock,
+            {1, 1, static_cast<uint8_t>(alignedNActual/8), static_cast<uint8_t>(alignedNActual/8)});
+            AscendC::PipeBarrier<PIPE_V>();
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+            if(chunkSize==fullChunkSize) AscendC::DataCopy(aUbTensor, attnInputThisSubBlock, mActualThisSubBlock*nActual);
+            else AscendC::DataCopyPad(aUbTensor, attnInputThisSubBlock, aInputUbParams, aInputUbPadParams);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+            AscendC::Mul(outUbTensor, aUbTensor, gbrcUpUbTensor, mActualThisSubBlock * alignedNActual);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            if(std::is_same<AElementOutput, half>::value)
+            {
+                AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * alignedNActual);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                CopyOutputToL1(outUbFPTensor, gbrcStart, mActualThisSubBlock, nActual, alignedNActual);
+                if (!enableL1Output) {
+                    if(chunkSize==fullChunkSize) AscendC::DataCopy(maskOutputThisSubBlock, outUbFPTensor, mActualThisSubBlock*nActual);
+                    else AscendC::DataCopyPad(maskOutputThisSubBlock, outUbFPTensor, aOutputUbParams);
+                }
+            }
+            else
+            {
+                AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * alignedNActual);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                CopyOutputToL1(outUbBFTensor, gbrcStart, mActualThisSubBlock, nActual, alignedNActual);
+                if (!enableL1Output) {
+                    if(chunkSize==fullChunkSize) AscendC::DataCopy(maskOutputThisSubBlock, outUbBFTensor, mActualThisSubBlock*nActual);
+                    else AscendC::DataCopyPad(maskOutputThisSubBlock, outUbBFTensor, aOutputUbParams);
+                }
+            }
+        }
+        else // mActualThisSubBlock  > 32 ; <=64
+        {
+            AscendC::ResetMask();
+            AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
+
+            AscendC::DataCopyParams gfloatUbParams{1, (uint16_t)(mActual*sizeof(float)), 0, 0};
+            AscendC::DataCopyParams ghalfUbParams{1, (uint16_t)(mActual*sizeof(half)), 0, 0};
+            AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
+
+            AscendC::LocalTensor<float> gUbTensor = (pingpongFlag == 0) ? gUbTensorPing : gUbTensorPong;
+            AscendC::LocalTensor<GElementInput> gUbFPTensor = (pingpongFlag == 0) ? gUbFPTensorPing : gUbFPTensorPong;
+            AscendC::LocalTensor<GElementInput> gUbBFTensor = (pingpongFlag == 0) ? gUbBFTensorPing : gUbBFTensorPong;
+
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+            if constexpr(std::is_same<GElementInput, float>::value) {
+                AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gfloatUbParams, gUbPadParams);
+            } else {
+                AscendC::DataCopyPad(gUbFPTensor, gInputThisSubBlock, ghalfUbParams, gUbPadParams);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            if constexpr(!std::is_same<GElementInput, float>::value) {
+                AscendC::Cast(gUbTensor, gUbFPTensor, AscendC::RoundMode::CAST_NONE, mActual);
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+            AscendC::Copy(gcompUbTensor, gUbTensor, 64, 2, {1, 1, 8, 8});
+            AscendC::PipeBarrier<PIPE_V>();
+
+            uint32_t mActualThisStage = 0;
+            uint32_t stageCount = CeilDiv(mActualThisSubBlock, VEC_TILE_ROWS);
+            for(uint32_t stage = 0; stage < stageCount; ++stage)
+            {
+                uint32_t tileOffset = stage * VEC_TILE_ROWS;
+                mActualThisStage = (tileOffset + VEC_TILE_ROWS <= mActualThisSubBlock) ?
+                    VEC_TILE_ROWS : (mActualThisSubBlock - tileOffset);
+                gbrcStart = mOffset + tileOffset;
+                gbrcRealStart = gbrcStart & ~7;
+                gbrcRealProcess = gbrcStart + mActualThisStage - gbrcRealStart;
+
+                gbrcEffStart = gbrcStart - gbrcRealStart;
+
+                AscendC::GlobalTensor<AElementOutput> maskOutputThisSubBlock = maskOutput[gbrcStart * nActual];
+                AscendC::GlobalTensor<AElementInput> attnInputThisSubBlock = attnInput[gbrcStart * nActual];
+
+                AscendC::DataCopyParams aInputUbParams{(uint16_t)mActualThisStage, (uint16_t)(nActual*sizeof(float)), 0, aInputDstStride};
+                AscendC::DataCopyPadParams aInputUbPadParams{false, 0, 0, 0};
+                AscendC::DataCopyExtParams aOutputUbParams{(uint16_t)mActualThisStage, (uint32_t)(nActual*sizeof(half)), 0, 0, 0};
+
+                AscendC::LocalTensor<float> aUbTensor = (pingpongFlag == 0) ? aUbTensorPing : aUbTensorPong;
+                AscendC::LocalTensor<float> outUbTensor = (pingpongFlag == 0) ? outUbTensorPing : outUbTensorPong;
+                AscendC::LocalTensor<AElementOutput> outUbFPTensor = (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
+                AscendC::LocalTensor<AElementOutput> outUbBFTensor = (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
+
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+                if(chunkSize==fullChunkSize) AscendC::DataCopy(aUbTensor, attnInputThisSubBlock, mActualThisStage*nActual);
+                else AscendC::DataCopyPad(aUbTensor, attnInputThisSubBlock, aInputUbParams, aInputUbPadParams);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+
+                uint32_t dstUpShape_[2] = {mActualThisStage, alignedNActual};
+                uint32_t srcUpShape_[2] = {1, alignedNActual};
+                uint32_t dstLeftShape_[2] = {gbrcRealProcess, alignedNActual};
+                uint32_t srcLeftShape_[2] = {gbrcRealProcess, 1};
+
+                AscendC::Broadcast<float, 2, 0>(gbrcUpUbTensor, gcompUbTensor, dstUpShape_, srcUpShape_, shareUbTensor);
+                AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gcompUbTensor[gbrcRealStart], dstLeftShape_, srcLeftShape_, shareUbTensor);
+                AscendC::PipeBarrier<PIPE_V>();
+                __ubuf__ float* gbrcUpAddr = (__ubuf__ float*)gbrcUpUbTensor.GetPhyAddr();
+                __ubuf__ float* gbrcLeftAddr =
+                    (__ubuf__ float*)gbrcLeftcastUbTensor[gbrcEffStart * alignedNActual].GetPhyAddr();
+                constexpr uint32_t VF_DUAL_ELEMENTS = 2 * AscendC::VECTOR_REG_WIDTH / sizeof(float);
+                uint32_t totalElements = mActualThisStage * alignedNActual;
+                uint32_t vfElements = totalElements / VF_DUAL_ELEMENTS * VF_DUAL_ELEMENTS;
+                if (vfElements != 0) {
+                    AscendC::VF_CALL<GdnFwdoQKMaskSubMinsExpVf>(
+                        gbrcUpAddr, gbrcLeftAddr, gbrcUpAddr, vfElements);
+                }
+                uint32_t tailElements = totalElements - vfElements;
+                if (tailElements != 0) {
+                    AscendC::Sub(gbrcUpUbTensor[vfElements],
+                        gbrcLeftcastUbTensor[gbrcEffStart * alignedNActual + vfElements],
+                        gbrcUpUbTensor[vfElements], tailElements);
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Mins(gbrcUpUbTensor[vfElements], gbrcUpUbTensor[vfElements], 0.0f, tailElements);
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Exp(gbrcUpUbTensor[vfElements], gbrcUpUbTensor[vfElements], tailElements);
+                }
+                AscendC::PipeBarrier<PIPE_V>();
+
+                gbrcRealEnd = CeilDiv(gbrcStart + mActualThisStage, 8) * 8;
+                AscendC::Mul(gbrcUpUbTensor[gbrcRealStart], gbrcUpUbTensor[gbrcRealStart], maskUbTensor[gbrcEffStart * 64], gbrcRealEnd - gbrcRealStart, mActualThisStage,
+                {1, 1, 1, static_cast<uint8_t>(alignedNActual/8), static_cast<uint8_t>(alignedNActual/8), static_cast<uint8_t>(64/8)});
+                AscendC::PipeBarrier<PIPE_V>();
+                mulsRemain = alignedNActual - gbrcRealEnd;
+                mulsRemainIdx = gbrcRealEnd;
+                while(mulsRemain > 64)
+                {
+                    AscendC::Muls(gbrcUpUbTensor[mulsRemainIdx], gbrcUpUbTensor[mulsRemainIdx], (float)0.0, 64, mActualThisStage,
+                    {1, 1, static_cast<uint8_t>(alignedNActual/8), static_cast<uint8_t>(alignedNActual/8)});
+                    mulsRemain -= 64;
+                    mulsRemainIdx += 64;
+                }
+                AscendC::Muls(gbrcUpUbTensor[mulsRemainIdx], gbrcUpUbTensor[mulsRemainIdx], (float)0.0, mulsRemain, mActualThisStage,
+                {1, 1, static_cast<uint8_t>(alignedNActual/8), static_cast<uint8_t>(alignedNActual/8)});
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+                AscendC::Mul(outUbTensor, aUbTensor, gbrcUpUbTensor, mActualThisStage * alignedNActual);
+                AscendC::PipeBarrier<PIPE_V>();
+                if(std::is_same<AElementOutput, half>::value)
+                {
+                    AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisStage * alignedNActual);
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    CopyOutputToL1(outUbFPTensor, gbrcStart, mActualThisStage, nActual, alignedNActual);
+                    if (!enableL1Output) {
+                        if(chunkSize==fullChunkSize) AscendC::DataCopy(maskOutputThisSubBlock, outUbFPTensor, mActualThisStage*nActual);
+                        else AscendC::DataCopyPad(maskOutputThisSubBlock, outUbFPTensor, aOutputUbParams);
+                    }
+                }
+                else
+                {
+                    AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisStage * alignedNActual);
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    CopyOutputToL1(outUbBFTensor, gbrcStart, mActualThisStage, nActual, alignedNActual);
+                    if (!enableL1Output) {
+                        if(chunkSize==fullChunkSize) AscendC::DataCopy(maskOutputThisSubBlock, outUbBFTensor, mActualThisStage*nActual);
+                        else AscendC::DataCopyPad(maskOutputThisSubBlock, outUbBFTensor, aOutputUbParams);
+                    }
+                }
+            }
+        }
+
+    }
+
+private:
+    CATLASS_DEVICE
+    void CopyOutputToL1(
+        AscendC::LocalTensor<AElementOutput> ubTensor,
+        uint32_t rowOffset,
+        uint32_t rows,
+        uint32_t cols,
+        uint32_t srcStride)
+    {
+        if (!enableL1Output || rows == 0) {
+            return;
+        }
+
+        auto ubLayout = tla::MakeLayout(
+            tla::MakeShape(rows, cols), tla::MakeStride(srcStride, tla::Int<1>{}), tla::MakeShape(rows, cols));
+        auto l1Layout = tla::MakeLayout<AElementOutput, LayoutL1MaskOutput>(tla::Int<128>{}, tla::Int<128>{});
+        auto tensorUb = tla::MakeTensor(ubTensor, ubLayout, Catlass::Arch::PositionUB{});
+        auto tensorL1 = tla::MakeTensor(l1Output, l1Layout, Catlass::Arch::PositionL1{});
+        auto tensorL1Tile = GetTile(tensorL1, tla::MakeCoord(rowOffset, 0), tla::MakeShape(rows, cols));
+
+        constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(AElementOutput);
+        uint32_t srcDValue = tla::get<0>(tensorUb.stride());
+        uint32_t dstNzNStride = tla::get<0, 0>(tensorL1Tile.stride()) / ELE_NUM_PER_C0;
+        uint32_t dstNzC0Stride = tla::get<1, 1>(tensorL1Tile.stride()) / ELE_NUM_PER_C0;
+        auto dstOffset = tensorL1Tile.layout()(tensorL1Tile.coord());
+        auto srcOffset = tensorUb.layout()(tensorUb.coord());
+        uint32_t copyCols = RoundUp<BYTE_PER_BLK>(cols * sizeof(AElementOutput)) / BYTE_PER_BLK;
+
+        if (copyCols > rows) {
+            for (uint32_t i = 0; i < rows; ++i) {
+                uint32_t dst = i * dstNzNStride * BYTE_PER_BLK / sizeof(AElementOutput);
+                uint32_t src = i * srcDValue;
+                AscendC::DataCopyParams params(copyCols, 1, 0, dstNzC0Stride - 1);
+                AscendC::DataCopy(
+                    tensorL1Tile.data()[dstOffset + dst], tensorUb.data()[srcOffset + src], params);
+            }
+        } else {
+            for (uint32_t i = 0; i < copyCols; ++i) {
+                uint32_t dst = i * dstNzC0Stride * BYTE_PER_BLK / sizeof(AElementOutput);
+                uint32_t src = i * BYTE_PER_BLK / sizeof(AElementOutput);
+                AscendC::DataCopyParams params(
+                    rows, 1, srcDValue * sizeof(AElementOutput) / BYTE_PER_BLK - 1, dstNzNStride - 1);
+                AscendC::DataCopy(
+                    tensorL1Tile.data()[dstOffset + dst], tensorUb.data()[srcOffset + src], params);
+            }
+        }
+    }
+
+    AscendC::LocalTensor<float> maskUbTensor;
+    AscendC::LocalTensor<float> gbrcLeftcastUbTensor;
+    AscendC::LocalTensor<float> gbrcUpUbTensor;
+    AscendC::LocalTensor<float> gcompUbTensor;
+    AscendC::LocalTensor<uint8_t> shareUbTensor;
+
+    AscendC::LocalTensor<float> gUbTensorPing;
+    AscendC::LocalTensor<GElementInput> gUbFPTensorPing;
+    AscendC::LocalTensor<GElementInput> gUbBFTensorPing;
+    AscendC::LocalTensor<float> aUbTensorPing;
+    AscendC::LocalTensor<float> outUbTensorPing;
+    AscendC::LocalTensor<AElementOutput> outUbFPTensorPing;
+    AscendC::LocalTensor<AElementOutput> outUbBFTensorPing;
+
+    AscendC::LocalTensor<float> gUbTensorPong;
+    AscendC::LocalTensor<GElementInput> gUbFPTensorPong;
+    AscendC::LocalTensor<GElementInput> gUbBFTensorPong;
+    AscendC::LocalTensor<float> aUbTensorPong;
+    AscendC::LocalTensor<float> outUbTensorPong;
+    AscendC::LocalTensor<AElementOutput> outUbFPTensorPong;
+    AscendC::LocalTensor<AElementOutput> outUbBFTensorPong;
+    AscendC::LocalTensor<AElementOutput> l1Output;
+    bool enableL1Output{false};
+
+};
+}
+
+#endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/epilogue/gdn_fwd_o_epilogue_policies.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/epilogue/gdn_fwd_o_epilogue_policies.hpp
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CATLASS_EPILOGUE_GDN_FWD_O_EPILOGUE_POLICIES_HPP
+#define CATLASS_EPILOGUE_GDN_FWD_O_EPILOGUE_POLICIES_HPP
+
+#include "catlass/catlass.hpp"
+
+namespace Catlass::Epilogue {
+
+struct EpilogueAtlasGDNFwdOQkmask {
+    using ArchTag = Arch::Ascend950;
+};
+
+struct EpilogueAtlasGDNFwdOOutput {
+    using ArchTag = Arch::Ascend950;
+};
+
+}  // namespace Catlass::Epilogue
+
+#endif  // CATLASS_EPILOGUE_GDN_FWD_O_EPILOGUE_POLICIES_HPP

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/gemm/block/block_scheduler_gdn_fwd_o.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/gemm/block/block_scheduler_gdn_fwd_o.hpp
@@ -1,0 +1,330 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CATLASS_GEMM_SCHEDULER_GDN_FWD_O_HPP
+#define CATLASS_GEMM_SCHEDULER_GDN_FWD_O_HPP
+
+#include "../../../chunk_fwd_o_struct.h"
+
+// constexpr uint32_t PING_PONG_STAGES = 1;
+constexpr uint32_t PING_PONG_STAGES = 2;
+constexpr uint32_t BYTE_SIZE_16_BIT = 2;
+
+template <typename T>
+CATLASS_DEVICE T AlignUp(T a, T b) {
+    return (b == 0) ? 0 : (a + b - 1) / b * b;
+}
+
+template <typename T>
+CATLASS_DEVICE T Min(T a, T b) {
+    return (a > b) ? b : a;
+}
+
+template <typename T>
+CATLASS_DEVICE T Max(T a, T b) {
+    return (a > b) ? a : b;
+}
+
+template <typename T>
+CATLASS_DEVICE T CeilDiv(T a, T b) {
+    return (b == 0) ? 0 : (a + b - 1) / b;
+}
+
+namespace Catlass::Gemm::Block {
+
+
+struct GDNFwdOOffsets {
+    int64_t qkOffset;
+    int64_t ovOffset;
+    int64_t hOffset;
+    int64_t gOffset;
+    int64_t attnWorkOffset;
+    int64_t hvWorkOffset;
+    uint32_t vBlockOffset;
+    uint32_t vBlockDim;
+    bool isFinalState;
+    uint32_t blockTokens;
+    // for debug
+    uint32_t batchIdx;
+    uint32_t headIdx;
+    uint32_t chunkIdx;
+
+};
+
+struct BlockSchedulerGdnFwdO {
+    uint32_t shapeBatch;
+    uint32_t seqlen;
+    uint32_t kNumHead;
+    uint32_t vNumHead;
+    uint32_t kHeadDim;
+    uint32_t vHeadDim;
+    uint32_t chunkSize;
+    uint32_t isVariedLen;
+    uint32_t tokenBatch;
+    uint32_t numChunks{0};
+    uint32_t vBlockSize{128};
+
+    uint32_t taskIdx;
+    uint32_t cubeCoreIdx;
+    uint32_t cubeCoreNum;
+    uint32_t vLoops;
+    uint32_t taskNum;
+    uint32_t headGroups;
+
+    bool isRunning;
+    bool processNewTask {true};
+    bool firstLoop {true};
+    bool lastLoop {false};
+    GDNFwdOOffsets offsets[PING_PONG_STAGES];
+    int32_t currStage{PING_PONG_STAGES - 1};
+
+    uint32_t baseTaskIdx;
+    uint32_t vIdx;
+    uint32_t baseHeadIdx;
+    uint32_t chunkIdx;
+    uint32_t headInnerIdx;
+    uint32_t vHeadIdx;
+    uint32_t kHeadIdx;
+    uint32_t shapeBatchIdx;
+    uint32_t tokenBatchIdx;
+
+    uint32_t batchChunkIdx;
+    uint32_t batchChunkStartIdx;
+    uint32_t tokenOffset;
+    uint32_t batchChunks;
+    uint32_t batchTokens;
+
+    AscendC::GlobalTensor<int64_t> gmSeqlen;
+    AscendC::GlobalTensor<int64_t> gmChunkOffsets;
+
+    Arch::CrossCoreFlag cube1Done[PING_PONG_STAGES] {Arch::CrossCoreFlag{0}, Arch::CrossCoreFlag{1}};
+    Arch::CrossCoreFlag vec1Done[PING_PONG_STAGES] {Arch::CrossCoreFlag{2}, Arch::CrossCoreFlag{3}};
+    Arch::CrossCoreFlag cube3Done[PING_PONG_STAGES] {Arch::CrossCoreFlag{4}, Arch::CrossCoreFlag{5}};
+    Arch::CrossCoreFlag vec2Done[PING_PONG_STAGES] {Arch::CrossCoreFlag{6}, Arch::CrossCoreFlag{7}};
+
+    CATLASS_DEVICE
+    BlockSchedulerGdnFwdO() {}
+
+    CATLASS_DEVICE
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::ChunkFwdOTilingData *tilingData,
+              uint32_t coreIdx, uint32_t coreNum) {
+        shapeBatch = tilingData->shapeBatch;
+        seqlen = tilingData->seqlen;
+        kNumHead = tilingData->kNumHead;
+        vNumHead = tilingData->vNumHead;
+        kHeadDim = tilingData->kHeadDim;
+        vHeadDim = tilingData->vHeadDim;
+        chunkSize = tilingData->chunkSize;
+        isVariedLen = tilingData->isVariedLen;
+        tokenBatch = tilingData->tokenBatch;
+
+        gmSeqlen.SetGlobalBuffer((__gm__ int64_t *)cu_seqlens);
+        gmChunkOffsets.SetGlobalBuffer((__gm__ int64_t *)chunk_offsets);
+
+        if (isVariedLen) {
+            for (uint32_t b = 1; b <= tokenBatch; b++) {
+                numChunks += (gmSeqlen.GetValue(b) - gmSeqlen.GetValue(b - 1) + chunkSize - 1) / chunkSize;
+            }
+        } else {
+            numChunks = (seqlen + chunkSize - 1) / chunkSize;
+        }
+
+        cubeCoreIdx = coreIdx;
+        cubeCoreNum = coreNum;
+        vLoops = CeilDiv(vHeadDim, vBlockSize);
+        taskNum = vLoops * shapeBatch * numChunks * vNumHead;
+        headGroups = vNumHead / kNumHead;
+        taskIdx = cubeCoreIdx * PING_PONG_STAGES;
+        isRunning = taskIdx < taskNum;
+
+    }
+
+    CATLASS_DEVICE
+    void InitTask() {
+        if (processNewTask) {
+            headInnerIdx = 0;
+            baseTaskIdx = taskIdx;
+        } else {
+            headInnerIdx = (headInnerIdx + 1) % PING_PONG_STAGES;
+        }
+
+        uint32_t curTaskIdx = baseTaskIdx + headInnerIdx;
+        if (unlikely(curTaskIdx >= taskNum)) {
+            isRunning = false;
+            processNewTask = true;
+            currStage = (currStage + 1) % PING_PONG_STAGES;
+            return;
+        }
+
+        vIdx = curTaskIdx / (shapeBatch * numChunks * vNumHead);
+        shapeBatchIdx = (curTaskIdx - vIdx * shapeBatch * numChunks * vNumHead) / (numChunks * vNumHead);
+        chunkIdx = (curTaskIdx - vIdx * shapeBatch * numChunks * vNumHead - shapeBatchIdx * numChunks * vNumHead) / vNumHead;
+        baseHeadIdx = curTaskIdx % vNumHead;
+        tokenBatchIdx = isVariedLen ? gmChunkOffsets.GetValue(2 * chunkIdx) : 0;
+        batchChunkIdx = isVariedLen ? gmChunkOffsets.GetValue(2 * chunkIdx + 1) : chunkIdx;
+        batchChunkStartIdx = chunkIdx - batchChunkIdx;
+        tokenOffset = isVariedLen ? gmSeqlen.GetValue(tokenBatchIdx) : 0;
+        batchTokens = isVariedLen ? (gmSeqlen.GetValue(tokenBatchIdx + 1) - tokenOffset) : seqlen;
+
+        vHeadIdx = baseHeadIdx;
+        kHeadIdx = vHeadIdx / headGroups;
+        uint32_t vBlockOffset = vIdx * vBlockSize;
+        uint32_t vBlockDim = Min(vBlockSize, vHeadDim - vBlockOffset);
+        const int64_t tokenStart = static_cast<int64_t>(tokenOffset) +
+                                   static_cast<int64_t>(batchChunkIdx) * chunkSize;
+        const int64_t qkRowOffset = (static_cast<int64_t>(shapeBatchIdx) * kNumHead + kHeadIdx) * seqlen +
+                                    tokenStart;
+        const int64_t ovRowOffset = (static_cast<int64_t>(shapeBatchIdx) * vNumHead + vHeadIdx) * seqlen +
+                                    tokenStart;
+        const int64_t hBlockOffset = (static_cast<int64_t>(shapeBatchIdx) * vNumHead * numChunks +
+                                      static_cast<int64_t>(vHeadIdx) * numChunks + chunkIdx) * kHeadDim;
+        const int64_t workspaceSlotIdx = static_cast<int64_t>(cubeCoreIdx) * PING_PONG_STAGES + currStage;
+        offsets[currStage].qkOffset = qkRowOffset * kHeadDim;
+        offsets[currStage].ovOffset = ovRowOffset * vHeadDim + vBlockOffset;
+        offsets[currStage].hOffset = hBlockOffset * vHeadDim + vBlockOffset;
+        offsets[currStage].gOffset = ovRowOffset;
+        offsets[currStage].attnWorkOffset = workspaceSlotIdx * chunkSize * chunkSize;
+        offsets[currStage].hvWorkOffset = workspaceSlotIdx * chunkSize * vBlockSize;
+        offsets[currStage].vBlockOffset = vBlockOffset;
+        offsets[currStage].vBlockDim = vBlockDim;
+        offsets[currStage].isFinalState = chunkIdx == (numChunks - 1) || (isVariedLen && gmChunkOffsets.GetValue(2 * chunkIdx + 3) == 0);
+        offsets[currStage].blockTokens = offsets[currStage].isFinalState ? (batchTokens - batchChunkIdx * chunkSize) : chunkSize;
+        offsets[currStage].batchIdx = shapeBatchIdx;
+        offsets[currStage].headIdx = vHeadIdx;
+        offsets[currStage].chunkIdx = chunkIdx;
+
+        processNewTask = headInnerIdx == PING_PONG_STAGES - 1;
+        if (processNewTask) {
+            taskIdx += PING_PONG_STAGES * cubeCoreNum;
+        }
+
+        currStage = (currStage + 1) % PING_PONG_STAGES;
+    }
+
+    CATLASS_DEVICE
+    uint32_t GetStage(uint32_t distance) const {
+        return (static_cast<uint32_t>(currStage) + PING_PONG_STAGES - distance) % PING_PONG_STAGES;
+    }
+
+
+};
+
+struct BlockSchedulerGdnFwdOCube : public BlockSchedulerGdnFwdO {
+    CATLASS_DEVICE
+    BlockSchedulerGdnFwdOCube() {}
+
+    CATLASS_DEVICE
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::ChunkFwdOTilingData *tilingData) {
+        BlockSchedulerGdnFwdO::Init(cu_seqlens, chunk_offsets, tilingData, AscendC::GetBlockIdx(),
+                                    AscendC::GetBlockNum());
+    }
+
+    CATLASS_DEVICE
+    bool NeedProcessCube1() {
+        return true;
+    }
+
+    CATLASS_DEVICE
+    GDNFwdOOffsets& GetCube1Offsets() {
+        return offsets[GetCube1Stage()];
+    }
+
+    CATLASS_DEVICE
+    uint32_t GetCube1Stage() const {
+        return GetStage(1);
+    }
+
+    CATLASS_DEVICE
+    GemmCoord GetCube1Shape() {
+        GDNFwdOOffsets& cube1Offsets = GetCube1Offsets();
+        return GemmCoord{cube1Offsets.blockTokens, cube1Offsets.blockTokens, kHeadDim};
+    }
+
+    CATLASS_DEVICE
+    bool NeedProcessCube23() {
+        if (unlikely(firstLoop)) {
+            firstLoop = false;
+            return false;
+        }
+        return true;
+    }
+
+    CATLASS_DEVICE
+    GDNFwdOOffsets& GetCube23Offsets() {
+        return offsets[GetCube23Stage()];
+    }
+
+    CATLASS_DEVICE
+    uint32_t GetCube23Stage() const {
+        return GetStage(2);
+    }
+
+    CATLASS_DEVICE
+    GemmCoord GetCube2Shape() {
+        GDNFwdOOffsets& cube2Offsets = GetCube23Offsets();
+        return GemmCoord{kHeadDim, vHeadDim, cube2Offsets.blockTokens};
+    }
+
+    CATLASS_DEVICE
+    GemmCoord GetCube3Shape() {
+        GDNFwdOOffsets& cube2Offsets = GetCube23Offsets();
+        return GemmCoord{kHeadDim, vHeadDim, cube2Offsets.blockTokens};
+    }
+
+};
+
+struct BlockSchedulerGdnFwdOVec : public BlockSchedulerGdnFwdO {
+    CATLASS_DEVICE
+    BlockSchedulerGdnFwdOVec() {}
+
+    CATLASS_DEVICE
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::ChunkFwdOTilingData *tilingData) {
+        BlockSchedulerGdnFwdO::Init(cu_seqlens, chunk_offsets, tilingData,
+                                    AscendC::GetBlockIdx() / AscendC::GetSubBlockNum(), AscendC::GetBlockNum());
+    }
+
+    CATLASS_DEVICE
+    bool NeedProcessVec1() {
+        return isRunning;
+    }
+
+    CATLASS_DEVICE
+    bool NeedProcessVec2() {
+        if (unlikely(firstLoop)) {
+            firstLoop = false;
+            return false;
+        }
+        return true;
+    }
+
+    CATLASS_DEVICE
+    GDNFwdOOffsets& GetVec1Offsets() {
+        return offsets[GetVec1Stage()];
+    }
+
+    CATLASS_DEVICE
+    uint32_t GetVec1Stage() const {
+        return GetStage(1);
+    }
+
+    CATLASS_DEVICE
+    GDNFwdOOffsets& GetVec2Offsets() {
+        return offsets[GetVec2Stage()];
+    }
+
+    CATLASS_DEVICE
+    uint32_t GetVec2Stage() const {
+        return GetStage(2);
+    }
+
+};
+
+}  // namespace Catlass::Gemm::Block
+
+#endif // CATLASS_GEMM_SCHEDULER_GDN_FWD_O_HPP

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/gemm/kernel/gdn_fwd_o_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/gemm/kernel/gdn_fwd_o_kernel.hpp
@@ -1,0 +1,461 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#define CATLASS_ARCH 3510
+
+#include "catlass/arch/arch.hpp"
+#include "catlass/arch/cross_core_sync.hpp"
+#include "catlass/arch/resource.hpp"
+#include "catlass/catlass.hpp"
+#include "catlass/debug.hpp"
+#include "catlass/epilogue/block/block_epilogue.hpp"
+#include "../../epilogue/block/block_epilogue_gdn_fwdo_qkmask.hpp"
+#include "../../epilogue/block/block_epilogue_gdn_fwdo_output.hpp"
+#include "catlass/gemm/block/block_mmad.hpp"
+#include "kernel_utils/block/block_mmad_pingpong_tla_multi.hpp"
+#include "catlass/gemm/block/block_swizzle.hpp"
+#include "../block/block_scheduler_gdn_fwd_o.hpp"
+#include "catlass/gemm/dispatch_policy.hpp"
+#include "catlass/gemm/gemm_type.hpp"
+#include "catlass/layout/layout.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "tla/tensor.hpp"
+#include "tla/layout.hpp"
+#include "tla/tensor.hpp"
+
+using _0 = tla::Int<0>;
+using _1 = tla::Int<1>;
+using _2 = tla::Int<2>;
+using _4 = tla::Int<4>;
+using _8 = tla::Int<8>;
+using _16 = tla::Int<16>;
+using _32 = tla::Int<32>;
+using _64 = tla::Int<64>;
+using _128 = tla::Int<128>;
+using _256 = tla::Int<256>;
+using _512 = tla::Int<512>;
+using _1024 = tla::Int<1024>;
+using _2048 = tla::Int<2048>;
+using _4096 = tla::Int<4096>;
+using _8192 = tla::Int<8192>;
+using _16384 = tla::Int<16384>;
+using _32768 = tla::Int<32768>;
+using _65536 = tla::Int<65536>;
+
+
+
+#include "kernel_operator.h"
+#include "../../../chunk_fwd_o_struct.h"
+using namespace Catlass;
+using namespace tla;
+
+// template <>
+namespace Catlass::Gemm::Kernel {
+
+template<
+    typename INPUT_TYPE,
+    typename G_TYPE,
+    typename WORKSPACE_TYPE
+>
+class GDNFwdOKernel {
+public:
+
+    using ArchTag = Arch::Ascend950;
+    using GDNFwdOOffsets = Catlass::Gemm::Block::GDNFwdOOffsets;
+
+    using CubeScheduler = typename Catlass::Gemm::Block::BlockSchedulerGdnFwdOCube;
+    using VecScheduler = typename Catlass::Gemm::Block::BlockSchedulerGdnFwdOVec;
+
+    using DispatchPolicyTla = Gemm::MmadPingpongTlaMulti<ArchTag, true, false>;
+    using L1TileShapeQKTla = Shape<_128, _128, _128>;
+    using L0TileShapeQKTla = L1TileShapeQKTla;
+    using L1TileShapeV128Tla = Shape<_128, _128, _128>;
+    using L0TileShapeV128Tla = L1TileShapeV128Tla;
+    using L1TileShapeV256Tla = Shape<_128, _256, _128>;
+    using L0TileShapeV256Tla = Shape<_128, _256, _64>;
+    using QType = Gemm::GemmType<INPUT_TYPE, layout::RowMajor>;
+    using KType = Gemm::GemmType<INPUT_TYPE, layout::ColumnMajor>;
+    using AttenType = Gemm::GemmType<WORKSPACE_TYPE, layout::RowMajor>;
+    using AttenMaskedType = Gemm::GemmType<INPUT_TYPE, layout::RowMajor>;
+    using HType = Gemm::GemmType<INPUT_TYPE, layout::RowMajor>;
+    using OinterType = Gemm::GemmType<WORKSPACE_TYPE, layout::RowMajor>;
+    using VNEWType = Gemm::GemmType<INPUT_TYPE, layout::RowMajor>;
+
+    using GType = Gemm::GemmType<G_TYPE, layout::RowMajor>;
+    using OType = Gemm::GemmType<INPUT_TYPE, layout::RowMajor>;
+    using MaskType = Gemm::GemmType<bool, layout::RowMajor>;
+
+    static constexpr bool ENABLE_REUSE_Q_L1_FOR_QH = true;
+    static constexpr bool ENABLE_VEC1_UB_TO_L1_FOR_CUBE3 = true;
+    static constexpr uint32_t VEC1_L1_STAGES = PING_PONG_STAGES;
+    static constexpr uint32_t VEC1_L1_TILE_SIZE = 128 * 128 * sizeof(INPUT_TYPE);
+
+    // cube 1
+    using TileCopyQK = Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::ColumnMajor, WORKSPACE_TYPE, layout::RowMajor>;
+    using BlockMmadQK = Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeQKTla, L0TileShapeQKTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyQK>;
+
+    // cube 2
+    using TileCopyQH = Catlass::Gemm::Tile::PackedTileCopyTlaToUB<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor, void, Catlass::Gemm::Tile::CopyL0CToUBMode::SPLIT_M>;
+    using BlockMmadQH128 = Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeV128Tla, L0TileShapeV128Tla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyQH>;
+    using BlockMmadQH256 = Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeV256Tla, L0TileShapeV256Tla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyQH>;
+
+    // cube 3
+    using TileCopyAttenVNEW = Catlass::Gemm::Tile::PackedTileCopyTlaToUB<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor, void, Catlass::Gemm::Tile::CopyL0CToUBMode::SPLIT_M>;
+    using BlockMmadAttenVNEW128 = Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeV128Tla, L0TileShapeV128Tla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyAttenVNEW>;
+    using BlockMmadAttenVNEW256 = Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeV256Tla, L0TileShapeV256Tla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyAttenVNEW>;
+
+    // vec 1
+    using DispatchPolicyGDNFwdOQkmask = Epilogue::EpilogueAtlasGDNFwdOQkmask;
+    using EpilogueGDNFwdOQkmask = Epilogue::Block::BlockEpilogue<DispatchPolicyGDNFwdOQkmask, AttenMaskedType, GType, AttenType, MaskType>;
+
+    // vec 2
+    using DispatchPolicyGDNFwdOOutput = Epilogue::EpilogueAtlasGDNFwdOOutput;
+    using EpilogueGDNFwdOOutput = Epilogue::Block::BlockEpilogue<DispatchPolicyGDNFwdOOutput, OType, GType, OinterType, OinterType>;
+
+    using ElementQ = typename BlockMmadQK::ElementA;
+    using LayoutQ = Catlass::layout::RowMajor;
+
+    using ElementK =  typename BlockMmadQK::ElementB;
+    using LayoutK = Catlass::layout::ColumnMajor;
+
+    using ElementAtten = typename BlockMmadQK::ElementC;
+    using LayoutAtten = Catlass::layout::RowMajor;
+
+    using ElementAttenMasked = typename BlockMmadQH128::ElementA;
+    using LayoutAttenMasked = Catlass::layout::RowMajor;
+
+    using ElementH = typename BlockMmadQH128::ElementB;
+    using LayoutH = Catlass::layout::RowMajor;
+
+    using ElementOinter = typename BlockMmadQH128::ElementC;
+    using LayoutOinter = Catlass::layout::RowMajor;
+
+
+    using ElementVNEW = typename BlockMmadAttenVNEW128::ElementB;
+    using LayoutVNEW = Catlass::layout::RowMajor;
+
+
+    using ElementG = G_TYPE;
+    using ElementMask = bool;
+
+    using L1TileShape = typename BlockMmadQK::L1TileShape;
+
+    uint32_t shapeBatch;
+    uint32_t seqlen;
+    uint32_t kNumHead;
+    uint32_t vNumHead;
+    uint32_t kHeadDim;
+    uint32_t vHeadDim;
+    uint32_t chunkSize;
+    float scale;
+    uint32_t numChunks;
+    uint32_t isVariedLen;
+    uint32_t tokenBatch;
+    int64_t vWorkspaceOffset;
+    int64_t hWorkspaceOffset;
+    int64_t attnWorkspaceOffset;
+    int64_t aftermaskWorkspaceOffset;
+    int64_t maskWorkspaceOffset;
+
+    AscendC::GlobalTensor<ElementQ> gmQ;
+    AscendC::GlobalTensor<ElementK> gmK;
+    AscendC::GlobalTensor<ElementVNEW> gmV;
+    AscendC::GlobalTensor<ElementH> gmH;
+    AscendC::GlobalTensor<ElementG> gmG;
+    AscendC::GlobalTensor<ElementVNEW> gmO;
+    AscendC::GlobalTensor<ElementOinter> gmVWorkspace;
+    AscendC::GlobalTensor<ElementOinter> gmHWorkspace;
+    AscendC::GlobalTensor<ElementAtten> gmAttnWorkspace;
+    AscendC::GlobalTensor<ElementAttenMasked> gmAftermaskWorkspace;
+    AscendC::GlobalTensor<ElementMask> gmMask;
+    AscendC::LocalTensor<ElementAttenMasked> l1AttenMaskWorkspace[VEC1_L1_STAGES];
+
+    AscendC::LocalTensor<ElementAtten> ubAttenPing;
+    AscendC::LocalTensor<ElementAtten> ubAttenPong;
+    AscendC::LocalTensor<ElementOinter> ubHWorkPing;
+    AscendC::LocalTensor<ElementOinter> ubHWorkPong;
+    AscendC::LocalTensor<ElementOinter> ubVWorkPing;
+    AscendC::LocalTensor<ElementOinter> ubVWorkPong;
+
+    CubeScheduler cubeBlockScheduler;
+    VecScheduler vecBlockScheduler;
+
+    Arch::Resource<ArchTag> resource;
+
+    __aicore__ inline GDNFwdOKernel() {}
+
+    __aicore__ inline void Init(GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR h, GM_ADDR g,
+        GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, GM_ADDR o, const GDN::ChunkFwdOTilingData *tilingData,
+        GM_ADDR user) {
+
+        shapeBatch = tilingData->shapeBatch;
+        seqlen = tilingData->seqlen;
+        kNumHead = tilingData->kNumHead;
+        vNumHead = tilingData->vNumHead;
+        kHeadDim = tilingData->kHeadDim;
+        vHeadDim = tilingData->vHeadDim;
+        scale = tilingData->scale;
+        chunkSize = tilingData->chunkSize;
+        isVariedLen = tilingData->isVariedLen;
+        tokenBatch = tilingData->tokenBatch;
+        vWorkspaceOffset = tilingData->vWorkspaceOffset;
+        hWorkspaceOffset = tilingData->hWorkspaceOffset;
+        attnWorkspaceOffset = tilingData->attnWorkspaceOffset;
+        aftermaskWorkspaceOffset = tilingData->aftermaskWorkspaceOffset;
+        maskWorkspaceOffset = tilingData->maskWorkspaceOffset;
+
+        gmQ.SetGlobalBuffer((__gm__ ElementQ *)q);
+        gmK.SetGlobalBuffer((__gm__ ElementK *)k);
+        gmV.SetGlobalBuffer((__gm__ ElementVNEW *)v);
+        gmH.SetGlobalBuffer((__gm__ ElementH *)h);
+        gmG.SetGlobalBuffer((__gm__ ElementG *)g);
+        gmO.SetGlobalBuffer((__gm__ ElementVNEW *)o);
+        gmVWorkspace.SetGlobalBuffer((__gm__ ElementOinter *)(user + vWorkspaceOffset));
+        gmHWorkspace.SetGlobalBuffer((__gm__ ElementOinter *)(user + hWorkspaceOffset));
+        gmAttnWorkspace.SetGlobalBuffer((__gm__ ElementAtten *)(user + attnWorkspaceOffset));
+        gmAftermaskWorkspace.SetGlobalBuffer((__gm__ ElementAttenMasked *)(user + aftermaskWorkspaceOffset));
+        gmMask.SetGlobalBuffer((__gm__ ElementMask *)(user + maskWorkspaceOffset));
+
+        constexpr uint32_t UB_WORK_SLOT_BYTES = 64 * 128 * sizeof(ElementOinter);
+        constexpr uint32_t UB_WORK_BASE = 71 * 1024;
+        constexpr uint32_t UB_V_WORK_PING_OFFSET = UB_WORK_BASE;
+        constexpr uint32_t UB_H_WORK_PING_OFFSET = UB_V_WORK_PING_OFFSET + UB_WORK_SLOT_BYTES;
+        constexpr uint32_t UB_V_WORK_PONG_OFFSET = UB_H_WORK_PING_OFFSET + UB_WORK_SLOT_BYTES;
+        constexpr uint32_t UB_H_WORK_PONG_OFFSET = UB_V_WORK_PONG_OFFSET + UB_WORK_SLOT_BYTES;
+
+        ubAttenPing = resource.ubBuf.template GetBufferByByte<ElementAtten>(UB_V_WORK_PING_OFFSET);
+        ubAttenPong = resource.ubBuf.template GetBufferByByte<ElementAtten>(UB_V_WORK_PONG_OFFSET);
+        ubHWorkPing = resource.ubBuf.template GetBufferByByte<ElementOinter>(UB_H_WORK_PING_OFFSET);
+        ubHWorkPong = resource.ubBuf.template GetBufferByByte<ElementOinter>(UB_H_WORK_PONG_OFFSET);
+        ubVWorkPing = resource.ubBuf.template GetBufferByByte<ElementOinter>(UB_V_WORK_PING_OFFSET);
+        ubVWorkPong = resource.ubBuf.template GetBufferByByte<ElementOinter>(UB_V_WORK_PONG_OFFSET);
+
+        if ASCEND_IS_AIC {
+            cubeBlockScheduler.Init(cu_seqlens, chunk_offsets, tilingData);
+        }
+
+        if ASCEND_IS_AIV {
+            vecBlockScheduler.Init(cu_seqlens, chunk_offsets, tilingData);
+        }
+    }
+
+    __aicore__ inline void Process() {
+        if ASCEND_IS_AIC {
+            uint32_t coreIdx = AscendC::GetBlockIdx();
+            uint32_t coreNum = AscendC::GetBlockNum();
+            uint32_t subBlockNum = AscendC::GetSubBlockNum();
+            uint32_t l1BufAddrStart = ENABLE_VEC1_UB_TO_L1_FOR_CUBE3 ?
+                VEC1_L1_TILE_SIZE * VEC1_L1_STAGES : 0;
+
+            if constexpr (ENABLE_VEC1_UB_TO_L1_FOR_CUBE3) {
+                for (uint32_t i = 0; i < VEC1_L1_STAGES; ++i) {
+                    l1AttenMaskWorkspace[i] = resource.l1Buf.template GetBufferByByte<ElementAttenMasked>(
+                        i * VEC1_L1_TILE_SIZE);
+                }
+            }
+
+            BlockMmadQK blockMmadQK(resource, l1BufAddrStart);
+            BlockMmadQH128 blockMmadQH128(resource, l1BufAddrStart);
+            BlockMmadQH256 blockMmadQH256(resource, l1BufAddrStart);
+            BlockMmadAttenVNEW128 blockMmadAttenVNEW128(resource, l1BufAddrStart);
+            BlockMmadAttenVNEW256 blockMmadAttenVNEW256(resource, l1BufAddrStart);
+
+            auto qLayout = tla::MakeLayout<ElementQ, LayoutQ>(shapeBatch * kNumHead * seqlen, kHeadDim);
+            auto kLayout = tla::MakeLayout<ElementK, LayoutK>(kHeadDim, shapeBatch * kNumHead * seqlen);
+            auto hLayout = tla::MakeLayout<ElementH, LayoutH>(shapeBatch * vNumHead * seqlen * kHeadDim, vHeadDim);
+            auto vnewLayout = tla::MakeLayout<ElementVNEW, LayoutVNEW>(shapeBatch * vNumHead * seqlen, vHeadDim);
+
+            bool needRun = false;
+            uint32_t cube2pingpongFlag = 0;
+            uint32_t cube3pingpongFlag = 0;
+            uint32_t l0c2ubProduceCount = 0;
+            uint32_t l0c2ubProducedStages[PING_PONG_STAGES] = {0};
+
+            while (cubeBlockScheduler.isRunning) {
+                cubeBlockScheduler.InitTask();
+
+                if (cubeBlockScheduler.isRunning && coreIdx < coreNum) {
+
+                    GDNFwdOOffsets& cube1Offsets = cubeBlockScheduler.GetCube1Offsets();
+                    uint32_t cube1Stage = cubeBlockScheduler.GetCube1Stage();
+                    int64_t cube1OffsetQ = cube1Offsets.qkOffset;
+                    int64_t cube1OffsetK = cube1Offsets.qkOffset;
+                    int64_t cube1OffsetAttn = cube1Offsets.attnWorkOffset;
+                    auto attenLayout = tla::MakeLayout<ElementAtten, LayoutAtten>(coreNum * chunkSize * PING_PONG_STAGES, cube1Offsets.blockTokens);
+                    auto tensorQ = tla::MakeTensor(gmQ[cube1OffsetQ], qLayout, Catlass::Arch::PositionGM{});
+                    auto tensorK = tla::MakeTensor(gmK[cube1OffsetK], kLayout, Catlass::Arch::PositionGM{});
+                    auto tensorAttn = tla::MakeTensor(gmAttnWorkspace[cube1OffsetAttn], attenLayout, Catlass::Arch::PositionGM{});
+                    GemmCoord cube1Shape{cube1Offsets.blockTokens, cube1Offsets.blockTokens, kHeadDim};
+                    auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.k()));
+                    auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.k(), cube1Shape.n()));
+                    auto tensorBlockAttn = GetTile(tensorAttn, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.n()));
+                    blockMmadQK.preSetFlags();
+                    blockMmadQK(tensorBlockQ, tensorBlockK, tensorBlockAttn, cube1Shape);
+                    blockMmadQK.finalWaitFlags();
+                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done[cube1Stage]);
+
+                }
+                // AscendC::PipeBarrier<PIPE_ALL>();
+
+                if (needRun && coreIdx < coreNum) {
+                    uint32_t cube23Stage = cubeBlockScheduler.GetCube23Stage();
+                    for (uint32_t i = 0; i < subBlockNum; ++i) {
+                        Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done[cube23Stage]);
+                    }
+                    GDNFwdOOffsets& cube2Offsets = cubeBlockScheduler.GetCube23Offsets();
+                    int64_t cube2OffsetQ = cube2Offsets.qkOffset;
+                    int64_t cube2OffsetH = cube2Offsets.hOffset;
+                    auto cube2OinterLayout = tla::MakeLayout<ElementOinter, LayoutOinter>(
+                        cube2Offsets.blockTokens, cube2Offsets.vBlockDim);
+                    auto tensorQ = tla::MakeTensor(gmQ[cube2OffsetQ], qLayout, Catlass::Arch::PositionGM{});
+                    auto tensorH = tla::MakeTensor(gmH[cube2OffsetH], hLayout, Catlass::Arch::PositionGM{});
+                    AscendC::LocalTensor<ElementOinter> ubHWork = (cube2pingpongFlag == 0) ? ubHWorkPing : ubHWorkPong;
+                    auto tensorHWork = tla::MakeTensor(ubHWork, cube2OinterLayout, Catlass::Arch::PositionUB{});
+                    GemmCoord cube2Shape{cube2Offsets.blockTokens, cube2Offsets.vBlockDim, kHeadDim};
+                    auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.k()));
+                    auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.k(), cube2Shape.n()));
+                    if (cube2Offsets.vBlockDim <= 128) {
+                        blockMmadQH128.preSetFlags();
+                        if constexpr (ENABLE_REUSE_Q_L1_FOR_QH) {
+                            blockMmadQH128.SkipNextADataCopy();
+                        }
+                        blockMmadQH128(tensorBlockQ, tensorBlockH, tensorHWork, cube2Shape);
+                        blockMmadQH128.finalWaitFlags();
+                    } else {
+                        blockMmadQH256.preSetFlags();
+                        if constexpr (ENABLE_REUSE_Q_L1_FOR_QH) {
+                            blockMmadQH256.SkipNextADataCopy();
+                        }
+                        blockMmadQH256(tensorBlockQ, tensorBlockH, tensorHWork, cube2Shape);
+                        blockMmadQH256.finalWaitFlags();
+                    }
+                    cube2pingpongFlag = 1 - cube2pingpongFlag;
+                }
+
+                AscendC::PipeBarrier<PIPE_MTE2>();
+                AscendC::PipeBarrier<PIPE_FIX>();
+
+                if (needRun && coreIdx < coreNum) {
+                    GDNFwdOOffsets& cube3Offsets = cubeBlockScheduler.GetCube23Offsets();
+                    int64_t cube3OffsetAttnMask = cube3Offsets.attnWorkOffset;
+                    int64_t cube3OffsetV = cube3Offsets.ovOffset;
+                    auto ointerLayout = tla::MakeLayout<ElementOinter, LayoutOinter>(
+                        cube3Offsets.blockTokens, cube3Offsets.vBlockDim);
+                    auto attenLayout = tla::MakeLayout<ElementAtten, LayoutAtten>(coreNum * chunkSize * PING_PONG_STAGES, cube3Offsets.blockTokens);
+                    auto tensorAttnMask = tla::MakeTensor(gmAftermaskWorkspace[cube3OffsetAttnMask], attenLayout, Catlass::Arch::PositionGM{});
+                    auto tensorV = tla::MakeTensor(gmV[cube3OffsetV], vnewLayout, Catlass::Arch::PositionGM{});
+                    AscendC::LocalTensor<ElementOinter> ubVWork = (cube3pingpongFlag == 0) ? ubVWorkPing : ubVWorkPong;
+                    auto tensorVWork = tla::MakeTensor(ubVWork, ointerLayout, Catlass::Arch::PositionUB{});
+                    GemmCoord cube3Shape{cube3Offsets.blockTokens, cube3Offsets.vBlockDim, cube3Offsets.blockTokens};
+                    auto tensorBlockAttnMask = GetTile(tensorAttnMask, tla::MakeCoord(0, 0), tla::MakeShape(cube3Shape.m(), cube3Shape.k()));
+                    auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), tla::MakeShape(cube3Shape.k(), cube3Shape.n()));
+                    if (cube3Offsets.vBlockDim <= 128) {
+                        blockMmadAttenVNEW128.preSetFlags();
+                        if constexpr (ENABLE_VEC1_UB_TO_L1_FOR_CUBE3) {
+                            uint32_t l1Stage = cubeBlockScheduler.GetCube23Stage();
+                            blockMmadAttenVNEW128.UseExternalL1ATensor(l1AttenMaskWorkspace[l1Stage]);
+                        }
+                        blockMmadAttenVNEW128(tensorBlockAttnMask, tensorBlockV, tensorVWork, cube3Shape);
+                        blockMmadAttenVNEW128.finalWaitFlags();
+                    } else {
+                        blockMmadAttenVNEW256.preSetFlags();
+                        if constexpr (ENABLE_VEC1_UB_TO_L1_FOR_CUBE3) {
+                            uint32_t l1Stage = cubeBlockScheduler.GetCube23Stage();
+                            blockMmadAttenVNEW256.UseExternalL1ATensor(l1AttenMaskWorkspace[l1Stage]);
+                        }
+                        blockMmadAttenVNEW256(tensorBlockAttnMask, tensorBlockV, tensorVWork, cube3Shape);
+                        blockMmadAttenVNEW256.finalWaitFlags();
+                    }
+                    cube3pingpongFlag = 1 - cube3pingpongFlag;
+                    l0c2ubProducedStages[l0c2ubProduceCount % PING_PONG_STAGES] = cubeBlockScheduler.GetCube23Stage();
+                    ++l0c2ubProduceCount;
+                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube3Done[cubeBlockScheduler.GetCube23Stage()]);
+                }
+                needRun = true;
+                // AscendC::PipeBarrier<PIPE_ALL>();
+            }
+
+            uint32_t l0c2ubDrainCount = (l0c2ubProduceCount < PING_PONG_STAGES) ? l0c2ubProduceCount : PING_PONG_STAGES;
+            uint32_t l0c2ubDrainStart = l0c2ubProduceCount - l0c2ubDrainCount;
+        }
+
+        if ASCEND_IS_AIV {
+
+            uint32_t coreIdx = AscendC::GetBlockIdx();
+            uint32_t coreNum = AscendC::GetBlockNum();
+            uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
+            uint32_t subBlockNum = AscendC::GetSubBlockNum();
+
+            if constexpr (ENABLE_VEC1_UB_TO_L1_FOR_CUBE3) {
+                for (uint32_t i = 0; i < VEC1_L1_STAGES; ++i) {
+                    l1AttenMaskWorkspace[i] = resource.l1Buf.template GetBufferByByte<ElementAttenMasked>(
+                        i * VEC1_L1_TILE_SIZE);
+                }
+            }
+
+            AscendC::LocalTensor<float> maskUbTensor = resource.ubBuf.template GetBufferByByte<float>(0);
+            AscendC::Duplicate<float>(maskUbTensor, (float)0.0, 64*64);
+            AscendC::PipeBarrier<PIPE_V>();
+            for(uint32_t i = 0; i < 64; ++ i) AscendC::Duplicate<float>(maskUbTensor[i * 64], (float)1.0, i + 1);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            bool needRun = false;
+            uint32_t vec1pingpongFlag = 0;
+            uint32_t vec2pingpongFlag = 0;
+
+            while (vecBlockScheduler.isRunning) {
+                vecBlockScheduler.InitTask();
+
+                if (vecBlockScheduler.isRunning && coreIdx < coreNum * subBlockNum) {
+                    uint32_t vec1Stage = vecBlockScheduler.GetVec1Stage();
+                    Arch::CrossCoreWaitFlag(vecBlockScheduler.cube1Done[vec1Stage]);
+                    GDNFwdOOffsets& vec1Offsets = vecBlockScheduler.GetVec1Offsets();
+                    int64_t vec1OffsetAttnMask = vec1Offsets.attnWorkOffset;
+                    int64_t vec1OffsetG = vec1Offsets.gOffset;
+                    int64_t vec1OffsetAttn = vec1Offsets.attnWorkOffset;
+                    EpilogueGDNFwdOQkmask epilogueGDNFwdOQkmask(resource);
+                    if constexpr (ENABLE_VEC1_UB_TO_L1_FOR_CUBE3) {
+                        epilogueGDNFwdOQkmask.EnableL1Output(l1AttenMaskWorkspace[vec1Stage]);
+                    }
+                    epilogueGDNFwdOQkmask(
+                        gmAftermaskWorkspace[vec1OffsetAttnMask],
+                        gmG[vec1OffsetG], gmAttnWorkspace[vec1OffsetAttn], gmMask,
+                        chunkSize, vec1Offsets.blockTokens, kHeadDim, vHeadDim, vec1pingpongFlag, vec1Offsets.batchIdx, vec1Offsets.headIdx, vec1Offsets.chunkIdx
+                    );
+                    vec1pingpongFlag = 1 - vec1pingpongFlag;
+                    Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec1Done[vec1Stage]);
+                }
+
+                // AscendC::PipeBarrier<PIPE_ALL>();
+
+                if (needRun && coreIdx < coreNum * subBlockNum) {
+                    uint32_t vec2Stage = vecBlockScheduler.GetVec2Stage();
+                    Arch::CrossCoreWaitFlag(vecBlockScheduler.cube3Done[vec2Stage]);
+                    GDNFwdOOffsets& vec2Offsets = vecBlockScheduler.GetVec2Offsets();
+                    int64_t vec2OffsetO = vec2Offsets.ovOffset;
+                    int64_t vec2OffsetG = vec2Offsets.gOffset;
+                    AscendC::LocalTensor<ElementOinter> ubVWork = (vec2pingpongFlag == 0) ? ubVWorkPing : ubVWorkPong;
+                    AscendC::LocalTensor<ElementOinter> ubHWork = (vec2pingpongFlag == 0) ? ubHWorkPing : ubHWorkPong;
+                    EpilogueGDNFwdOOutput epilogueGDNFwdOOutput(resource);
+                    epilogueGDNFwdOOutput(
+                        gmO[vec2OffsetO],
+                        gmG[vec2OffsetG], ubVWork, ubHWork,
+                        scale, vec2Offsets.blockTokens, kHeadDim, vec2Offsets.vBlockDim, vHeadDim, vec2pingpongFlag,
+                        vec2Offsets.batchIdx, vec2Offsets.headIdx, vec2Offsets.chunkIdx
+                    );
+                    vec2pingpongFlag = 1 - vec2pingpongFlag;
+                }
+                needRun = true;
+            }
+        }
+    }
+
+};
+
+}

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/chunk_fwd_o.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/chunk_fwd_o.cpp
@@ -13,7 +13,11 @@
  */
 
 #include "chunk_fwd_o_struct.h"
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#include "arch35/gemm/kernel/gdn_fwd_o_kernel.hpp"
+#else
 #include "gemm/kernel/gdn_fwd_o_kernel.hpp"
+#endif
 #ifndef TORCH_MODE
 #include "lib/matmul_intf.h"
 #endif


### PR DESCRIPTION
0.分离arch35和非arch35代码
1.cube2/3 l0c2ub
2.regbase vec 改造
3.cube2复用cube1的Q矩阵
4.ub2l1

# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:不涉及
- 背景与目标:GDN AscendC算子的Fwd_o针对A5架构的优化
- 本 PR 解决的问题:GDN AscendC算子的Fwd_o针对A5架构的优化

| Scene | [B,T,H,D] | Chunk size | Layout | fwd_o A5 PR 32core improvement | fwd_o A5 DT 28core improvement |
| :--- | :--- | :---: | :---: | :---: | :---: |
| Long context | [1,32768,32,128] | 64 | BNSD | 4.70% | 5.10% |
| TND | [1,32768,32,128] | 64 | TND | 5.00% | 2.50% |
| Short context | [1,256,32,128] | 64 | BNSD | 11.10% | 9.80% |
| Midium context & multi-batch & chunksize64 | [64,1024,8,128] | 64 | BNSD | 5.60% | 2.80% |
| Midium context & multi-batch & chunksize128 | [64,1024,8,128] | 128 | BNSD | 13.50% | 8.80% |

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @stevenzhangdongyu
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
