### PR TITLE
bwd_dhu支持输入gk/h0/dht，输出dh0

### DIFF
--- a/examples/fast_kernel_launch_example/csrc/chunk_gated_delta_rule_bwd_dhu/ascend910b/chunk_gated_delta_rule_bwd_dhu.cpp
+++ b/examples/fast_kernel_launch_example/csrc/chunk_gated_delta_rule_bwd_dhu/ascend910b/chunk_gated_delta_rule_bwd_dhu.cpp
@@ -45,8 +45,6 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_bwd_dhu_me
     at::OptionalIntArrayRef chunk_indices)
 {
     (void)scale;
-    (void)gK;
-    (void)dht;
 
     int64_t B = q.size(0);
     int64_t Hk = q.size(1);
@@ -63,7 +61,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_bwd_dhu_me
     at::Tensor dv2 = at::empty_like(dv);
     at::Tensor dh0;
     if (h0.has_value()) {
-        dh0 = at::empty({B, Hv, chunkNum, K, V}, q.options());
+        int64_t stateBatch = cu_seqlens.has_value() ? static_cast<int64_t>(cu_seqlens.value().size()) - 1 : B;
+        dh0 = at::empty({stateBatch, Hv, K, V}, q.options().dtype(at::kFloat));
     } else {
         dh0 = at::empty({0}, q.options());
     }
@@ -92,7 +91,8 @@ void CheckSameDevice(const at::Tensor &base, const at::Tensor &tensor, const cha
 }
 
 void CheckInputs(const at::Tensor &q, const at::Tensor &k, const at::Tensor &w, const at::Tensor &d_o,
-                 const at::Tensor &dv, const at::Tensor &g, at::OptionalIntArrayRef cu_seqlens,
+                 const at::Tensor &dv, const at::Tensor &g, const c10::optional<at::Tensor> &gK,
+                 const c10::optional<at::Tensor> &h0, const c10::optional<at::Tensor> &dht, at::OptionalIntArrayRef cu_seqlens,
                  at::OptionalIntArrayRef chunk_indices)
 {
     CheckInputRank(q, 4, "q");
@@ -127,6 +127,24 @@ void CheckInputs(const at::Tensor &q, const at::Tensor &k, const at::Tensor &w, 
               "GVA requires Hv divisible by Hk; Hk=", Hk, " Hv=", Hv);
     TORCH_CHECK(g.size(0) == B && g.size(1) == Hv && g.size(2) == T,
               "g must be [B,Hv,T]; g=", g.sizes());
+    int64_t stateBatch = cu_seqlens.has_value() ? static_cast<int64_t>(cu_seqlens.value().size()) - 1 : B;
+    if (gK.has_value()) {
+        CheckInputRank(gK.value(), 4, "gK");
+        CheckSameDevice(q, gK.value(), "gK");
+        TORCH_CHECK(gK.value().sizes() == at::IntArrayRef({B, Hv, T, K}), "gK must be [B,Hv,T,K].");
+        TORCH_CHECK(gK.value().scalar_type() == g.scalar_type(), "gK must have the same dtype as g.");
+    }
+    if (h0.has_value()) {
+        CheckInputRank(h0.value(), 4, "h0");
+        CheckSameDevice(q, h0.value(), "h0");
+        TORCH_CHECK(h0.value().sizes() == at::IntArrayRef({stateBatch, Hv, K, V}), "h0 must be [N,Hv,K,V].");
+    }
+    if (dht.has_value()) {
+        CheckInputRank(dht.value(), 4, "dht");
+        CheckSameDevice(q, dht.value(), "dht");
+        TORCH_CHECK(dht.value().sizes() == at::IntArrayRef({stateBatch, Hv, K, V}), "dht must be [N,Hv,K,V].");
+        TORCH_CHECK(dht.value().scalar_type() == at::kFloat, "dht must be float32.");
+    }
 
     auto qDtype = q.scalar_type();
     auto gDtype = g.scalar_type();
@@ -158,7 +176,8 @@ ge::DataType ToGeDtype(at::ScalarType dtype)
 
 ChunkGatedDeltaRuleBwdDhuTilingResult CalcTilingParams(
     const at::Tensor &q, const at::Tensor &k, const at::Tensor &w, const at::Tensor &d_o, const at::Tensor &dv,
-    const at::Tensor &g, double scale, int64_t chunk_size, at::OptionalIntArrayRef cu_seqlens,
+    const at::Tensor &g, const c10::optional<at::Tensor> &gK, const c10::optional<at::Tensor> &h0,
+    const c10::optional<at::Tensor> &dht, double scale, int64_t chunk_size, at::OptionalIntArrayRef cu_seqlens,
     at::OptionalIntArrayRef chunk_indices)
 {
     auto qSizes = q.sizes();
@@ -180,10 +199,35 @@ ChunkGatedDeltaRuleBwdDhuTilingResult CalcTilingParams(
                                 {dvSizes[0], dvSizes[1], dvSizes[2], dvSizes[3]});
     gert::StorageShape gShape({gSizes[0], gSizes[1], gSizes[2]}, {gSizes[0], gSizes[1], gSizes[2]});
 
+    gert::StorageShape *gkShapePtr = nullptr;
+    gert::StorageShape *h0ShapePtr = nullptr;
+    gert::StorageShape *dhtShapePtr = nullptr;
+    gert::StorageShape gkShape;
+    gert::StorageShape h0Shape;
+    gert::StorageShape dhtShape;
     gert::StorageShape *cuSeqlensShapePtr = nullptr;
     gert::StorageShape *chunkIndicesShapePtr = nullptr;
     gert::StorageShape cuSeqlensShape;
     gert::StorageShape chunkIndicesShape;
+
+    if (gK.has_value()) {
+        auto sizes = gK.value().sizes();
+        gkShape = gert::StorageShape({sizes[0], sizes[1], sizes[2], sizes[3]},
+                                     {sizes[0], sizes[1], sizes[2], sizes[3]});
+        gkShapePtr = &gkShape;
+    }
+    if (h0.has_value()) {
+        auto sizes = h0.value().sizes();
+        h0Shape = gert::StorageShape({sizes[0], sizes[1], sizes[2], sizes[3]},
+                                     {sizes[0], sizes[1], sizes[2], sizes[3]});
+        h0ShapePtr = &h0Shape;
+    }
+    if (dht.has_value()) {
+        auto sizes = dht.value().sizes();
+        dhtShape = gert::StorageShape({sizes[0], sizes[1], sizes[2], sizes[3]},
+                                      {sizes[0], sizes[1], sizes[2], sizes[3]});
+        dhtShapePtr = &dhtShape;
+    }
 
     if (cu_seqlens.has_value()) {
         int64_t cuDim0 = static_cast<int64_t>(cu_seqlens.value().size());
@@ -212,11 +256,19 @@ ChunkGatedDeltaRuleBwdDhuTilingResult CalcTilingParams(
         &doShape,
         &dvShape,
         &gShape,
+        gkShapePtr,
+        h0ShapePtr,
+        dhtShapePtr,
         cuSeqlensShapePtr,
         chunkIndicesShapePtr,
         ToGeDtype(q.scalar_type()),
         ToGeDtype(g.scalar_type()),
+        gK.has_value() ? ToGeDtype(gK.value().scalar_type()) : ge::DT_FLOAT,
+        dht.has_value() ? ToGeDtype(dht.value().scalar_type()) : ge::DT_FLOAT,
         true,
+        gK.has_value(),
+        h0.has_value(),
+        dht.has_value(),
         true,
         scale,
         static_cast<int32_t>(chunk_size),
@@ -236,9 +288,6 @@ __global__ __aicore__ void chunk_gated_delta_rule_bwd_dhu_kernel(
     GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR dh, GM_ADDR dh0, GM_ADDR dv2, GM_ADDR workspace,
     const GDN::ChunkGatedDeltaRuleBwdDhuTilingData tilingData)
 {
-    (void)gk;
-    (void)h0;
-    (void)dht;
     AscendC::AscendCUtils::SetOverflow(1);
     AscendC::SetSysWorkspaceForce(workspace);
     GM_ADDR userWS = AscendC::GetUserWorkspace(workspace);
@@ -251,17 +300,17 @@ __global__ __aicore__ void chunk_gated_delta_rule_bwd_dhu_kernel(
         KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
     }
     GDN::ChunkGatedDeltaRuleBwdDhuKernelImpl<DT, GT>(
-        q, k, w, d_o, dv, g, cu_seqlens, chunk_indices, dh, dh0, dv2, userWS, &tilingData);
+        q, k, w, d_o, dv, g, gk, h0, dht, cu_seqlens, chunk_indices, dh, dh0, dv2, userWS, &tilingData);
 }
 
 template <typename DT, typename GT>
 void LaunchChunkGatedDeltaRuleBwdDhu(uint32_t blockDim, aclrtStream stream, GM_ADDR q, GM_ADDR k, GM_ADDR w, GM_ADDR d_o,
-                                     GM_ADDR dv, GM_ADDR g, GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR dh,
-                                     GM_ADDR dh0, GM_ADDR dv2, GM_ADDR workspace,
+                                     GM_ADDR dv, GM_ADDR g, GM_ADDR gk, GM_ADDR h0, GM_ADDR dht, GM_ADDR cu_seqlens,
+                                     GM_ADDR chunk_indices, GM_ADDR dh, GM_ADDR dh0, GM_ADDR dv2, GM_ADDR workspace,
                                      const GDN::ChunkGatedDeltaRuleBwdDhuTilingData &tiling)
 {
     chunk_gated_delta_rule_bwd_dhu_kernel<DT, GT><<<blockDim, nullptr, stream>>>(
-        q, k, w, d_o, dv, g, nullptr, nullptr, nullptr, cu_seqlens, chunk_indices, dh, dh0, dv2, workspace, tiling);
+        q, k, w, d_o, dv, g, gk, h0, dht, cu_seqlens, chunk_indices, dh, dh0, dv2, workspace, tiling);
 }
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_bwd_dhu_npu(
@@ -271,13 +320,9 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_bwd_dhu_np
     at::OptionalIntArrayRef chunk_indices)
 {
     TORCH_CHECK(g.has_value(), "chunk_gated_delta_rule_bwd_dhu requires g to be provided.");
-    TORCH_CHECK(!gK.has_value(), "gK is not supported and must be None.");
-    TORCH_CHECK(!h0.has_value(), "h0 is not supported in fast kernel launch and must be None.");
-    TORCH_CHECK(!dht.has_value(), "dht is not supported in fast kernel launch and must be None.");
-
     const c10::OptionalDeviceGuard guard(q.device());
     const at::Tensor &gTensor = g.value();
-    CheckInputs(q, k, w, d_o, dv, gTensor, cu_seqlens, chunk_indices);
+    CheckInputs(q, k, w, d_o, dv, gTensor, gK, h0, dht, cu_seqlens, chunk_indices);
 
     auto outputs = chunk_gated_delta_rule_bwd_dhu_meta(q, k, w, d_o, dv, scale, chunk_size, g, gK, h0, dht,
                                                        cu_seqlens, chunk_indices);
@@ -286,7 +331,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_bwd_dhu_np
     auto dv2 = std::get<2>(outputs);
 
     auto stream = c10_npu::getCurrentNPUStream().stream(false);
-    auto tilingResult = CalcTilingParams(q, k, w, d_o, dv, gTensor, scale, chunk_size, cu_seqlens, chunk_indices);
+    auto tilingResult = CalcTilingParams(q, k, w, d_o, dv, gTensor, gK, h0, dht, scale, chunk_size,
+                                         cu_seqlens, chunk_indices);
 
     GM_ADDR qPtr = (GM_ADDR)q.data_ptr();
     GM_ADDR kPtr = (GM_ADDR)k.data_ptr();
@@ -294,6 +340,9 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_bwd_dhu_np
     GM_ADDR doPtr = (GM_ADDR)d_o.data_ptr();
     GM_ADDR dvPtr = (GM_ADDR)dv.data_ptr();
     GM_ADDR gPtr = (GM_ADDR)gTensor.data_ptr();
+    GM_ADDR gkPtr = gK.has_value() ? (GM_ADDR)gK.value().data_ptr() : nullptr;
+    GM_ADDR h0Ptr = h0.has_value() ? (GM_ADDR)h0.value().data_ptr() : nullptr;
+    GM_ADDR dhtPtr = dht.has_value() ? (GM_ADDR)dht.value().data_ptr() : nullptr;
     GM_ADDR dhPtr = (GM_ADDR)dh.data_ptr();
     GM_ADDR dh0Ptr = dh0.numel() > 0 ? (GM_ADDR)dh0.data_ptr() : nullptr;
     GM_ADDR dv2Ptr = (GM_ADDR)dv2.data_ptr();
@@ -331,19 +380,19 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_bwd_dhu_np
     auto aclCall = [=]() -> int {
         if (qDtype == at::kBFloat16 && gDtype == at::kBFloat16) {
             LaunchChunkGatedDeltaRuleBwdDhu<bfloat16_t, bfloat16_t>(
-                blockDim, stream, qPtr, kPtr, wPtr, doPtr, dvPtr, gPtr, cuSeqlensPtr, chunkIndicesPtr, dhPtr, dh0Ptr,
+                blockDim, stream, qPtr, kPtr, wPtr, doPtr, dvPtr, gPtr, gkPtr, h0Ptr, dhtPtr, cuSeqlensPtr, chunkIndicesPtr, dhPtr, dh0Ptr,
                 dv2Ptr, workspaceGm, tiling);
         } else if (qDtype == at::kHalf && gDtype == at::kHalf) {
             LaunchChunkGatedDeltaRuleBwdDhu<half, half>(
-                blockDim, stream, qPtr, kPtr, wPtr, doPtr, dvPtr, gPtr, cuSeqlensPtr, chunkIndicesPtr, dhPtr, dh0Ptr,
+                blockDim, stream, qPtr, kPtr, wPtr, doPtr, dvPtr, gPtr, gkPtr, h0Ptr, dhtPtr, cuSeqlensPtr, chunkIndicesPtr, dhPtr, dh0Ptr,
                 dv2Ptr, workspaceGm, tiling);
         } else if (qDtype == at::kBFloat16 && gDtype == at::kFloat) {
             LaunchChunkGatedDeltaRuleBwdDhu<bfloat16_t, float>(
-                blockDim, stream, qPtr, kPtr, wPtr, doPtr, dvPtr, gPtr, cuSeqlensPtr, chunkIndicesPtr, dhPtr, dh0Ptr,
+                blockDim, stream, qPtr, kPtr, wPtr, doPtr, dvPtr, gPtr, gkPtr, h0Ptr, dhtPtr, cuSeqlensPtr, chunkIndicesPtr, dhPtr, dh0Ptr,
                 dv2Ptr, workspaceGm, tiling);
         } else if (qDtype == at::kHalf && gDtype == at::kFloat) {
             LaunchChunkGatedDeltaRuleBwdDhu<half, float>(
-                blockDim, stream, qPtr, kPtr, wPtr, doPtr, dvPtr, gPtr, cuSeqlensPtr, chunkIndicesPtr, dhPtr, dh0Ptr,
+                blockDim, stream, qPtr, kPtr, wPtr, doPtr, dvPtr, gPtr, gkPtr, h0Ptr, dhtPtr, cuSeqlensPtr, chunkIndicesPtr, dhPtr, dh0Ptr,
                 dv2Ptr, workspaceGm, tiling);
         } else {
             TORCH_CHECK(false, "Unsupported dtype combination: q=", qDtype, ", g=", gDtype);

--- a/examples/fast_kernel_launch_example/tests/chunk_gated_delta_rule_bwd_dhu/test_chunk_gated_delta_rule_bwd_dhu.py
+++ b/examples/fast_kernel_launch_example/tests/chunk_gated_delta_rule_bwd_dhu/test_chunk_gated_delta_rule_bwd_dhu.py
@@ -222,7 +222,7 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
             if g is not None:
                 bg_last = g[:, :, global_last_idx]
                 b_g = g[:, :, global_start_t:global_end_t]
-                gate_factor = torch.exp(bg_last.unsqueeze(-1) - b_g).unsqueeze(-1)
+                gate_factor = torch.exp2(bg_last.unsqueeze(-1) - b_g).unsqueeze(-1)
                 m_t = torch.arange(block_size_t, device=device, dtype=torch.float32) < float(block_size_t)
                 mask_expanded = m_t.view(1, 1, block_size_t, 1)
                 b_dv = b_dv * gate_factor * mask_expanded
@@ -234,8 +234,8 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
             b_w_t = w_blk.transpose(-1, -2)
 
             if g is not None:
-                bg_last_exp = torch.exp(bg_last)
-                b_g_exp = torch.exp(b_g)
+                bg_last_exp = torch.exp2(bg_last)
+                b_g_exp = torch.exp2(b_g)
                 b_dh_for_update = b_dh * bg_last_exp.unsqueeze(-1).unsqueeze(-1)
                 b_q_gated = b_q_t * b_g_exp.unsqueeze(-2)
             else:
@@ -268,8 +268,8 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
                     if g is not None:
                         bg_last = g[b, i_h, global_last_idx]
                         b_g = g[b, i_h, global_start_t:global_end_t]
-                        bg_last_exp = torch.exp(bg_last)
-                        b_g_exp = torch.exp(b_g)
+                        bg_last_exp = torch.exp2(bg_last)
+                        b_g_exp = torch.exp2(b_g)
 
                     b_do = do[b, i_h, global_start_t:global_end_t, :]
                     b_dv_existing = dv[b, i_h, global_start_t:global_end_t, :]
@@ -278,7 +278,7 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
 
                     if g is not None:
                         m_t = torch.arange(block_size_t, device=device) < block_size_t
-                        gate_factor = torch.exp(bg_last - b_g).unsqueeze(-1)
+                        gate_factor = torch.exp2(bg_last - b_g).unsqueeze(-1)
                         mask_expanded = m_t.unsqueeze(-1).float()
                         b_dv *= gate_factor * mask_expanded
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/ATK/executor_chunk_gated_delta_rule_bwd_dhu.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/ATK/executor_chunk_gated_delta_rule_bwd_dhu.py
@@ -167,8 +167,8 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
                 if g is not None:
                     bg_last = g[b, i_h, global_last_idx]
                     b_g = g[b, i_h, global_start_t:global_end_t]
-                    bg_last_exp = torch.exp(bg_last)
-                    b_g_exp = torch.exp(b_g)
+                    bg_last_exp = torch.exp2(bg_last)
+                    b_g_exp = torch.exp2(b_g)
 
                 b_do = do[b, i_h, global_start_t:global_end_t, :]
                 b_dv_existing = dv[b, i_h, global_start_t:global_end_t, :]
@@ -178,7 +178,7 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
 
                 if g is not None:
                     m_t = torch.arange(block_size_t, device=device) < block_size_t
-                    gate_factor = torch.exp(bg_last - b_g).unsqueeze(-1)
+                    gate_factor = torch.exp2(bg_last - b_g).unsqueeze(-1)
                     mask_expanded = m_t.unsqueeze(-1).float()
                     b_dv *= gate_factor * mask_expanded
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/README.md
@@ -60,7 +60,7 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhu(
 | `w` | 输入 | 必选 | Weight（衰减权重）输入张量 | 参与隐藏状态更新 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, K]` | 支持 |
 | `dO` | 输入 | 必选 | 前向输出 `o` 的梯度张量 | 即上游输出梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, V]` | 支持 |
 | `dv` | 输入 | 必选 | Value 的上游梯度张量 | 将与来自 `dh` 的贡献叠加后输出为 `dv2` | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, V]` | 支持 |
-| `gOptional` | 输入 | 必选 | 标量 Gate 张量 | 对隐藏状态递推施加自然指数门控 `exp(g)` | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, HV, T]` | 支持 |
+| `gOptional` | 输入 | 必选 | 标量 Gate 张量 | 对隐藏状态递推施加 base-2 门控 `exp2(g)` | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, HV, T]` | 支持 |
 | `gkOptional` | 输入 | 可选 | Key-wise Gate 张量 | 对每个 Key 维度施加 base-2 门控 `exp2(gk)` | `FLOAT16`、`BFLOAT16`、`FLOAT`（与 `g` 同 dtype） | `ND` | `[B, HV, T, K]` | 支持 |
 | `h0Optional` | 输入 | 可选 | 初始隐藏状态张量 | 提供时声明需要输出 `dh0`；其数值不参与本算子的反向递推 | `FLOAT16`、`BFLOAT16` | `ND` | `[N, HV, K, V]` | 支持 |
 | `dhtOptional` | 输入 | 可选 | 末尾隐藏状态的梯度张量 | 反向递推的起始梯度 | `FLOAT` | `ND` | `[B, HV, K, V]` | 支持 |
@@ -163,7 +163,7 @@ B = 1
 # dv2：叠加来自隐藏状态的 Value 梯度
 b_dv  = k_chunk @ b_dh                        # 从当前 dh 产生的 dv 贡献
 if g:
-    b_dv *= exp(g_last - g_chunk)[:, None]     # 门控衰减
+    b_dv *= exp2(g_last - g_chunk)[:, None]    # 门控衰减
 dv2_chunk = b_dv + dv_chunk                   # 与上游 dv 叠加
 
 # dh 存储（在更新前记录当前 chunk 的 dh）
@@ -171,8 +171,8 @@ dh[:, :, i_t] = b_dh
 
 # 反向递推更新 b_dh（传递给上一 chunk）
 if g:
-    b_dh *= exp(g_last)
-term1 = (q_chunk * exp(g_chunk))^T @ dO_chunk * scale
+    b_dh *= exp2(g_last)
+term1 = (q_chunk * exp2(g_chunk))^T @ dO_chunk * scale
 term2 = w_chunk^T @ dv2_chunk
 b_dh = b_dh + term1 - term2
 ```

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/README.md
@@ -60,10 +60,10 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhu(
 | `w` | 输入 | 必选 | Weight（衰减权重）输入张量 | 参与隐藏状态更新 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, K]` | 支持 |
 | `dO` | 输入 | 必选 | 前向输出 `o` 的梯度张量 | 即上游输出梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, V]` | 支持 |
 | `dv` | 输入 | 必选 | Value 的上游梯度张量 | 将与来自 `dh` 的贡献叠加后输出为 `dv2` | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, V]` | 支持 |
-| `gOptional` | 输入 | 可选 | Gate 张量 | 对隐藏状态递推施加指数门控 `exp(g)` | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, HV, T]` | 支持 |
-| `gkOptional` | 输入 | 可选 | Key-wise Gate 张量 | 对每个 Key 维度施加额外门控 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, K]` | 支持 |
-| `h0Optional` | 输入 | 可选 | 初始隐藏状态张量 | 提供时参与递推初始化 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, K, V]` | 支持 |
-| `dhtOptional` | 输入 | 可选 | 末尾隐藏状态的梯度张量 | 反向递推的起始梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, K, V]` | 支持 |
+| `gOptional` | 输入 | 必选 | 标量 Gate 张量 | 对隐藏状态递推施加自然指数门控 `exp(g)` | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, HV, T]` | 支持 |
+| `gkOptional` | 输入 | 可选 | Key-wise Gate 张量 | 对每个 Key 维度施加 base-2 门控 `exp2(gk)` | `FLOAT16`、`BFLOAT16`、`FLOAT`（与 `g` 同 dtype） | `ND` | `[B, HV, T, K]` | 支持 |
+| `h0Optional` | 输入 | 可选 | 初始隐藏状态张量 | 提供时声明需要输出 `dh0`；其数值不参与本算子的反向递推 | `FLOAT16`、`BFLOAT16` | `ND` | `[N, HV, K, V]` | 支持 |
+| `dhtOptional` | 输入 | 可选 | 末尾隐藏状态的梯度张量 | 反向递推的起始梯度 | `FLOAT` | `ND` | `[B, HV, K, V]` | 支持 |
 | `cuSeqlensOptional` | 输入 | 可选 | 变长序列的累计长度信息 | 变长模式输入，形状为 `[N+1]` | `INT64` | `ND` | 1 维 | - |
 | `chunkIndicesOptional` | 输入 | 可选 | 分块索引信息 | 变长模式输入，扁平化存储 `[seqIdx0, chunkIdx0, ...]`，长度为 `2 * numChunks` | `INT64` | `ND` | 1 维 | - |
 
@@ -79,7 +79,7 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhu(
 | 参数名 | 输入/输出 | 描述 | 数据类型 | 数据格式 | 维度（Shape） | 非连续 Tensor |
 |---|---|---|---|---|---|---|
 | `dhOut` | 输出 | 各 chunk 起始时刻的隐藏状态梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, NT, K, V]` | 支持 |
-| `dh0Out` | 输出 | 初始隐藏状态 `h0` 的梯度（仅当 `h0Optional` 非空时有意义）| `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, K, V]` | 支持 |
+| `dh0Out` | 输出 | 初始隐藏状态 `h0` 的梯度（仅当 `h0Optional` 非空时有意义）| `FLOAT` | `ND` | `[N, HV, K, V]` | 支持 |
 | `dv2Out` | 输出 | 融合了隐藏状态贡献后的 Value 梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, V]` | 支持 |
 | `workspaceSize` | 输出 | Device 侧所需 workspace 大小 | `uint64_t` | - | 标量 | - |
 | `executor` | 输出 | 算子执行器，封装了计算流程 | `aclOpExecutor*` | - | - | - |
