### PR TITLE
[Performance][KDA] Optimize chunk KDA intra backward on A5

### DIFF
--- a/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_host/chunk_kda_bwd_intra_tiling_processor.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_host/chunk_kda_bwd_intra_tiling_processor.h
@@ -64,6 +64,7 @@ struct ChunkKdaBwdIntraTilingContext {
     int64_t chunkMetadataElements;
     uint32_t aicCoreNum;
     size_t systemWorkspaceSize;
+    bool isA5;
 };
 
 class ChunkKdaBwdIntraTilingProcessor {
@@ -292,7 +293,10 @@ private:
     {
         const uint64_t bt = static_cast<uint64_t>(tiling_.chunkSize);
         const uint64_t k = static_cast<uint64_t>(tiling_.headDim);
-        const uint64_t bc = 16;
+        const bool useA5DenseK128Row32 =
+            ctx_.isA5 && ctx_.layoutMode == KDA_BWD_LAYOUT_DENSE_BNSD &&
+            tiling_.headDim == 128 && tiling_.chunkSize == 64;
+        const uint64_t bc = useA5DenseK128Row32 ? 32 : 16;
 
         tiling_.aLowerOffset = 0;
         tiling_.bLowerOffset = static_cast<int64_t>(

--- a/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_host/op_tiling/chunk_kda_bwd_intra_tiling.cpp
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_host/op_tiling/chunk_kda_bwd_intra_tiling.cpp
@@ -60,6 +60,7 @@ ge::graphStatus Tiling4ChunkKdaBwdIntra(gert::TilingContext *context)
                 chunkMetadataTensor->GetStorageShape().GetShapeSize()),
         static_cast<uint32_t>(platform.GetCoreNumAic()),
         static_cast<size_t>(platform.GetLibApiWorkSpaceSize()),
+        platform.GetCurNpuArch() == NpuArch::DAV_3510,
     };
     ChunkKdaBwdIntraTilingProcessor processor(ctx, *tiling);
     OP_CHECK_IF(processor.Process() != ge::GRAPH_SUCCESS, , return ge::GRAPH_FAILED);

--- a/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/arch35/chunk_kda_bwd_intra_cube.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/arch35/chunk_kda_bwd_intra_cube.h
@@ -89,6 +89,9 @@ public:
     }
 
 private:
+    static constexpr uint32_t kProcessRowBlock =
+        ProcessRowBlock<K_DIM, VARLEN_TND>::value;
+
     __aicore__ inline void ProcessBlockMmad()
     {
         using DispatchPolicy = Catlass::Gemm::MmadPingpong<ArchTag, true, false>;
@@ -126,11 +129,13 @@ private:
             const ChunkTask task =
                 GetChunkTask<VARLEN_TND>(tiling_, chunkMetadataGm_, taskIdx);
             const uint32_t validLen = task.end - task.begin;
-            const uint32_t rowBlockCount = (validLen + kRowBlock - 1) / kRowBlock;
+            const uint32_t rowBlockCount =
+                (validLen + kProcessRowBlock - 1) / kProcessRowBlock;
             for (uint32_t rowBlock = 0; rowBlock < rowBlockCount; ++rowBlock) {
-                const uint32_t rowStart = rowBlock * kRowBlock;
+                const uint32_t rowStart = rowBlock * kProcessRowBlock;
                 const uint32_t validRows =
-                    rowStart + kRowBlock <= validLen ? kRowBlock : validLen - rowStart;
+                    rowStart + kProcessRowBlock <= validLen ?
+                        kProcessRowBlock : validLen - rowStart;
                 const uint32_t prefix = rowStart + validRows;
                 const uint32_t future = validLen - rowStart;
                 for (uint32_t headInWindow = 0; headInWindow < headCount; ++headInWindow) {
@@ -208,11 +213,13 @@ private:
             const ChunkTask task =
                 GetChunkTask<VARLEN_TND>(tiling_, chunkMetadataGm_, taskIdx);
             const uint32_t validLen = task.end - task.begin;
-            const uint32_t rowBlockCount = (validLen + kRowBlock - 1) / kRowBlock;
+            const uint32_t rowBlockCount =
+                (validLen + kProcessRowBlock - 1) / kProcessRowBlock;
             for (uint32_t rowBlock = 0; rowBlock < rowBlockCount; ++rowBlock) {
-                const uint32_t rowStart = rowBlock * kRowBlock;
+                const uint32_t rowStart = rowBlock * kProcessRowBlock;
                 const uint32_t validRows =
-                    rowStart + kRowBlock <= validLen ? kRowBlock : validLen - rowStart;
+                    rowStart + kProcessRowBlock <= validLen ?
+                        kProcessRowBlock : validLen - rowStart;
                 const uint32_t prefix = rowStart + validRows;
                 const uint32_t future = validLen - rowStart;
                 for (uint32_t headInWindow = 0; headInWindow < headCount; ++headInWindow) {
@@ -255,8 +262,8 @@ private:
         upperC.SetGlobalBuffer((__gm__ Element *)(
             workspace_ + slotBase + tiling_.resultRegionOffset + tiling_.resultDkUpperOffset));
 
-        const uint32_t lowerRows = 2 * kRowBlock;
-        const uint32_t upperRows = kRowBlock;
+        const uint32_t lowerRows = 2 * kProcessRowBlock;
+        const uint32_t upperRows = kProcessRowBlock;
         const uint32_t upperReduction = 2 * future;
         auto lowerLayoutA = tla::MakeLayout<Element, RowMajor>(lowerRows, prefix);
         auto lowerLayoutB = tla::MakeLayout<Element, RowMajor>(prefix, K_DIM);
@@ -397,7 +404,7 @@ private:
         c.SetGlobalBuffer((__gm__ float *)(
             workspace_ + slotBase + tiling_.resultRegionOffset + tiling_.resultDqOffset));
 
-        const uint32_t m = 2 * kRowBlock;
+        const uint32_t m = 2 * kProcessRowBlock;
         auto layoutA = tla::MakeLayout<float, RowMajor>(m, prefix);
         auto layoutB = tla::MakeLayout<float, RowMajor>(prefix, K_DIM);
         auto layoutC = tla::MakeLayout<float, RowMajor>(m, K_DIM);
@@ -422,19 +429,21 @@ private:
             workspace_ + slotBase + tiling_.resultRegionOffset + tiling_.resultDkUpperOffset));
 
         const uint32_t reduction = 2 * future;
-        auto layoutA = tla::MakeLayout<float, ColumnMajor>(kRowBlock, reduction);
+        auto layoutA =
+            tla::MakeLayout<float, ColumnMajor>(kProcessRowBlock, reduction);
         auto layoutB = tla::MakeLayout<float, RowMajor>(reduction, K_DIM);
-        auto layoutC = tla::MakeLayout<float, RowMajor>(kRowBlock, K_DIM);
+        auto layoutC =
+            tla::MakeLayout<float, RowMajor>(kProcessRowBlock, K_DIM);
         auto tensorA = tla::MakeTensor(a, layoutA, Catlass::Arch::PositionGM{});
         auto tensorB = tla::MakeTensor(b, layoutB, Catlass::Arch::PositionGM{});
         auto tensorC = tla::MakeTensor(c, layoutC, Catlass::Arch::PositionGM{});
-        Catlass::GemmCoord shape{kRowBlock, K_DIM, reduction};
+        Catlass::GemmCoord shape{kProcessRowBlock, K_DIM, reduction};
         UpperMmad mma(resource);
         mma(tensorA, tensorB, tensorC, shape);
     }
 
-    static constexpr uint32_t kLowerRows = 2 * kRowBlock;
-    static constexpr uint32_t kUpperRows = kRowBlock;
+    static constexpr uint32_t kLowerRows = 2 * kProcessRowBlock;
+    static constexpr uint32_t kUpperRows = kProcessRowBlock;
     static constexpr uint32_t kLowerReduction = CHUNK_SIZE;
     static constexpr uint32_t kUpperReduction = 2 * CHUNK_SIZE;
     static constexpr uint32_t kLowerL1ABytes = kLowerRows * kLowerReduction * sizeof(Element);

--- a/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/arch35/chunk_kda_bwd_intra_cube.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/arch35/chunk_kda_bwd_intra_cube.h
@@ -339,12 +339,6 @@ private:
         copyLowerL1ToL0B(lowerL0TensorB, lowerL1TensorB);
         AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(kLowerEvent);
         AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(kLowerEvent);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(kUpperEvent);
-        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(kUpperEvent);
-        copyUpperL1ToL0A(upperL0TensorA, upperL1TensorA);
-        copyUpperL1ToL0B(upperL0TensorB, upperL1TensorB);
-        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(kUpperEvent);
-        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(kUpperEvent);
 
         using Accumulator = typename LowerCopy::ElementAccumulator;
         AscendC::LocalTensor<Accumulator> lowerL0C =
@@ -363,18 +357,29 @@ private:
                   lowerRows, K_DIM, prefix, true, 0b11);
         AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(kLowerEvent);
         AscendC::SetFlag<AscendC::HardEvent::M_FIX>(kLowerEvent);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(kUpperEvent);
-        AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(kUpperEvent);
-        upperMmad(upperL0CTensor, upperL0TensorA, upperL0TensorB,
-                  upperRows, K_DIM, upperReduction, true, 0b11);
-        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(kUpperEvent);
-        AscendC::SetFlag<AscendC::HardEvent::M_FIX>(kUpperEvent);
+
+        // Lower and Upper reuse the same L0A/L0B storage. Once Lower MMAD
+        // releases it, Upper MTE1 can refill L0 while Lower FIX writes GM.
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(kUpperEvent);
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(kLowerEvent);
+        copyUpperL1ToL0A(upperL0TensorA, upperL1TensorA);
+        copyUpperL1ToL0B(upperL0TensorB, upperL1TensorB);
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(kUpperEvent);
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(kUpperEvent);
 
         CopyLowerL0CToGm<decltype(lowerTensorC)> copyLowerL0CToGm;
         CopyUpperL0CToGm<decltype(upperTensorC)> copyUpperL0CToGm;
         AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(kLowerEvent);
         copyLowerL0CToGm(lowerTensorC, lowerL0CTensor, 0b11);
         AscendC::SetFlag<AscendC::HardEvent::FIX_M>(kLowerEvent);
+
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(kUpperEvent);
+        AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(kUpperEvent);
+        upperMmad(upperL0CTensor, upperL0TensorA, upperL0TensorB,
+                  upperRows, K_DIM, upperReduction, true, 0b11);
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(kLowerEvent);
+        AscendC::SetFlag<AscendC::HardEvent::M_FIX>(kUpperEvent);
+
         AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(kUpperEvent);
         copyUpperL0CToGm(upperTensorC, upperL0CTensor, 0b11);
         AscendC::SetFlag<AscendC::HardEvent::FIX_M>(kUpperEvent);
@@ -456,12 +461,14 @@ private:
     static constexpr uint32_t kUpperL0ABytes = kUpperL1ABytes;
     static constexpr uint32_t kUpperL0BBytes = kUpperL1BBytes;
     static constexpr uint32_t kLowerL0AOffset = 0;
-    static constexpr uint32_t kUpperL0AOffset = kLowerL0AOffset + kLowerL0ABytes;
+    static constexpr uint32_t kUpperL0AOffset = kLowerL0AOffset;
     static constexpr uint32_t kLowerL0BOffset = 0;
-    static constexpr uint32_t kUpperL0BOffset = kLowerL0BOffset + kLowerL0BBytes;
-    static constexpr uint32_t kL0AUsedBytes = kUpperL0AOffset + kUpperL0ABytes;
-    static constexpr uint32_t kL0BUsedBytes = kUpperL0BOffset + kUpperL0BBytes;
-    static constexpr uint32_t kL0ABCapacityBytes = 128 * 1024;
+    static constexpr uint32_t kUpperL0BOffset = kLowerL0BOffset;
+    static constexpr uint32_t kL0AUsedBytes =
+        kLowerL0ABytes > kUpperL0ABytes ? kLowerL0ABytes : kUpperL0ABytes;
+    static constexpr uint32_t kL0BUsedBytes =
+        kLowerL0BBytes > kUpperL0BBytes ? kLowerL0BBytes : kUpperL0BBytes;
+    static constexpr uint32_t kL0ABCapacityBytes = 64 * 1024;
 
     static constexpr uint32_t kLowerL0CBytes = kLowerRows * K_DIM * sizeof(Element);
     static constexpr uint32_t kUpperL0CBytes = kUpperRows * K_DIM * sizeof(Element);

--- a/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/arch35/chunk_kda_bwd_intra_cube.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/arch35/chunk_kda_bwd_intra_cube.h
@@ -8,10 +8,13 @@
 #define CATLASS_ARCH 3510
 #include "catlass/arch/arch.hpp"
 #include "catlass/arch/cross_core_sync.hpp"
+#include "catlass/arch/resource.hpp"
 #include "catlass/catlass.hpp"
 #include "catlass/gemm/block/block_mmad.hpp"
 #include "catlass/gemm/dispatch_policy.hpp"
 #include "catlass/gemm_coord.hpp"
+#include "catlass/gemm/tile/tile_copy.hpp"
+#include "catlass/gemm/tile/tile_mmad.hpp"
 #include "catlass/layout/layout.hpp"
 #include "tla/layout.hpp"
 #include "tla/tensor.hpp"
@@ -25,6 +28,37 @@ template <uint32_t K_DIM, uint32_t CHUNK_SIZE, bool SAFE_GATE, bool VARLEN_TND>
 class ChunkKdaBwdIntraCubeProcess {
 public:
     using ArchTag = Catlass::Arch::Ascend950;
+    using Element = float;
+    using RowMajor = Catlass::layout::RowMajor;
+    using ColumnMajor = Catlass::layout::ColumnMajor;
+
+    using LowerCopy = Catlass::Gemm::Tile::PackedTileCopyTla<
+        ArchTag, Element, RowMajor, Element, RowMajor, Element, RowMajor>;
+    using UpperCopy = Catlass::Gemm::Tile::PackedTileCopyTla<
+        ArchTag, Element, ColumnMajor, Element, RowMajor, Element, RowMajor>;
+    using LowerL1ALayout = typename LowerCopy::LayoutTagL1A;
+    using LowerL1BLayout = typename LowerCopy::LayoutTagL1B;
+    using LowerL0ALayout = typename LowerCopy::LayoutTagL0A;
+    using LowerL0BLayout = typename LowerCopy::LayoutTagL0B;
+    using UpperL1ALayout = typename UpperCopy::LayoutTagL1A;
+    using UpperL1BLayout = typename UpperCopy::LayoutTagL1B;
+    using UpperL0ALayout = typename UpperCopy::LayoutTagL0A;
+    using UpperL0BLayout = typename UpperCopy::LayoutTagL0B;
+    using LowerTileMmad = Catlass::Gemm::Tile::TileMmadTla<ArchTag, Element, LowerL1ALayout>;
+    using UpperTileMmad = Catlass::Gemm::Tile::TileMmadTla<ArchTag, Element, UpperL1ALayout>;
+
+    template <typename Tensor>
+    using CopyLowerGmToL1A = typename LowerCopy::template CopyGmToL1A<Tensor>;
+    template <typename Tensor>
+    using CopyLowerGmToL1B = typename LowerCopy::template CopyGmToL1B<Tensor>;
+    template <typename Tensor>
+    using CopyLowerL0CToGm = typename LowerCopy::template CopyL0CToDst<Tensor>;
+    template <typename Tensor>
+    using CopyUpperGmToL1A = typename UpperCopy::template CopyGmToL1A<Tensor>;
+    template <typename Tensor>
+    using CopyUpperGmToL1B = typename UpperCopy::template CopyGmToL1B<Tensor>;
+    template <typename Tensor>
+    using CopyUpperL0CToGm = typename UpperCopy::template CopyL0CToDst<Tensor>;
 
     __aicore__ ChunkKdaBwdIntraCubeProcess(GM_ADDR chunkMetadata, GM_ADDR workspace)
         : chunkMetadata_(chunkMetadata), workspace_(workspace)
@@ -47,8 +81,17 @@ public:
     __aicore__ inline void Process()
     {
         AscendC::SetHF32Mode(false);
+        if constexpr (K_DIM == 128) {
+            ProcessPipelinedK128();
+        } else {
+            ProcessBlockMmad();
+        }
+    }
+
+private:
+    __aicore__ inline void ProcessBlockMmad()
+    {
         using DispatchPolicy = Catlass::Gemm::MmadPingpong<ArchTag, true, false>;
-        using Element = float;
         static constexpr uint32_t kL0ReductionTile = K_DIM == 256 ? 32 : 64;
         using LowerL1Shape = tla::Shape<tla::Int<32>, tla::Int<K_DIM>, tla::Int<CHUNK_SIZE>>;
         using LowerL0Shape =
@@ -57,12 +100,6 @@ public:
         using UpperL0Shape =
             tla::Shape<tla::Int<16>, tla::Int<K_DIM>, tla::Int<kL0ReductionTile>>;
 
-        using RowMajor = Catlass::layout::RowMajor;
-        using ColumnMajor = Catlass::layout::ColumnMajor;
-        using LowerCopy = Catlass::Gemm::Tile::PackedTileCopyTla<
-            ArchTag, Element, RowMajor, Element, RowMajor, Element, RowMajor>;
-        using UpperCopy = Catlass::Gemm::Tile::PackedTileCopyTla<
-            ArchTag, Element, ColumnMajor, Element, RowMajor, Element, RowMajor>;
         using LowerMmad = Catlass::Gemm::Block::BlockMmadTla<
             DispatchPolicy, LowerL1Shape, LowerL0Shape, Element, Element, Element, void, LowerCopy>;
         using UpperMmad = Catlass::Gemm::Block::BlockMmadTla<
@@ -117,7 +154,228 @@ public:
         }
     }
 
-private:
+    __aicore__ inline void InitPipelineFlags()
+    {
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(kLowerEvent);
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(kUpperEvent);
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(kLowerEvent);
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(kUpperEvent);
+        AscendC::SetFlag<AscendC::HardEvent::FIX_M>(kLowerEvent);
+        AscendC::SetFlag<AscendC::HardEvent::FIX_M>(kUpperEvent);
+    }
+
+    __aicore__ inline void DrainPipelineFlags()
+    {
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(kLowerEvent);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(kUpperEvent);
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(kLowerEvent);
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(kUpperEvent);
+        AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(kLowerEvent);
+        AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(kUpperEvent);
+    }
+
+    __aicore__ inline void ProcessPipelinedK128()
+    {
+        static_assert(K_DIM == 128, "The explicit A5 lower/upper pipeline is specialized for K=128.");
+        static_assert(kL1UsedBytes <= kL1CapacityBytes,
+                      "chunk_kda_bwd_intra A5 pipeline exceeds the 512KB L1 capacity.");
+        static_assert(kL0AUsedBytes <= kL0ABCapacityBytes,
+                      "chunk_kda_bwd_intra A5 pipeline exceeds the L0A capacity.");
+        static_assert(kL0BUsedBytes <= kL0ABCapacityBytes,
+                      "chunk_kda_bwd_intra A5 pipeline exceeds the L0B capacity.");
+        static_assert(kL0CUsedBytes <= kL0CCapacityBytes,
+                      "chunk_kda_bwd_intra A5 pipeline exceeds the 256KB L0C capacity.");
+
+        Catlass::Arch::Resource<ArchTag> resource;
+        InitPipelineFlags();
+        const uint32_t coreIdx = AscendC::GetBlockIdx();
+        const uint32_t coreNum = AscendC::GetBlockNum();
+        const uint32_t headNum = static_cast<uint32_t>(tiling_.headNum);
+        const uint32_t headWindowCount =
+            (headNum + kHeadsPerWindow - 1) / kHeadsPerWindow;
+        const uint64_t taskGroupCount =
+            static_cast<uint64_t>(tiling_.chunkNum) * headWindowCount;
+        uint32_t taskIdx = coreIdx / headWindowCount;
+        uint32_t headWindowIdx = coreIdx % headWindowCount;
+        const uint32_t taskStride = coreNum / headWindowCount;
+        const uint32_t headWindowStride = coreNum % headWindowCount;
+        uint64_t windowIdx = 0;
+
+        for (uint64_t taskGroupIdx = coreIdx; taskGroupIdx < taskGroupCount;
+             taskGroupIdx += coreNum) {
+            const uint32_t headBase = headWindowIdx * kHeadsPerWindow;
+            const uint32_t headCount = headBase + 1 < headNum ? 2 : 1;
+            const ChunkTask task =
+                GetChunkTask<VARLEN_TND>(tiling_, chunkMetadataGm_, taskIdx);
+            const uint32_t validLen = task.end - task.begin;
+            const uint32_t rowBlockCount = (validLen + kRowBlock - 1) / kRowBlock;
+            for (uint32_t rowBlock = 0; rowBlock < rowBlockCount; ++rowBlock) {
+                const uint32_t rowStart = rowBlock * kRowBlock;
+                const uint32_t validRows =
+                    rowStart + kRowBlock <= validLen ? kRowBlock : validLen - rowStart;
+                const uint32_t prefix = rowStart + validRows;
+                const uint32_t future = validLen - rowStart;
+                for (uint32_t headInWindow = 0; headInWindow < headCount; ++headInWindow) {
+                    Catlass::Arch::CrossCoreWaitFlag(vecToCubeReadyFlag_);
+                    const uint32_t slot = WorkspaceSlot(windowIdx, headInWindow);
+                    const uint64_t slotBase =
+                        static_cast<uint64_t>(coreIdx) * tiling_.workspaceCoreSize +
+                        static_cast<uint64_t>(slot) * tiling_.workspaceSlotSize;
+                    RunLowerUpperPipeline(resource, slotBase, prefix, future);
+                    Catlass::Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeToVecReadyFlag_);
+                }
+                ++windowIdx;
+            }
+            taskIdx += taskStride;
+            headWindowIdx += headWindowStride;
+            if (headWindowIdx >= headWindowCount) {
+                headWindowIdx -= headWindowCount;
+                ++taskIdx;
+            }
+        }
+        DrainPipelineFlags();
+    }
+
+    __aicore__ inline void RunLowerUpperPipeline(
+        Catlass::Arch::Resource<ArchTag> &resource, uint64_t slotBase,
+        uint32_t prefix, uint32_t future)
+    {
+        AscendC::GlobalTensor<Element> lowerA;
+        AscendC::GlobalTensor<Element> lowerB;
+        AscendC::GlobalTensor<Element> lowerC;
+        AscendC::GlobalTensor<Element> upperA;
+        AscendC::GlobalTensor<Element> upperB;
+        AscendC::GlobalTensor<Element> upperC;
+        lowerA.SetGlobalBuffer((__gm__ Element *)(workspace_ + slotBase + tiling_.aLowerOffset));
+        lowerB.SetGlobalBuffer((__gm__ Element *)(workspace_ + slotBase + tiling_.bLowerOffset));
+        lowerC.SetGlobalBuffer((__gm__ Element *)(
+            workspace_ + slotBase + tiling_.resultRegionOffset + tiling_.resultDqOffset));
+        upperA.SetGlobalBuffer((__gm__ Element *)(workspace_ + slotBase + tiling_.aUpperOffset));
+        upperB.SetGlobalBuffer((__gm__ Element *)(workspace_ + slotBase + tiling_.bUpperOffset));
+        upperC.SetGlobalBuffer((__gm__ Element *)(
+            workspace_ + slotBase + tiling_.resultRegionOffset + tiling_.resultDkUpperOffset));
+
+        const uint32_t lowerRows = 2 * kRowBlock;
+        const uint32_t upperRows = kRowBlock;
+        const uint32_t upperReduction = 2 * future;
+        auto lowerLayoutA = tla::MakeLayout<Element, RowMajor>(lowerRows, prefix);
+        auto lowerLayoutB = tla::MakeLayout<Element, RowMajor>(prefix, K_DIM);
+        auto lowerLayoutC = tla::MakeLayout<Element, RowMajor>(lowerRows, K_DIM);
+        auto upperLayoutA = tla::MakeLayout<Element, ColumnMajor>(upperRows, upperReduction);
+        auto upperLayoutB = tla::MakeLayout<Element, RowMajor>(upperReduction, K_DIM);
+        auto upperLayoutC = tla::MakeLayout<Element, RowMajor>(upperRows, K_DIM);
+        auto lowerTensorA = tla::MakeTensor(lowerA, lowerLayoutA, Catlass::Arch::PositionGM{});
+        auto lowerTensorB = tla::MakeTensor(lowerB, lowerLayoutB, Catlass::Arch::PositionGM{});
+        auto lowerTensorC = tla::MakeTensor(lowerC, lowerLayoutC, Catlass::Arch::PositionGM{});
+        auto upperTensorA = tla::MakeTensor(upperA, upperLayoutA, Catlass::Arch::PositionGM{});
+        auto upperTensorB = tla::MakeTensor(upperB, upperLayoutB, Catlass::Arch::PositionGM{});
+        auto upperTensorC = tla::MakeTensor(upperC, upperLayoutC, Catlass::Arch::PositionGM{});
+
+        AscendC::LocalTensor<Element> lowerL1A =
+            resource.l1Buf.template GetBufferByByte<Element>(kLowerL1AOffset);
+        AscendC::LocalTensor<Element> lowerL1B =
+            resource.l1Buf.template GetBufferByByte<Element>(kLowerL1BOffset);
+        AscendC::LocalTensor<Element> upperL1A =
+            resource.l1Buf.template GetBufferByByte<Element>(kUpperL1AOffset);
+        AscendC::LocalTensor<Element> upperL1B =
+            resource.l1Buf.template GetBufferByByte<Element>(kUpperL1BOffset);
+        auto lowerL1TensorA = tla::MakeTensor(
+            lowerL1A, tla::MakeLayout<Element, LowerL1ALayout>(lowerRows, prefix),
+            Catlass::Arch::PositionL1{});
+        auto lowerL1TensorB = tla::MakeTensor(
+            lowerL1B, tla::MakeLayout<Element, LowerL1BLayout>(prefix, K_DIM),
+            Catlass::Arch::PositionL1{});
+        auto upperL1TensorA = tla::MakeTensor(
+            upperL1A, tla::MakeLayout<Element, UpperL1ALayout>(upperRows, upperReduction),
+            Catlass::Arch::PositionL1{});
+        auto upperL1TensorB = tla::MakeTensor(
+            upperL1B, tla::MakeLayout<Element, UpperL1BLayout>(upperReduction, K_DIM),
+            Catlass::Arch::PositionL1{});
+
+        CopyLowerGmToL1A<decltype(lowerTensorA)> copyLowerGmToL1A;
+        CopyLowerGmToL1B<decltype(lowerTensorB)> copyLowerGmToL1B;
+        CopyUpperGmToL1A<decltype(upperTensorA)> copyUpperGmToL1A;
+        CopyUpperGmToL1B<decltype(upperTensorB)> copyUpperGmToL1B;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(kLowerEvent);
+        copyLowerGmToL1A(lowerL1TensorA, lowerTensorA);
+        copyLowerGmToL1B(lowerL1TensorB, lowerTensorB);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(kLowerEvent);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(kUpperEvent);
+        copyUpperGmToL1A(upperL1TensorA, upperTensorA);
+        copyUpperGmToL1B(upperL1TensorB, upperTensorB);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(kUpperEvent);
+
+        AscendC::LocalTensor<Element> lowerL0A =
+            resource.l0ABuf.template GetBufferByByte<Element>(kLowerL0AOffset);
+        AscendC::LocalTensor<Element> lowerL0B =
+            resource.l0BBuf.template GetBufferByByte<Element>(kLowerL0BOffset);
+        AscendC::LocalTensor<Element> upperL0A =
+            resource.l0ABuf.template GetBufferByByte<Element>(kUpperL0AOffset);
+        AscendC::LocalTensor<Element> upperL0B =
+            resource.l0BBuf.template GetBufferByByte<Element>(kUpperL0BOffset);
+        auto lowerL0TensorA = tla::MakeTensor(
+            lowerL0A, tla::MakeLayout<Element, LowerL0ALayout>(lowerRows, prefix),
+            Catlass::Arch::PositionL0A{});
+        auto lowerL0TensorB = tla::MakeTensor(
+            lowerL0B, tla::MakeLayout<Element, LowerL0BLayout>(prefix, K_DIM),
+            Catlass::Arch::PositionL0B{});
+        auto upperL0TensorA = tla::MakeTensor(
+            upperL0A, tla::MakeLayout<Element, UpperL0ALayout>(upperRows, upperReduction),
+            Catlass::Arch::PositionL0A{});
+        auto upperL0TensorB = tla::MakeTensor(
+            upperL0B, tla::MakeLayout<Element, UpperL0BLayout>(upperReduction, K_DIM),
+            Catlass::Arch::PositionL0B{});
+        typename LowerCopy::CopyL1ToL0A copyLowerL1ToL0A;
+        typename LowerCopy::CopyL1ToL0B copyLowerL1ToL0B;
+        typename UpperCopy::CopyL1ToL0A copyUpperL1ToL0A;
+        typename UpperCopy::CopyL1ToL0B copyUpperL1ToL0B;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(kLowerEvent);
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(kLowerEvent);
+        copyLowerL1ToL0A(lowerL0TensorA, lowerL1TensorA);
+        copyLowerL1ToL0B(lowerL0TensorB, lowerL1TensorB);
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(kLowerEvent);
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(kLowerEvent);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(kUpperEvent);
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(kUpperEvent);
+        copyUpperL1ToL0A(upperL0TensorA, upperL1TensorA);
+        copyUpperL1ToL0B(upperL0TensorB, upperL1TensorB);
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(kUpperEvent);
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(kUpperEvent);
+
+        using Accumulator = typename LowerCopy::ElementAccumulator;
+        AscendC::LocalTensor<Accumulator> lowerL0C =
+            resource.l0CBuf.template GetBufferByByte<Accumulator>(kLowerL0COffset);
+        AscendC::LocalTensor<Accumulator> upperL0C =
+            resource.l0CBuf.template GetBufferByByte<Accumulator>(kUpperL0COffset);
+        auto lowerL0CTensor = tla::MakeTensor(
+            lowerL0C, tla::MakeLayoutL0C(lowerRows, K_DIM), Catlass::Arch::PositionL0C{});
+        auto upperL0CTensor = tla::MakeTensor(
+            upperL0C, tla::MakeLayoutL0C(upperRows, K_DIM), Catlass::Arch::PositionL0C{});
+        LowerTileMmad lowerMmad;
+        UpperTileMmad upperMmad;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(kLowerEvent);
+        AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(kLowerEvent);
+        lowerMmad(lowerL0CTensor, lowerL0TensorA, lowerL0TensorB,
+                  lowerRows, K_DIM, prefix, true, 0b11);
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(kLowerEvent);
+        AscendC::SetFlag<AscendC::HardEvent::M_FIX>(kLowerEvent);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(kUpperEvent);
+        AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(kUpperEvent);
+        upperMmad(upperL0CTensor, upperL0TensorA, upperL0TensorB,
+                  upperRows, K_DIM, upperReduction, true, 0b11);
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(kUpperEvent);
+        AscendC::SetFlag<AscendC::HardEvent::M_FIX>(kUpperEvent);
+
+        CopyLowerL0CToGm<decltype(lowerTensorC)> copyLowerL0CToGm;
+        CopyUpperL0CToGm<decltype(upperTensorC)> copyUpperL0CToGm;
+        AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(kLowerEvent);
+        copyLowerL0CToGm(lowerTensorC, lowerL0CTensor, 0b11);
+        AscendC::SetFlag<AscendC::HardEvent::FIX_M>(kLowerEvent);
+        AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(kUpperEvent);
+        copyUpperL0CToGm(upperTensorC, upperL0CTensor, 0b11);
+        AscendC::SetFlag<AscendC::HardEvent::FIX_M>(kUpperEvent);
+    }
+
     template <typename LowerMmad, typename RowMajor>
     __aicore__ inline void RunLower(
         Catlass::Arch::Resource<ArchTag> &resource, uint64_t slotBase, uint32_t prefix)
