### PR TITLE
fix: 避免自定义 libopapi.so 遮蔽 CANN

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ python -m pip install --force-reinstall --no-deps dist/flash_linear_attention_np
 
 如果使用 Release 下载的 wheel，将命令中的 `dist/flash_linear_attention_npu-*.whl` 替换为实际下载路径。
 
+方式 A wheel 不安装或执行 shell 环境钩子。无论使用系统 Python、Conda、venv
+还是 Docker，每次进入新的 shell 后都需要先按 Step 1 手工 source CANN 的
+`set_env.sh`。调用 `fla_npu.ops.ascendc` 算子时会在当前 Python 进程内定位并加载
+wheel 内嵌 OPP；wheel 通过绝对路径加载 `libcust_opapi.so`，不会再生成或加载
+可能覆盖 CANN 运行库的自定义 `libopapi.so`。
+
 #### 方式 B 产物安装
 
 先确认方式 A 的完整 wheel 已经安装到当前 Python 环境，然后安装 run 包。安装器会在覆盖前列出当前 run 包携带的算子，并标出安装后的算子状态：`WARNING` 表示安装后不可用，包括不在当前 run 包范围内但会受局部 `libcust_opapi.so`、tiling so、proto so 整体替换影响的算子，以及当前 run 包内但 aclnn ABI 修改或删除的算子；`NOTICE` 表示新增或无法完整确认的 ABI，需要确认当前 Python wheel 是否已有对应 wrapper；`OK` 表示当前 run 包内且 aclnn ABI 一致的算子。`op_api/include/aclnnop` 中新增、删除、修改的 aclnn ABI 头文件会合并显示到对应算子的状态原因里；删除只按当前 run 包携带的算子范围判断，非 `--quiet` 模式只在状态表后确认一次。
@@ -114,6 +120,8 @@ python -m pip install --force-reinstall --no-deps torch_custom/fla_npu/dist/flas
 安装 run 包后需要重启 Python 进程，已经 `dlopen` 的 `libcust_opapi.so` 不会在同一进程内热替换。
 
 `import fla_npu` 是轻量导入，不会自动导入 `torch` / `torch_npu`，也不会自动注册 `torch.ops.npu`。默认 wheel 通过 Python ctypes 直调 aclnn/opapi，推荐使用 `fla_npu.ops.ascendc`；`torch_npu.ops.*` 会在导入 `fla_npu.ops.ascendc` 后挂到同一套 Python wrapper。只有用 `FLA_NPU_BUILD_LEGACY_EXTENSION=1` 额外编出 legacy 扩展时，才可显式调用 `fla_npu.load_legacy_torch_ops()` 兼容旧 `torch.ops.npu.*`。
+
+`fla_npu.ops.ascendc` 调用会优先使用 wheel 内嵌 OPP，找不到时会继续从 `FLA_NPU_OPP_PATH`、`ASCEND_CUSTOM_OPP_PATH` 和 `ASCEND_OPP_PATH` 查找已安装 OPP。外部 OPP 的 `op_api/lib` 目录同样不得包含自定义 `libopapi.so`；如果残留该文件并可能遮蔽 CANN 运行库，调用时会明确报错并要求清理旧别名。
 
 ### Step 4. 测试安装成功
 

--- a/ci/run_checks.sh
+++ b/ci/run_checks.sh
@@ -141,6 +141,8 @@ PY
 fi
 export PYTORCH_VERSION
 
+python3 tests/test_wheel_environment.py
+
 bash ci/prepare_ci_cache.sh
 
 cleanup_installed_fla_npu_python_packages() {

--- a/scripts/check_packaged_wheel_api.py
+++ b/scripts/check_packaged_wheel_api.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -73,6 +74,40 @@ def _require_packaged_opp_configs(fla_npu_module) -> None:
         )
 
 
