### PR TITLE
fix(kda): 修复 A5 BF16 满 chunk Finalize 输出翻倍

### DIFF
--- a/fla/ops/ascendc/kda/chunk_kda_fwd_finalize/op_kernel/chunk_kda_fwd_finalize_kernel.hpp
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd_finalize/op_kernel/chunk_kda_fwd_finalize_kernel.hpp
@@ -556,9 +556,10 @@ private:
         return maxRows;
     }
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
-    __aicore__ inline void ComputeOutputCubeFusedA5(uint64_t b, uint64_t hv, uint64_t chunkIdx, uint64_t start,
-                                                    uint64_t curT)
+    __aicore__ inline void ComputeOutputCubeStagedA5(uint64_t b, uint64_t hv, uint64_t chunkIdx, uint64_t start,
+                                                     uint64_t curT)
     {
+        SetMMLayoutTransform(true);
         using ElementA = T;
         using ElementB = T;
         using ElementC = OUT_T;
@@ -578,7 +579,6 @@ private:
         constexpr uint16_t kMte2Event = 0;
         constexpr uint16_t kMte1Event = 0;
         constexpr uint16_t kMmadEvent = 0;
-        constexpr uint16_t kFixEvent = 0;
         constexpr uint32_t kL1A0Offset = 0;
         constexpr uint32_t kL1B0Offset = 64 * 128 * sizeof(ElementA);
         constexpr uint32_t kL1A1Offset = kL1B0Offset + 128 * 128 * sizeof(ElementB);
@@ -618,12 +618,16 @@ private:
                                                  Catlass::Arch::PositionGM{});
                 auto tensorO = tla::MakeTensor(o_[KVOffset(b, hv, start + mOffset, nOffset, V_)], layoutO,
                                                Catlass::Arch::PositionGM{});
+                auto tensorLocal = tla::MakeTensor(u_[KVOffset(b, hv, start + mOffset, nOffset, V_)], layoutO,
+                                                   Catlass::Arch::PositionGM{});
 
                 auto blockQ = GetTile(tensorQ, tla::MakeCoord(0, 0), tla::MakeShape(curM, K_));
                 auto blockH = GetTile(tensorH, tla::MakeCoord(0, 0), tla::MakeShape(K_, curN));
                 auto blockAqk = GetTile(tensorAqk, tla::MakeCoord(0, 0), tla::MakeShape(curM, curT));
                 auto blockVNew = GetTile(tensorVNew, tla::MakeCoord(0, 0), tla::MakeShape(curT, curN));
                 auto blockO = GetTile(tensorO, tla::MakeCoord(0, 0), tla::MakeShape(curM, curN));
+                auto blockLocal =
+                    GetTile(tensorLocal, tla::MakeCoord(0, 0), tla::MakeShape(curM, curN));
 
                 using CopyGmToL1A0 = typename TileCopy::template CopyGmToL1A<decltype(blockQ)>;
                 using CopyGmToL1B0 = typename TileCopy::template CopyGmToL1B<decltype(blockH)>;
@@ -687,9 +691,11 @@ private:
                 copyL1ToL0B(tileL0B0, tileL1B0);
                 SetFlag<HardEvent::MTE1_M>(kMte1Event);
                 WaitFlag<HardEvent::MTE1_M>(kMte1Event);
-                tileMmad(tileL0C, tileL0A0, tileL0B0, curM, curN, static_cast<uint32_t>(K_), true, 0);
+                tileMmad(tileL0C, tileL0A0, tileL0B0, curM, curN, static_cast<uint32_t>(K_), true, 0b11);
                 SetFlag<HardEvent::M_MTE1>(kMmadEvent);
                 WaitFlag<HardEvent::M_MTE1>(kMmadEvent);
+                copyL0CToDst(blockO, tileL0C, 0b11);
+                PipeBarrier<PIPE_ALL>();
 
                 copyL1ToL0A(tileL0A1, tileL1A1);
                 copyL1ToL0B(tileL0B1, tileL1B1);
