### PR TITLE
fix(build/install): 清理 wheel 构建残留的 *.egg-info，run 包默认安装到 wheel OPP

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,14 @@ wheel 内嵌 OPP；wheel 通过绝对路径加载 `libcust_opapi.so`，不会再
 
 ```sh
 # 覆盖当前 Python 环境中 flash-linear-attention-npu wheel 内嵌的 OPP
+# （无参数直接运行 .run 也是同样的行为，等价于 --install / --full）
 ./build_out/fla-npu-*.run --install
 # 或等价写法
 ./build_out/fla-npu-*.run --full
+
+# 如需装到 CANN OPP 目录（ASCEND_CUSTOM_OPP_PATH / ASCEND_OPP_PATH），
+# 使用 --cann 或 --install-path=<绝对路径>
+# ./build_out/fla-npu-*.run --cann
 
 # 如果 Python wrapper 也有修改，再安装单独编译出的 wheel
 WHEEL_PATH="dist/本轮构建生成的-wheel-文件名.whl"

--- a/cmake/scripts/custom/help.info
+++ b/cmake/scripts/custom/help.info
@@ -1,6 +1,7 @@
   --install                         Merge this run package into the active Python flash-linear-attention-npu wheel OPP
-  --full                            Same as --install
+  --full                            Same as --install (default behavior)
                                     Lists package operators, support status, and scoped aclnn ABI changes
-  --install-path                    Install operator package to specific dir path
+  --cann                            Install into the CANN OPP layout (ASCEND_CUSTOM_OPP_PATH / ASCEND_OPP_PATH)
+  --install-path                    Install operator package to specific dir path (CANN layout)
   --install-for-all                 Allow other users to use the operator package
   --quiet                           Quiet install mode

--- a/cmake/scripts/custom/install.sh
+++ b/cmake/scripts/custom/install.sh
@@ -19,7 +19,8 @@ vendordir=vendors/$vendor_name
 
 QUIET="n"
 INSTALL_FOR_ALL="n"
-WHEEL_INSTALL="n"
+WHEEL_INSTALL="y"
+MODE_SET="n"
 
 
 while true
@@ -31,11 +32,23 @@ do
     ;;
     --full|--install)
         WHEEL_INSTALL="y"
+        MODE_SET="y"
+        shift
+    ;;
+    --cann)
+        WHEEL_INSTALL="n"
+        MODE_SET="y"
         shift
     ;;
     --install-path=*)
         INSTALL_PATH=$(echo $1 | cut -d"=" -f2-)
         INSTALL_PATH=${INSTALL_PATH%*/}
+        # An explicit install path targets the CANN OPP layout, unless a
+        # wheel/cann install mode was already requested explicitly.
+        if [ "${MODE_SET}" = "n" ]; then
+            WHEEL_INSTALL="n"
+            MODE_SET="y"
+        fi
         shift
     ;;
     --install-for-all)
@@ -71,17 +84,19 @@ get_wheel_opp_root() {
     local python_bin
     python_bin=$(get_python_bin)
     if [ -z "${python_bin}" ]; then
-        log "[ERROR] python is required to locate the installed fla_npu wheel OPP."
-        exit 1
+        log "[WARNING] python is required to locate the installed fla_npu wheel OPP."
+        return 1
     fi
 
     "${python_bin}" - <<'PY'
 import importlib.util
+import sys
 from pathlib import Path
 
 spec = importlib.util.find_spec("fla_npu")
 if spec is None or spec.origin is None:
-    raise SystemExit("fla_npu is not importable. Install flash-linear-attention-npu wheel first.")
+    print("fla_npu is not importable. Install flash-linear-attention-npu wheel first.", file=sys.stderr)
+    raise SystemExit(1)
 
 package_dir = Path(spec.origin).resolve().parent
 print(package_dir / "opp")
@@ -404,6 +419,10 @@ install_wheel_opp_package() {
     fi
 
     wheel_opp_root=$(get_wheel_opp_root)
+    if [ -z "${wheel_opp_root}" ]; then
+        log "[WARNING] fla_npu wheel is not importable, falling back to CANN OPP install."
+        return 1
+    fi
     wheel_opp_root="${wheel_opp_root%/}"
     dst_vendor="${wheel_opp_root}/${vendordir}"
 
@@ -429,7 +448,6 @@ install_wheel_opp_package() {
 if [ "${WHEEL_INSTALL}" = "y" ]; then
     install_wheel_opp_package
 fi
-
 if [ -n "${INSTALL_PATH}" ]; then
     if [[ ! "${INSTALL_PATH}" = /* ]]; then
         log "[ERROR] use absolute path for --install-path argument"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import glob
 import importlib
 from importlib import metadata as importlib_metadata
 import importlib.util
@@ -474,6 +475,20 @@ def _stage_run_package(run_file, opp_root):
     print(f"[fla-npu build] Embedded OPP staged at {vendor_dir}")
 
 
+def _cleanup_build_residuals():
+    """Remove setuptools egg-info artifacts from the repo root.
+
+    Building a wheel from the source root leaves ``*.egg-info`` directories
+    behind. When the repo root is on ``sys.path`` (e.g. the CANN set_env.sh
+    appends a trailing ``:`` to PYTHONPATH, which makes Python add the current
+    directory), those stale metadata dirs shadow the real installed
+    distribution: ``pip show`` reports the source root as Location and
+    ``pip install --force-reinstall`` fails to uninstall the previous build.
+    """
+    for egg_info in glob.glob(str(REPO_ROOT / "*.egg-info")):
+        shutil.rmtree(egg_info, ignore_errors=True)
+
+
 def _build_torch_extension_inplace():
     for so_file in FLA_NPU_PACKAGE_DIR.glob("custom_aclnn_extension_lib*.so"):
         so_file.unlink()
@@ -538,6 +553,10 @@ if _bdist_wheel is not None:
             build_tag = get_wheel_build_tag(REPO_ROOT)
             if build_tag:
                 self.build_number = build_tag
+
+        def run(self):
+            super().run()
+            _cleanup_build_residuals()
 
     CMDCLASS["bdist_wheel"] = FlaNpuBdistWheel
 


### PR DESCRIPTION
## Summary
Building a wheel from the source root leaves `*.egg-info` metadata directories behind in the repo root. When the CANN `set_env.sh` appends a trailing `:` to `PYTHONPATH` (which happens whenever the original `PYTHONPATH` is empty), Python treats the empty path component as the current working directory and puts the repo root ahead of `site-packages` on `sys.path`. The stale `*.egg-info` then shadows the real installed distribution:

- `pip show flash-linear-attention-npu` reports the **source root** as `Location`
- `pip install --force-reinstall` fails with `Can't uninstall 'flash-linear-attention-npu'. No files were found to uninstall.`

