### PR TITLE
docs: 整改生态仓 README 易用性

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -85,6 +85,7 @@
 在每套 CANN / 产品环境中先确认基础信息。
 
 ```sh
+# 默认 CANN 安装路径；自定义安装路径时替换为实际路径下对应的 set_env.sh
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
 cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
 npu-smi info

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ ABI 敏感路径包括 `*_def.cpp`、`aclnn_*.h/.cpp`、`torch_custom/fla_npu/*.
 先准备环境：
 
 ```sh
+# CANN 安装于自定义路径时，请替换为实际路径下对应的 set_env.sh
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
 python -m pip install -r requirements.txt
 python scripts/check_npu_env.py --build-only
@@ -137,14 +138,21 @@ FLA_NPU_SOC=ascend910b python -m pip wheel --no-build-isolation --no-deps . -w d
 - A3：`ascend910_93`
 - A5：`ascend950`
 
-源码或适配修改后仍执行完整 wheel 构建；构建流程会清理上一轮中间产物：
+源码或适配修改后仍执行完整 wheel 构建；构建流程会清理上一轮 `build/`、`build_out/`、`output/` 中间产物，不再支持增量构建：
 
 ```sh
 FLA_NPU_SOC=ascend910b python -m pip wheel --no-build-isolation --no-deps . -w dist
 ```
 
+只重编部分算子的 Ascend C 产物时，可用 `FLA_NPU_OPS` 指定算子（逗号分隔）走单算子 wheel 构建（`setup.py` 会透传给 `build.sh --ops=<op>`）：
+
+```sh
+FLA_NPU_SOC=ascend910b FLA_NPU_OPS=chunk_fwd_o,chunk_bwd_dv_local \
+  python -m pip wheel --no-build-isolation --no-deps . -w dist
+```
+
 只构建部分算子用于定位时，显式构建单算子 run 包；该产物不能替代完整 wheel
-的全量重编：
+的全量重编（`--soc` 需指定为实际芯片类型）：
 
 ```sh
 bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu --ops=chunk_fwd_o

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,18 @@
   #### 4. PR 上库  
   Committer 检视通过后，Maintainer 将进行最终审核。确认无误后，将标注 `/lgtm` 和 `/approve` 标签合入PR。
 
+### 本仓特有的贡献要求
+
+本仓在 CANN 算子上层还维护了 `torch_custom/fla_npu` 的 Python runtime 适配，新增算子除上述最小交付件外，还必须满足：
+
+- **提供稳定 Python 入口**：新增算子必须在 `fla_npu.ops.ascendc` 下提供可调用的 Python 接口（经 `_aclnn_ctypes.py` wrapper + `_ASCENDC_OPS` 注册），不得仅以 legacy `torch.ops.npu.*` / `torch_npu.ops.*` 路径交付。
+- **交付内容**：至少包含
+  - `torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py` 中的 `npu_<op>(...)` wrapper；
+  - `torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py` 的 `_ASCENDC_OPS` 注册（需要时同步 `BACKWARD_OPS` 正反向映射与 `MUTATED_ARGUMENTS` mutation 契约）；
+  - `torch_custom/fla_npu/test/test_npu_<op>.py` 单算子测试并接入 `test.sh`。
+- **默认调用路径**：新增算子与测试默认使用 `fla_npu.ops.ascendc`，新代码不要默认依赖 legacy 路径（legacy 路径仅用于兼容性验证，且需要 `FLA_NPU_BUILD_LEGACY_EXTENSION=1` 额外构建）。
+- 具体接入步骤见[开发者指南](docs/开发者指南.md)的场景 3 与 `torch_custom/fla_npu/README.md`。
+
 ### 文档纠错
 
   如果您在本项目中发现某些算子文档描述错误，欢迎您新建Issue进行反馈和修复。

--- a/README.md
+++ b/README.md
@@ -9,41 +9,73 @@
 
 flash-linear-attention-npu 算子库由天津大学主导开发，是一个面向昇腾架构的高性能线性注意力算子库，对标 Flash-Linear-Attention 项目，旨在为昇腾平台提供高效的线性注意力计算实现。
 
+本仓不自动安装 `torch`、`torch_npu`、`torchnpugen`、`triton-ascend`，这些包必须与 CANN 与 Python 版本匹配，需要使用者按环境自行安装；版本不匹配时，构建或运行会报错。依赖匹配关系与检查方式见下文 Step 1 / Step 2。
+
 ## ⚡️快速上手
+
+### Step 0. 确认硬件与目标芯片
+
+在开始前，先确认机器上可用的 NPU 类型：
+
+```sh
+npu-smi info
+```
+
+确认机器类型后，按目标芯片选择后续构建参数（`--soc` / `FLA_NPU_SOC`）：
+
+| 产品 | `--soc` / `FLA_NPU_SOC` |
+| ---- | --------------------------- |
+| A2   | `ascend910b`              |
+| A3   | `ascend910_93`            |
+| A5   | `ascend950`               |
 
 ### Step 1. 部署 CANN 开发环境
 
 首先需安装 CANN 开发包，提供 NPU 算子运行所需的底层驱动与工具链。
-推荐使用是社区版8.5.2，总共要下2个run包，这里以A3机器为例（即需要下载A3-ops、toolkit）
-下载地址为
-[https://www.hiascend.com/developer/download/community/result?module=cann&amp;cann=8.5.2](https://www.hiascend.com/developer/download/community/result?module=cann&cann=8.5.2)
-需要找到与你当前机器对应的包
+推荐使用最新的社区稳定版本（不低于 8.5.2，如需使用更新版本请参考 `check_npu_env.py` 支持的 CANN / torch_npu 版本组合），总共需要下载 2 个 run 包。
+下载地址为社区 CANN 下载页（最新稳定版）
+[https://www.hiascend.com/zh/cann/download?versionId=752&ids=d803%2Ch0501%2Ch0601%2Ch0703](https://www.hiascend.com/zh/cann/download?versionId=752&ids=d803%2Ch0501%2Ch0601%2Ch0703)
+在其中找到与你当前机器对应的包
 
 ```
-#设置需要安装的路径
+# 设置需要安装的路径（请替换为实际安装路径）
 export INSTALL_PATH=/usr/local/Ascend
 
+# toolkit 与机型对应的 ops 包都必须安装；ops 包命名格式为
+# Ascend-cann-<chip_type>-ops_<version>_linux-<arch>.run，
+# 例如 A3 机器对应 Ascend-cann-A3-ops*.run，A2 机器对应 Ascend-cann-910b-ops*.run，A5 机器对应 Ascend-cann-950-ops*.run
 ./Ascend-cann-toolkit*run --install-path=$INSTALL_PATH --full  --quiet
-./Ascend-cann-A3*run --install-path=$INSTALL_PATH --install --quiet
+./Ascend-cann-*-ops*.run --install-path=$INSTALL_PATH --install --quiet
 source $INSTALL_PATH/ascend-toolkit/set_env.sh
 ```
 
+> 若 CANN 安装在自定义路径，请将 `INSTALL_PATH` 设置为实际安装路径，并 source 实际路径下对应的 `set_env.sh`（上述 `/usr/local/Ascend` 仅为默认安装路径）。每次进入新的 shell（含 Docker / Conda / venv）后，都需要重新 source `set_env.sh` 才能正常编译与运行。
+
 ### Step 2. 编译
 
-#### 方式 A：【推荐】源码一键编译并生成 wheel
+#### 【推荐】源码一键编译并生成 wheel
 
 在已完成 CANN、PyTorch、torch-npu、torchnpugen、triton-ascend 环境准备后，推荐直接在仓库根目录生成单 wheel。默认目标芯片为 `ascend910b`，A3/A5 机器需要显式指定 `FLA_NPU_SOC`。本仓不会自动安装 `torch`、`torch_npu`、`torchnpugen` 或 `triton-ascend`，因为这些包必须和 CANN、Python、`torch_npu` 可用版本匹配；在新的 conda 环境中请先安装匹配依赖，再执行预检：
 
 ```sh
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
 python -m pip install -r requirements.txt
+python scripts/check_npu_env.py
+```
+
+完整预检会同时检测运行与编译环境，检查 `torch` / `torch_npu` / `triton-ascend` 是否可导入、版本下限与 NPU 可用性（`torch.npu.is_available()`）；torch 系依赖缺失或版本不匹配时，`pip wheel` 会在构建或打包阶段报错，请按 CANN 与 Python 版本匹配的列表先行安装。在无 NPU 卡的纯构建环境里，`is_available()` 为 `False` 且该检查会报 `FAIL`，属预期现象——此时若只需产出 wheel 构建，可用 `--build-only` 跳过 torch 系检查：
+
+```sh
 python scripts/check_npu_env.py --build-only
 ```
 
-如果依赖缺失，预检和一键编包都会在真正编译前失败，并列出缺失项，例如 `torch`、`torch_npu`、`torchnpugen.*`、`triton` 或 `triton-ascend distribution was not found`。依赖通过后再生成 wheel：
+预检覆盖编译链上的 `cmake`、`gcc`/`g++`、`setuptools` 版本要求，`make` / `patch` / `bisheng` 存在性检查，以及 `wheel` / `packaging` / `psutil`（`--no-build-isolation` 构建时需本机已装）的导入检查。其余组件未纳入预检，缺失时会在 `pip wheel` 阶段才报错。各组件的最低版本要求与详细说明见[开发者指南](docs/开发者指南.md) 场景 2 的工具链依赖表。
+
+> `triton-ascend` 与 CANN 版本需要匹配：CANN 8.x 使用 `>=3.2.0` 即可；CANN 9.x（9.0.0+）因 Ascend Triton 后端 JIT 编译 `npu_utils.cpp` 依赖更新的 `rt.h` 头文件，需要 **`>=3.2.1`**（3.2.0 在 CANN 9.1.0 上会编译失败）。预检会按检测到的 CANN 版本自动校验 `triton-ascend` 是否满足对应下限。
+
+预检通过后再生成 wheel：
 
 ```sh
-source /usr/local/Ascend/ascend-toolkit/set_env.sh
 FLA_NPU_SOC=ascend910b python scripts/build_wheel.py
 ```
 
@@ -63,76 +95,39 @@ FLA_NPU_SOC=ascend910b python scripts/build_wheel.py
 的 wheel，因此安装时必须传入本轮构建生成的准确文件名，并使用 Step 3 的强制覆盖
 命令，避免通配符选中旧产物。
 
-方式 A 编译可用环境变量：
+编译可用环境变量：
 
 | 环境变量                          | 可选范围                                          | 作用 / 建议                                                                                                                        | 默认           |
 | --------------------------------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------- |
 | `FLA_NPU_SOC`                   | `ascend910b` / `ascend910_93` / `ascend950` | 目标芯片；按实际运行机器选择                                                                                                       | `ascend910b` |
+| `FLA_NPU_OPS`                   | 算子名，逗号分隔（如 `chunk_fwd_o,chunk_bwd_dv_local`） | 只构建指定算子的 wheel；适合已安装完整 wheel 后快速替换少量算子的 Ascend C 产物，未设置则全量构建 | 空（全量） |
 | `FLA_NPU_DISABLE_LOCAL_VERSION` | `TRUE` / `FALSE`                              | wheel 版本号不追加 SOC/torch/ABI 本地版本；内部统一发版需要固定版本号时可设`TRUE`，日常构建建议保持 `FALSE` 以区分产物兼容范围 | `FALSE`      |
 
 布尔变量设为 `TRUE` 时也接受 `1`、`YES`、`ON`；未设置或其他值按 `FALSE` 处理。
 
-#### 方式 B：【备选】单独编译算子 run 包和 Python wheel
-
-只有在已经安装方式 A 的完整 wheel、但需要快速替换少量算子的 Ascend C 产物时，才建议使用该方式。`--ops=op1,op2,...` 只会生成指定算子的 run 包；run 包安装时会把当前 run 包里的 `packages/vendors/fla_npu_transformer` 合并覆盖到当前 Python 环境已安装的 `site-packages/fla_npu/opp/vendors/fla_npu_transformer`，从而更新 `aclnn`、tiling、kernel 和相关配置。
-
-```sh
-# 编译一个或多个算子 run 包，--soc 需指定为当前机器芯片类型 {ascend910b/ascend910_93/ascend950}
-bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu --ops=chunk_fwd_o
-
-# 如果 Python wrapper 也有修改，再单独编译 Python runtime wheel
-cd torch_custom/fla_npu
-python3 setup.py bdist_wheel
-
-# 如需继续验证旧 torch.ops.npu 路径，可显式编译 legacy PyTorch C++ extension
-FLA_NPU_BUILD_LEGACY_EXTENSION=1 bash gen.sh npu_custom.yaml
-FLA_NPU_BUILD_LEGACY_EXTENSION=1 python3 setup.py bdist_wheel
-```
+> 需要单独编译一个或多个算子 run 包的开发者场景（如已安装完整 wheel 后快速替换少量算子的
+> Ascend C 产物），见[开发者指南](docs/开发者指南.md) 场景 1。
 
 ### Step 3. 安装
 
-#### 方式 A 产物安装
-
-方式 A 产物可以来自本地源码一键编译，也可以直接使用 [Release v26.6.0](https://github.com/flashserve/flash-linear-attention-npu/releases/tag/v26.6.0) 提供的官方验证 wheel。下载或构建完成后执行：
+产物可以来自本地源码一键编译，也可以直接使用 [Release v26.6.0](https://github.com/flashserve/flash-linear-attention-npu/releases/tag/v26.6.0) 提供的官方验证 wheel。下载或构建完成后执行：
 
 ```sh
-WHEEL_PATH="dist/本轮构建生成的-wheel-文件名.whl"
+# 将 WHEEL_PATH 设置为实际 wheel 文件路径：
+# 本地构建产物位于 dist/ 目录，请使用构建日志输出的准确文件名（勿用通配符，避免匹配多个产物）；
+# Release 下载的 wheel 则填实际下载路径。
+WHEEL_PATH="dist/<准确wheel文件名>.whl"
 python -m pip install --force-reinstall --no-cache-dir --no-deps "$WHEEL_PATH"
 ```
 
-将 `WHEEL_PATH` 设置为本轮构建日志中输出的准确 wheel 文件；如果使用 Release
-下载的 wheel，则设置为实际下载路径。
+> 重新构建的 wheel 版本号与已安装的旧 wheel 可能相同。版本号相同时，不带 `--force-reinstall` 的 `pip install` 会认为"已是最新版本"而跳过，导致实际仍是旧代码。上面的命令已带 `--force-reinstall` 强制覆盖；若想先清理再装，可先执行 `python -m pip uninstall -y flash-linear-attention-npu`。
 
-方式 A wheel 不安装或执行 shell 环境钩子。无论使用系统 Python、Conda、venv
+wheel 不安装或执行 shell 环境钩子。无论使用系统 Python、Conda、venv
 还是 Docker，每次进入新的 shell 后都需要先按 Step 1 手工 source CANN 的
 `set_env.sh`。调用 `fla_npu.ops.ascendc` 算子时会在当前 Python 进程内定位并加载
 wheel 内嵌 OPP；wheel 通过绝对路径加载 `libcust_opapi.so`，不会再生成或加载
 可能覆盖 CANN 运行库的自定义 `libopapi.so`。如果旧版 run 包曾在 wheel 中遗留该别名，
 新 runtime 会在首次加载 OPP 时删除它；目录不可写时会给出明确的手工清理提示。
-
-#### 方式 B 产物安装
-
-先确认方式 A 的完整 wheel 已经安装到当前 Python 环境，然后安装 run 包。安装器会在覆盖前列出当前 run 包携带的算子，并标出安装后的算子状态：`WARNING` 表示安装后不可用，包括不在当前 run 包范围内但会受局部 `libcust_opapi.so`、tiling so、proto so 整体替换影响的算子，以及当前 run 包内但 aclnn ABI 修改或删除的算子；`NOTICE` 表示新增或无法完整确认的 ABI，需要确认当前 Python wheel 是否已有对应 wrapper；`OK` 表示当前 run 包内且 aclnn ABI 一致的算子。`op_api/include/aclnnop` 中新增、删除、修改的 aclnn ABI 头文件会合并显示到对应算子的状态原因里；删除只按当前 run 包携带的算子范围判断，非 `--quiet` 模式只在状态表后确认一次。
-
-```sh
-# 覆盖当前 Python 环境中 flash-linear-attention-npu wheel 内嵌的 OPP
-# （无参数直接运行 .run 也是同样的行为，等价于 --install / --full）
-./build_out/fla-npu-*.run --install
-# 或等价写法
-./build_out/fla-npu-*.run --full
-
-# 如需装到 CANN OPP 目录（ASCEND_CUSTOM_OPP_PATH / ASCEND_OPP_PATH），
-# 使用 --cann 或 --install-path=<绝对路径>
-# ./build_out/fla-npu-*.run --cann
-
-# 如果 Python wrapper 也有修改，再安装单独编译出的 wheel
-WHEEL_PATH="dist/本轮构建生成的-wheel-文件名.whl"
-python -m pip install --force-reinstall --no-cache-dir --no-deps "$WHEEL_PATH"
-```
-
-run 包覆盖完成后会重写幂等的 `set_env.bash`，并把实际 OPP 文件清单刷新到 wheel
-的 `RECORD`。因此重复覆盖同一个 run 包不会累积环境变量或文件记录，后续
-`pip --force-reinstall` 也能先清理 run 包增加的文件，再安装新 wheel。
 
 `import fla_npu` 会定位 OPP 并加载 `libcust_opapi.so`。执行前必须先 source CANN
 的 `set_env.sh`；CANN 环境未初始化、OPP 不完整或动态库加载失败时，import 会直接
@@ -143,49 +138,28 @@ run 包覆盖完成后会重写幂等的 `set_env.bash`，并把实际 OPP 文�
 
 `fla_npu.ops.ascendc` 调用会优先使用 wheel 内嵌 OPP，找不到时会继续从 `FLA_NPU_OPP_PATH`、`ASCEND_CUSTOM_OPP_PATH` 和 `ASCEND_OPP_PATH` 查找已安装 OPP。外部 OPP 的 `op_api/lib` 目录同样不得包含自定义 `libopapi.so`；runtime 会先尝试删除旧版本遗留的别名，目录不可写时再明确报错并要求手工清理。
 
+> 已安装完整 wheel 后，如需用单算子 run 包快速替换部分算子的 Ascend C 产物（含安装器
+> 的算子状态说明），见[开发者指南](docs/开发者指南.md) 场景 1。
+
 ### Step 4. 测试安装成功
 
-安装后两种方式均可用以下命令验证：
+安装后可用以下命令验证：
 
 ```sh
-python -c "import fla_npu; print('fla_npu runtime loaded')"
+python -c "import fla_npu; print('ok')"
 python -c "from fla_npu.ops import ascendc; print(hasattr(ascendc, 'chunk_fwd_o'))"
 python scripts/check_packaged_wheel_api.py
 ```
+
+`import fla_npu` 成功即表示 wheel 与内嵌 OPP 加载正常。推荐使用 `fla_npu.ops.ascendc` 稳定 Python 入口调用算子。
+
+`torch.ops.npu.*` / `torch_npu.ops.*` 是旧版本（v26.6.0 及更早）的调用方式，**v26.6.0 之后不再维护旧版本兼容接口**，新代码请使用 `fla_npu.ops.ascendc` 下的稳定 Python 入口。迁移期如需临时兼容（`install_torch_npu_ops_compat()` / `load_legacy_torch_ops()`）及其注意事项（如 `hasattr(torch_npu.ops, ...)` 的版本差异），见[兼容与迁移指南](docs/兼容与迁移指南.md)。
 
 不再使用时，按 distribution 名卸载：
 
 ```sh
 python -m pip uninstall -y flash-linear-attention-npu
 ```
-
-wheel 原始文件、pip 安装期生成的 `__pycache__`、单算子 run 包覆盖写入的 OPP 文件
-及对应 metadata 都由安装后的 `RECORD` 管理；卸载后不应残留 `fla_npu/` 或
-`flash_linear_attention_npu-*.dist-info/`。
-
-修改源码、Python 适配或单算子 run 包后，可以用安装流程看护脚本在隔离 venv 中
-检查重复安装、卸载和主要调用通路。参数必须指向确定的单个产物；下面的 base wheel、
-run 包和 updated wheel 会分别安装两次，每次都在新 Python 进程中检查 OPP 布局、
-`RECORD`、环境变量、公开 API 和 `libcust_opapi.so` 动态库映射。run 包覆盖后及最终
-整包验证后还会执行 `pip uninstall`，确认包目录、distribution metadata 和
-`RECORD` 登记文件均无残留：
-
-```sh
-python scripts/check_install_workflows.py \
-  --wheel dist/<exact-base-wheel>.whl \
-  --run-package build_out/<exact-scoped-run-package>.run \
-  --updated-wheel dist/<exact-updated-wheel>.whl \
-  --wheel-op chunk_gated_delta_rule_fwd_h \
-  --run-op chunk_gated_delta_rule_fwd_h \
-  --updated-wheel-op chunk_gated_delta_rule_fwd_h \
-  --work-cwd .
-```
-
-新增适配时，用 `--updated-wheel-op` 声明新增的公开 API。只验证 standalone
-Python wheel 加单算子 run 包时，将 `--base-mode` 设为 `skeleton`。该脚本看护
-打包安装和主要加载通路，不替代算子自身的精度、泛化或性能测试。
-
-`torch.ops.npu.*` 是 legacy extension 的过渡用法，后续版本不再支持。新代码优先使用 `fla_npu.ops.ascendc` 下的稳定 Python 入口。
 
 ### 测试单算子
 
@@ -272,22 +246,19 @@ NPU CI 的 Example/ST 用例由 [`ci/example_st_cases.json`](ci/example_st_cases
 
 当前端到端 Example/ST 已支持 `gate_source=g`；`gk` / `g+gk` 先作为用例 schema 预留，待 NPU fwd_h 路径支持后再启用。
 
-## Memory Checking with msSanitizer
+## 开发者指引
 
-编译时开启 `--sanitizer`（Ascend 910）或运行时注入（Ascend 950）即可使用 msSanitizer 进行算子内存异常检测：
+开发者相关操作（单独编译单算子、一键编包、增加新算子、确认 wheel 来自最新源码）按场景拆分为独立文档；测试单算子和端到端验证见上文 Step 4：
 
-```sh
-# 910（ascend910b/ascend910_93）：编译期静态插桩，产物带 __sanitizer_report_* 符号，直接运行测试
-FLA_NPU_SOC=ascend910b python scripts/build_wheel.py -g --sanitizer
+- [开发者指南](docs/开发者指南.md)
 
-# 950（ascend950）：无 sanitizer stub，编译只需 -g 定位信息，内存检测靠运行时注入
-FLA_NPU_SOC=ascend950 python scripts/build_wheel.py -g
-mssanitizer --tool=memcheck -- python -m pytest -q -s tests/xxx.py
-```
+旧版本（v26.6.0 及更早）用户升级与兼容迁移见[兼容与迁移指南](docs/兼容与迁移指南.md)。
 
 ## 维护文档
 
-NPU CI 维护说明见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。
+- NPU CI 维护说明见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。
+- 旧版本用户升级与兼容迁移见 [`docs/兼容与迁移指南.md`](docs/兼容与迁移指南.md)。
+- 开发者分场景指南见 [`docs/开发者指南.md`](docs/开发者指南.md)。
 
 ## 🔍目录结构
 
@@ -320,6 +291,7 @@ NPU CI 维护说明见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部
 ├── examples                           # 端到端算子开发和调用示例
 │   └── flash_gated_delta_rule.py      # 完整GDN接入调用示例
 ├── scripts                            # 脚本目录，包含算子构建相关配置文件
+├── docs                               # 文档目录（兼容迁移指南、开发者指南等）
 ├── tests                              # 测试工程目录
 ├── gdn-verify.sh                      # GDN 一键验证脚本
 ├── CMakeLists.txt

--- a/docs/兼容与迁移指南.md
+++ b/docs/兼容与迁移指南.md
@@ -1,0 +1,95 @@
+# 兼容与迁移指南（旧版本 → 最新）
+
+本文档面向从旧版本（v26.6.0 及更早）迁移到最新版本的用户，说明调用方式变化、兼容路径与验证差异。主流程安装 / 使用请见根 [README](../README.md)。
+
+## 背景：调用方式演进
+
+| 版本           | 调用方式                          | 状态                     |
+| -------------- | --------------------------------- | ------------------------ |
+| v26.6.0 及更早 | `torch.ops.npu.*` / `torch_npu.ops.*` | 旧方式，已停止演进       |
+| v26.6.0 之后   | `fla_npu.ops.ascendc` 稳定 Python 入口 | 推荐使用，接口保持稳定   |
+
+**v26.6.0 之后不再维护旧版本兼容接口**。`fla_npu.ops.ascendc` 通过 Python ctypes 直调
+`libcust_opapi.so`，不依赖 PyTorch / torch_npu dispatcher ABI，接口语义稳定、后续版本
+不会变动。`torch.ops.npu.*` / `torch_npu.ops.*` 仅作为迁移期临时兼容能力保留，不推荐
+新增代码使用，也不会默认使能。
+
+## 从旧版本升级步骤
+
+1. **卸载旧包并清理残留**：
+
+   ```sh
+   python -m pip uninstall -y flash-linear-attention-npu
+   ```
+
+   若旧 wheel / legacy extension 在 `site-packages` 遗留了 `custom_aclnn_extension_lib*.so`、`fla_npu/` 或自定义 `libopapi.so`，请手工确认后删除。
+2. **安装新版本 wheel**：见根 [README](../README.md) 的 Step 3 / Step 4。
+3. **迁移代码调用**：将旧入口替换为 `fla_npu.ops.ascendc` 下对应接口，例如：
+
+   | 旧（≤ v26.6.0）                                        | 新                                                                    |
+   | ------------------------------------------------------- | --------------------------------------------------------------------- |
+   | `torch.ops.npu.npu_chunk_fwd_o(...)`                  | `from fla_npu.ops.ascendc import chunk_fwd_o; chunk_fwd_o(...)`     |
+   | `torch_npu.ops.npu_chunk_gated_delta_rule_fwd_h(...)` | `from fla_npu.ops.ascendc import chunk_gated_delta_rule_fwd_h; ...` |
+4. **验证**：
+
+   ```sh
+   python scripts/check_packaged_wheel_api.py
+   cd torch_custom/fla_npu/test && bash test.sh --device 0 --op gdn_fwd_o
+   ```
+
+## 迁移期临时兼容
+
+新接口 `fla_npu.ops.ascendc` 是稳定 Python 入口，语义保持兼容、后续版本不会变动，
+新代码请始终使用它。以下兼容能力仅供存量代码在迁移期临时使用，新代码请勿使用
+legacy 路径。
+
+### 兼容 `torch_npu.ops.*`
+
+将 Python wrapper 挂到 `torch_npu.ops.*`：
+
+```python
+from fla_npu.ops import ascendc
+import torch_npu
+
+ascendc.install_torch_npu_ops_compat()
+torch_npu.ops.npu_xxx(...)
+```
+
+> 注意：`fla_npu` 顶层不自动导入 `ops` 子模块，必须先执行
+> `from fla_npu.ops import ascendc`（或 `import fla_npu.ops.ascendc`），否则直接写
+> `fla_npu.ops.ascendc.install_torch_npu_ops_compat()` 会报 `AttributeError`。
+
+### 兼容更旧的 `torch.ops.npu.*`
+
+需额外构建 legacy extension：
+
+```sh
+bash gen.sh npu_custom.yaml
+FLA_NPU_BUILD_LEGACY_EXTENSION=1 python3 setup.py bdist_wheel
+```
+
+```python
+import fla_npu
+
+fla_npu.load_legacy_torch_ops()
+torch.ops.npu.npu_xxx(...)
+```
+
+legacy extension 会重新绑定 PyTorch、Python、C++ ABI 和 torch_npu dispatcher 行为，
+因此只用于历史接口兼容或专项验证。
+
+## 新旧版本行为差异
+
+- **构建环境变量**：旧版支持 `FLA_NPU_INCREMENTAL_BUILD`（复用 `build/` 的增量构建）、`FLA_NPU_OPS`（只构建指定算子的 wheel）、`FLA_NPU_SKIP_RUN_BUILD` / `FLA_NPU_SKIP_RUN_INSTALL`（跳过 run 包编译或内嵌）；新版保留了 `FLA_NPU_OPS`（`setup.py` 会透传给 `build.sh --ops=<op>`），但移除了 `FLA_NPU_INCREMENTAL_BUILD` / `FLA_NPU_SKIP_RUN_BUILD` / `FLA_NPU_SKIP_RUN_INSTALL`，统一走全量构建（自动清理 `build/`、`build_out/`、`output/` 中间产物）。单算子定位可直接用 `bash build.sh --pkg --soc=<soc> --vendor_name=fla_npu --ops=<op>` 构建 run 包，或在编译 wheel 时设 `FLA_NPU_OPS=<op>`；旧脚本中的 `FLA_NPU_INCREMENTAL_BUILD=1` 需要删除。
+- **安装验证命令**：旧版用 `fla_npu.is_legacy_torch_ops_loaded()` 和 `hasattr(torch_npu.ops, 'chunk_fwd_o')` 验证，新版不再适用（见根 README 的 Step 4 说明）；统一改用 `python -c "import fla_npu; print('ok')"` + `python scripts/check_packaged_wheel_api.py`。
+- **`torch_npu.ops` 挂载行为**：旧版 wheel（2026-07 之前的中间版本）导入 `fla_npu.ops.ascendc` 即自动挂载 `torch_npu.ops.*`；新版 wheel 默认不挂载，迁移期需显式调用 `install_torch_npu_ops_compat()`。
+- **`test.sh` 算子名**：`recompute_wu_fwd` 在新版统一为 `recompute_w_u_fwd`。
+
+## 使用 `hasattr(torch_npu.ops, ...)` 验证时的注意事项
+
+- **新版 wheel**：默认不注册 `torch_npu.ops.*` 兼容入口，`torch_npu.ops` 属性本身不存在，
+  旧版验证命令 `hasattr(torch_npu.ops, 'chunk_fwd_o')` 会抛 `AttributeError` 而非返回
+  `False`——这是预期行为，不要用它来验证新版安装。需要该兼容入口时，先导入子模块再显式
+  调用 `install_torch_npu_ops_compat()`（见上文）。
+- **旧版 wheel**：导入 `fla_npu.ops.ascendc` 时会自动注册 `torch_npu.ops.*`，`hasattr(...)`
+  返回 `True`，属旧版行为，不代表新 wheel 的行为。

--- a/docs/开发者指南.md
+++ b/docs/开发者指南.md
@@ -1,0 +1,323 @@
+# 开发者指南
+
+本文档面向在 `flash-linear-attention-npu` 仓库内进行开发的开发者，按场景拆分为：单独编译单算子、增加新算子、测试单算子、端到端验证，以及如何确认 wheel 来自最新源码。开始前先看[调用链路与场景选择](#调用链路与场景选择)，确定当前改动该走哪个场景。
+
+- [调用链路与场景选择](#调用链路与场景选择)
+- [场景 1：单独编译单算子（run 包）](#场景-1单独编译单算子run-包)
+- [场景 2：一键编包（wheel）](#场景-2一键编包wheel)
+- [场景 3：增加一个新算子（目录结构 + torch_custom）](#场景-3增加一个新算子目录结构--torch_custom)
+- [场景 4：测试单算子](#场景-4测试单算子)
+- [场景 5：端到端 Example/ST 验证](#场景-5端到端-examplest-验证)
+- [如何确认新构建的 wheel 来自最新源码](#如何确认新构建的-wheel-来自最新源码)
+
+## 调用链路与场景选择
+
+先搞清楚「你改了什么 → 想要什么 → 用哪个场景」，再动手。选场景只看两个问题：
+
+1. **你改的是哪一类代码？** Ascend C 算子（host / kernel / tiling）、Python wrapper / 打包构建、还是新增算子。
+2. **你想要什么产物？** run 包（只替换算子的 Ascend C 产物）、完整 wheel、还是只要验证结果。
+
+### 完整链路
+
+从「改代码」到「NPU 上跑起来」的链路，各环节在后面的场景中都有对应操作：
+
+```
+① 改代码
+   ├─ Ascend C 算子（host / kernel / tiling）
+   ├─ Python wrapper（_aclnn_ctypes.py 等）＋ 打包 / 构建（setup.py / build.sh）
+   └─ 新增算子（源码目录 ＋ torch_custom 注册）
+        │
+        ▼
+② 构建产物
+   ├─ wheel（Python wrapper ＋ 内嵌 OPP） → pip install，客户直接使用
+   └─ run 包（仅 Ascend C 产物）        → 覆盖已安装 wheel 内嵌 OPP
+        │
+        ▼
+③ 验证
+   ├─ 场景 4：单算子（ATK / test.sh）
+   └─ 场景 5：端到端（Example / ST）
+        │
+        ▼
+④ 确认生效
+   └─ md5 比对：确认实际加载的产物来自最新源码
+```
+
+### 怎么选场景
+
+按下面的决策树逐条对照即可：
+
+```
+你在做什么？
+│
+├─ 只安装、不碰源码
+│     → 用 Release 官方 wheel：根 README Step 3 安装 ＋ Step 4 验证
+│
+├─ 改了 Ascend C 算子（kernel / host / tiling），已装好完整 wheel
+│     → 场景 1：只编这个算子的 run 包再覆盖安装
+│       bash build.sh --pkg --soc=<soc> --vendor_name=fla_npu --ops=<op>
+│
+├─ 改了 Python wrapper，或打包 / 构建流程，或想要一整份 wheel
+│     → 场景 2：一键编包（默认全量，或 FLA_NPU_OPS 只编指定算子）
+│       python scripts/build_wheel.py
+│
+├─ 新增一个算子（源码目录 ＋ wrapper 注册）
+│     → 场景 3：先搭目录结构，之后再用场景 1 或 2 编包
+│
+├─ 验证单个算子的精度 / 性能 / 确定性
+│     → 场景 4：bash tests/atk/run_test_cpu.sh -op=<op> -npu_device_id=0
+│
+└─ 端到端验证 GDN 调用链，或新增 CI / ST 用例
+      → 场景 5：python examples/flash_gated_delta_rule.py
+        （新增用例改 ci/example_st_cases.json）
+```
+
+### 场景速查表
+
+| 你的目标 | 场景 | 关键命令 | 产物 |
+| --- | --- | --- | --- |
+| 快速替换已装 wheel 里某个算子的 Ascend C 产物 | 1 | `bash build.sh --pkg --soc=<soc> --vendor_name=fla_npu --ops=<op>` | `.run` 包 |
+| Python wrapper / 打包 / 全量 wheel | 2 | `python scripts/build_wheel.py` | wheel |
+| 只编指定算子成 wheel | 2 | `FLA_NPU_OPS=<op1,op2> python scripts/build_wheel.py` | wheel |
+| 新增算子 | 3 | 见[场景 3](#场景-3增加一个新算子目录结构--torch_custom) | 源码 |
+| 单算子精度 / 性能 / 确定性 | 4 | `bash tests/atk/run_test_cpu.sh -op=<op> -npu_device_id=0` | - |
+| 端到端 GDN / CI 用例 | 5 | `python examples/flash_gated_delta_rule.py` | - |
+| 确认装的是最新编译产物 | md5 节 | `python scripts/verify_libcust_opapi_md5.py` | `[OK]` / `[FAIL]` |
+
+> 拿不准时：凡是**想换掉已装 wheel 里某个算子的代码** → 场景 1；凡是**改了 Python wrapper 或想重新打一版 wheel** → 场景 2；**验证**一律走场景 4 / 5。
+
+## 场景 1：单独编译单算子（run 包）
+
+当已经安装了完整 wheel，只需快速替换少量算子的 Ascend C 产物时使用。
+`--ops=op1,op2,...` 只会生成指定算子的 run 包；run 包安装时会把当前 run 包里的
+`packages/vendors/fla_npu_transformer` 合并覆盖到当前 Python 环境已安装的
+`site-packages/fla_npu/opp/vendors/fla_npu_transformer`，从而更新 `aclnn`、tiling、kernel 和相关配置。
+
+```sh
+# 编译一个或多个算子 run 包，--soc 需指定为当前机器芯片类型 {ascend910b/ascend910_93/ascend950}
+bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu --ops=chunk_fwd_o
+
+# 如果 Python wrapper 也有修改，再单独编译 Python runtime wheel
+cd torch_custom/fla_npu
+python3 setup.py bdist_wheel
+```
+
+### 安装 run 包
+
+先确认完整 wheel 已经安装到当前 Python 环境，然后安装 run 包。安装器会在覆盖前
+列出当前 run 包携带的算子，并标出安装后的算子状态：`WARNING` 表示安装后不可用，
+包括不在当前 run 包范围内但会受局部 `libcust_opapi.so`、tiling so、proto so 整体
+替换影响的算子，以及当前 run 包内但 aclnn ABI 修改或删除的算子；`NOTICE` 表示新增
+或无法完整确认的 ABI，需要确认当前 Python wheel 是否已有对应 wrapper；`OK` 表示当前
+run 包内且 aclnn ABI 一致的算子。`op_api/include/aclnnop` 中新增、删除、修改的 aclnn
+ABI 头文件会合并显示到对应算子的状态原因里；删除只按当前 run 包携带的算子范围判断，
+非 `--quiet` 模式只在状态表后确认一次。
+
+```sh
+# 覆盖当前 Python 环境中 flash-linear-attention-npu wheel 内嵌的 OPP
+./build_out/fla-npu-*.run --install
+# 或等价写法
+./build_out/fla-npu-*.run --full
+
+# 如需装到 CANN OPP 目录（ASCEND_CUSTOM_OPP_PATH / ASCEND_OPP_PATH），
+# 使用 --cann 或 --install-path=<绝对路径>
+# ./build_out/fla-npu-*.run --cann
+
+# 如果 Python wrapper 也有修改，再安装单独编译出的 wheel（路径替换为实际产物文件名）
+WHEEL_PATH="torch_custom/fla_npu/dist/<准确wheel文件名>.whl"
+python -m pip install --force-reinstall --no-cache-dir --no-deps "$WHEEL_PATH"
+```
+
+run 包覆盖完成后会重写幂等的 `set_env.bash`，并把实际 OPP 文件清单刷新到 wheel
+的 `RECORD`。因此重复覆盖同一个 run 包不会累积环境变量或文件记录，后续
+`pip --force-reinstall` 也能先清理 run 包增加的文件，再安装新 wheel。
+
+> 常规使用者推荐直接用根 README Step 2 / Step 3 的一键编包 + wheel 安装主流程；
+> 本场景仅在需要快速替换单个算子产物时使用。
+
+## 场景 2：一键编包（wheel）
+
+在仓库根目录用 `pip wheel` 构建 wheel（默认全量，或用 `FLA_NPU_OPS` 只编指定算子），
+构建流程会清理上一轮 `build/`、`build_out/` 和 `output/` 中间产物，不依赖 Git diff 或旧
+CMake 状态决定编译范围：
+
+```sh
+FLA_NPU_SOC=ascend910b python -m pip wheel --no-build-isolation --no-deps . -w dist
+```
+
+`pip wheel` 默认**全量**编包（一次编译全部已注册算子并打包成一个 wheel）；设置 `FLA_NPU_OPS=<op>` 环境变量可以只编译指定算子并打成 wheel：
+
+```sh
+FLA_NPU_SOC=ascend910b FLA_NPU_OPS=chunk_fwd_o,chunk_bwd_dv_local \
+  python -m pip wheel --no-build-isolation --no-deps . -w dist
+```
+
+`FLA_NPU_OPS` 会透传给 `build.sh --ops=<op>`（算子名用逗号分隔）。适合已安装完整
+wheel 后快速替换少量算子的 Ascend C 产物；未设置时全量构建。需要单独编译一个或多个
+算子的 run 包时，请使用场景 1 的 `bash build.sh --pkg ... --ops=<op>` 方式；如果只改了
+Python wrapper，也可以在 `torch_custom/fla_npu` 下单独执行 `python3 setup.py bdist_wheel`
+重新生成 Python wheel。
+
+### 工具链依赖表
+
+`python scripts/check_npu_env.py` 预检覆盖编译链上的 `cmake`、`gcc`/`g++`、
+`setuptools` 版本要求，`make` / `patch` / `bisheng` 存在性检查，以及
+`wheel` / `packaging` / `psutil`（`--no-build-isolation` 构建时需本机已装）的导入检查。
+其余组件未纳入预检，缺失时会在 `pip wheel` 阶段才报错：
+
+| 组件 | 版本要求 | 说明 |
+| ---- | ------- | ---- |
+| `cmake` | >= 3.16 | 项目 `CMakeLists.txt` 的最低要求 |
+| `gcc` / `g++` | >= 7.3 | host 侧编译 |
+| `make` | 任意 | CMake 默认 `Unix Makefiles` 生成器后端（`ninja` 亦可） |
+| `patch` | 任意 | CMake 第三方源码（abseil-cpp / ascend protobuf）的 `PATCH_COMMAND` 依赖，缺失时在预检直接报错 |
+| `bisheng` | 随 CANN（无独立版本判断） | 昇腾 kernel 编译工具，随 CANN toolkit 安装并在 source 后进入 PATH |
+| Python 头文件 | 与解释器匹配 | 仅 `FLA_NPU_BUILD_LEGACY_EXTENSION=1` 编译 legacy C++ 扩展时需要；默认 wheel 构建不需要 |
+| `setuptools` / `wheel` / `packaging` / `psutil` | `setuptools>=70.1`，其余任意 | `pyproject.toml` 声明的构建依赖；`--no-build-isolation` 构建时需本机已装 |
+
+## 场景 3：增加一个新算子（目录结构 + torch_custom）
+
+### 3.1 目录结构
+
+新增一个算子通常涉及以下目录：
+
+| 目录 | 作用 |
+| --- | --- |
+| `fla/ops/ascendc/<模块>/<算子>/` | Ascend C 算子实现（host / kernel / tiling / proto） |
+| `torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py` | Python ctypes wrapper |
+| `torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py` | `_ASCENDC_OPS` 注册 |
+| `torch_custom/fla_npu/test/test_npu_<op>.py` | 算子测试脚本 |
+
+以 `gdn` 模块下的反向算子 `chunk_bwd_dv_local` 为例，参考目录结构如下：
+
+```
+fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/
+├── CMakeLists.txt                  # 算子的编译目标声明
+├── op_host/                        # host 侧：算子注册 + tiling + aclnn 接口
+│   ├── chunk_bwd_dv_local_def.cpp  # 算子定义（proto 注册）
+│   ├── chunk_bwd_dv_local_tiling.cpp  # tiling 计算
+│   ├── chunk_bwd_dv_local_tiling_processor.h
+│   └── op_api/
+│       ├── aclnn_chunk_bwd_dv_local.h   # aclnn 接口头（clang-format 风格签名）
+│       └── aclnn_chunk_bwd_dv_local.cpp
+└── op_kernel/                      # kernel 侧：Ascend C 算子实现
+    ├── chunk_bwd_dv_local.cpp
+    ├── chunk_bwd_dv_local_struct.h
+    ├── chunk_bwd_dv_local_cube.h   # cube 侧实现
+    ├── chunk_bwd_dv_local_vector.h # vector 侧实现
+    └── chunk_bwd_dv_local_common.h
+```
+
+对应的 Python 调用侧文件：
+
+```
+torch_custom/fla_npu/fla_npu/ops/ascendc/
+├── _aclnn_ctypes.py                # 新增 npu_chunk_bwd_dv_local(...) ctypes wrapper
+└── __init__.py                     # _ASCENDC_OPS 中注册 chunk_bwd_dv_local
+torch_custom/fla_npu/test/
+└── test_npu_chunk_bwd_dv_local.py  # 新增算子测试脚本
+```
+
+新算子的 host / kernel 文件均可参考 `fla/ops/ascendc/gdn/` 下已有算子的对应文件补齐。
+
+### 3.2 为已有 Ascend C 算子新增 Python 调用接口
+
+核心链路：
+
+1. 在 `torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py` 中按 `aclnn_xxx.h` 签名新增 `npu_xxx(...)` wrapper。
+2. 在 `torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py` 的 `_ASCENDC_OPS` 注册算子名，注册后自动导出 `npu_xxx` 及去掉 `npu_` 前缀的短名。
+3. 新增测试 `torch_custom/fla_npu/test/test_npu_<op>.py` 并接入 `test.sh`。
+4. 重新构建 wheel / run 包并安装验证。
+
+详细步骤（含示例骨架、特殊参数、正反向绑定、mutation 契约）见
+[`torch_custom/fla_npu/README.md`](../torch_custom/fla_npu/README.md)。
+
+### 3.3 算子调用方式
+
+推荐通过 `fla_npu.ops.ascendc` 或 `fla_npu.ops.triton` 导入对应算子；具体入参可参考
+`torch_custom/fla_npu/test` 下的对应算子测试脚本。例如：
+
+```python
+import torch
+import fla_npu
+from fla_npu.ops.ascendc import chunk_bwd_dv_local
+
+dv = chunk_bwd_dv_local(...)
+```
+
+## 场景 4：测试单算子
+
+单算子看护的命令与 `-op` 可选值已在根 [README](../README.md) Step 4 的"测试单算子"节完整列出
+（ATK 工程）；本场景仅补充开发调试时可用的 `test.sh` 选项：
+
+```sh
+cd torch_custom/fla_npu/test
+bash test.sh --device 0 --mode dry-run   # 只打印将执行的命令，不真正运行
+```
+
+## 场景 5：端到端 Example/ST 验证
+
+运行方式见根 [README](../README.md) Step 4 的"端到端 Example/ST 验证"节；
+本场景面向在 [`ci/example_st_cases.json`](../ci/example_st_cases.json) 中新增 CI 用例的开发者：
+
+- 当前默认启用 `case1_current_default`，shape 与直接运行默认值一致；
+- 新增用例需显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、
+  `Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、
+  `output_final_state`、`qk_l2norm` 等行为字段；
+- 当前已支持 `gate_source=g`；`gk` / `g+gk` 先作为用例 schema 预留，待 NPU fwd_h
+  路径支持后再启用。
+
+## 如何确认新构建的 wheel 来自最新源码
+
+重新构建后，需要确认实际安装的 wheel 确实来自最新修改的源码，避免因版本号相同被
+`pip` 跳过（详见根 README Step 3）。推荐使用 md5 比对脚本确认：
+
+### 比对运行时加载与最新编译产物的 md5
+
+`import fla_npu` 时会在 Python 进程内定位并加载 wheel 内嵌 OPP，并把实际加载的
+`libcust_opapi.so` 路径写入环境变量 `FLA_NPU_OP_API_LIB`（同时把 vendor 目录注入
+`ASCEND_CUSTOM_OPP_PATH`）。md5 比对脚本**无需导入 fla_npu、也无需先 source CANN
+环境**——它直接按 fla_npu 相同的候选顺序解析"运行时将加载的 `libcust_opapi.so`"
+（`FLA_NPU_OPP_PATH` → 已安装包内嵌 OPP → `ASCEND_CUSTOM_OPP_PATH` →
+`ASCEND_OPP_PATH`），只做纯文件 md5 比对。脚本默认对比两部分：
+
+- `libcust_opapi.so`（host 侧 aclnn 接口库）；
+- kernel `.o`（NPU 上实际执行的算子二进制，位于
+  `op_impl/ai_core/tbe/kernel/`）。kernel 改动**不会**改变
+  `libcust_opapi.so` 的 md5，因此默认就会比对该目录，避免只改 kernel 时漏检。
+
+```sh
+# 不带参数：自动与 build/ 下的编译产物对比（libcust_opapi.so + 全部 kernel .o）
+python scripts/verify_libcust_opapi_md5.py
+
+# 新编了 run 包：与 run 包内的 libcust_opapi.so 对比（自动提取）
+python scripts/verify_libcust_opapi_md5.py --run-package build_out/fla-npu-fla_npu_linux-aarch64.run
+
+# 或显式指定编译产物路径（lib 与 kernel 均可单独指定）
+python scripts/verify_libcust_opapi_md5.py --built-lib build/libcust_opapi.so
+python scripts/verify_libcust_opapi_md5.py --built-kernel build/lib/fla_npu/opp/vendors/fla_npu_transformer/op_impl/ai_core/tbe/kernel
+
+# 只比对 libcust_opapi.so，跳过 kernel .o 对比
+python scripts/verify_libcust_opapi_md5.py --no-kernel
+
+# 加 --python：同时比对 Python wrapper（.py 源码打包进 wheel 时是纯拷贝，
+# 与 libcust_opapi.so 同源；只改 wrapper 源码后也需重装 wheel）
+python scripts/verify_libcust_opapi_md5.py --python
+```
+
+脚本输出运行时加载与编译产物的路径与 md5，并给出 `[OK]`（一致，新安装的 OPP
+生效）或 `[FAIL]`（不一致，当前加载的是旧 OPP，需要重新安装新 wheel / run 包）
+结论。kernel `.o` 全量共约 85 个、10 MB，md5 比对耗时不足 0.1 秒；不一致时脚本
+列出 diff 的算子目录与文件（如 `ascend910b/chunk_fwd_o/ChunkFwdO_*.o`）。
+`--python` 模式会把 `fla_npu/__init__.py`、`ops/ascendc/__init__.py`、
+`_aclnn_ctypes.py`、`_runtime.py` 的已安装文件与 `torch_custom/fla_npu/fla_npu/`
+下源码逐个比对 md5，任一不一致即报 `[FAIL]`。
+
+> 注意：三类产物的 md5 相互独立，各自只反映对应侧的改动。
+> 只改 kernel 源码 → `libcust_opapi.so` md5 不变、kernel `.o` md5 变（默认模式检出）；
+> 只改 host 侧算子定义/tiling → 两者都变；
+> 只改 Python wrapper → OPP 侧 md5 都不变，需加 `--python` 确认 wrapper 已更新。
+
+### 辅助确认：临时打印标记
+
+如需进一步确认实际执行的代码来自新源码，可在源码修改处临时打印标记
+（如 `print("[DEBUG] new build")`，或查看 `__pycache__` 的时间戳），确认输出后移除。

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,32 +1,56 @@
-## 简介
+# Examples 说明
 
-> 说明：
+本目录提供 flash-linear-attention-npu 的端到端示例与算子开发参考模板：
 
-> - 关于AI Core的介绍请参见[《Ascend C算子开发》](https://hiascend.com/document/redirect/CannCommunityOpdevAscendC)中“概念原理和术语 > 硬件架构与数据处理原理”。
-
-本项目提供了AI Core算子的开发和调用样例，请开发者根据实际情况参考对应实现。
+- `flash_gated_delta_rule.py`：GDN 模块端到端接入示例，组装 GDN 相关前向/反向算子，覆盖 AscendC 与 Triton 调用链。
+- `add_example/`：一个完整的 Ascend C 算子工程模板（add 算子），包含 `op_host`（def / tiling / infershape）、`op_kernel`、`op_graph` 与测试工程，可作为新增 Ascend C 算子的目录结构参考。
+- `fast_kernel_launch_example/`：演示如何使用 Ascend C + PyTorch Extension 能力开发自定义 NPU 算子，单个交付件完成算子开发与 PyTorch 框架适配，并支持 `<<<>>>` 语法启动核函数。
 
 ## 目录说明
 
 ```
-├── example                       
-│   ├── add_example                # AI Core算子名
-│   │   ├── CMakeLists.txt         # 算子编译配置文件，保留原文件即可   
-│   │   ├── examples               # 算子使用示例
-│   │   ├── op_graph               # 算子构图相关目录
-│   │   ├── op_host                # 算子信息库、Tiling、InferShape相关实现
-│   │   └── op_kernel              # 算子kernel目录
-│   ├── mc2                        # 通算融合类算子示例
-│   │   ├── all_gather_add         # AI Core算子名
-│   │   │   └── ...              
-│   ├── CMakeLists.txt             # 算子编译配置文件，保留原文件即可
-│   └── README.md                  # 算子说明文档
-
+├── flash_gated_delta_rule.py        # GDN 端到端调用示例
+├── add_example/                     # Ascend C 算子工程模板（add 算子）
+│   ├── CMakeLists.txt
+│   ├── examples/                    # 算子使用示例（test_aclnn_add_example.cpp）
+│   ├── op_graph/                    # 算子构图相关目录
+│   ├── op_host/                     # def / tiling / infershape 实现
+│   ├── op_kernel/                   # AI Core kernel
+│   ├── op_kernel_aicpu/             # AICPU kernel（含 fallback 场景）
+│   ├── tests/                       # 测试工程
+│   └── README.md                    # 算子说明文档
+├── fast_kernel_launch_example/      # Ascend C + PyTorch Extension 快速开发示例
+│   ├── ascend_ops/                  # 算子源码与 PyTorch 适配
+│   ├── csrc/                        # C++ 侧封装
+│   ├── tests/                       # 测试用例
+│   ├── setup.py / build_and_test.sh # 构建与测试脚本
+│   └── README.md                    # 示例说明与安装步骤
+└── CMakeLists.txt                   # 编译配置（遍历含 CMakeLists.txt 的子目录）
 ```
 
-## 算子开发样例
+## 快速运行
 
-|样例目录| 	样例介绍	           |算子开发|算子调用 |
-|---|------------------|---|---|
-| add_example | 	实现两个张量相加功能的算子。	 | 算子端到端开发过程参见[AI Core算子开发指南](../docs/zh/develop/aicore_develop_guide.md)。 |调用样例参见[README](add_example/README.md)|
-| mc2/all_gather_add | 	实现AllGatherAdd通算算子 。	 | 算子端到端开发过程参见[AI Core算子开发指南](../docs/zh/develop/aicore_develop_guide.md)。 |调用样例参见[README](mc2/all_gather_add/README.md)|
+### GDN 端到端示例
+
+完成 README 的构建与安装后，直接运行：
+
+```sh
+python examples/flash_gated_delta_rule.py
+```
+
+该脚本会组装 GDN 相关前向/反向算子，覆盖 AscendC 与 Triton 调用链，输出各算子的运行结果与精度对比。
+
+### add_example
+
+参考 `add_example/README.md` 与 `add_example/examples/test_aclnn_add_example.cpp`，以 `add_example` 为模板实现自定义 Ascend C 算子，并接入本仓 `torch_custom/fla_npu` 的 Python 接口（新增接口步骤见[开发者指南](../docs/开发者指南.md)的场景 3）。
+
+### fast_kernel_launch_example
+
+进入 `fast_kernel_launch_example/`，按该目录 `README.md` 安装依赖、构建 wheel 并运行测试，即可体验单文件交付的算子开发流程。
+
+## 新增示例要求
+
+- 新增示例必须可独立运行，避免依赖其他示例的中间产物。
+- 涉及新算子的示例，需同时提供该算子的单算子测试（`torch_custom/fla_npu/test/test_npu_<op>.py`）并接入 `test.sh`。
+- 示例代码优先使用稳定 Python 入口 `fla_npu.ops.ascendc` / `fla_npu.ops.triton`，不要默认走 legacy `torch.ops.npu.*` 路径。
+- 在 `examples/` 新增子目录时，如需参与统一编译，请提供对应 `CMakeLists.txt`。

--- a/scripts/check_npu_env.py
+++ b/scripts/check_npu_env.py
@@ -8,6 +8,7 @@ import importlib.util
 import os
 import re
 import shutil
+import subprocess
 import sys
 from importlib import metadata
 from typing import Optional, Tuple
@@ -19,6 +20,16 @@ MIN_PYTHON = (3, 9)
 MIN_TORCH = "2.6.0"
 MIN_TRITON_ASCEND = "3.2.0"
 MIN_TRITON_ASCEND_A5 = "3.2.1"
+# CANN 9.x (9.0.0+) requires triton-ascend >= 3.2.1: 3.2.0 fails to JIT-compile
+# triton/backends/ascend/npu_utils.cpp on CANN 9.1.0 (RT_LIMIT_TYPE_SIMT_WARP_STACK_SIZE).
+MIN_TRITON_ASCEND_CANN9 = "3.2.1"
+
+# Toolchain and build dependencies checked in addition to the torch-related
+# checks. Values mirror CMakeLists.txt (cmake_minimum_required),
+# install_deps.sh (gcc) and pyproject.toml ([build-system] requires).
+MIN_CMAKE = "3.16"
+MIN_GCC = "7.3"
+MIN_SETUPTOOLS = "70.1"
 TORCH_NPU_GDN_FIX_MINIMUMS = {
     "2.7.1": "2.7.1.post5",
     "2.8.0": "2.8.0.post5",
@@ -156,13 +167,211 @@ def _check_triton_ascend_a5_compat(failures: list[str], actual: str) -> None:
         )
 
 
+def _check_triton_ascend_cann_compat(failures: list[str], actual: str) -> None:
+    """CANN 9.x needs triton-ascend >= 3.2.1.
+
+    3.2.0 is the generic lower bound, but on CANN 9.0.0+ the Ascend Triton
+    backend JIT-compiles npu_utils.cpp against newer rt.h headers and fails
+    (e.g. RT_LIMIT_TYPE_SIMT_WARP_STACK_SIZE), so raise the floor for CANN 9.x.
+    """
+    cann = _detect_cann_version()
+    cann_match = re.search(r"(\d+\.\d+)", cann)
+    if not cann_match:
+        return
+    if int(cann_match.group(1).split(".")[0]) < 9:
+        return
+    actual_version = _version_obj(actual)
+    if actual_version is None or actual_version < Version(MIN_TRITON_ASCEND_CANN9):
+        _fail(
+            failures,
+            f"triton-ascend>={MIN_TRITON_ASCEND_CANN9} is required for CANN {cann_match.group(1)} "
+            f"(detected); got {actual}. triton-ascend 3.2.0 fails to JIT-compile "
+            "npu_utils.cpp on CANN 9.x.",
+        )
+
+
+def _check_cmake_version(failures: list[str]) -> None:
+    """Check the CMake version against the project's minimum requirement.
+
+    The lower bound comes from ``cmake_minimum_required(VERSION 3.16)`` in
+    ``CMakeLists.txt`` (mirrored by ``install_deps.sh``), so any version
+    >= MIN_CMAKE is supported.
+    """
+    cmake = shutil.which("cmake")
+    if cmake is None:
+        _fail(failures, f"cmake not found (cmake>={MIN_CMAKE} is required)")
+        return
+    try:
+        output = subprocess.run(
+            [cmake, "--version"], capture_output=True, text=True, timeout=10
+        ).stdout
+    except OSError as exc:
+        _fail(failures, f"cmake: cannot run {cmake}: {exc}")
+        return
+    match = re.search(r"cmake version ([\d.]+)", output)
+    if not match:
+        _fail(failures, f"cmake: cannot parse version from: {output.strip()!r}")
+        return
+    actual = match.group(1)
+    _ok(f"cmake: {cmake} (version {actual})")
+    _check_min_version(failures, "cmake", actual, MIN_CMAKE)
+
+
+def _check_setuptools_version(failures: list[str]) -> None:
+    """Check the setuptools version against the build-system requirement.
+
+    ``pyproject.toml`` declares ``setuptools>=70.1`` because setuptools only
+    ships ``setuptools.command.bdist_wheel`` (used by setup.py as a fallback)
+    from 70.x onward, so any version >= MIN_SETUPTOOLS is supported.
+    """
+    try:
+        actual = metadata.version("setuptools")
+    except Exception as exc:
+        _fail(failures, f"setuptools: cannot determine version: {exc}")
+        return
+    _ok(f"setuptools version: {actual}")
+    _check_min_version(failures, "setuptools", actual, MIN_SETUPTOOLS)
+
+
+def _check_build_system_deps(failures: list[str]) -> None:
+    """Check the other pyproject build-system dependencies are importable.
+
+    The README build flow runs ``pip wheel --no-build-isolation``, so the
+    build-system packages declared in ``pyproject.toml`` (wheel, packaging,
+    psutil) must already be installed in the current interpreter. setuptools is
+    checked separately with a version bound; the remaining three have no
+    minimum version.
+    """
+    for module_name in ("wheel", "packaging", "psutil"):
+        try:
+            module = importlib.import_module(module_name)
+            _ok(
+                f"{module_name} version: "
+                f"{getattr(module, '__version__', '<unknown>')}"
+            )
+        except Exception as exc:
+            _fail(
+                failures,
+                f"{module_name} not importable (pyproject build-system requires "
+                f"it when using --no-build-isolation): {exc}",
+            )
+
+
+def _check_gcc_version(failures: list[str]) -> None:
+    """Check the host C/C++ compiler version against install_deps.sh.
+
+    ``install_deps.sh`` requires gcc/g++ >= 7.3.0; host-side C++ code in
+    build.sh and the Ascend C host wrapper are compiled with it.
+    """
+    gcc = shutil.which("gcc")
+    if gcc is None:
+        _fail(failures, f"gcc not found (gcc>={MIN_GCC} is required)")
+    else:
+        _ok(f"gcc: {gcc}")
+        actual = _tool_version(gcc, r"(\d+\.\d+\.\d+)")
+        if actual:
+            _check_min_version(failures, "gcc", actual, MIN_GCC)
+        else:
+            _fail(failures, "gcc: cannot parse version")
+
+    gxx = shutil.which("g++")
+    if gxx is None:
+        _fail(failures, f"g++ not found (g++>={MIN_GCC} is required)")
+    else:
+        _ok(f"g++: {gxx}")
+        actual = _tool_version(gxx, r"(\d+\.\d+\.\d+)")
+        if actual:
+            _check_min_version(failures, "g++", actual, MIN_GCC)
+        else:
+            _fail(failures, "g++: cannot parse version")
+
+
+def _check_make_exists(failures: list[str]) -> None:
+    """Check that a CMake build backend is available.
+
+    The build uses CMake's default ``Unix Makefiles`` generator (ninja is an
+    alternative, so either make or ninja is sufficient).
+    """
+    make = shutil.which("make")
+    ninja = shutil.which("ninja")
+    if make:
+        _ok(f"make: {make}")
+    elif ninja:
+        _ok(f"make not found; ninja: {ninja}")
+    else:
+        _fail(failures, "make not found (nor ninja as a CMake build backend)")
+
+
+def _check_patch_exists(failures: list[str]) -> None:
+    """Check that the system ``patch`` command is available.
+
+    The CMake third-party build applies source patches via
+    ``PATCH_COMMAND patch -p1 < ...`` (abseil-cpp and ascend protobuf), so a
+    missing ``patch`` only surfaces halfway through the build. It has no
+    version requirement, so we only check presence.
+    """
+    patch = shutil.which("patch")
+    if patch:
+        _ok(f"patch: {patch}")
+    else:
+        _fail(
+            failures,
+            "patch not found. It is required by the CMake third-party build "
+            "(abseil-cpp / ascend protobuf PATCH_COMMAND); install it with the "
+            "system package manager (e.g. apt-get install -y patch).",
+        )
+
+
+def _check_bisheng_exists(failures: list[str]) -> None:
+    """Check that the Ascend C kernel compiler (bisheng) is available.
+
+    bisheng is shipped with the CANN toolkit and exported to PATH by the CANN
+    ``setenv.bash``; build.sh fails if ``which bisheng`` is empty. Its
+    ``--version`` reports a clang version, not a CANN component version, so we
+    only check presence, not a minimum version.
+    """
+    bisheng = shutil.which("bisheng")
+    if bisheng:
+        _ok(f"bisheng: {bisheng}")
+    else:
+        _fail(
+            failures,
+            "bisheng not found. It is shipped with the CANN toolkit and should be "
+            "on PATH after sourcing the CANN set_env.sh/setenv.bash.",
+        )
+
+
+def _tool_version(tool: str, pattern: str) -> Optional[str]:
+    """Run ``tool --version`` and return the first regex match group, or None."""
+    try:
+        output = subprocess.run(
+            [tool, "--version"], capture_output=True, text=True, timeout=10
+        ).stdout
+    except OSError:
+        return None
+    match = re.search(pattern, output)
+    return match.group(1) if match else None
+
+
 def _detect_cann_version() -> str:
-    candidates = []
-    for env_name in ("ASCEND_HOME_PATH", "ASCEND_OPP_PATH"):
-        value = os.getenv(env_name)
-        if not value:
-            continue
-        path = os.path.abspath(value)
+    # The OPP install dir's version.info is the authoritative CANN version
+    # (e.g. "Version=8.3.0.1.200" or "Version=9.1.0-beta.1"). ASCEND_HOME_PATH
+    # can resolve to driver install files whose version is not the CANN
+    # version (e.g. "version=25.5.1"), so it is only consulted after the OPP
+    # dir, and driver-version-like values are skipped.
+    opp = os.getenv("ASCEND_OPP_PATH")
+    candidates: list[str] = []
+    if opp:
+        path = os.path.abspath(opp)
+        candidates.extend(
+            [
+                os.path.join(path, "version.info"),
+                os.path.join(os.path.dirname(path), "version.info"),
+            ]
+        )
+    home = os.getenv("ASCEND_HOME_PATH")
+    if home:
+        path = os.path.abspath(home)
         candidates.extend(
             [
                 os.path.join(path, "version.info"),
@@ -177,15 +386,21 @@ def _detect_cann_version() -> str:
             continue
         try:
             with open(candidate, "r", encoding="utf-8", errors="ignore") as file:
-                for line in file:
-                    stripped = line.strip()
-                    lower = stripped.lower()
-                    if "version" in lower and "=" in stripped:
-                        return stripped
-                    if lower.startswith("version"):
-                        return stripped
+                lines = [line.strip() for line in file]
         except OSError:
             continue
+        for line in lines:
+            if "driver" in line.lower():
+                continue
+            key, _, value = line.partition("=")
+            if key.strip().lower() == "version" and value.strip():
+                return line
+        for line in lines:
+            if "driver" in line.lower():
+                continue
+            key, _, value = line.partition("=")
+            if key.strip().lower() == "version_dir" and value.strip():
+                return line
     return "<unknown>"
 
 
@@ -233,6 +448,14 @@ def main() -> int:
     else:
         _fail(failures, "ASCEND_HOME_PATH or ASCEND_OPP_PATH must be set")
 
+    _check_cmake_version(failures)
+    _check_gcc_version(failures)
+    _check_make_exists(failures)
+    _check_patch_exists(failures)
+    _check_bisheng_exists(failures)
+    _check_setuptools_version(failures)
+    _check_build_system_deps(failures)
+
     check_runtime = not args.build_only or args.legacy_extension
     if not check_runtime:
         _ok("skipping torch/torch_npu/triton checks for Python-only wheel build")
@@ -278,6 +501,7 @@ def main() -> int:
         if triton_ascend_version:
             _ok(f"triton-ascend version: {triton_ascend_version}")
             _check_min_version(failures, "triton-ascend", triton_ascend_version, MIN_TRITON_ASCEND)
+            _check_triton_ascend_cann_compat(failures, triton_ascend_version)
             _check_triton_ascend_a5_compat(failures, triton_ascend_version)
         elif triton is not None:
             _fail(failures, "triton is importable, but triton-ascend distribution was not found")

--- a/scripts/verify_libcust_opapi_md5.py
+++ b/scripts/verify_libcust_opapi_md5.py
@@ -1,0 +1,413 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Verify that the running fla_npu really loads freshly built artifacts.
+
+Three kinds of artifacts are compared between what ``import fla_npu`` actually
+loads at runtime and the freshly built/staged copies:
+
+1. OPP library: ``libcust_opapi.so``
+   - runtime: resolved by mirroring fla_npu's own search order (see
+     ``_resolve_runtime_lib``), without importing/loading fla_npu, so no CANN
+     environment is required to run this script;
+   - built:   ``build/libcust_opapi.so`` by default, or ``--built-lib`` /
+     ``--run-package`` (extracted from a Makeself run package).
+2. Kernel binaries: the ``*.o`` NPU kernels under
+   ``op_impl/ai_core/tbe/kernel/``.  These are what actually runs on the NPU;
+   a kernel-only source change does not alter ``libcust_opapi.so``, so without
+   this comparison the script would not notice a stale kernel.  Compared by
+   default against ``build/lib/fla_npu/opp/vendors/.../kernel``; disable with
+   ``--no-kernel``.
+3. Python wrapper: the core ``.py`` files under the installed package
+   (``fla_npu/__init__.py``, ``ops/ascendc/*.py``), compared against the
+   sources under ``torch_custom/fla_npu/fla_npu/``.  Opt-in via ``--python``.
+
+If both sides are found, it reports whether their md5 match.  ``[OK]`` means
+the running wheel is exactly the one freshly built; ``[FAIL]`` means a stale
+copy is still in use and the new wheel / run package must be reinstalled.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+
+# Python wrapper files that are pure copies of the sources (no build-time
+# rewriting), as paths relative to the fla_npu package root, so the runtime
+# side can be located through the installed package directory.
+PYTHON_WRAPPER_MODULES = (
+    "__init__.py",
+    "ops/ascendc/__init__.py",
+    "ops/ascendc/_aclnn_ctypes.py",
+    "ops/ascendc/_runtime.py",
+)
+
+
+def _md5(path: Path) -> str:
+    digest = hashlib.md5()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _resolve_run_package_lib(run_package: Path) -> Path | None:
+    """Locate libcust_opapi.so inside a .run package (Makeself self-extracting archive)."""
+    import subprocess
+    import tempfile
+
+    if not run_package.exists():
+        print(f"[WARN] run package not found: {run_package}", file=sys.stderr)
+        return None
+    with tempfile.TemporaryDirectory(prefix="fla-npu-run-extract-") as tmp:
+        try:
+            proc = subprocess.run(
+                [str(run_package), f"--extract={tmp}", "--noexec"],
+                check=True,
+                capture_output=True,
+                timeout=300,
+            )
+        except subprocess.CalledProcessError as exc:
+            print(
+                f"[WARN] failed to extract run package {run_package} "
+                f"(exit {exc.returncode}):\n{exc.stderr.decode(errors='replace')[-500:]}",
+                file=sys.stderr,
+            )
+            return None
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            print(f"[WARN] failed to extract run package {run_package}: {exc}", file=sys.stderr)
+            return None
+        extracted = Path(tmp) / "packages" / "vendors" / "fla_npu_transformer" / "op_api" / "lib" / "libcust_opapi.so"
+        if not extracted.exists():
+            return None
+        # Copy to a stable location so the md5 survives tempdir cleanup.
+        stable = run_package.parent / f".{run_package.name}.libcust_opapi.so"
+        try:
+            import shutil
+
+            shutil.copy2(extracted, stable)
+            return stable
+        except OSError:
+            return extracted
+
+
+def _find_built_lib(repo_root: Path, built_lib: str | None, run_package: str | None) -> Path | None:
+    if run_package:
+        return _resolve_run_package_lib(Path(run_package))
+    if built_lib:
+        candidate = Path(built_lib)
+        if candidate.exists():
+            return candidate
+        return None
+
+    candidates = [
+        repo_root / "build" / "libcust_opapi.so",
+        repo_root / "build" / "lib" / "fla_npu" / "opp" / "vendors" / "fla_npu_transformer" / "op_api" / "lib" / "libcust_opapi.so",
+    ]
+    return next((path for path in candidates if path.exists()), None)
+
+
+def _installed_fla_npu_root() -> Path | None:
+    """Locate the installed fla_npu package directory without importing it.
+
+    ``importlib.util.find_spec`` returns the module spec without executing
+    ``fla_npu/__init__.py``, so no CANN library is loaded and no CANN
+    environment is required.
+    """
+    spec = importlib.util.find_spec("fla_npu")
+    if spec is None or not spec.submodule_search_locations:
+        return None
+    return Path(next(iter(spec.submodule_search_locations))).resolve()
+
+
+def _resolve_runtime_lib() -> Path | None:
+    """Resolve the libcust_opapi.so that ``import fla_npu`` would load.
+
+    Mirrors ``fla_npu/__init__.py`` (``_candidate_opp_roots`` +
+    ``_resolve_vendor_dir``) without actually loading anything:
+
+    1. ``FLA_NPU_OPP_PATH`` (external-OPP debug override), if set;
+    2. the OPP embedded inside the installed package (site-packages/fla_npu/opp);
+    3. ``ASCEND_CUSTOM_OPP_PATH`` / ``ASCEND_OPP_PATH`` from the CANN env.
+
+    The first root containing ``op_api/lib/libcust_opapi.so`` (directly, under
+    ``vendors/fla_npu_transformer``, or as a single vendor) wins.
+    """
+    candidates: list[Path] = []
+    override = os.environ.get("FLA_NPU_OPP_PATH", "").strip()
+    if override:
+        candidates.append(Path(override).expanduser())
+
+    installed_root = _installed_fla_npu_root()
+    if installed_root is not None:
+        candidates.append(installed_root / "opp")
+
+    for env_name in ("ASCEND_CUSTOM_OPP_PATH", "ASCEND_OPP_PATH"):
+        for part in os.environ.get(env_name, "").split(os.pathsep):
+            if part:
+                candidates.append(Path(part).expanduser())
+
+    seen: set[Path] = set()
+    for root in candidates:
+        root = root.resolve()
+        if root in seen:
+            continue
+        seen.add(root)
+
+        direct = root / "op_api" / "lib" / "libcust_opapi.so"
+        if direct.exists():
+            return direct
+
+        vendors_root = root / "vendors"
+        vendor_dir = vendors_root / "fla_npu_transformer"
+        lib = vendor_dir / "op_api" / "lib" / "libcust_opapi.so"
+        if lib.exists():
+            return lib
+
+        if vendors_root.exists():
+            vendor_dirs = [
+                path
+                for path in vendors_root.iterdir()
+                if path.is_dir() and (path / "op_api" / "lib" / "libcust_opapi.so").exists()
+            ]
+            if len(vendor_dirs) == 1:
+                return vendor_dirs[0] / "op_api" / "lib" / "libcust_opapi.so"
+
+    return None
+
+
+def _check_opp_lib(repo_root: Path, built_lib: str | None, run_package: str | None) -> bool:
+    loaded_lib = _resolve_runtime_lib()
+    if loaded_lib is None:
+        print(
+            "[FAIL] runtime libcust_opapi.so not found; "
+            "fla_npu is not installed or no OPP root is resolvable."
+        )
+        return False
+
+    loaded_md5 = _md5(loaded_lib)
+    print(f"loaded libcust_opapi.so: {loaded_lib}")
+    print(f"loaded md5:              {loaded_md5}")
+
+    built_lib_path = _find_built_lib(repo_root, built_lib, run_package)
+    if built_lib_path is None:
+        print(
+            "[WARN] no freshly built libcust_opapi.so found; pass --built-lib or --run-package "
+            "to compare against a build artifact."
+        )
+        return True
+
+    built_md5 = _md5(built_lib_path)
+    print(f"built  libcust_opapi.so: {built_lib_path}")
+    print(f"built  md5:              {built_md5}")
+
+    if loaded_md5 == built_md5:
+        print("[OK] loaded libcust_opapi.so matches the freshly built one.")
+        return True
+    print(
+        "[FAIL] loaded libcust_opapi.so differs from the freshly built one; "
+        "the running wheel still uses an older OPP. Reinstall the new wheel/run package."
+    )
+    return False
+
+
+def _kernel_dir_from_lib(lib_path: Path) -> Path | None:
+    """Derive the kernel ``.o`` root from a libcust_opapi.so path.
+
+    Inside a vendor OPP the layout is::
+
+        .../vendors/fla_npu_transformer/op_api/lib/libcust_opapi.so
+        .../vendors/fla_npu_transformer/op_impl/ai_core/tbe/kernel/<soc>/<op>/*.o
+    """
+    kernel = lib_path.parents[2] / "op_impl" / "ai_core" / "tbe" / "kernel"
+    return kernel if kernel.is_dir() else None
+
+
+def _collect_kernel_objects(root: Path) -> dict[str, str]:
+    """Map ``soc/op/name.o`` -> md5 for every ``*.o`` under a kernel root."""
+    objs: dict[str, str] = {}
+    for path in root.rglob("*.o"):
+        objs[str(path.relative_to(root))] = _md5(path)
+    return objs
+
+
+MAX_KERNEL_DIFF_PRINT = 20
+
+
+def _check_kernel_o(repo_root: Path, built_kernel: str | None = None) -> bool:
+    """Compare the runtime embedded OPP kernel ``.o`` files with the freshly built ones.
+
+    Kernel ``.o`` files are what actually run on the NPU and are not part of
+    ``libcust_opapi.so``, so a kernel-only source change can only be detected
+    through them.
+    """
+    loaded_lib = _resolve_runtime_lib()
+    runtime_root = _kernel_dir_from_lib(loaded_lib) if loaded_lib else None
+    if runtime_root is None:
+        print("[WARN] runtime OPP kernel dir not found; kernel .o comparison skipped.")
+        return True
+
+    built_root = (
+        Path(built_kernel).resolve()
+        if built_kernel
+        else repo_root
+        / "build"
+        / "lib"
+        / "fla_npu"
+        / "opp"
+        / "vendors"
+        / "fla_npu_transformer"
+        / "op_impl"
+        / "ai_core"
+        / "tbe"
+        / "kernel"
+    )
+    if not built_root.is_dir():
+        print(f"[WARN] freshly built kernel dir not found: {built_root}; kernel .o comparison skipped.")
+        return True
+
+    runtime_objs = _collect_kernel_objects(runtime_root)
+    built_objs = _collect_kernel_objects(built_root)
+    print(f"runtime kernel: {runtime_root} ({len(runtime_objs)} .o)")
+    print(f"built   kernel: {built_root} ({len(built_objs)} .o)")
+
+    problems: list[str] = []
+    n_diff = 0
+    n_missing = 0
+    for rel in sorted(set(runtime_objs) | set(built_objs)):
+        in_runtime = rel in runtime_objs
+        in_built = rel in built_objs
+        if in_runtime and in_built:
+            if runtime_objs[rel] != built_objs[rel]:
+                n_diff += 1
+                if n_diff <= MAX_KERNEL_DIFF_PRINT:
+                    problems.append(
+                        f"[DIFF] {rel}\n"
+                        f"  runtime md5: {runtime_objs[rel]}\n"
+                        f"  built   md5: {built_objs[rel]}"
+                    )
+        else:
+            n_missing += 1
+            side = "runtime side" if in_runtime else "built side"
+            if n_missing <= MAX_KERNEL_DIFF_PRINT:
+                problems.append(f"[MISSING] {rel} (only on {side})")
+
+    for line in problems:
+        print(line)
+    tail = len(problems) - MAX_KERNEL_DIFF_PRINT
+    if tail > 0:
+        print(f"  ... and {tail} more")
+
+    if n_diff == 0 and n_missing == 0:
+        print(f"[OK] all {len(runtime_objs)} kernel .o files match the freshly built OPP.")
+        return True
+    print(
+        f"[FAIL] {n_diff} kernel .o differ, {n_missing} present on one side only; "
+        "the running wheel still uses an older kernel. "
+        "Reinstall the new wheel/run package."
+    )
+    return False
+
+
+def _check_python_wrapper(repo_root: Path) -> bool:
+    """Compare installed wrapper .py files against their sources."""
+    installed_root = _installed_fla_npu_root()
+    if installed_root is None:
+        print("[WARN] installed fla_npu package not found; wrapper comparison skipped.", file=sys.stderr)
+        return True
+    source_root = repo_root / "torch_custom" / "fla_npu" / "fla_npu"
+    if not source_root.exists():
+        print(f"[WARN] wrapper source dir not found: {source_root}", file=sys.stderr)
+        return True
+
+    ok = True
+    checked = 0
+    for rel in PYTHON_WRAPPER_MODULES:
+        installed = installed_root / rel
+        source = source_root / rel
+        if not installed.exists():
+            print(f"[FAIL] installed wrapper file not found: {installed}")
+            ok = False
+            continue
+        if not source.exists():
+            print(f"[WARN] wrapper source file not found: {source}", file=sys.stderr)
+            continue
+        imd5 = _md5(installed)
+        smd5 = _md5(source)
+        status = "OK" if imd5 == smd5 else "FAIL"
+        if imd5 != smd5:
+            ok = False
+        print(f"[{status}] {rel}")
+        print(f"  loaded: {installed}  md5={imd5}")
+        print(f"  source: {source}      md5={smd5}")
+        checked += 1
+
+    if checked == 0:
+        print("[WARN] no Python wrapper files compared", file=sys.stderr)
+        return True
+    if ok:
+        print("[OK] installed Python wrapper files match the current sources.")
+    else:
+        print(
+            "[FAIL] some installed Python wrapper files differ from the current sources; "
+            "reinstall the newly built wheel."
+        )
+    return ok
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--built-lib",
+        default=None,
+        help="Path to the freshly built libcust_opapi.so. Defaults to the one staged under build/.",
+    )
+    parser.add_argument(
+        "--run-package",
+        default=None,
+        help="Path to a freshly built fla-npu-*.run package; its libcust_opapi.so is extracted for comparison.",
+    )
+    parser.add_argument(
+        "--python",
+        action="store_true",
+        help="Also compare the installed Python wrapper files against the current sources.",
+    )
+    parser.add_argument(
+        "--no-kernel",
+        action="store_true",
+        help="Skip the kernel .o comparison (kernel .o are compared by default).",
+    )
+    parser.add_argument(
+        "--built-kernel",
+        default=None,
+        help="Path to the freshly built kernel .o root. Defaults to the one staged under build/.",
+    )
+    args = parser.parse_args()
+
+    # No fla_npu import here: the script is purely file-based md5 comparison,
+    # so it works without a sourced CANN environment or a loadable fla_npu.
+    repo_root = Path(__file__).resolve().parents[1]
+
+    results = [_check_opp_lib(repo_root, args.built_lib, args.run_package)]
+    if not args.no_kernel:
+        results.append(_check_kernel_o(repo_root, args.built_kernel))
+    if args.python:
+        results.append(_check_python_wrapper(repo_root))
+
+    return 0 if all(results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,10 @@ except Exception:
 REPO_ROOT = Path(__file__).resolve().parent
 TORCH_EXTENSION_DIR = REPO_ROOT / "torch_custom" / "fla_npu"
 FLA_NPU_PACKAGE_DIR = TORCH_EXTENSION_DIR / "fla_npu"
+# The Triton core sources live outside torch_custom/fla_npu (in fla/), so the
+# root find_packages(where=TORCH_EXTENSION_DIR) cannot discover them. Mirror the
+# mapping used by torch_custom/fla_npu/setup.py so the root wheel also ships
+# fla_npu.ops.triton.triton_core.
 TRITON_CORE_PACKAGE = "fla_npu.ops.triton.triton_core"
 TRITON_CORE_SOURCE = REPO_ROOT / "fla" / "ops" / "triton" / "triton_core"
 
@@ -344,6 +348,7 @@ def _install_run_package(run_file, install_path):
 
 def _build_run_package():
     soc = os.getenv("FLA_NPU_SOC", DEFAULT_SOC)
+    ops_filter = os.getenv("FLA_NPU_OPS", "").strip()
     build_out = REPO_ROOT / "build_out"
     if build_out.exists():
         shutil.rmtree(build_out)
@@ -354,6 +359,8 @@ def _build_run_package():
         "--pkg",
         f"--vendor_name={DEFAULT_VENDOR_NAME}",
     ]
+    if ops_filter:
+        cmd.append(f"--ops={ops_filter}")
     build_args = os.getenv("FLA_NPU_BUILD_ARGS", "").strip()
     if build_args:
         cmd.extend(shlex.split(build_args))
@@ -571,6 +578,7 @@ class BinaryDistribution(Distribution):
 
 
 CMDCLASS = {"build_py": FlaNpuBuildPy}
+
 
 if _bdist_wheel is not None:
     class FlaNpuBdistWheel(_bdist_wheel):

--- a/tests/test_wheel_environment.py
+++ b/tests/test_wheel_environment.py
@@ -137,11 +137,15 @@ class WheelEnvironmentTest(unittest.TestCase):
         build_source = (REPO_ROOT / "build.sh").read_text(encoding="utf-8")
 
         self.assertNotIn("FLA_NPU_INCREMENTAL_BUILD", setup_source)
-        self.assertNotIn("FLA_NPU_OPS", setup_source)
         self.assertNotIn("FLA_NPU_SKIP_RUN_BUILD", setup_source)
         self.assertNotIn("FLA_NPU_SKIP_RUN_INSTALL", setup_source)
         self.assertNotIn("--incremental", build_source)
         self.assertIn("set_env\n\nclean\nclean_build_out", build_source)
+
+    def test_package_build_supports_single_op_filter(self) -> None:
+        setup_source = (REPO_ROOT / "setup.py").read_text(encoding="utf-8")
+        self.assertIn("FLA_NPU_OPS", setup_source)
+        self.assertIn("--ops=", setup_source)
 
     def test_generated_set_env_is_idempotent(self) -> None:
         rewrite_set_env = self.setup_globals["_rewrite_set_env"]

--- a/torch_custom/fla_npu/README.md
+++ b/torch_custom/fla_npu/README.md
@@ -16,12 +16,21 @@ from fla_npu.ops.ascendc import chunk_fwd_o
 
 默认路径通过 Python `ctypes` 直调已安装 OPP 里的 `libcust_opapi.so`，不依赖 PyTorch dispatcher 注册，也不会默认编译或加载 `torch_npu` 自定义扩展。旧的 `torch.ops.npu.*` / `torch_npu.ops.*` 兼容路径仍可做，但只作为迁移期可选能力，不推荐新增代码使用，也不会默认使能。
 
-`import fla_npu` 会立即加载 OPP 中的 `libcust_opapi.so`。导入前必须先 source CANN
-的 `set_env.sh`；使用方式 B standalone wheel 时，还必须先安装算子 run 包，或设置
-`FLA_NPU_OPP_PATH` 指向已有 OPP root / vendor 目录。CANN 环境未初始化、OPP 不完整
-或动态库加载失败时，import 会直接报错。FLA 自定义 op_api 只使用
-`libcust_opapi.so`，不要在 custom OPP 的 `op_api/lib` 目录创建会遮蔽 CANN 运行库
-的 `libopapi.so` 别名。
+## 导入契约
+
+`import fla_npu` 会定位 OPP 并加载 `libcust_opapi.so`。**导入 / 构建前请先 source CANN 的 `set_env.sh`**（默认路径为 `/usr/local/Ascend/ascend-toolkit/set_env.sh`；自定义安装路径时替换为实际路径下对应的 `set_env.sh`）；CANN 环境未初始化、OPP 不完整或动态库加载失败时，import 会直接报错：
+
+```sh
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+```
+
+| 现象 | 原因 / 处理 |
+|---|---|
+| 导入失败，`fla_npu/opp/vendors/fla_npu_transformer` 下找不到 `libcust_opapi.so` | 安装的是 standalone wheel（不内嵌 OPP）：需先安装算子 run 包，或通过环境变量 `FLA_NPU_OPP_PATH` 指向外部 OPP 目录 |
+| `dlopen` 报错、找不到依赖库 | 未 source CANN `set_env.sh`，或新开 shell 后环境变量丢失，需要重新 source |
+| 安装 run 包后调用接口报 ABI / 行为异常 | 已加载的 `libcust_opapi.so` 不会在同一 Python 进程内热替换，请重启 Python 进程 |
+
+FLA 自定义 op_api 只使用 `libcust_opapi.so`，不要在 custom OPP 的 `op_api/lib` 目录创建会遮蔽 CANN 运行库的 `libopapi.so` 别名。
 
 ## 默认交付件
 
@@ -96,8 +105,9 @@ torch.ops.npu.npu_xxx(...)
 3. 在 wrapper 内申请输出 tensor，并把输出传给 `_call_aclnn(...)`。
 4. 如果 aclnn 参数里有 `char *`、字符串、或 ctypes 不能安全自动转换的参数，在 `_GET_WORKSPACE_ARGTYPES` 中补充 `GetWorkspaceSize` 的 `argtypes`。
 5. 在 `fla_npu/ops/ascendc/__init__.py` 的 `_ASCENDC_OPS` 中加入 `npu_xxx`，这样会自动导出 `npu_xxx` 和去掉 `npu_` 前缀后的短名。
-6. 如果存在明确的正反向关系，在 `BACKWARD_OPS` 中补充映射；需要 autograd 自动绑定时，在 `__init__.py` 中增加对应 `torch.autograd.Function` 包装。
-7. 新增或更新测试，默认调用 `fla_npu.ops.ascendc` 路径。
+6. 如果存在明确的正反向关系，在 `BACKWARD_OPS` 中补充映射（例如 `causal_conv1d` → `causal_conv1d_bwd`）；需要 autograd 自动绑定时，在 `__init__.py` 中增加对应 `torch.autograd.Function` 包装。
+7. 如果算子会就地修改某个输入 tensor（例如 `causal_conv1d` 会更新 `conv_states`），在 `MUTATED_ARGUMENTS` 中登记对应参数名。ctypes 直接写 tensor storage 时 PyTorch 无法从 Python 调用自动发现副作用，登记后 wrapper 会负责 grad 限制与版本计数（mutation 契约测试参考 `test/test_ascendc_mutation_contract.py`）。
+8. 新增或更新测试，默认调用 `fla_npu.ops.ascendc` 路径。
 
 新增算子通常不需要修改 `_runtime.py`，也不需要感知 `_AclTensor`、`_AclIntArray`、workspace 申请或 stream launch 细节。只有公共 ctypes 调发框架本身需要演进时，才修改 `_runtime.py`。
 
@@ -125,7 +135,9 @@ def npu_my_op(x, weight, *, scale=1.0, indices=None):
 
 ```bash
 python3 setup.py bdist_wheel
-python3 -m pip install --force-reinstall --no-deps dist/flash_linear_attention_npu-*.whl
+# WHEEL_PATH 使用构建日志输出的准确文件名（勿用通配符，避免匹配多个产物）
+WHEEL_PATH="dist/<准确wheel文件名>.whl"
+python3 -m pip install --force-reinstall --no-cache-dir --no-deps "$WHEEL_PATH"
 ```
 
 这个 standalone wheel 会先安装 Python runtime 和空的 OPP vendor 骨架：
@@ -148,7 +160,9 @@ bash build.sh --pkg --soc=ascend910b --vendor_name=fla_npu
 
 ```bash
 FLA_NPU_SOC=ascend910b python3 -m pip wheel --no-build-isolation --no-deps . -w dist
-python3 -m pip install --force-reinstall --no-deps dist/flash_linear_attention_npu-*.whl
+# WHEEL_PATH 使用构建日志输出的准确文件名（勿用通配符，避免匹配多个产物）
+WHEEL_PATH="dist/<准确wheel文件名>.whl"
+python3 -m pip install --force-reinstall --no-cache-dir --no-deps "$WHEEL_PATH"
 python3 scripts/check_packaged_wheel_api.py
 ```
 
@@ -162,6 +176,8 @@ bash build.sh --pkg --soc=ascend910b --vendor_name=fla_npu --ops=chunk_fwd_o
 安装器会列出 scoped run 包覆盖后的算子状态。`WARNING` 表示安装后不可用，`NOTICE` 表示需要人工关注，`OK` 表示 ABI 一致并继续可用。
 覆盖完成后只保留 `libcust_opapi.so`，并同步刷新已安装 wheel 的 `RECORD`；重复安装
 同一个 run 包不会重复追加 OPP 路径。
+
+> 安装流程看护（PR #274 新增）：`scripts/check_install_workflows.py` 用于校验 wheel / run 包 / 安装流程是否符合约定。构建与安装完成后执行 `python scripts/check_install_workflows.py`，CI 也会自动运行该检查。
 
 ## legacy torch_npu / torch.ops.npu 路径
 
@@ -199,6 +215,8 @@ legacy 路径会生成或使用：
 - `npu_custom.yaml`、`test_native_functions.yaml`、`deprecated.yaml`
 
 这些兼容路径不会默认使能。`torch.ops.npu` legacy extension 会重新绑定 PyTorch、Python、C++ ABI 和 torch_npu dispatcher 行为，因此只用于历史接口兼容或专项验证。新增算子默认不要以 legacy extension 作为唯一调用方式。
+
+`torch.ops.npu.*` / `torch_npu.ops.*` 只支持到 v26.6.0，从旧版本迁移到最新版本的完整步骤见[兼容与迁移指南](../../docs/兼容与迁移指南.md)。新代码请勿使用 legacy 路径。
 
 ## 测试要求
 

--- a/torch_custom/fla_npu/test/test.sh
+++ b/torch_custom/fla_npu/test/test.sh
@@ -18,7 +18,13 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-export PYTHONPATH="$(cd "$SCRIPT_DIR/.." && pwd):${PYTHONPATH:-}"
+# 源码树内建 OPP（libcust_opapi.so）存在时才把源码路径 prepend 到 PYTHONPATH；
+# 否则（例如只安装了 wheel 的用户）直接使用当前环境已安装的 fla_npu，
+# 避免源码树骨架 OPP 遮蔽已安装 wheel 的内嵌 OPP。
+SOURCE_OPP="$SCRIPT_DIR/../fla_npu/opp/vendors/fla_npu_transformer"
+if [ -f "$SOURCE_OPP/op_api/lib/libcust_opapi.so" ]; then
+    export PYTHONPATH="$(cd "$SCRIPT_DIR/.." && pwd):${PYTHONPATH:-}"
+fi
 TEST_DEVICE_ID=""
 SINGLE_OP=""
 DRY_RUN=false


### PR DESCRIPTION
基于最新 main（含 PR #274）重新提交，合并 #274 的构建/安装语义：
- 修正 check_npu_env --build-only 描述、移除增量构建、修正安装/验证命令
- 新增全新环境上手步骤、旧版本升级章节与 torch_custom 新接口接入指引
- 保留 #274 新增的 shell 环境钩子、卸载说明与 check_install_workflows 看护脚本说明
- 同步 AGENTS/examples/CONTRIBUTING/PR 模板

# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @Coding-Pangolin
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
