### PR TITLE
fix(dqkwg): 修复 A5 编译选项绑定错误

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/CMakeLists.txt
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/CMakeLists.txt
@@ -21,7 +21,7 @@ add_ops_compile_options(
 )
 if("${ASCEND_COMPUTE_UNIT}" STREQUAL "ascend950")
     add_ops_compile_options(
-        OP_NAME PrepareWyReprBwdDa
+        OP_NAME ChunkBwdDqkwg
         COMPUTE_UNIT Ascend950PR_9599
         OPTIONS -mllvm -cce-aicore-dcci-before-kernel-end=false
     )


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

已知悉当前提交需要重新触发 NPU CI，并以当前 head commit 的验证结果为准。

## 关联 Issue / 背景

- 关联 Issue: Closes #285
- 背景与目标: `chunk_bwd_dqkwg` 在 A5 上运行时返回 `ACLNN_ERR_INNER`。
- 本 PR 解决的问题: 修正 A5 专用编译参数绑定到了错误算子的问题，使该参数作用于 `ChunkBwdDqkwg`。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `chunk_bwd_dqkwg`
- 涉及目录 / 文件: `chunk_bwd_dqkwg/op_host/CMakeLists.txt`
- 责任人 / 提交人: @weinachuan
- 修改范围: A5 Ascend C 编译参数配置
- 输入 / 输出 / shape / dtype / format 支持范围: 不变
- 明确不包含的范围: 不修改 tiling、kernel、op_api、Python 接口和其他算子
- 是否影响公共模块或其他算子: 否
- ABI / 接口兼容性: 不涉及 ABI 变化
- ABI 不兼容风险说明: 无

## 版本与产品编译矩阵

| 产品 | `--soc` | 结果 | 说明 |
| --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | 本次修改仅在 A5 条件分支生效 |
| A3 | `ascend910_93` | 未执行 | 本次修改仅在 A5 条件分支生效 |
| A5 | `ascend950` | 待 NPU CI 验证 | 当前 A5 环境不可达 |

## 验证方法

- 检查 A5 配置块绑定到 `ChunkBwdDqkwg`
- 检查配置块不再错误引用 `PrepareWyReprBwdDa`
- 执行 `git diff --check`
- PR 创建后触发 NPU CI，补充 A5 编译、issue 原用例和 Example ST

## 修改算子测试

- 静态配置断言: 通过
- `git diff --check`: 通过
- A5 单算子与精度验证: 待 NPU CI
- A5 issue #285 原始用例: 待 NPU CI

## 整体 Example ST 验证

| 产品 | 结果 |
| --- | --- |
| A2 | 未执行 |
| A3 | 未执行 |
| A5 | 待 NPU CI 验证 |

## 兼容性、风险与回退

- 兼容性说明: 仅修正 A5 编译选项的目标算子，不影响公共接口。
- 风险点: A5 二进制编译行为发生变化，需要 NPU CI 验证原问题及回归场景。
- 回退方案: 回退本 PR 单个提交。
- [x] 如验证不满足准入要求或引入问题，将及时回退或修复。

## Checklist

- [x] 已关联 Issue
- [x] 已明确修改范围
- [ ] 已完成 A2 / A3 / A5 编译验证
- [ ] 已完成 A2 / A3 / A5 单算子验证
- [ ] 已完成整体 Example ST
- [x] 已确认没有无关改动
- [x] 不涉及文档和公共接口变化
- [x] PR 标题符合规范