The wheel itself carries its own `.dist-info` metadata, so the repo-root `*.egg-info` is purely a stale build artifact with no runtime value.

## Change
- In `setup.py`, override `bdist_wheel.run()` to clean up repo-root `*.egg-info` after the wheel is built.
- Cleanup is scoped strictly to `*.egg-info`; `dist/`, `build/`, and other artifacts are untouched.
- Does not affect `pip install -e .` (editable installs use a different command class) or `sdist`.

## Test plan
- Verified `FLA_NPU_SOC=ascend950 python -m pip wheel --no-build-isolation --no-deps . -w dist` builds successfully and leaves **no** `flash_linear_attention_npu.egg-info` in the repo root.
- After a build, `pip show flash-linear-attention-npu` and `python -m pip show flash-linear-attention-npu` both report `Location` as the real `site-packages` even when running inside the source dir with the CANN environment sourced.

# pip show 误判 Location 为源码目录：根因分析与修复方案

## 背景

在源码目录内执行安装与查询时，出现以下异常现象：

```
$ python -m pip install --force-reinstall --no-cache-dir --no-deps dist/flash_linear_attention_npu-26.7.0.dev0-950.x86_64-py3-none-any.whl
Found existing installation: flash-linear-attention-npu 26.7.0.dev0
Can't uninstall 'flash-linear-attention-npu'. No files were found to uninstall.
Successfully installed flash-linear-attention-npu-26.7.0.dev0

$ pip show flash-linear-attention-npu
Name: flash-linear-attention-npu
Version: 26.7.0.dev0
Location: /home/npu_user7/fangziyang/0810/flash-linear-attention-npu   # ← 误判为源码目录
```

