### PR TITLE
fix: 修复 causal_conv1d_bwd ctypes ABI 参数错位

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,13 @@ from fla_npu.ops.triton import chunk_local_cumsum
 
 ctypes 算子如果会通过 data pointer 修改输入 tensor，必须在公共 wrapper 中显式维护 alias/mutation 契约：列出 mutated args，处理 eager autograd 版本计数，明确被修改状态的 grad 限制，并补充 mutation 测试。未增加 `torch.library` mutation schema、FakeTensor 和 `opcheck` 前，不得宣称该 mutable 路径支持 `torch.compile`、functionalization 或 `torch.export`；需要完整图编译支持时优先提供纯 Python custom-op 适配或返回新状态的 functional API，不得为此退回 PyTorch C++ extension。
 
+## ctypes aclnn ABI 一致性红线
+
+1. `torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py` 中显式声明的 `GetWorkspaceSize` 参数类型，必须逐项对照对应 `aclnn*GetWorkspaceSize` 原型，严格保持输入、可选输入、属性、输出、`workspaceSize` 和 `executor` 的数量、顺序与 C 类型一致。每一项必须用行内注释标明对应参数名，禁止仅凭相邻算子、旧版本或参数总数推测。
+2. wrapper 构造的实参数量和顺序必须与参数类型表去掉末尾 `workspaceSize`、`executor` 后完全一致。新增或修改显式参数类型时，必须补充不依赖 NPU 的 ABI 契约测试，同时断言完整类型序列、wrapper 实参数量和逐项 ctypes 类型；不能只依赖上板执行发现 `ctypes.ArgumentError`。
+3. `_aclnn_ctypes.py`、`_runtime.py` 等共享适配文件中的无关算子条目不得随当前算子重构被删除、重排或改型。修改共享 ABI 表后必须检查聚焦 diff，并运行所有 ctypes ABI 契约测试；PR 的验证范围不能只覆盖当前功能算子。
+4. 修改 aclnn C++ 原型时，必须在同一变更中同步 Python ctypes 类型表、wrapper 实参、schema、公开文档和 ABI 测试。仅修改 Python 适配但不改变公开 C++ 原型时，也必须明确说明 ABI 不变，并以对应原型作为修复依据。
+
 ## 算子开发交付 checklist
 
 新增或修改 Ascend C 算子时，交付前逐项核对：

--- a/ci/run_checks.sh
+++ b/ci/run_checks.sh
@@ -473,6 +473,7 @@ fi
 
 echo "[CI] mode=$ci_mode soc=$ci_soc ops=${ci_ops:-<all>} jobs=$ci_jobs cpack_jobs=$ci_cpack_jobs"
 