@@ -697,18 +703,14 @@ private:
                 SetFlag<HardEvent::MTE1_MTE2>(kMte2Event);
                 WaitFlag<HardEvent::MTE1_M>(kMte1Event);
                 WaitFlag<HardEvent::MTE1_MTE2>(kMte2Event);
-                tileMmad(tileL0C, tileL0A1, tileL0B1, curM, curN, static_cast<uint32_t>(curT), false, 0);
+                tileMmad(tileL0C, tileL0A1, tileL0B1, curM, curN, static_cast<uint32_t>(curT), true, 0b11);
                 SetFlag<HardEvent::M_MTE1>(kMmadEvent);
                 WaitFlag<HardEvent::M_MTE1>(kMmadEvent);
-                SetFlag<HardEvent::M_FIX>(kFixEvent);
-                WaitFlag<HardEvent::M_FIX>(kFixEvent);
-                copyL0CToDst(blockO, tileL0C);
-                SetFlag<HardEvent::FIX_M>(kFixEvent);
-                WaitFlag<HardEvent::FIX_M>(kFixEvent);
-                SetFlag<HardEvent::FIX_MTE2>(kFixEvent);
-                WaitFlag<HardEvent::FIX_MTE2>(kFixEvent);
+                copyL0CToDst(blockLocal, tileL0C, 0b11);
+                PipeBarrier<PIPE_ALL>();
             }
         }
+        SetMMLayoutTransform(false);
     }
 
     __aicore__ inline void PrefetchOutputTileA5(Catlass::Arch::Resource<KdaArchTag> &resource, uint32_t slot,
@@ -970,7 +972,7 @@ private:
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
         SetLoadDataPaddingValue<T>(static_cast<T>(0));
         if (BT_ == 64 && curT == BT_) {
-            ComputeOutputCubeFusedA5(b, hv, chunkIdx, start, curT);
+            ComputeOutputCubeStagedA5(b, hv, chunkIdx, start, curT);
             return;
         }
 #endif
@@ -1044,13 +1046,7 @@ private:
             ScoreVectorMaxRows(5 * sizeof(float) + 2 * sizeof(T) + sizeof(GK_T));
         const uint64_t gateWritebackBytes =
             gateWritebackRows * K_ * (3 * sizeof(T) + sizeof(GK_T));
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
-        const bool fusedA5Output = BT_ == 64 && curT == BT_;
-        uint64_t maxRows =
-            KDA_VEC_ARENA_ELEMENTS / ((fusedA5Output ? 1 : 3) * V_);
-#else
         uint64_t maxRows = KDA_VEC_ARENA_ELEMENTS / (3 * V_);
-#endif
         const uint64_t typedMaxRows = gateWritebackBytes / (V_ * sizeof(T));
         if (maxRows > typedMaxRows) {
             maxRows = typedMaxRows;
@@ -1067,24 +1063,6 @@ private:
             const uint64_t elems = tileRows * V_;
             const uint64_t ti = start + tileRow;
             LocalTensor<float> arena = vecBuf_.Get<float>();
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
-            LocalTensor<float> stateLocal = arena;
-            LocalTensor<float> localLocal = arena[elems];
-            LocalTensor<float> outLocal =
-                fusedA5Output ? arena : arena[2 * elems];
-            LocalTensor<T> outTyped = gateWritebackBuf_.Get<T>();
-
-            CopyVectorIn(stateLocal, o_, KVOffset(b, hv, ti, 0, V_), elems);
-            if (!fusedA5Output) {
-                CopyVectorIn(localLocal, u_, KVOffset(b, hv, ti, 0, V_), elems);
-            }
-            SetFlag<HardEvent::MTE2_V>(mte2ToVEvent_);
-            WaitFlag<HardEvent::MTE2_V>(mte2ToVEvent_);
-            if (!fusedA5Output) {
-                Add(outLocal, stateLocal, localLocal, static_cast<uint32_t>(elems));
-                PipeBarrier<PIPE_V>();
-            }
-#else
             LocalTensor<float> stateLocal = arena;
             LocalTensor<float> localLocal = arena[elems];
             LocalTensor<float> outLocal = arena[2 * elems];
@@ -1096,7 +1074,6 @@ private:
             WaitFlag<HardEvent::MTE2_V>(mte2ToVEvent_);
             Add(outLocal, stateLocal, localLocal, static_cast<uint32_t>(elems));
             PipeBarrier<PIPE_V>();
-#endif
             ClampFp32ToOutputType(outLocal, static_cast<uint32_t>(elems));
             Cast(outTyped, outLocal, RoundMode::CAST_RINT, static_cast<uint32_t>(elems));
             PipeBarrier<PIPE_V>();

--- a/tests/op_cases/chunk_kda_fwd.json
+++ b/tests/op_cases/chunk_kda_fwd.json
@@ -96,6 +96,7 @@
       "chunk_kda_fwd_dtype_layout_generalization",
       "chunk_kda_fwd_tail_or_varlen",
       "chunk_kda_fwd_a5_varlen_tail_finalize",
+      "chunk_kda_fwd_a5_bf16_full_chunk_finalize",
       "chunk_kda_fwd_tnd_layout",
       "chunk_kda_fwd_state_v_first",
       "chunk_kda_fwd_optional_output_matrix",
@@ -105,6 +106,7 @@
       "chunk_kda_fwd_dtype_layout_generalization",
       "chunk_kda_fwd_tail_or_varlen",
       "chunk_kda_fwd_a5_varlen_tail_finalize",
+      "chunk_kda_fwd_a5_bf16_full_chunk_finalize",
       "chunk_kda_fwd_tnd_layout",
       "chunk_kda_fwd_state_v_first",
       "chunk_kda_fwd_chunk128_writeback_boundary"
@@ -415,6 +417,67 @@
         ]
       },
       "seed": 20261312