@@ -165,6 +423,43 @@ private:
         UpperMmad mma(resource);
         mma(tensorA, tensorB, tensorC, shape);
     }
+
+    static constexpr uint32_t kLowerRows = 2 * kRowBlock;
+    static constexpr uint32_t kUpperRows = kRowBlock;
+    static constexpr uint32_t kLowerReduction = CHUNK_SIZE;
+    static constexpr uint32_t kUpperReduction = 2 * CHUNK_SIZE;
+    static constexpr uint32_t kLowerL1ABytes = kLowerRows * kLowerReduction * sizeof(Element);
+    static constexpr uint32_t kLowerL1BBytes = kLowerReduction * K_DIM * sizeof(Element);
+    static constexpr uint32_t kUpperL1ABytes = kUpperRows * kUpperReduction * sizeof(Element);
+    static constexpr uint32_t kUpperL1BBytes = kUpperReduction * K_DIM * sizeof(Element);
+    static constexpr uint32_t kLowerL1AOffset = 0;
+    static constexpr uint32_t kLowerL1BOffset = kLowerL1AOffset + kLowerL1ABytes;
+    static constexpr uint32_t kUpperL1AOffset = kLowerL1BOffset + kLowerL1BBytes;
+    static constexpr uint32_t kUpperL1BOffset = kUpperL1AOffset + kUpperL1ABytes;
+    static constexpr uint32_t kL1UsedBytes = kUpperL1BOffset + kUpperL1BBytes;
+    static constexpr uint32_t kL1CapacityBytes = 512 * 1024;
+
+    static constexpr uint32_t kLowerL0ABytes = kLowerL1ABytes;
+    static constexpr uint32_t kLowerL0BBytes = kLowerL1BBytes;
+    static constexpr uint32_t kUpperL0ABytes = kUpperL1ABytes;
+    static constexpr uint32_t kUpperL0BBytes = kUpperL1BBytes;
+    static constexpr uint32_t kLowerL0AOffset = 0;
+    static constexpr uint32_t kUpperL0AOffset = kLowerL0AOffset + kLowerL0ABytes;
+    static constexpr uint32_t kLowerL0BOffset = 0;
+    static constexpr uint32_t kUpperL0BOffset = kLowerL0BOffset + kLowerL0BBytes;
+    static constexpr uint32_t kL0AUsedBytes = kUpperL0AOffset + kUpperL0ABytes;
+    static constexpr uint32_t kL0BUsedBytes = kUpperL0BOffset + kUpperL0BBytes;
+    static constexpr uint32_t kL0ABCapacityBytes = 128 * 1024;
+
+    static constexpr uint32_t kLowerL0CBytes = kLowerRows * K_DIM * sizeof(Element);
+    static constexpr uint32_t kUpperL0CBytes = kUpperRows * K_DIM * sizeof(Element);
+    static constexpr uint32_t kLowerL0COffset = 0;
+    static constexpr uint32_t kUpperL0COffset = kLowerL0COffset + kLowerL0CBytes;
+    static constexpr uint32_t kL0CUsedBytes = kUpperL0COffset + kUpperL0CBytes;
+    static constexpr uint32_t kL0CCapacityBytes = 256 * 1024;
+
+    static constexpr int32_t kLowerEvent = 0;
+    static constexpr int32_t kUpperEvent = 1;
 
     GM_ADDR chunkMetadata_;
     GM_ADDR workspace_;