@@ -114,9 +114,10 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhu(
   - 同时出现时启用变长模式（varlen）
   - 变长模式仅支持 `B = 1`
 
-- `gOptional`：
-  - 数据类型可以为 `FLOAT16`、`BFLOAT16` 或 `FLOAT`
-  - 数据类型需与 `q` 类型一致，或为 `FLOAT`（FP32）
+- `gOptional`：必须提供；数据类型可以为 `FLOAT16`、`BFLOAT16` 或 `FLOAT`，且需与 `q` 类型一致或为 `FLOAT`（FP32）。
+- `gkOptional`：若提供，形状为 `[B, HV, T, K]`，数据类型必须与 `gOptional` 相同；其最后一个 token 的 gate 以 `exp2` 作用于对应 K 行。
+- `dhtOptional`：若提供，必须为 FP32，并作为最后一个 chunk 的反向状态梯度；不要求同时提供 `h0Optional`。
+- `h0Optional`：数值本身仅用于声明需要 `dh0Out`；`dh0Out` 为 FP32，定长形状为 `[B, HV, K, V]`，变长形状为 `[N, HV, K, V]`。
 
 ---
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/chunk_gated_delta_rule_bwd_dhu_def.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/chunk_gated_delta_rule_bwd_dhu_def.cpp
@@ -64,7 +64,7 @@ public:
 
         this->Input("gk")
             .ParamType(OPTIONAL)
-            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
@@ -78,7 +78,7 @@ public:
             
         this->Input("dht")
             .ParamType(OPTIONAL)
-            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
@@ -107,7 +107,7 @@ public:
             
         this->Output("dh0")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_api/chunk_gated_delta_rule_bwd_dhu.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_api/chunk_gated_delta_rule_bwd_dhu.cpp
@@ -62,7 +62,7 @@ const std::array<const aclTensor *, 3> ChunkGatedDeltaRuleBwdDhu(
     if (dh0Out == nullptr) {
         op::Shape zeroShape;
         zeroShape.AppendDim(0);
-        dh0OutKernel = executor->AllocTensor(zeroShape, q->GetDataType(), op::Format::FORMAT_ND);
+        dh0OutKernel = executor->AllocTensor(zeroShape, op::DataType::DT_FLOAT, op::Format::FORMAT_ND);
     } else {
         dh0OutKernel = dh0Out;
     }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.cpp
@@ -26,6 +26,9 @@ constexpr uint32_t INPUT_W_IDX = 2;
 constexpr uint32_t INPUT_DO_IDX = 3;
 constexpr uint32_t INPUT_DV_IDX = 4;
 constexpr uint32_t INPUT_G_IDX = 5;
+constexpr uint32_t INPUT_GK_IDX = 6;
+constexpr uint32_t INPUT_H0_IDX = 7;
+constexpr uint32_t INPUT_DHT_IDX = 8;
 constexpr uint32_t INPUT_CU_SEQLENS_IDX = 9;
 constexpr uint32_t INPUT_CHUNK_INDICES_IDX = 10;
 
@@ -57,6 +60,9 @@ static void ChunkGatedDeltaRuleBwdDhuTilingDataPrint(gert::TilingContext *contex
     OP_LOGD(nodeName, "qDoWs is %lu.", tiling.qDoWs);
     OP_LOGD(nodeName, "isVarLen is %lu.", tiling.isVarLen);
     OP_LOGD(nodeName, "isScale is %lu.", tiling.isScale);
+    OP_LOGD(nodeName, "hasGk is %lu.", tiling.hasGk);
+    OP_LOGD(nodeName, "hasH0 is %lu.", tiling.hasH0);
+    OP_LOGD(nodeName, "hasDht is %lu.", tiling.hasDht);
     OP_LOGD(nodeName, "usedCoreNum is %u.", tiling.usedCoreNum);
     OP_LOGD(nodeName, "scale is %f.", tiling.scale);
 }
@@ -81,6 +87,8 @@ ASCENDC_EXTERN_C ge::graphStatus Tiling4ChunkGDRBwdDhu(gert::TilingContext *cont
     ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, maxUbSize);
 
     const auto gInputDesc = context->GetOptionalInputDesc(INPUT_G_IDX);
+    const auto gkInputDesc = context->GetOptionalInputDesc(INPUT_GK_IDX);
+    const auto dhtInputDesc = context->GetOptionalInputDesc(INPUT_DHT_IDX);
     const auto qInputDesc = context->GetInputDesc(INPUT_Q_IDX);
     OP_CHECK_NULL_WITH_CONTEXT(context, qInputDesc);
 
@@ -90,6 +98,9 @@ ASCENDC_EXTERN_C ge::graphStatus Tiling4ChunkGDRBwdDhu(gert::TilingContext *cont
         gShape = *context->GetOptionalInputShape(INPUT_G_IDX);
         gShapePtr = &gShape;
     }
+    const gert::StorageShape *gkShapePtr = context->GetOptionalInputShape(INPUT_GK_IDX);
+    const gert::StorageShape *h0ShapePtr = context->GetOptionalInputShape(INPUT_H0_IDX);
+    const gert::StorageShape *dhtShapePtr = context->GetOptionalInputShape(INPUT_DHT_IDX);
 
     ChunkGatedDeltaRuleBwdDhuTilingContext ctx{
         context->GetNodeName(),
@@ -99,11 +110,19 @@ ASCENDC_EXTERN_C ge::graphStatus Tiling4ChunkGDRBwdDhu(gert::TilingContext *cont
         context->GetInputShape(INPUT_DO_IDX),
         context->GetInputShape(INPUT_DV_IDX),
         gShapePtr,
+        gkShapePtr,
+        h0ShapePtr,
+        dhtShapePtr,
         context->GetOptionalInputShape(INPUT_CU_SEQLENS_IDX),
         context->GetOptionalInputShape(INPUT_CHUNK_INDICES_IDX),
         qInputDesc->GetDataType(),
         gInputDesc != nullptr ? gInputDesc->GetDataType() : ge::DT_FLOAT,
+        gkInputDesc != nullptr ? gkInputDesc->GetDataType() : ge::DT_FLOAT,
+        dhtInputDesc != nullptr ? dhtInputDesc->GetDataType() : ge::DT_FLOAT,
         gShapePtr != nullptr,
+        gkShapePtr != nullptr,
+        h0ShapePtr != nullptr,
+        dhtShapePtr != nullptr,
         scalePtr != nullptr,
         scalePtr != nullptr ? *scalePtr : 1.0,
         chunkSizePtr != nullptr ? static_cast<int32_t>(*chunkSizePtr) : static_cast<int32_t>(64),

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.cpp
@@ -58,6 +58,10 @@ static void ChunkGatedDeltaRuleBwdDhuTilingDataPrint(gert::TilingContext *contex
     OP_LOGD(nodeName, "qWs is %lu.", tiling.qWs);
     OP_LOGD(nodeName, "wDv2Ws is %lu.", tiling.wDv2Ws);
     OP_LOGD(nodeName, "qDoWs is %lu.", tiling.qDoWs);
+    OP_LOGD(nodeName, "qDoWsOffset is %lu bytes.", tiling.qDoWsOffset);
+    OP_LOGD(nodeName, "wDv2WsOffset is %lu bytes.", tiling.wDv2WsOffset);
+    OP_LOGD(nodeName, "bdhWsOffset is %lu bytes.", tiling.bdhWsOffset);
+    OP_LOGD(nodeName, "bdhWs is %lu FP32 elements.", tiling.bdhWs);
     OP_LOGD(nodeName, "isVarLen is %lu.", tiling.isVarLen);
     OP_LOGD(nodeName, "isScale is %lu.", tiling.isScale);
     OP_LOGD(nodeName, "hasGk is %lu.", tiling.hasGk);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
@@ -66,11 +66,19 @@ struct ChunkGatedDeltaRuleBwdDhuTilingContext {
     const gert::StorageShape *doShape;
     const gert::StorageShape *dvShape;
     const gert::StorageShape *gShape;
+    const gert::StorageShape *gkShape;
+    const gert::StorageShape *h0Shape;
+    const gert::StorageShape *dhtShape;
     const gert::StorageShape *cuSeqlensShape;
     const gert::StorageShape *chunkIndicesShape;
     ge::DataType qDtype;
     ge::DataType gDtype;
+    ge::DataType gkDtype;
+    ge::DataType dhtDtype;
     bool hasG;
+    bool hasGk;
+    bool hasH0;
+    bool hasDht;
     bool hasScaleAttr;
     double scaleAttr;
     int32_t chunkSize;
@@ -196,6 +204,9 @@ public:
         tiling_.T = T_;
         tiling_.K = K_;
         tiling_.V = V_;
+        tiling_.hasGk = ctx_.hasGk ? 1 : 0;
+        tiling_.hasH0 = ctx_.hasH0 ? 1 : 0;
+        tiling_.hasDht = ctx_.hasDht ? 1 : 0;
         tiling_.isScale = isScale ? 1 : 0;
         tiling_.scale = scale;
         tiling_.chunkSize = chunkSize_;
@@ -235,6 +246,31 @@ public:
         OP_CHECK_IF(isVariableLen_ && B_ != 1,
                     OP_LOGE(ctx_.nodeName, "B must be 1 when sequence is variable len, but got %lu.", B_),
                     return ge::GRAPH_FAILED);
+        const uint64_t stateBatch = isVariableLen_ ? tiling_.seqNum : B_;
+        if (ctx_.hasGk) {
+            const gert::Shape gkShape = ctx_.gkShape->GetStorageShape();
+            OP_CHECK_IF(gkShape.GetDim(0) != static_cast<int64_t>(B_) ||
+                            gkShape.GetDim(1) != static_cast<int64_t>(Hv_) ||
+                            gkShape.GetDim(2) != static_cast<int64_t>(T_) ||
+                            gkShape.GetDim(3) != static_cast<int64_t>(K_),
+                        OP_LOGE(ctx_.nodeName, "gk must be [B,Hv,T,K]."), return ge::GRAPH_FAILED);
+        }
+        if (ctx_.hasH0) {
+            const gert::Shape h0Shape = ctx_.h0Shape->GetStorageShape();
+            OP_CHECK_IF(h0Shape.GetDim(0) != static_cast<int64_t>(stateBatch) ||
+                            h0Shape.GetDim(1) != static_cast<int64_t>(Hv_) ||
+                            h0Shape.GetDim(2) != static_cast<int64_t>(K_) ||
+                            h0Shape.GetDim(3) != static_cast<int64_t>(V_),
+                        OP_LOGE(ctx_.nodeName, "h0 must be [N,Hv,K,V]."), return ge::GRAPH_FAILED);
+        }
+        if (ctx_.hasDht) {
+            const gert::Shape dhtShape = ctx_.dhtShape->GetStorageShape();
+            OP_CHECK_IF(dhtShape.GetDim(0) != static_cast<int64_t>(stateBatch) ||
+                            dhtShape.GetDim(1) != static_cast<int64_t>(Hv_) ||
+                            dhtShape.GetDim(2) != static_cast<int64_t>(K_) ||
+                            dhtShape.GetDim(3) != static_cast<int64_t>(V_),
+                        OP_LOGE(ctx_.nodeName, "dht must be [N,Hv,K,V]."), return ge::GRAPH_FAILED);
+        }
         return ge::GRAPH_SUCCESS;
     }
 
@@ -254,6 +290,14 @@ public:
             tilingKey_ = GDN::CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_KEY_G_FP32;
         } else {
             tilingKey_ = GDN::CHUNK_GATED_DELTA_RULE_BWD_DHU_TILING_KEY;
+        }
+        if (ctx_.hasGk && ctx_.gkDtype != gDtype) {
+            OP_LOGE(ctx_.nodeName, "gk must have the same dtype as g.");
+            return ge::GRAPH_FAILED;
+        }
+        if (ctx_.hasDht && ctx_.dhtDtype != ge::DT_FLOAT) {
+            OP_LOGE(ctx_.nodeName, "dht must be float32.");
+            return ge::GRAPH_FAILED;
         }
         return ge::GRAPH_SUCCESS;
     }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
@@ -345,14 +345,25 @@ public:
         const uint64_t qWs = K_ * chunkSize_ * usedCoreNum;
         const uint64_t wDv2Ws = K_ * V_ * usedCoreNum;
         const uint64_t qDoWs = K_ * V_ * usedCoreNum;
-        const size_t usrWsSize =
-            static_cast<size_t>((bdvWs + qWs + wDv2Ws + qDoWs) * CHUNK_GDR_BWD_DHU_HALF_DTYPE_SIZE);
+        const uint64_t qDoWsOffset =
+            (bdvWs + qWs) * CHUNK_GDR_BWD_DHU_HALF_DTYPE_SIZE;
+        const uint64_t wDv2WsOffset =
+            qDoWsOffset + qDoWs * CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE;
+        const uint64_t bdhWsOffset =
+            wDv2WsOffset + wDv2Ws * CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE;
+        const uint64_t bdhWs = K_ * V_ * usedCoreNum;
+        const size_t usrWsSize = static_cast<size_t>(
+            bdhWsOffset + bdhWs * CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE);
 
         workspaceSize_ = usrWsSize + ctx_.sysWorkspaceSize;
         tiling_.bdvWs = bdvWs;
         tiling_.qWs = qWs;
         tiling_.wDv2Ws = wDv2Ws;
         tiling_.qDoWs = qDoWs;
+        tiling_.qDoWsOffset = qDoWsOffset;
+        tiling_.wDv2WsOffset = wDv2WsOffset;
+        tiling_.bdhWsOffset = bdhWsOffset;
+        tiling_.bdhWs = bdhWs;
         return ge::GRAPH_SUCCESS;
     }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
@@ -319,9 +319,10 @@ public:
         const uint32_t gatedQPeak = CHUNK_GDR_BWD_DHU_NUM_2 * static_cast<uint32_t>(chunkSize_) *
                                         CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE +
                                     dqkBufByte + dqkCastBufByte + gBrcbBufByte;
-        const uint32_t dhPeak = CHUNK_GDR_BWD_DHU_NUM_2 * dhCastBufByte +
-                                halfK * static_cast<uint32_t>(V_) * CHUNK_GDR_BWD_DHU_HALF_DTYPE_SIZE;
-        const uint32_t tBufByte = std::max(dhPeak, std::max(dvPeak, gatedQPeak));
+        const uint32_t dhScratch = dhCastBufByte +
+                                   halfK * static_cast<uint32_t>(V_) * CHUNK_GDR_BWD_DHU_HALF_DTYPE_SIZE;
+        const uint32_t scratchPeak = std::max(dhScratch, std::max(dvPeak, gatedQPeak));
+        const uint32_t tBufByte = scratchPeak + dhCastBufByte;
 
         OP_CHECK_IF(tBufByte > ctx_.ubSize,
                     OP_LOGE(ctx_.nodeName, "K/V is too large, K should less than 128 and V should less than 256."),
@@ -349,11 +350,8 @@ public:
             (bdvWs + qWs) * CHUNK_GDR_BWD_DHU_HALF_DTYPE_SIZE;
         const uint64_t wDv2WsOffset =
             qDoWsOffset + qDoWs * CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE;
-        const uint64_t bdhWsOffset =
-            wDv2WsOffset + wDv2Ws * CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE;
-        const uint64_t bdhWs = K_ * V_ * usedCoreNum;
         const size_t usrWsSize = static_cast<size_t>(
-            bdhWsOffset + bdhWs * CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE);
+            wDv2WsOffset + wDv2Ws * CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE);
 
         workspaceSize_ = usrWsSize + ctx_.sysWorkspaceSize;
         tiling_.bdvWs = bdvWs;
@@ -362,8 +360,8 @@ public:
         tiling_.qDoWs = qDoWs;
         tiling_.qDoWsOffset = qDoWsOffset;
         tiling_.wDv2WsOffset = wDv2WsOffset;
-        tiling_.bdhWsOffset = bdhWsOffset;
-        tiling_.bdhWs = bdhWs;
+        tiling_.bdhWsOffset = usrWsSize;
+        tiling_.bdhWs = 0;
         return ge::GRAPH_SUCCESS;
     }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
@@ -349,9 +349,9 @@ public:
         const uint64_t qDoWsOffset =
             (bdvWs + qWs) * CHUNK_GDR_BWD_DHU_HALF_DTYPE_SIZE;
         const uint64_t wDv2WsOffset =
-            qDoWsOffset + qDoWs * CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE;
+            qDoWsOffset + qDoWs * CHUNK_GDR_BWD_DHU_HALF_DTYPE_SIZE;
         const size_t usrWsSize = static_cast<size_t>(
-            wDv2WsOffset + wDv2Ws * CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE);
+            wDv2WsOffset + wDv2Ws * CHUNK_GDR_BWD_DHU_HALF_DTYPE_SIZE);
 
         workspaceSize_ = usrWsSize + ctx_.sysWorkspaceSize;
         tiling_.bdvWs = bdvWs;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