+    },
+    {
+      "id": "chunk_kda_fwd_a5_bf16_full_chunk_finalize",
+      "tags": [
+        "accuracy",
+        "generalization",
+        "regression"
+      ],
+      "shape": {
+        "B": 1,
+        "H_k": 2,
+        "H_v": 2,
+        "T": 128,
+        "K": 128,
+        "V": 128,
+        "chunk_size": 64,
+        "N_c": 2
+      },
+      "dtype": {
+        "q_k_v": "bfloat16",
+        "g_beta_state": "float32"
+      },
+      "layout": "BSND",
+      "attrs": {
+        "layout": "BSND",
+        "scale": 0.0883883476,
+        "chunk_size": 64,
+        "output_final_state": true,
+        "disable_recompute": true,
+        "return_intermediate_states": true,
+        "safe_gate": true,
+        "lower_bound": -5.0,
+        "use_gate_in_kernel": true,
+        "state_v_first": true
+      },
+      "optional_inputs": {
+        "initial_state": null,
+        "cu_seqlens": null,
+        "chunk_indices": null
+      },
+      "soc": [
+        "ascend950"
+      ],
+      "run_on": [
+        "ascendc"
+      ],
+      "reference": "tests/reference/chunk_kda_reference.py",
+      "expect": {
+        "return_code": "ACLNN_SUCCESS",
+        "finite_outputs": true,
+        "compare_outputs": [
+          "attn_out",
+          "final_state",
+          "gk",
+          "Aqk/Akk",
+          "w/qg/kg",
+          "u/v_new",
+          "h"
+        ]
+      },
+      "seed": 20260731
     },
     {
       "id": "chunk_kda_fwd_tnd_layout",

--- a/tests/operators/chunk_kda_fwd/ut/op_kernel/test_contract.py
+++ b/tests/operators/chunk_kda_fwd/ut/op_kernel/test_contract.py
@@ -302,22 +302,47 @@ def test_a5_fused_post_wu_protects_l0c_reuse_with_fix_to_cube_events():
     assert "FIX_MTE2>(KDA_POST_EVENT_FIX)" not in fused
 
 
-def test_a5_finalize_fused_cube_is_limited_to_full_chunks():
+def test_a5_finalize_stages_full_chunk_mmads_without_l0c_accumulation():
     finalize = STAGE_IMPLEMENTATIONS["output"].read_text(encoding="utf-8")
     dispatch = finalize.split(
         "__aicore__ inline void ComputeOutputCube(", 1
     )[1].split("using ElementA = T;", 1)[0]
+    staged = finalize.split(
+        "__aicore__ inline void ComputeOutputCubeStagedA5", 1
+    )[1].split("__aicore__ inline void PrefetchOutputTileA5", 1)[0]
     writeback = finalize.split(
         "__aicore__ inline void FinalizeOutputRows(", 1
     )[1].split("__aicore__ inline bool ResolveFlatChunk(", 1)[0]
 
     assert "BT_ == 64 && curT == BT_" in dispatch
-    assert "ComputeOutputCubeFusedA5" in dispatch
-    assert "const bool fusedA5Output = BT_ == 64 && curT == BT_;" in writeback
-    assert "fusedA5Output ? 1 : 3" in writeback
-    assert "if (!fusedA5Output)" in writeback
+    assert "ComputeOutputCubeStagedA5" in dispatch
+    assert staged.count("true, 0b11") == 2
+    assert "false, 0b11" not in staged
+    assert "copyL0CToDst(blockO, tileL0C, 0b11);" in staged
+    assert "copyL0CToDst(blockLocal, tileL0C, 0b11);" in staged
+    assert "fusedA5Output" not in writeback
     assert "CopyVectorIn(localLocal, u_" in writeback
     assert "Add(outLocal, stateLocal, localLocal" in writeback
+
+
+def test_manifest_registers_a5_bf16_full_chunk_finalize_regression():
+    manifest = json.loads(CASE_MANIFEST.read_text(encoding="utf-8"))
+    case = next(
+        item
+        for item in manifest["cases"]
+        if item["id"] == "chunk_kda_fwd_a5_bf16_full_chunk_finalize"
+    )
+    coverage = manifest["coverage_requirements"]
+
+    assert case["id"] in coverage["accuracy_case_ids"]
+    assert case["id"] in coverage["generalization_case_ids"]
+    assert case["dtype"]["q_k_v"] == "bfloat16"
+    assert case["layout"] == "BSND"
+    assert case["shape"]["chunk_size"] == 64
+    assert case["shape"]["T"] % case["shape"]["chunk_size"] == 0
+    assert case["attrs"]["safe_gate"] is True
+    assert case["attrs"]["state_v_first"] is True
+    assert case["soc"] == ["ascend950"]
 
 
 def test_fwd_h_uses_fixed_scalar_exp_and_keywise_exp2_on_a2_and_a5():


### PR DESCRIPTION
# Pull Request 模板

## 关联 Issue / 背景

- 关联 Issue: Refs #227
- 背景与目标: 修复 PR #228 合入后发现的 A5 BF16 满 chunk `ChunkKdaFwdFinalize` 输出翻倍问题，恢复 KDA 正向在 A2/A5 上与 FLA 标杆的一致性。
- 本 PR 解决的问题: A5 手写满 chunk 路径连续两次 MMAD 复用 L0C 累加状态项和局部项，导致局部项重复累加，`attn_out` 约为标杆的 2 倍。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `chunk_kda_fwd_finalize`、`chunk_kda_fwd`
- 涉及目录 / 文件: `fla/ops/ascendc/kda/chunk_kda_fwd_finalize/op_kernel/`、`tests/op_cases/chunk_kda_fwd.json`、`tests/operators/chunk_kda_fwd/ut/op_kernel/`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 公共契约不变；新增回归覆盖 BF16、BSND、`chunk_size=64`、满 chunk 和 `state_v_first=true`。
- 明确不包含的范围: KDA 反向、接口调整、性能专项优化。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` | 结果 |
| --- | --- | --- |
| A2 | `ascend910b` | 通过 |
| A3 | `ascend910_93` | 通过 |
| A5 | `ascend950` | 通过 |

</details>

<details>
<summary>验证方法</summary>

### 1. 环境确认

- CANN 版本: 9.1 beta 系列
- 产品 / 芯片类型: A2、A5 设备验证；A2/A3/A5 编译验证
- 机器或 CI 链接: 本地专项验证；由 NPU CI 继续复核

### 2. 编译验证

A2/A3/A5 均完成 KDA scoped 构建；A3 完整包含 `chunk_kda_fwd`、三个阶段 L0、`chunk_gated_delta_rule_fwd_h`、`kda_gate_cumsum` 和布局转换算子。

### 3. 修改算子 test 验证

```sh
python -m pytest -q tests/operators/chunk_kda_fwd/ut/op_kernel/test_contract.py
```

结果: `34 passed, 2 skipped`。

### 4. 整体 example ST 验证

本 PR 未修改公共接口或 example；完整 Example ST 未重跑。

</details>

<details>
<summary>修改算子测试</summary>

| 产品 | 场景 | 结果 |
| --- | --- | --- |
| A2 | `[1,18432,96,128]`、BF16、`chunk_size=64`、`safe_gate=true`、`state_v_first=true` | 11/11 输出通过 |
| A3 | scoped OPP 编译 | 通过 |
| A5 | `[1,18432,96,128]`、BF16、`chunk_size=64`、`safe_gate=true`、`state_v_first=true` | 11/11 输出通过 |

- 精度对比: A5 `attn_out` 相对 L2 为 `0.0044251`，cosine 为 `0.9999902`，最大绝对误差为 `0.0009765625`；CT 采样拟合尺度从修复前约 `1.9986` 恢复为 `0.99995`。
- 性能对比: A5 `msopprof` 下 Finalize 为 `3.890 ms`，核心通路为 `33.243 ms`，完整公开语义为 `53.840 ms`。修复前输出错误，耗时不作为有效性能标杆。
- 边界 / 异常场景: 新增 A5 BF16/BSND/chunk64/full-chunk 回归用例，并增加静态契约防止恢复跨 MMAD 的 L0C 累加。
- 未覆盖风险: A3 未执行设备精度测试；完整 Example ST 和 sanitizer 本次未重跑。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 结果 |
| --- | --- | --- |
| A2 | `ascend910b` | 本次未重跑 |
| A3 | `ascend910_93` | 本次未执行 |
| A5 | `ascend950` | 本次未重跑 |

- 端到端场景说明: 本次使用完整 `chunk_kda_fwd` L2 验证 H96 KDA 正向输出。
- 与本 PR 修改算子的关联: 直接覆盖 `ChunkKdaFwdFinalize` 的 `attn_out` 输出。
- 未覆盖原因及补充计划: 本 PR 为 PR #228 的聚焦正确性修复，由 NPU CI 继续覆盖整体 Example ST。

</details>

## 兼容性、风险与回退

- 兼容性说明: 公共输入、输出、shape、dtype、layout 和属性语义均不变。
- 风险点: A5 正确路径增加一次独立 workspace 写出和 AIV FP32 相加；已使用 `msopprof` 记录性能。
- 回退方案: 整体回退本提交，恢复 PR #228 合入版本。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 详细测试结果和 CT 可视化已归档至公开报告：[KDA 正向精度测试报告](https://github.com/weinachuan/flash-linear-attention-npu-io/blob/main/test-reports/v26.8.0/2026-07-31_kda_forward_accuracy_validation.md)。
- 修复后两次 FP32 Cube MMAD 分别写出 state/local workspace，由 AIV 完成 FP32 相加，不再跨 MMAD 累加 L0C。