而同样的流程在 `/tmp` 下执行，`pip show` 的 Location 正常指向 site-packages：

```
$ cd /tmp && pip show flash-linear-attention-npu
Location: /home/npu_user7/jianshuqiang/miniconda3/envs/fzy/lib/python3.10/site-packages
```

## 核心结论

**这不是某个 commit 引入的代码回归，而是三个环境条件叠加触发的 pip 元数据误判**：

1. 源码根存在 `*.egg-info` 构建残留（setuptools 构建 wheel 的标准产物，从仓库诞生起就存在）；
2. `PYTHONPATH` 带**尾随冒号**（CANN `set_env.sh` 在原始 PYTHONPATH 为空时必然产生）；
3. 在源码目录内执行 pip 命令。

三个条件缺一不可。

---

## 为什么带尾随冒号会命中源码 egg-info？

### ① PYTHONPATH 的空路径项 = 当前工作目录

Python 解释器启动时，把 `PYTHONPATH` 按 `:` 切分后依次插入 `sys.path`（排在标准库与 site-packages 之前）。**空字符串条目被解析为"当前工作目录"**。

实测验证：

```bash
PYTHONPATH="/a:/b:"   # 尾随冒号 → 空路径项
python -c "import sys; print(sys.path)"
# ['', '/a', '/b', '<当前工作目录>', stdlib..., site-packages...]

PYTHONPATH="/a:/b"    # 无尾随冒号
# ['', '/a', '/b', stdlib..., site-packages...]
```

CANN `set_env.sh` 的第 129 行：

```bash
export PYTHONPATH="$version_dirpath/python/site-packages:$version_dirpath/opp/built-in/op_impl/ai_core/tbe:$PYTHONPATH"
```

当原始 `PYTHONPATH` 为空时，赋值结果是：

```
/home/npu_user7/hxw/envs/0804/cann-9.2.0/python/site-packages:/home/npu_user7/hxw/envs/0804/cann-9.2.0/opp/built-in/op_impl/ai_core/tbe:
```

末尾多了一个冒号，即产生空路径项，等价于把**当前工作目录**加进 sys.path，且位置在 site-packages **之前**。

### ② pip 按 sys.path 顺序扫描发行版元数据

pip 的 metadata 后端（Python 3.10 默认 pkg_resources；Python 3.11+ 默认 importlib.metadata）都按 `sys.path` 的顺序扫描每个目录下的 `*.egg-info` / `*.dist-info`。

由于源码目录被插入到 site-packages 前面，其根下的 `flash_linear_attention_npu.egg-info` 会被**最先**发现。

### ③ pkg_resources 的"同名只保留第一个"遮蔽

pkg_resources 的 `WorkingSet.add()` 对已经注册过的同名发行版直接丢弃后扫到的（源码注释即 "ignore hidden distros"）：

```python
# pip/_vendor/pkg_resources/__init__.py
def add(self, dist, entry=None, insert=True, replace=False):
    ...
    if not replace and dist.key in self.by_key:
        # ignore hidden distros
        return
    self.by_key[dist.key] = dist
```

于是源码根的 egg-info 先注册进 `by_key`，site-packages 里真实安装的 dist-info 因同名被跳过。`pip show` 从 `by_key` 取到的就是源码目录的 egg-info：

- **Location** 显示源码目录（egg-info 所在目录）；
- 该 egg-info **没有 RECORD 文件**（它只是构建时生成的元数据目录，没有安装文件记录），所以 `pip install --force-reinstall` 卸载时找不到任何文件，报 "No files were found to uninstall"。

### 不带尾随冒号为什么正常？

不带尾随冒号时，cwd 不会进入 sys.path；而 `python -m pip` 路径下，pip 自身的 `__main__.py` 还会主动把 sys.path[0] 里的 cwd 弹出：

```python
# pip/__main__.py
if sys.path[0] in ("", os.getcwd()):
    sys.path.pop(0)
```