@@ -319,7 +319,8 @@ public:
         const uint32_t gatedQPeak = CHUNK_GDR_BWD_DHU_NUM_2 * static_cast<uint32_t>(chunkSize_) *
                                         CHUNK_GDR_BWD_DHU_FP32_DTYPE_SIZE +
                                     dqkBufByte + dqkCastBufByte + gBrcbBufByte;
-        const uint32_t dhPeak = CHUNK_GDR_BWD_DHU_NUM_2 * dhCastBufByte;
+        const uint32_t dhPeak = CHUNK_GDR_BWD_DHU_NUM_2 * dhCastBufByte +
+                                halfK * static_cast<uint32_t>(V_) * CHUNK_GDR_BWD_DHU_HALF_DTYPE_SIZE;
         const uint32_t tBufByte = std::max(dhPeak, std::max(dvPeak, gatedQPeak));
 
         OP_CHECK_IF(tBufByte > ctx_.ubSize,

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu.cpp
@@ -33,10 +33,10 @@ namespace GDN {
 
 template <typename DT, typename GT>
 __aicore__ inline void ChunkGatedDeltaRuleBwdDhuKernelImpl(
-    GM_ADDR q, GM_ADDR k, GM_ADDR w, GM_ADDR d_o, GM_ADDR dv, GM_ADDR g, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
-    GM_ADDR dh, GM_ADDR dh0, GM_ADDR dv2, GM_ADDR userWS, const ChunkGatedDeltaRuleBwdDhuTilingData *tilingData)
+    GM_ADDR q, GM_ADDR k, GM_ADDR w, GM_ADDR d_o, GM_ADDR dv, GM_ADDR g, GM_ADDR gk, GM_ADDR h0, GM_ADDR dht,
+    GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR dh, GM_ADDR dh0, GM_ADDR dv2, GM_ADDR userWS,
+    const ChunkGatedDeltaRuleBwdDhuTilingData *tilingData)
 {
-    (void)dh0;
     if ASCEND_IS_AIC {
         GDRCube<DT, GT> cubeOp(k, w, d_o, dh, dv2, cu_seqlens, chunk_indices, userWS);
         cubeOp.Init(*tilingData);
@@ -44,7 +44,7 @@ __aicore__ inline void ChunkGatedDeltaRuleBwdDhuKernelImpl(
     }
     if ASCEND_IS_AIV {
         ChunkGDRBwdDhu::GDRVec<DT, GT> op;
-        op.Init(q, k, w, d_o, dv, g, cu_seqlens, dv2, dh, userWS, *tilingData);
+        op.Init(q, k, w, d_o, dv, g, gk, h0, dht, cu_seqlens, dv2, dh, dh0, userWS, *tilingData);
         op.Process();
     }
 }
@@ -56,9 +56,6 @@ extern "C" __global__ __aicore__ void chunk_gated_delta_rule_bwd_dhu(
     GM_ADDR q, GM_ADDR k, GM_ADDR w, GM_ADDR d_o, GM_ADDR dv, GM_ADDR g, GM_ADDR gk, GM_ADDR h0, GM_ADDR dht,
     GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR dh, GM_ADDR dh0, GM_ADDR dv2, GM_ADDR workspace, GM_ADDR tiling)
 {
-    (void)gk;
-    (void)h0;
-    (void)dht;
     GM_ADDR userWS = AscendC::GetUserWorkspace(workspace);
     if (userWS == nullptr) {
         return;
@@ -70,11 +67,11 @@ extern "C" __global__ __aicore__ void chunk_gated_delta_rule_bwd_dhu(
     if (TILING_KEY_IS(1)) {
         KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
         GDN::ChunkGatedDeltaRuleBwdDhuKernelImpl<DTYPE_Q, DTYPE_Q>(
-            q, k, w, d_o, dv, g, cu_seqlens, chunk_indices, dh, dh0, dv2, userWS, &tilingData);
+            q, k, w, d_o, dv, g, gk, h0, dht, cu_seqlens, chunk_indices, dh, dh0, dv2, userWS, &tilingData);
     } else if (TILING_KEY_IS(2)) {
         KERNEL_TASK_TYPE(2, KERNEL_TYPE_MIX_AIC_1_2);
         GDN::ChunkGatedDeltaRuleBwdDhuKernelImpl<DTYPE_Q, float>(
-            q, k, w, d_o, dv, g, cu_seqlens, chunk_indices, dh, dh0, dv2, userWS, &tilingData);
+            q, k, w, d_o, dv, g, gk, h0, dht, cu_seqlens, chunk_indices, dh, dh0, dv2, userWS, &tilingData);
     }
 }
 #endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
@@ -69,9 +69,10 @@ protected:
     GlobalTensor<float> dh0Gm;
     // inprocess workspace gm
     GlobalTensor<DT> bdvGm;
-    GlobalTensor<DT> wv2Gm;
-    GlobalTensor<DT> qdoGm;
+    GlobalTensor<float> wv2Gm;
+    GlobalTensor<float> qdoGm;
     GlobalTensor<DT> gatedQGm;
+    GlobalTensor<float> bdhStateGm;
     
     // calc gated q
     LocalTensor<DT> qLocal; // [BT/2,K]
@@ -118,6 +119,10 @@ protected:
     uint64_t qWs = 0;
     uint64_t wDv2Ws = 0;
     uint64_t qDoWs = 0;
+    uint64_t qDoWsOffset = 0;
+    uint64_t wDv2WsOffset = 0;
+    uint64_t bdhWsOffset = 0;
+    uint64_t bdhWs = 0;
     uint64_t isVarLen = 0;
     uint64_t isScale = 0;
     uint64_t hasGk = 0;
@@ -159,6 +164,10 @@ __aicore__ inline void GDRBase<DT, GT>::InitTilingData(const ChunkGatedDeltaRule
     this->qWs = tilingData.qWs;
     this->wDv2Ws = tilingData.wDv2Ws;
     this->qDoWs = tilingData.qDoWs;
+    this->qDoWsOffset = tilingData.qDoWsOffset;
+    this->wDv2WsOffset = tilingData.wDv2WsOffset;
+    this->bdhWsOffset = tilingData.bdhWsOffset;
+    this->bdhWs = tilingData.bdhWs;
     this->isVarLen = tilingData.isVarLen;
     this->isScale = tilingData.isScale;
     this->hasGk = tilingData.hasGk;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
@@ -72,7 +72,6 @@ protected:
     GlobalTensor<float> wv2Gm;
     GlobalTensor<float> qdoGm;
     GlobalTensor<DT> gatedQGm;
-    GlobalTensor<float> bdhStateGm;
     
     // calc gated q
     LocalTensor<DT> qLocal; // [BT/2,K]

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
@@ -96,6 +96,7 @@ protected:
     LocalTensor<float> wv2CastLocal;
     LocalTensor<DT> qdoLocal; // [K/2,V]
     LocalTensor<float> qdoCastLocal;
+    LocalTensor<GT> gkLocal;
     
     // tiling data
     uint64_t B = 0;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
@@ -59,11 +59,14 @@ protected:
     // inputGm
     GlobalTensor<DT> qGm;
     GlobalTensor<GT> gGm;
+    GlobalTensor<GT> gkGm;
+    GlobalTensor<float> dhtGm;
     GlobalTensor<DT> dvGm;
     GlobalTensor<int64_t> cuSeqlensGm;
     // output gm, also used as input
     GlobalTensor<DT> dv2Gm;
     GlobalTensor<DT> dhGm;
+    GlobalTensor<float> dh0Gm;
     // inprocess workspace gm
     GlobalTensor<DT> bdvGm;
     GlobalTensor<DT> wv2Gm;
@@ -116,6 +119,9 @@ protected:
     uint64_t qDoWs = 0;
     uint64_t isVarLen = 0;
     uint64_t isScale = 0;
+    uint64_t hasGk = 0;
+    uint64_t hasH0 = 0;
+    uint64_t hasDht = 0;
     uint32_t usedCoreNum = 0;
     float  scale = 0;
 
@@ -154,6 +160,9 @@ __aicore__ inline void GDRBase<DT, GT>::InitTilingData(const ChunkGatedDeltaRule
     this->qDoWs = tilingData.qDoWs;
     this->isVarLen = tilingData.isVarLen;
     this->isScale = tilingData.isScale;
+    this->hasGk = tilingData.hasGk;
+    this->hasH0 = tilingData.hasH0;
+    this->hasDht = tilingData.hasDht;
     this->usedCoreNum = tilingData.usedCoreNum;
     this->scale = tilingData.scale;
     this->coreIdx = GetBlockIdx();

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_base.h
@@ -69,8 +69,8 @@ protected:
     GlobalTensor<float> dh0Gm;
     // inprocess workspace gm
     GlobalTensor<DT> bdvGm;
-    GlobalTensor<float> wv2Gm;
-    GlobalTensor<float> qdoGm;
+    GlobalTensor<DT> wv2Gm;
+    GlobalTensor<DT> qdoGm;
     GlobalTensor<DT> gatedQGm;
     
     // calc gated q

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_cube.h
@@ -464,25 +464,22 @@ public:
                                                     tla::MakeShape(params.K, params.V));                        
                         // gatedQ @ do
                         // | bdv coreNum * K * V | gQ coreNum * BT * K | qDo coreNum * K * V | wDv2 coreNum * K * V | 
-                        PipeBarrier<PIPE_ALL>();
                         // load L1B
-                        
-                        copyGmToL1B_Dh1(tensorL1B1, tensorGmTileB1);
-                        PipeBarrier<PIPE_ALL>();
-                        
-                        // w @ dv2 load L1A
 
+                        copyGmToL1B_Dh1(tensorL1B1, tensorGmTileB1);
+                        constexpr uint32_t EVENT_TERM_PRELOAD_L1B = 1;
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_TERM_PRELOAD_L1B);
+
+                        // w @ dv2 load L1A
                         copyGmToL1A_Dh2(tensorL1A2, tensorGmTileA2);
-                        // PipeBarrier<PIPE_ALL>();
 
                         // copy L1B -> L0B
-
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_TERM_PRELOAD_L1B);
                         copyL1ToL0B_Dh1(tensorL0B1, tensorTileL1B1);
                         PipeBarrier<PIPE_ALL>();
 
                         // copy L1A -> L0A
                         copyL1ToL0A_Dh2(tensorL0A2, tensorTileL1A2);
-                        // PipeBarrier<PIPE_ALL>();
 
                         // load L1A
                         CrossCoreWaitFlag(CROSS_CORE_V2C_GQ); // vec计算完一个chunk的gatedQ,通知cube可以开始计算对应的dh term1
@@ -490,35 +487,41 @@ public:
                         PipeBarrier<PIPE_ALL>();
 
                         // copy L1A -> L0A
-
                         copyL1ToL0A_Dh1(tensorL0A1, tensorTileL1A1);
                         PipeBarrier<PIPE_ALL>();
 
-
+                        constexpr uint32_t EVENT_TERM_L1B = 0;
+                        constexpr uint32_t EVENT_TERM_L0B = 0;
+                        constexpr uint32_t EVENT_TERM_L0C = 0;
                         tileMmadDh1(tensorTileL0C1, tensorL0A1, tensorL0B1, initC, unitFlag);
-                        PipeBarrier<PIPE_ALL>();
-                        copyL0CToGm_Dh1(tensorBlockDh1, tensorL0C1);
-                        PipeBarrier<PIPE_ALL>();
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_TERM_L0B);
+                        AscendC::SetFlag<AscendC::HardEvent::M_FIX>(EVENT_TERM_L0C);
+
+                        // Prefetch dv2 while term1 is running; the two operands use independent L1 buffers.
+                        CrossCoreWaitFlag(CROSS_CORE_V2C_DV2);
+                        copyGmToL1B_Dh2(tensorL1B2, tensorGmTileB2);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_TERM_L1B);
+
+                        // Overlap term1 FIX writeback with the term2 L1-to-L0B transfer.
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_TERM_L0B);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_TERM_L1B);
+                        copyL1ToL0B_Dh2(tensorL0B2, tensorTileL1B2);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(EVENT_TERM_L0B);
+
+                        AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(EVENT_TERM_L0C);
+                        copyL0CToGm_Dh1(tensorBlockDh1, tensorL0C1, unitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::FIX_M>(EVENT_TERM_L0C);
+                        AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(EVENT_TERM_L0C);
                         CrossCoreSetFlag<0x2, PIPE_FIX>(CROSS_CORE_C2V_TERM1);
 
                         // w @ dv2 -> bdh_term2
-                        // PipeBarrier<PIPE_ALL>();
-                        // load L1B
-                        CrossCoreWaitFlag(CROSS_CORE_V2C_DV2);
-                        copyGmToL1B_Dh2(tensorL1B2, tensorGmTileB2);
-                        PipeBarrier<PIPE_ALL>();
-
-                        // copy L1B -> L0B
-
-                        copyL1ToL0B_Dh2(tensorL0B2, tensorTileL1B2);
-                        PipeBarrier<PIPE_ALL>();
-
-                        // bool initC = true; //k方向没有循环
-                        // uint8_t unitFlag = 0;
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(EVENT_TERM_L0B);
                         tileMmadDh2(tensorTileL0C2, tensorL0A2, tensorL0B2, initC, unitFlag);
-                        PipeBarrier<PIPE_ALL>();
-                        copyL0CToGm_Dh2(tensorBlockDh2, tensorL0C2);
-                        PipeBarrier<PIPE_ALL>();
+                        AscendC::SetFlag<AscendC::HardEvent::M_FIX>(EVENT_TERM_L0C);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(EVENT_TERM_L0C);
+                        copyL0CToGm_Dh2(tensorBlockDh2, tensorL0C2, unitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::FIX_M>(EVENT_TERM_L0C);
+                        AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(EVENT_TERM_L0C);
                         CrossCoreSetFlag<0x2, PIPE_FIX>(CROSS_CORE_C2V_TERM2);
                     }
                 }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_cube.h