--- a/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/arch35/chunk_kda_bwd_intra_cube.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/arch35/chunk_kda_bwd_intra_cube.h
@@ -279,18 +279,22 @@ private:
             resource.l1Buf.template GetBufferByByte<Element>(kUpperL1AOffset);
         AscendC::LocalTensor<Element> upperL1B =
             resource.l1Buf.template GetBufferByByte<Element>(kUpperL1BOffset);
-        auto lowerL1TensorA = tla::MakeTensor(
-            lowerL1A, tla::MakeLayout<Element, LowerL1ALayout>(lowerRows, prefix),
-            Catlass::Arch::PositionL1{});
-        auto lowerL1TensorB = tla::MakeTensor(
-            lowerL1B, tla::MakeLayout<Element, LowerL1BLayout>(prefix, K_DIM),
-            Catlass::Arch::PositionL1{});
-        auto upperL1TensorA = tla::MakeTensor(
-            upperL1A, tla::MakeLayout<Element, UpperL1ALayout>(upperRows, upperReduction),
-            Catlass::Arch::PositionL1{});
-        auto upperL1TensorB = tla::MakeTensor(
-            upperL1B, tla::MakeLayout<Element, UpperL1BLayout>(upperReduction, K_DIM),
-            Catlass::Arch::PositionL1{});
+        auto lowerL1BaseA = tla::MakeTensor(
+            lowerL1A, kLowerL1ALayoutSpec, Catlass::Arch::PositionL1{});
+        auto lowerL1BaseB = tla::MakeTensor(
+            lowerL1B, kLowerL1BLayoutSpec, Catlass::Arch::PositionL1{});
+        auto upperL1BaseA = tla::MakeTensor(
+            upperL1A, kUpperL1ALayoutSpec, Catlass::Arch::PositionL1{});
+        auto upperL1BaseB = tla::MakeTensor(
+            upperL1B, kUpperL1BLayoutSpec, Catlass::Arch::PositionL1{});
+        auto lowerL1TensorA = tla::GetTile(
+            lowerL1BaseA, tla::MakeCoord(0U, 0U), tla::MakeShape(lowerRows, prefix));
+        auto lowerL1TensorB = tla::GetTile(
+            lowerL1BaseB, tla::MakeCoord(0U, 0U), tla::MakeShape(prefix, K_DIM));
+        auto upperL1TensorA = tla::GetTile(
+            upperL1BaseA, tla::MakeCoord(0U, 0U), tla::MakeShape(upperRows, upperReduction));
+        auto upperL1TensorB = tla::GetTile(
+            upperL1BaseB, tla::MakeCoord(0U, 0U), tla::MakeShape(upperReduction, K_DIM));
 
         CopyLowerGmToL1A<decltype(lowerTensorA)> copyLowerGmToL1A;
         CopyLowerGmToL1B<decltype(lowerTensorB)> copyLowerGmToL1B;
@@ -438,6 +442,14 @@ private:
     static constexpr uint32_t kUpperL1BOffset = kUpperL1AOffset + kUpperL1ABytes;
     static constexpr uint32_t kL1UsedBytes = kUpperL1BOffset + kUpperL1BBytes;
     static constexpr uint32_t kL1CapacityBytes = 512 * 1024;
+    static constexpr auto kLowerL1ALayoutSpec = tla::MakeLayout<Element, LowerL1ALayout>(
+        tla::Int<kLowerRows>{}, tla::Int<kLowerReduction>{});
+    static constexpr auto kLowerL1BLayoutSpec = tla::MakeLayout<Element, LowerL1BLayout>(
+        tla::Int<kLowerReduction>{}, tla::Int<K_DIM>{});
+    static constexpr auto kUpperL1ALayoutSpec = tla::MakeLayout<Element, UpperL1ALayout>(
+        tla::Int<kUpperRows>{}, tla::Int<kUpperReduction>{});
+    static constexpr auto kUpperL1BLayoutSpec = tla::MakeLayout<Element, UpperL1BLayout>(
+        tla::Int<kUpperReduction>{}, tla::Int<K_DIM>{});
 
     static constexpr uint32_t kLowerL0ABytes = kLowerL1ABytes;
     static constexpr uint32_t kLowerL0BBytes = kLowerL1BBytes;

