### PR TITLE
fix: 修复 A5 KDA BF16 sub-16 尾块精度与确定性

### DIFF
--- a/fla/ops/ascendc/kda/chunk_kda_fwd/docs/design.md
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/docs/design.md
@@ -3,7 +3,8 @@
 ## 目标
 
 1. 顶层接口对齐非 CP 的 FLA `chunk_kda_fwd`。
-2. 不新增公开算子原型；A5 快路径复用既有 `ChunkKdaFwd` 原型和外层 kernel 入口。
+2. 不新增公开算子原型；A5 特化复用既有 `ChunkKdaFwd` L0 调用接口和
+   `chunk_kda_fwd` device kernel launch 入口。
 3. A2/A3/A5 使用同一数学定义；A5 保留 regbase 双发射特化。
 4. 输入 layout 与输出 layout 解耦。
 5. FwdH 同时服务 KDA 与 GDN，并支持可选 scalar gate、key-wise gate 和 `state_v_first`。
@@ -16,9 +17,21 @@ raw g -> ChunkKdaFwd[
 ] -> attn_out
 ```
 
-`aclnnChunkKdaFwd` 做公开 layout 的连续化和必要视图转换，然后只启动一个物理
-`ChunkKdaFwd` L0。Gate、Prepare、Post-WU、FwdH 和 Finalize 均是该 L0 内部阶段，不再注册或
-启动私有阶段 L0。选择所需信息均由既有输入、shape 和属性推导，不增加公开属性或接口字段。
+接口调用链按层级划分为：
+
+```text
+fla_npu.ops.ascendc.chunk_kda_fwd
+  -> aclnnChunkKdaFwd
+  -> ChunkKdaFwd L0 注册与 launcher
+  -> chunk_kda_fwd device kernel launch 入口
+  -> Gate / Prepare / Post-WU / FwdH / Finalize 内部阶段
+```
+
+`aclnnChunkKdaFwd` 负责公开 layout 的连续化和必要视图转换，并调用一次已注册的
+`ChunkKdaFwd` L0 接口。L0 launcher 继续使用 `chunk_kda_fwd` device kernel launch 入口。
+Gate、Prepare、Post-WU、FwdH 和 Finalize 只是该 kernel 内部计算阶段，不注册
+`ChunkKdaFwdPrepare`、`ChunkKdaFwdPostWu` 或 `ChunkKdaFwdFinalize` L0 算子。模板选择所需信息
+均由既有输入、shape 和属性推导，不增加公开属性或接口字段。
 
 ## 阶段职责
 
@@ -51,6 +64,9 @@ w, u, kg, v_new_seed
 ```
 
 `Akk` 的 head 循环按 `H_v` 执行，GQA 映射只在读取 q/k head 时换算，避免按 `H_k` 重复或漏算。
+Post-WU 是否作为单独的内部阶段执行由 tiling 决定。满足 A5 dense-aligned 融合条件时，Prepare
+直接调用 Post-WU 计算组件；其他场景在 Prepare 结束并完成同步后执行内部 Post-WU 阶段。两种
+方式都复用同一 `ChunkKdaFwd` L0 调用接口和 device kernel launch 入口。
 
 ### FwdH state propagation
 
@@ -104,21 +120,95 @@ head-major 阶段结果，`hOut` 为空时由 kernel workspace 承接；`hOut` �
 
 ## 模板化方案与 tiling key
 
-物理 `ChunkKdaFwd` 只有一个外层 `op_kernel/chunk_kda_fwd.cpp` 入口。A5 实现位于
-`op_kernel/arch35/*.h`，host 侧 A5 模板选择位于 `op_host/arch35/*.h`。Prepare、Post-WU、
-Finalize 的内部实现头与统一 kernel 入口同属 `chunk_kda_fwd/op_kernel/`，不存在对应的独立 L0
-原型或 `.cpp` 入口。
+本文中的“模板”指由 tiling 或 kernel 条件选择、具有独立数据切分或流水组织的计算路径。
+C++ 中仅用于 dtype、常量传播或代码复用的普通 `template` helper 不单独列为场景模板。
 
-- `tiling key=1`：非 chunk=64、K=V=128 场景的通用模板族。
-- `tiling key=2`：chunk=64、K=V=128 模板族，包括 dense、tail 和 varlen。
+### 接口与实现目录
 
-两个 key 是同一物理 L0 的编译期场景变体，不是平台编号、独立算子或独立接口。A2/A3/A5
-均生成两个 key；同一个 key 内再由编译架构选择根目录通用实现或 `arch35/` 实现。host 的
-`SetTilingKey` 只检查 chunk、K、V，不检查 SoC。
+`ChunkKdaFwd` 保留一套 L0 注册、launcher 和 `op_kernel/chunk_kda_fwd.cpp` device kernel launch
+入口。A2/A3 通用实现位于 `op_kernel/*.h`，A5 特化位于 `op_kernel/arch35/*.h`，A5 host 派生
+选项位于 `op_host/arch35/chunk_kda_fwd_tiling_impl.h`。Prepare、Post-WU 和 Finalize 的 `.h`
+文件是同一 kernel 内部计算组件，不是独立 L0 算子接口。
 
