### PR TITLE
feat: add one-click KDA forward benchmark workflow

### DIFF
--- a/scripts/benchmark_kda_main.sh
+++ b/scripts/benchmark_kda_main.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+
+source_dir="$(realpath "$SCRIPT_DIR/..")"
+repo_url=""
+ref=""
+soc="${FLA_NPU_SOC:-}"
+device="0"
+work_root="${PWD}/outputs/kda-main-benchmark"
+cann_env=""
+conda_init=""
+conda_env=""
+case_filter="all"
+warm_up="5"
+launch_count="5000"
+case_timeout="300"
+decode_step="1"
+clone_retries="3"
+aic_metrics="BasicInfo"
+ops="chunk_kda_fwd,kda_gate_cumsum,chunk_gated_delta_rule_fwd_h,recurrent_kda"
+
+usage() {
+    cat <<'EOF'
+Usage: bash scripts/benchmark_kda_main.sh [options]
+
+Build the current checkout into an isolated fla_npu wheel, then profile the KDA
+matrix with msopprof. Results are written as CSV, Markdown, and JSON. Remote
+fetching is opt-in; pass both --repo-url and --ref when it is required.
+Decode cases carry one state through 10 consecutive calls, average the last 5
+device-kernel durations, and extrapolate that steady-state mean to S=8192.
+
+Options:
+  --work-root DIR        Parent directory for source, wheel, profiles, and logs
+  --source-dir DIR       Existing source checkout (default: this repository)
+  --repo-url URL         Repository URL for an explicit remote fetch
+  --ref REF              Branch, tag, SHA, or refs/pull/<N>/head to fetch
+  --soc SOC              Required: ascend910b, ascend910_93, or ascend950
+  --device ID            Physical NPU exposed to the benchmark (default: 0)
+  --cann-env FILE        CANN set_env.sh to source before building
+  --conda-init FILE      Conda profile script; required with --conda-env
+  --conda-env NAME       Conda environment to activate
+  --cases IDS            Comma-separated case IDs, or all
+  --warm-up N            msopprof replay warm-up count (default: 5)
+  --launch-count N       Maximum matching kernels to collect (default: 5000)
+  --case-timeout SEC     Timeout for one worker/profile command (default: 300)
+  --decode-step N        Recurrent tokens per decode call, 1-8 (default: 1)
+  --aic-metrics NAME     msopprof AI Core metrics set (default: BasicInfo)
+  --ops IDS              Comma-separated operators for the scoped wheel build
+  --clone-retries N      Source fetch attempts (default: 3)
+  -h, --help             Show this help
+
+Environment:
+  FLA_NPU_SOC            SOC used when --soc is omitted
+  FLA_NPU_ALLOWED_ROOT   Optional absolute root. The script refuses writes
+                         outside it when set.
+
+Examples:
+  bash scripts/benchmark_kda_main.sh --soc ascend910b \
+    --work-root "$PWD/outputs/kda-perf"
+  bash scripts/benchmark_kda_main.sh --soc ascend950 \
+    --cann-env /path/to/Ascend/ascend-toolkit/set_env.sh
+  bash scripts/benchmark_kda_main.sh --soc ascend950 \
+    --repo-url https://github.com/example/project.git \
+    --ref refs/pull/276/head
+EOF
+}
+
+source_env_file() {
+    local path="$1"
+    set +u
+    # shellcheck disable=SC1090
+    source "$path"
+    set -u
+}
+
+cmake_version_is_supported() {
+    local version="$1"
+    if [[ "$version" =~ ^([0-9]+)\.([0-9]+)(\.[0-9]+)?$ ]]; then
+        local major="${BASH_REMATCH[1]}"
+        local minor="${BASH_REMATCH[2]}"
+        ((major == 3 && minor >= 16))
+        return
+    fi
+    return 1
+}
+
+while (($#)); do
+    case "$1" in
+        --work-root) work_root="$2"; shift 2 ;;
+        --source-dir) source_dir="$2"; shift 2 ;;
+        --repo-url) repo_url="$2"; shift 2 ;;
+        --ref) ref="$2"; shift 2 ;;
+        --soc) soc="$2"; shift 2 ;;
+        --device) device="$2"; shift 2 ;;
+        --cann-env) cann_env="$2"; shift 2 ;;
+        --conda-init) conda_init="$2"; shift 2 ;;
+        --conda-env) conda_env="$2"; shift 2 ;;
+        --cases) case_filter="$2"; shift 2 ;;
+        --warm-up) warm_up="$2"; shift 2 ;;
+        --launch-count) launch_count="$2"; shift 2 ;;
+        --case-timeout) case_timeout="$2"; shift 2 ;;
+        --decode-step) decode_step="$2"; shift 2 ;;
+        --aic-metrics) aic_metrics="$2"; shift 2 ;;
+        --ops) ops="$2"; shift 2 ;;
+        --clone-retries) clone_retries="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+[[ -n "$soc" ]] || { echo "--soc is required (or set FLA_NPU_SOC)" >&2; exit 2; }
+case "$soc" in
+    ascend910b|ascend910_93|ascend950) ;;
+    *) echo "Unsupported SOC: $soc" >&2; exit 2 ;;
+esac
+[[ "$device" =~ ^[0-9]+$ ]] || { echo "--device must be a non-negative integer" >&2; exit 2; }
+[[ "$warm_up" =~ ^[0-9]+$ ]] || { echo "--warm-up must be a non-negative integer" >&2; exit 2; }
+[[ "$launch_count" =~ ^[1-9][0-9]*$ ]] || { echo "--launch-count must be positive" >&2; exit 2; }
+[[ "$case_timeout" =~ ^[1-9][0-9]*$ ]] || { echo "--case-timeout must be positive" >&2; exit 2; }
+[[ "$decode_step" =~ ^[1-8]$ ]] || { echo "--decode-step must be in [1, 8]" >&2; exit 2; }
+[[ "$clone_retries" =~ ^[1-9][0-9]*$ ]] || { echo "--clone-retries must be positive" >&2; exit 2; }
+[[ -n "$aic_metrics" ]] || { echo "--aic-metrics must not be empty" >&2; exit 2; }
+[[ -n "$ops" ]] || { echo "--ops must not be empty" >&2; exit 2; }
+if [[ -n "$repo_url" || -n "$ref" ]]; then
+    [[ -n "$repo_url" && -n "$ref" ]] || {
+        echo "--repo-url and --ref must be provided together" >&2
+        exit 2
+    }
+fi
+
+if [[ -n "$conda_env" ]]; then
+    [[ -n "$conda_init" ]] || { echo "--conda-init is required with --conda-env" >&2; exit 2; }
+    [[ -f "$conda_init" ]] || { echo "Conda profile script not found: $conda_init" >&2; exit 2; }
+    source_env_file "$conda_init"
+    conda activate "$conda_env"
+fi
+
+if [[ -n "$cann_env" ]]; then
+    [[ -f "$cann_env" ]] || { echo "CANN environment script not found: $cann_env" >&2; exit 2; }
+    source_env_file "$cann_env"
+fi
+
+for command_name in cksum git python3 npu-smi msopprof realpath timeout; do
+    command -v "$command_name" >/dev/null 2>&1 || {
+        echo "Required command not found: $command_name" >&2
+        exit 1
+    }
+done
+python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)' || {
+    echo "Python 3.9 or newer is required; found $(python3 --version 2>&1)" >&2
+    exit 1
+}
+[[ -n "${ASCEND_HOME_PATH:-}" || -n "${ASCEND_OPP_PATH:-}" ]] || {
+    echo "CANN is not active. Source set_env.sh or pass --cann-env." >&2
+    exit 1
+}
+
+mkdir -p -- "$work_root"
+work_root="$(realpath "$work_root")"
+[[ "$work_root" != "/" ]] || { echo "Refusing to use / as --work-root" >&2; exit 2; }
+if [[ -n "${FLA_NPU_ALLOWED_ROOT:-}" ]]; then
+    allowed_root="$(realpath "${FLA_NPU_ALLOWED_ROOT}")"
+    case "$work_root/" in
+        "$allowed_root"/*) ;;
+        *) echo "Work root is outside FLA_NPU_ALLOWED_ROOT: $work_root" >&2; exit 2 ;;
+    esac
+fi
+
+timestamp="$(date +%Y%m%d_%H%M%S)"
+run_dir="$work_root/run_${timestamp}_$$"
+cache_root="$work_root/cache"
+fetched_source_dir="$cache_root/source"
+wheel_dir="$run_dir/wheel"
+pip_cache_dir="$cache_root/pip"
+tmp_dir="$run_dir/tmp"
+result_dir="$run_dir/results"
+base_python="$(realpath "$(command -v python3)")"
+python_key="$("$base_python" -c 'import sys; print(sys.executable, sys.prefix, sys.version_info[:2])' | cksum | awk '{print $1}')"
+venv_dir="$cache_root/venv_${python_key}"
+mkdir -p -- "$run_dir" "$cache_root" "$pip_cache_dir" "$wheel_dir" "$tmp_dir" "$result_dir"
+
+on_error() {
+    status=$?
+    echo "Benchmark failed with status $status. Logs and partial outputs: $run_dir" >&2
+    exit "$status"
+}
+trap on_error ERR
+
+echo "[1/6] Checking NPU $device"
+npu-smi info -t board -i "$device" >/dev/null
+
+if [[ -n "$repo_url" ]]; then
+    echo "[2/6] Fetching $repo_url at $ref"
+    source_dir="$fetched_source_dir"
+    if [[ ! -d "$source_dir/.git" ]]; then
+        git init "$source_dir"
+        git -C "$source_dir" remote add origin "$repo_url"
+    elif [[ "$(git -C "$source_dir" remote get-url origin)" != "$repo_url" ]]; then
+        echo "Cached source uses a different origin: $source_dir" >&2
+        exit 1
+    fi
+    fetch_succeeded="0"
+    for ((attempt = 1; attempt <= clone_retries; attempt++)); do
+        echo "Source fetch attempt $attempt/$clone_retries"
+        fetch_args=(
+            -C "$source_dir"
+            -c http.lowSpeedLimit=1000
+            -c http.lowSpeedTime=30
+            fetch --depth 1 --filter=blob:none origin "$ref"
+        )
+        if GIT_TERMINAL_PROMPT=0 timeout 90 git "${fetch_args[@]}"; then
+            fetch_succeeded="1"
+            break
+        fi
+        ((attempt == clone_retries)) || sleep 5
+    done
+    [[ "$fetch_succeeded" == "1" ]] || { echo "Unable to fetch $repo_url at $ref" >&2; exit 1; }
+    git -C "$source_dir" checkout --detach --force FETCH_HEAD
+else
+    source_dir="$(realpath "$source_dir")"
+    [[ -d "$source_dir/.git" || -f "$source_dir/.git" ]] || {
+        echo "--source-dir is not a Git checkout: $source_dir" >&2
+        exit 2
+    }
+    echo "[2/6] Using local source checkout: $source_dir"
+    if [[ -n "$(git -C "$source_dir" status --short --untracked-files=no)" ]]; then
+        echo "Source checkout has tracked changes; the wheel will include them." >&2
+    fi
+fi
+commit="$(git -C "$source_dir" rev-parse HEAD)"
+runner_script="$source_dir/scripts/benchmark_kda_matrix.py"
+[[ -f "$runner_script" ]] || { echo "Benchmark runner is missing: $runner_script" >&2; exit 1; }
+echo "Source commit: $commit"
+
+echo "[3/6] Creating isolated Python environment"
+if [[ ! -x "$venv_dir/bin/python" ]]; then
+    "$base_python" -m venv --system-site-packages "$venv_dir"
+else
+    echo "Reusing cached Python environment: $venv_dir"
+fi
+venv_python="$venv_dir/bin/python"
+export PATH="$venv_dir/bin:$PATH"
+export PIP_CACHE_DIR="$pip_cache_dir"
+"$venv_python" -c 'import torch, torch_npu; print(f"torch={torch.__version__} torch_npu={torch_npu.__version__}")'
+
+echo "[4/6] Installing and checking build dependencies"
+build_requirements=(
+    "setuptools>=70.1"
+    wheel
+    packaging
+    psutil
+)
+cmake_version=""
+if command -v cmake >/dev/null 2>&1; then
+    cmake_version="$(cmake --version | sed -n '1s/^cmake version //p')"
+fi
+if ! cmake_version_is_supported "$cmake_version"; then
+    build_requirements+=("cmake>=3.16,<4")
+fi
+if ! command -v patch >/dev/null 2>&1; then
+    build_requirements+=("patch-ng==1.19.1")
+fi
+"$venv_python" -m pip install "${build_requirements[@]}"
+
+if ! command -v patch >/dev/null 2>&1; then
+    export FLA_NPU_PATCH_PYTHON="$venv_python"
+    patch_wrapper="$venv_dir/bin/patch"
+    cat > "$patch_wrapper" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${FLA_NPU_PATCH_PYTHON:?FLA_NPU_PATCH_PYTHON is required}"
+case "${1:-}" in
+    --version|-h|--help)
+        exec "$FLA_NPU_PATCH_PYTHON" -m patch_ng "$@"
+        ;;
+    -p1)
+        shift
+        set -- -p0 "$@"
+        ;;
+esac
+patch_input="$(mktemp "${TMPDIR:-/tmp}/fla-npu-patch.XXXXXX")"
+trap 'rm -f -- "$patch_input"' EXIT
+cat > "$patch_input"
+"$FLA_NPU_PATCH_PYTHON" -m patch_ng "$@" "$patch_input"
+EOF
+    chmod +x "$patch_wrapper"
+    echo "GNU patch not found; using the isolated patch-ng compatibility wrapper"
+fi
+
+for build_command in cmake make patch; do
+    command -v "$build_command" >/dev/null 2>&1 || {
+        echo "Required build command not found: $build_command" >&2
+        exit 1
+    }
+done
+echo "cmake=$(cmake --version | sed -n '1p')"
+echo "patch=$(patch --version | sed -n '1p')"
+export FLA_NPU_SOC="$soc"
+export FLA_NPU_OPS="$ops"
+export FLA_NPU_BUILD_LEGACY_EXTENSION="FALSE"
+export TMPDIR="$tmp_dir"
+export TORCH_EXTENSIONS_DIR="$run_dir/torch_extensions"
+export ASCEND_RT_VISIBLE_DEVICES="$device"
+mkdir -p -- "$TORCH_EXTENSIONS_DIR"
+"$venv_python" "$source_dir/scripts/check_npu_env.py" --build-only
+
+echo "[5/6] Building and installing the main-branch wheel"
+(
+    cd "$source_dir"
+    "$venv_python" -m pip wheel --no-build-isolation --no-deps . -w "$wheel_dir"
+)
+mapfile -t wheels < <(find "$wheel_dir" -maxdepth 1 -type f -name 'flash_linear_attention_npu-*.whl' -print)
+if ((${#wheels[@]} != 1)); then
+    echo "Expected one fla_npu wheel, found ${#wheels[@]}" >&2
+    exit 1
+fi
+"$venv_python" -m pip install --force-reinstall --no-deps "${wheels[0]}"
+"$venv_python" "$source_dir/scripts/check_packaged_wheel_api.py"
+
+echo "[6/6] Profiling the KDA forward matrix with msopprof"
+runner=(
+    "$runner_script"
+    --output-dir "$result_dir"
+    --repo-dir "$source_dir"
+    --repo-commit "$commit"
+    --soc "$soc"
+    --device-visible-id 0
+    --cases "$case_filter"
+    --warm-up "$warm_up"
+    --launch-count "$launch_count"
+    --case-timeout "$case_timeout"
+    --decode-step "$decode_step"
+    --aic-metrics "$aic_metrics"
+)
+"$venv_python" "${runner[@]}"
+
+trap - ERR
+echo "Completed. Results: $result_dir/results.md"

--- a/scripts/benchmark_kda_matrix.py
+++ b/scripts/benchmark_kda_matrix.py
@@ -1,0 +1,966 @@
+#!/usr/bin/env python3
+"""Profile the requested KDA matrix with msopprof."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+import platform
+import re
+import shlex
+import shutil
+import signal
+import statistics
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+HEADS = 96
+KEY_DIM = 128
+VALUE_DIM = 128
+CHUNK_SIZE = 64
+PROFILE_RANGE = "FLA_NPU_KDA_BENCH"
+DECODE_TOTAL_CALLS = 10
+DECODE_MEASURE_CALLS = 5
+PREFILL_KERNEL_FILTER = "|".join(
+    (
+        "ChunkKdaFwd*",
+        "chunk_kda_fwd*",
+        "ChunkKdaFwdPrepare*",
+        "chunk_kda_fwd_prepare*",
+        "ChunkKdaFwdPostWu*",
+        "chunk_kda_fwd_post_wu*",
+        "ChunkGatedDeltaRuleFwdH*",
+        "chunk_gated_delta_rule_fwd_h*",
+        "ChunkKdaFwdFinalize*",
+        "chunk_kda_fwd_finalize*",
+    )
+)
+DECODE_KERNEL_FILTER = "RecurrentKda*|recurrent_kda*"
+BASIC_INFO_FILE = re.compile(r"^OpBasicInfo(?:_.*)?\.csv$", re.IGNORECASE)
+DIAGNOSTIC_TREE_LIMIT = 500
+DIAGNOSTIC_CSV_LIMIT = 100
+DIAGNOSTIC_LOG_LINES = 240
+
+
+@dataclass(frozen=True)
+class Case:
+    case_id: str
+    phase: str
+    direction: str
+    batch: int
+    sequence: int
+    h100_us: Optional[float]
+    optimized_npu_us: Optional[float]
+
+
+CASES = (
+    Case("prefill_fwd_b1_s1024", "prefill", "fwd", 1, 1024, None, None),
+    Case("prefill_fwd_b1_s8192", "prefill", "fwd", 1, 8192, None, None),
+    Case("prefill_fwd_b1_s16384", "prefill", "fwd", 1, 16384, None, None),
+    Case("prefill_fwd_b1_s65536", "prefill", "fwd", 1, 65536, None, None),
+    Case("decode_fwd_b1_s8192", "decode", "fwd", 1, 8192, 17158.0, 109285.4),
+    Case("decode_fwd_b4_s8192", "decode", "fwd", 4, 8192, 54987.0, 436946.2),
+    Case("decode_fwd_b16_s8192", "decode", "fwd", 16, 8192, 188545.0, 1747650.0),
+    Case("decode_fwd_b64_s8192", "decode", "fwd", 64, 8192, None, 6990387.0),
+)
+CASE_BY_ID = {case.case_id: case for case in CASES}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--repo-dir", type=Path)
+    parser.add_argument("--repo-commit", default="unknown")
+    parser.add_argument("--soc", default="unknown")
+    parser.add_argument("--device-visible-id", type=int, default=0)
+    parser.add_argument("--cases", default="all")
+    parser.add_argument("--warm-up", type=int, default=5)
+    parser.add_argument("--launch-count", type=int, default=5000)
+    parser.add_argument("--case-timeout", type=int, default=300)
+    parser.add_argument("--decode-step", type=int, default=1)
+    parser.add_argument("--aic-metrics", default="BasicInfo")
+    parser.add_argument("--worker", choices=tuple(CASE_BY_ID))
+    return parser.parse_args()
+
+
+def selected_cases(value: str) -> list[Case]:
+    if value == "all":
+        return list(CASES)
+    ids = [item.strip() for item in value.split(",") if item.strip()]
+    unknown = sorted(set(ids) - set(CASE_BY_ID))
+    if unknown:
+        raise ValueError(f"unknown case IDs: {', '.join(unknown)}")
+    return [CASE_BY_ID[case_id] for case_id in ids]
+
+
+def shell_join(command: Iterable[object]) -> str:
+    return " ".join(shlex.quote(str(part)) for part in command)
+
+
+def make_prefill_inputs(torch, case: Case, device):
+    shape = (case.batch, case.sequence, HEADS, KEY_DIM)
+    q = torch.zeros(shape, dtype=torch.bfloat16, device=device)
+    k = torch.zeros_like(q)
+    v = torch.zeros(shape, dtype=torch.bfloat16, device=device)
+    gate = torch.full(shape, -1.0, dtype=torch.float32, device=device)
+    beta = torch.ones(
+        (case.batch, case.sequence, HEADS), dtype=torch.bfloat16, device=device
+    )
+    a_log = torch.zeros((HEADS,), dtype=torch.float32, device=device)
+    dt_bias = torch.zeros((HEADS * KEY_DIM,), dtype=torch.float32, device=device)
+    return q, k, v, gate, beta, a_log, dt_bias
+
+
+def run_in_profile_range(torch, operation):
+    import torch_npu
+
+    range_id = torch_npu.npu.mstx.range_start(PROFILE_RANGE)
+    if not isinstance(range_id, int):
+        raise RuntimeError("torch_npu MSTX range_start is unavailable")
+    try:
+        output = operation()
+        torch.npu.synchronize()
+        return output
+    finally:
+        torch_npu.npu.mstx.range_end(range_id)
+
+
+def run_prefill_forward(torch, case: Case, device) -> None:
+    from fla_npu.ops.ascendc import chunk_kda_fwd
+
+    q, k, v, gate, beta, a_log, dt_bias = make_prefill_inputs(torch, case, device)
+    torch.npu.synchronize()
+    outputs = run_in_profile_range(
+        torch,
+        lambda: chunk_kda_fwd(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            KEY_DIM**-0.5,
+            CHUNK_SIZE,
+            layout="BSND",
+            output_final_state=False,
+            safe_gate=True,
+            lower_bound=-5.0,
+            use_gate_in_kernel=True,
+            A_log=a_log,
+            dt_bias=dt_bias,
+            disable_recompute=False,
+            return_intermediate_states=False,
+            state_v_first=True,
+        ),
+    )
+    print(f"BENCH_OK output_shape={tuple(outputs[0].shape)}", flush=True)
+
+
+def run_decode_forward(torch, case: Case, device, decode_step: int) -> None:
+    from fla_npu.ops.ascendc import recurrent_kda
+
+    query = torch.ones(
+        (case.batch, decode_step, HEADS, KEY_DIM), dtype=torch.bfloat16, device=device
+    )
+    key = torch.zeros_like(query)
+    value = torch.zeros(
+        (case.batch, decode_step, HEADS, VALUE_DIM),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    gate = torch.zeros(
+        (case.batch, decode_step, HEADS, KEY_DIM), dtype=torch.float32, device=device
+    )
+    beta = torch.zeros(
+        (case.batch, decode_step, HEADS), dtype=torch.float32, device=device
+    )
+    state = torch.zeros(
+        (case.batch, HEADS, VALUE_DIM, KEY_DIM),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    cu_seqlens = (
+        torch.arange(case.batch + 1, dtype=torch.int32, device=device) * decode_step
+    )
+    a_log = torch.zeros((HEADS,), dtype=torch.float32, device=device)
+    dt_bias = torch.zeros((HEADS, KEY_DIM), dtype=torch.float32, device=device)
+
+    def operation():
+        return recurrent_kda(
+            query,
+            key,
+            value,
+            gate,
+            beta,
+            state,
+            cu_seqlens=cu_seqlens,
+            A_log=a_log,
+            dt_bias=dt_bias,
+            layout="BSND",
+            output_final_state=False,
+            inplace_final_state=True,
+            use_qk_l2norm_in_kernel=True,
+            use_gate_in_kernel=True,
+            use_beta_sigmoid_in_kernel=True,
+            allow_neg_eigval=True,
+            safe_gate=True,
+            lower_bound=-4.0,
+            state_v_first=True,
+        )
+
+    def measured_operations():
+        output = None
+        for _ in range(DECODE_MEASURE_CALLS):
+            output, _ = operation()
+        return output
+
+    torch.npu.synchronize()
+    for _ in range(DECODE_TOTAL_CALLS - DECODE_MEASURE_CALLS):
+        operation()
+    torch.npu.synchronize()
+    output = run_in_profile_range(torch, measured_operations)
+    print(
+        f"BENCH_OK output_shape={tuple(output.shape)} "
+        f"decode_calls={DECODE_TOTAL_CALLS} measured_calls={DECODE_MEASURE_CALLS}",
+        flush=True,
+    )
+
+
+def run_worker(case: Case, device_visible_id: int, decode_step: int) -> int:
+    import torch
+    import torch_npu  # noqa: F401
+
+    device = torch.device(f"npu:{device_visible_id}")
+    torch.npu.set_device(device)
+    torch.manual_seed(20260806)
+    if case.phase == "decode":
+        run_decode_forward(torch, case, device, decode_step)
+    else:
+        run_prefill_forward(torch, case, device)
+    return 0
+
+
+def iter_profile_files(profile_dir: Path) -> Iterable[Path]:
+    visited = set()
+    for root, dirnames, filenames in os.walk(profile_dir, followlinks=True):
+        try:
+            stat = os.stat(root)
+        except OSError:
+            dirnames.clear()
+            continue
+        directory_id = (stat.st_dev, stat.st_ino)
+        if directory_id in visited:
+            dirnames.clear()
+            continue
+        visited.add(directory_id)
+        dirnames.sort()
+        filenames.sort()
+        for filename in filenames:
+            yield Path(root) / filename
+
+
+def read_profile_rows(profile_dir: Path) -> list[dict]:
+    records = []
+    for path in iter_profile_files(profile_dir):
+        if not BASIC_INFO_FILE.fullmatch(path.name):
+            continue
+        with path.open(newline="", encoding="utf-8-sig") as stream:
+            for row in csv.DictReader(stream):
+                normalized = {(key or "").strip(): value for key, value in row.items()}
+                duration = normalized.get("Task Duration(us)")
+                if not duration:
+                    continue
+                records.append(
+                    {
+                        "instance": path.parent.parent.name,
+                        "replay": path.parent.name,
+                        "op_name": normalized.get("Op Name", path.parent.parent.name),
+                        "op_type": normalized.get("Op Type", ""),
+                        "duration_us": float(duration),
+                        "discovery_index": len(records),
+                    }
+                )
+    return records
+
+
+def relative_display(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def profile_tree_lines(profile_dir: Path) -> list[str]:
+    if not profile_dir.exists():
+        return ["<profile directory does not exist>"]
+    lines = []
+    try:
+        paths = sorted(profile_dir.rglob("*"), key=lambda item: str(item))
+    except OSError as exc:
+        return [f"<unable to enumerate profile directory: {exc}>"]
+    for path in paths[:DIAGNOSTIC_TREE_LIMIT]:
+        display = relative_display(path, profile_dir)
+        try:
+            if path.is_symlink():
+                lines.append(f"LINK {display} -> {os.readlink(path)}")
+            elif path.is_dir():
+                lines.append(f"DIR  {display}/")
+            else:
+                lines.append(f"FILE {display} size={path.stat().st_size}")
+        except OSError as exc:
+            lines.append(f"ERR  {display}: {exc}")
+    if len(paths) > DIAGNOSTIC_TREE_LIMIT:
+        lines.append(f"... truncated {len(paths) - DIAGNOSTIC_TREE_LIMIT} entries")
+    return lines or ["<profile directory is empty>"]
+
+
+def csv_diagnostic_lines(profile_dir: Path) -> list[str]:
+    csv_paths = [
+        path for path in iter_profile_files(profile_dir) if path.suffix.lower() == ".csv"
+    ]
+    lines = [f"discovered_csv_count={len(csv_paths)}"]
+    basic_info_paths = [path for path in csv_paths if BASIC_INFO_FILE.fullmatch(path.name)]
+    lines.append(f"matching_basic_info_count={len(basic_info_paths)}")
+    for path in csv_paths[:DIAGNOSTIC_CSV_LIMIT]:
+        display = relative_display(path, profile_dir)
+        try:
+            with path.open(newline="", encoding="utf-8-sig", errors="replace") as stream:
+                reader = csv.reader(stream)
+                header = next(reader, [])
+                first_row = next(reader, [])
+            lines.append(f"CSV {display}")
+            lines.append(f"  header={json.dumps(header, ensure_ascii=False)}")
+            lines.append(f"  first_row={json.dumps(first_row, ensure_ascii=False)}")
+        except Exception as exc:
+            lines.append(f"CSV {display} read_error={type(exc).__name__}: {exc}")
+    if len(csv_paths) > DIAGNOSTIC_CSV_LIMIT:
+        lines.append(f"... truncated {len(csv_paths) - DIAGNOSTIC_CSV_LIMIT} CSV files")
+    return lines
+
+
+def log_tail_lines(path: Path) -> list[str]:
+    if not path.exists():
+        return [f"<log does not exist: {path}>"]
+    text = path.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+    if len(lines) > DIAGNOSTIC_LOG_LINES:
+        return [f"... last {DIAGNOSTIC_LOG_LINES} of {len(lines)} lines"] + lines[
+            -DIAGNOSTIC_LOG_LINES:
+        ]
+    return lines or ["<log is empty>"]
+
+
+def write_case_diagnostics(
+    args: argparse.Namespace,
+    result: dict,
+    *,
+    stage: str,
+    returncode: Optional[int],
+    log_paths: Iterable[Path],
+) -> str:
+    profile_dir = Path(result["profile_dir"])
+    diagnostics_path = args.output_dir / "logs" / f"{result['case_id']}.diagnostics.txt"
+    lines = [
+        f"case={result['case_id']}",
+        f"stage={stage}",
+        f"status={result['status']}",
+        f"note={result['note']}",
+        f"returncode={returncode}",
+        f"python={sys.version}",
+        f"platform={platform.platform()}",
+        f"msopprof={shutil.which('msopprof')}",
+        f"worker_command={result.get('worker_command', '')}",
+        "profile_commands="
+        + json.dumps(result.get("profile_commands", []), ensure_ascii=False),
+        f"profile_mode={result.get('profile_mode', '')}",
+        f"profile_dir={profile_dir}",
+        f"ASCEND_HOME_PATH={os.environ.get('ASCEND_HOME_PATH', '')}",
+        f"ASCEND_OPP_PATH={os.environ.get('ASCEND_OPP_PATH', '')}",
+        f"ASCEND_CUSTOM_OPP_PATH={os.environ.get('ASCEND_CUSTOM_OPP_PATH', '')}",
+        f"ASCEND_RT_VISIBLE_DEVICES={os.environ.get('ASCEND_RT_VISIBLE_DEVICES', '')}",
+        f"LD_PRELOAD={os.environ.get('LD_PRELOAD', '')}",
+        "",
+        "== Profile tree ==",
+        *profile_tree_lines(profile_dir),
+        "",
+        "== CSV inspection ==",
+        *csv_diagnostic_lines(profile_dir),
+    ]
+    for path in log_paths:
+        lines.extend(("", f"== Log tail: {path} ==", *log_tail_lines(path)))
+    diagnostics_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(diagnostics_path)
+
+
+def summarize_profile(records: Iterable[dict]) -> tuple[float, list[dict]]:
+    grouped: dict[str, list[float]] = {}
+    names: dict[str, str] = {}
+    for record in records:
+        instance = record["instance"]
+        grouped.setdefault(instance, []).append(record["duration_us"])
+        names[instance] = record["op_name"]
+    if not grouped:
+        raise RuntimeError("msopprof produced no matching OpBasicInfo rows")
+    breakdown = []
+    for instance, values in grouped.items():
+        median_us = statistics.median(values)
+        breakdown.append(
+            {
+                "instance": instance,
+                "op_name": names[instance],
+                "samples": len(values),
+                "median_us": median_us,
+                "min_us": min(values),
+                "max_us": max(values),
+            }
+        )
+    breakdown.sort(key=lambda item: item["median_us"], reverse=True)
+    return sum(item["median_us"] for item in breakdown), breakdown
+
+
+def natural_sort_key(value: str) -> tuple:
+    return tuple(
+        (1, int(part)) if part.isdigit() else (0, part.lower())
+        for part in re.split(r"(\d+)", value)
+    )
+
+
+def is_recurrent_kda_record(record: dict) -> bool:
+    identity = " ".join(
+        str(record.get(field, "")) for field in ("instance", "op_name", "op_type")
+    )
+    return "recurrentkda" in re.sub(r"[^a-z0-9]", "", identity.lower())
+
+
+def summarize_decode_profile(records: Iterable[dict]) -> tuple[float, list[dict]]:
+    recurrent_records = [record for record in records if is_recurrent_kda_record(record)]
+    recurrent_records.sort(key=lambda item: item["discovery_index"])
+    grouped: dict[str, list[float]] = {}
+    names: dict[str, str] = {}
+    first_seen: dict[str, int] = {}
+    for record in recurrent_records:
+        instance = record["instance"]
+        grouped.setdefault(instance, []).append(record["duration_us"])
+        names[instance] = record["op_name"]
+        first_seen.setdefault(instance, record["discovery_index"])
+    if len(grouped) < DECODE_MEASURE_CALLS:
+        if len(recurrent_records) < DECODE_MEASURE_CALLS:
+            raise RuntimeError(
+                "msopprof produced fewer than "
+                f"{DECODE_MEASURE_CALLS} recurrent_kda duration samples"
+            )
+        breakdown = []
+        selected_start = len(recurrent_records) - DECODE_MEASURE_CALLS
+        for index, record in enumerate(recurrent_records):
+            duration_us = record["duration_us"]
+            breakdown.append(
+                {
+                    "instance": f"{record['instance']}#sample_{index + 1}",
+                    "source_instance": record["instance"],
+                    "op_name": record["op_name"],
+                    "samples": 1,
+                    "median_us": duration_us,
+                    "min_us": duration_us,
+                    "max_us": duration_us,
+                    "first_seen": record["discovery_index"],
+                    "selected": index >= selected_start,
+                }
+            )
+        selected = recurrent_records[-DECODE_MEASURE_CALLS:]
+        return statistics.mean(record["duration_us"] for record in selected), breakdown
+
+    breakdown = []
+    for instance, values in grouped.items():
+        breakdown.append(
+            {
+                "instance": instance,
+                "op_name": names[instance],
+                "samples": len(values),
+                "median_us": statistics.median(values),
+                "min_us": min(values),
+                "max_us": max(values),
+                "first_seen": first_seen[instance],
+                "selected": False,
+            }
+        )
+    breakdown.sort(
+        key=lambda item: (natural_sort_key(item["instance"]), item["first_seen"])
+    )
+    selected = breakdown[-DECODE_MEASURE_CALLS:]
+    for item in selected:
+        item["selected"] = True
+    return statistics.mean(item["median_us"] for item in selected), breakdown
+
+
+def classify_failure(log_text: str, returncode: int) -> tuple[str, str]:
+    runtime_errors = re.findall(r"(?:RuntimeError|ValueError):\s*(.+)", log_text)
+    if runtime_errors:
+        return "ERROR", runtime_errors[-1].strip()
+    if re.search(
+        r"out of memory|\bOOM\b|cannot allocate memory|ACL_ERROR_RT_MEMORY",
+        log_text,
+        re.IGNORECASE,
+    ):
+        return "OOM", "device memory allocation failed"
+    return "ERROR", f"msopprof/worker exited with status {returncode}"
+
+
+def run_logged(command, *, cwd: Path, env: dict, log, timeout: int) -> tuple[int, bool]:
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=env,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    try:
+        return process.wait(timeout=timeout), False
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait()
+        return process.returncode, True
+
+
+def requested_shape(case: Case) -> str:
+    return f"[{case.batch}, {case.sequence}, {HEADS}, {KEY_DIM}]"
+
+
+def executed_shape(case: Case, decode_step: int) -> str:
+    if case.phase == "decode":
+        return (
+            f"[{case.batch}, {decode_step}, {HEADS}, {KEY_DIM}] BSND x "
+            f"{DECODE_TOTAL_CALLS} consecutive calls; last {DECODE_MEASURE_CALLS} averaged; "
+            f"state=[{case.batch}, {HEADS}, {VALUE_DIM}, {KEY_DIM}]"
+        )
+    return requested_shape(case)
+
+
+def speedup(baseline_us: Optional[float], actual_us: Optional[float]) -> Optional[float]:
+    if baseline_us is None or actual_us is None or actual_us <= 0:
+        return None
+    return baseline_us / actual_us
+
+
+def kernel_name_filter(case: Case) -> str:
+    if case.phase == "prefill":
+        return PREFILL_KERNEL_FILTER
+    return DECODE_KERNEL_FILTER
+
+
+def profile_attempts(
+    args: argparse.Namespace, case: Case, case_dir: Path, worker: list[str]
+) -> list[dict]:
+    common_options = [
+        "msopprof",
+        f"--application={shell_join(worker)}",
+        f"--aic-metrics={args.aic_metrics}",
+        f"--launch-count={args.launch_count}",
+        f"--warm-up={args.warm_up}",
+        "--replay-mode=application",
+        "--kill=off",
+    ]
+    return [
+        {
+            "mode": "application_mstx",
+            "profile_dir": case_dir / "application_mstx",
+            "metric_scope": (
+                "sum of median msopprof BasicInfo durations in the KDA MSTX range "
+                "using application replay"
+            ),
+            "command": [
+                *common_options,
+                f"--output={case_dir / 'application_mstx'}",
+                "--mstx=on",
+                f"--mstx-include={PROFILE_RANGE}",
+            ],
+        },
+        {
+            "mode": "application_kernel_filter",
+            "profile_dir": case_dir / "application_kernel_filter",
+            "metric_scope": (
+                "sum of median msopprof BasicInfo durations for explicitly selected "
+                "KDA stages using application replay"
+            ),
+            "command": [
+                *common_options,
+                f"--output={case_dir / 'application_kernel_filter'}",
+                f"--kernel-name={kernel_name_filter(case)}",
+            ],
+        },
+    ]
+
+
+def run_profile(args: argparse.Namespace, case: Case) -> dict:
+    case_dir = args.output_dir / "profiles" / case.case_id
+    case_dir.mkdir(parents=True, exist_ok=False)
+    preflight_log_path = args.output_dir / "logs" / f"{case.case_id}.preflight.log"
+    worker = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--worker",
+        case.case_id,
+        "--device-visible-id",
+        str(args.device_visible_id),
+        "--decode-step",
+        str(args.decode_step),
+    ]
+    attempts = profile_attempts(args, case, case_dir, worker)
+    env = os.environ.copy()
+    env["TEST_DEVICE_ID"] = str(args.device_visible_id)
+    result = {
+        **asdict(case),
+        "requested_qkv_shape": requested_shape(case),
+        "executed_shape": executed_shape(case, args.decode_step),
+        "status": "PASS",
+        "fla_npu_us": None,
+        "speedup_vs_h100": None,
+        "speedup_vs_optimized_npu": None,
+        "metric_scope": "",
+        "profile_dir": str(case_dir),
+        "selected_profile_dir": "",
+        "log": "",
+        "diagnostics": "",
+        "worker_command": shell_join(worker),
+        "profile_commands": [shell_join(attempt["command"]) for attempt in attempts],
+        "profile_mode": "",
+        "note": "",
+        "breakdown": [],
+        "profiled_segment_us": None,
+        "aggregation_factor": 1,
+        "decode_step": args.decode_step if case.phase == "decode" else None,
+        "decode_total_calls": DECODE_TOTAL_CALLS if case.phase == "decode" else None,
+        "decode_measure_calls": DECODE_MEASURE_CALLS if case.phase == "decode" else None,
+    }
+    with preflight_log_path.open("w", encoding="utf-8") as preflight_log:
+        preflight_returncode, preflight_timed_out = run_logged(
+            worker,
+            cwd=args.repo_dir,
+            env=env,
+            log=preflight_log,
+            timeout=args.case_timeout,
+        )
+    if preflight_timed_out:
+        result["status"] = "TIMEOUT"
+        result["log"] = str(preflight_log_path)
+        result["note"] = f"preflight exceeded {args.case_timeout} seconds"
+        result["diagnostics"] = write_case_diagnostics(
+            args,
+            result,
+            stage="preflight_timeout",
+            returncode=preflight_returncode,
+            log_paths=(preflight_log_path,),
+        )
+        return result
+    if preflight_returncode != 0:
+        log_text = preflight_log_path.read_text(encoding="utf-8", errors="replace")
+        result["status"], note = classify_failure(log_text, preflight_returncode)
+        result["log"] = str(preflight_log_path)
+        result["note"] = f"preflight failed: {note}"
+        result["diagnostics"] = write_case_diagnostics(
+            args,
+            result,
+            stage="preflight",
+            returncode=preflight_returncode,
+            log_paths=(preflight_log_path,),
+        )
+        return result
+    attempt_notes = []
+    attempt_statuses = []
+    attempt_log_paths = []
+    profile_returncode = None
+    total_us = None
+    breakdown = []
+    for attempt in attempts:
+        mode = attempt["mode"]
+        log_path = args.output_dir / "logs" / f"{case.case_id}.{mode}.log"
+        attempt_log_paths.append(log_path)
+        command = attempt["command"]
+        result["log"] = str(log_path)
+        with log_path.open("w", encoding="utf-8") as log:
+            log.write(f"command={shell_join(command)}\n")
+            log.flush()
+            profile_returncode, profile_timed_out = run_logged(
+                command,
+                cwd=args.repo_dir,
+                env=env,
+                log=log,
+                timeout=args.case_timeout,
+            )
+        log_text = log_path.read_text(encoding="utf-8", errors="replace")
+        if profile_timed_out:
+            attempt_statuses.append("TIMEOUT")
+            attempt_notes.append(f"{mode}: exceeded {args.case_timeout} seconds")
+            continue
+        if profile_returncode != 0:
+            status, note = classify_failure(log_text, profile_returncode)
+            attempt_statuses.append(status)
+            attempt_notes.append(f"{mode}: {note}")
+            continue
+        try:
+            records = read_profile_rows(attempt["profile_dir"])
+            if case.phase == "decode":
+                total_us, breakdown = summarize_decode_profile(records)
+            else:
+                total_us, breakdown = summarize_profile(records)
+        except Exception as exc:
+            attempt_statuses.append("ERROR")
+            attempt_notes.append(f"{mode}: {exc}")
+            continue
+        result["profile_mode"] = mode
+        if case.phase == "decode":
+            result["metric_scope"] = (
+                f"mean of the last {DECODE_MEASURE_CALLS} recurrent_kda call durations "
+                f"after {DECODE_TOTAL_CALLS - DECODE_MEASURE_CALLS} warm-up calls"
+            )
+        else:
+            result["metric_scope"] = attempt["metric_scope"]
+        result["selected_profile_dir"] = str(attempt["profile_dir"])
+        break
+
+    if total_us is None:
+        if "OOM" in attempt_statuses:
+            result["status"] = "OOM"
+        elif attempt_statuses and all(status == "TIMEOUT" for status in attempt_statuses):
+            result["status"] = "TIMEOUT"
+        else:
+            result["status"] = "ERROR"
+        result["note"] = "; ".join(attempt_notes)
+        result["diagnostics"] = write_case_diagnostics(
+            args,
+            result,
+            stage="profile_attempts",
+            returncode=profile_returncode,
+            log_paths=(preflight_log_path, *attempt_log_paths),
+        )
+        return result
+    result["profiled_segment_us"] = total_us
+    if case.phase == "decode":
+        result["aggregation_factor"] = case.sequence // args.decode_step
+        total_us *= result["aggregation_factor"]
+    result["fla_npu_us"] = total_us
+    result["speedup_vs_h100"] = speedup(case.h100_us, total_us)
+    result["speedup_vs_optimized_npu"] = speedup(case.optimized_npu_us, total_us)
+    result["breakdown"] = breakdown
+    notes = []
+    if attempt_notes:
+        notes.append(
+            f"profiled with {result['profile_mode']} after " + "; ".join(attempt_notes)
+        )
+    if case.phase == "decode":
+        notes.append(
+            f"recurrent_kda runs {DECODE_TOTAL_CALLS} consecutive calls on one in-place BF16 "
+            f"[B,H,V,K] state; the mean of the last {DECODE_MEASURE_CALLS} call durations "
+            f"is multiplied by {result['aggregation_factor']} calls for full S={case.sequence}."
+        )
+    result["note"] = " ".join(notes)
+    return result
+
+
+def format_number(value: Optional[float], digits: int = 3) -> str:
+    if value is None:
+        return "-"
+    return f"{value:.{digits}f}"
+
+
+def write_reports(args: argparse.Namespace, results: list[dict]) -> None:
+    from importlib import metadata as package_metadata
+
+    metadata = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "repo_commit": args.repo_commit,
+        "soc": args.soc,
+        "device_visible_id": args.device_visible_id,
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "warm_up": args.warm_up,
+        "launch_count": args.launch_count,
+        "case_timeout": args.case_timeout,
+        "aic_metrics": args.aic_metrics,
+        "decode_step": args.decode_step,
+        "decode_total_calls": DECODE_TOTAL_CALLS,
+        "decode_measure_calls": DECODE_MEASURE_CALLS,
+        "decode_contract": (
+            "S=8192 is total recurrent progression length. Each recurrent_kda call processes "
+            f"T_step={args.decode_step} token(s) per sequence and updates the same state in place. "
+            f"The worker runs {DECODE_TOTAL_CALLS} consecutive calls and averages the last "
+            f"{DECODE_MEASURE_CALLS} device-kernel durations."
+        ),
+        "profile_attempt_order": [
+            "application replay with MSTX range filtering",
+            "application replay with explicit KDA stage filtering",
+        ],
+    }
+    try:
+        metadata["torch"] = package_metadata.version("torch")
+        metadata["torch_npu"] = package_metadata.version("torch-npu")
+    except package_metadata.PackageNotFoundError:
+        pass
+    payload = {"metadata": metadata, "results": results}
+    (args.output_dir / "results.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    diagnostics = [result for result in results if result.get("diagnostics")]
+    if diagnostics:
+        sections = []
+        for result in diagnostics:
+            path = Path(result["diagnostics"])
+            sections.extend(
+                (
+                    f"######## {result['case_id']} ########",
+                    path.read_text(encoding="utf-8", errors="replace"),
+                )
+            )
+        (args.output_dir / "diagnostics.txt").write_text(
+            "\n".join(sections), encoding="utf-8"
+        )
+
+    columns = (
+        "case_id",
+        "phase",
+        "direction",
+        "batch",
+        "sequence",
+        "requested_qkv_shape",
+        "executed_shape",
+        "status",
+        "h100_us",
+        "optimized_npu_us",
+        "fla_npu_us",
+        "profiled_segment_us",
+        "aggregation_factor",
+        "decode_step",
+        "decode_total_calls",
+        "decode_measure_calls",
+        "speedup_vs_h100",
+        "speedup_vs_optimized_npu",
+        "metric_scope",
+        "profile_mode",
+        "note",
+        "profile_dir",
+        "selected_profile_dir",
+        "log",
+        "diagnostics",
+    )
+    with (args.output_dir / "results.csv").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=columns, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(results)
+
+    lines = [
+        "# fla_npu main KDA performance",
+        "",
+        f"- commit: `{args.repo_commit}`",
+        f"- SOC: `{args.soc}`",
+        "- unit: microseconds",
+        f"- msopprof AI Core metrics: `{args.aic_metrics}`",
+        "- prefill metric: sum of median msopprof BasicInfo durations for selected KDA stages",
+        f"- decode metric: {DECODE_TOTAL_CALLS} consecutive calls, mean of the last "
+        f"{DECODE_MEASURE_CALLS} device-kernel durations, multiplied by "
+        f"`8192 / {args.decode_step}`",
+        f"- decode semantic: `S=8192` total recurrent steps, `T_step={args.decode_step}`, state carried in place",
+        "",
+        "| case | phase | dir | B | S | status | profiler | H100 us | optimized NPU us | "
+        "fla_npu us | vs H100 | vs optimized NPU |",
+        "| --- | --- | --- | ---: | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for result in results:
+        lines.append(
+            "| {case_id} | {phase} | {direction} | {batch} | {sequence} | {status} | "
+            "{profile_mode} | "
+            "{h100} | {optimized} | {actual} | {vs_h100} | {vs_optimized} |".format(
+                **result,
+                h100=format_number(result["h100_us"]),
+                optimized=format_number(result["optimized_npu_us"]),
+                actual=format_number(result["fla_npu_us"]),
+                vs_h100=(
+                    f"{result['speedup_vs_h100']:.3f}x"
+                    if result["speedup_vs_h100"] is not None
+                    else "-"
+                ),
+                vs_optimized=(
+                    f"{result['speedup_vs_optimized_npu']:.3f}x"
+                    if result["speedup_vs_optimized_npu"] is not None
+                    else "-"
+                ),
+            )
+        )
+    notes = [result for result in results if result["note"]]
+    if notes:
+        lines.extend(("", "## Notes", ""))
+        lines.extend(f"- `{result['case_id']}`: {result['note']}" for result in notes)
+    (args.output_dir / "results.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    if sys.version_info < (3, 9):
+        raise SystemExit(
+            "benchmark_kda_matrix.py requires Python 3.9 or newer; "
+            f"found {platform.python_version()}"
+        )
+    if not args.aic_metrics:
+        raise ValueError("--aic-metrics must not be empty")
+    if args.decode_step < 1 or args.decode_step > 8:
+        raise ValueError("--decode-step must be in [1, 8]")
+    if any(case.sequence % args.decode_step for case in CASES if case.phase == "decode"):
+        raise ValueError("--decode-step must divide every selected decode sequence length")
+    if args.worker:
+        return run_worker(CASE_BY_ID[args.worker], args.device_visible_id, args.decode_step)
+    if args.output_dir is None or args.repo_dir is None:
+        raise ValueError("--output-dir and --repo-dir are required in orchestrator mode")
+    if args.output_dir.exists() and any(args.output_dir.iterdir()):
+        raise FileExistsError(f"output directory is not empty: {args.output_dir}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "logs").mkdir()
+    results = []
+    for index, case in enumerate(selected_cases(args.cases), start=1):
+        print(f"[{index}] profiling {case.case_id}", flush=True)
+        result = run_profile(args, case)
+        results.append(result)
+        print(
+            f"    status={result['status']} fla_npu_us={format_number(result['fla_npu_us'])}",
+            flush=True,
+        )
+        if result["status"] != "PASS":
+            print(f"    note={result['note']}", flush=True)
+            if result.get("diagnostics"):
+                print(f"    diagnostics={result['diagnostics']}", flush=True)
+        write_reports(args, results)
+    print((args.output_dir / "results.md").read_text(encoding="utf-8"), flush=True)
+    diagnostics_path = args.output_dir / "diagnostics.txt"
+    if diagnostics_path.exists():
+        print(f"Diagnostics: {diagnostics_path}", flush=True)
+    failed_case_ids = [
+        result["case_id"] for result in results if result["status"] != "PASS"
+    ]
+    if failed_case_ids:
+        print(
+            "Benchmark failed cases: " + ", ".join(failed_case_ids),
+            file=sys.stderr,
+            flush=True,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/operators/chunk_kda_fwd/README.md
+++ b/tests/operators/chunk_kda_fwd/README.md
@@ -54,6 +54,23 @@ FLA_NPU_RUN_OPERATOR_TESTS=1 pytest -q tests/operators/chunk_kda_fwd/st/test_exa
 cd examples/fast_kernel_launch_example && FAST_KERNEL_OP_NAME=chunk_kda_fwd pytest -q tests/chunk_kda_fwd
 ```
 
+`scripts/benchmark_kda_main.sh` 提供独立 wheel 构建、安装、打包 API 自检和 `msopprof`
+报告聚合入口。默认直接使用当前
+checkout，不访问远端仓库；需要验证远端 ref 时才同时传入 `--repo-url` 和 `--ref`：
+
+```bash
+bash scripts/benchmark_kda_main.sh \
+  --soc ascend950 \
+  --device 0 \
+  --work-root "$PWD/outputs/kda-main-benchmark" \
+  --cases prefill_fwd_b1_s8192,prefill_fwd_b1_s16384
+```
+
+该入口的 prefill 固定为 BF16、`H=96`、`K=V=128`、`chunk_size=64`、
+`initial_state=None`、`output_final_state=False`、`use_gate_in_kernel=True`、
+`safe_gate=True`、`state_v_first=True`。报告使用 `msopprof` 设备侧耗时；任一 case 出现
+`ERROR`、`OOM` 或 `TIMEOUT` 时，入口返回非零状态并保留逐 case 诊断。
+
 A5 PR264 一键构建、隔离安装和基础验收：
 
 ```bash


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> 本 PR 创建后按仓库规则请求 Admin 在当前 head commit 上触发 NPU CI；后续如更新 commit，需要重新触发。

## 关联 Issue / 背景

- 关联 Issue: 无；按本次要求仅提交 Draft PR，暂不创建独立 issue。
- 背景与目标: 提供跨 A2/A3/A5 的 KDA 正向一键性能测试入口，从拉取主线、构建安装 wheel 到输出 msopprof 报告形成闭环。
- 本 PR 解决的问题: 统一 prefill/decode case、decode 小步长推进语义、profiling 口径、错误分类和结果格式，避免依赖机器硬编码或 Python wall time。

## 变更类型

- [ ] Bug 修复
- [x] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `chunk_kda_fwd`、`recurrent_kda`（仅性能测试入口）
- 涉及目录 / 文件: `scripts/benchmark_kda_main.sh`、`scripts/benchmark_kda_matrix.py`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: prefill 覆盖 `B=1,S=1024/8192/65536,H=96,K=V=128`；decode 覆盖 `B=1/4/16/64,S=8192,H=96,K=V=128`，单次 `decode_step=1..8`，Q/K/V 为 BF16，state 为 BF16 V-first。
- 明确不包含的范围: 不修改算子实现、公共 API、精度逻辑或 backward；不提供 Python wall time 性能结论。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无，仅新增独立脚本。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

静态检查：

```sh
bash -n scripts/benchmark_kda_main.sh
python3 -m py_compile scripts/benchmark_kda_matrix.py
shellcheck scripts/benchmark_kda_main.sh
git diff --check
```

A2/A3/A5 一键验证：

```sh
bash scripts/benchmark_kda_main.sh \
  --soc <ascend910b|ascend910_93|ascend950> \
  --device 0 \
  --work-root <work_dir> \
  --cases all \
  --decode-step 1
```

通过标准：wheel 构建安装和打包 API 自检通过；所有 case 生成 msopprof BasicInfo 结果；报告中无 `ERROR`、`OOM` 或 `TIMEOUT`。

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未验证 | 一键脚本 | 未执行 | 本次只在 CANN 9.1 环境验证 |
| A3 | `ascend910_93` | 未验证 | 一键脚本 | 未执行 | 当前无可用环境 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1 beta1 | 一键脚本，1k prefill 与 B1 decode smoke | 未通过 | wheel 构建、安装和打包 API 自检通过；算子预检因 tiling compile-info 缺少 `_pattern` 返回 561103 |
| A3 | `ascend910_93` | 未验证 | 一键脚本 | 未执行 | 当前无可用环境 |
| A5 | `ascend950` | 未验证 | 一键脚本 | 未执行 | 需要在 A5 DT 环境补齐 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 一键脚本 smoke case | 未通过 | prefill/decode 均在 workspace 查询阶段返回 561103，未形成性能结论 |
| A3 | `ascend910_93` | 一键脚本 | 未执行 | 当前无可用环境 |
| A5 | `ascend950` | 一键脚本 | 未执行 | 需要在 A5 DT 环境补齐 |

- 精度对比: 不涉及精度实现变更。
- 性能对比: A2 环境阻塞，未生成可公开的有效性能数字。
- 边界 / 异常场景: 已验证缺少 `--soc`、运行错误分类和 case 超时保护。
- 未覆盖风险: A3/A5 实际构建与 msopprof 输出格式尚未验证；A2 需在兼容 CANN 环境复测。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 仅新增独立性能脚本，不修改 example 或算子实现 |
| A3 | `ascend910_93` | 同上 | 未执行 | 当前无可用环境 |
| A5 | `ascend950` | 同上 | 未执行 | 当前无可用环境 |

- 端到端场景说明: 不涉及端到端行为变更。
- 与本 PR 修改算子的关联: 仅新增 `chunk_kda_fwd`/`recurrent_kda` 性能测试入口。
- 未覆盖原因及补充计划: 合入前由 NPU CI 或对应平台补齐必要验证。

</details>

## 兼容性、风险与回退

- 兼容性说明: SOC、设备、CANN、conda、源码地址、分支和工作目录均参数化；默认不写死 A2/A5 服务器环境。A5 使用 `--soc ascend950`。
- 风险点: 不同 CANN/msopprof 版本的输出目录或 CSV 字段可能变化；decode 总耗时按单段 msopprof 结果乘以调用次数聚合，不包含 Python launch wall time。
- 回退方案: 删除新增的两个脚本即可，不影响任何已有接口或运行路径。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因（本次仅提交 Draft PR，暂不创建独立 issue）
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- prefill 使用 `chunk_kda_fwd` 并在 MSTX 范围内汇总复合算子的 device kernel 时间。
- decode 遵循 `recurrent_kda` 每条序列单次长度不超过 8 的契约；`S=8192` 表示累计推进长度，默认 `decode_step=1`，同一 BF16 state 原位续接。
- `results.json` 同时保留单段 `profile_range_us` 和完整 workload 的 `aggregation_factor`，便于复核聚合口径。