@@ -169,6 +169,8 @@ public:
         uint64_t seqNum = 0;
         uint64_t usedCoreNum = 0;
         bool isVarLen = false;
+        bool hasDht = false;
+        bool hasH0 = false;
         uint64_t bdvWorkspaceOffset = 0;
         uint64_t gQWorkspaceOffset = 0;
         uint64_t bdhTerm1WorkspaceOffset = 0;
@@ -184,6 +186,7 @@ public:
                GM_ADDR w_ , LayoutW layoutW_, GM_ADDR dv2_ , LayoutDv2 layoutDv2_, LayoutBdh layoutBdh_,
                GM_ADDR cu_seqlens_, uint64_t B_, uint64_t T_, uint64_t Hv_, uint64_t Hk_, uint64_t K_, uint64_t V_,
                uint64_t BT_, uint64_t chunkNum_, uint64_t seqNum_, uint64_t usedCoreNum_, bool isVarLen_,
+               bool hasDht_, bool hasH0_,
                uint64_t bdvWorkspaceOffset_, uint64_t gQWorkspaceOffset_,uint64_t bdhTerm1WorkspaceOffset_, uint64_t bdhTerm2WorkspaceOffset_): 
             k(k_), 
             layoutK(layoutK_),
@@ -211,6 +214,8 @@ public:
             seqNum(seqNum_),
             usedCoreNum(usedCoreNum_),
             isVarLen(isVarLen_),
+            hasDht(hasDht_),
+            hasH0(hasH0_),
             bdvWorkspaceOffset(bdvWorkspaceOffset_),
             gQWorkspaceOffset(gQWorkspaceOffset_),
             bdhTerm1WorkspaceOffset(bdhTerm1WorkspaceOffset_),
@@ -276,11 +281,11 @@ public:
                     uint32_t curBT = 0;
                     for (int32_t chunkIdx = curChunkNum - 1; chunkIdx >= 0; chunkIdx --) {
                     // cacl k @ dh
-                    if (chunkIdx == curChunkNum -1) {
+                    if (chunkIdx == curChunkNum -1 && !params.hasDht) {
                         curBT = curSeqLen - chunkIdx * params.BT;
                         // skip k_i @ dh_0
                     } else {
-                        curBT = params.BT;  // BT = 64/128 is always 16 aligned
+                        curBT = chunkIdx == curChunkNum - 1 ? curSeqLen - chunkIdx * params.BT : params.BT;
                         // init GlobalTensor
                         gmK.SetGlobalBuffer((__gm__ ElementK *)params.k + gmOffsetQK + chunkIdx * params.BT * params.K);
                          // 用的是上一次chunk迭代的结果
@@ -354,7 +359,7 @@ public:
                     } // end chunk k @ dh
                     
 
-                    if (chunkIdx != 0)
+                    if (chunkIdx != 0 || params.hasH0)
                     {
                         gmGq.SetGlobalBuffer((__gm__ ElementGq *)params.workspace + params.gQWorkspaceOffset + coreIdx * params.BT * params.K);
                         gmDo.SetGlobalBuffer((__gm__ ElementDo *)params.dO + gmOffsetV + chunkIdx * params.BT * params.V);
@@ -727,6 +732,7 @@ __aicore__ inline void GDRCube<DT, GT>::Process()
                                      w, layoutW, dv2, layoutDv2, layoutBdh, // w^T @ dv2 -> bdh[workspace] 
                                      cu_seqlens, this->B, this->T, this->Hv, this->Hk, this->K, this->V, 
                                      this->chunkSize, this->chunkNum, this->seqNum, this->usedCoreNum, static_cast<bool>(this->isVarLen),
+                                     static_cast<bool>(this->hasDht), static_cast<bool>(this->hasH0),
                                      bdvWorkspaceOffset, gQWorkspaceOffset, bdhTerm1WorkspaceOffset, bdhTerm2WorkspaceOffset};
     kernel(param);
     return;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_cube.h
@@ -484,9 +484,11 @@ public:
                         // load L1A
                         CrossCoreWaitFlag(CROSS_CORE_V2C_GQ); // vec计算完一个chunk的gatedQ,通知cube可以开始计算对应的dh term1
                         copyGmToL1A_Dh1(tensorL1A1, tensorGmTileA1);
-                        PipeBarrier<PIPE_ALL>();
+                        constexpr uint32_t EVENT_TERM1_L1A_READY = 0;
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_TERM1_L1A_READY);
 
                         // copy L1A -> L0A
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_TERM1_L1A_READY);
                         copyL1ToL0A_Dh1(tensorL0A1, tensorTileL1A1);
                         PipeBarrier<PIPE_ALL>();
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_cube.h
@@ -60,7 +60,7 @@ public:
     using ElementW = DT;
     using ElementDo = DT;
     using ElementDv2 = DT;
-    using ElementBdh = float;
+    using ElementBdh = DT;
     using ElementAccumulator = float;
     using ElementInt = int64_t;
 
@@ -685,8 +685,6 @@ __aicore__ inline void GDRCube<DT, GT>::Process()
     using LayoutTagChunkIndices = layout::RowMajor;
 
     using ElementHalf = half;
-    using ElementFloat = float;
-
     //输入
     LayoutTagK tagK = LayoutTagK::MakeLayout<ElementHalf>(this->T, this->K);
     LayoutTagDh tagDh = LayoutTagDh::MakeLayout<ElementHalf>(this->K, this->V);
@@ -694,7 +692,7 @@ __aicore__ inline void GDRCube<DT, GT>::Process()
 
     LayoutTagGq tagGq = LayoutTagGq::MakeLayout<ElementHalf>(this->K, this->chunkSize);
     LayoutTagDo tagDo = LayoutTagDo::MakeLayout<ElementHalf>(this->T, this->V);
-    LayoutTagBdh tagBdh = LayoutTagBdh::MakeLayout<ElementFloat>(this->K, this->V);
+    LayoutTagBdh tagBdh = LayoutTagBdh::MakeLayout<ElementHalf>(this->K, this->V);
 
     LayoutTagW tagW = LayoutTagW::MakeLayout<ElementHalf>(this->K, this->T);
     LayoutTagDv2 tagDv2 = LayoutTagDv2::MakeLayout<ElementHalf>(this->T, this->V);
@@ -726,9 +724,9 @@ __aicore__ inline void GDRCube<DT, GT>::Process()
     using L0TileShapeBdv = tla::Shape<_128, _256, _128>;
 
     using TileCopyDh1 = 
-            Gemm::Tile::PackedTileCopyTla<ArchTag, DT, LayoutTagGq, DT, LayoutTagDo, float, LayoutTagBdh>;
+            Gemm::Tile::PackedTileCopyTla<ArchTag, DT, LayoutTagGq, DT, LayoutTagDo, DT, LayoutTagBdh>;
     using TileCopyDh2 = 
-            Gemm::Tile::PackedTileCopyTla<ArchTag, DT, LayoutTagW, DT, LayoutTagDv2, float, LayoutTagBdh>;
+            Gemm::Tile::PackedTileCopyTla<ArchTag, DT, LayoutTagW, DT, LayoutTagDv2, DT, LayoutTagBdh>;
     using L1TileShapeDh = tla::Shape<_128, _256, _128>; // K,V, BT
     using L0TileShapeDh = tla::Shape<_128, _256, _128>;
     // kernel level

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_cube.h
@@ -60,6 +60,7 @@ public:
     using ElementW = DT;
     using ElementDo = DT;
     using ElementDv2 = DT;
+    using ElementBdh = float;
     using ElementAccumulator = float;
     using ElementInt = int64_t;
 