-在 arch35 上，key2 的完整 64 行 chunk 使用 Prepare/Post-WU 成批融合流水；tail 使用同一物理
-L0 内的边界实现。dense 对齐场景使用 arch35 FwdH；tail/varlen 内嵌共享 FwdH。其他架构在
-同一 key2 下使用其对应实现。tiling key 不改变算子原型、输出契约或数学定义。
+### 编译期 shape 模板
+
+| tiling key | 编译期常量 | A2/A3 实现 | A5 实现 | 覆盖场景 |
+| --- | --- | --- | --- | --- |
+| `key=1` 通用 shape 模板 | `COMPILE_BT/K/V=0/0/0` | 根目录通用实现 | 根目录通用实现 | 不满足 `chunk=64,K=128,V=128` 的 dense、tail、varlen、GQA 等场景 |
+| `key=2` chunk64/K128/V128 模板 | `COMPILE_BT/K/V=64/128/128` | 根目录通用实现，使用编译期常量 | `arch35` 特化实现 | `chunk=64,K=V=128` 的 dense、tail、varlen 和不同 head 数 |
+
+`SetTilingKey` 只检查 chunk、K、V，不检查 SoC、layout、是否 varlen 或是否存在尾块。因此 tiling
+key 表示 shape 模板族，不表示平台、接口或算子版本。平台差异由同一 key 编译时的架构分支选择。
+
+### A5 key2 执行组合模板
+
+`ConfigureChunkKdaFwdArch35` 从既有输入和输出实例化状态派生四个内部选项。选项不属于公开
+属性，不改变 L0、aclnn L2 或 Python 接口。
+
+| 执行组合 | 选择条件 | 内部阶段顺序 |
+| --- | --- | --- |
+| standalone Gate | `computeGateInPrepare=false` | Gate 完整执行并同步，再进入 Prepare |
+| Prepare 内联 Gate | BF16 q/k/v、raw g 为 FP32、存在 `A_log`、`use_gate_in_kernel=true`、`safe_gate=true` | Prepare AIV 在 gate-product 流水中计算 chunk-local gk |
+| A5 dense FwdH | BF16 且非 varlen、`T % 64 == 0` | 使用 `ChunkKdaFwdFwdH` arch35 dense 模板 |
+| Prepare/Post-WU 阶段内流水融合 | A5 key2、BF16、`safe_gate=true`、dense-aligned、`H_v % 2 == 0`，且未选择下一行模板 | Prepare AIC 按 head pair 生产后，直接调用 Post-WU 组件分批消费 |
+| Post-WU/FwdH 阶段内流水融合 | 上一行条件成立，同时 Gate 已在 Prepare 内计算，且不导出 `qg/v_new/h` | dense FwdH 直接完成 W/U 和状态传播所需计算 |
+| 独立内部 Post-WU 阶段 | 上述两种 Post-WU 融合均未选择 | Prepare 完成同步后调用 `RunChunkKdaPostWu` |
+| 通用 FwdH backend | FP16、varlen、存在非对齐尾块或不满足 dense FwdH 条件 | 选择共享 `GDNFwdHTileShapes128/256` 模板 |
+
+因此“Prepare/Post-WU 融合”只描述满足表中条件的执行组合，不表示所有 key2 场景都取消了
+内部 Post-WU 阶段。特别是 varlen 和非对齐尾块使用独立内部 Post-WU 阶段。
+
+### Gate 与 Prepare 内部模板
+
+| 模板 | 选择条件 | 主要实现 |
+| --- | --- | --- |
+| Gate 通用 chunk-cumsum | standalone Gate | 复用 `KdaGateCumsum::DispatchKdaGateCumsum`，支持 raw/已激活 gate 和 safe true/false |
+| Gate/Prepare arch35 regbase | A5 key2、BF16、raw FP32、`A_log`、safe gate | 16-row gate tile、两套 UB staging，MTE2 与 VEC 交叠；gk、qg、w seed 和 kg 因子成批生成 |
+| Prepare 通用 score/solve | key1，以及 A2/A3 key2 | 通用 Aqk/Akk MMAD、causal mask、三角 solve 和 seed 写回 |
+| Prepare arch35 key2 通用边界 | A5 key2 的 odd head、safe false、tail 或 varlen 等未命中成批融合的场景 | 保留同一数学定义，使用有界 score queue、AIC/AIV 握手和 padded tail |
+| Prepare arch35 safe-gate head-pair | A5 key2、safe gate、`H_v % 2 == 0` | 两个 head lane，共享两级 score queue；32-row score block；Akk solve 与后续 score 搬运交叠 |
+| Prepare arch35 full-chunk fused-score | 上一行且 `curT=64`，并命中 fused Post-WU | QK/Akk 两次 MMAD 使用手工 L1/L0 流水，Aqk/Akk mask 和 beta seed 在写回前完成 |
+
+### Post-WU 内部模板
+
+| 模板 | 选择条件 | 主要实现 |
+| --- | --- | --- |
+| Post-WU 通用模板 | key1，以及 A2/A3 key2 | 通用 Cube/Vector 计算 `w=Akk@w_seed`、`u=Akk@u_seed`，并生成 kg |
+| Post-WU arch35 full-chunk head-pair | A5 key2、`curT=64`、融合组合 | 每批最多 4 个 chunk task、每 task 两个 head lane；Prepare 生产后直接消费 |
+| Post-WU arch35 full-chunk standalone | A5 key2、`curT=64`、未融合 | W/U 两套 MTE2 staging 与 MMAD/Fixpipe 流水；Kg 使用 16-row tile 和 32-row 双缓冲 |
+| Post-WU arch35 tail 16-63 | A5 key2、`16<=curT<64` | padded Cube 与按有效行写回，保留通用尾块同步协议 |
+| Post-WU arch35 BF16 sub-16 | A5 key2、BF16、`1<=curT<16` | `ComputeTailWuRegbaseArch35` 先完整暂存 W/U seed 和 Akk；单 AIV FP32 regbase 累加并写回，避免 W seed 与 W 输出原地复用时的跨 AIV 读写竞争 |
+| Post-WU arch35 sub-16 fallback | A5 key2、非 BF16、`1<=curT<16` | 使用通用逐行 Vector 路径；key1 和 A2/A3 由 Post-WU 通用模板覆盖 |
+
+Post-WU sub-16 模板的最坏 staging 为
+`2*15*128*sizeof(BF16)+15*64*sizeof(BF16)=9,600 B`，不新增 workspace 或公开输出。
+
+### FwdH 内部模板
+
+| 模板 | 选择条件 | 主要实现 |
+| --- | --- | --- |
+| `GDNFwdHTileShapes128` | 通用 backend 且 `V<=128` | 共享 FwdH，FP32 state update，支持 dense/varlen/tail |
+| `GDNFwdHTileShapes256` | 通用 backend 且 `128<V<=256` | V=256 分块，其他语义与 128 模板一致 |
+| `ChunkKdaFwdFwdH` arch35 dense | A5 key2、BF16、非 varlen、`T%64=0` | 16-token sub-chunk、4-slot L1 staging，AIC MMAD/Fixpipe 与 AIV gate/state 更新协作 |
+| arch35 dense fused Post-WU/FwdH | `fusePostWuIntoFwdH=true` | FwdH 从 Prepare seed 直接形成 W/U 与 v_new，不导出未请求的 qg/v_new/h |
+
+### Finalize 内部模板
+
+| 模板 | 选择条件 | 主要实现 |
+| --- | --- | --- |
+| Finalize 通用模板 | key1，以及 A2/A3 key2 | 通用 Cube 计算两项矩阵乘，AIV 完成 FP32 相加、类型转换与 sequence-major 写回 |
+| Finalize arch35 dense-aligned pipeline | A5 key2、非 varlen、`T%64=0` | `ProcessOutAicPipelinedArch35` 使用双 L1 slot，使下一输出 tile 的 MTE2 与当前 MTE1/MMAD/Fixpipe 交叠 |
+| Finalize arch35 full-chunk staged | A5 key2、`curT=64` 且未命中 dense-aligned pipeline | 分阶段计算 `qg_scaled@h` 与 `Aqk@v_new`，保持 FP32 中间结果 |
+| Finalize arch35 tail 16-63 | A5 key2、`16<=curT<64` | padded Cube 计算两项结果，AIV 按有效行相加并写回 |
+| Finalize arch35 BF16 sub-16 | A5 key2、BF16、`1<=curT<16` | `ComputeTailOutputRegbaseRows` 一次暂存 h、v_new、qg 和 Aqk，单次 MTE2-to-V 交接后以 FP32 regbase 直接累加两项，绕开尾块标量 EventID 链 |
+| Finalize arch35 sub-16 fallback | A5 key2、非 BF16、`1<=curT<16` | 通用 FP32 Vector 逐行归约；key1 和 A2/A3 由 Finalize 通用模板覆盖 |
+
+Finalize sub-16 模板的最坏 staging 为
+`(128*128+2*15*128+15*16)*sizeof(BF16)=40,928 B`，小于现有 `gateWritebackBuf_`
+在 key2 BF16 下的 `40,960 B`，因此阈值固定为 16，不依赖运行时试探。
+
+所有模板保持相同公式、公开输出顺序、可选输出语义和 layout 契约。模板选择不得改变
+`ChunkKdaFwd` L0、`aclnnChunkKdaFwd` 或 `fla_npu.ops.ascendc.chunk_kda_fwd` 的接口。
 
 ## 性能设计
 

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_finalize.h
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_finalize.h
@@ -82,6 +82,85 @@ constexpr uint32_t KDA_GATE_TILE_ROWS = 32;
 constexpr uint32_t KDA_CUBE_MIN_REDUCTION = 16;
 
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+constexpr AscendC::MicroAPI::CastTrait KDA_TAIL_BF16_TO_FP32 = {
+    AscendC::MicroAPI::RegLayout::ZERO,
+    AscendC::MicroAPI::SatMode::SAT,
+    AscendC::MicroAPI::MaskMergeMode::ZEROING,
+    AscendC::RoundMode::CAST_NONE,
+};
+
+static __simd_vf__ inline void ComputeKdaTailOutputRegbase(
+    __ubuf__ float *dst, __ubuf__ bfloat16_t *h, __ubuf__ bfloat16_t *vNew,
+    __ubuf__ bfloat16_t *qgScaled, __ubuf__ bfloat16_t *aqk,
+    uint16_t rows, uint16_t curT)
+{
+    using namespace AscendC::MicroAPI;
+    constexpr uint16_t DIM = 128;
+    constexpr uint16_t FP32_REG_ELEMENTS = AscendC::VECTOR_REG_WIDTH / sizeof(float);
+    constexpr uint16_t AQK_ROW_ELEMENTS = 16;
+    MaskReg fullMask = CreateMask<float, MaskPattern::ALL>();
+
+    for (uint16_t row = 0; row < rows; ++row) {
+        RegTensor<float> acc0;
+        RegTensor<float> acc1;
+        Duplicate(acc0, 0.0f, fullMask);
+        Duplicate(acc1, 0.0f, fullMask);
+
+        for (uint16_t d = 0; d < DIM; ++d) {
+            RegTensor<bfloat16_t> matrixRaw0;
+            RegTensor<bfloat16_t> matrixRaw1;
+            RegTensor<bfloat16_t> weightRaw;
+            RegTensor<float> matrix0;
+            RegTensor<float> matrix1;
+            RegTensor<float> weight;
+            RegTensor<float> product0;
+            RegTensor<float> product1;
+            DataCopy<bfloat16_t, LoadDist::DIST_UNPACK_B16>(
+                matrixRaw0, h + static_cast<uint32_t>(d) * DIM);
+            DataCopy<bfloat16_t, LoadDist::DIST_UNPACK_B16>(
+                matrixRaw1, h + static_cast<uint32_t>(d) * DIM + FP32_REG_ELEMENTS);
+            LoadAlign<bfloat16_t, LoadDist::DIST_BRC_B16>(
+                weightRaw, qgScaled + static_cast<uint32_t>(row) * DIM + d);
+            Cast<float, bfloat16_t, KDA_TAIL_BF16_TO_FP32>(matrix0, matrixRaw0, fullMask);
+            Cast<float, bfloat16_t, KDA_TAIL_BF16_TO_FP32>(matrix1, matrixRaw1, fullMask);
+            Cast<float, bfloat16_t, KDA_TAIL_BF16_TO_FP32>(weight, weightRaw, fullMask);
+            Mul(product0, matrix0, weight, fullMask);
+            Mul(product1, matrix1, weight, fullMask);
+            Add(acc0, acc0, product0, fullMask);
+            Add(acc1, acc1, product1, fullMask);
+        }
+
+        for (uint16_t token = 0; token < curT; ++token) {
+            RegTensor<bfloat16_t> matrixRaw0;
+            RegTensor<bfloat16_t> matrixRaw1;
+            RegTensor<bfloat16_t> weightRaw;
+            RegTensor<float> matrix0;
+            RegTensor<float> matrix1;
+            RegTensor<float> weight;
+            RegTensor<float> product0;
+            RegTensor<float> product1;
+            DataCopy<bfloat16_t, LoadDist::DIST_UNPACK_B16>(
+                matrixRaw0, vNew + static_cast<uint32_t>(token) * DIM);
+            DataCopy<bfloat16_t, LoadDist::DIST_UNPACK_B16>(
+                matrixRaw1, vNew + static_cast<uint32_t>(token) * DIM + FP32_REG_ELEMENTS);
+            LoadAlign<bfloat16_t, LoadDist::DIST_BRC_B16>(
+                weightRaw, aqk + static_cast<uint32_t>(row) * AQK_ROW_ELEMENTS + token);
+            Cast<float, bfloat16_t, KDA_TAIL_BF16_TO_FP32>(matrix0, matrixRaw0, fullMask);
+            Cast<float, bfloat16_t, KDA_TAIL_BF16_TO_FP32>(matrix1, matrixRaw1, fullMask);
+            Cast<float, bfloat16_t, KDA_TAIL_BF16_TO_FP32>(weight, weightRaw, fullMask);
+            Mul(product0, matrix0, weight, fullMask);
+            Mul(product1, matrix1, weight, fullMask);
+            Add(acc0, acc0, product0, fullMask);
+            Add(acc1, acc1, product1, fullMask);
+        }
+
+        DataCopy(dst + static_cast<uint32_t>(row) * DIM, acc0, fullMask);
+        DataCopy(dst + static_cast<uint32_t>(row) * DIM + FP32_REG_ELEMENTS, acc1, fullMask);
+    }
+}
+#endif
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
 using KdaArchTag = Catlass::Arch::Ascend950;
 #else
 using KdaArchTag = Catlass::Arch::AtlasA2;
