### PR TITLE
Solve-tri支持BNSD和NTD输出格式

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/README.md
@@ -10,9 +10,13 @@
 
 $$Y = (I + A)^{-1}$$
 
-该算子支持两种数据布局：
-- **BSND**: `[Batch, T, Head, chunkSize]`
-- **TND**: `[num_tokens, Head, chunkSize]`（变长序列模式）
+该算子支持四种数据布局：
+- **BSND**: `[Batch, T, Head, chunkSize]`，单 chunk 内数据不连续（行步长 = H×BT）
+- **BNSD**: `[Batch, Head, T, chunkSize]`，单 chunk 内数据连续（行步长 = BT，BSND 的转置）
+- **TND**: `[total_T, Head, chunkSize]`，变长序列模式，单 chunk 内数据不连续
+- **NTD**: `[Head, total_T, chunkSize]`，变长序列模式，单 chunk 内数据连续（TND 的转置）
+
+> BNSD/NTD 由于单 chunk 内数据连续，DataCopy 可使用 blockCount=1 实现连续搬运，效率高于 BSND/TND。
 
 ---
 
@@ -59,7 +63,7 @@ torch.ops.npu.npu_solve_tri(
 | x | FLOAT16/BFLOAT16 | 是 | 输入下三角矩阵 |
 | cu_seqlens | INT64 | TND 模式必须 | 累积序列长度 |
 | chunk_indices | INT64 | TND 模式必须 | chunk 索引数组 |
-| layout | string | 否 | 数据布局，默认 "bsnd" |
+| layout | string | 否 | 数据布局，支持 "bsnd"、"bnsd"、"tnd"、"ntd"，默认 "bsnd" |
 
 ---
 
@@ -68,9 +72,9 @@ torch.ops.npu.npu_solve_tri(
 1. **数据类型**：仅支持 FLOAT16 和 BFLOAT16
 2. **chunkSize**：最后一维仅支持 64 或 128
 3. **输入维度**：
-   - BHTD/BSND: 4D tensor
-   - TND: 3D tensor
-4. **变长模式**：TND layout 必须提供 cu_seqlens 和 chunk_indices
+   - BNSD/BSND: 4D tensor
+   - TND/NTD: 3D tensor
+4. **变长模式**：TND/NTD layout 必须提供 cu_seqlens 和 chunk_indices
 
 ---
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/docs/aclnnSolveTri.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/docs/aclnnSolveTri.md
@@ -56,7 +56,7 @@ aclnnStatus aclnnSolveTri(
 | x | 输入 | 公式中的输入矩阵 A，Device 侧的 aclTensor，数据类型支持 FLOAT16、BFLOAT16 |
 | cuSeqlens | 输入 | 变长序列模式下的累积序列长度，可选参数。Device 侧的 aclIntArray，数据类型为 INT64 |
 | chunkIndices | 输入 | 变长序列模式下的 chunk 索引，可选参数。Device 侧的 aclIntArray，数据类型为 INT64 |
-| layout | 输入 | 数据布局模式，支持 "bsnd"、"tnd" |
+| layout | 输入 | 数据布局模式，支持 "bsnd"、"bnsd"、"tnd"、"ntd"，默认 "bsnd" |
 | xOut | 输出 | 公式中的输出矩阵 Y，Device 侧的 aclTensor，数据类型与 x 一致 |
 | workspaceSize | 输出 | 返回执行该算子所需的 workspace 大小 |
 | executor | 输出 | 返回算子执行器 |
@@ -75,9 +75,11 @@ aclnnStatus aclnnSolveTri(
 1. **数据类型**：输入 x 仅支持 FLOAT16 和 BFLOAT16
 2. **chunkSize**：最后一维（矩阵大小）仅支持 64 或 128
 3. **数据布局**：
-   - `bsnd`: 输入 shape 为 `[B, T, H, chunkSize]`
-   - `tnd`: 输入 shape 为 `[total_T, H, chunkSize]`，需配合 cu_seqlens 和 chunk_indices 使用
-4. **变长模式**：当 layout 为 "tnd" 时，cu_seqlens 和 chunk_indices 必须提供，数据类型为 INT64
+   - `bnsd`: 输入 shape 为 `[B, H, S, chunkSize]`，单 chunk 内数据连续
+   - `bsnd`: 输入 shape 为 `[B, S, H, chunkSize]`，单 chunk 内数据不连续
+   - `tnd`: 输入 shape 为 `[total_T, H, chunkSize]`，需配合 cu_seqlens 和 chunk_indices 使用，单 chunk 内数据不连续
+   - `ntd`: 输入 shape 为 `[H, total_T, chunkSize]`，需配合 cu_seqlens 和 chunk_indices 使用，单 chunk 内数据连续（TND 的转置）
+4. **变长模式**：当 layout 为 "tnd" 或 "ntd" 时，cu_seqlens 和 chunk_indices 必须提供，数据类型为 INT64
 
 ## 输出说明
 
@@ -107,10 +109,10 @@ torch.ops.npu.npu_solve_tri(
 
 | 参数 | 类型 | 描述 |
 |------|------|------|
-| x | Tensor | 输入下三角矩阵，shape 为 `[B, H, T, chunkSize]` (bhtd)、`[B, T, H, chunkSize]` (bsnd) 或 `[total_T, H, chunkSize]` (tnd) |
+| x | Tensor | 输入下三角矩阵，shape 为 `[B, H, T, chunkSize]` (bnsd)、`[B, T, H, chunkSize]` (bsnd)、`[total_T, H, chunkSize]` (tnd) 或 `[H, total_T, chunkSize]` (ntd) |
 | cu_seqlens | Optional[List[int]] | 变长模式下的累积序列长度，如 `[0, 100, 200]` 表示两个序列长度分别为 100 和 100 |
 | chunk_indices | Optional[List[int]] | 变长模式下的 chunk 索引，格式为 `[seq_id_0, chunk_id_0, seq_id_1, chunk_id_1, ...]` |
-| layout | str | 数据布局，可选 "bsnd"、"tnd"，默认 "bsnd" |
+| layout | str | 数据布局，可选 "bsnd"、"bnsd"、"tnd"、"ntd"，默认 "bsnd" |
 
 ### 返回值
 
@@ -148,5 +150,21 @@ y_tnd = torch.ops.npu.npu_solve_tri(
     cu_seqlens=cu_seqlens,
     chunk_indices=chunk_indices,
     layout="tnd"
+)
+
+
+# BNSD layout (BSND 的转置，单 chunk 内数据连续)
+B, H, T, chunkSize = 2, 4, 128, 64
+x_bnsd = torch.randn(B, H, T, chunkSize, dtype=torch.float16, device="npu")
+y_bnsd = torch.ops.npu.npu_solve_tri(x_bnsd, layout="bnsd")
+
+
+# NTD layout (TND 的转置，单 chunk 内数据连续)
+x_ntd = torch.randn(H, total_T, chunkSize, dtype=torch.float16, device="npu")
+y_ntd = torch.ops.npu.npu_solve_tri(
+    x_ntd,
+    cu_seqlens=cu_seqlens,
+    chunk_indices=chunk_indices,
+    layout="ntd"
 )
 ```

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_host/solve_tri_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_host/solve_tri_tiling.cpp
@@ -22,56 +22,75 @@ constexpr uint32_t ATTR_LAYOUT_IDX = 0;
      int64_t coreNum = ascendcPlatform.GetCoreNumAic();
      if (coreNum == 0) return ge::GRAPH_FAILED;
  
-     // Get input shape: [B, H, T, BT] (BHTD), [B, T, H, BT] (BSND), or [total_T, H, BT] (THD)
+     // Get input shape:
+     //   BNSD (mode 0): [B, H, S, BT]            (4D, chunks contiguous)
+     //   BSND (mode 1): [B, S, H, BT]            (4D, chunks non-contiguous)
+     //   TND  (mode 2): [total_T, H, BT]         (3D, varlen, chunks non-contiguous)
+     //   NTD  (mode 3): [H, total_T, BT]         (3D, varlen, chunks contiguous; transpose of TND)
      auto inputShape = context->GetInputShape(INPUT_X_IDX);
      if (inputShape == nullptr) return ge::GRAPH_FAILED;
      auto shape = inputShape->GetStorageShape();
      int64_t ndim = shape.GetDimNum();
      if (ndim != 3 && ndim != 4) return ge::GRAPH_FAILED;
-
+ 
      // Get layout attribute to determine shape parsing
      auto attrs = context->GetAttrs();
      const char *layoutStr = attrs->GetStr(ATTR_LAYOUT_IDX);
      std::string layout = layoutStr ? layoutStr : "bsnd";
-
-     // layoutMode: 0=BHTD, 1=BSND, 2=THD
+ 
+     // layoutMode: 0=BNSD, 1=BSND, 2=TND, 3=NTD
+     // "bhtd" 保留为 mode 0 的兼容别名（等价于 bnsd）
      int64_t layoutMode = 1;  // default to BSND
-     if (layout == "bhtd") {
+     if (layout == "bnsd" || layout == "bhtd") {
          layoutMode = 0;
      } else if (layout == "bsnd") {
          layoutMode = 1;
      } else if (layout == "tnd") {
          layoutMode = 2;
+     } else if (layout == "ntd") {
+         layoutMode = 3;
      }
-
+ 
      int64_t B, H, T, BT;
      if (ndim == 4) {
          if (layoutMode == 0) {
-             // BHTD: [B, H, T, BT]
+             // BNSD: [B, H, S, BT]
              B = shape.GetDim(0);
              H = shape.GetDim(1);
              T = shape.GetDim(2);
              BT = shape.GetDim(3);
          } else {
-             // BSND: [B, T, H, BT]
+             // BSND: [B, S, H, BT]
              B = shape.GetDim(0);
              T = shape.GetDim(1);
              H = shape.GetDim(2);
              BT = shape.GetDim(3);
          }
      } else {
-         // 3D THD: [total_T, H, BT]
-         B = 1;
-         T = shape.GetDim(0);
-         H = shape.GetDim(1);
-         BT = shape.GetDim(2);
+         // 3D varlen
+         if (layoutMode == 3) {
+             // NTD: [H, total_T, BT]
+             B = 1;
+             H = shape.GetDim(0);
+             T = shape.GetDim(1);
+             BT = shape.GetDim(2);
+         } else {
+             // TND: [total_T, H, BT]
+             B = 1;
+             T = shape.GetDim(0);
+             H = shape.GetDim(1);
+             BT = shape.GetDim(2);
+         }
      }
-
+ 
      int64_t chunkSize = BT;
-
-    // isVarlen only for THD mode
-    int64_t isVarlen = (layoutMode == 2) ? 1 : 0;
+ 
+    // isVarlen only for TND/NTD mode
+    int64_t isVarlen = (layoutMode == 2 || layoutMode == 3) ? 1 : 0;
     int64_t hasCuSeqlens = isVarlen;
+
+    // totalTokens: NTD 偏移计算需要（= T，即 total_T）；其余模式置 0
+    int64_t totalTokens = (layoutMode == 3) ? T : 0;
 
     int64_t totalChunks = 0;
     int64_t numChunks = 0;
@@ -121,6 +140,7 @@ constexpr uint32_t ATTR_LAYOUT_IDX = 0;
     tiling.set_totalChunks(totalChunks);
     tiling.set_layoutMode(layoutMode);
     tiling.set_dtypeMode(dtypeMode);
+    tiling.set_totalTokens(totalTokens);
  
      context->SetTilingKey(1);
      tiling.SaveToBuffer(context->GetRawTilingData()->GetData(),

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_host/solve_tri_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_host/solve_tri_tiling.h
@@ -23,9 +23,10 @@
      TILING_DATA_FIELD_DEF(int64_t, lastChunkValidSize);
      TILING_DATA_FIELD_DEF(int64_t, isVarlen);
      TILING_DATA_FIELD_DEF(int64_t, totalChunks);
-     TILING_DATA_FIELD_DEF(int64_t, layoutMode);
-     TILING_DATA_FIELD_DEF(int64_t, dtypeMode);  // 0=fp16, 1=bf16
- END_TILING_DATA_DEF;
+    TILING_DATA_FIELD_DEF(int64_t, layoutMode);
+    TILING_DATA_FIELD_DEF(int64_t, dtypeMode);  // 0=fp16, 1=bf16
+    TILING_DATA_FIELD_DEF(int64_t, totalTokens);  // NTD: total tokens (= seqLen), 用于 head 维在外的偏移计算
+END_TILING_DATA_DEF;
  
  REGISTER_TILING_DATA_CLASS(SolveTri, SolveTriTilingData)
  

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/arch35/solve_tri_ascend950.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/arch35/solve_tri_ascend950.h
@@ -34,9 +34,9 @@ using namespace AscendC;
 //   - 注：原 SyncAll 固定调度版已整体替换为 CrossCoreFlag（MBH 一并切换）。
 //
 // 【布局 / 变长 TND】
-//   - GM 偏移按 [B,H,T,BT](bhtd) / [B,T,H,BT](bsnd) / [total_T,H,BT](tnd 变长) 完整公式；
-//     tnd 由 cu_seqlens / chunk_indices（INT64，GetValue）确定每 tile 偏移与序列长度。
-//   - 行跨度 row_stride = (bhtd) chunk_size : num_head*chunk_size。
+//   - GM 偏移按 [B,H,T,BT](bnsd) / [B,T,H,BT](bsnd) / [total_T,H,BT](tnd 变长) / [H,total_T,BT](ntd 变长) 完整公式；
+//     tnd/ntd 由 cu_seqlens / chunk_indices（INT64，GetValue）确定每 tile 偏移与序列长度。
+//   - 行跨度 row_stride = (bnsd/ntd) chunk_size : (bsnd/tnd) num_head*chunk_size。
 //
 // 【尾块（partial chunk）正确性】
 //   - actual_size = 该 chunk 的有效行数（尾块 < cur）。cur = ChunkAlign(actual_size)。
@@ -62,9 +62,10 @@ public:
         chunk_size = tilingData->chunkSize;
         chunk_num_in_seq = tilingData->numChunks;
         chunk_num_total = tilingData->totalTiles; // 主循环上界 = 全部 tile 数
-        mode = tilingData->layoutMode;            // 0=bhtd, 1=bsnd, 2=tnd
+        mode = tilingData->layoutMode;            // 0=bnsd, 1=bsnd, 2=tnd, 3=ntd
         is_lower = tilingData->isLower;
         tiles_per_core = tilingData->tilesPerCore;
+        total_tokens = tilingData->totalTokens;   // NTD: total_T（head 维在外的偏移计算）
 
         // GM（INT64 索引）
         gm_a.SetGlobalBuffer(reinterpret_cast<__gm__ InDtype *>(aGm));
@@ -252,21 +253,21 @@ public:
         int64_t local_seq_length = seq_length;
         int64_t local_chunk_num_in_seq = chunk_num_in_seq;
 
-        if (mode == 0) { // BHTD: [B, H, T, BT]
+        if (mode == 0) { // BNSD: [B, H, S, BT]  (chunks contiguous, row_stride = BT)
             seq_idx = loop_idx / (chunk_num_in_seq * num_head);
             head_idx = (loop_idx / chunk_num_in_seq) % num_head;
             chunk_in_seq_idx = loop_idx % chunk_num_in_seq;
             x_gm_offset = seq_idx * num_head * seq_length * chunk_size +
                           head_idx * seq_length * chunk_size +
                           chunk_in_seq_idx * chunk_size * chunk_size;
-        } else if (mode == 1) { // BSND: [B, T, H, BT]
+        } else if (mode == 1) { // BSND: [B, S, H, BT]  (non-contiguous, row_stride = H*BT)
             seq_idx = loop_idx / (chunk_num_in_seq * num_head);
             chunk_in_seq_idx = loop_idx % (chunk_num_in_seq * num_head) / num_head;
             head_idx = loop_idx % (chunk_num_in_seq * num_head) % num_head;
             x_gm_offset = seq_idx * seq_length * num_head * chunk_size +
                           chunk_in_seq_idx * chunk_size * num_head * chunk_size +
                           head_idx * chunk_size;
-        } else { // TND varlen: [total_T, H, BT]; B = 1
+        } else if (mode == 2) { // TND varlen: [total_T, H, BT]; B = 1  (non-contiguous, row_stride = H*BT)
             chunk_idx = loop_idx / num_head;
             head_idx = loop_idx % num_head;
             seq_idx = gm_chunk_indices.GetValue(chunk_idx * 2);
@@ -276,6 +277,17 @@ public:
             int64_t bos = gm_cu_seqlens.GetValue(seq_idx);
             x_gm_offset = (bos + chunk_in_seq_idx * chunk_size) * num_head * chunk_size +
                           head_idx * chunk_size;
+        } else { // NTD varlen: [H, total_T, BT]; B = 1  (contiguous, row_stride = BT)
+            chunk_idx = loop_idx / num_head;
+            head_idx = loop_idx % num_head;
+            seq_idx = gm_chunk_indices.GetValue(chunk_idx * 2);
+            chunk_in_seq_idx = gm_chunk_indices.GetValue(chunk_idx * 2 + 1);
+            local_seq_length = gm_cu_seqlens.GetValue(seq_idx + 1) - gm_cu_seqlens.GetValue(seq_idx);
+            local_chunk_num_in_seq = CeilDiv(local_seq_length, chunk_size);
+            int64_t bos = gm_cu_seqlens.GetValue(seq_idx);
+            // head 在最外维: head_idx * total_T * BT + (bos + chunk*BT) * BT
+            x_gm_offset = head_idx * total_tokens * chunk_size +
+                          (bos + chunk_in_seq_idx * chunk_size) * chunk_size;
         }
 
         bool is_last = (chunk_in_seq_idx == (local_chunk_num_in_seq - 1));
@@ -298,15 +310,24 @@ public:
         }
 
         // 对角 16x16 块 GM(ND) -> ub_A(NZ 块对角)；尾块只读 actual_size 行（逐分形裁剪）。
-        uint16_t src_blk_stride = static_cast<uint16_t>(row_stride / 16 - 1);
-        uint64_t num_valid_fracs = static_cast<uint64_t>(CeilDiv(actual_size, 16));
-        for (uint64_t i = 0; i < num_valid_fracs; i++) {
-            int64_t rows64 = actual_size - static_cast<int64_t>(i) * 16;
-            uint16_t rows = static_cast<uint16_t>(rows64 >= 16 ? 16 : rows64);
-            uint64_t srcOffset = i * (16 * (uint64_t)row_stride + 16);
-            uint64_t dstOffset = i * ((uint64_t)cur * 16 + 16 * 16);
-            AscendC::DataCopy(ub_A[dstOffset], gm_a[x_gm_offset + srcOffset],
-                              AscendC::DataCopyParams(rows, 1, src_blk_stride, 0));
+        // 连续布局 (BNSD/NTD, row_stride == chunk_size) 下，当 cur == 16 时整个 chunk 在 GM
+        // 中连续，可用 blockCount=1, blockLen=16 一次性搬运 256 个元素，避免多行 DataCopy 开销。
+        // cur > 16 时对角块仍非连续，保留逐分形搬运。
+        bool contiguous = (row_stride == cur);
+        if (contiguous && cur == 16) {
+            AscendC::DataCopy(ub_A[0], gm_a[x_gm_offset],
+                              AscendC::DataCopyParams(1, 16, 0, 0));
+        } else {
+            uint16_t src_blk_stride = static_cast<uint16_t>(row_stride / 16 - 1);
+            uint64_t num_valid_fracs = static_cast<uint64_t>(CeilDiv(actual_size, 16));
+            for (uint64_t i = 0; i < num_valid_fracs; i++) {
+                int64_t rows64 = actual_size - static_cast<int64_t>(i) * 16;
+                uint16_t rows = static_cast<uint16_t>(rows64 >= 16 ? 16 : rows64);
+                uint64_t srcOffset = i * (16 * (uint64_t)row_stride + 16);
+                uint64_t dstOffset = i * ((uint64_t)cur * 16 + 16 * 16);
+                AscendC::DataCopy(ub_A[dstOffset], gm_a[x_gm_offset + srcOffset],
+                                  AscendC::DataCopyParams(rows, 1, src_blk_stride, 0));
+            }
         }
         SetFlag<AscendC::HardEvent::MTE2_MTE3>(0);   // gather(MTE2, 写 ub_A) -> ub_to_l1(MTE3, 读 ub_A)
         WaitFlag<AscendC::HardEvent::MTE2_MTE3>(0);
@@ -504,7 +525,9 @@ public:
     {
         int32_t drvStart = is_lower ? 1 : 0;
         int32_t othStart = is_lower ? 0 : 1;
-        int64_t row_stride = (mode == 0) ? chunk_size : (num_head * chunk_size);
+        // BNSD(0)/NTD(3): 单 chunk 内数据连续, row_stride = BT
+        // BSND(1)/TND(2): 单 chunk 内数据不连续, row_stride = H*BT
+        int64_t row_stride = (mode == 0 || mode == 3) ? chunk_size : (num_head * chunk_size);
 
         if ASCEND_IS_AIV {
             if (sub_block_idx == 0) {
@@ -594,6 +617,7 @@ private:
     int64_t mode;
     int64_t is_lower;
     int64_t tiles_per_core;
+    int64_t total_tokens;   // NTD: total_T，用于 head 维在外的偏移计算
 
     // Core
     int64_t num_core;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/solve_tri_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_kernel/solve_tri_cube.h
@@ -161,7 +161,6 @@ private:
 
     // 预计算的 Nd2NzParams 模板（减少 scalar 开销）
     Nd2NzParams scratchToL1Params_;    // scratch GM → L1 slot（MatmulToSlot 等使用）
-    Nd2NzParams diagLoadParams_;       // 对角块 GM → L1（LoadInputTile 使用）
     Nd2NzParams fullLoadParams_;       // 整矩阵 GM → L1（MCH 最后一轮使用）
     int64_t layoutMode_;
     GlobalTensor<int64_t> cuSeqlensGM_;
@@ -194,11 +193,11 @@ __aicore__ inline void SolveTriCube<MATRIX_SIZE, T>::Init(
     totalChunks_ = tilingData->totalChunks;
     layoutMode_ = tilingData->layoutMode;
 
-    // 行间步长: BHTD=BT, BSND/THD=H*BT
-    if (layoutMode_ == 0) {
-        rowStride_ = matrixSize_;  // BHTD
+    // 行间步长: BNSD(0)/NTD(3) = BT (单 chunk 内连续), BSND(1)/TND(2) = H*BT (非连续)
+    if (layoutMode_ == 0 || layoutMode_ == 3) {
+        rowStride_ = matrixSize_;  // BNSD or NTD (contiguous)
     } else {
-        rowStride_ = numHeads_ * matrixSize_;  // BSND or THD
+        rowStride_ = numHeads_ * matrixSize_;  // BSND or TND (non-contiguous)
     }
     
     // AIC 的核索引
@@ -238,17 +237,7 @@ __aicore__ inline void SolveTriCube<MATRIX_SIZE, T>::Init(
     scratchToL1Params_.dstNzC0Stride = MATRIX_SIZE;
     scratchToL1Params_.dstNzMatrixStride = 0;
 
-    // 2. 对角块 GM → L1（LoadInputTile 使用）
-    diagLoadParams_.nValue = FRAC;
-    diagLoadParams_.dValue = FRAC;
-    diagLoadParams_.srcDValue = static_cast<uint32_t>(rowStride_);
-    diagLoadParams_.srcNdMatrixStride = FRAC * static_cast<int32_t>(rowStride_) + FRAC;
-    diagLoadParams_.dstNzNStride = 1;
-    diagLoadParams_.dstNzC0Stride = FRAC;
-    diagLoadParams_.dstNzMatrixStride = (NUM_FRACS + 1) * FRAC_LEN;
-    // diagLoadParams_.ndNum 在运行时设置
-
-    // 3. 整矩阵 GM → L1（MCH 最后一轮使用）
+    // 2. 整矩阵 GM → L1（MCH 最后一轮使用）
     fullLoadParams_.ndNum = 1;
     fullLoadParams_.srcDValue = static_cast<uint32_t>(rowStride_);
     fullLoadParams_.srcNdMatrixStride = 0;
@@ -286,8 +275,22 @@ __aicore__ inline int64_t SolveTriCube<MATRIX_SIZE, T>::GetTileGMOffset(int64_t 
     int64_t H = numHeads_;
     int64_t BT = matrixSize_;
 
-    if (layoutMode_ == 2) {
-        // THD 变长格式: [total_T, H, BT]
+    if (layoutMode_ == 3) {
+        // NTD 变长格式: [H, total_T, BT] (B=1, chunks contiguous, row_stride = BT)
+        // 遍历顺序: chunk_global → H (H 变化最快)
+        int64_t chunk_global_idx = tileIdx / H;
+        int64_t h = tileIdx % H;
+
+        int64_t seq_idx = chunkIndicesGM_.GetValue(chunk_global_idx * 2);
+        int64_t chunk_in_seq = chunkIndicesGM_.GetValue(chunk_global_idx * 2 + 1);
+
+        int64_t bos = cuSeqlensGM_.GetValue(seq_idx);
+
+        // head 在最外维: h * total_T * BT + (bos + chunk_in_seq * BT) * BT
+        return h * seqLen_ * BT + (bos + chunk_in_seq * BT) * BT;
+
+    } else if (layoutMode_ == 2) {
+        // TND 变长格式: [total_T, H, BT]
         // 遍历顺序: chunk_global → H (H 变化最快)
         int64_t chunk_global_idx = tileIdx / H;
         int64_t h = tileIdx % H;
@@ -303,7 +306,7 @@ __aicore__ inline int64_t SolveTriCube<MATRIX_SIZE, T>::GetTileGMOffset(int64_t 
         return (bos + chunk_in_seq * BT) * H * BT + h * BT;
 
     } else if (layoutMode_ == 1) {
-        // BSND 格式: [B, T, H, BT]
+        // BSND 格式: [B, S, H, BT]
         // 遍历顺序: B → chunk → H (H 变化最快)
         int64_t seqT = seqLen_;
 
@@ -315,7 +318,7 @@ __aicore__ inline int64_t SolveTriCube<MATRIX_SIZE, T>::GetTileGMOffset(int64_t 
         return b * seqT * H * BT + chunk * BT * H * BT + h * BT;
 
     } else {
-        // BHTD 格式: [B, H, T, BT]
+        // BNSD 格式 (mode 0): [B, H, S, BT]
         // 遍历顺序: B → H → chunk (chunk 变化最快)
         int64_t seqT = seqLen_;
         int64_t chunk = tileIdx % numChunks_;
@@ -328,8 +331,8 @@ __aicore__ inline int64_t SolveTriCube<MATRIX_SIZE, T>::GetTileGMOffset(int64_t 
 template <int MATRIX_SIZE, typename T>
 __aicore__ inline int64_t SolveTriCube<MATRIX_SIZE, T>::GetTileValidSize(int64_t tileIdx)
 {
-    if (layoutMode_ == 2) {
-        // THD: 动态计算每个序列的尾块
+    if (layoutMode_ == 2 || layoutMode_ == 3) {
+        // TND/NTD: 动态计算每个序列的尾块
         int64_t H = numHeads_;
         int64_t BT = matrixSize_;
         int64_t chunk_global_idx = tileIdx / H;
@@ -348,13 +351,13 @@ __aicore__ inline int64_t SolveTriCube<MATRIX_SIZE, T>::GetTileValidSize(int64_t
         int64_t remaining = seq_len - chunk_start;
         return (remaining >= BT) ? BT : remaining;
     } else {
-        // BHTD/BSND: 使用预计算的 lastChunkValidSize
+        // BNSD/BSND: 使用预计算的 lastChunkValidSize
         int64_t chunk;
         if (layoutMode_ == 1) {
             // BSND: tileIdx = b×(H×numChunks) + chunk×H + h
             chunk = (tileIdx / numHeads_) % numChunks_;
         } else {
-            // BHTD: tileIdx = b×(H×numChunks) + h×numChunks + chunk
+            // BNSD: tileIdx = b×(H×numChunks) + h×numChunks + chunk
             chunk = tileIdx % numChunks_;
         }
         if (chunk == numChunks_ - 1) {
@@ -771,17 +774,28 @@ __aicore__ inline void SolveTriCube<MATRIX_SIZE, T>::LoadDiagonalBlocksToL0B(
 template <int MATRIX_SIZE, typename T>
 __aicore__ inline void SolveTriCube<MATRIX_SIZE, T>::LoadInputTile(int64_t gmOffset, int64_t validSize)
 {
-    // MCH 路径：批量搬运所有对角 fractals
-    // 使用 Nd2Nz 的 ndNum + srcNdMatrixStride 一次性搬运所有对角块
-    // validSize < MATRIX_SIZE 时为尾块，最后一个对角块如果不足 16x16，硬件自动补零
+    // MCH 路径：基础 DataCopy 逐对角 16x16 搬入 L1(NZ)，对齐 A5 实现，避免 Nd2Nz
+    // 连续布局且 MATRIX_SIZE==16 时可一次搬完整 fractal；尾块按有效行裁剪，其余靠 ClearSlot 补零
     ClearSlot(SLOT_INPUT);
     PipeBarrier<PIPE_MTE2>();
 
-    int32_t numDiagFracs = (static_cast<int32_t>(validSize) + FRAC - 1) / FRAC;
-
-    // 使用预计算的参数模板，只修改变化的字段
-    diagLoadParams_.ndNum = numDiagFracs;
-    DataCopy(l1_[SLOT_INPUT * L1_SLOT_ELEMS], inputGM_[gmOffset], diagLoadParams_);
+    LocalTensor<T> dstBase = l1_[SLOT_INPUT * L1_SLOT_ELEMS];
+    bool contiguous = (rowStride_ == MATRIX_SIZE);
+    if (contiguous && MATRIX_SIZE == FRAC && validSize == FRAC) {
+        DataCopy(dstBase, inputGM_[gmOffset], DataCopyParams(1, 16, 0, 0));
+    } else {
+        uint16_t srcBlkStride = static_cast<uint16_t>(rowStride_ / FRAC - 1);
+        int32_t numDiagFracs = (static_cast<int32_t>(validSize) + FRAC - 1) / FRAC;
+        for (int32_t i = 0; i < numDiagFracs; ++i) {
+            int32_t rowsLeft = static_cast<int32_t>(validSize) - i * FRAC;
+            uint16_t rows = static_cast<uint16_t>(rowsLeft >= FRAC ? FRAC : rowsLeft);
+            int64_t srcOffset = static_cast<int64_t>(i) * (FRAC * rowStride_ + FRAC);
+            // NZ 对角块间距：(NUM_FRACS + 1) * FRAC_LEN == MATRIX_SIZE * FRAC + FRAC_LEN
+            int64_t dstOffset = static_cast<int64_t>(i) * (MATRIX_SIZE * FRAC + FRAC_LEN);
+            DataCopy(dstBase[dstOffset], inputGM_[gmOffset + srcOffset],
+                     DataCopyParams(rows, 1, srcBlkStride, 0));
+        }
+    }
     SetFlag<HardEvent::MTE2_MTE1>(EVT_MTE2_MTE1);
     WaitFlag<HardEvent::MTE2_MTE1>(EVT_MTE2_MTE1);
 }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/test/test.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/test/test.py
@@ -3,103 +3,292 @@ test.py - Test SolveTri operator on NPU.
 
 Computes (I + A)^{-1} where A is strictly lower triangular.
 Compares NPU output against CPU golden (numpy inverse).
+
+支持四种数据布局：
+  - bsnd: [B, T, H, BT]  (单 chunk 内数据不连续)
+  - bnsd: [B, H, T, BT]  (单 chunk 内数据连续, BSND 的转置)
+  - tnd:  [total_T, H, BT]  (变长序列, 单 chunk 内数据不连续)
+  - ntd:  [H, total_T, BT]  (变长序列, 单 chunk 内数据连续, TND 的转置)
 """
 import torch
 import torch_npu
 import numpy as np
-import fla_npu
+from fla_npu.ops import ascendc as ascendc_ops
 
 torch.npu.utils.set_device(0)
 
 
-def solve_tril_golden(A_tensor):
-    """CPU golden: compute (I + A)^{-1} for each chunk."""
-    A = A_tensor.float().numpy()
-    B, H, T, BT = A.shape
-    num_chunks = T // BT
-    result = np.zeros_like(A)
-
-    for b in range(B):
-        for h in range(H):
-            for c in range(num_chunks):
-                row_start = c * BT
-                row_end = row_start + BT
-                block = A[b, h, row_start:row_end, :BT]
-                eye = np.eye(BT, dtype=np.float32)
-                M = eye + block
-                M_inv = np.linalg.inv(M)
-                result[b, h, row_start:row_end, :BT] = M_inv
-
-    return torch.from_numpy(result).half()
+# ============================================================================
+# Golden / verify helpers
+# ============================================================================
+def _inverse_block(block_np):
+    """CPU golden: compute (I + A)^{-1} for a single chunk."""
+    n = block_np.shape[0]
+    eye = np.eye(n, dtype=np.float32)
+    M = eye + block_np
+    return np.linalg.inv(M)
 
 
-def generate_lower_tri_input(B, H, T, BT, dtype=torch.float16):
-    """Generate random strictly lower triangular input."""
-    A = torch.randn(B, H, T, BT, dtype=dtype) * 0.1
-    num_chunks = T // BT
-    for b in range(B):
-        for h in range(H):
-            for c in range(num_chunks):
-                row_start = c * BT
-                for i in range(BT):
-                    for j in range(i, BT):
-                        A[b, h, row_start + i, j] = 0.0
-    return A
+def _make_lower_tri_block(actual_size, dtype):
+    """Generate random strictly lower triangular block."""
+    block = torch.randn(actual_size, actual_size, dtype=dtype) * 0.1
+    return torch.tril(block, diagonal=-1)
 
 
-def verify_inverse(A, result, atol=1e-3):
-    """Verify (I+A) * result ≈ I."""
+def verify_inverse_dense(A, result, layout, chunk_size, atol=1e-3):
+    """Verify (I+A) * result ≈ I for dense layouts (bsnd/bnsd)."""
     A_f = A.float().numpy()
     R_f = result.float().numpy()
-    B, H, T, BT = A_f.shape
-    num_chunks = T // BT
+    if layout == "bsnd":
+        B, T, H, BT = A_f.shape
+    else:  # bnsd
+        B, H, T, BT = A_f.shape
+    num_chunks = (T + chunk_size - 1) // chunk_size
     max_err = 0.0
 
     for b in range(B):
         for h in range(H):
             for c in range(num_chunks):
-                s = c * BT
-                block = A_f[b, h, s:s+BT, :BT]
-                inv_block = R_f[b, h, s:s+BT, :BT]
-                eye = np.eye(BT, dtype=np.float32)
-                product = (eye + block) @ inv_block
-                err = np.abs(product - eye).max()
+                s = c * chunk_size
+                e = min(s + chunk_size, T)
+                actual = e - s
+                if layout == "bsnd":
+                    block = A_f[b, s:e, h, :actual]
+                    inv_block = R_f[b, s:e, h, :actual]
+                else:
+                    block = A_f[b, h, s:e, :actual]
+                    inv_block = R_f[b, h, s:e, :actual]
+                eye = np.eye(actual, dtype=np.float32)
+                err = np.abs((eye + block) @ inv_block - eye).max()
                 max_err = max(max_err, err)
-
     return max_err < atol, max_err
 
 
-def test_solve_tri(B, H, T, BT, dtype=torch.float16):
-    """Run one test case."""
-    print(f"  Test: B={B}, H={H}, T={T}, BT={BT}, dtype={dtype}")
+def verify_inverse_varlen(A, result, layout, chunk_size, cu_seqlens, chunk_indices, atol=1e-3):
+    """Verify (I+A) * result ≈ I for varlen layouts (tnd/ntd)."""
+    A_f = A.float().numpy()
+    R_f = result.float().numpy()
+    if layout == "tnd":
+        total_T, H, BT = A_f.shape
+    else:  # ntd
+        H, total_T, BT = A_f.shape
+    num_seqs = len(cu_seqlens) - 1
+    total_chunks = len(chunk_indices) // 2
+    max_err = 0.0
 
-    A = generate_lower_tri_input(B, H, T, BT, dtype)
-    golden = solve_tril_golden(A)
+    for chunk_idx in range(total_chunks):
+        seq_idx = chunk_indices[chunk_idx * 2]
+        chunk_in_seq = chunk_indices[chunk_idx * 2 + 1]
+        bos = cu_seqlens[seq_idx]
+        eos = cu_seqlens[seq_idx + 1]
+        seq_len = eos - bos
+        s = bos + chunk_in_seq * chunk_size
+        e = min(s + chunk_size, eos)
+        actual = e - s
+        for h in range(H):
+            if layout == "tnd":
+                block = A_f[s:e, h, :actual]
+                inv_block = R_f[s:e, h, :actual]
+            else:  # ntd
+                block = A_f[h, s:e, :actual]
+                inv_block = R_f[h, s:e, :actual]
+            eye = np.eye(actual, dtype=np.float32)
+            err = np.abs((eye + block) @ inv_block - eye).max()
+            max_err = max(max_err, err)
+    return max_err < atol, max_err
 
-    # Call NPU operator
+
+# ============================================================================
+# Dense layout (bsnd/bnsd)
+# ============================================================================
+def generate_dense_input(B, H, T, BT, layout, dtype=torch.float16, seed=42):
+    """Generate random strictly lower triangular input for bsnd/bnsd."""
+    torch.manual_seed(seed)
+    num_chunks = (T + BT - 1) // BT
+    if layout == "bsnd":
+        A = torch.zeros(B, T, H, BT, dtype=dtype)
+    else:  # bnsd
+        A = torch.zeros(B, H, T, BT, dtype=dtype)
+
+    for b in range(B):
+        for h in range(H):
+            for c in range(num_chunks):
+                s = c * BT
+                e = min(s + BT, T)
+                actual = e - s
+                block = _make_lower_tri_block(actual, dtype)
+                if layout == "bsnd":
+                    A[b, s:e, h, :actual] = block
+                else:
+                    A[b, h, s:e, :actual] = block
+    return A
+
+
+def solve_tril_golden_dense(A, layout, BT):
+    """CPU golden for dense layouts."""
+    A_np = A.float().numpy()
+    if layout == "bsnd":
+        B, T, H, _ = A_np.shape
+    else:
+        B, H, T, _ = A_np.shape
+    num_chunks = (T + BT - 1) // BT
+    result = np.zeros_like(A_np)
+
+    for b in range(B):
+        for h in range(H):
+            for c in range(num_chunks):
+                s = c * BT
+                e = min(s + BT, T)
+                actual = e - s
+                if layout == "bsnd":
+                    block = A_np[b, s:e, h, :actual]
+                else:
+                    block = A_np[b, h, s:e, :actual]
+                inv = _inverse_block(block)
+                if layout == "bsnd":
+                    result[b, s:e, h, :actual] = inv
+                else:
+                    result[b, h, s:e, :actual] = inv
+    return torch.from_numpy(result).to(A.dtype)
+
+
+def test_dense(B, H, T, BT, layout, dtype=torch.float16):
+    """Run one dense test case (bsnd or bnsd)."""
+    print(f"  Test: layout={layout}, B={B}, H={H}, T={T}, BT={BT}, dtype={dtype}")
+    A = generate_dense_input(B, H, T, BT, layout, dtype)
+    golden = solve_tril_golden_dense(A, layout, BT)
+
     A_npu = A.npu()
-    out_npu = torch.ops.npu.npu_solve_tri(A_npu, layout="bhtd")
+    out_npu = ascendc_ops.npu_solve_tri(A_npu, layout=layout)
     out_cpu = out_npu.cpu()
 
-    # Compare with golden
     diff = (out_cpu.float() - golden.float()).abs()
     max_diff = diff.max().item()
     mean_diff = diff.mean().item()
 
-    # Verify inverse property
-    passed, verify_err = verify_inverse(A, out_cpu)
+    passed, verify_err = verify_inverse_dense(A, out_cpu, layout, BT)
     status = "PASS" if passed else "FAIL"
     print(f"    [{status}] max_diff={max_diff:.6f}, mean_diff={mean_diff:.8f}, verify_err={verify_err:.6f}")
     return passed
 
 
+# ============================================================================
+# Varlen layout (tnd/ntd)
+# ============================================================================
+def prepare_chunk_indices(seq_lens, chunk_size):
+    """Build chunk_indices flat list from seq_lens."""
+    indices = []
+    for seq_idx, seq_len in enumerate(seq_lens):
+        n = (seq_len + chunk_size - 1) // chunk_size
+        for c in range(n):
+            indices.extend([seq_idx, c])
+    return indices
+
+
+def generate_varlen_input(seq_lens, H, BT, layout, dtype=torch.float16, seed=42):
+    """Generate random strictly lower triangular input for tnd/ntd."""
+    torch.manual_seed(seed)
+    total_T = sum(seq_lens)
+    if layout == "tnd":
+        A = torch.zeros(total_T, H, BT, dtype=dtype)
+    else:  # ntd
+        A = torch.zeros(H, total_T, BT, dtype=dtype)
+
+    cu_seqlens = [0]
+    for s in seq_lens:
+        cu_seqlens.append(cu_seqlens[-1] + s)
+
+    num_seqs = len(seq_lens)
+    for seq_idx in range(num_seqs):
+        bos = cu_seqlens[seq_idx]
+        eos = cu_seqlens[seq_idx + 1]
+        seq_len = eos - bos
+        num_chunks = (seq_len + BT - 1) // BT
+        for h in range(H):
+            for c in range(num_chunks):
+                s = bos + c * BT
+                e = min(s + BT, eos)
+                actual = e - s
+                block = _make_lower_tri_block(actual, dtype)
+                if layout == "tnd":
+                    A[s:e, h, :actual] = block
+                else:
+                    A[h, s:e, :actual] = block
+    return A, cu_seqlens
+
+
+def solve_tril_golden_varlen(A, layout, BT, cu_seqlens, chunk_indices):
+    """CPU golden for varlen layouts."""
+    A_np = A.float().numpy()
+    if layout == "tnd":
+        total_T, H, _ = A_np.shape
+    else:
+        H, total_T, _ = A_np.shape
+    result = np.zeros_like(A_np)
+    total_chunks = len(chunk_indices) // 2
+
+    for chunk_idx in range(total_chunks):
+        seq_idx = chunk_indices[chunk_idx * 2]
+        chunk_in_seq = chunk_indices[chunk_idx * 2 + 1]
+        bos = cu_seqlens[seq_idx]
+        eos = cu_seqlens[seq_idx + 1]
+        s = bos + chunk_in_seq * BT
+        e = min(s + BT, eos)
+        actual = e - s
+        for h in range(H):
+            if layout == "tnd":
+                block = A_np[s:e, h, :actual]
+            else:
+                block = A_np[h, s:e, :actual]
+            inv = _inverse_block(block)
+            if layout == "tnd":
+                result[s:e, h, :actual] = inv
+            else:
+                result[h, s:e, :actual] = inv
+    return torch.from_numpy(result).to(A.dtype)
+
+
+def test_varlen(seq_lens, H, BT, layout, dtype=torch.float16):
+    """Run one varlen test case (tnd or ntd)."""
+    print(f"  Test: layout={layout}, seq_lens={seq_lens}, H={H}, BT={BT}, dtype={dtype}")
+    A, cu_seqlens = generate_varlen_input(seq_lens, H, BT, layout, dtype)
+    chunk_indices = prepare_chunk_indices(seq_lens, BT)
+    golden = solve_tril_golden_varlen(A, layout, BT, cu_seqlens, chunk_indices)
+
+    A_npu = A.npu()
+    out_npu = ascendc_ops.npu_solve_tri(
+        A_npu,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        layout=layout,
+    )
+    out_cpu = out_npu.cpu()
+
+    diff = (out_cpu.float() - golden.float()).abs()
+    max_diff = diff.max().item()
+    mean_diff = diff.mean().item()
+
+    passed, verify_err = verify_inverse_varlen(
+        A, out_cpu, layout, BT, cu_seqlens, chunk_indices
+    )
+    status = "PASS" if passed else "FAIL"
+    print(f"    [{status}] max_diff={max_diff:.6f}, mean_diff={mean_diff:.8f}, verify_err={verify_err:.6f}")
+    return passed
+
+
+# ============================================================================
+# Main
+# ============================================================================
 def main():
     print("=" * 60)
-    print("SolveTri NPU Test")
+    print("SolveTri NPU Test (4 layouts: bsnd/bnsd/tnd/ntd)")
     print("=" * 60)
 
-    test_cases = [
-        # B, H, T, BT
+    results = []
+
+    # ---- Dense: BSND ----
+    print("\n--- Dense layout: BSND [B, T, H, BT] ---")
+    for B, H, T, BT in [
         (1, 1, 16, 16),
         (2, 4, 32, 16),
         (1, 2, 32, 32),
@@ -107,12 +296,49 @@ def main():
         (1, 2, 64, 64),
         (2, 4, 128, 64),
         (1, 2, 128, 128),
-    ]
+    ]:
+        results.append(test_dense(B, H, T, BT, "bsnd"))
 
-    results = []
-    for B, H, T, BT in test_cases:
-        passed = test_solve_tri(B, H, T, BT)
-        results.append(passed)
+    # ---- Dense: BNSD (BSND 的转置, 单 chunk 内数据连续) ----
+    print("\n--- Dense layout: BNSD [B, H, T, BT] (contiguous) ---")
+    for B, H, T, BT in [
+        (1, 1, 16, 16),
+        (2, 4, 32, 16),
+        (1, 2, 32, 32),
+        (2, 4, 64, 32),
+        (1, 2, 64, 64),
+        (2, 4, 128, 64),
+        (1, 2, 128, 128),
+    ]:
+        results.append(test_dense(B, H, T, BT, "bnsd"))
+
+    # ---- Varlen: TND ----
+    print("\n--- Varlen layout: TND [total_T, H, BT] ---")
+    for seq_lens, H, BT in [
+        ([64], 1, 32),
+        ([32, 32, 32], 2, 32),
+        ([45], 1, 32),
+        ([100, 50, 35], 2, 32),
+        ([64], 1, 64),
+        ([100, 80], 2, 64),
+        ([128], 1, 128),
+        ([100, 80, 60], 2, 128),
+    ]:
+        results.append(test_varlen(seq_lens, H, BT, "tnd"))
+
+    # ---- Varlen: NTD (TND 的转置, 单 chunk 内数据连续) ----
+    print("\n--- Varlen layout: NTD [H, total_T, BT] (contiguous) ---")
+    for seq_lens, H, BT in [
+        ([64], 1, 32),
+        ([32, 32, 32], 2, 32),
+        ([45], 1, 32),
+        ([100, 50, 35], 2, 32),
+        ([64], 1, 64),
+        ([100, 80], 2, 64),
+        ([128], 1, 128),
+        ([100, 80, 60], 2, 128),
+    ]:
+        results.append(test_varlen(seq_lens, H, BT, "ntd"))
 
     print("\n" + "=" * 60)
     total = len(results)
@@ -120,7 +346,10 @@ def main():
     print(f"Results: {passed}/{total} passed")
     if passed == total:
         print("All tests PASSED!")
-    return 0 if passed == total else 1
+        return 0
+    else:
+        print("Some tests FAILED!")
+        return 1
 
 
 if __name__ == "__main__":

--- a/torch_custom/fla_npu/test/test_npu_solve_tri_ascend910b.py
+++ b/torch_custom/fla_npu/test/test_npu_solve_tri_ascend910b.py
@@ -9,7 +9,7 @@
 # -----------------------------------------------------------------------------------------------------------
 
 """
-test_npu_solve_tri_ascend950.py - Test SolveTri custom operator on ascend950 via fla_npu.ops.ascendc
+test_npu_solve_tri_ascend910b.py - Test SolveTri custom operator on ascend910b (A2) via fla_npu.ops.ascendc
 
 支持四种布局：
   - BSND [B,T,H,BT]              (单 chunk 内数据不连续)
@@ -406,7 +406,7 @@ def run_all_cases(dtype):
 
 if __name__ == "__main__":
     print("=" * 60)
-    print("SolveTri NPU Test (ascend950, fla_npu.ops.ascendc) — fp16 + bf16")
+    print("SolveTri NPU Test (ascend910b/A2, fla_npu.ops.ascendc) — fp16 + bf16")
     print("=" * 60)
 
     results = []


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @ww-blue
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
