### PR TITLE
fix(runtime): 释放异步 aclnn 调用的 workspace

### DIFF
--- a/docs/agents/torch-npu-decoupled-architecture.md
+++ b/docs/agents/torch-npu-decoupled-architecture.md
@@ -126,7 +126,7 @@ legacy `torch.ops.npu.*` 兼容路径仍可通过 `FLA_NPU_BUILD_LEGACY_EXTENSIO
 7. runtime 在目标 device 上分配 workspace。
 8. runtime 读取 `torch.npu.current_stream(target_device)` 的底层 stream pointer。
 9. ctypes 调用 `<aclnnOp>(workspace, size, executor, stream)`，将 kernel enqueue 到 current stream。
-10. runtime 销毁 descriptor，短期保活输出、workspace 和 helper tensor，并在退出 device guard 时恢复调用方原 device。
+10. runtime 销毁 descriptor；workspace 和 helper tensor 在同一 current stream 上交回 PyTorch NPU allocator，并在退出 device guard 时恢复调用方原 device。
 
 这条默认链路没有 `torch.ops.load_library()`，不查找 `torch.ops.npu.<op>`，也不加载 `custom_aclnn_extension_lib*.so`。
 
@@ -329,11 +329,12 @@ stream_ptr = int(stream.npu_stream)
 aclnn launch 返回时，kernel 通常只完成 enqueue。runtime 必须保证：
 
 - 用户输入 tensor 由调用方持有。
-- 输出 tensor、workspace 和临时 helper tensor 在设备消费完成前不被 Python GC 回收。
-- int-array descriptor 使用的临时 tensor 不提前释放。
+- 输出 tensor 由返回值和调用方持有，不在 runtime 内额外保留。
+- workspace 和临时 helper tensor 必须在目标 current stream 上分配，并由同一 stream 上 enqueue 的 kernel 消费。
+- workspace 和 helper tensor 的 Python 引用可在 enqueue 后释放；底层 block 的安全复用由 PyTorch NPU caching allocator 的 stream 生命周期管理。
 - descriptor 在 executor 构造和 launch 完成后销毁。
 
-本仓使用 `_RECENT_LAUNCH_STORAGE` 保存近期输出、workspace 和 helper tensor，不在默认路径做全局 synchronize。这个保活机制解决对象生命周期，不替代跨 stream event。
+runtime 不使用固定深度的全局保活队列，也不在默认路径做全局 synchronize。固定保留近期 workspace 会使显存随连续 launch 次数线性增长，尤其会放大包含内部中间张量的大融合算子显存占用。
 
 ### 5.5 ACL 私有格式和 NZ 透传
 

--- a/examples/flash_gated_delta_rule.py
+++ b/examples/flash_gated_delta_rule.py
@@ -857,11 +857,8 @@ def flash_chunk_gated_delta_rule_fwd(
         initial_state=initial_state,
         output_final_state=output_final_state,
         chunk_size=chunk_size,
-        save_new_value=True,
         cu_seqlens=cu_seqlens_list,
         chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
-        use_exp2=False,
-        transpose_state_layout=False,
     )
     if not output_final_state:
         final_state = None
@@ -877,7 +874,6 @@ def flash_chunk_gated_delta_rule_fwd(
         cu_seqlens=cu_seqlens_list,
         chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
         chunk_size=chunk_size,
-        transpose_state_layout=False,
     )
 
     g = g.transpose(1, 2).contiguous()
@@ -927,11 +923,8 @@ def flash_chunk_gated_delta_rule_bwd(
         initial_state=initial_state,
         output_final_state=False,
         chunk_size=chunk_size,
-        save_new_value=True,
         cu_seqlens=cu_seqlens_list,
         chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
-        use_exp2=False,
-        transpose_state_layout=False,
     )
 
     dv = ascendc_chunk_bwd_dv_local(

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/_runtime.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/_runtime.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import ctypes
 import sys
-from collections import deque
 from contextlib import contextmanager
 from typing import Iterable, Optional, Sequence
 
@@ -36,13 +35,6 @@ _ACL_FORMAT_BY_NAME = {
     "NCDHW": ACL_FORMAT_NCDHW,
     "NCL": ACL_FORMAT_NCL,
 }
-
-# aclnn launch 是异步的。输出 tensor、workspace buffer，以及为可选 int-array
-# 输入临时创建的小 tensor，都必须至少存活到队列里的 kernel 消费完成。这里用
-# 一个小 ring 保活即可：普通用户 tensor 会由 torch stream 语义保活，而在常见
-# test/example 流程里，deque 回绕前旧 launch 通常已经执行完。
-_RECENT_LAUNCH_STORAGE = deque(maxlen=128)
-
 
 def dtype_to_acl(dtype) -> int:
     import torch
@@ -413,10 +405,6 @@ def runtime() -> _AclnnRuntime:
     return _RUNTIME
 
 
-def finalize(outputs, workspace, keepalive_tensors):
-    _RECENT_LAUNCH_STORAGE.append((tuple(outputs), workspace, tuple(keepalive_tensors)))
-
-
 def _call_device(outputs: Sequence[object]):
     device = None
     device_index = None
@@ -446,7 +434,10 @@ def call_aclnn(name: str, build_args, outputs, *, get_workspace_argtypes=None):
     with _npu_device_guard(device):
         try:
             args = build_args(ctx)
-            workspace = aclnn_runtime.call(
+            # runtime.call 在目标 current stream 上分配 workspace 并把 kernel
+            # enqueue 到同一 stream。调用返回后可立即释放 Python 引用；NPU
+            # caching allocator 会按 stream 生命周期管理底层 block 的安全复用。
+            aclnn_runtime.call(
                 name,
                 args,
                 device,
@@ -454,5 +445,4 @@ def call_aclnn(name: str, build_args, outputs, *, get_workspace_argtypes=None):
             )
         finally:
             ctx.destroy()
-    finalize(outputs_tuple, workspace, ctx.keepalive_tensors)
     return outputs

--- a/torch_custom/fla_npu/test/test_runtime_device_guard.py
+++ b/torch_custom/fla_npu/test/test_runtime_device_guard.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 
 import contextlib
 import ctypes
+import gc
 import importlib.util
 import sys
 import types
 import unittest
+import weakref
 from pathlib import Path
 from unittest import mock
 
@@ -86,9 +88,6 @@ def fake_torch(npu: FakeNpu):
 
 
 class RuntimeDeviceGuardTest(unittest.TestCase):
-    def setUp(self):
-        RUNTIME._RECENT_LAUNCH_STORAGE.clear()
-
     def test_device_guard_switches_to_target_and_restores_previous_device(self):
         npu = FakeNpu(current_device=0)
         with mock.patch.dict(sys.modules, {"torch": fake_torch(npu)}):
@@ -175,6 +174,57 @@ class RuntimeDeviceGuardTest(unittest.TestCase):
             ],
         )
         self.assertEqual(npu.current_device(), 0)
+
+    def test_call_aclnn_does_not_retain_outputs_workspace_or_helpers(self):
+        npu = FakeNpu(current_device=0)
+        torch_module = fake_torch(npu)
+        workspace_ref = None
+
+        class FakeDescriptor:
+            def __init__(self, runtime, tensor):
+                self.ptr = 0xD00D
+
+            def destroy(self):
+                self.ptr = None
+
+        class Workspace:
+            pass
+
+        class FakeRuntime:
+            def call(self, name, args, device, *, get_workspace_argtypes=None):
+                nonlocal workspace_ref
+                workspace = Workspace()
+                workspace_ref = weakref.ref(workspace)
+                return workspace
+
+        with mock.patch.dict(sys.modules, {"torch": torch_module}):
+            with mock.patch.object(RUNTIME, "runtime", return_value=FakeRuntime()):
+                with mock.patch.object(RUNTIME, "_AclTensor", FakeDescriptor):
+                    output = FakeTensor(2)
+                    helper = FakeTensor(2)
+                    output_ref = weakref.ref(output)
+                    helper_ref = weakref.ref(helper)
+
+                    def build_args(ctx):
+                        ctx.keepalive_tensors.append(helper)
+                        return [ctx.tensor(output, "output")]
+
+                    result = RUNTIME.call_aclnn(
+                        "aclnnTest",
+                        build_args,
+                        output,
+                    )
+
+        self.assertIsNotNone(workspace_ref)
+        self.assertIsNone(workspace_ref())
+        self.assertIs(result, output)
+        del result
+        del output
+        del helper
+        del build_args
+        gc.collect()
+        self.assertIsNone(output_ref())
+        self.assertIsNone(helper_ref())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> 当前 head commit 已完成 `/run-npu-ci full`：手动验证通过，精度检查通过 4/4 个用例。

## 关联 Issue / 背景

- 关联 Issue: #258
- 背景与目标: AscendC ctypes 共享 runtime 为规避异步 launch 生命周期问题，使用固定深度全局队列强引用最近 128 次调用的输出、完整 aclnn workspace 和辅助张量。大 workspace 算子连续调用时，已完成调用的显存无法被 caching allocator 回收复用。
- 本 PR 解决的问题: aclnn kernel 在当前 stream 完成 enqueue 后立即释放 Python 强引用，依赖 NPU caching allocator 的 stream-safe 复用语义管理底层存储生命周期；同时补充 runtime 回归测试、架构文档，并修正现有 GDN Example 中已经失效的 `fwd_h`/`fwd_o` 参数。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: 共享 AscendC ctypes runtime；重点回归 `chunk_kda_fwd` 及 GDN Example/ST 调用链
- 涉及目录 / 文件: `torch_custom/fla_npu/fla_npu/ops/ascendc/_runtime.py`、runtime 单元测试、`examples/flash_gated_delta_rule.py`、runtime 架构文档
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [x] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不改变任何算子输入、输出、shape、dtype、format 或可选输出语义。
- 明确不包含的范围: 不修改 KDA kernel、tiling、数值算法和算子 ABI；不在本 PR 中处理 fused gate 且请求 `final_state` 时已存在的跨次 bitwise 非确定性。
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [x] 是，请说明影响面、兼容策略和回归范围: `call_aclnn` 是 AscendC ctypes 公共 launch 路径。本 PR 仅移除 launch 后的全局 Python 强引用，不改变调用协议；通过 runtime 单测、KDA 完整矩阵和 GDN Example/ST 回归。
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>修改算子测试</summary>

### CANN 9.0 及以上编译

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0 beta 系列 | `FLA_NPU_SOC=ascend910b python -m pip wheel --no-build-isolation --no-deps . -w dist` | 通过 | wheel 构建与 packaged API 检查通过 |
| A3 | `ascend910_93` | 9.1.0 beta 系列 | `FLA_NPU_SOC=ascend910_93 python -m pip wheel --no-build-isolation --no-deps . -w dist` | 通过 | wheel 构建通过 |
| A5 | `ascend950` | 9.1.0 beta 系列 | `FLA_NPU_SOC=ascend950 python -m pip wheel --no-build-isolation --no-deps . -w dist` | 通过 | wheel 构建与 packaged API 检查通过 |

### 单算子与 runtime 测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | runtime 单测；`chunk_kda_backend.py` 完整矩阵；连续 10 次显存回归 | 通过 | FP16/BF16、safe gate、layout、V256、chunk128、`state_v_first`、可选输出和负向契约均通过；释放调用者输出后无残留增长 |
| A3 | `ascend910_93` | runtime 单测；设备测试 | 编译通过 / 设备未执行 | A3 wheel 构建通过；本轮 full NPU CI 的设备侧 runtime 仅覆盖 A2 |
| A5 | `ascend950` | runtime 单测；`chunk_kda_backend.py` 完整矩阵；连续 10 次显存回归 | 通过 | FP16/BF16、safe gate、layout、V256、chunk128、`state_v_first`、可选输出和负向契约均通过；释放调用者输出后无残留增长 |

- full NPU CI: 当前 head commit 手动验证通过（full+example），精度检查通过 4/4 个用例。
- runtime 单元测试: 6/6 通过，覆盖 device guard、当前 stream、launch 后 workspace/输出/辅助张量不再被 Python 全局状态持有。
- 精度对比: A2/A5 KDA 完整矩阵通过；本 PR 不修改 kernel 数值路径。
- 显存对比: H96、T4096、K=V=128、chunk64、BF16、safe gate 场景，旧实现 5 次调用残留约 9.238 GiB；新实现连续 10 次调用仅在调用者持有返回值期间保留约 1.934 GiB 的真实输出，释放返回值后残留增长为 0。
- 性能对比: 相同 H96/T4096 场景的 `msopprof BasicInfo` 主算子总耗时，A2 约 11.254 ms（含输入输出转置约 12.204 ms），A5 约 7.398 ms（含输入输出转置约 8.157 ms）。本 PR 不修改 kernel/tiling，未观察到算子性能路径变化。
- 边界 / 异常场景: 可选输出组合和负向契约通过；异步连续调用后统一同步，未出现非法访问或结果生命周期问题。
- 未覆盖风险: A3 设备侧 runtime 未被本轮 CI 覆盖，仅完成编译验证。H96/T4096 fused gate 且 `output_final_state=true` 时，`attn_out` 和 `final_state` 存在修改前即可复现的跨次 bitwise 非确定性，其他输出 bitwise 一致；本 PR 前后行为相同，不属于本次显存修复引入的回归。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 | 4/4 通过 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 本轮 full NPU CI 的设备侧 runtime 仅覆盖 A2 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 | 4/4 通过 |

- 端到端场景说明: 覆盖 dense/TND varlen、FP16/BF16、正反向精度。
- 与本 PR 修改算子的关联: 验证共享 ctypes runtime 释放 launch 引用后，GDN 完整调用链和异步执行保持正确；同时验证 Example 参数与公开 API 一致。
- 未覆盖原因及补充计划: 当前 NPU CI runner 未提供 A3 设备侧覆盖；A3 已完成编译验证，后续在可用 A3 环境补充 runtime 与 Example/ST 回归。

</details>

## 兼容性、风险与回退

- 兼容性说明: 对外 Python API、aclnn ABI、算子输入输出和数值路径均保持不变。
- 风险点: 修复依赖 NPU caching allocator 对同一当前 stream 异步 enqueue 的 stream-safe 存储复用语义。runtime 在 workspace 创建、executor 获取和 kernel launch 全程使用同一当前 stream；回归测试覆盖立即释放 Python 引用后的异步连续调用。
- 回退方案: 回退 runtime 和对应测试/文档提交即可恢复旧行为，但会重新引入最多保留最近 128 次完整 workspace 的显存问题。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 本 PR 的目标是解除共享 runtime 对已完成 launch 的 Python 级强引用，不是通过减少 KDA 可选输出规避显存问题；调用者请求的输出仍完整返回。
- `examples/flash_gated_delta_rule.py` 的参数清理用于恢复当前主线公开 API 下的标准 Example/ST，不改变模型计算语义。
- 当前 head commit 的 full NPU CI 已通过；A3 设备侧未覆盖项已在矩阵和 checklist 中保持显式未完成。