@@ -363,15 +364,19 @@ public:
                     {
                         gmGq.SetGlobalBuffer((__gm__ ElementGq *)params.workspace + params.gQWorkspaceOffset + coreIdx * params.BT * params.K);
                         gmDo.SetGlobalBuffer((__gm__ ElementDo *)params.dO + gmOffsetV + chunkIdx * params.BT * params.V);
-                        gmDhTerm1.SetGlobalBuffer((__gm__ ElementDh *)params.workspace + params.bdhTerm1WorkspaceOffset + coreIdx * params.K * params.V);
+                        gmDhTerm1.SetGlobalBuffer(
+                            (__gm__ ElementBdh *)((__gm__ uint8_t *)params.workspace + params.bdhTerm1WorkspaceOffset) +
+                            coreIdx * params.K * params.V);
                         
                         gmW.SetGlobalBuffer((__gm__ ElementW *)params.w + gmOffsetW + chunkIdx * params.BT * params.K);
                         gmDv2.SetGlobalBuffer((__gm__ ElementDv2 *)params.dv2 + gmOffsetV + chunkIdx * params.BT * params.V);
-                        gmDhTerm2.SetGlobalBuffer((__gm__ ElementDh *)params.workspace + params.bdhTerm2WorkspaceOffset + coreIdx * params.K * params.V);
+                        gmDhTerm2.SetGlobalBuffer(
+                            (__gm__ ElementBdh *)((__gm__ uint8_t *)params.workspace + params.bdhTerm2WorkspaceOffset) +
+                            coreIdx * params.K * params.V);
 
                         auto tensorGq = tla::MakeTensor(gmGq, params.layoutGq, Arch::PositionGM{});
                         auto tensorDo = tla::MakeTensor(gmDo, params.layoutDo, Arch::PositionGM{});
-                        auto tensorDh1 = tla::MakeTensor(gmDhTerm1, params.layoutDh, Arch::PositionGM{});
+                        auto tensorDh1 = tla::MakeTensor(gmDhTerm1, params.layoutBdh, Arch::PositionGM{});
                         auto tensorBlockGq = GetTile(tensorGq,
                                                     tla::MakeCoord(0,0),
                                                     tla::MakeShape(params.K, curBT));
@@ -384,7 +389,7 @@ public:
                         
                         auto tensorW = tla::MakeTensor(gmW, params.layoutW, Arch::PositionGM{});
                         auto tensorDv2 = tla::MakeTensor(gmDv2, params.layoutDv2, Arch::PositionGM{});
-                        auto tensorDh2 = tla::MakeTensor(gmDhTerm2, params.layoutDh, Arch::PositionGM{});
+                        auto tensorDh2 = tla::MakeTensor(gmDhTerm2, params.layoutBdh, Arch::PositionGM{});
                         auto tensorBlockW = GetTile(tensorW,
                                                     tla::MakeCoord(0,0),
                                                     tla::MakeShape(params.K, curBT));
@@ -565,11 +570,11 @@ private:
 
     AscendC::GlobalTensor<ElementGq> gmGq;
     AscendC::GlobalTensor<ElementDo> gmDo;
-    AscendC::GlobalTensor<ElementDh> gmDhTerm1;
+    AscendC::GlobalTensor<ElementBdh> gmDhTerm1;
     
     AscendC::GlobalTensor<ElementDh> gmW;
     AscendC::GlobalTensor<ElementDh> gmDv2;
-    AscendC::GlobalTensor<ElementDh> gmDhTerm2;
+    AscendC::GlobalTensor<ElementBdh> gmDhTerm2;
 
     AscendC::LocalTensor<DT> l1ATensorBdv;
     AscendC::LocalTensor<DT> l1BTensorBdv;
@@ -657,8 +662,8 @@ __aicore__ inline void GDRCube<DT, GT>::Process()
 {
     uint64_t bdvWorkspaceOffset = 0;
     uint64_t gQWorkspaceOffset = this->bdvWs;
-    uint64_t bdhTerm1WorkspaceOffset = gQWorkspaceOffset + this->qWs;
-    uint64_t bdhTerm2WorkspaceOffset = bdhTerm1WorkspaceOffset + this->qDoWs;
+    uint64_t bdhTerm1WorkspaceOffset = this->qDoWsOffset;
+    uint64_t bdhTerm2WorkspaceOffset = this->wDv2WsOffset;
     //输入
     using LayoutTagK = layout::RowMajor;
     using LayoutTagDh = layout::RowMajor;
@@ -684,7 +689,7 @@ __aicore__ inline void GDRCube<DT, GT>::Process()
 
     LayoutTagGq tagGq = LayoutTagGq::MakeLayout<ElementHalf>(this->K, this->chunkSize);
     LayoutTagDo tagDo = LayoutTagDo::MakeLayout<ElementHalf>(this->T, this->V);
-    LayoutTagBdh tagBdh = LayoutTagBdh::MakeLayout<ElementHalf>(this->K, this->V);
+    LayoutTagBdh tagBdh = LayoutTagBdh::MakeLayout<ElementFloat>(this->K, this->V);
 
     LayoutTagW tagW = LayoutTagW::MakeLayout<ElementHalf>(this->K, this->T);
     LayoutTagDv2 tagDv2 = LayoutTagDv2::MakeLayout<ElementHalf>(this->T, this->V);
@@ -716,9 +721,9 @@ __aicore__ inline void GDRCube<DT, GT>::Process()
     using L0TileShapeBdv = tla::Shape<_128, _256, _128>;
 
     using TileCopyDh1 = 
-            Gemm::Tile::PackedTileCopyTla<ArchTag, DT, LayoutTagGq, DT, LayoutTagDo, DT, LayoutTagBdh>;
+            Gemm::Tile::PackedTileCopyTla<ArchTag, DT, LayoutTagGq, DT, LayoutTagDo, float, LayoutTagBdh>;
     using TileCopyDh2 = 
-            Gemm::Tile::PackedTileCopyTla<ArchTag, DT, LayoutTagW, DT, LayoutTagDv2, DT, LayoutTagBdh>;
+            Gemm::Tile::PackedTileCopyTla<ArchTag, DT, LayoutTagW, DT, LayoutTagDv2, float, LayoutTagBdh>;
     using L1TileShapeDh = tla::Shape<_128, _256, _128>; // K,V, BT
     using L0TileShapeDh = tla::Shape<_128, _256, _128>;
     // kernel level

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_cube.h
@@ -316,33 +316,39 @@ public:
                         CopyGmToL1B_Bdv copyGmToL1B_Bdv;
                         CopyL0CToGm_Bdv copyL0CToGm_Bdv;
 
-                        PipeBarrier<PIPE_ALL>();
                         // load L1A
                         auto tensorL1A = tla::MakeTensor(l1ATensorBdv, L1A_LAYOUT_BDV, Arch::PositionL1{});
                         auto tensorGmTileA = GetTile(tensorBlockK, tla::MakeCoord(0, 0), tla::MakeShape(curBT, params.K));
                         copyGmToL1A_Bdv(tensorL1A, tensorGmTileA);
-                        PipeBarrier<PIPE_ALL>();
+                        constexpr uint32_t EVENT_BDV_L1A = 2;
+                        constexpr uint32_t EVENT_BDV_L1B = 3;
+                        constexpr uint32_t EVENT_BDV_L0_READY = 1;
+                        constexpr uint32_t EVENT_BDV_L0C = 1;
+                        constexpr uint32_t EVENT_BDV_L0A_FREE = 2;
+                        constexpr uint32_t EVENT_BDV_L0B_FREE = 3;
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_BDV_L1A);
 
                         // copy L1A -> L0A
                         auto layoutAInL0 = tla::MakeLayout<ElementK, LayoutTagL0A_Bdv>(curBT, params.K);
                         auto tensorL0A = tla::MakeTensor(l0ATensorBdv, layoutAInL0, Arch::PositionL0A{});
                         auto tensorTileL1A = GetTile(tensorL1A, tla::MakeCoord(0, 0), tla::MakeShape(curBT, params.K));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_BDV_L1A);
                         copyL1ToL0A_Bdv(tensorL0A, tensorTileL1A);
-                        PipeBarrier<PIPE_ALL>();
 
                         // load L1B
                         CrossCoreWaitFlag(CROSS_CORE_V2C_BDH);
                         auto tensorL1B = tla::MakeTensor(l1BTensorBdv, L1B_LAYOUT_BDV, Arch::PositionL1{});
                         auto tensorGmTileB = GetTile(tensorBlockDh, tla::MakeCoord(0, 0), tla::MakeShape(params.K, params.V));
                         copyGmToL1B_Bdv(tensorL1B, tensorGmTileB);
-                        PipeBarrier<PIPE_ALL>();
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_BDV_L1B);
 
                         // copy L1B -> L0B
                         auto layoutBInL0 = tla::MakeLayout<ElementDh, LayoutTagL0B_Bdv>(params.K, params.V);
                         auto tensorL0B = tla::MakeTensor(l0BTensorBdv, layoutBInL0, Arch::PositionL0B{});
                         auto tensorTileL1B = GetTile(tensorL1B,  tla::MakeCoord(0, 0), tla::MakeShape(params.K, params.V));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_BDV_L1B);
                         copyL1ToL0B_Bdv(tensorL0B, tensorTileL1B);
-                        PipeBarrier<PIPE_ALL>();
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(EVENT_BDV_L0_READY);
 
                         bool initC = true; //k方向没有循环
                         uint8_t unitFlag = 0;
@@ -351,11 +357,17 @@ public:
                         auto tensorTileL0C = GetTile(tensorL0C,
                                                      tla::MakeCoord(0,0),
                                                      tla::MakeShape(curBT, params.V));
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(EVENT_BDV_L0_READY);
                         tileMmadBdv(tensorTileL0C, tensorL0A, tensorL0B, initC, unitFlag);
-                        
-                        PipeBarrier<PIPE_ALL>();
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_BDV_L0A_FREE);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_BDV_L0B_FREE);
+                        AscendC::SetFlag<AscendC::HardEvent::M_FIX>(EVENT_BDV_L0C);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_BDV_L0A_FREE);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_BDV_L0B_FREE);
+                        AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(EVENT_BDV_L0C);
                         copyL0CToGm_Bdv(tensorBlockBdv, tensorL0C);
-                        PipeBarrier<PIPE_ALL>();
+                        AscendC::SetFlag<AscendC::HardEvent::FIX_M>(EVENT_BDV_L0C);
+                        AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(EVENT_BDV_L0C);
                         CrossCoreSetFlag<0x2, PIPE_FIX>(CROSS_CORE_C2V_BDV); // 计算完一个chunk的bdv,通知vec可以开始计算对应的dv2
                     } // end chunk k @ dh
                     

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_struct.h
@@ -41,6 +41,10 @@ struct ChunkGatedDeltaRuleBwdDhuTilingData {
     uint64_t qWs;
     uint64_t wDv2Ws;
     uint64_t qDoWs;
+    uint64_t qDoWsOffset;
+    uint64_t wDv2WsOffset;
+    uint64_t bdhWsOffset;
+    uint64_t bdhWs;
     uint64_t isVarLen;
     uint64_t isScale;
     uint64_t hasGk;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_struct.h
@@ -43,6 +43,9 @@ struct ChunkGatedDeltaRuleBwdDhuTilingData {
     uint64_t qDoWs;
     uint64_t isVarLen;
     uint64_t isScale;
+    uint64_t hasGk;
+    uint64_t hasH0;
+    uint64_t hasDht;
     uint32_t usedCoreNum;
     float scale;
 };

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
@@ -58,7 +58,6 @@ protected:
     uint64_t gatedQOffset_ = 0;
     uint64_t qdoOffset_ = 0;
     uint64_t wV2Offset_ = 0;
-    uint64_t bdhStateOffset_ = 0;
 
     int32_t curChunkNum_ = 0;
     uint64_t dhBlockSize_ = 0;
@@ -113,18 +112,18 @@ __aicore__ inline void GDRVec<DT, GT>::InitUB()
     this->dvCastLocal = this->vecTbuf.template GetWithOffset<float>(this->dvBufSize, dv2Offset); // 64k
     dv2Offset += this->dvBufSize * FLOAT_DTYPE_SIZE;
     this->bdvCastLocal = this->vecTbuf.template GetWithOffset<float>(this->dvBufSize, dv2Offset); // 64k
-    // calc bdh = bdh + qdo*scale - wv2
-    // | bdhCastLocal/wv2CastLocal | qdoCastLocal | shared half input/output |
+    // Keep the recurrent FP32 bdh state outside the phase-shared scratch region.
+    // qdo and wv2 are consumed sequentially and can share one FP32 term buffer.
     uint64_t offsetDh = 0;
-    this->bdhCastLocal = this->vecTbuf.template Get<float>(this->dhBufSize);
-    this->wv2CastLocal = this->vecTbuf.template GetWithOffset<float>(this->dhBufSize, offsetDh);
-    offsetDh += this->dhBufSize * FLOAT_DTYPE_SIZE;
     this->qdoCastLocal = this->vecTbuf.template GetWithOffset<float>(this->dhBufSize, offsetDh);
+    this->wv2CastLocal = this->qdoCastLocal;
     offsetDh += this->dhBufSize * FLOAT_DTYPE_SIZE;
     this->bdhLocal = this->vecTbuf.template GetWithOffset<DT>(this->dhBufSize, offsetDh);
     this->wv2Local = this->vecTbuf.template GetWithOffset<DT>(this->dhBufSize, offsetDh);
     this->qdoLocal = this->vecTbuf.template GetWithOffset<DT>(this->dhBufSize, offsetDh);
     this->gkLocal = this->vecTbuf.template GetWithOffset<GT>(this->halfK, offsetDh);
+    const uint64_t bdhOffset = this->totalTbufByte - this->dhBufSize * FLOAT_DTYPE_SIZE;
+    this->bdhCastLocal = this->vecTbuf.template GetWithOffset<float>(this->dhBufSize, bdhOffset);
 }
 
 template <typename DT, typename GT>
@@ -152,14 +151,13 @@ __aicore__ inline void GDRVec<DT, GT>::InitGlobalTensor(GM_ADDR q, GM_ADDR dv, G
     }
 
     // workspace
-    // | DT bdv | DT gatedQ | FP32 qDoWs | FP32 wDv2Ws | FP32 bdhState |
+    // | DT bdv | DT gatedQ | FP32 qDoWs | FP32 wDv2Ws |
     uint64_t wsOffset = 0;
     this->bdvGm.SetGlobalBuffer((__gm__ DT *)workspace + wsOffset);
     wsOffset += this->bdvWs; 
     this->gatedQGm.SetGlobalBuffer((__gm__ DT *)workspace + wsOffset);
     this->qdoGm.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t *)workspace + this->qDoWsOffset));
     this->wv2Gm.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t *)workspace + this->wDv2WsOffset));
-    this->bdhStateGm.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t *)workspace + this->bdhWsOffset));
 }
 
 template <typename DT, typename GT>
@@ -280,7 +278,6 @@ __aicore__ inline void GDRVec<DT, GT>::CaclOffset(const uint32_t coarseTaskIdx, 
     gatedQOffset_ = cubeIdx_ * BT * this->K;
     qdoOffset_ = cubeIdx_ * dhBlockSize_;
     wV2Offset_ = cubeIdx_ * dhBlockSize_;
-    bdhStateOffset_ = cubeIdx_ * dhBlockSize_;
 
     gmOffsetK_ = (b * this->Hk + hq) * this->T * this->K + seqStartOffset * this->K;
     gmOffsetV_ = (b * this->Hv + h) * this->T * this->V + seqStartOffset * this->V;
@@ -302,7 +299,6 @@ __aicore__ inline void GDRVec<DT, GT>::CaclOffset(const uint32_t coarseTaskIdx, 
         gmOffsetG_ += this->halfBT;
         gmOffsetGk_ += this->halfK;
         gmOffsetState_ += this->halfK * this->V;
-        bdhStateOffset_ += this->halfK * this->V;
     }
 }
 
@@ -311,18 +307,17 @@ __aicore__ inline void GDRVec<DT, GT>::InitLastDh()
 {
     uint64_t lastDhOffset = gmOffsetH_ + static_cast<uint64_t>(curChunkNum_ - 1) * dhBlockSize_;
     if (this->hasDht) {
-        // qCastLocal and qLocal do not overlap, unlike the reused bdh buffers.
         for (uint64_t offset = 0; offset < this->dhBufSize; offset += this->qBufSize) {
             const uint64_t remaining = this->dhBufSize - offset;
             const uint32_t copyLen = static_cast<uint32_t>(remaining < this->qBufSize ? remaining : this->qBufSize);
-            CopyIn(this->qCastLocal, this->qCastLocal, this->dhtGm[gmOffsetState_ + offset], copyLen, false);
-            CopyOut(this->qCastLocal, this->qCastLocal, this->bdhStateGm[bdhStateOffset_ + offset], copyLen, false);
-            CopyOut(this->qLocal, this->qCastLocal, this->dhGm[lastDhOffset + offset], copyLen);
+            CopyIn(this->bdhCastLocal[offset], this->bdhCastLocal[offset],
+                   this->dhtGm[gmOffsetState_ + offset], copyLen, false);
+            CopyOut(this->bdhLocal, this->bdhCastLocal[offset], this->dhGm[lastDhOffset + offset], copyLen);
         }
         CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_BDH);
     } else {
+        Duplicate(this->bdhCastLocal, static_cast<float>(0.0), this->dhBufSize);
         InitOutput<DT>(this->dhGm[lastDhOffset], this->dhBufSize, 0);
-        InitOutput<float>(this->bdhStateGm[bdhStateOffset_], this->dhBufSize, 0);
     }
 }
 