--- a/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/arch35/chunk_kda_bwd_intra_regbase.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/arch35/chunk_kda_bwd_intra_regbase.h
@@ -109,12 +109,12 @@ static __simd_vf__ inline void KdaRegbaseScatterScalars(
 
 static __simd_vf__ inline void KdaRegbaseMaskLowerA(
     __ubuf__ float *dst, __ubuf__ float *src, uint16_t validRows,
-    uint16_t rowStart, uint16_t prefix)
+    uint16_t rowStart, uint16_t prefix, uint16_t rowBlock)
 {
     RegTensor<float> value;
     RegTensor<float> zero;
     Duplicate(zero, 0.0f);
-    for (uint32_t row = 0; row < kRowBlock; ++row) {
+    for (uint32_t row = 0; row < rowBlock; ++row) {
         const uint32_t validCols = row < validRows ? rowStart + row + 1 : 0;
         uint32_t remaining = prefix;
         for (uint32_t col = 0; col < prefix; col += kKdaRegbaseFp32Elements) {
@@ -132,21 +132,21 @@ static __simd_vf__ inline void KdaRegbaseMaskLowerA(
 
 static __simd_vf__ inline void KdaRegbaseMaskUpperA(
     __ubuf__ float *dst, __ubuf__ float *src, uint16_t future,
-    uint16_t validRows)
+    uint16_t validRows, uint16_t rowBlock)
 {
     RegTensor<float> value;
     RegTensor<float> zero;
     Duplicate(zero, 0.0f);
     for (uint32_t row = 0; row < future; ++row) {
-        const uint32_t validCols = row < validRows ? row + 1 : kRowBlock;
-        uint32_t fullRowRemaining = kRowBlock;
+        const uint32_t validCols = row < validRows ? row + 1 : rowBlock;
+        uint32_t fullRowRemaining = rowBlock;
         MaskReg fullRowMask = UpdateMask<float>(fullRowRemaining);
-        StoreAlign(dst + row * kRowBlock, zero, fullRowMask);
+        StoreAlign(dst + row * rowBlock, zero, fullRowMask);
         uint32_t copyRemaining = validCols;
         for (uint32_t col = 0; col < validCols; col += kKdaRegbaseFp32Elements) {
             MaskReg copyMask = UpdateMask<float>(copyRemaining);
-            LoadAlign(value, src + row * kRowBlock + col);
-            StoreAlign(dst + row * kRowBlock + col, value, copyMask);
+            LoadAlign(value, src + row * rowBlock + col);
+            StoreAlign(dst + row * rowBlock + col, value, copyMask);
         }
     }
 }

--- a/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/arch35/chunk_kda_bwd_intra_regbase.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/arch35/chunk_kda_bwd_intra_regbase.h
@@ -191,6 +191,38 @@ static __simd_vf__ inline void KdaRegbaseGateScale(
     }
 }
 
+static __simd_vf__ inline void KdaRegbaseGateScalePair(
+    __ubuf__ float *qData, __ubuf__ float *kData,
+    __ubuf__ float *gate, __ubuf__ float *anchor,
+    __ubuf__ float *beta, uint16_t rows, uint16_t cols)
+{
+    RegTensor<float> qReg;
+    RegTensor<float> kReg;
+    RegTensor<float> gateReg;
+    RegTensor<float> anchorReg;
+    RegTensor<float> scaleReg;
+    RegTensor<float> betaReg;
+    for (uint32_t row = 0; row < rows; ++row) {
+        DataCopy<float, LoadDist::DIST_BRC_B32>(betaReg, beta + row);
+        uint32_t remaining = cols;
+        for (uint32_t col = 0; col < cols; col += kKdaRegbaseFp32Elements) {
+            MaskReg mask = UpdateMask<float>(remaining);
+            DataCopy(qReg, qData + row * cols + col);
+            DataCopy(kReg, kData + row * cols + col);
+            DataCopy(gateReg, gate + row * cols + col);
+            DataCopy(anchorReg, anchor + col);
+            Sub(scaleReg, gateReg, anchorReg, mask);
+            Muls(scaleReg, scaleReg, kLn2, mask);
+            Exp(scaleReg, scaleReg, mask);
+            Mul(qReg, qReg, scaleReg, mask);
+            Mul(kReg, kReg, scaleReg, mask);
+            Mul(kReg, kReg, betaReg, mask);
+            DataCopy(qData + row * cols + col, qReg, mask);
+            DataCopy(kData + row * cols + col, kReg, mask);
+        }
+    }
+}
+
 static __simd_vf__ inline void KdaRegbaseFinishScale(
     __ubuf__ float *rawDq, __ubuf__ float *rawDkLower,
     __ubuf__ float *rawDkUpper, __ubuf__ float *k,

--- a/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/arch35/chunk_kda_bwd_intra_regbase.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/arch35/chunk_kda_bwd_intra_regbase.h
@@ -191,38 +191,6 @@ static __simd_vf__ inline void KdaRegbaseGateScale(
     }
 }
 
-static __simd_vf__ inline void KdaRegbaseGateScalePair(
-    __ubuf__ float *qData, __ubuf__ float *kData,
-    __ubuf__ float *gate, __ubuf__ float *anchor,
-    __ubuf__ float *beta, uint16_t rows, uint16_t cols)
-{
-    RegTensor<float> qReg;
-    RegTensor<float> kReg;
-    RegTensor<float> gateReg;
-    RegTensor<float> anchorReg;
-    RegTensor<float> scaleReg;
-    RegTensor<float> betaReg;
-    for (uint32_t row = 0; row < rows; ++row) {
-        DataCopy<float, LoadDist::DIST_BRC_B32>(betaReg, beta + row);
-        uint32_t remaining = cols;
-        for (uint32_t col = 0; col < cols; col += kKdaRegbaseFp32Elements) {
-            MaskReg mask = UpdateMask<float>(remaining);
-            DataCopy(qReg, qData + row * cols + col);
-            DataCopy(kReg, kData + row * cols + col);
-            DataCopy(gateReg, gate + row * cols + col);
-            DataCopy(anchorReg, anchor + col);
-            Sub(scaleReg, gateReg, anchorReg, mask);
-            Muls(scaleReg, scaleReg, kLn2, mask);
-            Exp(scaleReg, scaleReg, mask);
-            Mul(qReg, qReg, scaleReg, mask);
-            Mul(kReg, kReg, scaleReg, mask);
-            Mul(kReg, kReg, betaReg, mask);
-            DataCopy(qData + row * cols + col, qReg, mask);
-            DataCopy(kData + row * cols + col, kReg, mask);
-        }
-    }
-}
-
 static __simd_vf__ inline void KdaRegbaseFinishScale(
     __ubuf__ float *rawDq, __ubuf__ float *rawDkLower,
     __ubuf__ float *rawDkUpper, __ubuf__ float *k,

--- a/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/chunk_kda_bwd_intra_common.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/chunk_kda_bwd_intra_common.h
@@ -13,6 +13,18 @@ constexpr uint32_t kVecToCubeReadyFlag = 2;
 constexpr uint32_t kCubeToVecReadyFlag = 4;
 constexpr float kLn2 = 0.69314718055994530942f;
 
+template <uint32_t K_DIM, bool VARLEN_TND>
+struct ProcessRowBlock {
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    // A5 has enough UB/L1/L0 capacity to process two legacy 16-row tiles at
+    // once.  Keep varlen and non-K128 specializations on the proven 16-row
+    // path so this experiment only changes the dense K128 hot path.
+    static constexpr uint32_t value = !VARLEN_TND && K_DIM == 128 ? 32 : kRowBlock;
+#else
+    static constexpr uint32_t value = kRowBlock;
+#endif
+};
+
 __aicore__ inline uint32_t WorkspaceSlot(uint64_t windowIdx, uint32_t headInWindow)
 {
     return static_cast<uint32_t>(((windowIdx & 1U) << 1U) + headInWindow);

--- a/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/chunk_kda_bwd_intra_vector.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/chunk_kda_bwd_intra_vector.h
@@ -811,65 +811,6 @@ private:
         const ChunkTask &task, uint32_t head, uint32_t rowStart, uint32_t future,
         uint32_t subBlock, uint64_t slotBase)
     {
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
-        // On A5, each AIV owns half of K and prepares both q and k for that
-        // column range.  q and k share the same exp2(g - anchor), so compute
-        // it once instead of making both AIVs read g and evaluate Exp.
-        auto qData = Plane(0);
-        auto kData = Plane(2);
-        auto gate = Plane(4);
-        auto anchor = Plane(6);
-        auto beta = Plane(8);
-        const uint32_t cols = K_DIM / 2;
-        const uint32_t col = subBlock * cols;
-        const uint32_t anchorLocal = rowStart + 8 < task.end - task.begin ?
-                                     rowStart + 8 : task.end - task.begin - 1;
-        const uint32_t anchorRow = task.begin + anchorLocal;
-        Load(anchor,
-             gkGm_[TensorOffset<VARLEN_TND>(
-                 tiling_, task.batchIdx, head, anchorRow, col)],
-             cols);
-        for (uint32_t sourceRow = 0; sourceRow < future; sourceRow += kUpperPackRows) {
-            const uint32_t rows =
-                sourceRow + kUpperPackRows <= future ? kUpperPackRows : future - sourceRow;
-            const uint32_t token = task.begin + rowStart + sourceRow;
-            LoadMatrixRowsPair(
-                qData,
-                qGm_[TensorOffset<VARLEN_TND>(
-                    tiling_, task.batchIdx, head, token, col)],
-                rows, cols, TensorRowElements(),
-                kData,
-                kGm_[TensorOffset<VARLEN_TND>(
-                    tiling_, task.batchIdx, head, token, col)],
-                rows, cols, TensorRowElements());
-            LoadRows(
-                gate,
-                gkGm_[TensorOffset<VARLEN_TND>(
-                    tiling_, task.batchIdx, head, token, col)],
-                rows, cols, TensorRowElements());
-            LoadScalarRows(
-                beta,
-                betaGm_[ScalarOffset<VARLEN_TND>(
-                    tiling_, task.batchIdx, head, token)],
-                rows);
-            KdaRegbaseGateScalePair(
-                (__ubuf__ float *)qData.GetPhyAddr(),
-                (__ubuf__ float *)kData.GetPhyAddr(),
-                (__ubuf__ float *)gate.GetPhyAddr(),
-                (__ubuf__ float *)anchor.GetPhyAddr(),
-                (__ubuf__ float *)beta.GetPhyAddr(),
-                rows, cols);
-
-            const uint64_t qDstOffset =
-                slotBase / sizeof(float) + tiling_.bUpperOffset / sizeof(float) +
-                static_cast<uint64_t>(sourceRow) * K_DIM + col;
-            const uint64_t kDstOffset =
-                slotBase / sizeof(float) + tiling_.bUpperOffset / sizeof(float) +
-                static_cast<uint64_t>(future + sourceRow) * K_DIM + col;
-            StoreRows(workspaceGm_[qDstOffset], qData, rows, cols, K_DIM);
-            StoreRows(workspaceGm_[kDstOffset], kData, rows, cols, K_DIM);
-        }
-#else
         // data/gate/anchor/exponent may each contain 16 x 128 FP32 values.
         // Give every matrix two adjacent 4 KiB planes; beta temporaries start
         // after those non-overlapping 8 KiB regions.
@@ -959,7 +900,6 @@ private:
                 StoreRows(workspaceGm_[dstOffset], data, rows, cols, K_DIM);
             }
         }
-#endif
     }
 
     __aicore__ inline void FinishHead(

--- a/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/chunk_kda_bwd_intra_vector.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/chunk_kda_bwd_intra_vector.h
@@ -1009,49 +1009,68 @@ private:
             (__ubuf__ float *)dbAcc.GetPhyAddr(),
             ownedRows, cols);
 
-        auto inputGrad = Plane(8);  // planes 8-9, after gate's last use
-        auto output = Plane(12);    // planes 12-13, after anchor/beta's last use
+        auto output = Plane(12);  // planes 12-13, after anchor/beta's last use
 
-        LoadRows(inputGrad,
-                 dqGm_[TensorOffset<VARLEN_TND>(
-                     tiling_, task.batchIdx, head, tokenBegin, 0)],
-                 ownedRows, cols, TensorRowElements());
+        // The original gradients are consumed once and do not need to remain
+        // in the arena.  Reuse the existing 8 KiB matrix ping/pong buffers as
+        // their final RegBase operands: issue dq/dk together, then refill the
+        // released dq slot with dg while dq is being copied out.  This removes
+        // three 16 x 128 FP32 UB-to-UB copies and overlaps the mandatory MTE2
+        // reads with the neighbouring Vector/MTE3 work without increasing UB.
+        const uint32_t dqSlot = CopyInMatrixRows(
+            dqGm_[TensorOffset<VARLEN_TND>(
+                tiling_, task.batchIdx, head, tokenBegin, 0)],
+            ownedRows, cols, TensorRowElements());
+        const uint32_t dkSlot = CopyInMatrixRows(
+            dkGm_[TensorOffset<VARLEN_TND>(
+                tiling_, task.batchIdx, head, tokenBegin, 0)],
+            ownedRows, cols, TensorRowElements());
+
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(
+            matrixMte2ToVEvent_[dqSlot]);
         KdaRegbaseAdd2(
             (__ubuf__ float *)output.GetPhyAddr(),
-            (__ubuf__ float *)inputGrad.GetPhyAddr(),
+            (__ubuf__ float *)MatrixInput<float>(dqSlot).GetPhyAddr(),
             (__ubuf__ float *)rawDq.GetPhyAddr(),
             count);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(
+            matrixVToMte2Event_[dqSlot]);
+
+        const uint32_t dgSlot = CopyInMatrixRows(
+            dgGm_[TensorOffset<VARLEN_TND>(
+                tiling_, task.batchIdx, head, tokenBegin, 0)],
+            ownedRows, cols, TensorRowElements());
         StoreRows(dqOutGm_[TensorOffset<VARLEN_TND>(
                       tiling_, task.batchIdx, head, tokenBegin, 0)],
                   output, ownedRows, cols, TensorRowElements());
 
-        LoadRows(inputGrad,
-                 dkGm_[TensorOffset<VARLEN_TND>(
-                     tiling_, task.batchIdx, head, tokenBegin, 0)],
-                 ownedRows, cols, TensorRowElements());
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(
+            matrixMte2ToVEvent_[dkSlot]);
         KdaRegbaseAdd3(
             (__ubuf__ float *)output.GetPhyAddr(),
-            (__ubuf__ float *)inputGrad.GetPhyAddr(),
+            (__ubuf__ float *)MatrixInput<float>(dkSlot).GetPhyAddr(),
             (__ubuf__ float *)rawDkLower.GetPhyAddr(),
             (__ubuf__ float *)rawDkUpper.GetPhyAddr(),
             count);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(
+            matrixVToMte2Event_[dkSlot]);
         StoreRows(dkOutGm_[TensorOffset<VARLEN_TND>(
                       tiling_, task.batchIdx, head, tokenBegin, 0)],
                   output, ownedRows, cols, TensorRowElements());
 
-        LoadRows(inputGrad,
-                 dgGm_[TensorOffset<VARLEN_TND>(
-                     tiling_, task.batchIdx, head, tokenBegin, 0)],
-                 ownedRows, cols, TensorRowElements());
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(
+            matrixMte2ToVEvent_[dgSlot]);
         KdaRegbaseDg(
             (__ubuf__ float *)output.GetPhyAddr(),
-            (__ubuf__ float *)inputGrad.GetPhyAddr(),
+            (__ubuf__ float *)MatrixInput<float>(dgSlot).GetPhyAddr(),
             (__ubuf__ float *)q.GetPhyAddr(),
             (__ubuf__ float *)rawDq.GetPhyAddr(),
             (__ubuf__ float *)k.GetPhyAddr(),
             (__ubuf__ float *)rawDkLower.GetPhyAddr(),
             (__ubuf__ float *)rawDkUpper.GetPhyAddr(),
             count);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(
+            matrixVToMte2Event_[dgSlot]);
         StoreRows(dgOutGm_[TensorOffset<VARLEN_TND>(
                       tiling_, task.batchIdx, head, tokenBegin, 0)],
                   output, ownedRows, cols, TensorRowElements());

--- a/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/chunk_kda_bwd_intra_vector.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/chunk_kda_bwd_intra_vector.h
@@ -811,6 +811,65 @@ private:
         const ChunkTask &task, uint32_t head, uint32_t rowStart, uint32_t future,
         uint32_t subBlock, uint64_t slotBase)
     {
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+        // On A5, each AIV owns half of K and prepares both q and k for that
+        // column range.  q and k share the same exp2(g - anchor), so compute
+        // it once instead of making both AIVs read g and evaluate Exp.
+        auto qData = Plane(0);
+        auto kData = Plane(2);
+        auto gate = Plane(4);
+        auto anchor = Plane(6);
+        auto beta = Plane(8);
+        const uint32_t cols = K_DIM / 2;
+        const uint32_t col = subBlock * cols;
+        const uint32_t anchorLocal = rowStart + 8 < task.end - task.begin ?
+                                     rowStart + 8 : task.end - task.begin - 1;
+        const uint32_t anchorRow = task.begin + anchorLocal;
+        Load(anchor,
+             gkGm_[TensorOffset<VARLEN_TND>(
+                 tiling_, task.batchIdx, head, anchorRow, col)],
+             cols);
+        for (uint32_t sourceRow = 0; sourceRow < future; sourceRow += kUpperPackRows) {
+            const uint32_t rows =
+                sourceRow + kUpperPackRows <= future ? kUpperPackRows : future - sourceRow;
+            const uint32_t token = task.begin + rowStart + sourceRow;
+            LoadMatrixRowsPair(
+                qData,
+                qGm_[TensorOffset<VARLEN_TND>(
+                    tiling_, task.batchIdx, head, token, col)],
+                rows, cols, TensorRowElements(),
+                kData,
+                kGm_[TensorOffset<VARLEN_TND>(
+                    tiling_, task.batchIdx, head, token, col)],
+                rows, cols, TensorRowElements());
+            LoadRows(
+                gate,
+                gkGm_[TensorOffset<VARLEN_TND>(
+                    tiling_, task.batchIdx, head, token, col)],
+                rows, cols, TensorRowElements());
+            LoadScalarRows(
+                beta,
+                betaGm_[ScalarOffset<VARLEN_TND>(
+                    tiling_, task.batchIdx, head, token)],
+                rows);
+            KdaRegbaseGateScalePair(
+                (__ubuf__ float *)qData.GetPhyAddr(),
+                (__ubuf__ float *)kData.GetPhyAddr(),
+                (__ubuf__ float *)gate.GetPhyAddr(),
+                (__ubuf__ float *)anchor.GetPhyAddr(),
+                (__ubuf__ float *)beta.GetPhyAddr(),
+                rows, cols);
+
+            const uint64_t qDstOffset =
+                slotBase / sizeof(float) + tiling_.bUpperOffset / sizeof(float) +
+                static_cast<uint64_t>(sourceRow) * K_DIM + col;
+            const uint64_t kDstOffset =
+                slotBase / sizeof(float) + tiling_.bUpperOffset / sizeof(float) +
+                static_cast<uint64_t>(future + sourceRow) * K_DIM + col;
+            StoreRows(workspaceGm_[qDstOffset], qData, rows, cols, K_DIM);
+            StoreRows(workspaceGm_[kDstOffset], kData, rows, cols, K_DIM);
+        }
+#else
         // data/gate/anchor/exponent may each contain 16 x 128 FP32 values.
         // Give every matrix two adjacent 4 KiB planes; beta temporaries start
         // after those non-overlapping 8 KiB regions.
@@ -900,6 +959,7 @@ private:
                 StoreRows(workspaceGm_[dstOffset], data, rows, cols, K_DIM);
             }
         }