+def _require_safe_packaged_opapi(fla_npu_module) -> None:
+    package_root = Path(fla_npu_module.__file__).resolve().parent
+    vendor_dirs = list((package_root / "opp" / "vendors").glob("*"))
+    if not vendor_dirs:
+        raise AssertionError("packaged OPP vendor directory is missing")
+
+    custom_libraries = [
+        vendor_dir / "op_api" / "lib" / "libcust_opapi.so"
+        for vendor_dir in vendor_dirs
+    ]
+    if not any(path.is_file() for path in custom_libraries):
+        raise AssertionError("packaged libcust_opapi.so is missing")
+
+    conflicting_libraries = []
+    for vendor_dir in vendor_dirs:
+        candidate = vendor_dir / "op_api" / "lib" / "libopapi.so"
+        if candidate.exists() or candidate.is_symlink():
+            conflicting_libraries.append(candidate)
+    if conflicting_libraries:
+        raise AssertionError(
+            "packaged custom OPP must not contain CANN library alias libopapi.so: "
+            + ", ".join(str(path) for path in conflicting_libraries)
+        )
+
+    configured_library = Path(os.environ.get("FLA_NPU_OP_API_LIB", "")).resolve()
+    packaged_libraries = {
+        path.resolve() for path in custom_libraries if path.is_file()
+    }
+    if configured_library not in packaged_libraries:
+        raise AssertionError(
+            "FLA_NPU_OP_API_LIB must point to the packaged libcust_opapi.so"
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -113,6 +148,7 @@ def main() -> int:
             _require_attr(torch_npu.ops, f"npu_{name}", "torch_npu.ops")
 
     _require_packaged_opp_configs(fla_npu)
+    _require_safe_packaged_opapi(fla_npu)
 
     if ascendc.BACKWARD_OPS.get("causal_conv1d") != "causal_conv1d_bwd":
         raise AssertionError("causal_conv1d backward binding metadata is missing")

--- a/setup.py
+++ b/setup.py
@@ -380,11 +380,29 @@ def _rewrite_set_env(vendor_dir):
         "\n".join(
             [
                 "#!/bin/bash",
-                'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"',
-                'VENDOR_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"',
-                'OPP_ROOT="$(cd "${VENDOR_DIR}/../.." && pwd)"',
-                'export ASCEND_CUSTOM_OPP_PATH="${OPP_ROOT}:${VENDOR_DIR}:${ASCEND_CUSTOM_OPP_PATH}"',
-                'export LD_LIBRARY_PATH="${VENDOR_DIR}/op_api/lib:${LD_LIBRARY_PATH}"',
+                '_FLA_NPU_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"',
+                '_FLA_NPU_VENDOR_DIR="$(cd "${_FLA_NPU_SCRIPT_DIR}/.." && pwd)"',
+                '_FLA_NPU_OPP_ROOT="$(cd "${_FLA_NPU_VENDOR_DIR}/../.." && pwd)"',
+                "_fla_npu_prepend_path() {",
+                '    local name="$1"',
+                '    local value="$2"',
+                "    local current=\"\"",
+                '    if [[ -v "${name}" ]]; then',
+                '        current="${!name}"',
+                "    fi",
+                '    case ":${current}:" in',
+                '        *":${value}:"*) return 0 ;;',
+                "    esac",
+                '    printf -v "${name}" "%s" "${value}${current:+:${current}}"',
+                '    export "${name}"',
+                "}",
+                '_fla_npu_prepend_path ASCEND_CUSTOM_OPP_PATH "${_FLA_NPU_VENDOR_DIR}"',
+                '_fla_npu_prepend_path ASCEND_CUSTOM_OPP_PATH "${_FLA_NPU_OPP_ROOT}"',
+                '_fla_npu_prepend_path LD_LIBRARY_PATH "${_FLA_NPU_VENDOR_DIR}/op_api/lib"',
+                'export FLA_NPU_OPP_PATH="${_FLA_NPU_OPP_ROOT}"',
+                'export FLA_NPU_OP_API_LIB="${_FLA_NPU_VENDOR_DIR}/op_api/lib/libcust_opapi.so"',
+                "unset -f _fla_npu_prepend_path",
+                "unset _FLA_NPU_SCRIPT_DIR _FLA_NPU_VENDOR_DIR _FLA_NPU_OPP_ROOT",
                 "",
             ]
         ),
@@ -438,6 +456,13 @@ def _has_any_glob(root, patterns):
 
 def _validate_staged_opp(vendor_dir):
     vendor_dir = Path(vendor_dir)
+    conflicting_opapi = vendor_dir / "op_api" / "lib" / "libopapi.so"
+    if conflicting_opapi.exists() or conflicting_opapi.is_symlink():
+        raise RuntimeError(
+            "Embedded OPP must not contain libopapi.so because it shadows the "
+            f"CANN runtime library: {conflicting_opapi}"
+        )
+
     required_groups = {
         "custom op_api library": ("op_api/lib/libcust_opapi.so",),
         "host/proto shared library": (
@@ -493,7 +518,10 @@ def _stage_run_package(run_file, opp_root):
     op_api_alias = op_api_lib.with_name("libopapi.so")
     if op_api_alias.exists() or op_api_alias.is_symlink():
         op_api_alias.unlink()
-    shutil.copy2(op_api_lib, op_api_alias)
+        print(
+            "[fla-npu build] Removed conflicting custom libopapi.so alias; "
+            "CANN must provide libopapi.so"
+        )
     _validate_staged_opp(vendor_dir)
     print(f"[fla-npu build] Embedded OPP staged at {vendor_dir}")
 

--- a/tests/test_wheel_environment.py
+++ b/tests/test_wheel_environment.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import importlib
+import os
+import runpy
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import setuptools
+
+
+try:
+    import packaging.version  # noqa: F401
+except ImportError:
+    from pip._vendor import packaging as vendored_packaging
+    from pip._vendor.packaging import version as vendored_packaging_version
+
+    sys.modules["packaging"] = vendored_packaging
+    sys.modules["packaging.version"] = vendored_packaging_version
+
+
+if not hasattr(importlib, "metadata"):
+    # The project requires Python >=3.9. This compatibility shim only lets the
+    # source-only packaging tests run on older maintenance hosts.
+    metadata_module = types.ModuleType("importlib.metadata")
+
+    def _missing_distribution(_name: str) -> str:
+        raise RuntimeError("distribution metadata is unavailable")
+
+    metadata_module.version = _missing_distribution
+    importlib.metadata = metadata_module
+    sys.modules["importlib.metadata"] = metadata_module
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_setup() -> tuple[dict[str, object], dict[str, object]]:
+    setup_kwargs: dict[str, object] = {}
+
+    def capture_setup(**kwargs) -> None:
+        setup_kwargs.update(kwargs)
+
+    with mock.patch.object(setuptools, "setup", side_effect=capture_setup):
+        setup_globals = runpy.run_path(str(REPO_ROOT / "setup.py"))
+    return setup_globals, setup_kwargs
+
+
+def _create_minimal_vendor(vendor_dir: Path, *, include_alias: bool = False) -> None:
+    required_files = (
+        vendor_dir / "op_api" / "lib" / "libcust_opapi.so",
+        vendor_dir
+        / "op_impl"
+        / "ai_core"
+        / "tbe"
+        / "op_host"
+        / "lib"
+        / "linux"
+        / "x86_64"
+        / "libophost.so",
+        vendor_dir
+        / "op_impl"
+        / "ai_core"
+        / "tbe"
+        / "kernel"
+        / "ascend910b"
+        / "sample"
+        / "sample.o",
+        vendor_dir
+        / "op_impl"
+        / "ai_core"
+        / "tbe"
+        / "kernel"
+        / "config"
+        / "ascend910b"
+        / "binary_info_config.json",
+    )
+    for path in required_files:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"test")
+
+    if include_alias:
+        (vendor_dir / "op_api" / "lib" / "libopapi.so").write_bytes(b"unsafe")
+
+
+class WheelEnvironmentTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.setup_globals, cls.setup_kwargs = _load_setup()
+
+    def test_staging_removes_conflicting_libopapi_alias(self) -> None:
+        stage_run_package = self.setup_globals["_stage_run_package"]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            opp_root = Path(temp_dir) / "opp"
+
+            def fake_install_run_package(_run_file, target_root) -> None:
+                _create_minimal_vendor(
+                    Path(target_root) / "vendors" / "fla_npu_transformer",
+                    include_alias=True,
+                )
+
+            stage_run_package.__globals__["_install_run_package"] = fake_install_run_package
+            stage_run_package(Path(temp_dir) / "unused.run", opp_root)
+
+            lib_dir = (
+                opp_root
+                / "vendors"
+                / "fla_npu_transformer"
+                / "op_api"
+                / "lib"
+            )
+            self.assertTrue((lib_dir / "libcust_opapi.so").is_file())
+            self.assertFalse((lib_dir / "libopapi.so").exists())
+
+    def test_generated_set_env_is_idempotent(self) -> None:
+        rewrite_set_env = self.setup_globals["_rewrite_set_env"]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            vendor_dir = (
+                Path(temp_dir) / "opp" / "vendors" / "fla_npu_transformer"
+            )
+            rewrite_set_env(vendor_dir)
+            set_env = vendor_dir / "bin" / "set_env.bash"
+            script = f"""
+set -euo pipefail
+unset ASCEND_CUSTOM_OPP_PATH LD_LIBRARY_PATH FLA_NPU_OPP_PATH FLA_NPU_OP_API_LIB
+source {set_env!s}
+source {set_env!s}
+[[ "${{ASCEND_CUSTOM_OPP_PATH}}" == "{vendor_dir.parent.parent}:{vendor_dir}" ]]
+[[ "${{LD_LIBRARY_PATH}}" == "{vendor_dir}/op_api/lib" ]]
+[[ "${{FLA_NPU_OPP_PATH}}" == "{vendor_dir.parent.parent}" ]]
+[[ "${{FLA_NPU_OP_API_LIB}}" == "{vendor_dir}/op_api/lib/libcust_opapi.so" ]]
+"""
+            subprocess.run(["bash", "-c", script], check=True)
+
+    def test_external_opp_install_removes_conflicting_alias(self) -> None:
+        install_opp_globals = runpy.run_path(
+            str(
+                REPO_ROOT
+                / "torch_custom"
+                / "fla_npu"
+                / "fla_npu"
+                / "install_opp.py"
+            )
+        )
+        install_opp = install_opp_globals["install_opp"]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = Path(temp_dir)
+            package_opp_root = temp_root / "package-opp"
+            vendor_src = (
+                package_opp_root
+                / "vendors"
+                / "fla_npu_transformer"
+            )
+            _create_minimal_vendor(vendor_src, include_alias=True)
+            install_opp.__globals__["PACKAGE_OPP_ROOT"] = package_opp_root
+
+            install_root = temp_root / "external-opp"
+            install_opp(install_root)
+            installed_vendor = (
+                install_root
+                / "vendors"
+                / "fla_npu_transformer"
+            )
+            self.assertTrue(
+                (installed_vendor / "op_api" / "lib" / "libcust_opapi.so").is_file()
+            )
+            self.assertFalse(
+                (installed_vendor / "op_api" / "lib" / "libopapi.so").exists()
+            )
+
+    def test_runtime_rejects_conflicting_libopapi_alias(self) -> None:
+        runtime_globals = runpy.run_path(
+            str(
+                REPO_ROOT
+                / "torch_custom"
+                / "fla_npu"
+                / "fla_npu"
+                / "__init__.py"
+            )
+        )
+        prepare_opp = runtime_globals["_prepare_embedded_opp"]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            vendor_dir = (
+                Path(temp_dir)
+                / "opp"
+                / "vendors"
+                / "fla_npu_transformer"
+            )
+            _create_minimal_vendor(vendor_dir, include_alias=True)
+            prepare_opp.__globals__["_resolve_vendor_dir"] = lambda: vendor_dir
+
+            with mock.patch.dict(
+                os.environ,
+                {"ASCEND_HOME_PATH": "/fake/cann"},
+                clear=False,
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "contains libopapi.so",
+                ):
+                    prepare_opp()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torch_custom/fla_npu/README.md
+++ b/torch_custom/fla_npu/README.md
@@ -16,6 +16,8 @@ from fla_npu.ops.ascendc import chunk_fwd_o
 
 默认路径通过 Python `ctypes` 直调已安装 OPP 里的 `libcust_opapi.so`，不依赖 PyTorch dispatcher 注册，也不会默认编译或加载 `torch_npu` 自定义扩展。旧的 `torch.ops.npu.*` / `torch_npu.ops.*` 兼容路径仍可做，但只作为迁移期可选能力，不推荐新增代码使用，也不会默认使能。
 
+使用方式 B standalone wheel 时，需要先 source 已安装 custom OPP 的 `set_env.bash`，或设置 `FLA_NPU_OPP_PATH` 指向 OPP root / vendor 目录。FLA 自定义 op_api 只使用 `libcust_opapi.so`，不要在 custom OPP 的 `op_api/lib` 目录创建会遮蔽 CANN 运行库的 `libopapi.so` 别名。
+
 ## 默认交付件
 
 ### Python runtime wheel
@@ -45,7 +47,6 @@ fla_npu/opp/vendors/fla_npu_transformer
 关键产物包括：
 
 - `op_api/lib/libcust_opapi.so`：自定义 aclnn op_api 动态库。
-- `op_api/lib/libopapi.so`：wheel 内优先解析用的同名兼容副本。
 - `op_api/include/aclnnop/aclnn_*.h`：Python ctypes ABI 对齐依据。
 - `op_impl/ai_core/tbe/op_host/...`、`op_tiling/...`、`op_proto/...`：host、tiling、proto 动态库。
 - `op_impl/ai_core/tbe/kernel/...`：AI Core kernel `.o` 和 config。
@@ -136,7 +137,7 @@ bash build.sh --pkg --soc=ascend910b --vendor_name=fla_npu
 ./build_out/fla-npu-*.run --full
 ```
 
-安装完成后，`site-packages/fla_npu/opp/vendors/fla_npu_transformer` 下会包含 `libcust_opapi.so`、`libopapi.so`、aclnn 头文件、host/tiling/proto 动态库和 kernel 产物，`from fla_npu.ops.ascendc import 算子名` 的运行时布局与一键 wheel 保持一致。standalone wheel 的分发包名与一键 wheel 保持一致，均为 `flash-linear-attention-npu`；Python 导入名仍为 `fla_npu`。
+安装完成后，`site-packages/fla_npu/opp/vendors/fla_npu_transformer` 下会包含 `libcust_opapi.so`、aclnn 头文件、host/tiling/proto 动态库和 kernel 产物，`from fla_npu.ops.ascendc import 算子名` 的运行时布局与一键 wheel 保持一致。standalone wheel 的分发包名与一键 wheel 保持一致，均为 `flash-linear-attention-npu`；Python 导入名仍为 `fla_npu`。
 
 如果使用仓库根目录的一键 wheel，OPP 会内嵌到 `site-packages/fla_npu/opp`：
 

--- a/torch_custom/fla_npu/fla_npu/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/__init__.py
@@ -83,6 +83,13 @@ def _prepare_embedded_opp() -> pathlib.Path:
     op_api_lib = vendor_dir / "op_api" / "lib" / "libcust_opapi.so"
     if not op_api_lib.exists():
         raise FileNotFoundError(f"Embedded custom op_api library not found: {op_api_lib}")
+    op_api_alias = op_api_lib.with_name("libopapi.so")
+    if op_api_alias.exists() or op_api_alias.is_symlink():
+        raise RuntimeError(
+            "The FLA NPU custom OPP contains libopapi.so, which can shadow the "
+            "CANN runtime library. Reinstall a wheel that only contains "
+            f"libcust_opapi.so, or remove the stale alias: {op_api_alias}"
+        )
 
     _prepend_env_path("ASCEND_CUSTOM_OPP_PATH", vendor_dir)
     _prepend_env_path("ASCEND_CUSTOM_OPP_PATH", opp_root)
@@ -118,7 +125,6 @@ def load_ascendc_opapi_libraries() -> list[ctypes.CDLL]:
     vendor_dir = _prepare_embedded_opp()
     op_api_dir = vendor_dir / "op_api" / "lib"
     custom_opapi = op_api_dir / "libcust_opapi.so"
-    opapi_alias = op_api_dir / "libopapi.so"
 
     try:
         custom_library = _load_shared_library_required(custom_opapi)
@@ -128,8 +134,6 @@ def load_ascendc_opapi_libraries() -> list[ctypes.CDLL]:
             f"Dynamic loader error: {exc}"
         ) from exc
     libraries = [custom_library]
-    if opapi_alias.exists():
-        libraries.append(_load_shared_library_required(opapi_alias))
 
     _ASCENDC_OPAPI_LIBRARIES = libraries
     return libraries

--- a/torch_custom/fla_npu/fla_npu/install_opp.py
+++ b/torch_custom/fla_npu/fla_npu/install_opp.py
@@ -16,11 +16,29 @@ def _write_set_env(vendor_dir: Path) -> None:
         "\n".join(
             [
                 "#!/bin/bash",
-                'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"',
-                'VENDOR_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"',
-                'OPP_ROOT="$(cd "${VENDOR_DIR}/../.." && pwd)"',
-                'export ASCEND_CUSTOM_OPP_PATH="${OPP_ROOT}:${VENDOR_DIR}:${ASCEND_CUSTOM_OPP_PATH}"',
-                'export LD_LIBRARY_PATH="${VENDOR_DIR}/op_api/lib:${LD_LIBRARY_PATH}"',
+                '_FLA_NPU_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"',
+                '_FLA_NPU_VENDOR_DIR="$(cd "${_FLA_NPU_SCRIPT_DIR}/.." && pwd)"',
+                '_FLA_NPU_OPP_ROOT="$(cd "${_FLA_NPU_VENDOR_DIR}/../.." && pwd)"',
+                "_fla_npu_prepend_path() {",
+                '    local name="$1"',
+                '    local value="$2"',
+                "    local current=\"\"",
+                '    if [[ -v "${name}" ]]; then',
+                '        current="${!name}"',
+                "    fi",
+                '    case ":${current}:" in',
+                '        *":${value}:"*) return 0 ;;',
+                "    esac",
+                '    printf -v "${name}" "%s" "${value}${current:+:${current}}"',
+                '    export "${name}"',
+                "}",
+                '_fla_npu_prepend_path ASCEND_CUSTOM_OPP_PATH "${_FLA_NPU_VENDOR_DIR}"',
+                '_fla_npu_prepend_path ASCEND_CUSTOM_OPP_PATH "${_FLA_NPU_OPP_ROOT}"',
+                '_fla_npu_prepend_path LD_LIBRARY_PATH "${_FLA_NPU_VENDOR_DIR}/op_api/lib"',
+                'export FLA_NPU_OPP_PATH="${_FLA_NPU_OPP_ROOT}"',
+                'export FLA_NPU_OP_API_LIB="${_FLA_NPU_VENDOR_DIR}/op_api/lib/libcust_opapi.so"',
+                "unset -f _fla_npu_prepend_path",
+                "unset _FLA_NPU_SCRIPT_DIR _FLA_NPU_VENDOR_DIR _FLA_NPU_OPP_ROOT",
                 "",
             ]
         ),
@@ -57,6 +75,9 @@ def install_opp(install_path: Path, force: bool = False) -> None:
                 raise FileExistsError(f"{vendor_dst} already exists. Use --force to replace it.")
             shutil.rmtree(vendor_dst)
         shutil.copytree(vendor_src, vendor_dst)
+        op_api_alias = vendor_dst / "op_api" / "lib" / "libopapi.so"
+        if op_api_alias.exists() or op_api_alias.is_symlink():
+            op_api_alias.unlink()
         _write_set_env(vendor_dst)
         copied.append(vendor_dst)
 


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: #255
- 背景与目标: 主线方式 A wheel 同样存在自定义 `libopapi.so` 遮蔽 CANN 同名运行库的问题，本 PR 将修复同步到 `main`。
- 本 PR 解决的问题: 不再复制自定义 `libopapi.so`，构建和外置安装清理旧别名，运行时拒绝残留别名并通过绝对路径加载 `libcust_opapi.so`；同步补充打包检查、回归测试和 README。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: 无；涉及方式 A wheel、方式 B 外置 OPP 和公共 Python runtime。
- 涉及目录 / 文件: `setup.py`、`torch_custom/fla_npu/fla_npu/`、`scripts/check_packaged_wheel_api.py`、`tests/test_wheel_environment.py`、`ci/run_checks.sh`、相关 README。
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不涉及变化。
- 明确不包含的范围: 不修改算子 kernel、tiling、op_host、aclnn 接口、shape、dtype、layout、精度或性能逻辑；不安装 Conda 或其他 shell 自动激活钩子。
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [x] 是，请说明影响面、兼容策略和回归范围: 影响所有一体化 wheel 和外置 OPP；在线/离线编译命令不变，各环境继续手工 source CANN `set_env.sh`。回归覆盖 wheel 归档、外置 OPP、venv、非 Conda 目录、Docker、动态库来源和 NPU 调用。
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无 ABI 变化。

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

### 1. 源码与打包回归

```sh
python3 tests/test_wheel_environment.py
python3 -m py_compile setup.py scripts/check_packaged_wheel_api.py tests/test_wheel_environment.py
git diff --check
```

### 2. A2 一体化 wheel

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
FLA_NPU_SOC=ascend910b python -m pip wheel --no-build-isolation --no-deps . -w dist
```

检查 wheel 包含 `libcust_opapi.so`，不包含自定义 `libopapi.so` 和 shell 环境钩子。

### 3. 安装与运行时

- 在路径含空格的 venv 中安装 wheel，手工 source CANN 后执行 packaged API 检查。
- 在非 Conda 目标目录安装 wheel，手工 source CANN 后检查自定义库来源。
- 在无网络 Docker 中挂载 CANN/驱动，手工 source CANN 后执行 packaged API、动态库映射和 NPU 冒烟。
- 将自定义 `op_api/lib` 放在 `LD_LIBRARY_PATH` 前部，确认 `libcust_opapi.so` 来自 wheel，`libopapi.so` 仍来自 CANN。

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 不适用 | 未执行 | 本 PR 在 CANN 9.0 以上环境完成方式 A wheel 验证。 |
| A3 | `ascend910_93` |  | 不适用 | 未执行 | 由 NPU CI 补充验证。 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | CANN 9.1 | `FLA_NPU_SOC=ascend910b python -m pip wheel --no-build-isolation --no-deps . -w dist` | 通过 | 一体化 wheel 构建、归档、安装和已安装 API 检查通过。 |
| A3 | `ascend910_93` |  | 不适用 | 未执行 | 由 NPU CI 补充验证。 |
| A5 | `ascend950` |  | 不适用 | 未执行 | 由 NPU CI 补充验证。 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 tests/test_wheel_environment.py` | 通过 | 4 项专项测试通过；覆盖 staging 别名清理、外置 OPP 清理、运行时拒绝残留别名和手工 set_env 幂等。 |
| A2 | `ascend910b` | `python -m unittest test_npu_causal_conv1d.TestCausalConv1d.test_npu_causal_conv1d_prefill_batch_matches_cpu_golden` | 通过 | venv 与无网络 Docker 各通过 1 条实际 NPU 精度冒烟。 |
| A3 | `ascend910_93` | 不适用 | 未执行 | 公共打包逻辑，待 NPU CI 补充。 |
| A5 | `ascend950` | 不适用 | 未执行 | 公共打包逻辑，待 NPU CI 补充。 |

- 精度对比: NPU 冒烟与 CPU golden 比较通过；不修改算子数值实现。
- 性能对比: 不涉及算子性能路径。
- 边界 / 异常场景: 覆盖旧别名清理与拒绝、重复 source、路径含空格、venv、非 Conda 安装、无网络 Docker 和动态库搜索顺序。
- 未覆盖风险: A3/A5 由 NPU CI 补充。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 已重新触发 quick NPU CI。 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 由 NPU CI 补充。 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 由 NPU CI 补充。 |

- 端到端场景说明: 本地完成 A2 wheel、venv、非 Conda、无网络 Docker 和 NPU 冒烟；仓库端到端由 quick NPU CI 补充。
- 与本 PR 修改算子的关联: 无特定算子改动，验证公共 wheel 运行时未破坏现有调用链。
- 未覆盖原因及补充计划: A3/A5 环境由 NPU CI 补充。

</details>

## 兼容性、风险与回退

- 兼容性说明: 在线和离线方式 A 编译命令不变；新 wheel 只通过绝对路径加载 `libcust_opapi.so`，CANN 继续提供 `libopapi.so`；方式 B 仍手工加载外置 OPP。
- 风险点: 旧 wheel 或外置 OPP 若残留自定义 `libopapi.so`，运行时会明确拒绝，需要重新安装或删除旧别名。系统 Python、Conda、venv 和 Docker 均继续手工 source CANN `set_env.sh`。
- 回退方案: 回退本 PR 提交可恢复原行为。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 根因是 staging 主动将 `libcust_opapi.so` 复制为 `libopapi.so`，自定义库目录进入动态库搜索路径后遮蔽 CANN 同名运行库。
- 本 PR 不再包含 Conda 或其他 shell 自动激活钩子。
- v26.6.0 对应修复为 #256。