@@ -437,7 +432,6 @@ __aicore__ inline void GDRVec<DT, GT>::UpdateDh(const float gLastExp, uint64_t& 
                                                 const bool isLastChunk)
 {
     curGmOffsetH = gmOffsetH_ + chunkIdx_ * dhBlockSize_;
-    CopyIn(this->bdhCastLocal, this->bdhCastLocal, this->bdhStateGm[bdhStateOffset_], this->dhBufSize, false);
     Muls(this->bdhCastLocal, this->bdhCastLocal, gLastExp, this->dhBufSize);
     ApplyGk(this->bdhCastLocal);
     if (chunkIdx_ == 0 && !this->hasH0) {
@@ -448,21 +442,20 @@ __aicore__ inline void GDRVec<DT, GT>::UpdateDh(const float gLastExp, uint64_t& 
     {
         CopyIn(this->qdoCastLocal, this->qdoCastLocal, this->qdoGm[qdoOffset_], this->dhBufSize, false);
         if (this->isScale) {
-            Muls(this->qdoCastLocal, this->qdoCastLocal, this->scale, this->dhBufSize);
+            Axpy(this->bdhCastLocal, this->qdoCastLocal, this->scale, this->dhBufSize);
+        } else {
+            Add(this->bdhCastLocal, this->bdhCastLocal, this->qdoCastLocal, this->dhBufSize);
         }
-        Add(this->qdoCastLocal, this->bdhCastLocal, this->qdoCastLocal, this->dhBufSize);
     }
     CrossCoreWaitFlag(CROSS_CORE_C2V_TERM2);
     {
         CopyIn(this->wv2CastLocal, this->wv2CastLocal, this->wv2Gm[wV2Offset_], this->dhBufSize, false);
-        Muls(this->wv2CastLocal, this->wv2CastLocal, static_cast<float>(-1.0), this->dhBufSize);
-        Add(this->qdoCastLocal, this->qdoCastLocal, this->wv2CastLocal, this->dhBufSize);
+        Axpy(this->bdhCastLocal, this->wv2CastLocal, static_cast<float>(-1.0), this->dhBufSize);
     }
     if (chunkIdx_ == 0) {
-        CopyOut(this->qdoCastLocal, this->qdoCastLocal, this->dh0Gm[gmOffsetState_], this->dhBufSize, false);
+        CopyOut(this->bdhCastLocal, this->bdhCastLocal, this->dh0Gm[gmOffsetState_], this->dhBufSize, false);
     } else {
-        CopyOut(this->qdoCastLocal, this->qdoCastLocal, this->bdhStateGm[bdhStateOffset_], this->dhBufSize, false);
-        CopyOut(this->bdhLocal, this->qdoCastLocal, this->dhGm[curGmOffsetH - dhBlockSize_], this->dhBufSize);
+        CopyOut(this->bdhLocal, this->bdhCastLocal, this->dhGm[curGmOffsetH - dhBlockSize_], this->dhBufSize);
         CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_BDH);
     }
 }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
@@ -58,6 +58,7 @@ protected:
     uint64_t gatedQOffset_ = 0;
     uint64_t qdoOffset_ = 0;
     uint64_t wV2Offset_ = 0;
+    uint64_t bdhStateOffset_ = 0;
 
     int32_t curChunkNum_ = 0;
     uint64_t dhBlockSize_ = 0;
@@ -151,15 +152,14 @@ __aicore__ inline void GDRVec<DT, GT>::InitGlobalTensor(GM_ADDR q, GM_ADDR dv, G
     }
 
     // workspace
-    // | bdv | gatedQ | qDoWs | wDv2Ws |
+    // | DT bdv | DT gatedQ | FP32 qDoWs | FP32 wDv2Ws | FP32 bdhState |
     uint64_t wsOffset = 0;
     this->bdvGm.SetGlobalBuffer((__gm__ DT *)workspace + wsOffset);
     wsOffset += this->bdvWs; 
     this->gatedQGm.SetGlobalBuffer((__gm__ DT *)workspace + wsOffset);
-    wsOffset += this->qWs;
-    this->qdoGm.SetGlobalBuffer((__gm__ DT *)workspace + wsOffset);
-    wsOffset += this->qDoWs;
-    this->wv2Gm.SetGlobalBuffer((__gm__ DT *)workspace + wsOffset);
+    this->qdoGm.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t *)workspace + this->qDoWsOffset));
+    this->wv2Gm.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t *)workspace + this->wDv2WsOffset));
+    this->bdhStateGm.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t *)workspace + this->bdhWsOffset));
 }
 
 template <typename DT, typename GT>
@@ -280,6 +280,7 @@ __aicore__ inline void GDRVec<DT, GT>::CaclOffset(const uint32_t coarseTaskIdx, 
     gatedQOffset_ = cubeIdx_ * BT * this->K;
     qdoOffset_ = cubeIdx_ * dhBlockSize_;
     wV2Offset_ = cubeIdx_ * dhBlockSize_;
+    bdhStateOffset_ = cubeIdx_ * dhBlockSize_;
 
     gmOffsetK_ = (b * this->Hk + hq) * this->T * this->K + seqStartOffset * this->K;
     gmOffsetV_ = (b * this->Hv + h) * this->T * this->V + seqStartOffset * this->V;
@@ -301,6 +302,7 @@ __aicore__ inline void GDRVec<DT, GT>::CaclOffset(const uint32_t coarseTaskIdx, 
         gmOffsetG_ += this->halfBT;
         gmOffsetGk_ += this->halfK;
         gmOffsetState_ += this->halfK * this->V;
+        bdhStateOffset_ += this->halfK * this->V;
     }
 }
 
@@ -314,11 +316,13 @@ __aicore__ inline void GDRVec<DT, GT>::InitLastDh()
             const uint64_t remaining = this->dhBufSize - offset;
             const uint32_t copyLen = static_cast<uint32_t>(remaining < this->qBufSize ? remaining : this->qBufSize);
             CopyIn(this->qCastLocal, this->qCastLocal, this->dhtGm[gmOffsetState_ + offset], copyLen, false);
+            CopyOut(this->qCastLocal, this->qCastLocal, this->bdhStateGm[bdhStateOffset_ + offset], copyLen, false);
             CopyOut(this->qLocal, this->qCastLocal, this->dhGm[lastDhOffset + offset], copyLen);
         }
         CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_BDH);
     } else {
         InitOutput<DT>(this->dhGm[lastDhOffset], this->dhBufSize, 0);
+        InitOutput<float>(this->bdhStateGm[bdhStateOffset_], this->dhBufSize, 0);
     }
 }
 
@@ -433,7 +437,7 @@ __aicore__ inline void GDRVec<DT, GT>::UpdateDh(const float gLastExp, uint64_t& 
                                                 const bool isLastChunk)
 {
     curGmOffsetH = gmOffsetH_ + chunkIdx_ * dhBlockSize_;
-    CopyIn(this->bdhCastLocal, this->bdhLocal, this->dhGm[curGmOffsetH], this->dhBufSize);
+    CopyIn(this->bdhCastLocal, this->bdhCastLocal, this->bdhStateGm[bdhStateOffset_], this->dhBufSize, false);
     Muls(this->bdhCastLocal, this->bdhCastLocal, gLastExp, this->dhBufSize);
     ApplyGk(this->bdhCastLocal);
     if (chunkIdx_ == 0 && !this->hasH0) {
@@ -442,7 +446,7 @@ __aicore__ inline void GDRVec<DT, GT>::UpdateDh(const float gLastExp, uint64_t& 
     // dh_updated = dh_i-1 * exp2(bg_last) + term1*scale - term2
     CrossCoreWaitFlag(CROSS_CORE_C2V_TERM1); 
     {
-        CopyIn(this->qdoCastLocal, this->qdoLocal, this->qdoGm[qdoOffset_], this->dhBufSize);
+        CopyIn(this->qdoCastLocal, this->qdoCastLocal, this->qdoGm[qdoOffset_], this->dhBufSize, false);
         if (this->isScale) {
             Muls(this->qdoCastLocal, this->qdoCastLocal, this->scale, this->dhBufSize);
         }
@@ -450,13 +454,14 @@ __aicore__ inline void GDRVec<DT, GT>::UpdateDh(const float gLastExp, uint64_t& 
     }
     CrossCoreWaitFlag(CROSS_CORE_C2V_TERM2);
     {
-        CopyIn(this->wv2CastLocal, this->wv2Local, this->wv2Gm[wV2Offset_], this->dhBufSize);
+        CopyIn(this->wv2CastLocal, this->wv2CastLocal, this->wv2Gm[wV2Offset_], this->dhBufSize, false);
         Muls(this->wv2CastLocal, this->wv2CastLocal, static_cast<float>(-1.0), this->dhBufSize);
         Add(this->qdoCastLocal, this->qdoCastLocal, this->wv2CastLocal, this->dhBufSize);
     }
     if (chunkIdx_ == 0) {
         CopyOut(this->qdoCastLocal, this->qdoCastLocal, this->dh0Gm[gmOffsetState_], this->dhBufSize, false);
     } else {
+        CopyOut(this->qdoCastLocal, this->qdoCastLocal, this->bdhStateGm[bdhStateOffset_], this->dhBufSize, false);
         CopyOut(this->bdhLocal, this->qdoCastLocal, this->dhGm[curGmOffsetH - dhBlockSize_], this->dhBufSize);
         CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_BDH);
     }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
@@ -113,19 +113,17 @@ __aicore__ inline void GDRVec<DT, GT>::InitUB()
     dv2Offset += this->dvBufSize * FLOAT_DTYPE_SIZE;
     this->bdvCastLocal = this->vecTbuf.template GetWithOffset<float>(this->dvBufSize, dv2Offset); // 64k
     // calc bdh = bdh + qdo*scale - wv2
-    // | bdhCastLocal/wV2CastLocal 64 | qDoCastLocal 64 |
-    // | 32 | bdhLocal/wV2Local       | 32 | qDoLocal   |
+    // | bdhCastLocal/wv2CastLocal | qdoCastLocal | shared half input/output |
     uint64_t offsetDh = 0;
-    uint32_t halfDhBufByte = this->dhBufSize * HALF_DTYPE_SIZE;
-    this->bdhCastLocal = this->vecTbuf.template Get<float>(this->dhBufSize); 
-    this->bdhLocal = this->vecTbuf.template GetWithOffset<DT>(this->dhBufSize, halfDhBufByte);
-    // 复用
+    this->bdhCastLocal = this->vecTbuf.template Get<float>(this->dhBufSize);
     this->wv2CastLocal = this->vecTbuf.template GetWithOffset<float>(this->dhBufSize, offsetDh);
-    this->wv2Local = this->vecTbuf.template GetWithOffset<DT>(this->dhBufSize, offsetDh + halfDhBufByte);
     offsetDh += this->dhBufSize * FLOAT_DTYPE_SIZE;
     this->qdoCastLocal = this->vecTbuf.template GetWithOffset<float>(this->dhBufSize, offsetDh);
-    this->qdoLocal = this->vecTbuf.template GetWithOffset<DT>(this->dhBufSize, offsetDh + halfDhBufByte);
     offsetDh += this->dhBufSize * FLOAT_DTYPE_SIZE;
+    this->bdhLocal = this->vecTbuf.template GetWithOffset<DT>(this->dhBufSize, offsetDh);
+    this->wv2Local = this->vecTbuf.template GetWithOffset<DT>(this->dhBufSize, offsetDh);
+    this->qdoLocal = this->vecTbuf.template GetWithOffset<DT>(this->dhBufSize, offsetDh);
+    this->gkLocal = this->vecTbuf.template GetWithOffset<GT>(this->halfK, offsetDh);
 }
 
 template <typename DT, typename GT>
@@ -311,8 +309,13 @@ __aicore__ inline void GDRVec<DT, GT>::InitLastDh()
 {
     uint64_t lastDhOffset = gmOffsetH_ + static_cast<uint64_t>(curChunkNum_ - 1) * dhBlockSize_;
     if (this->hasDht) {
-        CopyIn(this->bdhCastLocal, this->bdhCastLocal, this->dhtGm[gmOffsetState_], this->dhBufSize, false);
-        CopyOut(this->bdhLocal, this->bdhCastLocal, this->dhGm[lastDhOffset], this->dhBufSize);
+        // qCastLocal and qLocal do not overlap, unlike the reused bdh buffers.
+        for (uint64_t offset = 0; offset < this->dhBufSize; offset += this->qBufSize) {
+            const uint64_t remaining = this->dhBufSize - offset;
+            const uint32_t copyLen = static_cast<uint32_t>(remaining < this->qBufSize ? remaining : this->qBufSize);
+            CopyIn(this->qCastLocal, this->qCastLocal, this->dhtGm[gmOffsetState_ + offset], copyLen, false);
+            CopyOut(this->qLocal, this->qCastLocal, this->dhGm[lastDhOffset + offset], copyLen);
+        }
         CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_BDH);
     } else {
         InitOutput<DT>(this->dhGm[lastDhOffset], this->dhBufSize, 0);
@@ -327,16 +330,20 @@ __aicore__ inline void GDRVec<DT, GT>::ApplyGk(LocalTensor<float> bdh)
     }
     uint64_t lastToken = bos_ + this->curBT - 1;
     if constexpr (std::is_same<GT, float>::value) {
-        CopyIn(this->qCastLocal, this->qCastLocal, this->gkGm[gmOffsetGk_ + lastToken * this->K], this->halfK, false);
+        CopyIn(
+            this->qdoCastLocal, this->qdoCastLocal,
+            this->gkGm[gmOffsetGk_ + lastToken * this->K], this->halfK, false);
     } else {
-        CopyIn(this->qCastLocal, this->gLocal, this->gkGm[gmOffsetGk_ + lastToken * this->K], this->halfK);
+        CopyIn(
+            this->qdoCastLocal, this->gkLocal,
+            this->gkGm[gmOffsetGk_ + lastToken * this->K], this->halfK);
     }
-    Muls(this->qCastLocal, this->qCastLocal, LN2, this->halfK);
+    Muls(this->qdoCastLocal, this->qdoCastLocal, LN2, this->halfK);
     PipeBarrier<PIPE_V>();
-    Exp(this->qCastLocal, this->qCastLocal, this->halfK);
+    Exp(this->qdoCastLocal, this->qdoCastLocal, this->halfK);
     PipeBarrier<PIPE_V>();
     for (uint32_t row = 0; row < this->halfK; row++) {
-        float decay = this->qCastLocal.GetValue(row);
+        float decay = this->qdoCastLocal.GetValue(row);
         Muls(bdh[row * this->V], bdh[row * this->V], decay, this->V);
     }
 }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
@@ -21,6 +21,8 @@
 using namespace AscendC;
 namespace ChunkGDRBwdDhu {
 
+constexpr float LN2 = 0.6931471805599453f;
+
 template <typename DT, typename GT>
 class GDRVec : public GDRBase<DT, GT>
 {
@@ -101,7 +103,7 @@ __aicore__ inline void GDRVec<DT, GT>::InitUB()
     offsetQ += this->qBufSize * FLOAT_DTYPE_SIZE;
     this->gBCLocal = this->vecTbuf.template GetWithOffset<float>(this->halfBT * FP32_PER_BLOCK, offsetQ); // 32k
 
-    // cacl bdv * exp(bg_last-bg) + dv_ori
+    // cacl bdv * exp2(bg_last-bg) + dv_ori
     // | gCastLocal | gBrcbLocal | dv/bdvLocal 32 | dvCast 64 | bdvCast 64 | 
     this->gBrcbLocal = this->vecTbuf.template GetWithOffset<float>(this->halfBT * FP32_PER_BLOCK, dv2Offset);
     dv2Offset += this->halfBT * BLOCK_SIZE;
@@ -199,7 +201,7 @@ __aicore__ inline void GDRVec<DT, GT>::Process( )
                 bos_ = chunkIdx_ * this->chunkSize;
                 // gatedQ = q * gExp
                 CalcGatedQ(gLast, gLastExp, isLastChunk);
-                // 計算dv2 dv2 = bdv * exp(bg_last - bg) + dv[B,H,T,V]
+                // 計算dv2 dv2 = bdv * exp2(bg_last - bg) + dv[B,H,T,V]
                 CalcDv2(gLast, curGmOffsetV, isLastChunk);
                 if (chunkIdx_ > 0 || this->hasH0) {
                     CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_DV2); // 计算完一个chunk的dv2,通知cube可以开始计算w @ dv2 
@@ -235,7 +237,7 @@ __aicore__ inline void GDRVec<DT, GT>::TailChunkProcess(uint32_t tailChunkLen)
     bos_ = chunkIdx_ * this->chunkSize;
     // gatedQ = q * gExp
     CalcGatedQ(gLast, gLastExp, true);
-    // 計算dv2 dv2 = bdv * exp(bg_last - bg) + dv[B,H,T,V]
+    // 計算dv2 dv2 = bdv * exp2(bg_last - bg) + dv[B,H,T,V]
     CalcDv2(gLast, curGmOffsetV, true);
     if (chunkIdx_ > 0 || this->hasH0) {
         CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_DV2); // 计算完一个chunk的dv2,通知cube可以开始计算w @ dv2 
@@ -329,7 +331,7 @@ __aicore__ inline void GDRVec<DT, GT>::ApplyGk(LocalTensor<float> bdh)
     } else {
         CopyIn(this->qCastLocal, this->gLocal, this->gkGm[gmOffsetGk_ + lastToken * this->K], this->halfK);
     }
-    Muls(this->qCastLocal, this->qCastLocal, 0.6931471805599453f, this->halfK);
+    Muls(this->qCastLocal, this->qCastLocal, LN2, this->halfK);
     PipeBarrier<PIPE_V>();
     Exp(this->qCastLocal, this->qCastLocal, this->halfK);
     PipeBarrier<PIPE_V>();
@@ -352,24 +354,28 @@ __aicore__ inline void GDRVec<DT, GT>::CalcGatedQ(float& gLast, float& gLastExp,
     if constexpr (std::is_same<GT, float>::value) {
         if (this->subBlockIdx == 0) {
             CopyIn(this->gCastLocal, this->gCastLocal, this->gGm[gmOffsetG_ + bos_], this->curBT, false);
-            Exp(this->gExpLocal, this->gCastLocal, this->curBT);
+            Muls(this->gExpLocal, this->gCastLocal, LN2, this->curBT);
+            Exp(this->gExpLocal, this->gExpLocal, this->curBT);
             gLast = this->gCastLocal.GetValue(static_cast<uint64_t>(this->curBT - 1));
             gLastExp = this->gExpLocal.GetValue(static_cast<uint64_t>(this->curBT - 1));
         } else {
             CopyIn(this->gCastLocal, this->gCastLocal, this->gGm[gmOffsetG_ + bos_], this->curCalcBT, false);
-            Exp(this->gExpLocal, this->gCastLocal, this->curCalcBT);
+            Muls(this->gExpLocal, this->gCastLocal, LN2, this->curCalcBT);
+            Exp(this->gExpLocal, this->gExpLocal, this->curCalcBT);
             gLast = this->gCastLocal.GetValue(this->curCalcBT - 1);
             gLastExp = this->gExpLocal.GetValue(this->curCalcBT - 1);
         }
     } else {
         if (this->subBlockIdx == 0) {
             CopyIn(this->gCastLocal, this->gLocal, this->gGm[gmOffsetG_ + bos_], this->curBT);
-            Exp(this->gExpLocal, this->gCastLocal, this->curBT);
+            Muls(this->gExpLocal, this->gCastLocal, LN2, this->curBT);
+            Exp(this->gExpLocal, this->gExpLocal, this->curBT);
             gLast = this->gCastLocal.GetValue(static_cast<uint64_t>(this->curBT - 1));
             gLastExp = this->gExpLocal.GetValue(static_cast<uint64_t>(this->curBT - 1));
         } else {
             CopyIn(this->gCastLocal, this->gLocal, this->gGm[gmOffsetG_ + bos_], this->curCalcBT);
-            Exp(this->gExpLocal, this->gCastLocal, this->curCalcBT);
+            Muls(this->gExpLocal, this->gCastLocal, LN2, this->curCalcBT);
+            Exp(this->gExpLocal, this->gExpLocal, this->curCalcBT);
             gLast = this->gCastLocal.GetValue(this->curCalcBT - 1);
             gLastExp = this->gExpLocal.GetValue(this->curCalcBT - 1);
         }
@@ -402,6 +408,7 @@ __aicore__ inline void GDRVec<DT, GT>::CalcDv2(const float gLast, uint64_t& curG
         CopyIn(this->dvCastLocal, this->vInLocal, this->dvGm[curGmOffsetV], this->dvBufSize);
         Muls(this->gCastLocal, this->gCastLocal, static_cast<float>(-1.0), this->halfBT);
         Adds(this->gCastLocal, this->gCastLocal, gLast, this->halfBT);
+        Muls(this->gCastLocal, this->gCastLocal, LN2, this->halfBT);
         Exp(this->gCastLocal, this->gCastLocal, this->halfBT);
         uint8_t repeatTimes = Ceil(this->halfBT, FP32_PER_BLOCK); // halfBT is 32 or 64
         Brcb(this->gBrcbLocal, this->gCastLocal, repeatTimes, {1,FP32_PER_BLOCK});
@@ -425,7 +432,7 @@ __aicore__ inline void GDRVec<DT, GT>::UpdateDh(const float gLastExp, uint64_t& 
     if (chunkIdx_ == 0 && !this->hasH0) {
         return;
     }
-    // dh_updated = dh_i-1 * exp(bg_last) + term1*scale - term2
+    // dh_updated = dh_i-1 * exp2(bg_last) + term1*scale - term2
     CrossCoreWaitFlag(CROSS_CORE_C2V_TERM1); 
     {
         CopyIn(this->qdoCastLocal, this->qdoLocal, this->qdoGm[qdoOffset_], this->dhBufSize);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
@@ -151,13 +151,13 @@ __aicore__ inline void GDRVec<DT, GT>::InitGlobalTensor(GM_ADDR q, GM_ADDR dv, G
     }
 
     // workspace
-    // | DT bdv | DT gatedQ | FP32 qDoWs | FP32 wDv2Ws |
+    // | DT bdv | DT gatedQ | DT qDoWs | DT wDv2Ws |
     uint64_t wsOffset = 0;
     this->bdvGm.SetGlobalBuffer((__gm__ DT *)workspace + wsOffset);
     wsOffset += this->bdvWs; 
     this->gatedQGm.SetGlobalBuffer((__gm__ DT *)workspace + wsOffset);
-    this->qdoGm.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t *)workspace + this->qDoWsOffset));
-    this->wv2Gm.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t *)workspace + this->wDv2WsOffset));
+    this->qdoGm.SetGlobalBuffer((__gm__ DT *)((__gm__ uint8_t *)workspace + this->qDoWsOffset));
+    this->wv2Gm.SetGlobalBuffer((__gm__ DT *)((__gm__ uint8_t *)workspace + this->wDv2WsOffset));
 }
 
 template <typename DT, typename GT>