+#endif
     }
 
     __aicore__ inline void FinishHead(

--- a/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/chunk_kda_bwd_intra_vector.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/chunk_kda_bwd_intra_vector.h
@@ -67,11 +67,11 @@ public:
         if constexpr (VARLEN_TND) {
 #if !(defined(__CCE_AICORE__) && __CCE_AICORE__ == 310)
             auto offsets = ScalarGatherOffsets();
-            for (uint32_t row = 0; row < kRowBlock; ++row) {
+            for (uint32_t row = 0; row < kProcessRowBlock; ++row) {
                 offsets.SetValue(
                     row, row * (32 / sizeof(float)) * sizeof(float));
                 offsets.SetValue(
-                    kRowBlock + row,
+                    kProcessRowBlock + row,
                     row * (32 / sizeof(bfloat16_t)) * sizeof(float));
             }
             AscendC::SetFlag<AscendC::HardEvent::S_V>(0);
@@ -102,11 +102,13 @@ public:
             const ChunkTask task =
                 GetChunkTask<VARLEN_TND>(tiling_, chunkMetadataGm_, taskIdx);
             const uint32_t validLen = task.end - task.begin;
-            const uint32_t rowBlockCount = (validLen + kRowBlock - 1) / kRowBlock;
+            const uint32_t rowBlockCount =
+                (validLen + kProcessRowBlock - 1) / kProcessRowBlock;
             for (uint32_t rowBlock = 0; rowBlock < rowBlockCount; ++rowBlock) {
-                const uint32_t rowStart = rowBlock * kRowBlock;
+                const uint32_t rowStart = rowBlock * kProcessRowBlock;
                 const uint32_t validRows =
-                    rowStart + kRowBlock <= validLen ? kRowBlock : validLen - rowStart;
+                    rowStart + kProcessRowBlock <= validLen ?
+                        kProcessRowBlock : validLen - rowStart;
 
                 // PR190-style two-head stage ordering: finish Vector-Pre for
                 // head0 then head1 before entering Vector-Post.  This lets
@@ -142,6 +144,8 @@ public:
     }
 
 private:
+    static constexpr uint32_t kProcessRowBlock =
+        ProcessRowBlock<K_DIM, VARLEN_TND>::value;
     static constexpr uint32_t kPlaneElements = 8 * 128;
     // Each AIV owns half of K in PackLowerB.  For the target K=128 path,
     // 16 FP32 rows x 64 columns exactly fill one 4 KiB arena plane.
@@ -159,9 +163,9 @@ private:
     static_assert(
         6 * kIoBufferBytes + kArenaBytes + kReduceTmpBytes <= kUbBudgetBytes,
         "Vector UB buffers exceed the A2/A3 192 KiB budget.");
-    static_assert(kRowBlock * CHUNK_SIZE <= kPlaneElements,
-                  "Packed A-matrix tile exceeds one arena plane.");
-    static_assert(kRowBlock * CHUNK_SIZE * sizeof(float) <= kIoBufferBytes,
+    static_assert(kProcessRowBlock * CHUNK_SIZE <= 2 * kPlaneElements,
+                  "Packed A-matrix tile exceeds its two-plane arena group.");
+    static_assert(kProcessRowBlock * CHUNK_SIZE * sizeof(float) <= kIoBufferBytes,
                   "Packed A-matrix FP32 tile exceeds the IO queue buffer.");
     static_assert(kLowerPackRows * (K_DIM / 2) <= kPlaneElements,
                   "PackLowerB row tile exceeds one arena plane.");
@@ -541,7 +545,7 @@ private:
         AscendC::PipeBarrier<PIPE_V>();
         inputQueue_.FreeTensor(ready);
         AscendC::Gather(
-            dst, stage, ScalarGatherOffsets()[kRowBlock],
+            dst, stage, ScalarGatherOffsets()[kProcessRowBlock],
             static_cast<uint32_t>(0), rows);
         AscendC::PipeBarrier<PIPE_V>();
 #endif
@@ -652,9 +656,11 @@ private:
         uint32_t prefix, uint32_t subBlock, uint64_t slotBase)
     {
         auto work = Plane(0);
-        auto masked = Plane(1);
+        // The A5 row32 tile occupies two consecutive 4 KiB planes.  Keep the
+        // masked destination in a disjoint two-plane group.
+        auto masked = Plane(2);
         auto &source = subBlock == 0 ? dAqkGm_ : dAkkGm_;
-        const uint32_t rowBase = subBlock * kRowBlock;
+        const uint32_t rowBase = subBlock * kProcessRowBlock;
 
         // DataCopyPad lays out each UB row at a 32-byte boundary.  Full chunks
         // therefore use one 16-row transfer for the aligned 16/32/48/64
@@ -668,9 +674,9 @@ private:
             KdaRegbaseMaskLowerA(
                 (__ubuf__ float *)masked.GetPhyAddr(),
                 (__ubuf__ float *)work.GetPhyAddr(),
-                validRows, rowStart, prefix);
+                validRows, rowStart, prefix, kProcessRowBlock);
 #else
-            AscendC::Duplicate(masked, 0.0f, kRowBlock * prefix);
+            AscendC::Duplicate(masked, 0.0f, kProcessRowBlock * prefix);
             AscendC::PipeBarrier<PIPE_V>();
             for (uint32_t row = 0; row < validRows; ++row) {
                 const uint32_t validCols = rowStart + row + 1;
@@ -682,11 +688,11 @@ private:
                 slotBase / sizeof(float) + tiling_.aLowerOffset / sizeof(float) +
                 static_cast<uint64_t>(rowBase) * prefix;
             StoreRows(
-                workspaceGm_[dstOffset], masked, kRowBlock, prefix, prefix);
+                workspaceGm_[dstOffset], masked, kProcessRowBlock, prefix, prefix);
             return;
         }
 
-        for (uint32_t row = 0; row < kRowBlock; ++row) {
+        for (uint32_t row = 0; row < kProcessRowBlock; ++row) {
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
             KdaRegbaseFill(
                 (__ubuf__ float *)work.GetPhyAddr(), 0.0f, prefix);
@@ -712,7 +718,7 @@ private:
         uint32_t future, uint32_t subBlock, uint64_t slotBase)
     {
         auto work = Plane(0);
-        auto masked = Plane(1);
+        auto masked = Plane(2);
         auto &source = subBlock == 0 ? dAqkGm_ : dAkkGm_;
         const uint32_t physicalRowBase = subBlock * future;
 
@@ -722,34 +728,39 @@ private:
         const uint64_t srcOffset =
             MatrixOffset<VARLEN_TND>(
                 tiling_, task.batchIdx, head, task.begin + rowStart, rowStart);
-        LoadRows(work, source[srcOffset], future, kRowBlock, MatrixRowElements());
+        LoadRows(
+            work, source[srcOffset], future, kProcessRowBlock,
+            MatrixRowElements());
 
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
         KdaRegbaseMaskUpperA(
             (__ubuf__ float *)masked.GetPhyAddr(),
             (__ubuf__ float *)work.GetPhyAddr(),
-            future, validRows);
+            future, validRows, kProcessRowBlock);
 #else
-        AscendC::Duplicate(masked, 0.0f, future * kRowBlock);
+        AscendC::Duplicate(masked, 0.0f, future * kProcessRowBlock);
         AscendC::PipeBarrier<PIPE_V>();
         const uint32_t maskedRows = future < validRows ? future : validRows;
         for (uint32_t row = 0; row < maskedRows; ++row) {
             AscendC::Adds(
-                masked[row * kRowBlock], work[row * kRowBlock], 0.0f, row + 1);
+                masked[row * kProcessRowBlock], work[row * kProcessRowBlock],
+                0.0f, row + 1);
         }
         if (future > maskedRows) {
-            const uint32_t tailElements = (future - maskedRows) * kRowBlock;
+            const uint32_t tailElements =
+                (future - maskedRows) * kProcessRowBlock;
             AscendC::Adds(
-                masked[maskedRows * kRowBlock], work[maskedRows * kRowBlock],
-                0.0f, tailElements);
+                masked[maskedRows * kProcessRowBlock],
+                work[maskedRows * kProcessRowBlock], 0.0f, tailElements);
         }
 #endif
 
         const uint64_t dstOffset =
             slotBase / sizeof(float) + tiling_.aUpperOffset / sizeof(float) +
-            static_cast<uint64_t>(physicalRowBase) * kRowBlock;
+            static_cast<uint64_t>(physicalRowBase) * kProcessRowBlock;
         StoreRows(
-            workspaceGm_[dstOffset], masked, future, kRowBlock, kRowBlock);
+            workspaceGm_[dstOffset], masked, future, kProcessRowBlock,
+            kProcessRowBlock);
     }
 
     __aicore__ inline void PackLowerB(
@@ -907,14 +918,21 @@ private:
         uint32_t slot)
     {
         const uint32_t subBlock = AscendC::GetSubBlockIdx();
-        const uint32_t ownedBegin = subBlock * 8;
-        if (ownedBegin >= validRows) {
-            return;
-        }
-        const uint32_t ownedRows =
-            ownedBegin + 8 <= validRows ? 8 : validRows - ownedBegin;
-        const uint32_t tokenBegin = task.begin + rowStart + ownedBegin;
-        const uint64_t slotBase = SlotBase(slot);
+        const uint32_t rowsPerSubBlock = kProcessRowBlock / 2;
+        // Keep the proven eight-row Vector arithmetic tile.  On the A5
+        // row32 path each AIV consumes two disjoint eight-row slices, while
+        // A2/A3 and varlen still execute exactly one slice.
+        for (uint32_t ownedOffset = 0; ownedOffset < rowsPerSubBlock;
+             ownedOffset += 8) {
+            const uint32_t ownedBegin =
+                subBlock * rowsPerSubBlock + ownedOffset;
+            if (ownedBegin >= validRows) {
+                continue;
+            }
+            const uint32_t ownedRows =
+                ownedBegin + 8 <= validRows ? 8 : validRows - ownedBegin;
+            const uint32_t tokenBegin = task.begin + rowStart + ownedBegin;
+            const uint64_t slotBase = SlotBase(slot);
 
         auto rawDq = Plane(0);
         auto rawDkLower = Plane(1);
@@ -1117,6 +1135,7 @@ private:
             dbOutGm_[ScalarOffset<VARLEN_TND>(
                 tiling_, task.batchIdx, head, tokenBegin)],
             dbAcc, ownedRows);
+        }
     }
 
     GM_ADDR q_;

