### PR TITLE
fix: 兼容 CANN 8.5 至 9.2 的 opbase 接口

### DIFF
--- a/cmake/custom_build.cmake
+++ b/cmake/custom_build.cmake
@@ -962,6 +962,7 @@ install(DIRECTORY ${OPBASE_SOURCE_PATH}/pkg_inc/op_common/atvoss
 )
 install(DIRECTORY ${OPBASE_SOURCE_PATH}/pkg_inc/op_common/op_kernel
         DESTINATION ${IMPL_INSTALL_DIR}/ascendc/common
+        OPTIONAL
 )
 
 foreach (op_dir ${OP_DIR_LIST})

--- a/cmake/third_party/opbase.cmake
+++ b/cmake/third_party/opbase.cmake
@@ -8,7 +8,23 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # ----------------------------------------------------------------------------
-set(OPBASE_TAG_ID c8d83f3e57a63a7375e89a2d6937452c0ae2e522)
+set(OPBASE_LEGACY_TAG_ID c8d83f3e57a63a7375e89a2d6937452c0ae2e522)
+set(OPBASE_CONST_API_TAG_ID c8cfc45e350d4e07cd8cab8448d3b40f9727ea4c)
+set(OPBASE_TAG_ID ${OPBASE_LEGACY_TAG_ID})
+
+set(OPBASE_ELEWISE_TILING_HEADER
+    "${ASCEND_CANN_PACKAGE_PATH}/${SYSTEM_PREFIX}/pkg_inc/op_common/atvoss/elewise/elewise_tiling.h")
+if(EXISTS "${OPBASE_ELEWISE_TILING_HEADER}")
+  file(READ "${OPBASE_ELEWISE_TILING_HEADER}" OPBASE_ELEWISE_TILING_CONTENT)
+  string(FIND "${OPBASE_ELEWISE_TILING_CONTENT}" "int64_t GetBlockDim() const;" OPBASE_CONST_API_POSITION)
+  if(NOT OPBASE_CONST_API_POSITION EQUAL -1)
+    set(OPBASE_TAG_ID ${OPBASE_CONST_API_TAG_ID})
+  endif()
+endif()
+message(STATUS "Select opbase revision: ${OPBASE_TAG_ID}")
+unset(OPBASE_ELEWISE_TILING_CONTENT)
+unset(OPBASE_CONST_API_POSITION)
+unset(OPBASE_ELEWISE_TILING_HEADER)
 
 if(EXISTS "${PROJECT_SOURCE_DIR}/../../ops-base")
   get_filename_component(OPBASE_SOURCE_PATH


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> 本 PR 创建后需要由仓库 Admin 手动触发 NPU CI；如果后续更新 commit，需要针对新的 head commit 重新触发。

## 关联 Issue / 背景

- 关联 Issue: #267
- 背景与目标: CANN 9.2.0 的 `elewise_tiling.h` 将 `GetBlockDim()`、`GetScheMode()` 等接口调整为 const 成员函数，仓库固定的旧 opbase 与新 CANN 头文件组合后会产生 const 限定不匹配的编译错误；同时需要保留 CANN 8.5.x 对旧接口的兼容。
- 本 PR 解决的问题: 根据当前 CANN 头文件的接口签名自动选择兼容的 opbase revision，并兼容新 opbase 不再提供 `pkg_inc/op_common/op_kernel` 目录的包结构变化。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: 所有依赖 opbase 的 Ascend C 算子（仅影响构建阶段）
- 涉及目录 / 文件: `cmake/third_party/opbase.cmake`、`cmake/custom_build.cmake`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 无变化。
- 明确不包含的范围: 不修改算子接口、Kernel、Tiling、精度逻辑和运行时行为。
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [x] 是，请说明影响面、兼容策略和回归范围: 影响公共构建依赖选择。旧 CANN 接口继续使用 `c8d83f3e57a63a7375e89a2d6937452c0ae2e522`，const 接口使用 `c8cfc45e350d4e07cd8cab8448d3b40f9727ea4c`。
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 不涉及 ABI 变化。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

### CANN 8.5.2 + A2

```sh
bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu
```

- 自动选择旧 opbase revision。
- 全量编译、打包和生成包完整性检查通过。

### CANN 9.2.0 + A2

```sh
bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu
```

- 自动选择 const API 对应的 opbase revision。
- 全量编译、打包和生成包完整性检查通过。

### 静态检查

```sh
git diff --check
```

- 检查通过。

</details>

<details>
<summary>修改算子测试</summary>

本 PR 不修改具体算子实现，仅验证公共构建和打包链路。

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 8.5.2 | `bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu` | 通过 | 全量编译、打包及生成包完整性检查通过 |
| A3 | `ascend910_93` | - | - | 未执行 | 当前无 A3 验证环境 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.2.0 | `bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu` | 通过 | 全量编译、打包及生成包完整性检查通过 |
| A3 | `ascend910_93` | - | - | 未执行 | 当前无 A3 验证环境 |
| A5 | `ascend950` | - | - | 未执行 | 当前无 A5 验证环境 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | - | 未执行 | 本 PR 不修改算子实现，当前环境无 NPU 运行条件 |
| A3 | `ascend910_93` | - | 未执行 | 当前无 A3 验证环境 |
| A5 | `ascend950` | - | 未执行 | 当前无 A5 验证环境 |

- 精度对比: 未执行；不涉及计算逻辑变化。
- 性能对比: 未执行；不涉及运行时逻辑变化。
- 边界 / 异常场景: 已覆盖旧 opbase 目录存在和新 opbase 目录缺失两种打包结构。
- 未覆盖风险: 尚未在 A3、A5 以及 NPU 运行时执行回归。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | - | 未执行 | 当前环境无 NPU 运行条件 |
| A3 | `ascend910_93` | - | 未执行 | 当前无 A3 验证环境 |
| A5 | `ascend950` | - | 未执行 | 当前无 A5 验证环境 |

- 端到端场景说明: 不涉及端到端调用逻辑变化。
- 与本 PR 修改算子的关联: 仅影响构建阶段的 opbase 依赖选择和头文件打包。
- 未覆盖原因及补充计划: PR 创建后请求仓库 NPU CI，并请具备 A3 环境的维护者回归 Issue #267 原始场景。

</details>

## 兼容性、风险与回退

- 兼容性说明: 已验证 CANN 8.5.2 与 CANN 9.2.0 的 A2 全量编译和打包；其他中间版本根据接口签名选择对应 revision。
- 风险点: 尚未逐一验证 CANN 8.5.x 至 9.2.0 的所有中间版本和 weekly 包，且未验证 A3、A5。
- 回退方案: 回退本 PR 提交，恢复固定使用旧 opbase revision 的行为。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 旧接口 opbase revision: `c8d83f3e57a63a7375e89a2d6937452c0ae2e522`
- const 接口 opbase revision: `c8cfc45e350d4e07cd8cab8448d3b40f9727ea4c`
- PR 计划以 Draft 状态创建，等待 A3 原始场景和 NPU CI 补充验证。