因此源码目录根本不在扫描范围内，site-packages 的真实安装正常胜出。

---

## 完整触发链路

```
构建 wheel（pip wheel / python -m build）
   ↓
setuptools 在源码根生成 *.egg-info（无 RECORD，纯元数据）
   ↓
source CANN set_env.sh（PYTHONPATH 为空时产生尾随冒号）
   ↓
Python 把空路径项解析为 cwd，源码目录进入 sys.path（排在 site-packages 之前）
   ↓
pkg_resources/importlib.metadata 扫描 sys.path：
    先发现源码根 egg-info → 注册 by_key
    后扫描 site-packages 的同名 dist-info → 被 "ignore hidden distros" 丢弃
   ↓
pip show → Location = 源码目录
pip install --force-reinstall → 卸载时找不到 RECORD → "No files were found to uninstall"
```

### 复现条件清单

| # | 条件 | 说明 |
|---|------|------|
| 1 | 源码根存在 `*.egg-info` | `pip wheel` 构建后必然产生，是 setuptools 标准行为 |
| 2 | `PYTHONPATH` 带尾随冒号 | CANN `set_env.sh` 在原始 PYTHONPATH 为空时必然产生（`.../tbe:`） |
| 3 | 在源码目录内执行 pip 命令 | cwd 已进 sys.path，位于 site-packages 之前 |

旧版本没遇到，是因为没有同时满足这三个条件（例如未在源码目录内执行、或 PYTHONPATH 非空时 set_env.sh 不会产生尾随冒号），而非代码回归。

---

## 修复方案：构建后自动清理源码根 egg-info

CANN 的 `set_env.sh` 无法修改，因此从仓库侧规避。

### 方案对比

| 方案 | 结论 |
|------|------|
| 自定义 `egg_info --egg-base` 重定向 | ❌ 破坏 PEP 517 metadata 生成（`_bubble_up_info_directory` 断言失败） |
| **自定义 `bdist_wheel` 构建后清理源码根 `*.egg-info`** | ✅ 采用 |
| 构建脚本手动清理 | 可用但依赖人工/流程，不自动 |

### 具体改动（setup.py）

```python
def _cleanup_build_residuals():
    """Remove setuptools egg-info artifacts from the repo root.

    Building a wheel from the source root leaves ``*.egg-info`` directories
    behind. When the repo root is on ``sys.path`` (e.g. the CANN set_env.sh
    appends a trailing ``:`` to PYTHONPATH, which makes Python add the current
    directory), those stale metadata dirs shadow the real installed
    distribution: ``pip show`` reports the source root as Location and
    ``pip install --force-reinstall`` fails to uninstall the previous build.
    """
    for egg_info in glob.glob(str(REPO_ROOT / "*.egg-info")):
        shutil.rmtree(egg_info, ignore_errors=True)

if _bdist_wheel is not None:
    class FlaNpuBdistWheel(_bdist_wheel):
        def finalize_options(self):
            super().finalize_options()
            self.root_is_pure = True
            build_tag = get_wheel_build_tag(REPO_ROOT)
            if build_tag:
                self.build_number = build_tag

        def run(self):
            super().run()
            _cleanup_build_residuals()

    CMDCLASS["bdist_wheel"] = FlaNpuBdistWheel
```

### 执行时机

清理发生在 `bdist_wheel.run()` 中，即 **wheel 已生成完毕之后**。构建时序：

```
Preparing metadata (pyproject.toml)  → 在 /tmp 临时目录生成 egg-info，不碰源码根
running egg_info                     → 在源码根生成 egg-info
构建 wheel                           → 把元数据打进 wheel 的 .dist-info
wheel 生成完成
→ 删除源码根 *.egg-info              ← 此时 wheel 已完整，删除只清残留
```

### 负面影响评估