@@ -576,6 +655,50 @@ private:
             WaitFlag<HardEvent::S_MTE2>(sToMte2Event_);
         }
     }
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    __aicore__ inline void ComputeTailOutputRegbaseRows(
+        LocalTensor<float> &dst, uint64_t b, uint64_t hv, uint64_t chunkIdx,
+        uint64_t start, uint64_t curT, uint64_t rowBegin, uint64_t rows)
+    {
+        // Keep sub-16 tails on one MTE2-to-V handoff; the scalar event chain can retain stale state.
+        constexpr uint64_t dim = 128;
+        constexpr uint64_t maxTailRows = KDA_CUBE_MIN_REDUCTION - 1;
+        constexpr uint64_t aqkStagedCols = KDA_CUBE_MIN_REDUCTION;
+        constexpr uint64_t hOffset = 0;
+        constexpr uint64_t vNewOffset = hOffset + dim * dim;
+        constexpr uint64_t qgOffset = vNewOffset + maxTailRows * dim;
+        constexpr uint64_t aqkOffset = qgOffset + maxTailRows * dim;
+        LocalTensor<bfloat16_t> staging = gateWritebackBuf_.Get<bfloat16_t>();
+        LocalTensor<bfloat16_t> hLocal = staging[hOffset];
+        LocalTensor<bfloat16_t> vNewLocal = staging[vNewOffset];
+        LocalTensor<bfloat16_t> qgLocal = staging[qgOffset];
+        LocalTensor<bfloat16_t> aqkLocal = staging[aqkOffset];
+
+        CopyVectorIn(
+            hLocal, propagatedH_, HOffset(b, hv, chunkIdx, 0, 0), dim * dim);
+        CopyVectorIn(
+            vNewLocal, propagatedVNew_, KVOffset(b, hv, start, 0, V_), curT * dim);
+        CopyVectorIn(
+            qgLocal, preparedQG_, KVOffset(b, hv, start + rowBegin, 0, K_), rows * dim);
+        for (uint64_t row = 0; row < rows; ++row) {
+            LocalTensor<bfloat16_t> aqkRow = aqkLocal[row * aqkStagedCols];
+            CopyVectorIn(
+                aqkRow, preparedAqk_,
+                AOffset(b, hv, start + rowBegin + row, 0), aqkStagedCols);
+        }
+        SetFlag<HardEvent::MTE2_V>(mte2ToVEvent_);
+        WaitFlag<HardEvent::MTE2_V>(mte2ToVEvent_);
+        AscendC::VF_CALL<ComputeKdaTailOutputRegbase>(
+            reinterpret_cast<__ubuf__ float *>(dst.GetPhyAddr()),
+            reinterpret_cast<__ubuf__ bfloat16_t *>(hLocal.GetPhyAddr()),
+            reinterpret_cast<__ubuf__ bfloat16_t *>(vNewLocal.GetPhyAddr()),
+            reinterpret_cast<__ubuf__ bfloat16_t *>(qgLocal.GetPhyAddr()),
+            reinterpret_cast<__ubuf__ bfloat16_t *>(aqkLocal.GetPhyAddr()),
+            static_cast<uint16_t>(rows), static_cast<uint16_t>(curT));
+        PipeBarrier<PIPE_V>();
+    }
+#endif
 
     template <typename CopyT>
     __aicore__ inline void LoadAsFloatVector(GlobalTensor<CopyT> &src, uint64_t srcOffset,
@@ -1203,9 +1326,32 @@ private:
             LocalTensor<T> outTyped = gateWritebackBuf_.Get<T>();
 
             if (curT < KDA_CUBE_MIN_REDUCTION) {
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+                if constexpr (IsSameType<T, bfloat16_t>::value) {
+                    if (BT_ == 64 && K_ == 128 && V_ == 128) {
+                        ComputeTailOutputRegbaseRows(
+                            outLocal, b, hv, chunkIdx, start, curT, tileRow, tileRows);
+                    } else {
+                        ComputeTailStateRows(
+                            stateLocal, b, hv, chunkIdx, start, tileRow, tileRows);
+                        ComputeTailLocalRows(localLocal, b, hv, start, curT, tileRow, tileRows);
+                        Add(outLocal, stateLocal, localLocal, static_cast<uint32_t>(elems));
+                        PipeBarrier<PIPE_V>();
+                    }
+                } else {
+                    ComputeTailStateRows(
+                        stateLocal, b, hv, chunkIdx, start, tileRow, tileRows);
+                    ComputeTailLocalRows(localLocal, b, hv, start, curT, tileRow, tileRows);
+                    Add(outLocal, stateLocal, localLocal, static_cast<uint32_t>(elems));
+                    PipeBarrier<PIPE_V>();
+                }
+#else
                 ComputeTailStateRows(
                     stateLocal, b, hv, chunkIdx, start, tileRow, tileRows);
                 ComputeTailLocalRows(localLocal, b, hv, start, curT, tileRow, tileRows);
+                Add(outLocal, stateLocal, localLocal, static_cast<uint32_t>(elems));
+                PipeBarrier<PIPE_V>();
+#endif
             } else {
                 CopyVectorIn(stateLocal, o_, KVOffset(b, hv, ti, 0, V_), elems);
                 SetFlag<HardEvent::MTE2_V>(mte2ToVEvent_);
@@ -1213,9 +1359,9 @@ private:
                 CopyVectorIn(localLocal, u_, KVOffset(b, hv, ti, 0, V_), elems);
                 SetFlag<HardEvent::MTE2_V>(mte2ToVEvent_);
                 WaitFlag<HardEvent::MTE2_V>(mte2ToVEvent_);
+                Add(outLocal, stateLocal, localLocal, static_cast<uint32_t>(elems));
+                PipeBarrier<PIPE_V>();
             }
-            Add(outLocal, stateLocal, localLocal, static_cast<uint32_t>(elems));
-            PipeBarrier<PIPE_V>();
             ClampFp32ToOutputType(outLocal, static_cast<uint32_t>(elems));
             Cast(outTyped, outLocal, RoundMode::CAST_RINT, static_cast<uint32_t>(elems));
             PipeBarrier<PIPE_V>();

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_post_wu.h
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_post_wu.h
@@ -103,9 +103,76 @@ constexpr uint16_t KDA_POST_PIPELINE_STAGE_COUNT = 2;
 constexpr uint16_t KDA_POST_FUSED_BATCH_TASKS = 4;
 constexpr uint16_t KDA_POST_HEAD_PAIR_LANES = 2;
 constexpr uint16_t KDA_POST_PIPELINE_U_EVENT = KDA_POST_EVENT_FIX;
+constexpr uint16_t KDA_POST_REGBASE_TAIL_LIMIT = 16;
 constexpr bool KDA_ENABLE_POST_AIC_PIPELINE = true;
 
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+static __simd_vf__ inline void ComputeKdaTailWuRegbase(
+    __ubuf__ float *wOut, __ubuf__ float *uOut, __ubuf__ bfloat16_t *akk,
+    __ubuf__ bfloat16_t *wSeed, __ubuf__ bfloat16_t *uSeed,
+    uint16_t rows, uint16_t curT)
+{
+    using namespace AscendC::MicroAPI;
+    constexpr uint16_t DIM = 128;
+    constexpr uint16_t FP32_REG_ELEMENTS = AscendC::VECTOR_REG_WIDTH / sizeof(float);
+    constexpr uint16_t AKK_ROW_ELEMENTS = 64;
+    MaskReg fullMask = CreateMask<float, MaskPattern::ALL>();
+
+    for (uint16_t row = 0; row < rows; ++row) {
+        RegTensor<float> wAcc0;
+        RegTensor<float> wAcc1;
+        RegTensor<float> uAcc0;
+        RegTensor<float> uAcc1;
+        Duplicate(wAcc0, 0.0f, fullMask);
+        Duplicate(wAcc1, 0.0f, fullMask);
+        Duplicate(uAcc0, 0.0f, fullMask);
+        Duplicate(uAcc1, 0.0f, fullMask);
+
+        for (uint16_t token = 0; token < curT; ++token) {
+            RegTensor<bfloat16_t> wRaw0;
+            RegTensor<bfloat16_t> wRaw1;
+            RegTensor<bfloat16_t> uRaw0;
+            RegTensor<bfloat16_t> uRaw1;
+            RegTensor<bfloat16_t> weightRaw;
+            RegTensor<float> w0;
+            RegTensor<float> w1;
+            RegTensor<float> u0;
+            RegTensor<float> u1;
+            RegTensor<float> weight;
+            RegTensor<float> product;
+            DataCopy<bfloat16_t, LoadDist::DIST_UNPACK_B16>(
+                wRaw0, wSeed + static_cast<uint32_t>(token) * DIM);
+            DataCopy<bfloat16_t, LoadDist::DIST_UNPACK_B16>(
+                wRaw1, wSeed + static_cast<uint32_t>(token) * DIM + FP32_REG_ELEMENTS);
+            DataCopy<bfloat16_t, LoadDist::DIST_UNPACK_B16>(
+                uRaw0, uSeed + static_cast<uint32_t>(token) * DIM);
+            DataCopy<bfloat16_t, LoadDist::DIST_UNPACK_B16>(
+                uRaw1, uSeed + static_cast<uint32_t>(token) * DIM + FP32_REG_ELEMENTS);
+            LoadAlign<bfloat16_t, LoadDist::DIST_BRC_B16>(
+                weightRaw, akk + static_cast<uint32_t>(row) * AKK_ROW_ELEMENTS + token);
+            Cast<float, bfloat16_t, ctHalf2Fp32Zero>(w0, wRaw0, fullMask);
+            Cast<float, bfloat16_t, ctHalf2Fp32Zero>(w1, wRaw1, fullMask);
+            Cast<float, bfloat16_t, ctHalf2Fp32Zero>(u0, uRaw0, fullMask);
+            Cast<float, bfloat16_t, ctHalf2Fp32Zero>(u1, uRaw1, fullMask);
+            Cast<float, bfloat16_t, ctHalf2Fp32Zero>(weight, weightRaw, fullMask);
+            Mul(product, w0, weight, fullMask);
+            Add(wAcc0, wAcc0, product, fullMask);
+            Mul(product, w1, weight, fullMask);
+            Add(wAcc1, wAcc1, product, fullMask);
+            Mul(product, u0, weight, fullMask);
+            Add(uAcc0, uAcc0, product, fullMask);
+            Mul(product, u1, weight, fullMask);
+            Add(uAcc1, uAcc1, product, fullMask);
+        }
+
+        uint32_t outputOffset = static_cast<uint32_t>(row) * DIM;
+        DataCopy(wOut + outputOffset, wAcc0, fullMask);
+        DataCopy(wOut + outputOffset + FP32_REG_ELEMENTS, wAcc1, fullMask);
+        DataCopy(uOut + outputOffset, uAcc0, fullMask);
+        DataCopy(uOut + outputOffset + FP32_REG_ELEMENTS, uAcc1, fullMask);
+    }
+}
+
 template <typename InputT>
 __simd_callee__ inline void LoadPostKdaGateRegbasePair(
     AscendC::MicroAPI::RegTensor<float> &zeroReg,
@@ -1541,6 +1608,67 @@ private:
                 KVOffset(b, hv, start + row, 0, V_), curT, V_);
         }
     }