--- a/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/chunk_kda_bwd_intra_vector.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_intra/op_kernel/chunk_kda_bwd_intra_vector.h
@@ -913,15 +913,181 @@ private:
         }
     }
 
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    __aicore__ inline void FinishHeadA5Dense16(
+        const ChunkTask &task, uint32_t head, uint32_t rowStart, uint32_t validRows,
+        uint32_t slot)
+    {
+        static_assert(K_DIM == 128,
+                      "The A5 16-row Vector-Post path is specialized for K=128.");
+        static_assert(!VARLEN_TND,
+                      "The A5 16-row Vector-Post path is dense-only.");
+        static_assert(kProcessRowBlock == 32,
+                      "The A5 16-row Vector-Post path requires the proven row32 outer tile.");
+
+        const uint32_t subBlock = AscendC::GetSubBlockIdx();
+        const uint32_t ownedBegin = subBlock * 16;
+        if (ownedBegin >= validRows) {
+            return;
+        }
+        const uint32_t ownedRows =
+            ownedBegin + 16 <= validRows ? 16 : validRows - ownedBegin;
+        const uint32_t tokenBegin = task.begin + rowStart + ownedBegin;
+        const uint64_t slotBase = SlotBase(slot);
+
+        // One 16 x 128 FP32 matrix occupies two consecutive 4 KiB planes.
+        // Keep only the values that remain live across the scale and output
+        // phases.  Once scale finishes, gate/anchor/beta are dead and their
+        // planes are reused by inputGrad/output, so the existing 96 KiB arena
+        // is sufficient and no additional UB is reserved.
+        auto rawDq = Plane(0);       // planes 0-1
+        auto rawDkLower = Plane(2);  // planes 2-3
+        auto rawDkUpper = Plane(4);  // planes 4-5
+        auto k = Plane(6);           // planes 6-7
+        auto gate = Plane(8);        // planes 8-9; reused by inputGrad
+        auto q = Plane(10);          // planes 10-11
+        auto anchor = Plane(12);     // plane 12; reused by output
+        auto beta = Plane(13);       // plane 13; reused by output
+        auto dbAcc = Plane(14);      // plane 14
+
+        KdaRegbaseFill(
+            (__ubuf__ float *)dbAcc.GetPhyAddr(), 0.0f, ownedRows);
+
+        const uint32_t anchorLocal = rowStart + 8 < task.end - task.begin ?
+                                     rowStart + 8 : task.end - task.begin - 1;
+        const uint32_t anchorRow = task.begin + anchorLocal;
+        LoadScalarRows(
+            beta,
+            betaGm_[ScalarOffset<VARLEN_TND>(
+                tiling_, task.batchIdx, head, tokenBegin)],
+            ownedRows);
+
+        const uint32_t cols = 128;
+        const uint32_t count = ownedRows * cols;
+        Load(anchor,
+             gkGm_[TensorOffset<VARLEN_TND>(
+                 tiling_, task.batchIdx, head, anchorRow, 0)],
+             cols);
+        const uint64_t resultBase =
+            slotBase / sizeof(float) + tiling_.resultRegionOffset / sizeof(float);
+        LoadMatrixRowsPair(
+            q,
+            qGm_[TensorOffset<VARLEN_TND>(
+                tiling_, task.batchIdx, head, tokenBegin, 0)],
+            ownedRows, cols, TensorRowElements(),
+            k,
+            kGm_[TensorOffset<VARLEN_TND>(
+                tiling_, task.batchIdx, head, tokenBegin, 0)],
+            ownedRows, cols, TensorRowElements());
+        LoadMatrixRowsPair(
+            gate,
+            gkGm_[TensorOffset<VARLEN_TND>(
+                tiling_, task.batchIdx, head, tokenBegin, 0)],
+            ownedRows, cols, TensorRowElements(),
+            rawDq,
+            workspaceGm_[resultBase + tiling_.resultDqOffset / sizeof(float) +
+                         static_cast<uint64_t>(ownedBegin) * K_DIM],
+            ownedRows, cols, K_DIM);
+        LoadMatrixRowsPair(
+            rawDkLower,
+            workspaceGm_[resultBase + tiling_.resultDkLowerOffset / sizeof(float) +
+                         static_cast<uint64_t>(ownedBegin) * K_DIM],
+            ownedRows, cols, K_DIM,
+            rawDkUpper,
+            workspaceGm_[resultBase + tiling_.resultDkUpperOffset / sizeof(float) +
+                         static_cast<uint64_t>(ownedBegin) * K_DIM],
+            ownedRows, cols, K_DIM);
+
+        KdaRegbaseFinishScale(
+            (__ubuf__ float *)rawDq.GetPhyAddr(),
+            (__ubuf__ float *)rawDkLower.GetPhyAddr(),
+            (__ubuf__ float *)rawDkUpper.GetPhyAddr(),
+            (__ubuf__ float *)k.GetPhyAddr(),
+            (__ubuf__ float *)gate.GetPhyAddr(),
+            (__ubuf__ float *)anchor.GetPhyAddr(),
+            (__ubuf__ float *)beta.GetPhyAddr(),
+            (__ubuf__ float *)dbAcc.GetPhyAddr(),
+            ownedRows, cols);
+
+        auto inputGrad = Plane(8);  // planes 8-9, after gate's last use
+        auto output = Plane(12);    // planes 12-13, after anchor/beta's last use
+
+        LoadRows(inputGrad,
+                 dqGm_[TensorOffset<VARLEN_TND>(
+                     tiling_, task.batchIdx, head, tokenBegin, 0)],
+                 ownedRows, cols, TensorRowElements());
+        KdaRegbaseAdd2(
+            (__ubuf__ float *)output.GetPhyAddr(),
+            (__ubuf__ float *)inputGrad.GetPhyAddr(),
+            (__ubuf__ float *)rawDq.GetPhyAddr(),
+            count);
+        StoreRows(dqOutGm_[TensorOffset<VARLEN_TND>(
+                      tiling_, task.batchIdx, head, tokenBegin, 0)],
+                  output, ownedRows, cols, TensorRowElements());
+
+        LoadRows(inputGrad,
+                 dkGm_[TensorOffset<VARLEN_TND>(
+                     tiling_, task.batchIdx, head, tokenBegin, 0)],
+                 ownedRows, cols, TensorRowElements());
+        KdaRegbaseAdd3(
+            (__ubuf__ float *)output.GetPhyAddr(),
+            (__ubuf__ float *)inputGrad.GetPhyAddr(),
+            (__ubuf__ float *)rawDkLower.GetPhyAddr(),
+            (__ubuf__ float *)rawDkUpper.GetPhyAddr(),
+            count);
+        StoreRows(dkOutGm_[TensorOffset<VARLEN_TND>(
+                      tiling_, task.batchIdx, head, tokenBegin, 0)],
+                  output, ownedRows, cols, TensorRowElements());
+
+        LoadRows(inputGrad,
+                 dgGm_[TensorOffset<VARLEN_TND>(
+                     tiling_, task.batchIdx, head, tokenBegin, 0)],
+                 ownedRows, cols, TensorRowElements());
+        KdaRegbaseDg(
+            (__ubuf__ float *)output.GetPhyAddr(),
+            (__ubuf__ float *)inputGrad.GetPhyAddr(),
+            (__ubuf__ float *)q.GetPhyAddr(),
+            (__ubuf__ float *)rawDq.GetPhyAddr(),
+            (__ubuf__ float *)k.GetPhyAddr(),
+            (__ubuf__ float *)rawDkLower.GetPhyAddr(),
+            (__ubuf__ float *)rawDkUpper.GetPhyAddr(),
+            count);
+        StoreRows(dgOutGm_[TensorOffset<VARLEN_TND>(
+                      tiling_, task.batchIdx, head, tokenBegin, 0)],
+                  output, ownedRows, cols, TensorRowElements());
+
+        // output is no longer live; plane 13 can hold the final db input.
+        LoadScalarRows(
+            beta,
+            dbGm_[ScalarOffset<VARLEN_TND>(
+                tiling_, task.batchIdx, head, tokenBegin)],
+            ownedRows);
+        KdaRegbaseAdd2(
+            (__ubuf__ float *)dbAcc.GetPhyAddr(),
+            (__ubuf__ float *)dbAcc.GetPhyAddr(),
+            (__ubuf__ float *)beta.GetPhyAddr(),
+            ownedRows);
+        StoreScalarRows(
+            dbOutGm_[ScalarOffset<VARLEN_TND>(
+                tiling_, task.batchIdx, head, tokenBegin)],
+            dbAcc, ownedRows);
+    }
+#endif
+
     __aicore__ inline void FinishHead(
         const ChunkTask &task, uint32_t head, uint32_t rowStart, uint32_t validRows,
         uint32_t slot)
     {
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+        if constexpr (!VARLEN_TND && K_DIM == 128) {
+            FinishHeadA5Dense16(task, head, rowStart, validRows, slot);
+            return;
+        }
+#endif
         const uint32_t subBlock = AscendC::GetSubBlockIdx();
         const uint32_t rowsPerSubBlock = kProcessRowBlock / 2;
-        // Keep the proven eight-row Vector arithmetic tile.  On the A5
-        // row32 path each AIV consumes two disjoint eight-row slices, while
-        // A2/A3 and varlen still execute exactly one slice.
+        // Preserve the proven eight-row path for A2/A3, A5 varlen and all
+        // non-K128 specializations.
         for (uint32_t ownedOffset = 0; ownedOffset < rowsPerSubBlock;
              ownedOffset += 8) {
             const uint32_t ownedBegin =


### PR DESCRIPTION
## What changed

- pipeline the A5 lower/upper Cube stages to overlap Cube work with Vector-side preparation
- use static A5 L1 tile layouts and reuse L0 storage across Cube stages
- increase the dense A5 row block from 16 to 32 rows for the supported K=128, chunk-size=64 path
- batch A5 `FinishHead` work in 16-row groups and prefetch its gradient inputs
- keep the optimized scheduling gated to the A5 (`DAV_3510`) dense BNSD path

## Why

The original A5 path repeatedly initialized on-chip layouts and processed relatively small row groups. It also serialized parts of the lower/upper Cube stages and issued fine-grained `FinishHead` gradient loads. These costs left the AIV side dominated by GM/MTE2 traffic and limited throughput on the target 8K/16K workloads.

## Impact

For BNSD `[B=1, H=96, T, K=128]`, chunk size 64, and FP32 beta on Ascend950PR_9579:

| Sequence length | Event median | msprof median `aicore_time` |
|---|---:|---:|
| 8192 | 5.6949 ms | 5.5662 ms |
| 16384 | 11.3165 ms | 11.1861 ms |

The 16K/8K AI Core time ratio is approximately 2.01x, showing near-linear scaling with sequence length. The final PipeUtilization profiles report about 99% Cube utilization, with AIV MTE2 around 65% and AIV Vector around 60%.

## Validation

- A5 precision smoke passed for BNSD H1/T64, H3/T63, and H8/T65
- A5 BSND boundary precision smoke passed
- A5 8K and 16K direct event benchmarks passed with finite outputs
- A5 8K and 16K task-based msprof PipeUtilization collection completed successfully
- `git diff --check upstream/main...HEAD` passed