| 场景 | 是否受影响 | 依据 |
|------|-----------|------|
| `pip wheel` / `python -m build --wheel` 构建 | 无 | 删除发生在 wheel 生成之后，wheel 里的 `.dist-info` 已定型；下次构建会重新生成 egg-info |
| `pip install xxx.whl` 安装 | 无 | 完全不涉及源码根的 egg-info |
| `pip install -e .` editable 安装 | 无 | 已验证 `editable_wheel` 不是 `bdist_wheel` 子类，**不会触发清理**；且 editable 构建会自己重新生成 egg-info |
| `python setup.py sdist` | 无 | 不走 `bdist_wheel`，清理不触发 |
| 单独执行 `python setup.py egg_info` | 无 | 清理只在 `bdist_wheel.run()` 内，手动 egg_info 不受影响 |
| `dist/`、`build/` 等其他产物 | 无 | 清理范围严格限定 `REPO_ROOT/*.egg-info` |

**唯一理论上的边缘情况**：wheel 构建完成、egg-info 刚被删的极短瞬间，若有另一个进程恰好在源码目录跑 `pip show` 且 PYTHONPATH 带尾随冒号，可能短暂查不到源码蛋壳——但 site-packages 里的真实安装本来就在，本就不该依赖源码根的 egg-info。实际无影响。

### 验证结果

- 用 `FLA_NPU_SOC=ascend950 python -m pip wheel --no-build-isolation --no-deps . -w dist` 完整构建成功，wheel 正常产出，**源码根不再残留 egg-info**；
- 构建后即使 source 了 CANN 环境、在源码目录内执行 `pip show` / `python -m pip show`，Location 都稳定指向 site-packages；
- 清理范围仅 `*.egg-info`，`dist/`、`build/` 不受影响，无 lint 错误。

---

---

# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: 无（构建 / 安装流程修复，无外部 Issue）
- 背景与目标: 源码目录构建 wheel 会残留 `*.egg-info`，与 CANN `set_env.sh` 的尾随冒号 `PYTHONPATH` 叠加时会遮蔽真实安装（`pip show` 的 Location 误判为源码目录、`--force-reinstall` 卸载失败）；同时统一安装链路：run 包默认安装到 `flash-linear-attention-npu` wheel OPP，避免旧 run 包与 whl 双位置 kernel 残留。
- 本 PR 解决的问题:
  1. wheel 构建完成后自动清理源码根 `*.egg-info`（wheel 自带 `.dist-info`，残留元数据无运行时价值）；
  2. run 包无参执行默认合并安装到 wheel OPP（site-packages 内 vendors 布局），`--cann` / `--install-path` 可显式指定 CANN OPP 布局；
  3. 环境无可 import 的 fla_npu wheel 时，run 包自动回退 CANN OPP 安装而不是失败。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: 不涉及（本 PR 为构建 / 安装流程修复，无算子代码改动）
- 涉及目录 / 文件: `setup.py`、`cmake/scripts/custom/install.sh`、`cmake/scripts/custom/help.info`、`README.md`
- 责任人 / 提交人: @Coding-Pangolin
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不涉及
- 明确不包含的范围: 算子 kernel / tiling / op_api 逻辑；`pip install -e .`（editable）与 `sdist` 行为保持不变
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 不涉及

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

</details>

<details>
<summary>构建 / 安装验证（本 PR 不涉及算子测试）</summary>

| 场景 | 实际执行命令 | 结果 | 结论 |
| --- | --- | --- | --- |
| wheel 构建（源码根） | `FLA_NPU_SOC=ascend950 python -m pip wheel --no-build-isolation --no-deps . -w dist` | 通过 | 构建成功，wheel 正常产出，源码根不再残留 `flash_linear_attention_npu.egg-info` |
| 元数据定位 | source CANN `set_env.sh` 后在源码目录执行 `pip show flash-linear-attention-npu` / `python -m pip show flash-linear-attention-npu` | 通过 | Location 稳定指向 site-packages，不再误判源码目录 |
| 卸载重装 | `python -m pip install --force-reinstall --no-cache-dir --no-deps dist/flash_linear_attention_npu-*.whl` | 通过 | 不再报 `Can't uninstall 'flash-linear-attention-npu'. No files were found to uninstall.` |
| editable / sdist 回归 | `pip install -e .`、`python setup.py sdist` | 通过 | 不触发清理（`editable_wheel` 非 `bdist_wheel` 子类；`sdist` 不走 `bdist_wheel`） |
| run 包默认安装 | `./build_out/fla-npu-fla_npu_linux-aarch64.run`（无参数） | 通过 | 合并安装到 `flash-linear-attention-npu` wheel OPP（site-packages 内 vendors 布局） |
| run 包指定 CANN 布局 | `./build_out/fla-npu-fla_npu_linux-aarch64.run --cann` / `--install-path=...` | 通过 | 仍安装到 CANN OPP vendors 目录，保持旧流程能力 |
| 无 wheel 回退 | 在无可 import fla_npu wheel 的环境执行 run 包 | 通过 | 自动回退 CANN OPP 安装，不失败 |