+
+    __aicore__ inline void ComputeTailWuRegbaseArch35(
+        uint64_t b, uint64_t hv, uint64_t start, uint64_t curT,
+        uint64_t subBlockIdx, uint64_t subBlockNum)
+    {
+        // W aliases W-seed in GM: one AIV must stage every seed row before either output is overwritten.
+        constexpr uint64_t dim = 128;
+        constexpr uint64_t maxTailRows = KDA_POST_REGBASE_TAIL_LIMIT - 1;
+        constexpr uint64_t tileRowsLimit = 32;
+        constexpr uint64_t akkStagedCols = 64;
+        constexpr uint64_t wSeedOffset = 0;
+        constexpr uint64_t uSeedOffset = wSeedOffset + maxTailRows * dim;
+        constexpr uint64_t akkOffset = uSeedOffset + maxTailRows * dim;
+        (void)subBlockNum;
+        if (subBlockIdx != 0 || curT == 0 || curT > maxTailRows) {
+            return;
+        }
+
+        LocalTensor<bfloat16_t> staging = gateWritebackBuf_.Get<bfloat16_t>();
+        LocalTensor<bfloat16_t> wSeedLocal = staging[wSeedOffset];
+        LocalTensor<bfloat16_t> uSeedLocal = staging[uSeedOffset];
+        LocalTensor<bfloat16_t> akkLocal = staging[akkOffset];
+        CopyVectorIn(
+            wSeedLocal, preparedQG_, KVOffset(b, hv, start, 0, K_), curT * dim);
+        CopyVectorIn(
+            uSeedLocal, propagatedVNew_, KVOffset(b, hv, start, 0, V_), curT * dim);
+        for (uint64_t row = 0; row < curT; ++row) {
+            LocalTensor<bfloat16_t> akkRow = akkLocal[row * akkStagedCols];
+            CopyVectorIn(
+                akkRow, preparedAqk_, AOffset(b, hv, start + row, 0),
+                akkStagedCols);
+        }
+        SetFlag<HardEvent::MTE2_V>(mte2ToVEvent_);
+        WaitFlag<HardEvent::MTE2_V>(mte2ToVEvent_);
+
+        for (uint64_t tileRow = 0; tileRow < curT; tileRow += tileRowsLimit) {
+            const uint64_t tileRows = (curT - tileRow) > tileRowsLimit
+                ? tileRowsLimit
+                : (curT - tileRow);
+            LocalTensor<float> wFloat = vecBuf_.Get<float>();
+            LocalTensor<float> uFloat = wFloat[tileRows * dim];
+            LocalTensor<bfloat16_t> akkTile = akkLocal[tileRow * akkStagedCols];
+            AscendC::VF_CALL<ComputeKdaTailWuRegbase>(
+                reinterpret_cast<__ubuf__ float *>(wFloat.GetPhyAddr()),
+                reinterpret_cast<__ubuf__ float *>(uFloat.GetPhyAddr()),
+                reinterpret_cast<__ubuf__ bfloat16_t *>(akkTile.GetPhyAddr()),
+                reinterpret_cast<__ubuf__ bfloat16_t *>(wSeedLocal.GetPhyAddr()),
+                reinterpret_cast<__ubuf__ bfloat16_t *>(uSeedLocal.GetPhyAddr()),
+                static_cast<uint16_t>(tileRows), static_cast<uint16_t>(curT));
+            PipeBarrier<PIPE_V>();
+
+            for (uint64_t row = 0; row < tileRows; ++row) {
+                LocalTensor<float> wRow = wFloat[row * dim];
+                LocalTensor<float> uRow = uFloat[row * dim];
+                StoreFloatRow(
+                    w_, KVOffset(b, hv, start + tileRow + row, 0, K_), wRow, dim);
+                StoreFloatRow(
+                    u_, KVOffset(b, hv, start + tileRow + row, 0, V_), uRow, dim);
+            }
+        }
+    }
 #endif
     __aicore__ inline bool ResolveFlatChunk(uint64_t task, uint64_t &seq, uint64_t &b, uint64_t &h, uint64_t &hv,
                                             uint64_t &chunkIdx, uint64_t &start, uint64_t &end)
