### PR TITLE
refactor(dqkwg): remove dead code

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_tiling/chunk_bwd_dqkwg_tiling.cpp
@@ -17,17 +17,10 @@
 #include "tiling_base/data_copy_transpose_tiling.h"
 #include "tiling_base/tiling_templates_registry.h"
 #include "tiling_base/tiling_type.h"
-#include <cmath>
 #include <algorithm>
 
 namespace optiling {
 
-constexpr int64_t CONST_B = 1;
-constexpr int64_t CONST_HV = 4;
-constexpr int64_t CONST_HK = 4;
-constexpr int64_t CONST_T = 2816;
-constexpr int64_t CONST_K = 128;
-constexpr int64_t CONST_V = 128;
 constexpr int64_t CONST_BT = 64;
 
 // 数据类型大小
@@ -79,8 +72,6 @@ ASCENDC_EXTERN_C ge::graphStatus TilingChunkBwdDqkwg(gert::TilingContext* contex
         OP_LOGE(context->GetNodeName(), "HV must be a multiple of HK, but HV = %ld, HK = %ld.", HV, HK);
         return ge::GRAPH_FAILED;
     }
-    int64_t n_ratio = HV / HK;
-    (void)n_ratio;
     auto attr = context->GetAttrs();
     const int32_t* chunkSizePtr = attr->GetAttrPointer<int32_t>(ATTR_CHUNK_SIZE_ITEM);
     if (chunkSizePtr != nullptr) {

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg.cpp
@@ -58,9 +58,9 @@
 
          if ASCEND_IS_AIC {
              ChunkBwdDqkwgCubeProcess<DTYPE_Q, DTYPE_G> cubeProcess(
-                 q, k, v, g, h,
+                 q, k, v, h,
                  do_, dh, dv, cu_seqlens, chunk_indices,
-                 dq, dk, dw, dg,
+                 dq, dk,
                  userWorkspace
              );
              cubeProcess.Init(tilingData);
@@ -72,7 +72,7 @@
              TPipe tPipe; // 创建 TPipe 用于 Vector 端流水
              ChunkBwdDqkwgVectorProcess<DTYPE_Q, DTYPE_G> vectorProcess(
                  q, k, v, g, h,
-                 do_, dh, dv, cu_seqlens, chunk_indices, nullptr,        //mask = nullptr
+                 do_, dh, dv, cu_seqlens, chunk_indices,
                  dq, dk, dw, dg,
                  userWorkspace
              );

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_common.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_common.h
@@ -17,14 +17,6 @@
 
  #include "kernel_operator.h"
 
- constexpr uint64_t CONST_B = 1;
- constexpr uint64_t CONST_HV = 4;
- constexpr uint64_t CONST_HK = 4;
- constexpr uint64_t CONST_T = 2816;
- constexpr uint64_t CONST_K = 128;
- constexpr uint64_t CONST_V = 128;
- constexpr uint64_t CONST_BT = 64;
- constexpr uint64_t CONST_NUM_CHUNKS = 44;//CONST_T / CONST_BT;  // 32
  constexpr int32_t CAL_NUM_FLOAT = 64; // API一次能处理256B，能计算64个float元素
 
  // ============================================================================
@@ -56,11 +48,6 @@
  // ============================================================================
  constexpr uint64_t SYNC_AIC_AIV_FLAG_0 = 5;  // cube -> vector: 数据 ready (与基线一致)
  constexpr uint64_t SYNC_AIV_AIC_FLAG_0 = 3;  // vector -> cube: 信用 credit (与基线一致)
-
- // Cross-stage temporaries use a per-core group-aligned ring. Short-lived
- // temporaries use an independent shallow ring. The host passes the cross ring
- // depth in wsBtxKSyncSlotsPerHead; short depth is fixed here.
- constexpr uint32_t DqkwgShortRingDepth = 8;
 
  // short 环深自适应: dw/mm6/mul1 的存活窗口只需 2G-1 个 slot (G=groupRingDepth/4)。固定 8 是按最大 G=4 配的,
  // 但大 H / 大 BT 的 memory-bound case 实际 G=1~2 时, 深度 8 严重过配 -> 环装不进 L2 -> FixPipe/MTE2 疯狂 miss。
@@ -156,29 +143,9 @@
      AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(SYNC_AIV_AIC_FLAG_0);
  }
 
- constexpr uint32_t UB_SIZE = 192 * 1024;  // 192KB
- constexpr uint32_t ONE_BLOCK_32 = 32;
  constexpr uint32_t FP32_PER_REPEAT = 64;
- constexpr uint32_t FP16_PER_BLOCK = 16;  // 32 bytes / 2 bytes per fp16
-
- constexpr uint32_t FP16_SIZE = 2;
- constexpr uint32_t FP32_SIZE = 4;
- constexpr uint32_t BF16_SIZE = 2;
 
  #define CEIL_DIV(x, y) (((x) + (y) - 1) / (y))
- #define ALIGN_UP(x, align) (((x) + (align) - 1) / (align) * (align))
-
- template<typename T>
- struct TypeTraits {
-     using ComputeType = float;  // 默认计算类型为 fp32
-     static constexpr bool needsCast = true;
- };
-
- template<>
- struct TypeTraits<half> {
-     using ComputeType = float;
-     static constexpr bool needsCast = true;
- };
 
  __aicore__ void inline GetChunkOffset(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, uint64_t B, uint64_t HV, uint64_t T,
                                        uint64_t chunkSize, uint32_t loopIdx, uint32_t &bos, uint32_t &eos)

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_cube.h
@@ -28,24 +28,8 @@
  #include "catlass/status.hpp"
  #include "tla/layout.hpp"
  #include "tla/tensor.hpp"
-  using _0 = tla::Int<0>;
-       using _1 = tla::Int<1>;
-       using _2 = tla::Int<2>;
-       using _4 = tla::Int<4>;
-       using _8 = tla::Int<8>;
-       using _16 = tla::Int<16>;
-       using _32 = tla::Int<32>;
-       using _64 = tla::Int<64>;
        using _128 = tla::Int<128>;
        using _256 = tla::Int<256>;
-       using _512 = tla::Int<512>;
-       using _1024 = tla::Int<1024>;
-       using _2048 = tla::Int<2048>;
-       using _4096 = tla::Int<4096>;
-       using _8192 = tla::Int<8192>;
-       using _16384 = tla::Int<16384>;
-       using _32768 = tla::Int<32768>;
-       using _65536 = tla::Int<65536>;
        #else
        #define CATLASS_ARCH 2201
        #include "chunk_bwd_dqkwg_common.h"
@@ -102,7 +86,6 @@ namespace Catlass::Gemm::Kernel {
 
         // Single-stage buffer sizes (no pingpong)
         static constexpr uint32_t L1A_TILE_SIZE = TILE_M * TILE_K * sizeof(ElementA);
-        static constexpr uint32_t L1B_TILE_SIZE = TILE_K * TILE_N * sizeof(ElementB);
 
         // Static L1 layouts for tile-sized buffers
         static constexpr auto L1A_LAYOUT =
@@ -277,7 +260,6 @@ namespace Catlass::Gemm::Kernel {
             GM_ADDR ptrQ;      // [B, HK, T, K]
             GM_ADDR ptrK;      // [B, HK, T, K]
             GM_ADDR ptrV;      // [B, HV, T, V]
-            GM_ADDR ptrG;      // [B, HV, T]
             GM_ADDR ptrH;      // [B, HV, num_chunks, K, V]
             GM_ADDR ptrDo;     // [B, HV, T, V]
             GM_ADDR ptrDh;     // [B, HV, num_chunks, K, V]
@@ -289,8 +271,6 @@ namespace Catlass::Gemm::Kernel {
             // 输出指针
             GM_ADDR ptrDq;     // [B, HK, T, K]
             GM_ADDR ptrDk;     // [B, HK, T, K]
-            GM_ADDR ptrDw;     // [B, HV, T, K]
-            GM_ADDR ptrDg;     // [B, HV, T]
 
             // Workspace 指针
             GM_ADDR ptrWorkspace;
@@ -298,7 +278,6 @@ namespace Catlass::Gemm::Kernel {
             // Workspace 偏移
             uint64_t wsDwOffset;
             uint64_t wsBtxKSyncSlotsPerHead;
-            uint64_t wsDgLastOffset;
             uint64_t wsMm5Offset;
             uint64_t wsDsTempOffset;
             uint64_t wsMm6Offset;
@@ -314,33 +293,24 @@ namespace Catlass::Gemm::Kernel {
             uint64_t BT;// = CONST_BT;
             uint64_t numChunks;// = CONST_NUM_CHUNKS;
             uint64_t n_ratio;      // HV / HK
-            // uint64_t chunkSize = 64;
-            uint64_t isVarLen;
-
-            // 其他参数
-            float scale;
             uint64_t aicCoreNum = 0;  // CV 深融合 blockDim (cube/vector 共用), 由 host tiling 给出
 
             CATLASS_DEVICE
-            Params() {}
-
-            CATLASS_DEVICE
             Params(
-                GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
+                GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR h,
                 GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
-                GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
+                GM_ADDR dq, GM_ADDR dk,
                 GM_ADDR workspace,
                 uint64_t B, uint64_t HV, uint64_t HK, uint64_t T, uint64_t K, uint64_t V, uint64_t BT, uint64_t numChunks, uint64_t n_ratio,
-                uint64_t wsDw, uint64_t wsBtxKSlots, uint64_t wsDgLast, uint64_t wsMm5, uint64_t wsDsTemp,
-                uint64_t wsMm6, uint64_t wsMm7,
-                float s, uint64_t isVarLen
-            ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
+                uint64_t wsDw, uint64_t wsBtxKSlots, uint64_t wsMm5, uint64_t wsDsTemp,
+                uint64_t wsMm6, uint64_t wsMm7
+            ) : ptrQ(q), ptrK(k), ptrV(v), ptrH(h),
                 ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLens(cu_seqlen), ptrChunkIndices(chunk_indices),
-                ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
+                ptrDq(dq), ptrDk(dk),
                 ptrWorkspace(workspace),
-                wsDwOffset(wsDw), wsBtxKSyncSlotsPerHead(wsBtxKSlots), wsDgLastOffset(wsDgLast),
+                wsDwOffset(wsDw), wsBtxKSyncSlotsPerHead(wsBtxKSlots),
                 wsMm5Offset(wsMm5), wsDsTempOffset(wsDsTemp), wsMm6Offset(wsMm6), wsMm7Offset(wsMm7),
-                scale(s), B(B), HV(HV), HK(HK), T(T), K(K), V(V), BT(BT), numChunks(numChunks), n_ratio(n_ratio), isVarLen(isVarLen) {}
+                B(B), HV(HV), HK(HK), T(T), K(K), V(V), BT(BT), numChunks(numChunks), n_ratio(n_ratio) {}
         };
 
         CATLASS_DEVICE
@@ -374,7 +344,6 @@ namespace Catlass::Gemm::Kernel {
             auto layoutVxBT = LayoutColMajor::MakeLayout<ElementA>(params.V, params.BT);
             auto layoutBTxBT = LayoutRowMajor::MakeLayout<ElementA>(params.BT, params.BT);
             auto layoutBTxBT_T = LayoutColMajor::MakeLayout<ElementA>(params.BT, params.BT);
-            auto layoutKxV = LayoutRowMajor::MakeLayout<ElementA>(params.K, params.V);
             auto layoutVxK = LayoutColMajor::MakeLayout<ElementA>(params.V, params.K);
 
             uint32_t bos = 0;
@@ -734,13 +703,13 @@ namespace Catlass::Gemm::Kernel {
     class ChunkBwdDqkwgCubeProcess {
     public:
         __aicore__ inline ChunkBwdDqkwgCubeProcess(
-            GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
+            GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR h,
             GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
-            GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
+            GM_ADDR dq, GM_ADDR dk,
             GM_ADDR workspace
-        ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
+        ) : ptrQ(q), ptrK(k), ptrV(v), ptrH(h),
             ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLen(cu_seqlen), ptrChunkIndices(chunk_indices),
-            ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
+            ptrDq(dq), ptrDk(dk),
             ptrWorkspace(workspace) {}
 
         __aicore__ inline void Init(const ChunkBwdDqkwgTilingData &tiling);
@@ -751,7 +720,6 @@ namespace Catlass::Gemm::Kernel {
         GM_ADDR ptrQ;
         GM_ADDR ptrK;
         GM_ADDR ptrV;
-        GM_ADDR ptrG;
         GM_ADDR ptrH;
         GM_ADDR ptrDo;
         GM_ADDR ptrDh;
@@ -760,28 +728,23 @@ namespace Catlass::Gemm::Kernel {
         GM_ADDR ptrChunkIndices;
         GM_ADDR ptrDq;
         GM_ADDR ptrDk;
-        GM_ADDR ptrDw;
-        GM_ADDR ptrDg;
         GM_ADDR ptrWorkspace;
 
         // Tiling 参数
-        uint64_t B = CONST_B;
-        uint64_t HV = CONST_HV;
-        uint64_t HK = CONST_HK;
+        uint64_t B;
+        uint64_t HV;
+        uint64_t HK;
         uint64_t n_ratio = 1;
-        uint64_t T = CONST_T;
-        uint64_t K = CONST_K;
-        uint64_t V = CONST_V;
-        uint64_t BT = CONST_BT;
-        uint64_t numChunks = CONST_NUM_CHUNKS;
-        float scale;
-        uint64_t isVarLen;
+        uint64_t T;
+        uint64_t K;
+        uint64_t V;
+        uint64_t BT;
+        uint64_t numChunks;
         uint64_t aicCoreNum;  // CV 深融合 blockDim (cube/vector 共用)
 
         // Workspace 偏移
         uint64_t wsDwOffset;
         uint64_t wsBtxKSyncSlotsPerHead;
-        uint64_t wsDgLastOffset;
         uint64_t wsMm5Offset;
         uint64_t wsDsTempOffset;
         uint64_t wsMm6Offset;
@@ -790,7 +753,6 @@ namespace Catlass::Gemm::Kernel {
 
     template <typename DataType, typename GType>
     __aicore__ inline void ChunkBwdDqkwgCubeProcess<DataType, GType>::Init(const ChunkBwdDqkwgTilingData &tiling) {
-        scale = tiling.scale;
         B = tiling.B;
         HV = tiling.HV;
         HK = tiling.HK;
@@ -803,12 +765,10 @@ namespace Catlass::Gemm::Kernel {
         aicCoreNum = tiling.aicCoreNum;
         wsDwOffset = tiling.wsDwOffset;
         wsBtxKSyncSlotsPerHead = tiling.wsBtxKSyncSlotsPerHead;
-        wsDgLastOffset = tiling.wsDgLastOffset;
         wsMm5Offset = tiling.wsMm5Offset;
         wsDsTempOffset = tiling.wsDsTempOffset;
         wsMm6Offset = tiling.wsMm6Offset;
         wsMm7Offset = tiling.wsMm7Offset;
-        isVarLen = tiling.isVarLen;
     }
 
     template <typename DataType, typename GType>
@@ -889,24 +849,22 @@ namespace Catlass::Gemm::Kernel {
         if (V > 128) {
             MatmulKernelTiled kernel;
             typename MatmulKernelTiled::Params params(
-                ptrQ, ptrK, ptrV, ptrG, ptrH,
+                ptrQ, ptrK, ptrV, ptrH,
                 ptrDo, ptrDh, ptrDv, ptrCuSeqLen, ptrChunkIndices,
-                ptrDq, ptrDk, ptrDw, ptrDg,
+                ptrDq, ptrDk,
                 ptrWorkspace, B, HV, HK, T, K, V, BT, numChunks, n_ratio,
-                wsDwOffset, wsBtxKSyncSlotsPerHead, wsDgLastOffset, wsMm5Offset, wsDsTempOffset, wsMm6Offset, wsMm7Offset,
-                scale, isVarLen
+                wsDwOffset, wsBtxKSyncSlotsPerHead, wsMm5Offset, wsDsTempOffset, wsMm6Offset, wsMm7Offset
             );
             params.aicCoreNum = aicCoreNum;
             kernel(params);
         } else {
             MatmulKernel kernel;
             typename MatmulKernel::Params params(
-                ptrQ, ptrK, ptrV, ptrG, ptrH,
+                ptrQ, ptrK, ptrV, ptrH,
                 ptrDo, ptrDh, ptrDv, ptrCuSeqLen, ptrChunkIndices,
-                ptrDq, ptrDk, ptrDw, ptrDg,
+                ptrDq, ptrDk,
                 ptrWorkspace, B, HV, HK, T, K, V, BT, numChunks, n_ratio,
-                wsDwOffset, wsBtxKSyncSlotsPerHead, wsDgLastOffset, wsMm5Offset, wsDsTempOffset, wsMm6Offset, wsMm7Offset,
-                scale, isVarLen
+                wsDwOffset, wsBtxKSyncSlotsPerHead, wsMm5Offset, wsDsTempOffset, wsMm6Offset, wsMm7Offset
             );
             params.aicCoreNum = aicCoreNum;
             kernel(params);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_kernel/chunk_bwd_dqkwg_vector.h
@@ -40,7 +40,7 @@
  public:
      __aicore__ inline ChunkBwdDqkwgVectorProcess(
          GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
-         GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices, GM_ADDR mask_a,
+         GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
          GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
          GM_ADDR workspace
      );
@@ -63,15 +63,8 @@
                                                 uint64_t gOffset, uint32_t BT_sub_start, uint32_t real_BT,
                                                 uint32_t actual_chunk_len);
 
-     // 辅助函数
-     __aicore__ inline void ComputeExpScalar(float input, float &output);
-     __aicore__ inline void ApplyLowerTriangularMask(LocalTensor<float> &tensor, uint32_t size);
-     __aicore__ inline void ReduceSumX(LocalTensor<float> &src, LocalTensor<float> &dst,
-                                       uint32_t rows, uint32_t cols, int axis);
      __aicore__ inline void CopyGateWithPad(LocalTensor<GType> &dst, GlobalTensor<GType> &src,
                                             uint64_t offset, uint32_t validLen, uint32_t totalLen);
-     __aicore__ inline void RefineSmallDw(LocalTensor<float> &dw, uint64_t dvOffset,
-                                          uint64_t hOffset, uint32_t rows);
      __aicore__ inline void RepairDwChunkHeadBlock(LocalTensor<DataType> &dwOut,
                                                    LocalTensor<DataType> &tmp,
                                                    LocalTensor<float> &work,
@@ -92,7 +85,6 @@
      GM_ADDR ptrDv;
      GM_ADDR ptrCuSeqLen;
      GM_ADDR ptrChunkIndices;
-     GM_ADDR ptrMaskA;
      GM_ADDR ptrDq;
      GM_ADDR ptrDk;
      GM_ADDR ptrDw;
@@ -134,7 +126,6 @@
      GlobalTensor<DataType> gmQ, gmK, gmV, gmDo, gmH, gmDh, gmDv;
      GlobalTensor<DataType> gmDq, gmDk, gmDw;
      GlobalTensor<GType> gmG, gmDg;
-     GlobalTensor<DataType> gmWorkspace;
      GlobalTensor<float> gmDgLast;
      GlobalTensor<DataType> gmDwWorkspace;
      GlobalTensor<DataType> gmMm5, gmDsTemp, gmMul1, gmMm6, gmMm7;
@@ -144,8 +135,6 @@
      TQue<TPosition::VECIN, 2> inQue2;
      TQue<TPosition::VECIN, 2> inQue3;
      TQue<TPosition::VECIN, 2> inQue4;  //用于Add0累加
-     TQue<TPosition::VECIN, 2> inQue5;  //用于Part5 Add4中间结果
-     TQue<TPosition::VECIN, 2> inQue6;  //用于Part5 gLast中间结果
      TQue<TPosition::VECOUT, 2> outQue1;
      TQue<TPosition::VECOUT, 2> outQue2;
 
@@ -168,11 +157,11 @@
  template <typename DataType, typename GType>
  __aicore__ inline ChunkBwdDqkwgVectorProcess<DataType, GType>::ChunkBwdDqkwgVectorProcess(
      GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR h,
-     GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices, GM_ADDR mask_a,
+     GM_ADDR do_, GM_ADDR dh, GM_ADDR dv, GM_ADDR cu_seqlen, GM_ADDR chunk_indices,
      GM_ADDR dq, GM_ADDR dk, GM_ADDR dw, GM_ADDR dg,
      GM_ADDR workspace
  ) : ptrQ(q), ptrK(k), ptrV(v), ptrG(g), ptrH(h),
-     ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLen(cu_seqlen), ptrChunkIndices(chunk_indices), ptrMaskA(mask_a),
+     ptrDo(do_), ptrDh(dh), ptrDv(dv), ptrCuSeqLen(cu_seqlen), ptrChunkIndices(chunk_indices),
      ptrDq(dq), ptrDk(dk), ptrDw(dw), ptrDg(dg),
      ptrWorkspace(workspace) {}
 
@@ -200,7 +189,6 @@
      wsMm6Offset = tiling.wsMm6Offset;
      wsMm7Offset = tiling.wsMm7Offset;
      wsMul1Offset = tiling.wsMul1Offset;
-     uint64_t dgLastSize = tiling.dgLastSize;
      isVarLen = tiling.isVarLen;
      mul0RowNum = tiling.mul0RowNum;
 
@@ -224,7 +212,6 @@
      gmDw.SetGlobalBuffer((__gm__ DataType *)ptrDw);
      gmDg.SetGlobalBuffer((__gm__ GType *)ptrDg);
 
-     gmWorkspace.SetGlobalBuffer((__gm__ DataType *)ptrWorkspace);
      gmDwWorkspace.SetGlobalBuffer((__gm__ DataType *)((__gm__ uint8_t*)ptrWorkspace + wsDwOffset));
      gmDgLast.SetGlobalBuffer((__gm__ float *)((__gm__ uint8_t*)ptrWorkspace + wsDgLastOffset));     //中间结果使用float
 
@@ -312,36 +299,6 @@
      uint8_t rightPadding = static_cast<uint8_t>((elemsPerBlock - (validLen % elemsPerBlock)) % elemsPerBlock);
      DataCopyPadExtParams<GType> padParams{true, 0, rightPadding, 0};
      DataCopyPad(dst, src[offset], copyParams, padParams);
- }
-
- template <typename DataType, typename GType>
- __aicore__ inline void ChunkBwdDqkwgVectorProcess<DataType, GType>::RefineSmallDw(
-     LocalTensor<float> &dw, uint64_t dvOffset, uint64_t hOffset, uint32_t rows) {
-     if constexpr (std::is_same<DataType, half>::value) {
-         constexpr float refineAbsMin = 3.0e-5f;
-         constexpr float refineAbsMax = 2.0e-4f;
-         uint32_t kLimit = static_cast<uint32_t>(K);
-         uint32_t vLimit = static_cast<uint32_t>(V);
-         for (uint32_t r = 0; r < rows; ++r) {
-             for (uint32_t kIdx = 0; kIdx < kLimit; ++kIdx) {
-                 uint32_t outIdx = r * kLimit + kIdx;
-                 float val = dw.GetValue(outIdx);
-                 float absVal = val >= 0.0f ? val : -val;
-                 bool refineSmall = absVal >= refineAbsMin && absVal <= refineAbsMax;
-                 bool refineChunkHeadZero = r == 0 && absVal <= refineAbsMax;
-                 bool refineChunkHeadRepairCols = r == 0 && kIdx < FP16_ELEMENTS_PER_BLOCK;
-                 if (refineSmall || refineChunkHeadZero || refineChunkHeadRepairCols) {
-                     float sum = 0.0f;
-                     for (uint32_t vIdx = 0; vIdx < vLimit; ++vIdx) {
-                         float dvVal = static_cast<float>(gmDv.GetValue(dvOffset + r * vLimit + vIdx));
-                         float hVal = static_cast<float>(gmH.GetValue(hOffset + kIdx * vLimit + vIdx));
-                         sum += dvVal * hVal;
-                     }
-                     dw.SetValue(outIdx, sum);
-                 }
-             }
-         }
-     }
  }
 
  template <typename DataType, typename GType>


### PR DESCRIPTION
## 关联 Issue / 背景

- 无需关联 Issue：本 PR 仅清理 chunk_bwd_dqkwg 算子中经引用审计确认的死代码。
- 目标：减少无效实现、状态与参数透传，降低维护成本，不改变算子对外行为。

## 变更类型

- [x] 代码重构 / 死代码清理

## 算子责任范围

- 涉及算子：chunk_bwd_dqkwg
- 涉及目录：op_host/op_tiling、op_kernel
- 提交人：zhang_e2016
- 修改范围：删除未引用的 vector helper、队列与 GlobalTensor 成员；删除 cube 内未消费的参数链、布局、常量与默认 shape；删除 host tiling 未使用常量和临时计算。
- RepairDwChunkHeadBlock 保留：最新 main 中仍在 FP16 chunk-head 修复路径调用。
- 输入 / 输出 / shape / dtype / format：不变。
- 明确不包含：op def、aclnn/torch 接口、测试、文档、公共模块。
- 是否影响公共模块或其他算子：否。
- ABI / 接口兼容性：不涉及算子 def、aclnn 接口或 torch 接口入参、返回值、属性变化；仅收紧 kernel 内部类构造参数。

## 验证

- git diff --check：通过。
- 已对删除标识符执行精确引用复扫：无残留。
- 分支基于最新 origin/main 6f0765865e8016ca000e9e6afc7300e3537caceb，仅 1 个提交、5 个 dqkwg 算子文件。
- A2 / A3 / A5 编译与 NPU 精度测试：未执行。配置的远端 910B 主机 199.103.1.2:22 当前不可达；请由仓库 Admin 在当前 head commit 上触发 NPU CI。

## 兼容性、风险与回退

- 兼容性：外部 ABI、tiling 数据结构和 workspace 布局均未修改。
- 风险点：内部构造参数删除若有未覆盖实例化点会导致编译失败；已通过全仓引用审计确认当前只有同步修改的实例化点，仍需 NPU CI 完成正式编译门禁。
- 回退方案：回退本 PR 的单一提交。
- [x] 若引入阻塞性问题，提交人会第一时间回退或配合维护者修复。

## Checklist

- [x] 已说明无需关联 Issue 的原因。
- [x] 已明确算子责任范围和不包含范围。
- [x] A2 / A3 / A5 编译与算子测试（等待 NPU CI）。
- [x] 已确认没有无关格式化或大规模重构。
- [x] 文档无需更新：对外行为与接口不变。
- [x] PR 标题使用 refactor 类型。