- 精度 / 性能对比: 不涉及（构建与安装流程变更，不触碰算子执行路径）。
- 边界 / 异常场景: 清理范围严格限定 `REPO_ROOT/*.egg-info`，`dist/`、`build/` 等产物不受影响；删除发生在 wheel 生成完成后，下次构建会重新生成 egg-info。
- 未覆盖风险: 不同 pip / setuptools 版本下 metadata 后端行为（pkg_resources vs importlib.metadata）已实测覆盖 3.10/3.11 两种默认；极端并发场景（wheel 刚构建完、egg-info 刚删除的瞬间有其他进程在源码目录查 `pip show`）理论上有极短窗口，实际无影响。

</details>

<details>
<summary>整体 Example ST 验证</summary>

本 PR 为构建 / 安装流程变更，不涉及算子执行路径；整体 example ST 不受影响，可触发 `/run-npu-ci quick` 回归确认。

</details>

## 兼容性、风险与回退

- 兼容性说明: run 包无参执行的行为变更（旧行为直接安装到 CANN OPP vendors；新行为默认合并安装到 wheel OPP），通过 `--cann` / `--install-path` 保留旧布局能力；`pip install -e .`、`sdist` 行为不变。
- 风险点: 存量用户若依赖“run 包直接装到 CANN vendors”的旧行为，升级后需显式 `--cann`；旧 run 包残留（`opp/vendors` 下旧 vendor）仍可能遮蔽 built-in kernel，升级路径需按 README 说明清理。
- 回退方案: 改动集中在 `setup.py` 的 `bdist_wheel` 子类与 `install.sh` 分支，可整体 revert，不影响算子功能。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因（内部构建 / 安装流程修复，无外部 Issue）
- [x] 已明确本 PR 的算子责任范围和不包含范围（不涉及算子）
- [ ] 不适用 - CANN 8.5 及以上已验证 A2 / A3 可以编译通过（本 PR 不涉及算子编译；已用 `FLA_NPU_SOC=ascend950` 验证 wheel 构建链路）
- [ ] 不适用 - 已验证修改算子的对应 test 在 A2 / A3 / A5 通过（本 PR 不涉及算子测试，已做构建 / 安装回归）
- [ ] 不适用 - 已验证整体 example ST 在 A2 / A3 / A5 通过（构建 / 安装流程变更，不触碰算子执行路径）
- [x] 已完成必要的精度、性能或回归验证（构建、元数据定位、卸载重装、run 包安装/回退回归）
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用（`README.md` 同步 run 包安装行为与 `--cann` 说明）
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 根因分析：`PYTHONPATH` 尾随冒号 → 空路径项解析为当前工作目录 → 源码根进入 `sys.path`（site-packages 之前）→ pip 的 metadata 后端先发现源码根 `*.egg-info` 并注册 `by_key`，site-packages 同名 dist-info 被 “ignore hidden distros” 丢弃。三个条件（源码根 egg-info 残留 + 尾随冒号 + 源码目录内执行）缺一不可。
- 方案对比：自定义 `bdist_wheel` 构建后清理 vs `egg_info --egg-base` 重定向（后者会破坏 PEP 517 metadata 生成，`_bubble_up_info_directory` 断言失败），最终采用前者。
- run 包默认安装到 wheel OPP 的动机：统一安装链路，避免旧 run 包（CANN vendors）与新 whl（site-packages）双位置 kernel 并存导致运行时 kernel 归属不确定；升级场景仍建议清理 `opp/vendors` 下旧 vendor。