@@ -1708,7 +1836,19 @@ private:
         }
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
         if (curT < BT_) {
-            ComputeTailWuVector(b, hv, chunkIdx, start, curT, subBlockIdx, subBlockNum);
+            if constexpr (IsSameType<T, bfloat16_t>::value) {
+                if (BT_ == 64 && K_ == 128 && V_ == 128 &&
+                    curT < KDA_POST_REGBASE_TAIL_LIMIT) {
+                    ComputeTailWuRegbaseArch35(
+                        b, hv, start, curT, subBlockIdx, subBlockNum);
+                } else {
+                    ComputeTailWuVector(
+                        b, hv, chunkIdx, start, curT, subBlockIdx, subBlockNum);
+                }
+            } else {
+                ComputeTailWuVector(
+                    b, hv, chunkIdx, start, curT, subBlockIdx, subBlockNum);
+            }
             CopyScratchWAndFinalizeKg(
                 b, h, hv, chunkIdx, start, curT, subBlockIdx, subBlockNum);
             return;

--- a/tests/op_cases/chunk_kda_fwd.json
+++ b/tests/op_cases/chunk_kda_fwd.json
@@ -97,6 +97,9 @@
       "chunk_kda_fwd_tail_or_varlen",
       "chunk_kda_fwd_a5_varlen_tail_finalize",
       "chunk_kda_fwd_a5_bf16_full_chunk_finalize",
+      "chunk_kda_fwd_a5_bf16_sub16_varlen_h96",
+      "chunk_kda_fwd_a5_bf16_sub16_dense_h29",
+      "chunk_kda_fwd_a5_bf16_sub16_minimal_h1",
       "chunk_kda_fwd_tnd_layout",
       "chunk_kda_fwd_state_v_first",
       "chunk_kda_fwd_optional_output_matrix",
@@ -107,6 +110,9 @@
       "chunk_kda_fwd_tail_or_varlen",
       "chunk_kda_fwd_a5_varlen_tail_finalize",
       "chunk_kda_fwd_a5_bf16_full_chunk_finalize",
+      "chunk_kda_fwd_a5_bf16_sub16_varlen_h96",
+      "chunk_kda_fwd_a5_bf16_sub16_dense_h29",
+      "chunk_kda_fwd_a5_bf16_sub16_minimal_h1",
       "chunk_kda_fwd_tnd_layout",
       "chunk_kda_fwd_state_v_first",
       "chunk_kda_fwd_chunk128_writeback_boundary"
@@ -482,6 +488,205 @@
         ]
       },
       "seed": 20260731