+python3 torch_custom/fla_npu/test/test_aclnn_ctypes_abi.py
 python3 torch_custom/fla_npu/test/test_runtime_device_guard.py
 python3 torch_custom/fla_npu/test/test_ascendc_mutation_contract.py
 

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
@@ -40,20 +40,21 @@ from ._runtime import (
 # ctypes from narrowing or mis-converting arguments.
 _GET_WORKSPACE_ARGTYPES = {
     "aclnnCausalConv1dBwd": [
-        ctypes.c_void_p,
-        ctypes.c_void_p,
-        ctypes.c_void_p,
-        ctypes.c_void_p,
-        ctypes.c_void_p,
-        ctypes.c_void_p,
-        ctypes.c_void_p,
-        ctypes.c_int64,
-        ctypes.c_char_p,
-        ctypes.c_void_p,
-        ctypes.c_void_p,
-        ctypes.c_void_p,
-        ctypes.POINTER(ctypes.c_uint64),
-        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.c_void_p,  # x
+        ctypes.c_void_p,  # yOptional
+        ctypes.c_void_p,  # weight
+        ctypes.c_void_p,  # dy
+        ctypes.c_void_p,  # initialStateOptional
+        ctypes.c_void_p,  # dhtOptional
+        ctypes.c_void_p,  # queryStartLocOptional
+        ctypes.c_int64,  # activation
+        ctypes.c_char_p,  # inputLayoutOptional
+        ctypes.c_void_p,  # dxOut
+        ctypes.c_void_p,  # dwOutOptional
+        ctypes.c_void_p,  # dbOutOptional
+        ctypes.c_void_p,  # dh0OutOptional
+        ctypes.POINTER(ctypes.c_uint64),  # workspaceSize
+        ctypes.POINTER(ctypes.c_void_p),  # executor
     ],
     "aclnnSolveTri": [
         ctypes.c_void_p,

--- a/torch_custom/fla_npu/test/test_aclnn_ctypes_abi.py
+++ b/torch_custom/fla_npu/test/test_aclnn_ctypes_abi.py
@@ -1,0 +1,134 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import ctypes
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ASCENDC_DIR = Path(__file__).resolve().parents[1] / "fla_npu" / "ops" / "ascendc"
+
+
+def load_aclnn_ctypes_module():
+    package_name = "fla_npu_test_aclnn_ctypes"
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(ASCENDC_DIR)]
+    sys.modules[package_name] = package
+
+    for module_name in ("_runtime", "_kda_policy", "_aclnn_ctypes"):
+        qualified_name = f"{package_name}.{module_name}"
+        spec = importlib.util.spec_from_file_location(
+            qualified_name,
+            ASCENDC_DIR / f"{module_name}.py",
+        )
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[qualified_name] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+    return sys.modules[f"{package_name}._aclnn_ctypes"]
+
+
+ACLNN_CTYPES = load_aclnn_ctypes_module()
+
+
+class FakeTensor:
+    def __init__(self, shape):
+        self.shape = tuple(shape)
+
+
+class FakeCallContext:
+    def __init__(self):
+        self.descriptor_names = []
+
+    def tensor(self, tensor, name):
+        del tensor
+        self.descriptor_names.append(name)
+        return ctypes.c_void_p(0x1000 + len(self.descriptor_names))
+
+    def int_array(self, values):
+        del values
+        self.descriptor_names.append("query_start_loc")
+        return ctypes.c_void_p(0x2000)
+
+
+class AclnnCtypesAbiTest(unittest.TestCase):
+    def test_causal_conv1d_bwd_signature_matches_aclnn_prototype(self):
+        expected_argtypes = [
+            *([ctypes.c_void_p] * 7),
+            ctypes.c_int64,
+            ctypes.c_char_p,
+            *([ctypes.c_void_p] * 4),
+            ctypes.POINTER(ctypes.c_uint64),
+            ctypes.POINTER(ctypes.c_void_p),
+        ]
+        self.assertEqual(
+            ACLNN_CTYPES._GET_WORKSPACE_ARGTYPES["aclnnCausalConv1dBwd"],
+            expected_argtypes,
+        )
+
+    def test_causal_conv1d_bwd_wrapper_builds_one_value_per_operator_argtype(self):
+        captured = {}
+
+        def fake_empty(shape, like, **kwargs):
+            del like, kwargs
+            return FakeTensor(shape)
+
+        def fake_call_aclnn(name, build_args, outputs):
+            context = FakeCallContext()
+            captured["name"] = name
+            captured["args"] = build_args(context)
+            captured["descriptor_names"] = context.descriptor_names
+            return outputs
+
+        x = FakeTensor((2, 17, 80))
+        weight = FakeTensor((4, 80))
+        dy = FakeTensor((2, 17, 80))
+        with mock.patch.object(ACLNN_CTYPES, "_empty", side_effect=fake_empty):
+            with mock.patch.object(ACLNN_CTYPES, "_call_aclnn", side_effect=fake_call_aclnn):
+                outputs = ACLNN_CTYPES.npu_causal_conv1d_bwd(
+                    x=x,
+                    y=None,
+                    weight=weight,
+                    dy=dy,
+                    input_layout="BSH",
+                )
+
+        operator_argtypes = ACLNN_CTYPES._GET_WORKSPACE_ARGTYPES["aclnnCausalConv1dBwd"][:-2]
+        self.assertEqual(captured["name"], "aclnnCausalConv1dBwd")
+        self.assertEqual(len(outputs), 4)
+        self.assertEqual(len(captured["args"]), len(operator_argtypes))
+        self.assertEqual([type(arg) for arg in captured["args"]], operator_argtypes)
+        self.assertEqual(
+            captured["descriptor_names"],
+            [
+                "x",
+                "y",
+                "weight",
+                "dy",
+                "initial_state",
+                "dht",
+                "query_start_loc",
+                "dx",
+                "dw",
+                "db",
+                "dh0",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torch_custom/fla_npu/test/test_ascendc_mutation_contract.py
+++ b/torch_custom/fla_npu/test/test_ascendc_mutation_contract.py
@@ -63,8 +63,19 @@ def load_ascendc_module(raw_calls):
         raw_calls.append(conv_states)
         return "output"
 
-    def npu_recurrent_kda(q, k, v, g, beta, initial_state=None, *, cu_seqlens, **kwargs):
-        del q, k, v, g, beta, cu_seqlens, kwargs
+    def npu_recurrent_kda(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        initial_state=None,
+        *,
+        cu_seqlens,
+        inplace_final_state=True,
+        **kwargs,
+    ):
+        del q, k, v, g, beta, cu_seqlens, inplace_final_state, kwargs
         raw_calls.append(initial_state)
         return "output", initial_state
 


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval。可在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full` 请求触发。

## 关联 Issue / 背景

- 关联 Issue: Closes #289
- 背景与目标: 修复 `fla_npu.ops.ascendc` 调用 `causal_conv1d_bwd` 时的 ctypes 参数类型错位。
- 本 PR 解决的问题: `aclnnCausalConv1dBwdGetWorkspaceSize` 的 Python ctypes 类型表遗漏 `dh0OutOptional`，导致 `workspaceSize` 和 `executor` 参数整体前移，在 kernel 启动前触发 `ctypes.ArgumentError`。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `causal_conv1d_bwd`
- 涉及目录 / 文件: `torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py`、`torch_custom/fla_npu/test/test_aclnn_ctypes_abi.py`、`torch_custom/fla_npu/test/test_ascendc_mutation_contract.py`、`ci/run_checks.sh`、`AGENTS.md`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 保持不变。
- 明确不包含的范围: 不修改 kernel、tiling、op_host、op_api、schema 和公共 Python 接口。
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [x] 是，共享 ctypes 类型表中的修改仅限 `causal_conv1d_bwd` 条目；通过聚焦差异和现有 runtime 回归测试检查其他调用路径。
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无。该修改将 Python ctypes 声明恢复为现有 C++ 原型定义的 13 个算子参数，公共 ABI 不变。

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0-beta.1 | `FLA_NPU_SOC=ascend910b FLA_NPU_OPS=causal_conv1d_bwd python -m pip wheel --no-build-isolation --no-deps . -w dist` | 通过 | 一体化 wheel 构建和隔离安装通过。 |
| A3 | `ascend910_93` | 9.1.0-beta.1 | `bash build.sh --pkg --soc=ascend910_93 --ops=causal_conv1d_bwd --vendor_name=fla_npu` | 通过 | 部分 run 包构建和打包通过。 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0-beta.1 | `FLA_NPU_SOC=ascend910b FLA_NPU_OPS=causal_conv1d_bwd python -m pip wheel --no-build-isolation --no-deps . -w dist` | 通过 | 一体化 wheel 构建和隔离安装通过。 |
| A3 | `ascend910_93` | 9.1.0-beta.1 | `bash build.sh --pkg --soc=ascend910_93 --ops=causal_conv1d_bwd --vendor_name=fla_npu` | 通过 | 部分 run 包构建和打包通过。 |
| A5 | `ascend950` | 9.1.0 | `FLA_NPU_SOC=ascend950 FLA_NPU_OPS=causal_conv1d_bwd python -m pip wheel --no-build-isolation --no-deps . -w dist` | 通过 | 部分 wheel 构建通过。 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 test_npu_causal_conv1d_bwd.py` | 通过 | BSH、BNSD、TND、NTD 场景通过；覆盖 FP16、BF16、FP32 及 activation 0/1/2，输出精度与 CPU 参考实现一致。 |
| A3 | `ascend910_93` | - | 未执行 | 已完成编译验证，缺少 A3 上板验证。 |
| A5 | `ascend950` | `python3 test_npu_causal_conv1d_bwd.py` | 通过 | BSH、BNSD、TND、NTD 场景通过；覆盖 FP16、BF16、FP32 及 activation 0/1/2，输出精度与 CPU 参考实现一致。 |

- 精度对比: A2、A5 单算子输出与 CPU 参考实现一致。
- 性能对比: 不涉及 kernel 和性能路径变更，未执行性能对比。
- 边界 / 异常场景: 新增不依赖 NPU 的 ABI 契约测试，覆盖完整类型序列、wrapper 实参数量、逐项 ctypes 类型及输出顺序，并已接入 `ci/run_checks.sh`。
- 未覆盖风险: A3 上板和整体 Example ST 未执行；NPU CI 已触发但 runner 仍在排队。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐。 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐。 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 本地已完成修改算子单算子验证，整体链路待 NPU CI 补齐。 |

- 端到端场景说明: GDN 端到端训练链路。
- 与本 PR 修改算子的关联: 训练反向过程调用 `causal_conv1d_bwd`。
- 未覆盖原因及补充计划: 本 PR 为 Python ctypes ABI 修复，整体 Example ST 由 NPU CI 补齐。

</details>

## 兼容性、风险与回退

- 兼容性说明: 公共 C++ ABI、Python API 和算子功能范围均不变。
- 风险点: `_GET_WORKSPACE_ARGTYPES` 属于共享适配表；已增加完整类型序列及 wrapper 实参顺序测试。
- 回退方案: 回退本 PR 提交即可。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 已执行 `python3 torch_custom/fla_npu/test/test_aclnn_ctypes_abi.py -v`，2/2 通过。
- 已执行 `python3 torch_custom/fla_npu/test/test_runtime_device_guard.py -v`，7/7 通过。
- 已执行 `python3 torch_custom/fla_npu/test/test_ascendc_mutation_contract.py -v`，3/3 通过；同步修正了主线测试 fixture 未声明 `inplace_final_state` 的问题。
- ABI 契约测试已接入 `ci/run_checks.sh`，并完成脚本语法检查。
- 已执行 Python 语法编译检查和 `git diff --check`，均通过。
- 已检查 `docs/torch-npu-decoupled-architecture.md`；本次仅恢复既有 ABI 对应关系，不改变解耦架构、stream、保活或安装行为，无需修改该文档。
