### PR TITLE
fix: 兼容 CANN 8.5 至 9.2 的 opbase（v26.1.0）

### DIFF
--- a/cmake/custom_build.cmake
+++ b/cmake/custom_build.cmake
@@ -953,6 +953,7 @@ install(DIRECTORY ${OPBASE_SOURCE_PATH}/pkg_inc/op_common/atvoss
 )
 install(DIRECTORY ${OPBASE_SOURCE_PATH}/pkg_inc/op_common/op_kernel
         DESTINATION ${IMPL_INSTALL_DIR}/ascendc/common
+        OPTIONAL
 )
 
 foreach (op_dir ${OP_DIR_LIST})

--- a/cmake/third_party/opbase.cmake
+++ b/cmake/third_party/opbase.cmake
@@ -6,7 +6,23 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # ----------------------------------------------------------------------------
-set(OPBASE_TAG_ID c8d83f3e57a63a7375e89a2d6937452c0ae2e522)
+set(OPBASE_LEGACY_TAG_ID c8d83f3e57a63a7375e89a2d6937452c0ae2e522)
+set(OPBASE_CONST_API_TAG_ID c8cfc45e350d4e07cd8cab8448d3b40f9727ea4c)
+set(OPBASE_TAG_ID ${OPBASE_LEGACY_TAG_ID})
+
+set(OPBASE_ELEWISE_TILING_HEADER
+    "${ASCEND_CANN_PACKAGE_PATH}/${SYSTEM_PREFIX}/pkg_inc/op_common/atvoss/elewise/elewise_tiling.h")
+if(EXISTS "${OPBASE_ELEWISE_TILING_HEADER}")
+  file(READ "${OPBASE_ELEWISE_TILING_HEADER}" OPBASE_ELEWISE_TILING_CONTENT)
+  string(FIND "${OPBASE_ELEWISE_TILING_CONTENT}" "int64_t GetBlockDim() const;" OPBASE_CONST_API_POSITION)
+  if(NOT OPBASE_CONST_API_POSITION EQUAL -1)
+    set(OPBASE_TAG_ID ${OPBASE_CONST_API_TAG_ID})
+  endif()
+endif()
+message(STATUS "Select opbase revision: ${OPBASE_TAG_ID}")
+unset(OPBASE_ELEWISE_TILING_CONTENT)
+unset(OPBASE_CONST_API_POSITION)
+unset(OPBASE_ELEWISE_TILING_HEADER)
 
 if(EXISTS "${PROJECT_SOURCE_DIR}/../../ops-base")
   get_filename_component(OPBASE_SOURCE_PATH


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> 本 PR 按仓库分支保护和 NPU CI 规则处理。

## 关联 Issue / 背景

- 关联 Issue: #267
- 背景与目标: 将 #269 的 CANN 8.5.x–9.2.0 opbase 兼容修复回移到 `v26.1.0`。
- 本 PR 解决的问题: 固定使用旧 opbase 时，CANN 新版 `ElewiseTiling` 头文件的 `const` 成员函数签名与 opbase 实现不一致，导致编译失败；另外，旧 opbase 不包含 `pkg_inc/op_common/op_kernel` 目录，打包安装规则会失败。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: 所有使用 opbase 的 Ascend C 算子（仅构建链路）
- 涉及目录 / 文件: `cmake/third_party/opbase.cmake`、`cmake/custom_build.cmake`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不变。
- 明确不包含的范围: 不修改算子实现、接口、精度、shape、dtype 或 format。
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [x] 是，请说明影响面、兼容策略和回归范围: 影响 opbase 公共构建依赖；根据已安装 CANN 头文件签名选择匹配的固定 opbase 提交。
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

- CANN 版本: 9.1.0
- 产品 / 芯片类型: A2 / `ascend910b`
- 编译命令: `bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu`
- 结果: 全量 A2 编译完成，标准 `package` 目标返回 0，自动选择 opbase `c8d83f3e57a63a7375e89a2d6937452c0ae2e522`，生成 run 包，编译日志无 compiler error。
- 生成包自检: run 包 SHA-256 完整性和安装自检通过。

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0 | `bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu` | 通过 | run 包生成且自检通过 |
| A3 | `ascend910_93` |  |  | 未执行 | 本次回移按 A2 验证范围执行 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0 | `bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu` | 通过 | run 包生成且自检通过 |
| A3 | `ascend910_93` |  |  | 未执行 | 本次回移按 A2 验证范围执行 |
| A5 | `ascend950` |  |  | 未执行 | 本次回移按 A2 验证范围执行 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 未执行 | 本 PR 仅修改构建依赖选择，不修改算子逻辑 |
| A3 | `ascend910_93` |  | 未执行 | 同上 |
| A5 | `ascend950` |  | 未执行 | 同上 |

- 精度对比: 未执行，不涉及 kernel 逻辑变更。
- 性能对比: 未执行，不涉及 kernel 逻辑变更。
- 边界 / 异常场景: 已验证 CANN 9.1.0 的非 `const` 头文件签名会选择旧 opbase。
- 未覆盖风险: A3、A5 和上卡运行未在本次回移验证中执行。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 未执行 | 本次仅进行编译、打包和包自检 |
| A3 | `ascend910_93` |  | 未执行 | 同上 |
| A5 | `ascend950` |  | 未执行 | 同上 |

- 端到端场景说明: 未执行。
- 与本 PR 修改算子的关联: 本 PR 仅影响构建期 opbase 版本选择和打包目录兼容。
- 未覆盖原因及补充计划: 本次按 CANN 9.1.0 + A2 回移验证范围执行。

</details>

## 兼容性、风险与回退

- 兼容性说明: 检测到 `int64_t GetBlockDim() const;` 时选择新 opbase `c8cfc45e350d4e07cd8cab8448d3b40f9727ea4c`；其他情况保持旧 opbase `c8d83f3e57a63a7375e89a2d6937452c0ae2e522`。
- 风险点: 未识别的未来 CANN 头文件签名仍需同步更新版本选择规则。
- 回退方案: 回退本 PR 的单个提交，恢复目标分支原固定 opbase 版本和安装规则。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 本 PR 是 #269 的 `v26.1.0` 回移。
- 本次回移已执行 `git diff --check`、精确冲突标记检查和目标分支 ahead/behind 检查。