+    },
+    {
+      "id": "chunk_kda_fwd_a5_bf16_sub16_varlen_h96",
+      "tags": [
+        "accuracy",
+        "generalization",
+        "boundary",
+        "tail",
+        "regression",
+        "determinism"
+      ],
+      "shape": {
+        "N": 4,
+        "H_k": 96,
+        "H_v": 96,
+        "T": 281,
+        "K": 128,
+        "V": 128,
+        "chunk_size": 64,
+        "N_c": 8
+      },
+      "dtype": {
+        "q_k_v": "bfloat16",
+        "g": "float32",
+        "beta": "bfloat16",
+        "state": "float32"
+      },
+      "layout": "NTD",
+      "attrs": {
+        "layout": "NTD",
+        "scale": 0.0883883476,
+        "chunk_size": 64,
+        "output_final_state": true,
+        "disable_recompute": true,
+        "return_intermediate_states": true,
+        "safe_gate": true,
+        "lower_bound": -5.0,
+        "use_gate_in_kernel": true,
+        "state_v_first": false
+      },
+      "optional_inputs": {
+        "initial_state": null,
+        "cu_seqlens": [
+          0,
+          65,
+          131,
+          202,
+          281
+        ],
+        "chunk_indices": null
+      },
+      "soc": [
+        "ascend950"
+      ],
+      "run_on": [
+        "ascendc"
+      ],
+      "reference": "tests/reference/chunk_kda_reference.py",
+      "expect": {
+        "return_code": "ACLNN_SUCCESS",
+        "finite_outputs": true,
+        "binary_deterministic_runs": 50,
+        "compare_outputs": [
+          "attn_out",
+          "final_state",
+          "gk",
+          "Aqk/Akk",
+          "w/qg/kg",
+          "u/v_new",
+          "h"
+        ]
+      },
+      "seed": 20260929
+    },
+    {
+      "id": "chunk_kda_fwd_a5_bf16_sub16_dense_h29",
+      "tags": [
+        "accuracy",
+        "generalization",
+        "boundary",
+        "tail",
+        "regression"
+      ],
+      "shape": {
+        "B": 1,
+        "H_k": 29,
+        "H_v": 29,
+        "T": 79,
+        "K": 128,
+        "V": 128,
+        "chunk_size": 64,
+        "N_c": 2
+      },
+      "dtype": {
+        "q_k_v": "bfloat16",
+        "g": "float32",
+        "beta": "bfloat16",
+        "state": "float32"
+      },
+      "layout": "BSND",
+      "attrs": {
+        "layout": "BSND",
+        "scale": 0.0883883476,
+        "chunk_size": 64,
+        "output_final_state": true,
+        "disable_recompute": true,
+        "return_intermediate_states": true,
+        "safe_gate": false,
+        "lower_bound": -5.0,
+        "use_gate_in_kernel": true,
+        "state_v_first": false
+      },
+      "optional_inputs": {
+        "initial_state": null,
+        "cu_seqlens": null,
+        "chunk_indices": null
+      },
+      "soc": [
+        "ascend950"
+      ],
+      "run_on": [
+        "ascendc"
+      ],
+      "reference": "tests/reference/chunk_kda_reference.py",
+      "expect": {
+        "return_code": "ACLNN_SUCCESS",
+        "finite_outputs": true,
+        "compare_outputs": [
+          "attn_out",
+          "final_state",
+          "gk",
+          "Aqk/Akk",
+          "w/qg/kg",
+          "u/v_new",
+          "h"
+        ]
+      },
+      "seed": 20260844
+    },
+    {
+      "id": "chunk_kda_fwd_a5_bf16_sub16_minimal_h1",
+      "tags": [
+        "accuracy",
+        "generalization",
+        "boundary",
+        "tail",
+        "regression",
+        "optional_output"
+      ],
+      "shape": {
+        "B": 1,
+        "H_k": 1,
+        "H_v": 1,
+        "T": 65,
+        "K": 128,
+        "V": 128,
+        "chunk_size": 64,
+        "N_c": 2
+      },
+      "dtype": {
+        "q_k_v": "bfloat16",
+        "g": "float32",
+        "beta": "bfloat16",
+        "state": "float32"
+      },
+      "layout": "BSND",
+      "attrs": {
+        "layout": "BSND",
+        "scale": 0.0883883476,
+        "chunk_size": 64,
+        "output_final_state": false,
+        "disable_recompute": false,
+        "return_intermediate_states": false,
+        "safe_gate": true,
+        "lower_bound": -5.0,
+        "use_gate_in_kernel": true,
+        "state_v_first": false
+      },
+      "optional_inputs": {
+        "initial_state": null,
+        "cu_seqlens": null,
+        "chunk_indices": null
+      },
+      "soc": [
+        "ascend950"
+      ],
+      "run_on": [
+        "ascendc"
+      ],
+      "reference": "tests/reference/chunk_kda_reference.py",
+      "expect": {
+        "return_code": "ACLNN_SUCCESS",
+        "finite_outputs": true,
+        "compare_outputs": [
+          "attn_out",
+          "Aqk/Akk"
+        ]
+      },
+      "seed": 20260866
     },
     {
       "id": "chunk_kda_fwd_tnd_layout",

--- a/tests/operators/chunk_kda_fwd/README.md
+++ b/tests/operators/chunk_kda_fwd/README.md
@@ -19,6 +19,7 @@
 | `ut/op_kernel/test_contract.py` | kernel 入口、tiling key 说明和 direct launch 静态契约 |
 | `performance/profile.py` | 读取 performance tag 并通过 msopprof 运行设备侧 profiling |
 | `st/test_example.py` | example tag 与仓内数值执行后端的 ST 入口 |
+| `st/validate_a5_tail_template.py` | A5 BF16 chunk64/K128/V128 非对齐尾块逐输出精度、公式重组和确定性回归 |
 | `integration/validate_triton_ascend_adapter.py` | AscendC 正向接入模型现有 Triton 反向，包含 H=96 长序列契约、精度和确定性验证 |
 
 - legacy 通路：`torch.ops.npu.npu_chunk_kda_fwd`，由主 route case 验证显式加载。
@@ -50,6 +51,7 @@ python tests/operators/chunk_kda_fwd/performance/profile.py --case-id chunk_kda_
 python tests/operators/chunk_kda_fwd/performance/profile.py --case-id chunk_kda_fwd_h96_t16k_model_performance
 python tests/operators/chunk_kda_fwd/st/probe_a5_tail.py --device 0
 python tests/operators/chunk_kda_fwd/st/probe_a5_tail.py --device 0 --long-seq
+python tests/operators/chunk_kda_fwd/st/validate_a5_tail_template.py --device 0 --repeats 50
 FLA_NPU_RUN_OPERATOR_TESTS=1 pytest -q tests/operators/chunk_kda_fwd/st/test_example.py
 cd examples/fast_kernel_launch_example && FAST_KERNEL_OP_NAME=chunk_kda_fwd pytest -q tests/chunk_kda_fwd
 ```

--- a/tests/operators/chunk_kda_fwd/st/validate_a5_tail_template.py
+++ b/tests/operators/chunk_kda_fwd/st/validate_a5_tail_template.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Validate the A5 BF16 chunk64/K128/V128 non-aligned tail template."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import torch
+
+from fla_npu.ops.ascendc import chunk_kda_fwd
+from tests.reference.chunk_kda_reference import chunk_kda_forward_reference
+
+
+ROOT = Path(__file__).resolve().parents[4]
+MANIFEST = ROOT / "tests/op_cases/chunk_kda_fwd.json"
+CASE_IDS = (
+    "chunk_kda_fwd_a5_bf16_sub16_varlen_h96",
+    "chunk_kda_fwd_a5_bf16_sub16_dense_h29",
+    "chunk_kda_fwd_a5_bf16_sub16_minimal_h1",
+)
+RCP_LN2 = 1.4426950408889634
+OUTPUT_NAMES = (
+    "attn_out", "final_state", "gk", "Aqk", "Akk", "w", "u", "qg",
+    "kg", "v_new", "h", "initial_state",
+)
+
+
+def _load_cases(selected_ids: set[str] | None) -> tuple[dict, list[dict]]:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    required = set(CASE_IDS) if selected_ids is None else selected_ids
+    cases = [case for case in manifest["cases"] if case["id"] in required]
+    found = {case["id"] for case in cases}
+    if found != required:
+        raise RuntimeError(f"missing case ids: {sorted(required - found)}")
+    return manifest, cases
+
+
+def _spans(case: dict) -> list[tuple[int, int]]:
+    cu = case["optional_inputs"].get("cu_seqlens")
+    if cu is not None:
+        return list(zip(cu, cu[1:]))
+    return [(0, int(case["shape"]["T"]))]
+
+
+def _gate_cumsum(raw_gate, a_log, dt_bias, safe_gate, lower_bound, spans, chunk_size):
+    dim = raw_gate.shape[-1]
+    x = raw_gate.float() + dt_bias.reshape(-1, dim)[:, None, :].float()
+    a = torch.exp(a_log.float())[:, None, None]
+    activated = (
+        float(lower_bound) * torch.sigmoid(a * x)
+        if safe_gate
+        else -a * torch.nn.functional.softplus(x)
+    )
+    result = torch.empty_like(activated)
+    for seq_start, seq_end in spans:
+        for start in range(seq_start, seq_end, chunk_size):
+            end = min(start + chunk_size, seq_end)
+            result[:, start:end] = torch.cumsum(
+                activated[:, start:end] * RCP_LN2, dim=1
+            )
+    return result
+
+
+def _reference_outputs(reference, gk, layout, saved):
+    if layout == "NTD":
+        values = (
+            reference.o.squeeze(0), reference.final_state, gk,
+            reference.Aqk.squeeze(0).permute(1, 0, 2).contiguous(),
+            reference.Akk.squeeze(0).permute(1, 0, 2).contiguous(),
+            reference.w.squeeze(0).permute(1, 0, 2).contiguous(),
+            reference.u.squeeze(0).permute(1, 0, 2).contiguous(),
+            reference.qg.squeeze(0).permute(1, 0, 2).contiguous(),
+            reference.kg.squeeze(0).permute(1, 0, 2).contiguous(),
+            reference.v_new.squeeze(0).permute(1, 0, 2).contiguous(),
+            reference.h.squeeze(0), None,
+        )
+    else:
+        values = (
+            reference.o, reference.final_state, gk.unsqueeze(0),
+            reference.Aqk.permute(0, 2, 1, 3).contiguous(),
+            reference.Akk.permute(0, 2, 1, 3).contiguous(),
+            reference.w.permute(0, 2, 1, 3).contiguous(),
+            reference.u.permute(0, 2, 1, 3).contiguous(),
+            reference.qg.permute(0, 2, 1, 3).contiguous(),
+            reference.kg.permute(0, 2, 1, 3).contiguous(),
+            reference.v_new.permute(0, 2, 1, 3).contiguous(),
+            reference.h, None,
+        )
+    if saved:
+        return values
+    return values[:2] + (None,) + values[3:5] + (None,) * 7
+
+
+def _tail_recomposition_error(outputs, case, spans) -> float | None:
+    attrs = case["attrs"]
+    if not attrs["disable_recompute"]:
+        return None
+    chunk_size = int(case["shape"]["chunk_size"])
+    layout = attrs["layout"]
+    scale = float(attrs["scale"])
+    errors = []
+    chunk_base = 0
+    for seq_start, seq_end in spans:
+        chunk_count = math.ceil((seq_end - seq_start) / chunk_size)
+        tail = (seq_end - seq_start) % chunk_size
+        if tail:
+            tail_start = seq_end - tail
+            h_index = chunk_base + chunk_count - 1
+            if layout == "NTD":
+                qg = outputs[7][:, tail_start:seq_end].float() * scale
+                h = outputs[10][h_index].float()
+                state = torch.einsum("htk,hkv->htv", qg, h)
+                local = torch.einsum(
+                    "hts,hsv->htv",
+                    outputs[3][:, tail_start:seq_end, :tail].float(),
+                    outputs[9][:, tail_start:seq_end].float(),
+                )
+                actual = outputs[0][tail_start:seq_end].permute(1, 0, 2)
+            else:
+                qg = outputs[7][0, :, tail_start:seq_end].float() * scale
+                h = outputs[10][0, h_index].float()
+                state = torch.einsum("htk,hkv->htv", qg, h)
+                local = torch.einsum(
+                    "hts,hsv->htv",
+                    outputs[3][0, :, tail_start:seq_end, :tail].float(),
+                    outputs[9][0, :, tail_start:seq_end].float(),
+                )
+                actual = outputs[0][0, tail_start:seq_end].permute(1, 0, 2)
+            expected = (state + local).to(torch.bfloat16)
+            errors.append(float((actual.float() - expected.float()).abs().max().item()))
+        chunk_base += chunk_count
+    return max(errors, default=None)
+
+
+def _run_case(case, device, tolerance):
+    shape, attrs = case["shape"], case["attrs"]
+    heads = int(shape["H_k"])
+    total_t = int(shape["T"])
+    dim = int(shape["K"])
+    chunk_size = int(shape["chunk_size"])
+    spans = _spans(case)
+    torch.manual_seed(int(case["seed"]))
+    q_head = (torch.randn(heads, total_t, dim) * 0.02).to(torch.bfloat16).to(device)
+    k_head = (torch.randn(heads, total_t, dim) * 0.02).to(torch.bfloat16).to(device)
+    v_head = (torch.randn(heads, total_t, dim) * 0.02).to(torch.bfloat16).to(device)
+    raw_gate = (torch.randn(heads, total_t, dim) * 0.2).to(device)
+    beta_head = torch.sigmoid(torch.randn(heads, total_t)).to(torch.bfloat16).to(device)
+    a_log = (torch.randn(heads) * 0.2 - 0.5).to(device)
+    dt_bias = (torch.randn(heads * dim) * 0.1).to(device)
+    safe_gate = bool(attrs["safe_gate"])
+    lower_bound = float(attrs["lower_bound"])
+    gk = _gate_cumsum(
+        raw_gate, a_log, dt_bias, safe_gate, lower_bound, spans, chunk_size
+    )
+
+    q_ref = q_head.permute(1, 0, 2).unsqueeze(0).contiguous()
+    k_ref = k_head.permute(1, 0, 2).unsqueeze(0).contiguous()
+    v_ref = v_head.permute(1, 0, 2).unsqueeze(0).contiguous()
+    gk_ref = gk.permute(1, 0, 2).unsqueeze(0).contiguous()
+    beta_ref = beta_head.permute(1, 0).unsqueeze(0).contiguous()
+    cu_values = case["optional_inputs"].get("cu_seqlens")
+    cu_tensor = (
+        None
+        if cu_values is None
+        else torch.tensor(cu_values, dtype=torch.int64, device=device)
+    )
+    reference = chunk_kda_forward_reference(
+        q_ref, k_ref, v_ref, gk_ref, beta_ref, float(attrs["scale"]),
+        chunk_size, output_final_state=bool(attrs["output_final_state"]),
+        cu_seqlens=cu_tensor,
+    )
+
+    layout = attrs["layout"]
+    inputs = (
+        (q_head, k_head, v_head, raw_gate, beta_head)
+        if layout == "NTD"
+        else (
+            q_ref, k_ref, v_ref,
+            raw_gate.permute(1, 0, 2).unsqueeze(0).contiguous(), beta_ref,
+        )
+    )
+    kwargs = dict(
+        layout=layout,
+        cu_seqlens=None if cu_values is None else tuple(cu_values),
+        output_final_state=bool(attrs["output_final_state"]),
+        safe_gate=safe_gate,
+        lower_bound=lower_bound,
+        use_gate_in_kernel=True,
+        A_log=a_log,
+        dt_bias=dt_bias,
+        disable_recompute=bool(attrs["disable_recompute"]),
+        return_intermediate_states=bool(attrs["return_intermediate_states"]),
+    )
+    outputs = chunk_kda_fwd(
+        *inputs, float(attrs["scale"]), chunk_size, **kwargs
+    )
+    torch.npu.synchronize()
+    expected = _reference_outputs(
+        reference, gk, layout, bool(attrs["disable_recompute"])
+    )
+    errors = {}
+    for name, actual, target in zip(OUTPUT_NAMES, outputs, expected):
+        if actual is None or target is None:
+            if actual is not target:
+                raise AssertionError(f"{case['id']}: optional output {name} differs")
+            errors[name] = None
+            continue
+        if not torch.isfinite(actual.float()).all().item():
+            raise AssertionError(f"{case['id']}: {name} contains NaN or Inf")
+        errors[name] = float((actual.float() - target.float()).abs().max().item())
+        torch.testing.assert_close(
+            actual.float(), target.float(),
+            rtol=float(tolerance["rtol"]), atol=float(tolerance["atol"]),
+            msg=f"{case['id']}: {name}",
+        )
+    tail_error = _tail_recomposition_error(outputs, case, spans)
+    if tail_error is not None and tail_error > 1e-6:
+        raise AssertionError(
+            f"{case['id']}: tail recomposition max_abs={tail_error} exceeds 1e-6"
+        )
+    return {
+        "id": case["id"],
+        "errors": errors,
+        "tail_recomposition_max_abs": tail_error,
+        "status": "PASS",
+    }, inputs, kwargs
+
+
+def _check_determinism(inputs, kwargs, scale, chunk_size, repeats):
+    chunk_kda_fwd(*inputs, scale, chunk_size, **kwargs)
+    torch.npu.synchronize()
+    baseline = chunk_kda_fwd(*inputs, scale, chunk_size, **kwargs)
+    torch.npu.synchronize()
+    baseline = tuple(None if value is None else value.detach().clone() for value in baseline)
+    torch.npu.synchronize()
+    for repeat in range(1, repeats):
+        current = chunk_kda_fwd(*inputs, scale, chunk_size, **kwargs)
+        torch.npu.synchronize()
+        for name, expected, actual in zip(OUTPUT_NAMES, baseline, current):
+            if expected is None or actual is None:
+                if expected is not actual:
+                    raise AssertionError(f"repeat={repeat}: optional output {name} differs")
+            elif not torch.equal(expected.view(torch.uint8), actual.view(torch.uint8)):
+                raise AssertionError(f"repeat={repeat}: output {name} is not bitwise equal")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--case-id", action="append", choices=CASE_IDS)
+    parser.add_argument("--repeats", type=int, default=50)
+    parser.add_argument("--output-json")
+    args = parser.parse_args()
+    if args.repeats < 1:
+        raise ValueError("--repeats must be positive")
+    torch.npu.set_device(args.device)
+    device = torch.device(f"npu:{args.device}")
+    selected = None if args.case_id is None else set(args.case_id)
+    manifest, cases = _load_cases(selected)
+    tolerance = manifest["tolerance"]["bfloat16"]
+    results = []
+    for case in cases:
+        result, inputs, kwargs = _run_case(case, device, tolerance)
+        expected_repeats = int(case["expect"].get("binary_deterministic_runs", 0))
+        if expected_repeats:
+            repeats = args.repeats if args.repeats else expected_repeats
+            _check_determinism(
+                inputs, kwargs, float(case["attrs"]["scale"]),
+                int(case["shape"]["chunk_size"]), repeats,
+            )
+            result["binary_deterministic_runs"] = repeats
+        results.append(result)
+        print(json.dumps(result, ensure_ascii=False), flush=True)
+    summary = {"passed": len(results), "failed": 0, "status": "PASS", "results": results}
+    if args.output_json:
+        output = Path(args.output_json)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(summary, ensure_ascii=False), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/operators/chunk_kda_fwd/ut/op_kernel/test_contract.py
+++ b/tests/operators/chunk_kda_fwd/ut/op_kernel/test_contract.py
@@ -45,7 +45,7 @@ def test_direct_launch_keeps_registered_public_entry():
     assert registration.count('m.impl("chunk_kda_fwd_direct"') == 2
 
 
-def test_a5_reuses_public_physical_entry_with_internal_stage_implementations():
+def test_a5_reuses_chunk_kda_fwd_kernel_launch_entry_with_internal_arch35_stages():
     assert not LEGACY_COMMON_KERNEL.exists()
     assert KERNEL_ENTRY.exists()
     assert TILING_ENTRY.exists()
@@ -195,13 +195,50 @@ def test_optional_output_workspace_uses_ir_instantiation_state():
     assert "hExport == nullptr ? placeholderShape : hShape5" in aclnn
 
 
-def test_varlen_and_tail_use_the_same_physical_l0():
+def test_varlen_and_tail_reuse_chunk_kda_fwd_l0_registration_and_launcher():
     l0 = (OP_ROOT / "op_host/op_api/chunk_kda_fwd.cpp").read_text(encoding="utf-8")
     assert l0.count("l0op::ChunkKdaFwd(") == 0
     assert l0.count("OP_TYPE_REGISTER(ChunkKdaFwd);") == 1
     assert l0.count("ADD_TO_LAUNCHER_LIST_AICORE(") == 1
     for stage in ("ChunkKdaFwdPrepare", "ChunkKdaFwdPostWu", "ChunkKdaFwdFinalize"):
         assert stage not in l0
+
+
+def test_a5_bf16_sub16_tail_uses_bounded_regbase_templates():
+    finalize = ARCH35_STAGE_IMPLEMENTATIONS["output"].read_text(encoding="utf-8")
+    post_wu = ARCH35_STAGE_IMPLEMENTATIONS["post_wu"].read_text(encoding="utf-8")
+    manifest = json.loads(CASE_MANIFEST.read_text(encoding="utf-8"))
+    cases = {case["id"]: case for case in manifest["cases"]}
+
+    assert "ComputeKdaTailOutputRegbase" in finalize
+    assert "ComputeTailOutputRegbaseRows" in finalize
+    output_dispatch = finalize.rsplit(
+        "ComputeTailOutputRegbaseRows(", 1
+    )[0][-500:]
+    assert "BT_ == 64 && K_ == 128 && V_ == 128" in output_dispatch
+    assert "curT < KDA_CUBE_MIN_REDUCTION" in finalize
+
+    assert "ComputeKdaTailWuRegbase" in post_wu
+    assert "ComputeTailWuRegbaseArch35" in post_wu
+    assert "subBlockIdx != 0" in post_wu
+    assert "curT > maxTailRows" in post_wu
+    assert "BT_ == 64 && K_ == 128 && V_ == 128" in post_wu
+    assert "curT < KDA_POST_REGBASE_TAIL_LIMIT" in post_wu
+
+    h96 = cases["chunk_kda_fwd_a5_bf16_sub16_varlen_h96"]
+    assert h96["shape"] == {
+        "N": 4,
+        "H_k": 96,
+        "H_v": 96,
+        "T": 281,
+        "K": 128,
+        "V": 128,
+        "chunk_size": 64,
+        "N_c": 8,
+    }
+    cu = h96["optional_inputs"]["cu_seqlens"]
+    assert [length % 64 for length in (b - a for a, b in zip(cu, cu[1:]))] == [1, 2, 7, 15]
+    assert h96["expect"]["binary_deterministic_runs"] == 50
 
 
 def test_l0_keeps_the_public_result_contract():
@@ -231,7 +268,7 @@ def test_l0_keeps_the_public_result_contract():
     assert "ChunkKdaFwdFusedArch35" not in l0
 
 
-def test_prepare_post_wu_fusion_stays_inside_chunk_kda_fwd():
+def test_a5_dense_aligned_prepare_post_wu_fusion_stays_inside_chunk_kda_fwd():
     common = KERNEL_COMMON.read_text(encoding="utf-8")
     prepare = STAGE_IMPLEMENTATIONS["prepare"].read_text(encoding="utf-8")
     post_wu = STAGE_IMPLEMENTATIONS["post_wu"].read_text(encoding="utf-8")
@@ -1181,6 +1218,40 @@ def test_tiling_key_has_design_rationale():
     design = (OP_ROOT / "docs/design.md").read_text(encoding="utf-8")
     assert "模板化方案与 tiling key" in design
     assert "编译期" in design and "独立" in design
+
+
+def test_design_documents_all_internal_template_families_by_interface_layer():
+    design = (OP_ROOT / "docs/design.md").read_text(encoding="utf-8")
+    for interface_layer in (
+        "fla_npu.ops.ascendc.chunk_kda_fwd",
+        "aclnnChunkKdaFwd",
+        "ChunkKdaFwd L0",
+        "chunk_kda_fwd device kernel launch 入口",
+    ):
+        assert interface_layer in design
+    for template_family in (
+        "key=1` 通用 shape 模板",
+        "key=2` chunk64/K128/V128 模板",
+        "standalone Gate",
+        "Prepare 内联 Gate",
+        "Prepare/Post-WU 阶段内流水融合",
+        "Post-WU/FwdH 阶段内流水融合",
+        "独立内部 Post-WU 阶段",
+        "Prepare arch35 safe-gate head-pair",
+        "Post-WU arch35 BF16 sub-16",
+        "GDNFwdHTileShapes128",
+        "GDNFwdHTileShapes256",
+        "ChunkKdaFwdFwdH",
+        "Finalize arch35 dense-aligned pipeline",
+        "Finalize arch35 BF16 sub-16",
+        "ComputeTailWuRegbaseArch35",
+        "ComputeTailOutputRegbaseRows",
+    ):
+        assert template_family in design
+    assert "9,600 B" in design
+    assert "40,928 B" in design and "40,960 B" in design
+    assert "物理入口" not in design
+    assert "物理 L0" not in design
 
 
 def test_a5_gate_chunk_bulk_regbase_is_arch_guarded():


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> 本 PR 新建后需在当前 head commit 上触发 NPU CI；后续 push 新 commit 后需要重新触发。

