### PR TITLE
docs: 整改生态仓 README 易用性

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -85,6 +85,7 @@
 在每套 CANN / 产品环境中先确认基础信息。
 
 ```sh
+# 默认 CANN 安装路径；自定义安装路径时替换为实际路径下对应的 set_env.sh
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
 cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
 npu-smi info

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ ABI 敏感路径包括 `*_def.cpp`、`aclnn_*.h/.cpp`、`torch_custom/fla_npu/*.
 先准备环境：
 
 ```sh
+# CANN 安装于自定义路径时，请替换为实际路径下对应的 set_env.sh
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
 python -m pip install -r requirements.txt
 python scripts/check_npu_env.py --build-only
@@ -101,16 +102,10 @@ FLA_NPU_SOC=ascend910b python -m pip wheel --no-build-isolation --no-deps . -w d
 - A3：`ascend910_93`
 - A5：`ascend950`
 
-本地增量调试可以使用：
+修改源码或适配后，重新执行同一条一体化 wheel 构建命令即全量重编；构建流程会清理上一轮 `build/`、`build_out/`、`output/` 中间产物，不再支持增量构建。只定位单算子时，用 `bash build.sh --pkg --soc=<soc> --vendor_name=fla_npu --ops=<op>` 构建单算子 run 包：
 
 ```sh
-FLA_NPU_SOC=ascend910b FLA_NPU_INCREMENTAL_BUILD=1 python -m pip wheel --no-build-isolation --no-deps . -w dist
-```
-
-只构建部分算子用于定位时使用 `FLA_NPU_OPS`，不要和 `FLA_NPU_INCREMENTAL_BUILD` 同时使用：
-
-```sh
-FLA_NPU_SOC=ascend910b FLA_NPU_OPS=chunk_fwd_o python -m pip wheel --no-build-isolation --no-deps . -w dist
+bash build.sh --pkg --soc=ascend910b --vendor_name=fla_npu --ops=chunk_fwd_o
 ```
 
 分开编 OPP run 包和 `torch_custom` 适配时：

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,18 @@
   #### 4. PR 上库  
   Committer 检视通过后，Maintainer 将进行最终审核。确认无误后，将标注 `/lgtm` 和 `/approve` 标签合入PR。
 
+### 本仓特有的贡献要求
+
+本仓在 CANN 算子上层还维护了 `torch_custom/fla_npu` 的 Python runtime 适配，新增算子除上述最小交付件外，还必须满足：
+
+- **提供稳定 Python 入口**：新增算子必须在 `fla_npu.ops.ascendc` 下提供可调用的 Python 接口（经 `_aclnn_ctypes.py` wrapper + `_ASCENDC_OPS` 注册），不得仅以 legacy `torch.ops.npu.*` / `torch_npu.ops.*` 路径交付。
+- **交付内容**：至少包含
+  - `torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py` 中的 `npu_<op>(...)` wrapper；
+  - `torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py` 的 `_ASCENDC_OPS` 注册（需要时同步 `BACKWARD_OPS` 正反向映射与 `MUTATED_ARGUMENTS` mutation 契约）；
+  - `torch_custom/fla_npu/test/test_npu_<op>.py` 单算子测试并接入 `test.sh`。
+- **默认调用路径**：新增算子与测试默认使用 `fla_npu.ops.ascendc`，新代码不要默认依赖 legacy 路径（legacy 路径仅用于兼容性验证，且需要 `FLA_NPU_BUILD_LEGACY_EXTENSION=1` 额外构建）。
+- 具体接入步骤见根 README 的"在 torch_custom 新增 Python 接口"与 `torch_custom/fla_npu/README.md`。
+
 ### 文档纠错
 
   如果您在本项目中发现某些算子文档描述错误，欢迎您新建Issue进行反馈和修复。

--- a/README.md
+++ b/README.md
@@ -9,24 +9,44 @@
 
 flash-linear-attention-npu 算子库由天津大学主导开发，是一个面向昇腾架构的高性能线性注意力算子库，对标 Flash-Linear-Attention 项目，旨在为昇腾平台提供高效的线性注意力计算实现。
 
+本仓不自动安装 `torch`、`torch_npu`、`torchnpugen`、`triton-ascend`，这些包必须与 CANN 与 Python 版本匹配，需要使用者按环境自行安装；版本不匹配时，构建或运行会报错。依赖匹配关系与检查方式见下文 Step 1 / Step 2。
+
 ## ⚡️快速上手
+
+### Step 0. 确认硬件与目标芯片
+
+在开始前，先确认机器上可用的 NPU 类型：
+
+```sh
+npu-smi info
+```
+
+确认机器类型后，按目标芯片选择后续构建参数（`--soc` / `FLA_NPU_SOC`）：
+
+| 产品 | `--soc` / `FLA_NPU_SOC` |
+|---|---|
+| A2 | `ascend910b` |
+| A3 | `ascend910_93` |
+| A5 | `ascend950` |
 
 ### Step 1. 部署 CANN 开发环境
 
 首先需安装 CANN 开发包，提供 NPU 算子运行所需的底层驱动与工具链。
-推荐使用是社区版8.5.2，总共要下2个run包，这里以A3机器为例（即需要下载A3-ops、toolkit）
+推荐社区版 8.5.2，总共需要下载 2 个 run 包。这里以 A3 机器为例（即需要下载 A3-ops 与 toolkit），A2 / A5 机器请下载对应的 ops 与 toolkit 包。
 下载地址为
 [https://www.hiascend.com/developer/download/community/result?module=cann&cann=8.5.2](https://www.hiascend.com/developer/download/community/result?module=cann&cann=8.5.2)
 需要找到与你当前机器对应的包
 
 ```
-#设置需要安装的路径
+# 设置需要安装的路径（请替换为实际安装路径）
 export INSTALL_PATH=/usr/local/Ascend
 
 ./Ascend-cann-toolkit*run --install-path=$INSTALL_PATH --full  --quiet
 ./Ascend-cann-A3*run --install-path=$INSTALL_PATH --install --quiet
 source $INSTALL_PATH/ascend-toolkit/set_env.sh
 ```
+
+> 若 CANN 安装在自定义路径，请将 `INSTALL_PATH` 设置为实际安装路径，并 source 实际路径下对应的 `set_env.sh`（上述 `/usr/local/Ascend` 仅为默认安装路径）。每次进入新的 shell（含 Docker / Conda / venv）后，都需要重新 source `set_env.sh` 才能正常编译与运行。
 
 ### Step 2. 编译
 
@@ -40,28 +60,20 @@ python -m pip install -r requirements.txt
 python scripts/check_npu_env.py --build-only
 ```
 
-如果依赖缺失，预检和一键编包都会在真正编译前失败，并列出缺失项，例如 `torch`、`torch_npu`、`torchnpugen.*`、`triton` 或 `triton-ascend distribution was not found`。依赖通过后再生成 wheel：
+`--build-only` 预检只检查构建纯 Python wheel 所需的环境（Python / bash / CANN），不会检查 `torch`、`torch_npu`、`torchnpugen`、`triton-ascend` 等 torch 系依赖；这些依赖需要按 CANN 与 Python 版本自行匹配安装，缺失或版本不匹配时，请在构建前先安装正确版本。预检通过后再生成 wheel：
 
 ```sh
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
 FLA_NPU_SOC=ascend910b python -m pip wheel --no-build-isolation --no-deps . -w dist
 ```
 
-如果已经做过一次完整编译，之后只修改少量算子源码，可以复用上一次 CMake build 目录做完整 wheel 的真增量构建：
-
-```sh
-FLA_NPU_SOC=ascend910b FLA_NPU_INCREMENTAL_BUILD=1 python -m pip wheel --no-build-isolation --no-deps . -w dist
-```
-
-增量构建仅建议用于本地反复调试。构建完成后，wheel 会输出到 `dist/` 目录，按 Step 3 安装即可。
+修改源码或适配后，重新执行同一条一键编包命令做全量构建；构建流程会清理上一轮 `build/`、`build_out/`、`output/` 中间产物，避免增量编译带来的残留问题。构建完成后，wheel 会输出到 `dist/` 目录，按 Step 3 安装即可。
 
 方式 A 编译可用环境变量：
 
 | 环境变量 | 可选范围 | 作用 / 建议 | 默认 |
 |---|---|---|---|
 | `FLA_NPU_SOC` | `ascend910b` / `ascend910_93` / `ascend950` | 目标芯片；按实际运行机器选择 | `ascend910b` |
-| `FLA_NPU_INCREMENTAL_BUILD` | `TRUE` / `FALSE` | 复用 `build/` 做完整 wheel 的真增量构建；本地反复调试可设 `TRUE`，release wheel 或干净验证建议保持 `FALSE` | `FALSE` |
-| `FLA_NPU_OPS` | 逗号分隔的算子名，如 `chunk_fwd_o,recompute_wu_fwd` | 仅构建指定算子；用于单算子定位，不要用于 release wheel | 空 |
 | `FLA_NPU_SKIP_RUN_BUILD` | `TRUE` / `FALSE` | 跳过 run 包编译；仅在已准备好匹配的 `build_out/fla-npu-*.run` 且只重打 wheel 时可设 `TRUE`，常规构建建议保持 `FALSE` | `FALSE` |
 | `FLA_NPU_SKIP_RUN_INSTALL` | `TRUE` / `FALSE` | 跳过将 run 包安装产物内嵌到 wheel；会得到不含内嵌 OPP 的 wheel，除非使用外部 OPP 调试，否则建议保持 `FALSE` | `FALSE` |
 | `FLA_NPU_DISABLE_LOCAL_VERSION` | `TRUE` / `FALSE` | wheel 版本号不追加 SOC/torch/ABI 本地版本；内部统一发版需要固定版本号时可设 `TRUE`，日常构建建议保持 `FALSE` 以区分产物兼容范围 | `FALSE` |
@@ -79,10 +91,6 @@ bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu --ops=chunk_fwd_o
 # 如果 Python wrapper 也有修改，再单独编译 Python runtime wheel
 cd torch_custom/fla_npu
 python3 setup.py bdist_wheel
-
-# 如需继续验证旧 torch.ops.npu 路径，可显式编译 legacy PyTorch C++ extension
-FLA_NPU_BUILD_LEGACY_EXTENSION=1 bash gen.sh npu_custom.yaml
-FLA_NPU_BUILD_LEGACY_EXTENSION=1 python3 setup.py bdist_wheel
 ```
 
 ### Step 3. 安装
@@ -92,10 +100,12 @@ FLA_NPU_BUILD_LEGACY_EXTENSION=1 python3 setup.py bdist_wheel
 方式 A 产物可以来自本地源码一键编译，也可以直接使用 [Release v26.6.0](https://github.com/flashserve/flash-linear-attention-npu/releases/tag/v26.6.0) 提供的官方验证 wheel。下载或构建完成后执行：
 
 ```sh
-python -m pip install --force-reinstall --no-deps dist/flash_linear_attention_npu-*.whl
+# 将 WHEEL_PATH 设置为实际 wheel 文件路径：
+# 本地构建产物位于 dist/ 目录，请使用构建日志输出的准确文件名（勿用通配符，避免匹配多个产物）；
+# Release 下载的 wheel 则填实际下载路径。
+WHEEL_PATH="dist/<准确wheel文件名>.whl"
+python -m pip install --force-reinstall --no-cache-dir --no-deps "$WHEEL_PATH"
 ```
-
-如果使用 Release 下载的 wheel，将命令中的 `dist/flash_linear_attention_npu-*.whl` 替换为实际下载路径。
 
 #### 方式 B 产物安装
 
@@ -107,8 +117,9 @@ python -m pip install --force-reinstall --no-deps dist/flash_linear_attention_np
 # 或等价写法
 ./build_out/fla-npu-*.run --full
 
-# 如果 Python wrapper 也有修改，再安装单独编译出的 wheel
-python -m pip install --force-reinstall --no-deps torch_custom/fla_npu/dist/flash_linear_attention_npu-*.whl
+# 如果 Python wrapper 也有修改，再安装单独编译出的 wheel（路径替换为实际产物文件名）
+WHEEL_PATH="torch_custom/fla_npu/dist/<准确wheel文件名>.whl"
+python -m pip install --force-reinstall --no-cache-dir --no-deps "$WHEEL_PATH"
 ```
 
 安装 run 包后需要重启 Python 进程，已经 `dlopen` 的 `libcust_opapi.so` 不会在同一进程内热替换。
@@ -120,12 +131,65 @@ python -m pip install --force-reinstall --no-deps torch_custom/fla_npu/dist/flas
 安装后两种方式均可用以下命令验证：
 
 ```sh
-python -c "import fla_npu; print(fla_npu.is_legacy_torch_ops_loaded())"
-python -c "from fla_npu.ops import ascendc; import torch_npu; print(hasattr(torch_npu.ops, 'chunk_fwd_o'))"
+python -c "import fla_npu; print('ok')"
 python scripts/check_packaged_wheel_api.py
 ```
 
-`torch.ops.npu.*` 是 legacy extension 的过渡用法，后续版本不再支持。新代码优先使用 `fla_npu.ops.ascendc` 下的稳定 Python 入口。
+`import fla_npu` 成功即表示 wheel 与内嵌 OPP 加载正常。`torch_npu.ops.*` 兼容入口默认不注册，`hasattr(torch_npu.ops, 'chunk_fwd_o')` 为 `False` 属预期行为；需要时显式调用 `fla_npu.ops.ascendc.install_torch_npu_ops_compat()`。`torch.ops.npu.*` 是旧版本（≤ v26.6.0）的调用方式，后续版本不再支持，新代码请使用 `fla_npu.ops.ascendc` 下的稳定 Python 入口。
+
+上述检查通过后，可运行一个真实算子的冒烟测试，确认算子可被调用：
+
+```sh
+cd torch_custom/fla_npu/test
+bash test.sh --device 0 --op gdn_fwd_o
+```
+
+## 开发者指引
+
+### 从旧版本升级（v26.6.0 及更早 → 最新）
+
+`torch.ops.npu.*` / `torch_npu.ops.*` 是旧版本（v26.6.0 及更早）的默认调用方式，依赖 PyTorch / torch_npu dispatcher ABI；**v26.6.0 之后不再默认支持**，统一使用 `fla_npu.ops.ascendc` 稳定 Python 入口。升级步骤：
+
+1. **卸载旧包并清理残留**：
+
+   ```sh
+   python -m pip uninstall -y flash-linear-attention-npu
+   ```
+
+   若旧 wheel / legacy extension 在 `site-packages` 遗留了 `custom_aclnn_extension_lib*.so`、`fla_npu/` 或自定义 `libopapi.so`，请手工确认后删除。
+
+2. **安装新版本 wheel**：见上文 Step 3 / Step 4。
+
+3. **迁移代码调用**：将旧入口替换为 `fla_npu.ops.ascendc` 下对应接口，例如：
+
+   | 旧（≤ v26.6.0） | 新 |
+   |---|---|
+   | `torch.ops.npu.npu_chunk_fwd_o(...)` | `from fla_npu.ops.ascendc import chunk_fwd_o; chunk_fwd_o(...)` |
+   | `torch_npu.ops.npu_chunk_gated_delta_rule_fwd_h(...)` | `from fla_npu.ops.ascendc import chunk_gated_delta_rule_fwd_h; ...` |
+
+4. **验证**：
+
+   ```sh
+   python scripts/check_packaged_wheel_api.py
+   cd torch_custom/fla_npu/test && bash test.sh --device 0 --op gdn_fwd_o
+   ```
+
+5. **迁移期临时兼容**：存量代码暂未迁移完成时，可显式开启兼容路径（详见 `torch_custom/fla_npu/README.md` 的 legacy 章节）：
+   - `fla_npu.ops.ascendc.install_torch_npu_ops_compat()`：将 Python wrapper 挂到 `torch_npu.ops.*`；
+   - `fla_npu.load_legacy_torch_ops()`：兼容旧 `torch.ops.npu.*`，需用 `FLA_NPU_BUILD_LEGACY_EXTENSION=1` 额外构建 legacy extension。
+
+   新代码请勿使用 legacy 路径。
+
+### 在 torch_custom 新增 Python 接口
+
+为已有 Ascend C 算子新增 Python 调用接口，核心链路：
+
+1. 在 `torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py` 中按 `aclnn_xxx.h` 签名新增 `npu_xxx(...)` wrapper。
+2. 在 `torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py` 的 `_ASCENDC_OPS` 注册算子名，注册后自动导出 `npu_xxx` 及去掉 `npu_` 前缀的短名。
+3. 新增测试 `torch_custom/fla_npu/test/test_npu_<op>.py` 并接入 `test.sh`。
+4. 重新构建 wheel / run 包并安装验证。
+
+详细步骤（含示例骨架、特殊参数、正反向绑定、mutation 契约）见 [`torch_custom/fla_npu/README.md`](torch_custom/fla_npu/README.md)。
 
 ### 测试单算子
 
@@ -142,6 +206,8 @@ bash test.sh --device 0 --op causal_conv1d   # 单个 AscendC 测试任务
 - `chunk_gated_delta_rule_bwd_dhu`
 - `chunk_bwd_dv_local`
 - `causal_conv1d`
+- `chunk_local_cumsum`
+- `chunk_scaled_dot_kkt`
 - `prepare_wy_repr_bwd_da`
 - `chunk_bwd_dqkwg`
 - `gdn_fwd_o`

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,32 +1,56 @@
-## 简介
+# Examples 说明
 
-> 说明：
+本目录提供 flash-linear-attention-npu 的端到端示例与算子开发参考模板：
 
-> - 关于AI Core的介绍请参见[《Ascend C算子开发》](https://hiascend.com/document/redirect/CannCommunityOpdevAscendC)中“概念原理和术语 > 硬件架构与数据处理原理”。
-
-本项目提供了AI Core算子的开发和调用样例，请开发者根据实际情况参考对应实现。
+- `flash_gated_delta_rule.py`：GDN 模块端到端接入示例，组装 GDN 相关前向/反向算子，覆盖 AscendC 与 Triton 调用链。
+- `add_example/`：一个完整的 Ascend C 算子工程模板（add 算子），包含 `op_host`（def / tiling / infershape）、`op_kernel`、`op_graph` 与测试工程，可作为新增 Ascend C 算子的目录结构参考。
+- `fast_kernel_launch_example/`：演示如何使用 Ascend C + PyTorch Extension 能力开发自定义 NPU 算子，单个交付件完成算子开发与 PyTorch 框架适配，并支持 `<<<>>>` 语法启动核函数。
 
 ## 目录说明
 
 ```
-├── example                       
-│   ├── add_example                # AI Core算子名
-│   │   ├── CMakeLists.txt         # 算子编译配置文件，保留原文件即可   
-│   │   ├── examples               # 算子使用示例
-│   │   ├── op_graph               # 算子构图相关目录
-│   │   ├── op_host                # 算子信息库、Tiling、InferShape相关实现
-│   │   └── op_kernel              # 算子kernel目录
-│   ├── mc2                        # 通算融合类算子示例
-│   │   ├── all_gather_add         # AI Core算子名
-│   │   │   └── ...              
-│   ├── CMakeLists.txt             # 算子编译配置文件，保留原文件即可
-│   └── README.md                  # 算子说明文档
-
+├── flash_gated_delta_rule.py        # GDN 端到端调用示例
+├── add_example/                     # Ascend C 算子工程模板（add 算子）
+│   ├── CMakeLists.txt
+│   ├── examples/                    # 算子使用示例（test_aclnn_add_example.cpp）
+│   ├── op_graph/                    # 算子构图相关目录
+│   ├── op_host/                     # def / tiling / infershape 实现
+│   ├── op_kernel/                   # AI Core kernel
+│   ├── op_kernel_aicpu/             # AICPU kernel（含 fallback 场景）
+│   ├── tests/                       # 测试工程
+│   └── README.md                    # 算子说明文档
+├── fast_kernel_launch_example/      # Ascend C + PyTorch Extension 快速开发示例
+│   ├── ascend_ops/                  # 算子源码与 PyTorch 适配
+│   ├── csrc/                        # C++ 侧封装
+│   ├── tests/                       # 测试用例
+│   ├── setup.py / build_and_test.sh # 构建与测试脚本
+│   └── README.md                    # 示例说明与安装步骤
+└── CMakeLists.txt                   # 编译配置（遍历含 CMakeLists.txt 的子目录）
 ```
 
-## 算子开发样例
+## 快速运行
 
-|样例目录| 	样例介绍	           |算子开发|算子调用 |
-|---|------------------|---|---|
-| add_example | 	实现两个张量相加功能的算子。	 | 算子端到端开发过程参见[AI Core算子开发指南](../docs/zh/develop/aicore_develop_guide.md)。 |调用样例参见[README](add_example/README.md)|
-| mc2/all_gather_add | 	实现AllGatherAdd通算算子 。	 | 算子端到端开发过程参见[AI Core算子开发指南](../docs/zh/develop/aicore_develop_guide.md)。 |调用样例参见[README](mc2/all_gather_add/README.md)|
+### GDN 端到端示例
+
+完成 README 的构建与安装后，直接运行：
+
+```sh
+python examples/flash_gated_delta_rule.py
+```
+
+该脚本会组装 GDN 相关前向/反向算子，覆盖 AscendC 与 Triton 调用链，输出各算子的运行结果与精度对比。
+
+### add_example
+
+参考 `add_example/README.md` 与 `add_example/examples/test_aclnn_add_example.cpp`，以 `add_example` 为模板实现自定义 Ascend C 算子，并接入本仓 `torch_custom/fla_npu` 的 Python 接口（新增接口步骤见根 README 的"在 torch_custom 新增 Python 接口"）。
+
+### fast_kernel_launch_example
+
+进入 `fast_kernel_launch_example/`，按该目录 `README.md` 安装依赖、构建 wheel 并运行测试，即可体验单文件交付的算子开发流程。
+
+## 新增示例要求
+
+- 新增示例必须可独立运行，避免依赖其他示例的中间产物。
+- 涉及新算子的示例，需同时提供该算子的单算子测试（`torch_custom/fla_npu/test/test_npu_<op>.py`）并接入 `test.sh`。
+- 示例代码优先使用稳定 Python 入口 `fla_npu.ops.ascendc` / `fla_npu.ops.triton`，不要默认走 legacy `torch.ops.npu.*` 路径。
+- 在 `examples/` 新增子目录时，如需参与统一编译，请提供对应 `CMakeLists.txt`。

--- a/torch_custom/fla_npu/README.md
+++ b/torch_custom/fla_npu/README.md
@@ -16,6 +16,20 @@ from fla_npu.ops.ascendc import chunk_fwd_o
 
 默认路径通过 Python `ctypes` 直调已安装 OPP 里的 `libcust_opapi.so`，不依赖 PyTorch dispatcher 注册，也不会默认编译或加载 `torch_npu` 自定义扩展。旧的 `torch.ops.npu.*` / `torch_npu.ops.*` 兼容路径仍可做，但只作为迁移期可选能力，不推荐新增代码使用，也不会默认使能。
 
+## 导入契约
+
+`import fla_npu` 会定位 OPP 并加载 `libcust_opapi.so`。**导入 / 构建前请先 source CANN 的 `set_env.sh`**（默认路径为 `/usr/local/Ascend/ascend-toolkit/set_env.sh`；自定义安装路径时替换为实际路径下对应的 `set_env.sh`）：
+
+```sh
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+```
+
+| 现象 | 原因 / 处理 |
+|---|---|
+| 导入失败，`fla_npu/opp/vendors/fla_npu_transformer` 下找不到 `libcust_opapi.so` | 安装的是 standalone wheel（不内嵌 OPP）：需先安装算子 run 包，或通过环境变量 `FLA_NPU_OPP_PATH` 指向外部 OPP 目录 |
+| `dlopen` 报错、找不到依赖库 | 未 source CANN `set_env.sh`，或新开 shell 后环境变量丢失，需要重新 source |
+| 安装 run 包后调用接口报 ABI / 行为异常 | 已加载的 `libcust_opapi.so` 不会在同一 Python 进程内热替换，请重启 Python 进程 |
+
 ## 默认交付件
 
 ### Python runtime wheel
@@ -90,8 +104,9 @@ torch.ops.npu.npu_xxx(...)
 3. 在 wrapper 内申请输出 tensor，并把输出传给 `_call_aclnn(...)`。
 4. 如果 aclnn 参数里有 `char *`、字符串、或 ctypes 不能安全自动转换的参数，在 `_GET_WORKSPACE_ARGTYPES` 中补充 `GetWorkspaceSize` 的 `argtypes`。
 5. 在 `fla_npu/ops/ascendc/__init__.py` 的 `_ASCENDC_OPS` 中加入 `npu_xxx`，这样会自动导出 `npu_xxx` 和去掉 `npu_` 前缀后的短名。
-6. 如果存在明确的正反向关系，在 `BACKWARD_OPS` 中补充映射；需要 autograd 自动绑定时，在 `__init__.py` 中增加对应 `torch.autograd.Function` 包装。
-7. 新增或更新测试，默认调用 `fla_npu.ops.ascendc` 路径。
+6. 如果存在明确的正反向关系，在 `BACKWARD_OPS` 中补充映射（例如 `causal_conv1d` → `causal_conv1d_bwd`）；需要 autograd 自动绑定时，在 `__init__.py` 中增加对应 `torch.autograd.Function` 包装。
+7. 如果算子会就地修改某个输入 tensor（例如 `causal_conv1d` 会更新 `conv_states`），在 `MUTATED_ARGUMENTS` 中登记对应参数名。ctypes 直接写 tensor storage 时 PyTorch 无法从 Python 调用自动发现副作用，登记后 wrapper 会负责 grad 限制与版本计数（mutation 契约测试参考 `test/test_ascendc_mutation_contract.py`）。
+8. 新增或更新测试，默认调用 `fla_npu.ops.ascendc` 路径。
 
 新增算子通常不需要修改 `_runtime.py`，也不需要感知 `_AclTensor`、`_AclIntArray`、workspace 申请或 stream launch 细节。只有公共 ctypes 调发框架本身需要演进时，才修改 `_runtime.py`。
 
@@ -119,7 +134,9 @@ def npu_my_op(x, weight, *, scale=1.0, indices=None):
 
 ```bash
 python3 setup.py bdist_wheel
-python3 -m pip install --force-reinstall --no-deps dist/flash_linear_attention_npu-*.whl
+# WHEEL_PATH 使用构建日志输出的准确文件名（勿用通配符，避免匹配多个产物）
+WHEEL_PATH="dist/<准确wheel文件名>.whl"
+python3 -m pip install --force-reinstall --no-cache-dir --no-deps "$WHEEL_PATH"
 ```
 
 这个 standalone wheel 会先安装 Python runtime 和空的 OPP vendor 骨架：
@@ -142,7 +159,9 @@ bash build.sh --pkg --soc=ascend910b --vendor_name=fla_npu
 
 ```bash
 FLA_NPU_SOC=ascend910b python3 -m pip wheel --no-build-isolation --no-deps . -w dist
-python3 -m pip install --force-reinstall --no-deps dist/flash_linear_attention_npu-*.whl
+# WHEEL_PATH 使用构建日志输出的准确文件名（勿用通配符，避免匹配多个产物）
+WHEEL_PATH="dist/<准确wheel文件名>.whl"
+python3 -m pip install --force-reinstall --no-cache-dir --no-deps "$WHEEL_PATH"
 python3 scripts/check_packaged_wheel_api.py
 ```
 
@@ -154,6 +173,8 @@ bash build.sh --pkg --soc=ascend910b --vendor_name=fla_npu --ops=chunk_fwd_o
 ```
 
 安装器会列出 scoped run 包覆盖后的算子状态。`WARNING` 表示安装后不可用，`NOTICE` 表示需要人工关注，`OK` 表示 ABI 一致并继续可用。
+
+> 安装流程看护（PR #274 新增）：`scripts/check_install_workflows.py` 用于校验 wheel / run 包 / 安装流程是否符合约定。构建与安装完成后执行 `python scripts/check_install_workflows.py`，CI 也会自动运行该检查。
 
 ## legacy torch_npu / torch.ops.npu 路径
 
@@ -191,6 +212,8 @@ legacy 路径会生成或使用：
 - `npu_custom.yaml`、`test_native_functions.yaml`、`deprecated.yaml`
 
 这些兼容路径不会默认使能。`torch.ops.npu` legacy extension 会重新绑定 PyTorch、Python、C++ ABI 和 torch_npu dispatcher 行为，因此只用于历史接口兼容或专项验证。新增算子默认不要以 legacy extension 作为唯一调用方式。
+
+`torch.ops.npu.*` / `torch_npu.ops.*` 只支持到 v26.6.0，从旧版本迁移到最新版本的完整步骤见[根 README 的"从旧版本升级"章节](../../README.md)。新代码请勿使用 legacy 路径。
 
 ## 测试要求
 


### PR DESCRIPTION
## Summary
- 面向**使用者**：补齐全新环境上手步骤（Step 0 确认硬件/芯片 → 安装 CANN → 编译/安装 → 验证），修正 `check_npu_env.py --build-only` 描述、安装命令用精确 wheel 文件名、`set_env.sh` 自定义路径提示。
- 面向**开发者**：新增"从旧版本升级"章节（v26.6.0 及更早 `torch.ops.npu.*` → `fla_npu.ops.ascendc` 迁移对照、迁移期兼容），新增"在 torch_custom 新增 Python 接口"指引，并对齐 PR #274 后的构建/安装语义（移除增量构建 `FLA_NPU_INCREMENTAL_BUILD`/`FLA_NPU_OPS`，标注 `check_install_workflows.py` 为新增）。
- 同步周边文档：`torch_custom/fla_npu/README.md`（导入契约、接入步骤、legacy 迁移指引）、`AGENTS.md`、`examples/README.md`（重写为实际样例）、`CONTRIBUTING.md`（本仓特有贡献要求）、PR 模板（`set_env.sh` 提示）。

## 变更文件
- `README.md`
- `torch_custom/fla_npu/README.md`
- `AGENTS.md`
- `examples/README.md`
- `CONTRIBUTING.md`
- `.github/pull_request_template.md`

## 验证
- `python scripts/check_npu_env.py --build-only` 实测：缺 torch 也通过，跳过 torch 系检查（已按此修正文档描述）。
- `bash test.sh --device 0 --op gdn_fwd_o --mode dry-run` 实测正常；`--op` 可选值已与 `test.sh` 逐条核对补全。
- `bash build.sh --help` 确认 `--pkg/--soc/--ops/--vendor_name` 参数存在。
- 链接有效性、残留旧环境变量名、`git diff --check` 均通过。
- 需真实 NPU+torch 的算子冒烟（`bash test.sh --device 0 --op gdn_fwd_o` 实际执行）未在本机执行（缺 torch 环境）。

Made with [Cursor](https://cursor.com)