@@ -440,7 +440,7 @@ __aicore__ inline void GDRVec<DT, GT>::UpdateDh(const float gLastExp, uint64_t& 
     // dh_updated = dh_i-1 * exp2(bg_last) + term1*scale - term2
     CrossCoreWaitFlag(CROSS_CORE_C2V_TERM1); 
     {
-        CopyIn(this->qdoCastLocal, this->qdoCastLocal, this->qdoGm[qdoOffset_], this->dhBufSize, false);
+        CopyIn(this->qdoCastLocal, this->qdoLocal, this->qdoGm[qdoOffset_], this->dhBufSize);
         if (this->isScale) {
             Axpy(this->bdhCastLocal, this->qdoCastLocal, this->scale, this->dhBufSize);
         } else {
@@ -449,7 +449,7 @@ __aicore__ inline void GDRVec<DT, GT>::UpdateDh(const float gLastExp, uint64_t& 
     }
     CrossCoreWaitFlag(CROSS_CORE_C2V_TERM2);
     {
-        CopyIn(this->wv2CastLocal, this->wv2CastLocal, this->wv2Gm[wV2Offset_], this->dhBufSize, false);
+        CopyIn(this->wv2CastLocal, this->wv2Local, this->wv2Gm[wV2Offset_], this->dhBufSize);
         Axpy(this->bdhCastLocal, this->wv2CastLocal, static_cast<float>(-1.0), this->dhBufSize);
     }
     if (chunkIdx_ == 0) {

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vec.h
@@ -27,17 +27,21 @@ class GDRVec : public GDRBase<DT, GT>
 public:
     __aicore__ inline GDRVec(){};
     __aicore__ inline void Process();
-    __aicore__ inline void Init(GM_ADDR q, GM_ADDR k, GM_ADDR w, GM_ADDR d_o, GM_ADDR dv, GM_ADDR g, GM_ADDR cu_seqlens, 
-                                GM_ADDR dv2, GM_ADDR dh, GM_ADDR workspace, const ChunkGatedDeltaRuleBwdDhuTilingData& tilingData);
+    __aicore__ inline void Init(GM_ADDR q, GM_ADDR k, GM_ADDR w, GM_ADDR d_o, GM_ADDR dv, GM_ADDR g, GM_ADDR gk,
+                                GM_ADDR h0, GM_ADDR dht, GM_ADDR cu_seqlens, GM_ADDR dv2, GM_ADDR dh, GM_ADDR dh0,
+                                GM_ADDR workspace, const ChunkGatedDeltaRuleBwdDhuTilingData& tilingData);
 private:
     __aicore__ inline void TailChunkProcess(uint32_t tailChunkLen); 
     __aicore__ inline void InitUB();
-    __aicore__ inline void InitGlobalTensor(GM_ADDR q, GM_ADDR dv, GM_ADDR g, GM_ADDR cu_seqlens, 
-                                            GM_ADDR dv2, GM_ADDR dh, GM_ADDR workspace);
+    __aicore__ inline void InitGlobalTensor(GM_ADDR q, GM_ADDR dv, GM_ADDR g, GM_ADDR gk, GM_ADDR dht,
+                                            GM_ADDR cu_seqlens, GM_ADDR dv2, GM_ADDR dh, GM_ADDR dh0,
+                                            GM_ADDR workspace);
     __aicore__ inline void CaclOffset(const uint32_t coarseTaskIdx, const uint32_t h, uint64_t& tailChunkLen);
     __aicore__ inline void CalcGatedQ(float& gLast, float& gLastExp, const bool isLastChunk);
     __aicore__ inline void CalcDv2(const float gLast, uint64_t& curGmOffsetV, const bool isLastChunk);
     __aicore__ inline void UpdateDh(const float gLastExp, uint64_t& curGmOffsetH, const bool isLastChunk);
+    __aicore__ inline void InitLastDh();
+    __aicore__ inline void ApplyGk(LocalTensor<float> bdh);
 
 
 protected:
@@ -45,6 +49,8 @@ protected:
     uint64_t gmOffsetK_ = 0;
     uint64_t gmOffsetV_ = 0;
     uint64_t gmOffsetH_ = 0;
+    uint64_t gmOffsetGk_ = 0;
+    uint64_t gmOffsetState_ = 0;
 
     uint64_t bdvOffset_ = 0;
     uint64_t gatedQOffset_ = 0;
@@ -59,12 +65,15 @@ protected:
 }; // class GDRVec
 
 template <typename DT, typename GT>
-__aicore__ inline void GDRVec<DT, GT>::Init(GM_ADDR q, GM_ADDR k, GM_ADDR w, GM_ADDR d_o, GM_ADDR dv, GM_ADDR g, GM_ADDR cu_seqlens, 
-                                        GM_ADDR dv2, GM_ADDR dh, GM_ADDR workspace, const ChunkGatedDeltaRuleBwdDhuTilingData& tilingData)
+__aicore__ inline void GDRVec<DT, GT>::Init(GM_ADDR q, GM_ADDR k, GM_ADDR w, GM_ADDR d_o, GM_ADDR dv, GM_ADDR g,
+                                        GM_ADDR gk, GM_ADDR h0, GM_ADDR dht, GM_ADDR cu_seqlens, GM_ADDR dv2,
+                                        GM_ADDR dh, GM_ADDR dh0, GM_ADDR workspace,
+                                        const ChunkGatedDeltaRuleBwdDhuTilingData& tilingData)
 {
+    (void)h0;
     GDRBase<DT, GT>::InitTilingData(tilingData);
     InitUB();
-    InitGlobalTensor(q, dv, g, cu_seqlens, dv2, dh, workspace);
+    InitGlobalTensor(q, dv, g, gk, dht, cu_seqlens, dv2, dh, dh0, workspace);
 }
 
 template <typename DT, typename GT>
@@ -118,13 +127,24 @@ __aicore__ inline void GDRVec<DT, GT>::InitUB()
 }
 
 template <typename DT, typename GT>
-__aicore__ inline void GDRVec<DT, GT>::InitGlobalTensor(GM_ADDR q, GM_ADDR dv, GM_ADDR g, GM_ADDR cu_seqlens, GM_ADDR dv2, GM_ADDR dh, GM_ADDR workspace)
+__aicore__ inline void GDRVec<DT, GT>::InitGlobalTensor(GM_ADDR q, GM_ADDR dv, GM_ADDR g, GM_ADDR gk, GM_ADDR dht,
+                                                       GM_ADDR cu_seqlens, GM_ADDR dv2, GM_ADDR dh, GM_ADDR dh0,
+                                                       GM_ADDR workspace)
 {
     this->gGm.SetGlobalBuffer((__gm__ GT *)g);
+    if (this->hasGk) {
+        this->gkGm.SetGlobalBuffer((__gm__ GT *)gk);
+    }
+    if (this->hasDht) {
+        this->dhtGm.SetGlobalBuffer((__gm__ float *)dht);
+    }
     this->qGm.SetGlobalBuffer((__gm__ DT *)q);
     this->dvGm.SetGlobalBuffer((__gm__ DT *)dv);
     this->dv2Gm.SetGlobalBuffer((__gm__ DT *)dv2);
     this->dhGm.SetGlobalBuffer((__gm__ DT *)dh);
+    if (this->hasH0) {
+        this->dh0Gm.SetGlobalBuffer((__gm__ float *)dh0);
+    }
     
     if (this->isVarLen) {
         this->cuSeqlensGm.SetGlobalBuffer((__gm__ int64_t *)cu_seqlens);
@@ -155,6 +175,7 @@ __aicore__ inline void GDRVec<DT, GT>::Process( )
         for (uint32_t h = hq * static_cast<uint32_t>(this->hvPerHk); h < hGroupEnd; h++) {
             uint64_t tailChunkLen = 0;
             CaclOffset(i, h, tailChunkLen);
+            InitLastDh();
             float gLast = 0.0;
             float gLastExp = 0.0;
             uint64_t curGmOffsetV = 0;
@@ -180,11 +201,11 @@ __aicore__ inline void GDRVec<DT, GT>::Process( )
                 CalcGatedQ(gLast, gLastExp, isLastChunk);
                 // 計算dv2 dv2 = bdv * exp(bg_last - bg) + dv[B,H,T,V]
                 CalcDv2(gLast, curGmOffsetV, isLastChunk);
-                if (chunkIdx_ > 0) {
+                if (chunkIdx_ > 0 || this->hasH0) {
                     CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_DV2); // 计算完一个chunk的dv2,通知cube可以开始计算w @ dv2 
                 }
                 // updated dh
-                if (chunkIdx_ == 0 && !isLastChunk) {
+                if (chunkIdx_ == 0 && !this->hasH0) {
                     // 每個chunk更新bdh給下個chunk用，chunkIdx=0作爲最後一個chunk，所有的chunk都已經更新完了，無需更新bdh。
                     continue;
                 }
@@ -216,7 +237,7 @@ __aicore__ inline void GDRVec<DT, GT>::TailChunkProcess(uint32_t tailChunkLen)
     CalcGatedQ(gLast, gLastExp, true);
     // 計算dv2 dv2 = bdv * exp(bg_last - bg) + dv[B,H,T,V]
     CalcDv2(gLast, curGmOffsetV, true);
-    if (chunkIdx_ > 0) {
+    if (chunkIdx_ > 0 || this->hasH0) {
         CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_DV2); // 计算完一个chunk的dv2,通知cube可以开始计算w @ dv2 
     }
     // updated dh
@@ -264,6 +285,9 @@ __aicore__ inline void GDRVec<DT, GT>::CaclOffset(const uint32_t coarseTaskIdx, 
     gmOffsetV_ = (b * this->Hv + h) * this->T * this->V + seqStartOffset * this->V;
     gmOffsetH_ = (b * this->Hv + h) * this->chunkNum * dhBlockSize_ + preChunkNum * dhBlockSize_;
     gmOffsetG_ = (b * this->Hv + h) * this->T + seqStartOffset;
+    gmOffsetGk_ = ((b * this->Hv + h) * this->T + seqStartOffset) * this->K;
+    uint32_t seqIdx = this->isVarLen ? coarseTaskIdx / this->Hk : static_cast<uint32_t>(b);
+    gmOffsetState_ = (static_cast<uint64_t>(seqIdx) * this->Hv + h) * dhBlockSize_;
 
     if (this->subBlockIdx == 1) {
         gatedQOffset_ += this->halfBT * this->K;
@@ -275,6 +299,43 @@ __aicore__ inline void GDRVec<DT, GT>::CaclOffset(const uint32_t coarseTaskIdx, 
         gmOffsetV_ += this->halfBT * this->V;
         gmOffsetH_ += this->halfK * this->V;
         gmOffsetG_ += this->halfBT;
+        gmOffsetGk_ += this->halfK;
+        gmOffsetState_ += this->halfK * this->V;
+    }
+}
+
+template <typename DT, typename GT>
+__aicore__ inline void GDRVec<DT, GT>::InitLastDh()
+{
+    uint64_t lastDhOffset = gmOffsetH_ + static_cast<uint64_t>(curChunkNum_ - 1) * dhBlockSize_;
+    if (this->hasDht) {
+        CopyIn(this->bdhCastLocal, this->bdhCastLocal, this->dhtGm[gmOffsetState_], this->dhBufSize, false);
+        CopyOut(this->bdhLocal, this->bdhCastLocal, this->dhGm[lastDhOffset], this->dhBufSize);
+        CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_BDH);
+    } else {
+        InitOutput<DT>(this->dhGm[lastDhOffset], this->dhBufSize, 0);
+    }
+}
+
+template <typename DT, typename GT>
+__aicore__ inline void GDRVec<DT, GT>::ApplyGk(LocalTensor<float> bdh)
+{
+    if (!this->hasGk) {
+        return;
+    }
+    uint64_t lastToken = bos_ + this->curBT - 1;
+    if constexpr (std::is_same<GT, float>::value) {
+        CopyIn(this->qCastLocal, this->qCastLocal, this->gkGm[gmOffsetGk_ + lastToken * this->K], this->halfK, false);
+    } else {
+        CopyIn(this->qCastLocal, this->gLocal, this->gkGm[gmOffsetGk_ + lastToken * this->K], this->halfK);
+    }
+    Muls(this->qCastLocal, this->qCastLocal, 0.6931471805599453f, this->halfK);
+    PipeBarrier<PIPE_V>();
+    Exp(this->qCastLocal, this->qCastLocal, this->halfK);
+    PipeBarrier<PIPE_V>();
+    for (uint32_t row = 0; row < this->halfK; row++) {
+        float decay = this->qCastLocal.GetValue(row);
+        Muls(bdh[row * this->V], bdh[row * this->V], decay, this->V);
     }
 }
 
@@ -313,7 +374,7 @@ __aicore__ inline void GDRVec<DT, GT>::CalcGatedQ(float& gLast, float& gLastExp,
             gLastExp = this->gExpLocal.GetValue(this->curCalcBT - 1);
         }
     }
-    if (chunkIdx_ == 0) {
+    if (chunkIdx_ == 0 && !this->hasH0) {
         return; // chunkIdx==0时，不再需要更新dh，只需要拿到g和gLast用于计算dv2即可。
     }
     // COPY IN Q [B,Hk,T,K]
@@ -331,7 +392,7 @@ template <typename DT, typename GT>
 __aicore__ inline void GDRVec<DT, GT>::CalcDv2(const float gLast, uint64_t& curGmOffsetV, const bool isLastChunk)
 {
     curGmOffsetV = gmOffsetV_ + bos_ * this->V;
-    if (isLastChunk) {
+    if (isLastChunk && !this->hasDht) {
         // dv -> dv2 無需cast， 不依賴cube計算結果
         CopyIn(this->dvCastLocal, this->vInLocal, this->dvGm[curGmOffsetV], this->curCalcTV, false);
         SetFlag<HardEvent::MTE2_MTE3>(EVENT_MTE2_MTE3);
@@ -358,14 +419,10 @@ __aicore__ inline void GDRVec<DT, GT>::UpdateDh(const float gLastExp, uint64_t& 
                                                 const bool isLastChunk)
 {
     curGmOffsetH = gmOffsetH_ + chunkIdx_ * dhBlockSize_;
-    if (isLastChunk) {
-        // 初始化全零 dh_chunkIdx
-        InitOutput<DT>(this->dhGm[curGmOffsetH], this->dhBufSize, 0); // 兩個vec核各初始化一半
-    } else {
-        CopyIn(this->bdhCastLocal, this->bdhLocal, this->dhGm[curGmOffsetH], this->dhBufSize);
-        Muls(this->bdhCastLocal, this->bdhCastLocal, gLastExp, this->dhBufSize);
-    }
-    if (chunkIdx_ == 0) {
+    CopyIn(this->bdhCastLocal, this->bdhLocal, this->dhGm[curGmOffsetH], this->dhBufSize);
+    Muls(this->bdhCastLocal, this->bdhCastLocal, gLastExp, this->dhBufSize);
+    ApplyGk(this->bdhCastLocal);
+    if (chunkIdx_ == 0 && !this->hasH0) {
         return;
     }
     // dh_updated = dh_i-1 * exp(bg_last) + term1*scale - term2
@@ -375,9 +432,7 @@ __aicore__ inline void GDRVec<DT, GT>::UpdateDh(const float gLastExp, uint64_t& 
         if (this->isScale) {
             Muls(this->qdoCastLocal, this->qdoCastLocal, this->scale, this->dhBufSize);
         }
-        if (!isLastChunk) {
-            Add(this->qdoCastLocal, this->bdhCastLocal, this->qdoCastLocal, this->dhBufSize);
-        }
+        Add(this->qdoCastLocal, this->bdhCastLocal, this->qdoCastLocal, this->dhBufSize);
     }
     CrossCoreWaitFlag(CROSS_CORE_C2V_TERM2);
     {
@@ -385,8 +440,12 @@ __aicore__ inline void GDRVec<DT, GT>::UpdateDh(const float gLastExp, uint64_t& 
         Muls(this->wv2CastLocal, this->wv2CastLocal, static_cast<float>(-1.0), this->dhBufSize);
         Add(this->qdoCastLocal, this->qdoCastLocal, this->wv2CastLocal, this->dhBufSize);
     }
-    CopyOut(this->bdhLocal, this->qdoCastLocal, this->dhGm[curGmOffsetH - dhBlockSize_], this->dhBufSize);
-    CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_BDH);
+    if (chunkIdx_ == 0) {
+        CopyOut(this->qdoCastLocal, this->qdoCastLocal, this->dh0Gm[gmOffsetState_], this->dhBufSize, false);
+    } else {
+        CopyOut(this->bdhLocal, this->qdoCastLocal, this->dhGm[curGmOffsetH - dhBlockSize_], this->dhBufSize);
+        CrossCoreSetFlag<0x2, PIPE_MTE3>(CROSS_CORE_V2C_BDH);
+    }
 }
 
 } // namespace ChunkGDRBwdDhu

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/test/test_chunk_gated_delta_rule_bwd_dhu.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/test/test_chunk_gated_delta_rule_bwd_dhu.py
@@ -609,7 +609,7 @@ def test_state_and_gk(
     B: int = 1,
     Hk: int = 1,
     Hv: int = 1,
-    T: int = 128,
+    T: int = 320,
     K: int = 64,
     V: int = 32,
     chunk_size: int = 64,

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/test/test_chunk_gated_delta_rule_bwd_dhu.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/test/test_chunk_gated_delta_rule_bwd_dhu.py
@@ -247,6 +247,9 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
     cu_seqlens: Optional[List[int]] = None,
     chunk_indices: Optional[List[int]] = None,
     g: Optional[torch.Tensor] = None,
+    gk: Optional[torch.Tensor] = None,
+    h0: Optional[torch.Tensor] = None,
+    dht: Optional[torch.Tensor] = None,
     scale: Optional[float] = None,
     chunk_size: int = 64,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
@@ -331,7 +334,7 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
     if cu_seqlens is None:
         # 定长：对 (B, Hv) 向量化，仅沿 chunk 反向迭代。避免 B×Hv×NT 纯 Python 嵌套（大 B/Hv 时极慢甚至像卡死）。
         hq = torch.arange(Hv, device=device, dtype=torch.long) // hv_per_hk
-        b_dh = torch.zeros(B, Hv, K, V, device=device, dtype=torch.float32)
+        b_dh = dht.float().clone() if dht is not None else torch.zeros(B, Hv, K, V, device=device, dtype=torch.float32)
         for i_t in range(NT - 1, -1, -1):
             info = chunk_info[i_t]
             global_start_t = info["global_start_t"]
@@ -375,17 +378,26 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
                 b_dh_for_update = b_dh.clone()
                 b_q_gated = b_q_t
 
+            if gk is not None:
+                b_dh_for_update = b_dh_for_update * torch.exp2(gk[:, :, global_last_idx]).unsqueeze(-1)
+
             term1 = torch.matmul(b_q_gated.to(torch.float), b_do.to(torch.float)) * scale
             term2 = torch.matmul(b_w_t.to(torch.float), b_dv.to(torch.float))
             b_dh = b_dh_for_update + term1 - term2
     else:
+        dh0_buffers = torch.empty(
+            len(cu_seqlens) - 1, Hv, K, V, device=device, dtype=torch.float32
+        ) if h0 is not None else None
         for b in range(B):
             for i_h in range(Hv):
                 hq = i_h // hv_per_hk
                 num_tokens = len(cu_seqlens) - 1
                 b_dh_buffers = {}
                 for i_n in range(num_tokens):
-                    b_dh_buffers[i_n] = torch.zeros(K, V, device=device, dtype=torch.float32)
+                    if dht is not None:
+                        b_dh_buffers[i_n] = dht[i_n, i_h].float().clone()
+                    else:
+                        b_dh_buffers[i_n] = torch.zeros(K, V, device=device, dtype=torch.float32)
 
                 for i_t in range(NT - 1, -1, -1):
                     info = chunk_info[i_t]
@@ -431,6 +443,8 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
                     b_dh_for_update = b_dh.clone()
                     if g is not None:
                         b_dh_for_update = b_dh_for_update * bg_last_exp
+                    if gk is not None:
+                        b_dh_for_update = b_dh_for_update * torch.exp2(gk[b, i_h, global_last_idx]).unsqueeze(-1)
 
                     b_q_gated = b_q_t
                     if g is not None:
@@ -441,8 +455,15 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
 
                     new_b_dh = b_dh_for_update + term1 - term2
                     b_dh_buffers[i_n] = new_b_dh
+                if dh0_buffers is not None:
+                    for i_n in range(num_tokens):
+                        dh0_buffers[i_n, i_h] = b_dh_buffers[i_n]
 
-    return dh, None, dv2
+    if h0 is None:
+        return dh, None, dv2
+    if cu_seqlens is None:
+        return dh, b_dh, dv2
+    return dh, dh0_buffers, dv2
 
 
 def test_fix(
@@ -583,6 +604,39 @@ def test_variable(
 
     # print(f"test_variable 被调用了第 {test_variable.call_count} 次")
 
+
+def test_state_and_gk(
+    B: int = 1,
+    Hk: int = 1,
+    Hv: int = 1,
+    T: int = 128,
+    K: int = 64,
+    V: int = 32,
+    chunk_size: int = 64,
+    dtype: torch.dtype = torch.bfloat16,
+):
+    """Cover key-wise gate, final-state gradient, and FP32 dh0 output together."""
+    torch.manual_seed(17)
+    q, k, w, d_o, dv, g = create_bwd_dhu_random_inputs(B, Hk, Hv, T, K, V, dtype, dtype)
+    gk = create_gate_g(B, Hv, T * K, dtype, narrow=True).reshape(B, Hv, T, K)
+    h0 = rand_symmetric_uniform((B, Hv, K, V), dtype, 1e-2)
+    dht = rand_symmetric_uniform((B, Hv, K, V), torch.float32, 1e-2)
+
+    dh_ref, dh0_ref, dv2_ref = chunk_gated_delta_rule_bwd_dhu_torch(
+        q, k, w, d_o, dv, g=g, gk=gk, h0=h0, dht=dht, scale=1.0 / math.sqrt(K), chunk_size=chunk_size
+    )
+    dh, dh0, dv2 = torch.ops.npu.npu_chunk_gated_delta_rule_bwd_dhu(
+        q.npu(), k.npu(), w.npu(), d_o.npu(), dv.npu(),
+        scale=1.0 / math.sqrt(K), chunk_size=chunk_size,
+        g=g.npu(), gK=gk.npu(), h0=h0.npu(), dht=dht.npu(),
+        cu_seqlens=None, chunk_indices=None,
+    )
+    assert dh0 is not None and dh0.dtype == torch.float32
+    ct.single(dh.cpu(), dh_ref)
+    ct.single(dh0.cpu(), dh0_ref)
+    ct.single(dv2.cpu(), dv2_ref)
+    assert_finite_after_npu_golden_compare(dh.cpu(), dv2.cpu(), dh_ref, dv2_ref)
+
 if __name__ == "__main__":
     import os
     torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
@@ -596,3 +650,5 @@ if __name__ == "__main__":
     test_fix(B=1, Hk=4, Hv=4, T=128, K=128, V=128, chunk_size=64, scale=0.088, ktype=torch.bfloat16, gtype=torch.bfloat16)
     # GVA varlen smoke
     test_variable(B=1, Hk=4, Hv=8, T=512, K=128, V=128, chunk_size=64, scale=0.011, cu_seqlens_len=4, ktype=torch.bfloat16, gtype=torch.bfloat16)
+    # State and key-wise gate coverage (FP32 dht, FP32 dh0).
+    test_state_and_gk()

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/test/test_chunk_gated_delta_rule_bwd_dhu.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/test/test_chunk_gated_delta_rule_bwd_dhu.py
@@ -358,7 +358,7 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
             if g is not None:
                 bg_last = g[:, :, global_last_idx]
                 b_g = g[:, :, global_start_t:global_end_t]
-                gate_factor = torch.exp(bg_last.unsqueeze(-1) - b_g).unsqueeze(-1)
+                gate_factor = torch.exp2(bg_last.unsqueeze(-1) - b_g).unsqueeze(-1)
                 m_t = torch.arange(block_size_t, device=device, dtype=torch.float32) < float(block_size_t)
                 mask_expanded = m_t.view(1, 1, block_size_t, 1)
                 b_dv = b_dv * gate_factor * mask_expanded
@@ -370,8 +370,8 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
             b_w_t = w_blk.transpose(-1, -2)
 
             if g is not None:
-                bg_last_exp = torch.exp(bg_last)
-                b_g_exp = torch.exp(b_g)
+                bg_last_exp = torch.exp2(bg_last)
+                b_g_exp = torch.exp2(b_g)
                 b_dh_for_update = b_dh * bg_last_exp.unsqueeze(-1).unsqueeze(-1)
                 b_q_gated = b_q_t * b_g_exp.unsqueeze(-2)
             else:
@@ -417,8 +417,8 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
                     if g is not None:
                         bg_last = g[b, i_h, global_last_idx]
                         b_g = g[b, i_h, global_start_t:global_end_t]
-                        bg_last_exp = torch.exp(bg_last)
-                        b_g_exp = torch.exp(b_g)
+                        bg_last_exp = torch.exp2(bg_last)
+                        b_g_exp = torch.exp2(b_g)
 
                     b_do = do[b, i_h, global_start_t:global_end_t, :]
                     b_dv_existing = dv[b, i_h, global_start_t:global_end_t, :]
@@ -428,7 +428,7 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
 
                     if g is not None:
                         m_t = torch.arange(block_size_t, device=device) < block_size_t
-                        gate_factor = torch.exp(bg_last - b_g).unsqueeze(-1)
+                        gate_factor = torch.exp2(bg_last - b_g).unsqueeze(-1)
                         mask_expanded = m_t.unsqueeze(-1).float()
                         b_dv *= gate_factor * mask_expanded
 

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
@@ -218,13 +218,16 @@ def npu_chunk_gated_delta_rule_bwd_dhu(
     use_exp2=False,
     transpose_state_layout=False,
 ):
+    import torch
+
     q_shape = _shape(q)
     dv_shape = _shape(dv)
     B, _, T, K = q_shape
     Hv, V = dv_shape[1], dv_shape[3]
     NT = _chunk_num(T, int(chunk_size), chunk_indices)
     dh = _empty((B, Hv, NT, K, V), q)
-    dh0 = _empty((B, Hv, NT, K, V), q) if h0 is not None else None
+    state_batch = len(cu_seqlens) - 1 if cu_seqlens is not None else B
+    dh0 = _empty((state_batch, Hv, K, V), q, dtype=torch.float32) if h0 is not None else None
     dv2 = _empty_like(dv)
     outputs = (dh, dh0, dv2)
     return _call_aclnn(

--- a/torch_custom/fla_npu/test/test_bwd_dhu.py
+++ b/torch_custom/fla_npu/test/test_bwd_dhu.py
@@ -168,7 +168,7 @@ def chunk_gated_delta_rule_bwd_dhu_cpu(
             if g is not None:
                 bg_last = g[:, :, global_last_idx].to(torch.float32)
                 b_g = g[:, :, gs:ge].to(torch.float32)
-                gate_factor = torch.exp(bg_last.unsqueeze(-1) - b_g).unsqueeze(-1)
+                gate_factor = torch.exp2(bg_last.unsqueeze(-1) - b_g).unsqueeze(-1)
                 m_t = torch.arange(block_size_t, device=device, dtype=torch.float32) < float(block_size_t)
                 b_dv = b_dv * gate_factor * m_t.view(1, 1, block_size_t, 1)
 
@@ -178,8 +178,8 @@ def chunk_gated_delta_rule_bwd_dhu_cpu(
             b_q_t = q_blk.transpose(-1, -2)
             b_w_t = w_blk.transpose(-1, -2)
             if g is not None:
-                bg_last_exp = torch.exp(bg_last)
-                b_g_exp = torch.exp(b_g)
+                bg_last_exp = torch.exp2(bg_last)
+                b_g_exp = torch.exp2(b_g)
                 b_dh_for_update = b_dh * bg_last_exp.unsqueeze(-1).unsqueeze(-1)
                 b_q_gated = b_q_t * b_g_exp.unsqueeze(-2)
             else:
@@ -213,10 +213,10 @@ def chunk_gated_delta_rule_bwd_dhu_cpu(
                     if g is not None:
                         bg_last = g[b, i_h, global_last_idx].to(torch.float32)
                         b_g = g[b, i_h, gs:ge].to(torch.float32)
-                        bg_last_exp = torch.exp(bg_last)
-                        b_g_exp = torch.exp(b_g)
+                        bg_last_exp = torch.exp2(bg_last)
+                        b_g_exp = torch.exp2(b_g)
                         m_t = torch.arange(block_size_t, device=device) < block_size_t
-                        b_dv = b_dv * torch.exp(bg_last - b_g).unsqueeze(-1) * m_t.unsqueeze(-1).float()
+                        b_dv = b_dv * torch.exp2(bg_last - b_g).unsqueeze(-1) * m_t.unsqueeze(-1).float()
                     else:
                         bg_last_exp = b_g_exp = None
 


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @fazhenyao
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