## 关联 Issue / 背景

- 关联 Issue: Closes #281
- 背景与目标: 修复 A5 BF16、`chunk_size=64`、`K=V=128` 场景中 `1<=tail<16` 的输出精度和确定性问题，同时保持所有既有接口与其他模板行为不变。
- 本 PR 解决的问题: Finalize sub-16 标量事件链可能读取旧状态；Post-WU 的 W seed 与 W 输出原地复用时存在跨 AIV 读写竞争。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `ChunkKdaFwd`
- 涉及目录 / 文件: `fla/ops/ascendc/kda/chunk_kda_fwd/`、`tests/op_cases/chunk_kda_fwd.json`、`tests/operators/chunk_kda_fwd/`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [x] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不改变既有支持范围。新增模板仅命中 A5、BF16、`chunk_size=64`、`K=V=128`、`1<=curT<16`；覆盖 BSND/NTD、dense/varlen、safe gate true/false、保存输出和最小可选输出。
- 明确不包含的范围: 不修改算子原型、L0/aclnn/Python 接口、tiling key、layout 或可选输出语义；不修改 A2/A3、FP16、tail>=16 和 dense-aligned 模板。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无 ABI 变更；仅修改 `op_kernel/arch35` 内部模板和测试、设计文档。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

- 静态契约：逐项执行 `tests/operators/chunk_kda_fwd/ut/op_kernel/test_contract.py` 中全部测试。
- A5 重点回归：执行 `tests/operators/chunk_kda_fwd/st/validate_a5_tail_template.py`，比较独立参考实现、尾块公式重组结果和 50 次二进制确定性。
- 补充回归：执行 BF16 deferred-gate dense/varlen 用例及 H96/T8K、T16K 对齐 smoke。
- 合入门禁：PR 创建后触发 NPU CI，补齐 A2/A3 构建和整体 Example/ST。

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | `bash build.sh --pkg --soc=ascend910b --ops=chunk_kda_fwd --vendor_name=fla_npu` | 未执行 | 本 PR 只修改 arch35，实现不进入 A2 编译分支 |
| A3 | `ascend910_93` | 未执行 | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_kda_fwd --vendor_name=fla_npu` | 未执行 | 本 PR 只修改 arch35，实现不进入 A3 编译分支 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | `bash build.sh --pkg --soc=ascend910b --ops=chunk_kda_fwd --vendor_name=fla_npu` | 未执行 | 等待 NPU CI 补齐 |
| A3 | `ascend910_93` | 未执行 | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_kda_fwd --vendor_name=fla_npu` | 未执行 | 等待 NPU CI 补齐 |
| A5 | `ascend950` | CANN 9.x | A5 key2/BF16 kernel 定向编译 | 通过 | arch35 key2 BF16 对象编译通过并完成设备侧执行 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | 未执行 | 本 PR 不进入 A2 编译分支，等待 NPU CI 补齐 |
| A3 | `ascend910_93` | 未执行 | 未执行 | 本 PR 不进入 A3 编译分支，等待 NPU CI 补齐 |
| A5 | `ascend950` | `python tests/operators/chunk_kda_fwd/st/validate_a5_tail_template.py --device 0 --repeats 50` | 通过 | 3/3 场景通过；H96 varlen 覆盖尾长 1/2/7/15，全部 12 个返回位置 50 次二进制一致 |

- 静态契约: `test_contract.py` 全部 56 项通过；JSON、Python 语法和 diff 检查通过。
- 精度对比: H96 varlen `attn_out` 最大绝对误差 `4.77e-7`，尾块公式重组最大误差 `1.19e-7`；H29 dense safe false 和 H1 最小可选输出通过。
- 补充回归: A5 BF16 deferred gate 的 dense H96/T64 与 varlen H96/T65 全输出通过；H96/T8K、T16K 对齐场景执行及 finite 检查通过。
- 性能对比: 本 PR 修复 sub-16 边界正确性，未形成 msopprof 性能结论；dense-aligned 主路径不命中新模板。
- 边界 / 异常场景: 覆盖 tail=1/2/7/15、safe gate true/false、BSND/NTD、final state、保存输出和最小可选输出。
- 未覆盖风险: A2/A3 构建与设备回归、A5 sanitizer、整体 Example/ST 和仓库 NPU CI 尚待补齐。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 等待 NPU CI 补齐 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 等待 NPU CI 补齐 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 等待 NPU CI 补齐 |

- 端到端场景说明: 本 PR 聚焦 ChunkKdaFwd A5 BF16 sub-16 尾块。
- 与本 PR 修改算子的关联: Example/ST 需要覆盖 KDA 正向主调用链。
- 未覆盖原因及补充计划: 创建 PR 后触发 NPU CI。

</details>

## 兼容性、风险与回退

- 兼容性说明: `ChunkKdaFwd` L0、`aclnnChunkKdaFwd`、`fla_npu.ops.ascendc.chunk_kda_fwd` 以及 shape/dtype/layout/可选输出契约均不变。
- 风险点: sub-16 路径使用手工 UB staging 和 regbase 累加；已通过精度和确定性回归，sanitizer 尚待补齐。
- 回退方案: 回退本 PR commit 即恢复原 arch35 sub-16 Vector 路径，不影响接口和其他模板。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- `design.md` 已按接口层级完整列出 key1/key2、A5 执行组合以及 Gate/Prepare、Post-WU、FwdH、Finalize 的所有场景模板和选择条件。
- Finalize sub-16 最坏 staging 为 `40,928 B`，小于既有 `40,960 B` UB buffer；Post-WU sub-16 staging 为 `9,600 B`。
- 本 PR 不新增或修改任何公开接口；后续如需调整接口，必须另行说明必要性并在修改前确认。
