### PR TITLE
feat: 添加基于主线的 KDA 正向一键性能测试入口

### DIFF
--- a/scripts/benchmark_kda_b200_triton.py
+++ b/scripts/benchmark_kda_b200_triton.py
@@ -97,7 +97,8 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Run the eight dense KDA cases with the installed FLA Triton "
-            "implementation and report the mean of 10 CUDA-event timings."
+            "implementation and report the mean of 10 CUDA device-stream "
+            "timings."
         )
     )
     parser.add_argument("--device", type=int, default=0)
@@ -366,11 +367,11 @@ def summarize_timings(
     mean_us = sum(timings_us) / len(timings_us)
     effective_tflops = kda_flops(case) / (mean_us * 1e-6) / 1e12
     return {
-        "mean_us": mean_us,
-        "median_us": statistics.median(timings_us),
-        "min_us": min(timings_us),
-        "max_us": max(timings_us),
-        "stddev_us": statistics.pstdev(timings_us),
+        "device_mean_us": mean_us,
+        "device_median_us": statistics.median(timings_us),
+        "device_min_us": min(timings_us),
+        "device_max_us": max(timings_us),
+        "device_stddev_us": statistics.pstdev(timings_us),
         "effective_tflops": effective_tflops,
         "mfu_percent": effective_tflops / peak_tflops * 100.0,
         "a5_over_b200": case.a5_us / mean_us,
@@ -403,7 +404,7 @@ def benchmark_case(
         del outputs
         outputs = None
 
-    timings_us = []
+    device_timings_us = []
     for run_index in range(runs):
         if outputs is not None:
             del outputs
@@ -415,16 +416,16 @@ def benchmark_case(
         end.record()
         end.synchronize()
         elapsed_us = float(start.elapsed_time(end) * 1000.0)
-        timings_us.append(elapsed_us)
+        device_timings_us.append(elapsed_us)
         print(
             f"case={case.case_id} run={run_index + 1:02d}/{runs} "
-            f"elapsed_us={elapsed_us:.3f}",
+            f"device_elapsed_us={elapsed_us:.3f}",
             flush=True,
         )
 
     validate_outputs(torch, outputs, case)
     peak_memory_bytes = int(torch.cuda.max_memory_allocated(device))
-    summary = summarize_timings(case, timings_us, peak_tflops)
+    summary = summarize_timings(case, device_timings_us, peak_tflops)
     del outputs
     del inputs
     torch.cuda.synchronize(device)
@@ -439,7 +440,7 @@ def benchmark_case(
         "status": "PASS",
         "warmup": warmup,
         "runs": runs,
-        "timings_us": timings_us,
+        "device_timings_us": device_timings_us,
         "peak_memory_gib": peak_memory_bytes / 2**30,
         "total_flops": kda_flops(case),
         **summary,
@@ -458,14 +459,14 @@ def error_result(case: Case, warmup: int, runs: int, error: Exception) -> dict:
         "status": "ERROR",
         "warmup": warmup,
         "runs": runs,
-        "timings_us": [],
+        "device_timings_us": [],
         "peak_memory_gib": None,
         "total_flops": kda_flops(case),
-        "mean_us": None,
-        "median_us": None,
-        "min_us": None,
-        "max_us": None,
-        "stddev_us": None,
+        "device_mean_us": None,
+        "device_median_us": None,
+        "device_min_us": None,
+        "device_max_us": None,
+        "device_stddev_us": None,
         "effective_tflops": None,
         "mfu_percent": None,
         "a5_over_b200": None,
@@ -487,16 +488,18 @@ def markdown_report(metadata: dict, results: Sequence[dict]) -> str:
         f"- Triton: `{metadata['triton_version']}`",
         f"- warmup runs per case: `{metadata['warmup']}`",
         f"- measured runs per case: `{metadata['runs']}`",
+        "- timing: `CUDA device-stream elapsed time; host/Python time excluded`",
         f"- BF16 dense peak for MFU: `{metadata['peak_tflops']:.1f} TFLOPS`",
         "",
         "| Case | total tokens | layout mode | sequence count | chunk count | "
-        "recompute enabled | status | B200 mean us | B200 MFU | A5 us | "
+        "recompute enabled | status | B200 device mean us | B200 MFU | "
+        "A5 device profiler us | "
         "A5/B200 |",
         "| ---: | ---: | --- | ---: | ---: | --- | --- | ---: | ---: | ---: | ---: |",
     ]
     for result in results:
         values = dict(result)
-        values["mean_us_text"] = _number(result["mean_us"])
+        values["device_mean_us_text"] = _number(result["device_mean_us"])
         values["mfu_text"] = (
             ""
             if result["mfu_percent"] is None
@@ -509,7 +512,8 @@ def markdown_report(metadata: dict, results: Sequence[dict]) -> str:
         )
         lines.append(
             "| {case_id} | {total_tokens} | dense | 1 | {chunk_count} | "
-            "{recompute_enabled} | {status} | {mean_us_text} | {mfu_text} | "
+            "{recompute_enabled} | {status} | {device_mean_us_text} | "
+            "{mfu_text} | "
             "{a5_us:.3f} | {speedup_text} |".format(**values)
         )
     errors = [result for result in results if result["status"] != "PASS"]
@@ -539,11 +543,11 @@ def write_reports(output_dir: Path, metadata: dict, results: Sequence[dict]) -> 
         "status",
         "warmup",
         "runs",
-        "mean_us",
-        "median_us",
-        "min_us",
-        "max_us",
-        "stddev_us",
+        "device_mean_us",
+        "device_median_us",
+        "device_min_us",
+        "device_max_us",
+        "device_stddev_us",
         "effective_tflops",
         "mfu_percent",
         "peak_memory_gib",
@@ -563,16 +567,18 @@ def write_reports(output_dir: Path, metadata: dict, results: Sequence[dict]) -> 
         "w", newline="", encoding="utf-8"
     ) as stream:
         writer = csv.DictWriter(
-            stream, fieldnames=("case_id", "run", "elapsed_us")
+            stream, fieldnames=("case_id", "run", "device_elapsed_us")
         )
         writer.writeheader()
         for result in results:
-            for run, elapsed_us in enumerate(result["timings_us"], start=1):
+            for run, elapsed_us in enumerate(
+                result["device_timings_us"], start=1
+            ):
                 writer.writerow(
                     {
                         "case_id": result["case_id"],
                         "run": run,
-                        "elapsed_us": elapsed_us,
+                        "device_elapsed_us": elapsed_us,
                     }
                 )
 
@@ -641,7 +647,13 @@ def main() -> int:
         "warmup": args.warmup,
         "runs": args.runs,
         "peak_tflops": args.peak_tflops,
-        "timing_scope": "complete low-level FLA chunk_kda_fwd via CUDA events",
+        "timing_domain": "CUDA device",
+        "timing_scope": (
+            "complete low-level FLA chunk_kda_fwd device-stream elapsed time"
+        ),
+        "host_python_time_included": False,
+        "input_generation_time_included": False,
+        "compile_autotune_warmup_time_included": False,
         "backend_env": {
             "FLA_DISABLE_BACKEND_DISPATCH": "1",
             "FLA_TILELANG": "0",

--- a/scripts/benchmark_kda_b200_triton.py
+++ b/scripts/benchmark_kda_b200_triton.py
@@ -1,0 +1,687 @@
+#!/usr/bin/env python3
+"""Benchmark the FLA 0.5.2 Triton KDA forward implementation on one B200."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import gc
+import importlib
+import inspect
+import json
+import os
+import statistics
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+
+HEADS = 96
+KEY_DIM = 128
+VALUE_DIM = 128
+CHUNK_SIZE = 64
+SEQUENCE_LENGTHS = (1024, 8192, 16384, 65536)
+ATK_CASE_ID_START = 250
+SEED_BASE = 20260812
+EXPECTED_FLA_VERSION = "0.5.2"
+B200_BF16_DENSE_PEAK_TFLOPS = 2250.0
+A5_US = {
+    250: 576.645,
+    251: 631.411,
+    252: 4284.247,
+    253: 4773.215,
+    254: 8501.267,
+    255: 9520.606,
+    256: 33911.582,
+    257: 38118.852,
+}
+
+
+@dataclass(frozen=True)
+class Case:
+    case_id: int
+    total_tokens: int
+    disable_recompute: bool
+    seed: int
+    a5_us: float
+
+    @property
+    def recompute_enabled(self) -> bool:
+        return not self.disable_recompute
+
+    @property
+    def chunk_count(self) -> int:
+        return self.total_tokens // CHUNK_SIZE
+
+    @property
+    def case_key(self) -> str:
+        enabled = str(self.recompute_enabled).lower()
+        return (
+            f"ascend950_h96_t{self.total_tokens}_c64_dense_"
+            f"recompute_{enabled}"
+        )
+
+
+def build_cases() -> tuple[Case, ...]:
+    cases = []
+    for sequence_index, total_tokens in enumerate(SEQUENCE_LENGTHS):
+        for disable_recompute in (False, True):
+            case_id = (
+                ATK_CASE_ID_START
+                + sequence_index * 2
+                + int(disable_recompute)
+            )
+            cases.append(
+                Case(
+                    case_id=case_id,
+                    total_tokens=total_tokens,
+                    disable_recompute=disable_recompute,
+                    seed=SEED_BASE + sequence_index,
+                    a5_us=A5_US[case_id],
+                )
+            )
+    result = tuple(cases)
+    if tuple(case.case_id for case in result) != tuple(range(250, 258)):
+        raise RuntimeError("B200 Triton matrix must contain case IDs 250-257")
+    return result
+
+
+CASES = build_cases()
+CASE_BY_ID = {str(case.case_id): case for case in CASES}
+CASE_BY_KEY = {case.case_key: case for case in CASES}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the eight dense KDA cases with the installed FLA Triton "
+            "implementation and report the mean of 10 CUDA-event timings."
+        )
+    )
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--cases", default="all")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--runs", type=int, default=10)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument(
+        "--expected-fla-version",
+        default=EXPECTED_FLA_VERSION,
+        help="installed flash-linear-attention version required by the run",
+    )
+    parser.add_argument(
+        "--peak-tflops",
+        type=float,
+        default=B200_BF16_DENSE_PEAK_TFLOPS,
+        help="single-GPU dense BF16 peak used for MFU",
+    )
+    parser.add_argument("--allow-non-b200", action="store_true")
+    parser.add_argument("--list-cases", action="store_true")
+    return parser.parse_args()
+
+
+def select_cases(value: str) -> list[Case]:
+    if value == "all":
+        return list(CASES)
+    requested = [item.strip() for item in value.split(",") if item.strip()]
+    selectors = {**CASE_BY_ID, **CASE_BY_KEY}
+    unknown = sorted(set(requested).difference(selectors))
+    if unknown:
+        raise ValueError(f"unknown cases: {', '.join(unknown)}")
+    return [selectors[item] for item in requested]
+
+
+def default_output_dir() -> Path:
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return Path("output") / "kda-b200-triton" / f"run_{timestamp}_{os.getpid()}"
+
+
+def _distribution_metadata():
+    try:
+        from importlib import metadata
+    except ImportError:  # pragma: no cover - FLA 0.5.2 requires newer Python.
+        import importlib_metadata as metadata
+    return metadata
+
+
+def _is_within(path: Path, directory: Path) -> bool:
+    try:
+        path.relative_to(directory)
+    except ValueError:
+        return False
+    return True
+
+
+def load_installed_fla(expected_version: str):
+    metadata = _distribution_metadata()
+    try:
+        distribution = metadata.distribution("flash-linear-attention")
+    except metadata.PackageNotFoundError as exc:
+        raise RuntimeError(
+            "flash-linear-attention is not installed in the current Python environment"
+        ) from exc
+    if distribution.version != expected_version:
+        raise RuntimeError(
+            "unexpected flash-linear-attention version: "
+            f"expected {expected_version}, got {distribution.version}"
+        )
+
+    distribution_root = Path(distribution.locate_file("")).resolve()
+    installed_fla_root = Path(distribution.locate_file("fla")).resolve()
+    expected_source = installed_fla_root / "ops" / "kda" / "chunk_fwd.py"
+    if not expected_source.is_file():
+        raise RuntimeError(
+            "installed flash-linear-attention does not contain "
+            f"{expected_source}"
+        )
+
+    # This repository also has a minimal top-level `fla` package. Put the pip
+    # distribution first so the benchmark cannot silently import that package.
+    sys.path.insert(0, str(distribution_root))
+    for module_name in tuple(sys.modules):
+        if module_name == "fla" or module_name.startswith("fla."):
+            del sys.modules[module_name]
+
+    module = importlib.import_module("fla.ops.kda.chunk_fwd")
+    operation = getattr(module, "chunk_kda_fwd", None)
+    if not callable(operation):
+        raise RuntimeError("installed FLA chunk_kda_fwd is not callable")
+    source = inspect.getsourcefile(operation)
+    if source is None or not _is_within(Path(source).resolve(), installed_fla_root):
+        raise RuntimeError(
+            "chunk_kda_fwd was not imported from the installed "
+            "flash-linear-attention distribution"
+        )
+
+    required_parameters = {
+        "q",
+        "k",
+        "v",
+        "g",
+        "beta",
+        "scale",
+        "initial_state",
+        "output_final_state",
+        "state_v_first",
+        "chunk_size",
+        "safe_gate",
+        "lower_bound",
+        "use_gate_in_kernel",
+        "A_log",
+        "dt_bias",
+        "disable_recompute",
+        "return_intermediate_states",
+    }
+    signature = inspect.signature(operation)
+    if not any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    ):
+        missing = sorted(required_parameters.difference(signature.parameters))
+        if missing:
+            raise RuntimeError(
+                "installed FLA chunk_kda_fwd has an incompatible signature; "
+                f"missing parameters: {', '.join(missing)}"
+            )
+    return operation, distribution.version, Path(source).resolve()
+
+
+def normal_quantized(
+    torch,
+    shape: Sequence[int],
+    generator,
+    original_dtype,
+    device,
+    *,
+    mean: float = 0.0,
+    std: float = 1.0,
+    sigmoid: bool = False,
+    l2_normalize: bool = False,
+):
+    value = torch.randn(shape, generator=generator, dtype=torch.float32)
+    value = value.mul(std).add(mean)
+    if sigmoid:
+        value = torch.sigmoid(value)
+    if l2_normalize:
+        value = value * torch.rsqrt(
+            value.square().sum(dim=-1, keepdim=True) + 1e-6
+        )
+    return value.to(original_dtype).to(device)
+
+
+def make_inputs(torch, case: Case, device) -> dict:
+    shape = (1, case.total_tokens, HEADS, KEY_DIM)
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(case.seed)
+    return {
+        "q": normal_quantized(
+            torch,
+            shape,
+            generator,
+            torch.bfloat16,
+            device,
+            std=0.05,
+            l2_normalize=True,
+        ),
+        "k": normal_quantized(
+            torch,
+            shape,
+            generator,
+            torch.bfloat16,
+            device,
+            std=0.05,
+            l2_normalize=True,
+        ),
+        "v": normal_quantized(
+            torch, shape, generator, torch.bfloat16, device, std=0.05
+        ),
+        "g": normal_quantized(
+            torch, shape, generator, torch.float32, device, std=1.25
+        ),
+        "beta": normal_quantized(
+            torch,
+            (1, case.total_tokens, HEADS),
+            generator,
+            torch.bfloat16,
+            device,
+            mean=1.5,
+            std=0.35,
+            sigmoid=True,
+        ),
+        "A_log": normal_quantized(
+            torch,
+            (HEADS,),
+            generator,
+            torch.float32,
+            device,
+            std=0.12,
+        ),
+        "dt_bias": normal_quantized(
+            torch,
+            (HEADS * KEY_DIM,),
+            generator,
+            torch.float32,
+            device,
+            mean=-3.0,
+            std=1.65,
+        ),
+    }
+
+
+def invoke(operation: Callable, inputs: dict, case: Case):
+    return operation(
+        q=inputs["q"],
+        k=inputs["k"],
+        v=inputs["v"],
+        g=inputs["g"],
+        beta=inputs["beta"],
+        scale=KEY_DIM**-0.5,
+        initial_state=None,
+        output_final_state=False,
+        state_v_first=True,
+        cu_seqlens=None,
+        cu_seqlens_cpu=None,
+        chunk_indices=None,
+        chunk_size=CHUNK_SIZE,
+        safe_gate=True,
+        lower_bound=-5.0,
+        use_gate_in_kernel=True,
+        A_log=inputs["A_log"],
+        dt_bias=inputs["dt_bias"],
+        disable_recompute=case.disable_recompute,
+        return_intermediate_states=False,
+    )
+
+
+def validate_outputs(torch, outputs, case: Case) -> None:
+    if not isinstance(outputs, (tuple, list)) or len(outputs) != 12:
+        raise RuntimeError("FLA chunk_kda_fwd must return 12 values")
+    output = outputs[0]
+    expected_shape = (1, case.total_tokens, HEADS, VALUE_DIM)
+    if tuple(output.shape) != expected_shape:
+        raise RuntimeError(
+            f"unexpected output shape: expected {expected_shape}, got {tuple(output.shape)}"
+        )
+    if not bool(torch.isfinite(output).all().item()):
+        raise RuntimeError("attention output contains NaN or Inf")
+
+
+def kda_flops(case: Case) -> float:
+    chunk = CHUNK_SIZE
+    per_head_chunk = (
+        6 * chunk * chunk * KEY_DIM
+        + 4 * chunk * chunk * VALUE_DIM
+        + 6 * chunk * KEY_DIM * VALUE_DIM
+        + chunk * (chunk - 1) * (chunk + 1) / 3
+    )
+    return HEADS * case.chunk_count * per_head_chunk
+
+
+def summarize_timings(
+    case: Case, timings_us: Sequence[float], peak_tflops: float
+) -> dict:
+    if not timings_us:
+        raise ValueError("at least one timing is required")
+    mean_us = sum(timings_us) / len(timings_us)
+    effective_tflops = kda_flops(case) / (mean_us * 1e-6) / 1e12
+    return {
+        "mean_us": mean_us,
+        "median_us": statistics.median(timings_us),
+        "min_us": min(timings_us),
+        "max_us": max(timings_us),
+        "stddev_us": statistics.pstdev(timings_us),
+        "effective_tflops": effective_tflops,
+        "mfu_percent": effective_tflops / peak_tflops * 100.0,
+        "a5_over_b200": case.a5_us / mean_us,
+    }
+
+
+def benchmark_case(
+    torch,
+    operation: Callable,
+    case: Case,
+    device,
+    warmup: int,
+    runs: int,
+    peak_tflops: float,
+) -> dict:
+    gc.collect()
+    torch.cuda.empty_cache()
+    inputs = make_inputs(torch, case, device)
+    torch.cuda.synchronize(device)
+    torch.cuda.reset_peak_memory_stats(device)
+
+    outputs = None
+    for warmup_index in range(warmup):
+        outputs = invoke(operation, inputs, case)
+        torch.cuda.synchronize(device)
+        print(
+            f"case={case.case_id} warmup={warmup_index + 1}/{warmup}",
+            flush=True,
+        )
+        del outputs
+        outputs = None
+
+    timings_us = []
+    for run_index in range(runs):
+        if outputs is not None:
+            del outputs
+            outputs = None
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        outputs = invoke(operation, inputs, case)
+        end.record()
+        end.synchronize()
+        elapsed_us = float(start.elapsed_time(end) * 1000.0)
+        timings_us.append(elapsed_us)
+        print(
+            f"case={case.case_id} run={run_index + 1:02d}/{runs} "
+            f"elapsed_us={elapsed_us:.3f}",
+            flush=True,
+        )
+
+    validate_outputs(torch, outputs, case)
+    peak_memory_bytes = int(torch.cuda.max_memory_allocated(device))
+    summary = summarize_timings(case, timings_us, peak_tflops)
+    del outputs
+    del inputs
+    torch.cuda.synchronize(device)
+    torch.cuda.empty_cache()
+    return {
+        **asdict(case),
+        "case_key": case.case_key,
+        "layout_mode": "dense",
+        "sequence_count": 1,
+        "chunk_count": case.chunk_count,
+        "recompute_enabled": case.recompute_enabled,
+        "status": "PASS",
+        "warmup": warmup,
+        "runs": runs,
+        "timings_us": timings_us,
+        "peak_memory_gib": peak_memory_bytes / 2**30,
+        "total_flops": kda_flops(case),
+        **summary,
+        "error": "",
+    }
+
+
+def error_result(case: Case, warmup: int, runs: int, error: Exception) -> dict:
+    return {
+        **asdict(case),
+        "case_key": case.case_key,
+        "layout_mode": "dense",
+        "sequence_count": 1,
+        "chunk_count": case.chunk_count,
+        "recompute_enabled": case.recompute_enabled,
+        "status": "ERROR",
+        "warmup": warmup,
+        "runs": runs,
+        "timings_us": [],
+        "peak_memory_gib": None,
+        "total_flops": kda_flops(case),
+        "mean_us": None,
+        "median_us": None,
+        "min_us": None,
+        "max_us": None,
+        "stddev_us": None,
+        "effective_tflops": None,
+        "mfu_percent": None,
+        "a5_over_b200": None,
+        "error": f"{type(error).__name__}: {error}",
+    }
+
+
+def _number(value: Optional[float], digits: int = 3) -> str:
+    return "" if value is None else f"{value:.{digits}f}"
+
+
+def markdown_report(metadata: dict, results: Sequence[dict]) -> str:
+    lines = [
+        "# FLA Triton KDA performance on B200",
+        "",
+        f"- GPU: `{metadata['gpu_name']}`",
+        f"- flash-linear-attention: `{metadata['fla_version']}`",
+        f"- PyTorch: `{metadata['torch_version']}`",
+        f"- Triton: `{metadata['triton_version']}`",
+        f"- warmup runs per case: `{metadata['warmup']}`",
+        f"- measured runs per case: `{metadata['runs']}`",
+        f"- BF16 dense peak for MFU: `{metadata['peak_tflops']:.1f} TFLOPS`",
+        "",
+        "| Case | total tokens | layout mode | sequence count | chunk count | "
+        "recompute enabled | status | B200 mean us | B200 MFU | A5 us | "
+        "A5/B200 |",
+        "| ---: | ---: | --- | ---: | ---: | --- | --- | ---: | ---: | ---: | ---: |",
+    ]
+    for result in results:
+        values = dict(result)
+        values["mean_us_text"] = _number(result["mean_us"])
+        values["mfu_text"] = (
+            ""
+            if result["mfu_percent"] is None
+            else f"{result['mfu_percent']:.2f}%"
+        )
+        values["speedup_text"] = (
+            ""
+            if result["a5_over_b200"] is None
+            else f"{result['a5_over_b200']:.3f}x"
+        )
+        lines.append(
+            "| {case_id} | {total_tokens} | dense | 1 | {chunk_count} | "
+            "{recompute_enabled} | {status} | {mean_us_text} | {mfu_text} | "
+            "{a5_us:.3f} | {speedup_text} |".format(**values)
+        )
+    errors = [result for result in results if result["status"] != "PASS"]
+    if errors:
+        lines.extend(["", "## Errors", ""])
+        for result in errors:
+            lines.append(f"- case {result['case_id']}: `{result['error']}`")
+    return "\n".join(lines) + "\n"
+
+
+def write_reports(output_dir: Path, metadata: dict, results: Sequence[dict]) -> None:
+    output_dir.mkdir(parents=True, exist_ok=False)
+    payload = {"metadata": metadata, "results": list(results)}
+    (output_dir / "results.json").write_text(
+        json.dumps(payload, indent=2) + "\n", encoding="utf-8"
+    )
+
+    summary_fields = [
+        "case_id",
+        "case_key",
+        "total_tokens",
+        "layout_mode",
+        "sequence_count",
+        "chunk_count",
+        "recompute_enabled",
+        "disable_recompute",
+        "status",
+        "warmup",
+        "runs",
+        "mean_us",
+        "median_us",
+        "min_us",
+        "max_us",
+        "stddev_us",
+        "effective_tflops",
+        "mfu_percent",
+        "peak_memory_gib",
+        "a5_us",
+        "a5_over_b200",
+        "error",
+    ]
+    with (output_dir / "results.csv").open(
+        "w", newline="", encoding="utf-8"
+    ) as stream:
+        writer = csv.DictWriter(stream, fieldnames=summary_fields)
+        writer.writeheader()
+        for result in results:
+            writer.writerow({field: result.get(field) for field in summary_fields})
+
+    with (output_dir / "timings.csv").open(
+        "w", newline="", encoding="utf-8"
+    ) as stream:
+        writer = csv.DictWriter(
+            stream, fieldnames=("case_id", "run", "elapsed_us")
+        )
+        writer.writeheader()
+        for result in results:
+            for run, elapsed_us in enumerate(result["timings_us"], start=1):
+                writer.writerow(
+                    {
+                        "case_id": result["case_id"],
+                        "run": run,
+                        "elapsed_us": elapsed_us,
+                    }
+                )
+
+    report = markdown_report(metadata, results)
+    (output_dir / "results.md").write_text(report, encoding="utf-8")
+    print("\n" + report, end="")
+    print(f"Results: {output_dir.resolve()}", flush=True)
+
+
+def package_version(name: str) -> str:
+    metadata = _distribution_metadata()
+    try:
+        return metadata.version(name)
+    except metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def main() -> int:
+    args = parse_args()
+    cases = select_cases(args.cases)
+    if args.list_cases:
+        for case in cases:
+            print(
+                f"{case.case_id} {case.case_key} T={case.total_tokens} "
+                f"chunks={case.chunk_count} "
+                f"recompute_enabled={case.recompute_enabled}"
+            )
+        return 0
+    if args.warmup < 0 or args.runs <= 0:
+        raise ValueError("--warmup must be nonnegative and --runs must be positive")
+    if args.peak_tflops <= 0:
+        raise ValueError("--peak-tflops must be positive")
+
+    # FLA 0.5.2 can dispatch to optional non-Triton backends. These variables
+    # force its default Triton implementation before the package is imported.
+    os.environ["FLA_DISABLE_BACKEND_DISPATCH"] = "1"
+    os.environ["FLA_TILELANG"] = "0"
+    os.environ["FLA_FLASH_KDA"] = "0"
+
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is unavailable")
+    device = torch.device(f"cuda:{args.device}")
+    torch.cuda.set_device(device)
+    gpu_name = torch.cuda.get_device_name(device)
+    if "B200" not in gpu_name.upper() and not args.allow_non_b200:
+        raise RuntimeError(
+            f"expected an NVIDIA B200, got {gpu_name!r}; "
+            "use --allow-non-b200 only for intentional non-B200 runs"
+        )
+
+    operation, fla_version, fla_source = load_installed_fla(
+        args.expected_fla_version
+    )
+    output_dir = args.output_dir or default_output_dir()
+    metadata = {
+        "gpu_name": gpu_name,
+        "device": args.device,
+        "cuda_runtime": torch.version.cuda,
+        "torch_version": torch.__version__,
+        "triton_version": package_version("triton"),
+        "fla_version": fla_version,
+        "fla_source": "fla/ops/kda/chunk_fwd.py",
+        "fla_distribution_location_verified": True,
+        "warmup": args.warmup,
+        "runs": args.runs,
+        "peak_tflops": args.peak_tflops,
+        "timing_scope": "complete low-level FLA chunk_kda_fwd via CUDA events",
+        "backend_env": {
+            "FLA_DISABLE_BACKEND_DISPATCH": "1",
+            "FLA_TILELANG": "0",
+            "FLA_FLASH_KDA": "0",
+        },
+    }
+    print(
+        f"GPU={gpu_name} flash-linear-attention={fla_version} "
+        f"source={fla_source}",
+        flush=True,
+    )
+
+    results = []
+    with torch.inference_mode():
+        for case in cases:
+            print(
+                f"\n[{case.case_id}] T={case.total_tokens} "
+                f"recompute_enabled={case.recompute_enabled}",
+                flush=True,
+            )
+            try:
+                result = benchmark_case(
+                    torch,
+                    operation,
+                    case,
+                    device,
+                    args.warmup,
+                    args.runs,
+                    args.peak_tflops,
+                )
+            except Exception as exc:  # Keep later cases available after an OOM.
+                print(f"case={case.case_id} ERROR: {exc}", file=sys.stderr)
+                result = error_result(case, args.warmup, args.runs, exc)
+                gc.collect()
+                torch.cuda.empty_cache()
+            results.append(result)
+
+    write_reports(output_dir, metadata, results)
+    return 0 if all(result["status"] == "PASS" for result in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_kda_main.sh
+++ b/scripts/benchmark_kda_main.sh
@@ -103,6 +103,7 @@ while (($#)); do
         --case-timeout) case_timeout="$2"; shift 2 ;;
         --decode-step) decode_step="$2"; shift 2 ;;
         --aic-metrics) aic_metrics="$2"; shift 2 ;;
+        --aic-metrics=*) aic_metrics="${1#*=}"; shift ;;
         --ops) ops="$2"; shift 2 ;;
         --clone-retries) clone_retries="$2"; shift 2 ;;
         -h|--help) usage; exit 0 ;;

--- a/scripts/benchmark_kda_main.sh
+++ b/scripts/benchmark_kda_main.sh
@@ -26,7 +26,7 @@ usage() {
 Usage: bash scripts/benchmark_kda_main.sh [options]
 
 Build the current checkout into an isolated fla_npu wheel, then profile the KDA
-PR297 A5 positive matrix (case IDs 250-297) with msopprof. Results are written
+A5 dense matrix (case IDs 250-257) with msopprof. Results are written
 as CSV, Markdown, and JSON. Remote
 fetching is opt-in; pass both --repo-url and --ref when it is required.
 
@@ -40,7 +40,7 @@ Options:
   --cann-env FILE        CANN set_env.sh to source before building
   --conda-init FILE      Conda profile script; required with --conda-env
   --conda-env NAME       Conda environment to activate
-  --cases IDS            Comma-separated PR297 IDs/keys, or all (default: all)
+  --cases IDS            Comma-separated dense case IDs/keys, or all (default: all)
   --warm-up N            msopprof replay warm-up count (default: 5)
   --launch-count N       Maximum matching kernels to collect (default: 1)
   --case-timeout SEC     Timeout for one worker/profile command (default: 900)

--- a/scripts/benchmark_kda_main.sh
+++ b/scripts/benchmark_kda_main.sh
@@ -14,7 +14,7 @@ conda_init=""
 conda_env=""
 case_filter="all"
 warm_up="5"
-launch_count="5000"
+launch_count="1"
 case_timeout="900"
 decode_step="1"
 clone_retries="3"
@@ -42,7 +42,7 @@ Options:
   --conda-env NAME       Conda environment to activate
   --cases IDS            Comma-separated PR297 IDs/keys, or all (default: all)
   --warm-up N            msopprof replay warm-up count (default: 5)
-  --launch-count N       Maximum matching kernels to collect (default: 5000)
+  --launch-count N       Maximum matching kernels to collect (default: 1)
   --case-timeout SEC     Timeout for one worker/profile command (default: 900)
   --decode-step N        Deprecated compatibility option; only 1 is accepted
   --aic-metrics NAME     msopprof AI Core metrics set (default: Default)

--- a/scripts/benchmark_kda_main.sh
+++ b/scripts/benchmark_kda_main.sh
@@ -143,6 +143,18 @@ if [[ -n "$cann_env" ]]; then
     source_env_file "$cann_env"
 fi
 
+if [[ -z "${ASCEND_HOME_PATH:-}" && -z "${ASCEND_OPP_PATH:-}" ]]; then
+    for candidate in \
+        /usr/local/Ascend/cann/set_env.sh \
+        /usr/local/Ascend/ascend-toolkit/set_env.sh; do
+        if [[ -f "$candidate" ]]; then
+            echo "Auto-loading CANN environment: $candidate"
+            source_env_file "$candidate"
+            break
+        fi
+    done
+fi
+
 for command_name in cksum git python3 npu-smi msopprof realpath timeout; do
     command -v "$command_name" >/dev/null 2>&1 || {
         echo "Required command not found: $command_name" >&2
@@ -319,7 +331,7 @@ if ((${#wheels[@]} != 1)); then
     exit 1
 fi
 "$venv_python" -m pip install --force-reinstall --no-deps "${wheels[0]}"
-"$venv_python" "$source_dir/scripts/check_packaged_wheel_api.py"
+"$venv_python" "$source_dir/scripts/check_kda_benchmark_wheel.py"
 
 echo "[6/6] Profiling the KDA forward matrix with msopprof"
 runner=(

--- a/scripts/benchmark_kda_main.sh
+++ b/scripts/benchmark_kda_main.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+
+source_dir="$(realpath "$SCRIPT_DIR/..")"
+repo_url=""
+ref=""
+soc="${FLA_NPU_SOC:-}"
+device="0"
+work_root="${PWD}/outputs/kda-main-benchmark"
+cann_env=""
+conda_init=""
+conda_env=""
+case_filter="all"
+warm_up="5"
+launch_count="5000"
+case_timeout="900"
+decode_step="1"
+clone_retries="3"
+aic_metrics="Default"
+ops="chunk_kda_fwd,kda_gate_cumsum,chunk_gated_delta_rule_fwd_h"
+
+usage() {
+    cat <<'EOF'
+Usage: bash scripts/benchmark_kda_main.sh [options]
+
+Build the current checkout into an isolated fla_npu wheel, then profile the KDA
+PR297 A5 positive matrix (case IDs 250-297) with msopprof. Results are written
+as CSV, Markdown, and JSON. Remote
+fetching is opt-in; pass both --repo-url and --ref when it is required.
+
+Options:
+  --work-root DIR        Parent directory for source, wheel, profiles, and logs
+  --source-dir DIR       Existing source checkout (default: this repository)
+  --repo-url URL         Repository URL for an explicit remote fetch
+  --ref REF              Branch, tag, SHA, or refs/pull/<N>/head to fetch
+  --soc SOC              Required: ascend910b, ascend910_93, or ascend950
+  --device ID            Physical NPU exposed to the benchmark (default: 0)
+  --cann-env FILE        CANN set_env.sh to source before building
+  --conda-init FILE      Conda profile script; required with --conda-env
+  --conda-env NAME       Conda environment to activate
+  --cases IDS            Comma-separated PR297 IDs/keys, or all (default: all)
+  --warm-up N            msopprof replay warm-up count (default: 5)
+  --launch-count N       Maximum matching kernels to collect (default: 5000)
+  --case-timeout SEC     Timeout for one worker/profile command (default: 900)
+  --decode-step N        Deprecated compatibility option; only 1 is accepted
+  --aic-metrics NAME     msopprof AI Core metrics set (default: Default)
+                         Keep Default for full MTE/Cube/Vector/Fixpipe details
+  --ops IDS              Comma-separated operators for the scoped wheel build
+  --clone-retries N      Source fetch attempts (default: 3)
+  -h, --help             Show this help
+
+Environment:
+  FLA_NPU_SOC            SOC used when --soc is omitted
+  FLA_NPU_ALLOWED_ROOT   Optional absolute root. The script refuses writes
+                         outside it when set.
+
+Examples:
+  bash scripts/benchmark_kda_main.sh --soc ascend910b \
+    --work-root "$PWD/outputs/kda-perf"
+  bash scripts/benchmark_kda_main.sh --soc ascend950 \
+    --cann-env /path/to/Ascend/ascend-toolkit/set_env.sh
+  bash scripts/benchmark_kda_main.sh --soc ascend950 \
+    --repo-url https://github.com/example/project.git \
+    --ref refs/pull/276/head
+EOF
+}
+
+source_env_file() {
+    local path="$1"
+    set +u
+    # shellcheck disable=SC1090
+    source "$path"
+    set -u
+}
+
+cmake_version_is_supported() {
+    local version="$1"
+    if [[ "$version" =~ ^([0-9]+)\.([0-9]+)(\.[0-9]+)?$ ]]; then
+        local major="${BASH_REMATCH[1]}"
+        local minor="${BASH_REMATCH[2]}"
+        ((major == 3 && minor >= 16))
+        return
+    fi
+    return 1
+}
+
+while (($#)); do
+    case "$1" in
+        --work-root) work_root="$2"; shift 2 ;;
+        --source-dir) source_dir="$2"; shift 2 ;;
+        --repo-url) repo_url="$2"; shift 2 ;;
+        --ref) ref="$2"; shift 2 ;;
+        --soc) soc="$2"; shift 2 ;;
+        --device) device="$2"; shift 2 ;;
+        --cann-env) cann_env="$2"; shift 2 ;;
+        --conda-init) conda_init="$2"; shift 2 ;;
+        --conda-env) conda_env="$2"; shift 2 ;;
+        --cases) case_filter="$2"; shift 2 ;;
+        --warm-up) warm_up="$2"; shift 2 ;;
+        --launch-count) launch_count="$2"; shift 2 ;;
+        --case-timeout) case_timeout="$2"; shift 2 ;;
+        --decode-step) decode_step="$2"; shift 2 ;;
+        --aic-metrics) aic_metrics="$2"; shift 2 ;;
+        --ops) ops="$2"; shift 2 ;;
+        --clone-retries) clone_retries="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+[[ -n "$soc" ]] || { echo "--soc is required (or set FLA_NPU_SOC)" >&2; exit 2; }
+case "$soc" in
+    ascend910b|ascend910_93|ascend950) ;;
+    *) echo "Unsupported SOC: $soc" >&2; exit 2 ;;
+esac
+[[ "$device" =~ ^[0-9]+$ ]] || { echo "--device must be a non-negative integer" >&2; exit 2; }
+[[ "$warm_up" =~ ^[0-9]+$ ]] || { echo "--warm-up must be a non-negative integer" >&2; exit 2; }
+[[ "$launch_count" =~ ^[1-9][0-9]*$ ]] || { echo "--launch-count must be positive" >&2; exit 2; }
+[[ "$case_timeout" =~ ^[1-9][0-9]*$ ]] || { echo "--case-timeout must be positive" >&2; exit 2; }
+[[ "$decode_step" == "1" ]] || { echo "--decode-step is deprecated and only accepts 1" >&2; exit 2; }
+[[ "$clone_retries" =~ ^[1-9][0-9]*$ ]] || { echo "--clone-retries must be positive" >&2; exit 2; }
+[[ -n "$aic_metrics" ]] || { echo "--aic-metrics must not be empty" >&2; exit 2; }
+[[ -n "$ops" ]] || { echo "--ops must not be empty" >&2; exit 2; }
+if [[ -n "$repo_url" || -n "$ref" ]]; then
+    [[ -n "$repo_url" && -n "$ref" ]] || {
+        echo "--repo-url and --ref must be provided together" >&2
+        exit 2
+    }
+fi
+
+if [[ -n "$conda_env" ]]; then
+    [[ -n "$conda_init" ]] || { echo "--conda-init is required with --conda-env" >&2; exit 2; }
+    [[ -f "$conda_init" ]] || { echo "Conda profile script not found: $conda_init" >&2; exit 2; }
+    source_env_file "$conda_init"
+    conda activate "$conda_env"
+fi
+
+if [[ -n "$cann_env" ]]; then
+    [[ -f "$cann_env" ]] || { echo "CANN environment script not found: $cann_env" >&2; exit 2; }
+    source_env_file "$cann_env"
+fi
+
+for command_name in cksum git python3 npu-smi msopprof realpath timeout; do
+    command -v "$command_name" >/dev/null 2>&1 || {
+        echo "Required command not found: $command_name" >&2
+        exit 1
+    }
+done
+python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)' || {
+    echo "Python 3.9 or newer is required; found $(python3 --version 2>&1)" >&2
+    exit 1
+}
+[[ -n "${ASCEND_HOME_PATH:-}" || -n "${ASCEND_OPP_PATH:-}" ]] || {
+    echo "CANN is not active. Source set_env.sh or pass --cann-env." >&2
+    exit 1
+}
+
+mkdir -p -- "$work_root"
+work_root="$(realpath "$work_root")"
+[[ "$work_root" != "/" ]] || { echo "Refusing to use / as --work-root" >&2; exit 2; }
+if [[ -n "${FLA_NPU_ALLOWED_ROOT:-}" ]]; then
+    allowed_root="$(realpath "${FLA_NPU_ALLOWED_ROOT}")"
+    case "$work_root/" in
+        "$allowed_root"/*) ;;
+        *) echo "Work root is outside FLA_NPU_ALLOWED_ROOT: $work_root" >&2; exit 2 ;;
+    esac
+fi
+
+timestamp="$(date +%Y%m%d_%H%M%S)"
+run_dir="$work_root/run_${timestamp}_$$"
+cache_root="$work_root/cache"
+fetched_source_dir="$cache_root/source"
+wheel_dir="$run_dir/wheel"
+pip_cache_dir="$cache_root/pip"
+tmp_dir="$run_dir/tmp"
+result_dir="$run_dir/results"
+base_python="$(realpath "$(command -v python3)")"
+python_key="$("$base_python" -c 'import sys; print(sys.executable, sys.prefix, sys.version_info[:2])' | cksum | awk '{print $1}')"
+venv_dir="$cache_root/venv_${python_key}"
+mkdir -p -- "$run_dir" "$cache_root" "$pip_cache_dir" "$wheel_dir" "$tmp_dir" "$result_dir"
+
+on_error() {
+    status=$?
+    echo "Benchmark failed with status $status. Logs and partial outputs: $run_dir" >&2
+    exit "$status"
+}
+trap on_error ERR
+
+echo "[1/6] Checking NPU $device"
+npu-smi info -t board -i "$device" >/dev/null
+
+if [[ -n "$repo_url" ]]; then
+    echo "[2/6] Fetching $repo_url at $ref"
+    source_dir="$fetched_source_dir"
+    if [[ ! -d "$source_dir/.git" ]]; then
+        git init "$source_dir"
+        git -C "$source_dir" remote add origin "$repo_url"
+    elif [[ "$(git -C "$source_dir" remote get-url origin)" != "$repo_url" ]]; then
+        echo "Cached source uses a different origin: $source_dir" >&2
+        exit 1
+    fi
+    fetch_succeeded="0"
+    for ((attempt = 1; attempt <= clone_retries; attempt++)); do
+        echo "Source fetch attempt $attempt/$clone_retries"
+        fetch_args=(
+            -C "$source_dir"
+            -c http.lowSpeedLimit=1000
+            -c http.lowSpeedTime=30
+            fetch --depth 1 --filter=blob:none origin "$ref"
+        )
+        if GIT_TERMINAL_PROMPT=0 timeout 90 git "${fetch_args[@]}"; then
+            fetch_succeeded="1"
+            break
+        fi
+        ((attempt == clone_retries)) || sleep 5
+    done
+    [[ "$fetch_succeeded" == "1" ]] || { echo "Unable to fetch $repo_url at $ref" >&2; exit 1; }
+    git -C "$source_dir" checkout --detach --force FETCH_HEAD
+else
+    source_dir="$(realpath "$source_dir")"
+    [[ -d "$source_dir/.git" || -f "$source_dir/.git" ]] || {
+        echo "--source-dir is not a Git checkout: $source_dir" >&2
+        exit 2
+    }
+    echo "[2/6] Using local source checkout: $source_dir"
+    if [[ -n "$(git -C "$source_dir" status --short --untracked-files=no)" ]]; then
+        echo "Source checkout has tracked changes; the wheel will include them." >&2
+    fi
+fi
+commit="$(git -C "$source_dir" rev-parse HEAD)"
+runner_script="$source_dir/scripts/benchmark_kda_matrix.py"
+[[ -f "$runner_script" ]] || { echo "Benchmark runner is missing: $runner_script" >&2; exit 1; }
+echo "Source commit: $commit"
+
+echo "[3/6] Creating isolated Python environment"
+if [[ ! -x "$venv_dir/bin/python" ]]; then
+    "$base_python" -m venv --system-site-packages "$venv_dir"
+else
+    echo "Reusing cached Python environment: $venv_dir"
+fi
+venv_python="$venv_dir/bin/python"
+export PATH="$venv_dir/bin:$PATH"
+export PIP_CACHE_DIR="$pip_cache_dir"
+"$venv_python" -c 'import torch, torch_npu; print(f"torch={torch.__version__} torch_npu={torch_npu.__version__}")'
+
+echo "[4/6] Installing and checking build dependencies"
+build_requirements=(
+    "setuptools>=70.1"
+    wheel
+    packaging
+    psutil
+)
+cmake_version=""
+if command -v cmake >/dev/null 2>&1; then
+    cmake_version="$(cmake --version | sed -n '1s/^cmake version //p')"
+fi
+if ! cmake_version_is_supported "$cmake_version"; then
+    build_requirements+=("cmake>=3.16,<4")
+fi
+if ! command -v patch >/dev/null 2>&1; then
+    build_requirements+=("patch-ng==1.19.1")
+fi
+"$venv_python" -m pip install "${build_requirements[@]}"
+
+if ! command -v patch >/dev/null 2>&1; then
+    export FLA_NPU_PATCH_PYTHON="$venv_python"
+    patch_wrapper="$venv_dir/bin/patch"
+    cat > "$patch_wrapper" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${FLA_NPU_PATCH_PYTHON:?FLA_NPU_PATCH_PYTHON is required}"
+case "${1:-}" in
+    --version|-h|--help)
+        exec "$FLA_NPU_PATCH_PYTHON" -m patch_ng "$@"
+        ;;
+    -p1)
+        shift
+        set -- -p0 "$@"
+        ;;
+esac
+patch_input="$(mktemp "${TMPDIR:-/tmp}/fla-npu-patch.XXXXXX")"
+trap 'rm -f -- "$patch_input"' EXIT
+cat > "$patch_input"
+"$FLA_NPU_PATCH_PYTHON" -m patch_ng "$@" "$patch_input"
+EOF
+    chmod +x "$patch_wrapper"
+    echo "GNU patch not found; using the isolated patch-ng compatibility wrapper"
+fi
+
+for build_command in cmake make patch; do
+    command -v "$build_command" >/dev/null 2>&1 || {
+        echo "Required build command not found: $build_command" >&2
+        exit 1
+    }
+done
+echo "cmake=$(cmake --version | sed -n '1p')"
+echo "patch=$(patch --version | sed -n '1p')"
+export FLA_NPU_SOC="$soc"
+export FLA_NPU_OPS="$ops"
+export FLA_NPU_BUILD_LEGACY_EXTENSION="FALSE"
+export TMPDIR="$tmp_dir"
+export TORCH_EXTENSIONS_DIR="$run_dir/torch_extensions"
+export ASCEND_RT_VISIBLE_DEVICES="$device"
+mkdir -p -- "$TORCH_EXTENSIONS_DIR"
+"$venv_python" "$source_dir/scripts/check_npu_env.py" --build-only
+
+echo "[5/6] Building and installing the main-branch wheel"
+(
+    cd "$source_dir"
+    "$venv_python" -m pip wheel --no-build-isolation --no-deps . -w "$wheel_dir"
+)
+mapfile -t wheels < <(find "$wheel_dir" -maxdepth 1 -type f -name 'flash_linear_attention_npu-*.whl' -print)
+if ((${#wheels[@]} != 1)); then
+    echo "Expected one fla_npu wheel, found ${#wheels[@]}" >&2
+    exit 1
+fi
+"$venv_python" -m pip install --force-reinstall --no-deps "${wheels[0]}"
+"$venv_python" "$source_dir/scripts/check_packaged_wheel_api.py"
+
+echo "[6/6] Profiling the KDA forward matrix with msopprof"
+runner=(
+    "$runner_script"
+    --output-dir "$result_dir"
+    --repo-dir "$source_dir"
+    --repo-commit "$commit"
+    --soc "$soc"
+    --device-visible-id 0
+    --cases "$case_filter"
+    --warm-up "$warm_up"
+    --launch-count "$launch_count"
+    --case-timeout "$case_timeout"
+    --aic-metrics "$aic_metrics"
+)
+"$venv_python" "${runner[@]}"
+
+trap - ERR
+echo "Completed. Results: $result_dir/results.md"

--- a/scripts/benchmark_kda_main.sh
+++ b/scripts/benchmark_kda_main.sh
@@ -189,10 +189,14 @@ wheel_dir="$run_dir/wheel"
 pip_cache_dir="$cache_root/pip"
 tmp_dir="$run_dir/tmp"
 result_dir="$run_dir/results"
+ascend_log_dir="$run_dir/ascend_logs"
 base_python="$(realpath "$(command -v python3)")"
 python_key="$("$base_python" -c 'import sys; print(sys.executable, sys.prefix, sys.version_info[:2])' | cksum | awk '{print $1}')"
 venv_dir="$cache_root/venv_${python_key}"
-mkdir -p -- "$run_dir" "$cache_root" "$pip_cache_dir" "$wheel_dir" "$tmp_dir" "$result_dir"
+mkdir -p -- "$run_dir" "$cache_root" "$pip_cache_dir" "$wheel_dir" "$tmp_dir" "$result_dir" "$ascend_log_dir"
+export ASCEND_PROCESS_LOG_PATH="$ascend_log_dir"
+export ASCEND_HOST_LOG_FILE_NUM="${ASCEND_HOST_LOG_FILE_NUM:-10}"
+echo "Ascend process logs: $ASCEND_PROCESS_LOG_PATH"
 
 on_error() {
     status=$?

--- a/scripts/benchmark_kda_matrix.py
+++ b/scripts/benchmark_kda_matrix.py
@@ -219,7 +219,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--device-visible-id", type=int, default=0)
     parser.add_argument("--cases", default="all")
     parser.add_argument("--warm-up", type=int, default=5)
-    parser.add_argument("--launch-count", type=int, default=5000)
+    parser.add_argument("--launch-count", type=int, default=1)
     parser.add_argument("--case-timeout", type=int, default=900)
     parser.add_argument("--decode-step", type=int, default=1, help=argparse.SUPPRESS)
     parser.add_argument("--aic-metrics", default="Default")
@@ -795,34 +795,20 @@ def profile_attempts(
         f"--aic-metrics={args.aic_metrics}",
         f"--launch-count={args.launch_count}",
         f"--warm-up={args.warm_up}",
-        "--replay-mode=application",
+        "--replay-mode=kernel",
         "--kill=off",
     ]
     return [
         {
-            "mode": "application_mstx",
-            "profile_dir": case_dir / "application_mstx",
+            "mode": "kernel_filter",
+            "profile_dir": case_dir / "kernel_filter",
             "metric_scope": (
-                "sum of median msopprof BasicInfo durations in the KDA MSTX range "
-                "using application replay"
+                "msopprof BasicInfo duration for one selected KDA kernel using "
+                "a single application launch and kernel replay"
             ),
             "command": [
                 *common_options,
-                f"--output={case_dir / 'application_mstx'}",
-                "--mstx=on",
-                f"--mstx-include={PROFILE_RANGE}",
-            ],
-        },
-        {
-            "mode": "application_kernel_filter",
-            "profile_dir": case_dir / "application_kernel_filter",
-            "metric_scope": (
-                "sum of median msopprof BasicInfo durations for explicitly selected "
-                "KDA stages using application replay"
-            ),
-            "command": [
-                *common_options,
-                f"--output={case_dir / 'application_kernel_filter'}",
+                f"--output={case_dir / 'kernel_filter'}",
                 f"--kernel-name={kernel_name_filter(case)}",
             ],
         },
@@ -1343,8 +1329,7 @@ def write_reports(args: argparse.Namespace, results: list[dict]) -> None:
         "aic_metrics": args.aic_metrics,
         "matrix_contract": "PR297 A5 positive case IDs 250-297",
         "profile_attempt_order": [
-            "application replay with MSTX range filtering",
-            "application replay with explicit KDA stage filtering",
+            "single application launch with KDA kernel filtering and kernel replay",
         ],
     }
     try:
@@ -1423,7 +1408,7 @@ def write_reports(args: argparse.Namespace, results: list[dict]) -> None:
         "- unit: microseconds",
         f"- msopprof AI Core metrics: `{args.aic_metrics}`",
         "- matrix: PR297 A5 positive cases 250-297",
-        "- metric: sum of median msopprof BasicInfo durations for selected KDA stages",
+        "- metric: msopprof BasicInfo duration for one selected KDA kernel",
         "- full per-case kernel resources: `kernel_detail.xlsx` (one sheet per case)",
         "",
         "| ATK case | total tokens | sequence distribution | sequence count | chunk count | "

--- a/scripts/benchmark_kda_matrix.py
+++ b/scripts/benchmark_kda_matrix.py
@@ -15,6 +15,7 @@ import signal
 import statistics
 import subprocess
 import sys
+import threading
 import zipfile
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -711,12 +712,28 @@ def run_logged(command, *, cwd: Path, env: dict, log, timeout: int) -> tuple[int
         command,
         cwd=cwd,
         env=env,
-        stdout=log,
+        stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        bufsize=1,
         start_new_session=True,
     )
+
+    def copy_output() -> None:
+        assert process.stdout is not None
+        for line in process.stdout:
+            log.write(line)
+            log.flush()
+            print(f"    {line}", end="", flush=True)
+
+    output_thread = threading.Thread(target=copy_output, daemon=True)
+    output_thread.start()
     try:
-        return process.wait(timeout=timeout), False
+        returncode = process.wait(timeout=timeout)
+        output_thread.join(timeout=10)
+        return returncode, False
     except subprocess.TimeoutExpired:
         try:
             os.killpg(process.pid, signal.SIGTERM)
@@ -730,6 +747,7 @@ def run_logged(command, *, cwd: Path, env: dict, log, timeout: int) -> tuple[int
             except ProcessLookupError:
                 pass
             process.wait()
+        output_thread.join(timeout=10)
         return process.returncode, True
 
 
@@ -844,6 +862,11 @@ def run_profile(args: argparse.Namespace, case: Case) -> dict:
         "profiled_segment_us": None,
     }
     with preflight_log_path.open("w", encoding="utf-8") as preflight_log:
+        print(
+            f"    preflight started (timeout={args.case_timeout}s, "
+            f"log={preflight_log_path})",
+            flush=True,
+        )
         preflight_returncode, preflight_timed_out = run_logged(
             worker,
             cwd=args.repo_dir,
@@ -851,6 +874,7 @@ def run_profile(args: argparse.Namespace, case: Case) -> dict:
             log=preflight_log,
             timeout=args.case_timeout,
         )
+    print(f"    preflight finished (status={preflight_returncode})", flush=True)
     if preflight_timed_out:
         result["status"] = "TIMEOUT"
         result["log"] = str(preflight_log_path)
@@ -891,6 +915,11 @@ def run_profile(args: argparse.Namespace, case: Case) -> dict:
         with log_path.open("w", encoding="utf-8") as log:
             log.write(f"command={shell_join(command)}\n")
             log.flush()
+            print(
+                f"    profiler started (mode={mode}, timeout={args.case_timeout}s, "
+                f"log={log_path})",
+                flush=True,
+            )
             profile_returncode, profile_timed_out = run_logged(
                 command,
                 cwd=args.repo_dir,
@@ -898,6 +927,10 @@ def run_profile(args: argparse.Namespace, case: Case) -> dict:
                 log=log,
                 timeout=args.case_timeout,
             )
+        print(
+            f"    profiler finished (mode={mode}, status={profile_returncode})",
+            flush=True,
+        )
         log_text = log_path.read_text(encoding="utf-8", errors="replace")
         if profile_timed_out:
             attempt_statuses.append("TIMEOUT")

--- a/scripts/benchmark_kda_matrix.py
+++ b/scripts/benchmark_kda_matrix.py
@@ -1,0 +1,1447 @@
+#!/usr/bin/env python3
+"""Profile the requested KDA matrix with msopprof."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import platform
+import re
+import shlex
+import shutil
+import signal
+import statistics
+import subprocess
+import sys
+import zipfile
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+from xml.sax.saxutils import escape, quoteattr
+
+
+HEADS = 96
+KEY_DIM = 128
+VALUE_DIM = 128
+CHUNK_SIZE = 64
+PROFILE_RANGE = "FLA_NPU_KDA_BENCH"
+ATK_CASE_ID_START = 250
+SEQUENCE_LENGTHS = (1024, 1536, 2048, 4096, 8192, 16384)
+DISTRIBUTIONS = ("single", "balanced8", "mixed_tail", "short64")
+SEED_BASE = 20260812
+PREFILL_KERNEL_FILTER = "|".join(
+    (
+        "ChunkKdaFwd*",
+        "chunk_kda_fwd*",
+        "ChunkKdaFwdPrepare*",
+        "chunk_kda_fwd_prepare*",
+        "ChunkKdaFwdPostWu*",
+        "chunk_kda_fwd_post_wu*",
+        "ChunkGatedDeltaRuleFwdH*",
+        "chunk_gated_delta_rule_fwd_h*",
+        "ChunkKdaFwdFinalize*",
+        "chunk_kda_fwd_finalize*",
+    )
+)
+BASIC_INFO_FILE = re.compile(r"^OpBasicInfo(?:_.*)?\.csv$", re.IGNORECASE)
+PROFILE_METRIC_NAMES = (
+    "OpBasicInfo",
+    "PipeUtilization",
+    "ArithmeticUtilization",
+    "Memory",
+    "MemoryL0",
+    "MemoryUB",
+    "L2Cache",
+    "ResourceConflictRatio",
+)
+DETAIL_ALIASES = {
+    "task_duration_us": ("Task Duration(us)", "task_duration(us)"),
+    "aic_time_us": ("aic_time(us)",),
+    "aiv_time_us": ("aiv_time(us)",),
+    "mac_time_us": ("MAC Time(us)", "Mac Time(us)", "aic_cube_time(us)"),
+    "cube_time_us": ("aic_cube_time(us)",),
+    "cube_ratio": ("aic_cube_ratio",),
+    "cube_fp_ratio": ("aic_cube_fp_ratio",),
+    "cube_int_ratio": ("aic_cube_int_ratio",),
+    "vec_time_us": ("aiv_vec_time(us)",),
+    "vec_ratio": ("aiv_vec_ratio",),
+    "vec_vf_ratio": ("aiv_vec_vf_ratio",),
+    "vec_sfu_ratio": ("aiv_vec_sfu_ratio",),
+    "vec_simt_vf_ratio": ("aiv_vec_simt_vf_ratio",),
+    "aic_mte1_time_us": ("aic_mte1_time(us)",),
+    "aic_mte1_ratio": ("aic_mte1_ratio",),
+    "aic_mte1_active_bw_gb_s": ("aic_mte1_active_bw(GB/s)",),
+    "aic_mte2_time_us": ("aic_mte2_time(us)",),
+    "aic_mte2_ratio": ("aic_mte2_ratio",),
+    "aic_mte2_active_bw_gb_s": ("aic_mte2_active_bw(GB/s)",),
+    "aic_mte3_time_us": ("aic_mte3_time(us)",),
+    "aic_mte3_ratio": ("aic_mte3_ratio",),
+    "aic_mte3_active_bw_gb_s": ("aic_mte3_active_bw(GB/s)",),
+    "aic_fixpipe_time_us": ("aic_fixpipe_time(us)",),
+    "aic_fixpipe_ratio": ("aic_fixpipe_ratio",),
+    "aic_fixpipe_active_bw_gb_s": ("aic_fixpipe_active_bw(GB/s)",),
+    "aiv_mte2_time_us": ("aiv_mte2_time(us)",),
+    "aiv_mte2_ratio": ("aiv_mte2_ratio",),
+    "aiv_mte2_active_bw_gb_s": ("aiv_mte2_active_bw(GB/s)",),
+    "aiv_mte3_time_us": ("aiv_mte3_time(us)",),
+    "aiv_mte3_ratio": ("aiv_mte3_ratio",),
+    "aiv_mte3_active_bw_gb_s": ("aiv_mte3_active_bw(GB/s)",),
+    "aic_scalar_time_us": ("aic_scalar_time(us)",),
+    "aic_scalar_ratio": ("aic_scalar_ratio",),
+    "aiv_scalar_time_us": ("aiv_scalar_time(us)",),
+    "aiv_scalar_ratio": ("aiv_scalar_ratio",),
+}
+DIAGNOSTIC_TREE_LIMIT = 500
+DIAGNOSTIC_CSV_LIMIT = 100
+DIAGNOSTIC_LOG_LINES = 240
+
+
+@dataclass(frozen=True)
+class Case:
+    atk_case_id: int
+    case_id: str
+    case_key: str
+    phase: str
+    direction: str
+    batch: int
+    sequence: int
+    distribution: str
+    disable_recompute: bool
+    layout: str
+    cu_seqlens: tuple[int, ...]
+    explicit_chunk_indices: bool
+    seed: int
+    h100_us: Optional[float]
+    optimized_npu_us: Optional[float]
+
+
+def distribution_lengths(total: int, distribution: str) -> list[int]:
+    if distribution == "single":
+        return [total]
+    if distribution == "balanced8":
+        quotient, remainder = divmod(total, 8)
+        return [quotient + (index < remainder) for index in range(8)]
+    if distribution == "mixed_tail":
+        base = total // 8
+        values = [
+            base - 47,
+            base + 31,
+            base - 1,
+            base + 17,
+            base - 33,
+            base + 49,
+            base - 15,
+        ]
+        values.append(total - sum(values))
+        return values
+    if distribution == "short64":
+        quotient, remainder = divmod(total, CHUNK_SIZE)
+        values = [CHUNK_SIZE] * quotient
+        if remainder:
+            values.append(remainder)
+        return values
+    raise ValueError(f"unknown distribution: {distribution}")
+
+
+def cumulative_lengths(lengths: Iterable[int]) -> tuple[int, ...]:
+    values = [0]
+    for length in lengths:
+        if length <= 0:
+            raise ValueError(f"sequence length must be positive, got {length}")
+        values.append(values[-1] + int(length))
+    return tuple(values)
+
+
+def build_atk_cases() -> tuple[Case, ...]:
+    cases = []
+    pair_id = 0
+    for sequence in SEQUENCE_LENGTHS:
+        for distribution in DISTRIBUTIONS:
+            cu_seqlens = cumulative_lengths(
+                distribution_lengths(sequence, distribution)
+            )
+            for disable_recompute in (False, True):
+                atk_case_id = ATK_CASE_ID_START + pair_id * 2 + int(disable_recompute)
+                mode = "export" if disable_recompute else "recompute"
+                case_key = (
+                    f"ascend950_h96_t{sequence}_c64_packed_{distribution}_{mode}"
+                )
+                cases.append(
+                    Case(
+                        atk_case_id=atk_case_id,
+                        case_id=str(atk_case_id),
+                        case_key=case_key,
+                        phase="prefill",
+                        direction="fwd",
+                        batch=1,
+                        sequence=sequence,
+                        distribution=distribution,
+                        disable_recompute=disable_recompute,
+                        layout="BSND",
+                        cu_seqlens=cu_seqlens,
+                        explicit_chunk_indices=False,
+                        seed=SEED_BASE + pair_id,
+                        h100_us=None,
+                        optimized_npu_us=None,
+                    )
+                )
+            pair_id += 1
+    result = tuple(cases)
+    ids = tuple(case.atk_case_id for case in result)
+    if len(result) != 48 or ids != tuple(range(250, 298)):
+        raise RuntimeError("PR297 performance matrix must contain case IDs 250-297")
+    return result
+
+
+CASES = build_atk_cases()
+CASE_BY_ID = {case.case_id: case for case in CASES}
+CASE_BY_KEY = {case.case_key: case for case in CASES}
+LEGACY_CASE_ALIASES = {
+    "prefill_fwd_b1_s1024": "250",
+    "prefill_fwd_b1_s8192": "282",
+    "prefill_fwd_b1_s16384": "290",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--repo-dir", type=Path)
+    parser.add_argument("--repo-commit", default="unknown")
+    parser.add_argument("--soc", default="unknown")
+    parser.add_argument("--device-visible-id", type=int, default=0)
+    parser.add_argument("--cases", default="all")
+    parser.add_argument("--warm-up", type=int, default=5)
+    parser.add_argument("--launch-count", type=int, default=5000)
+    parser.add_argument("--case-timeout", type=int, default=900)
+    parser.add_argument("--decode-step", type=int, default=1, help=argparse.SUPPRESS)
+    parser.add_argument("--aic-metrics", default="Default")
+    parser.add_argument("--list-cases", action="store_true")
+    parser.add_argument("--worker")
+    return parser.parse_args()
+
+
+def selected_cases(value: str) -> list[Case]:
+    if value == "all":
+        return list(CASES)
+    ids = [
+        LEGACY_CASE_ALIASES.get(item.strip(), item.strip())
+        for item in value.split(",")
+        if item.strip()
+    ]
+    selectors = {**CASE_BY_KEY, **CASE_BY_ID}
+    unknown = sorted(set(ids) - set(selectors))
+    if unknown:
+        raise ValueError(f"unknown case IDs: {', '.join(unknown)}")
+    return [selectors[case_id] for case_id in ids]
+
+
+def shell_join(command: Iterable[object]) -> str:
+    return " ".join(shlex.quote(str(part)) for part in command)
+
+
+def normal_quantized(
+    torch,
+    shape,
+    generator,
+    original_dtype,
+    device,
+    *,
+    mean: float = 0.0,
+    std: float = 1.0,
+    sigmoid: bool = False,
+    l2_normalize: bool = False,
+):
+    value = torch.randn(shape, generator=generator, dtype=torch.float32)
+    value = value.mul(std).add(mean)
+    if sigmoid:
+        value = torch.sigmoid(value)
+    if l2_normalize:
+        value = value * torch.rsqrt(value.square().sum(dim=-1, keepdim=True) + 1e-6)
+    return value.to(original_dtype).to(device)
+
+
+def canonical_chunk_indices(
+    cu_seqlens: tuple[int, ...], chunk_size: int
+) -> tuple[int, ...]:
+    indices = []
+    for seq_id, (start, end) in enumerate(zip(cu_seqlens, cu_seqlens[1:])):
+        for chunk_id in range((end - start + chunk_size - 1) // chunk_size):
+            indices.extend((seq_id, chunk_id))
+    return tuple(indices)
+
+
+def make_prefill_inputs(torch, case: Case, device):
+    shape = (case.batch, case.sequence, HEADS, KEY_DIM)
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(case.seed)
+    q = normal_quantized(
+        torch, shape, generator, torch.bfloat16, device,
+        std=0.05, l2_normalize=True,
+    )
+    k = normal_quantized(
+        torch, shape, generator, torch.bfloat16, device,
+        std=0.05, l2_normalize=True,
+    )
+    v = normal_quantized(
+        torch, shape, generator, torch.bfloat16, device, std=0.05,
+    )
+    gate = normal_quantized(
+        torch, shape, generator, torch.float32, device, std=1.25,
+    )
+    beta = normal_quantized(
+        torch,
+        (case.batch, case.sequence, HEADS),
+        generator,
+        torch.bfloat16,
+        device,
+        mean=1.5,
+        std=0.35,
+        sigmoid=True,
+    )
+    a_log = normal_quantized(
+        torch, (HEADS,), generator, torch.float32, device, std=0.12,
+    )
+    dt_bias = normal_quantized(
+        torch,
+        (HEADS * KEY_DIM,),
+        generator,
+        torch.float32,
+        device,
+        mean=-3.0,
+        std=1.65,
+    )
+    return q, k, v, gate, beta, a_log, dt_bias
+
+
+def run_in_profile_range(torch, operation):
+    import torch_npu
+
+    range_id = torch_npu.npu.mstx.range_start(PROFILE_RANGE)
+    if not isinstance(range_id, int):
+        raise RuntimeError("torch_npu MSTX range_start is unavailable")
+    try:
+        output = operation()
+        torch.npu.synchronize()
+        return output
+    finally:
+        torch_npu.npu.mstx.range_end(range_id)
+
+
+def run_prefill_forward(torch, case: Case, device) -> None:
+    from fla_npu.ops.ascendc import chunk_kda_fwd
+
+    q, k, v, gate, beta, a_log, dt_bias = make_prefill_inputs(torch, case, device)
+    chunk_indices = (
+        canonical_chunk_indices(case.cu_seqlens, CHUNK_SIZE)
+        if case.explicit_chunk_indices
+        else None
+    )
+    torch.npu.synchronize()
+    outputs = run_in_profile_range(
+        torch,
+        lambda: chunk_kda_fwd(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            KEY_DIM**-0.5,
+            CHUNK_SIZE,
+            layout="BSND",
+            initial_state=None,
+            output_final_state=False,
+            cu_seqlens=list(case.cu_seqlens),
+            chunk_indices=chunk_indices,
+            safe_gate=True,
+            lower_bound=-5.0,
+            use_gate_in_kernel=True,
+            A_log=a_log,
+            dt_bias=dt_bias,
+            disable_recompute=case.disable_recompute,
+            return_intermediate_states=False,
+            state_v_first=True,
+        ),
+    )
+    print(
+        f"BENCH_OK atk_case_id={case.atk_case_id} case_key={case.case_key} "
+        f"output_shape={tuple(outputs[0].shape)}",
+        flush=True,
+    )
+
+
+def run_worker(case: Case, device_visible_id: int) -> int:
+    import torch
+    import torch_npu  # noqa: F401
+
+    device = torch.device(f"npu:{device_visible_id}")
+    torch.npu.set_device(device)
+    torch.manual_seed(case.seed)
+    run_prefill_forward(torch, case, device)
+    return 0
+
+
+def iter_profile_files(profile_dir: Path) -> Iterable[Path]:
+    visited = set()
+    for root, dirnames, filenames in os.walk(profile_dir, followlinks=True):
+        try:
+            stat = os.stat(root)
+        except OSError:
+            dirnames.clear()
+            continue
+        directory_id = (stat.st_dev, stat.st_ino)
+        if directory_id in visited:
+            dirnames.clear()
+            continue
+        visited.add(directory_id)
+        dirnames.sort()
+        filenames.sort()
+        for filename in filenames:
+            yield Path(root) / filename
+
+
+def profile_metric_name(path: Path) -> Optional[str]:
+    stem = path.stem.lower()
+    for name in sorted(PROFILE_METRIC_NAMES, key=len, reverse=True):
+        lowered = name.lower()
+        if stem == lowered or stem.startswith(f"{lowered}_"):
+            return name
+    return None
+
+
+def normalized_csv_row(row: dict) -> dict[str, str]:
+    return {
+        (key or "").strip(): "" if value is None else value.strip()
+        for key, value in row.items()
+        if (key or "").strip()
+    }
+
+
+def profile_row_location(
+    path: Path, row: dict[str, str], row_index: int
+) -> tuple[str, str]:
+    if path.parent.name.isdigit():
+        return path.parent.parent.name, path.parent.name
+    del row_index
+    replay = row.get("Task ID") or row.get("task_id") or "0"
+    return path.parent.name, replay
+
+
+def merge_raw_fields(target: dict, metric_name: str, source: dict[str, str]) -> None:
+    for key, value in source.items():
+        if key not in target or target[key] in ("", None):
+            target[key] = value
+        elif value not in ("", None) and target[key] != value:
+            target[f"{metric_name}.{key}"] = value
+
+
+def read_kernel_detail_rows(profile_dir: Path) -> list[dict]:
+    tables: dict[tuple[str, str], dict[str, list[dict]]] = {}
+    for path in iter_profile_files(profile_dir):
+        metric_name = profile_metric_name(path)
+        if metric_name is None:
+            continue
+        with path.open(newline="", encoding="utf-8-sig", errors="replace") as stream:
+            for row_index, row in enumerate(csv.DictReader(stream)):
+                normalized = normalized_csv_row(row)
+                instance, replay = profile_row_location(path, normalized, row_index)
+                tables.setdefault((instance, replay), {}).setdefault(
+                    metric_name, []
+                ).append(
+                    {
+                        "row_index": row_index,
+                    "source_csv": relative_display(path, profile_dir),
+                        "fields": normalized,
+                    }
+                )
+
+    records = []
+    for (instance, replay), metric_tables in tables.items():
+        basic_rows = metric_tables.get("OpBasicInfo", [])
+        resource_rows: dict[tuple[str, str, str], dict] = {}
+        for metric_name, rows in metric_tables.items():
+            if metric_name == "OpBasicInfo":
+                continue
+            for row in rows:
+                fields = row["fields"]
+                block_id = fields.get("block_id", fields.get("Block Id", ""))
+                sub_block_id = fields.get(
+                    "sub_block_id", fields.get("Sub Block Id", "")
+                )
+                identity = (
+                    block_id,
+                    sub_block_id,
+                    str(row["row_index"]) if block_id == "" else "",
+                )
+                record = resource_rows.setdefault(
+                    identity,
+                    {
+                        "kernel_instance": instance,
+                        "replay": replay,
+                        "block_id": block_id,
+                        "sub_block_id": sub_block_id,
+                        "metric_file_types": set(),
+                        "source_csvs": set(),
+                    },
+                )
+                record["metric_file_types"].add(metric_name)
+                record["source_csvs"].add(row["source_csv"])
+                merge_raw_fields(record, metric_name, fields)
+
+        if not resource_rows:
+            for row_index, basic in enumerate(basic_rows or ({"fields": {}},)):
+                resource_rows[("", "", str(row_index))] = {
+                    "kernel_instance": instance,
+                    "replay": replay,
+                    "block_id": "",
+                    "sub_block_id": "",
+                    "metric_file_types": set(),
+                    "source_csvs": set(),
+                }
+
+        for row_index, record in enumerate(resource_rows.values()):
+            if basic_rows:
+                basic = basic_rows[min(row_index, len(basic_rows) - 1)]
+                record["metric_file_types"].add("OpBasicInfo")
+                record["source_csvs"].add(basic["source_csv"])
+                merge_raw_fields(record, "OpBasicInfo", basic["fields"])
+            record["metric_file_types"] = ",".join(
+                sorted(record["metric_file_types"])
+            )
+            record["source_csvs"] = ",".join(sorted(record["source_csvs"]))
+            records.append(record)
+    records.sort(
+        key=lambda item: (
+            natural_sort_key(str(item["kernel_instance"])),
+            natural_sort_key(str(item["replay"])),
+            natural_sort_key(str(item["block_id"])),
+            natural_sort_key(str(item["sub_block_id"])),
+        )
+    )
+    return records
+
+
+def read_profile_rows(profile_dir: Path) -> list[dict]:
+    records = []
+    for path in iter_profile_files(profile_dir):
+        if not BASIC_INFO_FILE.fullmatch(path.name):
+            continue
+        with path.open(newline="", encoding="utf-8-sig") as stream:
+            for row in csv.DictReader(stream):
+                normalized = normalized_csv_row(row)
+                duration = normalized.get("Task Duration(us)")
+                if not duration:
+                    continue
+                instance, replay = profile_row_location(
+                    path, normalized, len(records)
+                )
+                records.append(
+                    {
+                        "instance": instance,
+                        "replay": replay,
+                        "op_name": normalized.get("Op Name", instance),
+                        "op_type": normalized.get("Op Type", ""),
+                        "duration_us": float(duration),
+                        "discovery_index": len(records),
+                    }
+                )
+    return records
+
+
+def relative_display(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def profile_tree_lines(profile_dir: Path) -> list[str]:
+    if not profile_dir.exists():
+        return ["<profile directory does not exist>"]
+    lines = []
+    try:
+        paths = sorted(profile_dir.rglob("*"), key=lambda item: str(item))
+    except OSError as exc:
+        return [f"<unable to enumerate profile directory: {exc}>"]
+    for path in paths[:DIAGNOSTIC_TREE_LIMIT]:
+        display = relative_display(path, profile_dir)
+        try:
+            if path.is_symlink():
+                lines.append(f"LINK {display} -> {os.readlink(path)}")
+            elif path.is_dir():
+                lines.append(f"DIR  {display}/")
+            else:
+                lines.append(f"FILE {display} size={path.stat().st_size}")
+        except OSError as exc:
+            lines.append(f"ERR  {display}: {exc}")
+    if len(paths) > DIAGNOSTIC_TREE_LIMIT:
+        lines.append(f"... truncated {len(paths) - DIAGNOSTIC_TREE_LIMIT} entries")
+    return lines or ["<profile directory is empty>"]
+
+
+def csv_diagnostic_lines(profile_dir: Path) -> list[str]:
+    csv_paths = [
+        path for path in iter_profile_files(profile_dir) if path.suffix.lower() == ".csv"
+    ]
+    lines = [f"discovered_csv_count={len(csv_paths)}"]
+    basic_info_paths = [path for path in csv_paths if BASIC_INFO_FILE.fullmatch(path.name)]
+    lines.append(f"matching_basic_info_count={len(basic_info_paths)}")
+    for path in csv_paths[:DIAGNOSTIC_CSV_LIMIT]:
+        display = relative_display(path, profile_dir)
+        try:
+            with path.open(newline="", encoding="utf-8-sig", errors="replace") as stream:
+                reader = csv.reader(stream)
+                header = next(reader, [])
+                first_row = next(reader, [])
+            lines.append(f"CSV {display}")
+            lines.append(f"  header={json.dumps(header, ensure_ascii=False)}")
+            lines.append(f"  first_row={json.dumps(first_row, ensure_ascii=False)}")
+        except Exception as exc:
+            lines.append(f"CSV {display} read_error={type(exc).__name__}: {exc}")
+    if len(csv_paths) > DIAGNOSTIC_CSV_LIMIT:
+        lines.append(f"... truncated {len(csv_paths) - DIAGNOSTIC_CSV_LIMIT} CSV files")
+    return lines
+
+
+def log_tail_lines(path: Path) -> list[str]:
+    if not path.exists():
+        return [f"<log does not exist: {path}>"]
+    text = path.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+    if len(lines) > DIAGNOSTIC_LOG_LINES:
+        return [f"... last {DIAGNOSTIC_LOG_LINES} of {len(lines)} lines"] + lines[
+            -DIAGNOSTIC_LOG_LINES:
+        ]
+    return lines or ["<log is empty>"]
+
+
+def write_case_diagnostics(
+    args: argparse.Namespace,
+    result: dict,
+    *,
+    stage: str,
+    returncode: Optional[int],
+    log_paths: Iterable[Path],
+) -> str:
+    profile_dir = Path(result["profile_dir"])
+    diagnostics_path = args.output_dir / "logs" / f"{result['case_id']}.diagnostics.txt"
+    lines = [
+        f"case={result['case_id']}",
+        f"stage={stage}",
+        f"status={result['status']}",
+        f"note={result['note']}",
+        f"returncode={returncode}",
+        f"python={sys.version}",
+        f"platform={platform.platform()}",
+        f"msopprof={shutil.which('msopprof')}",
+        f"worker_command={result.get('worker_command', '')}",
+        "profile_commands="
+        + json.dumps(result.get("profile_commands", []), ensure_ascii=False),
+        f"profile_mode={result.get('profile_mode', '')}",
+        f"profile_dir={profile_dir}",
+        f"ASCEND_HOME_PATH={os.environ.get('ASCEND_HOME_PATH', '')}",
+        f"ASCEND_OPP_PATH={os.environ.get('ASCEND_OPP_PATH', '')}",
+        f"ASCEND_CUSTOM_OPP_PATH={os.environ.get('ASCEND_CUSTOM_OPP_PATH', '')}",
+        f"ASCEND_RT_VISIBLE_DEVICES={os.environ.get('ASCEND_RT_VISIBLE_DEVICES', '')}",
+        f"LD_PRELOAD={os.environ.get('LD_PRELOAD', '')}",
+        "",
+        "== Profile tree ==",
+        *profile_tree_lines(profile_dir),
+        "",
+        "== CSV inspection ==",
+        *csv_diagnostic_lines(profile_dir),
+    ]
+    for path in log_paths:
+        lines.extend(("", f"== Log tail: {path} ==", *log_tail_lines(path)))
+    diagnostics_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(diagnostics_path)
+
+
+def summarize_profile(records: Iterable[dict]) -> tuple[float, list[dict]]:
+    grouped: dict[str, list[float]] = {}
+    names: dict[str, str] = {}
+    for record in records:
+        instance = record["instance"]
+        grouped.setdefault(instance, []).append(record["duration_us"])
+        names[instance] = record["op_name"]
+    if not grouped:
+        raise RuntimeError("msopprof produced no matching OpBasicInfo rows")
+    breakdown = []
+    for instance, values in grouped.items():
+        median_us = statistics.median(values)
+        breakdown.append(
+            {
+                "instance": instance,
+                "op_name": names[instance],
+                "samples": len(values),
+                "median_us": median_us,
+                "min_us": min(values),
+                "max_us": max(values),
+            }
+        )
+    breakdown.sort(key=lambda item: item["median_us"], reverse=True)
+    return sum(item["median_us"] for item in breakdown), breakdown
+
+
+def natural_sort_key(value: str) -> tuple:
+    return tuple(
+        (1, int(part)) if part.isdigit() else (0, part.lower())
+        for part in re.split(r"(\d+)", value)
+    )
+
+
+def classify_failure(log_text: str, returncode: int) -> tuple[str, str]:
+    runtime_errors = re.findall(r"(?:RuntimeError|ValueError):\s*(.+)", log_text)
+    if runtime_errors:
+        return "ERROR", runtime_errors[-1].strip()
+    if re.search(
+        r"out of memory|\bOOM\b|cannot allocate memory|ACL_ERROR_RT_MEMORY",
+        log_text,
+        re.IGNORECASE,
+    ):
+        return "OOM", "device memory allocation failed"
+    return "ERROR", f"msopprof/worker exited with status {returncode}"
+
+
+def run_logged(command, *, cwd: Path, env: dict, log, timeout: int) -> tuple[int, bool]:
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=env,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    try:
+        return process.wait(timeout=timeout), False
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait()
+        return process.returncode, True
+
+
+def requested_shape(case: Case) -> str:
+    return f"[{case.batch}, {case.sequence}, {HEADS}, {KEY_DIM}]"
+
+
+def executed_shape(case: Case) -> str:
+    return requested_shape(case)
+
+
+def case_chunk_count(case: Case) -> int:
+    return sum(
+        (end - start + CHUNK_SIZE - 1) // CHUNK_SIZE
+        for start, end in zip(case.cu_seqlens, case.cu_seqlens[1:])
+    )
+
+
+def speedup(baseline_us: Optional[float], actual_us: Optional[float]) -> Optional[float]:
+    if baseline_us is None or actual_us is None or actual_us <= 0:
+        return None
+    return baseline_us / actual_us
+
+
+def kernel_name_filter(case: Case) -> str:
+    del case
+    return PREFILL_KERNEL_FILTER
+
+
+def profile_attempts(
+    args: argparse.Namespace, case: Case, case_dir: Path, worker: list[str]
+) -> list[dict]:
+    common_options = [
+        "msopprof",
+        f"--application={shell_join(worker)}",
+        f"--aic-metrics={args.aic_metrics}",
+        f"--launch-count={args.launch_count}",
+        f"--warm-up={args.warm_up}",
+        "--replay-mode=application",
+        "--kill=off",
+    ]
+    return [
+        {
+            "mode": "application_mstx",
+            "profile_dir": case_dir / "application_mstx",
+            "metric_scope": (
+                "sum of median msopprof BasicInfo durations in the KDA MSTX range "
+                "using application replay"
+            ),
+            "command": [
+                *common_options,
+                f"--output={case_dir / 'application_mstx'}",
+                "--mstx=on",
+                f"--mstx-include={PROFILE_RANGE}",
+            ],
+        },
+        {
+            "mode": "application_kernel_filter",
+            "profile_dir": case_dir / "application_kernel_filter",
+            "metric_scope": (
+                "sum of median msopprof BasicInfo durations for explicitly selected "
+                "KDA stages using application replay"
+            ),
+            "command": [
+                *common_options,
+                f"--output={case_dir / 'application_kernel_filter'}",
+                f"--kernel-name={kernel_name_filter(case)}",
+            ],
+        },
+    ]
+
+
+def run_profile(args: argparse.Namespace, case: Case) -> dict:
+    case_dir = args.output_dir / "profiles" / case.case_id
+    case_dir.mkdir(parents=True, exist_ok=False)
+    preflight_log_path = args.output_dir / "logs" / f"{case.case_id}.preflight.log"
+    worker = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--worker",
+        case.case_id,
+        "--device-visible-id",
+        str(args.device_visible_id),
+    ]
+    attempts = profile_attempts(args, case, case_dir, worker)
+    env = os.environ.copy()
+    env["TEST_DEVICE_ID"] = str(args.device_visible_id)
+    result = {
+        **asdict(case),
+        "sequence_count": len(case.cu_seqlens) - 1,
+        "chunk_count": case_chunk_count(case),
+        "requested_qkv_shape": requested_shape(case),
+        "executed_shape": executed_shape(case),
+        "status": "PASS",
+        "fla_npu_us": None,
+        "speedup_vs_h100": None,
+        "speedup_vs_optimized_npu": None,
+        "metric_scope": "",
+        "profile_dir": str(case_dir),
+        "selected_profile_dir": "",
+        "log": "",
+        "diagnostics": "",
+        "worker_command": shell_join(worker),
+        "profile_commands": [shell_join(attempt["command"]) for attempt in attempts],
+        "profile_mode": "",
+        "aic_metrics": args.aic_metrics,
+        "note": "",
+        "breakdown": [],
+        "metric_file_types": [],
+        "missing_metric_file_types": [],
+        "_kernel_detail": [],
+        "profiled_segment_us": None,
+    }
+    with preflight_log_path.open("w", encoding="utf-8") as preflight_log:
+        preflight_returncode, preflight_timed_out = run_logged(
+            worker,
+            cwd=args.repo_dir,
+            env=env,
+            log=preflight_log,
+            timeout=args.case_timeout,
+        )
+    if preflight_timed_out:
+        result["status"] = "TIMEOUT"
+        result["log"] = str(preflight_log_path)
+        result["note"] = f"preflight exceeded {args.case_timeout} seconds"
+        result["diagnostics"] = write_case_diagnostics(
+            args,
+            result,
+            stage="preflight_timeout",
+            returncode=preflight_returncode,
+            log_paths=(preflight_log_path,),
+        )
+        return result
+    if preflight_returncode != 0:
+        log_text = preflight_log_path.read_text(encoding="utf-8", errors="replace")
+        result["status"], note = classify_failure(log_text, preflight_returncode)
+        result["log"] = str(preflight_log_path)
+        result["note"] = f"preflight failed: {note}"
+        result["diagnostics"] = write_case_diagnostics(
+            args,
+            result,
+            stage="preflight",
+            returncode=preflight_returncode,
+            log_paths=(preflight_log_path,),
+        )
+        return result
+    attempt_notes = []
+    attempt_statuses = []
+    attempt_log_paths = []
+    profile_returncode = None
+    total_us = None
+    breakdown = []
+    for attempt in attempts:
+        mode = attempt["mode"]
+        log_path = args.output_dir / "logs" / f"{case.case_id}.{mode}.log"
+        attempt_log_paths.append(log_path)
+        command = attempt["command"]
+        result["log"] = str(log_path)
+        with log_path.open("w", encoding="utf-8") as log:
+            log.write(f"command={shell_join(command)}\n")
+            log.flush()
+            profile_returncode, profile_timed_out = run_logged(
+                command,
+                cwd=args.repo_dir,
+                env=env,
+                log=log,
+                timeout=args.case_timeout,
+            )
+        log_text = log_path.read_text(encoding="utf-8", errors="replace")
+        if profile_timed_out:
+            attempt_statuses.append("TIMEOUT")
+            attempt_notes.append(f"{mode}: exceeded {args.case_timeout} seconds")
+            continue
+        if profile_returncode != 0:
+            status, note = classify_failure(log_text, profile_returncode)
+            attempt_statuses.append(status)
+            attempt_notes.append(f"{mode}: {note}")
+            continue
+        try:
+            records = read_profile_rows(attempt["profile_dir"])
+            total_us, breakdown = summarize_profile(records)
+            detail_rows = read_kernel_detail_rows(attempt["profile_dir"])
+            metric_file_types = sorted(
+                {
+                    metric_name
+                    for row in detail_rows
+                    for metric_name in row["metric_file_types"].split(",")
+                    if metric_name
+                }
+            )
+            if args.aic_metrics.lower() == "default":
+                missing = sorted(set(PROFILE_METRIC_NAMES) - set(metric_file_types))
+                if missing:
+                    raise RuntimeError(
+                        "msopprof Default output is incomplete; missing metric tables: "
+                        + ", ".join(missing)
+                    )
+        except Exception as exc:
+            attempt_statuses.append("ERROR")
+            attempt_notes.append(f"{mode}: {exc}")
+            continue
+        result["profile_mode"] = mode
+        result["metric_scope"] = attempt["metric_scope"]
+        result["selected_profile_dir"] = str(attempt["profile_dir"])
+        result["metric_file_types"] = metric_file_types
+        result["_kernel_detail"] = detail_rows
+        break
+
+    if total_us is None:
+        if "OOM" in attempt_statuses:
+            result["status"] = "OOM"
+        elif attempt_statuses and all(status == "TIMEOUT" for status in attempt_statuses):
+            result["status"] = "TIMEOUT"
+        else:
+            result["status"] = "ERROR"
+        result["note"] = "; ".join(attempt_notes)
+        result["diagnostics"] = write_case_diagnostics(
+            args,
+            result,
+            stage="profile_attempts",
+            returncode=profile_returncode,
+            log_paths=(preflight_log_path, *attempt_log_paths),
+        )
+        return result
+    result["profiled_segment_us"] = total_us
+    result["fla_npu_us"] = total_us
+    result["speedup_vs_h100"] = speedup(case.h100_us, total_us)
+    result["speedup_vs_optimized_npu"] = speedup(case.optimized_npu_us, total_us)
+    result["breakdown"] = breakdown
+    notes = []
+    if attempt_notes:
+        notes.append(
+            f"profiled with {result['profile_mode']} after " + "; ".join(attempt_notes)
+        )
+    result["note"] = " ".join(notes)
+    return result
+
+
+def format_number(value: Optional[float], digits: int = 3) -> str:
+    if value is None:
+        return "-"
+    return f"{value:.{digits}f}"
+
+
+def csv_value(value):
+    if isinstance(value, (list, tuple, dict)):
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    return value
+
+
+def alias_value(row: dict, candidates: Iterable[str]):
+    for candidate in candidates:
+        if candidate in row and row[candidate] not in ("", None):
+            return row[candidate]
+    return ""
+
+
+def case_matrix_row(case: Case, selected_ids: set[str]) -> dict:
+    return {
+        "selected": case.case_id in selected_ids,
+        "atk_case_id": case.atk_case_id,
+        "case_id": case.case_id,
+        "case_key": case.case_key,
+        "total_token_count": case.sequence,
+        "sequence_distribution": case.distribution,
+        "sequence_count": len(case.cu_seqlens) - 1,
+        "chunk_count": case_chunk_count(case),
+        "disable_recompute": case.disable_recompute,
+        "layout": case.layout,
+        "batch": case.batch,
+        "head_num": HEADS,
+        "key_dim": KEY_DIM,
+        "value_dim": VALUE_DIM,
+        "chunk_size": CHUNK_SIZE,
+        "initial_state": "None",
+        "output_final_state": False,
+        "use_gate_in_kernel": True,
+        "safe_gate": True,
+        "return_intermediate_states": False,
+        "state_v_first": True,
+        "explicit_chunk_indices": case.explicit_chunk_indices,
+        "cu_seqlens": csv_value(case.cu_seqlens),
+        "seed": case.seed,
+    }
+
+
+def write_case_matrix(args: argparse.Namespace) -> None:
+    selected_ids = {case.case_id for case in selected_cases(args.cases)}
+    rows = [case_matrix_row(case, selected_ids) for case in CASES]
+    with (args.output_dir / "case_matrix.csv").open(
+        "w", newline="", encoding="utf-8-sig"
+    ) as stream:
+        writer = csv.DictWriter(stream, fieldnames=tuple(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def build_kernel_detail_rows(results: list[dict]) -> list[dict]:
+    rows = []
+    for result in results:
+        details = result.get("_kernel_detail") or ({},)
+        for detail in details:
+            row = {
+                "atk_case_id": result["atk_case_id"],
+                "case_id": result["case_id"],
+                "case_key": result["case_key"],
+                "case_status": result["status"],
+                "total_token_count": result["sequence"],
+                "sequence_distribution": result["distribution"],
+                "sequence_count": result["sequence_count"],
+                "chunk_count": result["chunk_count"],
+                "disable_recompute": result["disable_recompute"],
+                "layout": result["layout"],
+                "batch": result["batch"],
+                "head_num": HEADS,
+                "key_dim": KEY_DIM,
+                "value_dim": VALUE_DIM,
+                "chunk_size": CHUNK_SIZE,
+                "cu_seqlens": csv_value(result["cu_seqlens"]),
+                "seed": result["seed"],
+                "profile_mode": result["profile_mode"],
+                "aic_metrics": result.get("aic_metrics", "Default"),
+                **detail,
+            }
+            for alias, candidates in DETAIL_ALIASES.items():
+                row[alias] = alias_value(row, candidates)
+            rows.append(row)
+    return rows
+
+
+def excel_column_name(index: int) -> str:
+    value = index + 1
+    result = ""
+    while value:
+        value, remainder = divmod(value - 1, 26)
+        result = chr(ord("A") + remainder) + result
+    return result
+
+
+def excel_value(value):
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped not in ("", "NA") and re.fullmatch(
+            r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?", stripped
+        ):
+            try:
+                return int(stripped) if re.fullmatch(r"[-+]?\d+", stripped) else float(stripped)
+            except ValueError:
+                pass
+    return value
+
+
+def xlsx_cell(reference: str, value, style: int = 0) -> str:
+    value = excel_value(value)
+    if value is None or value == "":
+        return f'<c r={quoteattr(reference)} s={quoteattr(str(style))}/>'
+    if isinstance(value, bool):
+        return (
+            f'<c r={quoteattr(reference)} s={quoteattr(str(style))} t="b">'
+            f"<v>{int(value)}</v></c>"
+        )
+    if isinstance(value, (int, float)):
+        numeric_style = 6 if isinstance(value, int) else 5
+        return (
+            f'<c r={quoteattr(reference)} s={quoteattr(str(style or numeric_style))}>'
+            f"<v>{value}</v></c>"
+        )
+    text = escape(str(value))
+    preserve = ' xml:space="preserve"' if text != text.strip() else ""
+    return (
+        f'<c r={quoteattr(reference)} s={quoteattr(str(style))} t="inlineStr">'
+        f"<is><t{preserve}>{text}</t></is></c>"
+    )
+
+
+def xlsx_row(row_number: int, values: Iterable, style: int = 0) -> str:
+    cells = "".join(
+        xlsx_cell(f"{excel_column_name(column)}{row_number}", value, style)
+        for column, value in enumerate(values)
+    )
+    return f'<row r="{row_number}">{cells}</row>'
+
+
+def xlsx_styles_xml() -> str:
+    return """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <fonts count="2">
+    <font><sz val="10"/><name val="Aptos"/></font>
+    <font><b/><color rgb="FFFFFFFF"/><sz val="10"/><name val="Aptos"/></font>
+  </fonts>
+  <fills count="5">
+    <fill><patternFill patternType="none"/></fill>
+    <fill><patternFill patternType="gray125"/></fill>
+    <fill><patternFill patternType="solid"><fgColor rgb="FF17365D"/><bgColor indexed="64"/></patternFill></fill>
+    <fill><patternFill patternType="solid"><fgColor rgb="FFD9EAF7"/><bgColor indexed="64"/></patternFill></fill>
+    <fill><patternFill patternType="solid"><fgColor rgb="FF1F4E78"/><bgColor indexed="64"/></patternFill></fill>
+  </fills>
+  <borders count="2">
+    <border><left/><right/><top/><bottom/><diagonal/></border>
+    <border><left style="thin"><color rgb="FFD9E2F3"/></left><right style="thin"><color rgb="FFD9E2F3"/></right><top style="thin"><color rgb="FFD9E2F3"/></top><bottom style="thin"><color rgb="FFD9E2F3"/></bottom><diagonal/></border>
+  </borders>
+  <cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
+  <cellXfs count="7">
+    <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
+    <xf numFmtId="0" fontId="1" fillId="2" borderId="0" xfId="0" applyAlignment="1"><alignment horizontal="left" vertical="center"/></xf>
+    <xf numFmtId="0" fontId="0" fillId="3" borderId="1" xfId="0" applyAlignment="1"><alignment horizontal="left" vertical="center"/></xf>
+    <xf numFmtId="0" fontId="0" fillId="0" borderId="1" xfId="0" applyAlignment="1"><alignment horizontal="left" vertical="center"/></xf>
+    <xf numFmtId="0" fontId="1" fillId="4" borderId="1" xfId="0" applyAlignment="1"><alignment horizontal="center" vertical="center" wrapText="1"/></xf>
+    <xf numFmtId="4" fontId="0" fillId="0" borderId="1" xfId="0" applyAlignment="1"><alignment horizontal="right" vertical="center"/></xf>
+    <xf numFmtId="3" fontId="0" fillId="0" borderId="1" xfId="0" applyAlignment="1"><alignment horizontal="right" vertical="center"/></xf>
+  </cellXfs>
+  <cellStyles count="1"><cellStyle name="Normal" xfId="0" builtinId="0"/></cellStyles>
+</styleSheet>"""
+
+
+def xlsx_sheet_xml(case: Case, result: Optional[dict], columns: tuple[str, ...]) -> str:
+    status = result["status"] if result else "NOT_RUN"
+    detail_rows = build_kernel_detail_rows([result]) if result else []
+    detail_rows = detail_rows or ({},)
+    metadata_rows = (
+        ("ATK case ID", case.atk_case_id, "Status", status, "Total tokens", case.sequence, "Distribution", case.distribution),
+        ("Sequence count", len(case.cu_seqlens) - 1, "Chunk count", case_chunk_count(case), "Disable recompute", case.disable_recompute, "Seed", case.seed),
+        ("Case key", case.case_key, "cu_seqlens", csv_value(case.cu_seqlens), "Layout", case.layout, "Chunk size", CHUNK_SIZE),
+    )
+    rows = [xlsx_row(1, (f"Chunk KDA performance detail - ATK case {case.atk_case_id}",), 1)]
+    for row_number, values in enumerate(metadata_rows, start=2):
+        cells = []
+        for column, value in enumerate(values):
+            style = 2 if column % 2 == 0 else 3
+            cells.append(xlsx_cell(f"{excel_column_name(column)}{row_number}", value, style))
+        rows.append(f'<row r="{row_number}" ht="22">{"".join(cells)}</row>')
+    rows.append(xlsx_row(5, columns, 4))
+    for row_number, detail in enumerate(detail_rows, start=6):
+        rows.append(xlsx_row(row_number, (detail.get(column, "") for column in columns)))
+    last_column = excel_column_name(max(len(columns), 8) - 1)
+    last_row = 5 + len(detail_rows)
+    widths = []
+    for index, column in enumerate(columns, start=1):
+        if column in ("source_csvs", "Op Name", "Op Type"):
+            width = 42
+        elif len(column) > 28:
+            width = 24
+        else:
+            width = min(max(len(column) + 2, 12), 22)
+        widths.append(f'<col min="{index}" max="{index}" width="{width}" customWidth="1"/>')
+    tab_color = "FF70AD47" if status == "PASS" else ("FFC00000" if status not in ("PASS", "NOT_RUN") else "FFB7B7B7")
+    return f'''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetPr><tabColor rgb="{tab_color}"/></sheetPr>
+  <dimension ref="A1:{last_column}{last_row}"/>
+  <sheetViews><sheetView showGridLines="0" workbookViewId="0"><pane ySplit="5" topLeftCell="A6" activePane="bottomLeft" state="frozen"/></sheetView></sheetViews>
+  <sheetFormatPr defaultRowHeight="15"/>
+  <cols>{''.join(widths)}</cols>
+  <sheetData>{''.join(rows)}</sheetData>
+  <mergeCells count="1"><mergeCell ref="A1:H1"/></mergeCells>
+  <autoFilter ref="A5:{excel_column_name(len(columns) - 1)}{last_row}"/>
+</worksheet>'''
+
+
+def write_kernel_detail_workbook(args: argparse.Namespace, results: list[dict]) -> None:
+    rows = build_kernel_detail_rows(results)
+    resource_columns = (
+        "metric_file_types",
+        "source_csvs",
+        "kernel_instance",
+        "replay",
+        "block_id",
+        "sub_block_id",
+        "Op Name",
+        "Op Type",
+        *DETAIL_ALIASES,
+    )
+    all_columns = {key for row in rows for key in row}
+    case_columns = {
+        "atk_case_id", "case_id", "case_key", "case_status", "total_token_count",
+        "sequence_distribution", "sequence_count", "chunk_count", "disable_recompute",
+        "layout", "batch", "head_num", "key_dim", "value_dim", "chunk_size",
+        "cu_seqlens", "seed", "profile_mode", "aic_metrics",
+    }
+    dynamic_columns = sorted(all_columns - set(resource_columns) - case_columns)
+    columns = (*resource_columns, *dynamic_columns)
+    result_by_case = {result["case_id"]: result for result in results}
+    workbook_path = args.output_dir / "kernel_detail.xlsx"
+    with zipfile.ZipFile(workbook_path, "w", zipfile.ZIP_DEFLATED) as workbook:
+        sheet_overrides = "".join(
+            f'<Override PartName="/xl/worksheets/sheet{index}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>'
+            for index in range(1, len(CASES) + 1)
+        )
+        workbook.writestr(
+            "[Content_Types].xml",
+            f'''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+  {sheet_overrides}
+</Types>''',
+        )
+        workbook.writestr(
+            "_rels/.rels",
+            '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>''',
+        )
+        sheets_xml = "".join(
+            f'<sheet name="case_{case.atk_case_id}" sheetId="{index}" r:id="rId{index}"/>'
+            for index, case in enumerate(CASES, start=1)
+        )
+        workbook.writestr(
+            "xl/workbook.xml",
+            f'''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <bookViews><workbookView activeTab="0"/></bookViews>
+  <sheets>{sheets_xml}</sheets>
+</workbook>''',
+        )
+        relationships = "".join(
+            f'<Relationship Id="rId{index}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet{index}.xml"/>'
+            for index in range(1, len(CASES) + 1)
+        )
+        relationships += (
+            f'<Relationship Id="rId{len(CASES) + 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>'
+        )
+        workbook.writestr(
+            "xl/_rels/workbook.xml.rels",
+            f'''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">{relationships}</Relationships>''',
+        )
+        workbook.writestr("xl/styles.xml", xlsx_styles_xml())
+        for index, case in enumerate(CASES, start=1):
+            workbook.writestr(
+                f"xl/worksheets/sheet{index}.xml",
+                xlsx_sheet_xml(case, result_by_case.get(case.case_id), columns),
+            )
+
+
+def write_reports(args: argparse.Namespace, results: list[dict]) -> None:
+    from importlib import metadata as package_metadata
+
+    metadata = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "repo_commit": args.repo_commit,
+        "soc": args.soc,
+        "device_visible_id": args.device_visible_id,
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "warm_up": args.warm_up,
+        "launch_count": args.launch_count,
+        "case_timeout": args.case_timeout,
+        "aic_metrics": args.aic_metrics,
+        "matrix_contract": "PR297 A5 positive case IDs 250-297",
+        "profile_attempt_order": [
+            "application replay with MSTX range filtering",
+            "application replay with explicit KDA stage filtering",
+        ],
+    }
+    try:
+        metadata["torch"] = package_metadata.version("torch")
+        metadata["torch_npu"] = package_metadata.version("torch-npu")
+    except package_metadata.PackageNotFoundError:
+        pass
+    public_results = [
+        {key: value for key, value in result.items() if not key.startswith("_")}
+        for result in results
+    ]
+    payload = {"metadata": metadata, "results": public_results}
+    (args.output_dir / "results.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    diagnostics = [result for result in results if result.get("diagnostics")]
+    if diagnostics:
+        sections = []
+        for result in diagnostics:
+            path = Path(result["diagnostics"])
+            sections.extend(
+                (
+                    f"######## {result['case_id']} ########",
+                    path.read_text(encoding="utf-8", errors="replace"),
+                )
+            )
+        (args.output_dir / "diagnostics.txt").write_text(
+            "\n".join(sections), encoding="utf-8"
+        )
+
+    columns = (
+        "atk_case_id",
+        "case_id",
+        "case_key",
+        "phase",
+        "direction",
+        "batch",
+        "sequence",
+        "distribution",
+        "sequence_count",
+        "chunk_count",
+        "disable_recompute",
+        "cu_seqlens",
+        "seed",
+        "requested_qkv_shape",
+        "executed_shape",
+        "status",
+        "h100_us",
+        "optimized_npu_us",
+        "fla_npu_us",
+        "profiled_segment_us",
+        "speedup_vs_h100",
+        "speedup_vs_optimized_npu",
+        "metric_scope",
+        "profile_mode",
+        "note",
+        "profile_dir",
+        "selected_profile_dir",
+        "log",
+        "diagnostics",
+    )
+    with (args.output_dir / "results.csv").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=columns, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(results)
+
+    write_case_matrix(args)
+    write_kernel_detail_workbook(args, results)
+
+    lines = [
+        "# fla_npu main KDA performance",
+        "",
+        f"- commit: `{args.repo_commit}`",
+        f"- SOC: `{args.soc}`",
+        "- unit: microseconds",
+        f"- msopprof AI Core metrics: `{args.aic_metrics}`",
+        "- matrix: PR297 A5 positive cases 250-297",
+        "- metric: sum of median msopprof BasicInfo durations for selected KDA stages",
+        "- full per-case kernel resources: `kernel_detail.xlsx` (one sheet per case)",
+        "",
+        "| ATK case | total tokens | sequence distribution | sequence count | chunk count | "
+        "disable recompute | status | profiler | fla_npu us |",
+        "| ---: | ---: | --- | ---: | ---: | --- | --- | --- | ---: |",
+    ]
+    for result in results:
+        lines.append(
+            "| {atk_case_id} | {sequence} | {distribution} | {sequence_count} | "
+            "{chunk_count} | {disable_recompute} | {status} | {profile_mode} | "
+            "{actual} |".format(
+                **result,
+                actual=format_number(result["fla_npu_us"]),
+            )
+        )
+    notes = [result for result in results if result["note"]]
+    if notes:
+        lines.extend(("", "## Notes", ""))
+        lines.extend(f"- `{result['case_id']}`: {result['note']}" for result in notes)
+    (args.output_dir / "results.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    if sys.version_info < (3, 9):
+        raise SystemExit(
+            "benchmark_kda_matrix.py requires Python 3.9 or newer; "
+            f"found {platform.python_version()}"
+        )
+    if not args.aic_metrics:
+        raise ValueError("--aic-metrics must not be empty")
+    if args.list_cases:
+        rows = [case_matrix_row(case, {item.case_id for item in CASES}) for case in CASES]
+        writer = csv.DictWriter(sys.stdout, fieldnames=tuple(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+        return 0
+    if args.worker:
+        if args.worker not in CASE_BY_ID:
+            raise ValueError(f"unknown worker case ID: {args.worker}")
+        return run_worker(CASE_BY_ID[args.worker], args.device_visible_id)
+    if args.output_dir is None or args.repo_dir is None:
+        raise ValueError("--output-dir and --repo-dir are required in orchestrator mode")
+    if args.output_dir.exists() and any(args.output_dir.iterdir()):
+        raise FileExistsError(f"output directory is not empty: {args.output_dir}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "logs").mkdir()
+    results = []
+    for index, case in enumerate(selected_cases(args.cases), start=1):
+        print(f"[{index}] profiling {case.case_id}", flush=True)
+        result = run_profile(args, case)
+        results.append(result)
+        print(
+            f"    status={result['status']} fla_npu_us={format_number(result['fla_npu_us'])}",
+            flush=True,
+        )
+        if result["status"] != "PASS":
+            print(f"    note={result['note']}", flush=True)
+            if result.get("diagnostics"):
+                print(f"    diagnostics={result['diagnostics']}", flush=True)
+        write_reports(args, results)
+    print((args.output_dir / "results.md").read_text(encoding="utf-8"), flush=True)
+    diagnostics_path = args.output_dir / "diagnostics.txt"
+    if diagnostics_path.exists():
+        print(f"Diagnostics: {diagnostics_path}", flush=True)
+    failed_case_ids = [
+        result["case_id"] for result in results if result["status"] != "PASS"
+    ]
+    if failed_case_ids:
+        print(
+            "Benchmark failed cases: " + ", ".join(failed_case_ids),
+            file=sys.stderr,
+            flush=True,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_kda_matrix.py
+++ b/scripts/benchmark_kda_matrix.py
@@ -30,8 +30,7 @@ VALUE_DIM = 128
 CHUNK_SIZE = 64
 PROFILE_RANGE = "FLA_NPU_KDA_BENCH"
 ATK_CASE_ID_START = 250
-SEQUENCE_LENGTHS = (1024, 1536, 2048, 4096, 8192, 16384)
-DISTRIBUTIONS = ("single", "balanced8", "mixed_tail", "short64")
+SEQUENCE_LENGTHS = (1024, 8192, 16384, 65536)
 SEED_BASE = 20260812
 PREFILL_KERNEL_FILTER = "|".join(
     (
@@ -115,88 +114,48 @@ class Case:
     distribution: str
     disable_recompute: bool
     layout: str
-    cu_seqlens: tuple[int, ...]
+    cu_seqlens: Optional[tuple[int, ...]]
     explicit_chunk_indices: bool
     seed: int
     h100_us: Optional[float]
     optimized_npu_us: Optional[float]
 
 
-def distribution_lengths(total: int, distribution: str) -> list[int]:
-    if distribution == "single":
-        return [total]
-    if distribution == "balanced8":
-        quotient, remainder = divmod(total, 8)
-        return [quotient + (index < remainder) for index in range(8)]
-    if distribution == "mixed_tail":
-        base = total // 8
-        values = [
-            base - 47,
-            base + 31,
-            base - 1,
-            base + 17,
-            base - 33,
-            base + 49,
-            base - 15,
-        ]
-        values.append(total - sum(values))
-        return values
-    if distribution == "short64":
-        quotient, remainder = divmod(total, CHUNK_SIZE)
-        values = [CHUNK_SIZE] * quotient
-        if remainder:
-            values.append(remainder)
-        return values
-    raise ValueError(f"unknown distribution: {distribution}")
-
-
-def cumulative_lengths(lengths: Iterable[int]) -> tuple[int, ...]:
-    values = [0]
-    for length in lengths:
-        if length <= 0:
-            raise ValueError(f"sequence length must be positive, got {length}")
-        values.append(values[-1] + int(length))
-    return tuple(values)
-
-
 def build_atk_cases() -> tuple[Case, ...]:
     cases = []
-    pair_id = 0
-    for sequence in SEQUENCE_LENGTHS:
-        for distribution in DISTRIBUTIONS:
-            cu_seqlens = cumulative_lengths(
-                distribution_lengths(sequence, distribution)
+    for sequence_index, sequence in enumerate(SEQUENCE_LENGTHS):
+        for disable_recompute in (False, True):
+            atk_case_id = (
+                ATK_CASE_ID_START + sequence_index * 2 + int(disable_recompute)
             )
-            for disable_recompute in (False, True):
-                atk_case_id = ATK_CASE_ID_START + pair_id * 2 + int(disable_recompute)
-                mode = "export" if disable_recompute else "recompute"
-                case_key = (
-                    f"ascend950_h96_t{sequence}_c64_packed_{distribution}_{mode}"
+            recompute_enabled = not disable_recompute
+            case_key = (
+                f"ascend950_h96_t{sequence}_c64_dense_"
+                f"recompute_{str(recompute_enabled).lower()}"
+            )
+            cases.append(
+                Case(
+                    atk_case_id=atk_case_id,
+                    case_id=str(atk_case_id),
+                    case_key=case_key,
+                    phase="prefill",
+                    direction="fwd",
+                    batch=1,
+                    sequence=sequence,
+                    distribution="dense",
+                    disable_recompute=disable_recompute,
+                    layout="BSND",
+                    cu_seqlens=None,
+                    explicit_chunk_indices=False,
+                    seed=SEED_BASE + sequence_index,
+                    h100_us=None,
+                    optimized_npu_us=None,
                 )
-                cases.append(
-                    Case(
-                        atk_case_id=atk_case_id,
-                        case_id=str(atk_case_id),
-                        case_key=case_key,
-                        phase="prefill",
-                        direction="fwd",
-                        batch=1,
-                        sequence=sequence,
-                        distribution=distribution,
-                        disable_recompute=disable_recompute,
-                        layout="BSND",
-                        cu_seqlens=cu_seqlens,
-                        explicit_chunk_indices=False,
-                        seed=SEED_BASE + pair_id,
-                        h100_us=None,
-                        optimized_npu_us=None,
-                    )
-                )
-            pair_id += 1
+            )
     result = tuple(cases)
     ids = tuple(case.atk_case_id for case in result)
-    if len(result) != 48 or ids != tuple(range(250, 298)):
-        raise RuntimeError("PR297 performance matrix must contain case IDs 250-297")
+    if len(result) != 8 or ids != tuple(range(250, 258)):
+        raise RuntimeError("dense performance matrix must contain case IDs 250-257")
     return result
 
 
@@ -205,8 +164,9 @@ CASE_BY_ID = {case.case_id: case for case in CASES}
 CASE_BY_KEY = {case.case_key: case for case in CASES}
 LEGACY_CASE_ALIASES = {
     "prefill_fwd_b1_s1024": "250",
-    "prefill_fwd_b1_s8192": "282",
-    "prefill_fwd_b1_s16384": "290",
+    "prefill_fwd_b1_s8192": "252",
+    "prefill_fwd_b1_s16384": "254",
+    "prefill_fwd_b1_s65536": "256",
 }
 
 
@@ -347,7 +307,7 @@ def run_prefill_forward(torch, case: Case, device) -> None:
     q, k, v, gate, beta, a_log, dt_bias = make_prefill_inputs(torch, case, device)
     chunk_indices = (
         canonical_chunk_indices(case.cu_seqlens, CHUNK_SIZE)
-        if case.explicit_chunk_indices
+        if case.explicit_chunk_indices and case.cu_seqlens is not None
         else None
     )
     torch.npu.synchronize()
@@ -364,7 +324,7 @@ def run_prefill_forward(torch, case: Case, device) -> None:
             layout="BSND",
             initial_state=None,
             output_final_state=False,
-            cu_seqlens=list(case.cu_seqlens),
+            cu_seqlens=(list(case.cu_seqlens) if case.cu_seqlens else None),
             chunk_indices=chunk_indices,
             safe_gate=True,
             lower_bound=-5.0,
@@ -769,6 +729,8 @@ def executed_shape(case: Case) -> str:
 
 
 def case_chunk_count(case: Case) -> int:
+    if case.cu_seqlens is None:
+        return case.batch * ((case.sequence + CHUNK_SIZE - 1) // CHUNK_SIZE)
     return sum(
         (end - start + CHUNK_SIZE - 1) // CHUNK_SIZE
         for start, end in zip(case.cu_seqlens, case.cu_seqlens[1:])
@@ -832,8 +794,9 @@ def run_profile(args: argparse.Namespace, case: Case) -> dict:
     env["TEST_DEVICE_ID"] = str(args.device_visible_id)
     result = {
         **asdict(case),
-        "sequence_count": len(case.cu_seqlens) - 1,
+        "sequence_count": case.batch if case.cu_seqlens is None else len(case.cu_seqlens) - 1,
         "chunk_count": case_chunk_count(case),
+        "recompute_enabled": not case.disable_recompute,
         "requested_qkv_shape": requested_shape(case),
         "executed_shape": executed_shape(case),
         "status": "PASS",
@@ -1023,8 +986,9 @@ def case_matrix_row(case: Case, selected_ids: set[str]) -> dict:
         "case_key": case.case_key,
         "total_token_count": case.sequence,
         "sequence_distribution": case.distribution,
-        "sequence_count": len(case.cu_seqlens) - 1,
+        "sequence_count": case.batch if case.cu_seqlens is None else len(case.cu_seqlens) - 1,
         "chunk_count": case_chunk_count(case),
+        "recompute_enabled": not case.disable_recompute,
         "disable_recompute": case.disable_recompute,
         "layout": case.layout,
         "batch": case.batch,
@@ -1070,6 +1034,7 @@ def build_kernel_detail_rows(results: list[dict]) -> list[dict]:
                 "sequence_count": result["sequence_count"],
                 "chunk_count": result["chunk_count"],
                 "disable_recompute": result["disable_recompute"],
+                "recompute_enabled": not result["disable_recompute"],
                 "layout": result["layout"],
                 "batch": result["batch"],
                 "head_num": HEADS,
@@ -1179,7 +1144,7 @@ def xlsx_sheet_xml(case: Case, result: Optional[dict], columns: tuple[str, ...])
     detail_rows = detail_rows or ({},)
     metadata_rows = (
         ("ATK case ID", case.atk_case_id, "Status", status, "Total tokens", case.sequence, "Distribution", case.distribution),
-        ("Sequence count", len(case.cu_seqlens) - 1, "Chunk count", case_chunk_count(case), "Disable recompute", case.disable_recompute, "Seed", case.seed),
+        ("Sequence count", case.batch if case.cu_seqlens is None else len(case.cu_seqlens) - 1, "Chunk count", case_chunk_count(case), "Recompute enabled", not case.disable_recompute, "Seed", case.seed),
         ("Case key", case.case_key, "cu_seqlens", csv_value(case.cu_seqlens), "Layout", case.layout, "Chunk size", CHUNK_SIZE),
     )
     rows = [xlsx_row(1, (f"Chunk KDA performance detail - ATK case {case.atk_case_id}",), 1)]
@@ -1232,7 +1197,7 @@ def write_kernel_detail_workbook(args: argparse.Namespace, results: list[dict]) 
     all_columns = {key for row in rows for key in row}
     case_columns = {
         "atk_case_id", "case_id", "case_key", "case_status", "total_token_count",
-        "sequence_distribution", "sequence_count", "chunk_count", "disable_recompute",
+        "sequence_distribution", "sequence_count", "chunk_count", "disable_recompute", "recompute_enabled",
         "layout", "batch", "head_num", "key_dim", "value_dim", "chunk_size",
         "cu_seqlens", "seed", "profile_mode", "aic_metrics",
     }
@@ -1327,7 +1292,7 @@ def write_reports(args: argparse.Namespace, results: list[dict]) -> None:
         "launch_count": args.launch_count,
         "case_timeout": args.case_timeout,
         "aic_metrics": args.aic_metrics,
-        "matrix_contract": "PR297 A5 positive case IDs 250-297",
+        "matrix_contract": "A5 dense case IDs 250-257",
         "profile_attempt_order": [
             "single application launch with KDA kernel filtering and kernel replay",
         ],
@@ -1372,6 +1337,7 @@ def write_reports(args: argparse.Namespace, results: list[dict]) -> None:
         "distribution",
         "sequence_count",
         "chunk_count",
+        "recompute_enabled",
         "disable_recompute",
         "cu_seqlens",
         "seed",
@@ -1407,18 +1373,18 @@ def write_reports(args: argparse.Namespace, results: list[dict]) -> None:
         f"- SOC: `{args.soc}`",
         "- unit: microseconds",
         f"- msopprof AI Core metrics: `{args.aic_metrics}`",
-        "- matrix: PR297 A5 positive cases 250-297",
+        "- matrix: A5 dense cases 250-257",
         "- metric: msopprof BasicInfo duration for one selected KDA kernel",
         "- full per-case kernel resources: `kernel_detail.xlsx` (one sheet per case)",
         "",
-        "| ATK case | total tokens | sequence distribution | sequence count | chunk count | "
-        "disable recompute | status | profiler | fla_npu us |",
+        "| Case | total tokens | layout mode | sequence count | chunk count | "
+        "recompute enabled | status | profiler | fla_npu us |",
         "| ---: | ---: | --- | ---: | ---: | --- | --- | --- | ---: |",
     ]
     for result in results:
         lines.append(
             "| {atk_case_id} | {sequence} | {distribution} | {sequence_count} | "
-            "{chunk_count} | {disable_recompute} | {status} | {profile_mode} | "
+            "{chunk_count} | {recompute_enabled} | {status} | {profile_mode} | "
             "{actual} |".format(
                 **result,
                 actual=format_number(result["fla_npu_us"]),

--- a/scripts/benchmark_kda_matrix.py
+++ b/scripts/benchmark_kda_matrix.py
@@ -98,6 +98,9 @@ DETAIL_ALIASES = {
 DIAGNOSTIC_TREE_LIMIT = 500
 DIAGNOSTIC_CSV_LIMIT = 100
 DIAGNOSTIC_LOG_LINES = 240
+INVALID_XML_CHARACTERS = re.compile(
+    "[\x00-\x08\x0B\x0C\x0E-\x1F\uD800-\uDFFF\uFFFE\uFFFF]"
+)
 
 
 @dataclass(frozen=True)
@@ -221,6 +224,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--decode-step", type=int, default=1, help=argparse.SUPPRESS)
     parser.add_argument("--aic-metrics", default="Default")
     parser.add_argument("--list-cases", action="store_true")
+    parser.add_argument(
+        "--repair-workbook",
+        type=Path,
+        metavar="RESULTS_DIR",
+        help="rebuild kernel_detail.xlsx from an existing results directory",
+    )
     parser.add_argument("--worker")
     return parser.parse_args()
 
@@ -1130,7 +1139,7 @@ def xlsx_cell(reference: str, value, style: int = 0) -> str:
             f'<c r={quoteattr(reference)} s={quoteattr(str(style or numeric_style))}>'
             f"<v>{value}</v></c>"
         )
-    text = escape(str(value))
+    text = escape(INVALID_XML_CHARACTERS.sub("", str(value)))
     preserve = ' xml:space="preserve"' if text != text.strip() else ""
     return (
         f'<c r={quoteattr(reference)} s={quoteattr(str(style))} t="inlineStr">'
@@ -1218,7 +1227,6 @@ def xlsx_sheet_xml(case: Case, result: Optional[dict], columns: tuple[str, ...])
   <cols>{''.join(widths)}</cols>
   <sheetData>{''.join(rows)}</sheetData>
   <mergeCells count="1"><mergeCell ref="A1:H1"/></mergeCells>
-  <autoFilter ref="A5:{excel_column_name(len(columns) - 1)}{last_row}"/>
 </worksheet>'''
 
 
@@ -1299,6 +1307,24 @@ def write_kernel_detail_workbook(args: argparse.Namespace, results: list[dict]) 
                 f"xl/worksheets/sheet{index}.xml",
                 xlsx_sheet_xml(case, result_by_case.get(case.case_id), columns),
             )
+
+
+def repair_kernel_detail_workbook(results_dir: Path) -> Path:
+    results_dir = results_dir.resolve()
+    results_file = results_dir / "results.json"
+    if not results_file.is_file():
+        raise FileNotFoundError(f"results file not found: {results_file}")
+    payload = json.loads(results_file.read_text(encoding="utf-8"))
+    results = payload.get("results")
+    if not isinstance(results, list):
+        raise ValueError(f"invalid results payload: {results_file}")
+    for result in results:
+        profile_dir = result.get("selected_profile_dir")
+        result["_kernel_detail"] = (
+            read_kernel_detail_rows(Path(profile_dir)) if profile_dir else []
+        )
+    write_kernel_detail_workbook(argparse.Namespace(output_dir=results_dir), results)
+    return results_dir / "kernel_detail.xlsx"
 
 
 def write_reports(args: argparse.Namespace, results: list[dict]) -> None:
@@ -1429,6 +1455,9 @@ def main() -> int:
         )
     if not args.aic_metrics:
         raise ValueError("--aic-metrics must not be empty")
+    if args.repair_workbook:
+        print(f"Rebuilt workbook: {repair_kernel_detail_workbook(args.repair_workbook)}")
+        return 0
     if args.list_cases:
         rows = [case_matrix_row(case, {item.case_id for item in CASES}) for case in CASES]
         writer = csv.DictWriter(sys.stdout, fieldnames=tuple(rows[0]))

--- a/scripts/check_kda_benchmark_wheel.py
+++ b/scripts/check_kda_benchmark_wheel.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Validate the scoped wheel required by the KDA benchmark."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+REQUIRED_EXPORTS = (
+    "chunk_kda_fwd",
+    "npu_chunk_kda_fwd",
+    "kda_gate_cumsum",
+    "npu_kda_gate_cumsum",
+    "chunk_gated_delta_rule_fwd_h",
+    "npu_chunk_gated_delta_rule_fwd_h",
+)
+REQUIRED_CONFIGS = (
+    "chunk_kda_fwd.json",
+    "kda_gate_cumsum.json",
+    "chunk_gated_delta_rule_fwd_h.json",
+)
+
+
+def main() -> int:
+    import fla_npu
+    from fla_npu.ops import ascendc
+
+    missing_exports = [name for name in REQUIRED_EXPORTS if not hasattr(ascendc, name)]
+    if missing_exports:
+        raise AssertionError("scoped wheel exports are missing: " + ", ".join(missing_exports))
+
+    package_root = Path(fla_npu.__file__).resolve().parent
+    config_dirs = list(
+        (package_root / "opp" / "vendors").glob(
+            "*/op_impl/ai_core/tbe/kernel/config/*"
+        )
+    )
+    missing_configs = [
+        name
+        for name in REQUIRED_CONFIGS
+        if not any((directory / name).is_file() for directory in config_dirs)
+    ]
+    if missing_configs:
+        raise AssertionError(
+            "scoped wheel OPP configs are missing: " + ", ".join(missing_configs)
+        )
+
+    libraries = list(
+        (package_root / "opp" / "vendors").glob("*/op_api/lib/libcust_opapi.so")
+    )
+    if not libraries:
+        raise AssertionError("scoped wheel libcust_opapi.so is missing")
+    configured = os.environ.get("FLA_NPU_OP_API_LIB")
+    if not configured or Path(configured).resolve() not in {
+        library.resolve() for library in libraries
+    }:
+        raise AssertionError("FLA_NPU_OP_API_LIB does not select the scoped wheel library")
+
+    print("KDA benchmark scoped wheel check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/operators/chunk_kda_fwd/README.md
+++ b/tests/operators/chunk_kda_fwd/README.md
@@ -100,6 +100,11 @@ bash scripts/benchmark_kda_main.sh \
 报告使用 `msopprof` 设备侧耗时，默认 `--aic-metrics Default`。不要改为
 `BasicInfo`，否则只能得到基础耗时，不能生成完整资源明细。结果目录包含：
 
+每个 ATK case 只启动一次 application，固定使用 `--launch-count 1` 和
+`--replay-mode=kernel`；`--warm-up 5` 保持开启。预热以及 Default 全指标所需的
+kernel replay 均由 msopprof 在同一个 application 进程内完成，不会重复调用 case worker，
+每个 case 日志中应只出现一次 `BENCH_OK`。
+
 | 文件 | 内容 |
 | --- | --- |
 | `case_matrix.csv` | 48 条固定用例及 `cu_seqlens`、序列数、chunk 数、随机种子和功能属性 |

--- a/tests/operators/chunk_kda_fwd/README.md
+++ b/tests/operators/chunk_kda_fwd/README.md
@@ -144,9 +144,11 @@ python scripts/benchmark_kda_matrix.py \
 python scripts/benchmark_kda_b200_triton.py --device 0
 ```
 
-默认每条 case 预热 5 次，随后正式执行 10 次。每次使用 CUDA event 记录完整低层
-`chunk_kda_fwd` 前向耗时并同步，最终取 10 次的算术平均值。输入生成、首次 Triton 编译、
-自动调优和预热耗时不计入正式结果。可显式写出默认参数或指定部分 case：
+默认每条 case 预热 5 次，随后正式执行 10 次。每次在当前 CUDA stream 上、紧邻完整低层
+`chunk_kda_fwd` 调用前后记录 CUDA event，最终取 10 次 device elapsed time 的算术平均值。
+该结果是一次 `chunk_kda_fwd` 的 CUDA device-stream 执行时间，不是 Python/脚本耗时；
+不包含输入生成、Python wall time、首次 Triton 编译、自动调优和预热耗时。可显式写出
+默认参数或指定部分 case：
 
 ```bash
 python scripts/benchmark_kda_b200_triton.py \
@@ -161,9 +163,9 @@ python scripts/benchmark_kda_b200_triton.py \
 
 | 文件 | 内容 |
 | --- | --- |
-| `results.md` | B200 平均耗时、MFU、A5 耗时和 A5/B200 耗时比汇总表 |
-| `results.csv` | 每条 case 的平均值、中位数、最小值、最大值、标准差和峰值显存 |
-| `timings.csv` | 每条 case 的 10 次原始 CUDA event 耗时 |
+| `results.md` | B200 device 平均耗时、MFU、A5 device profiler 耗时和耗时比汇总表 |
+| `results.csv` | 每条 case 的 device 平均值、中位数、最小值、最大值和标准差 |
+| `timings.csv` | 每条 case 的 10 次原始 CUDA device elapsed time |
 | `results.json` | GPU、PyTorch、Triton、FLA 版本、FLA 安装位置校验状态和完整结果 |
 
 脚本默认按单张 B200 的 BF16 dense 峰值 `2250 TFLOPS` 计算 MFU。若测试环境采用其他

--- a/tests/operators/chunk_kda_fwd/README.md
+++ b/tests/operators/chunk_kda_fwd/README.md
@@ -92,6 +92,8 @@ bash scripts/benchmark_kda_main.sh \
 为兼容旧的一键命令，`--decode-step 1` 会被接受但不参与 KDA 正向测试；旧 case 名
 `prefill_fwd_b1_s1024`、`prefill_fwd_b1_s8192`、`prefill_fwd_b1_s16384`
 分别映射到 ATK case 250、282、290。新增测试应直接使用 ATK case ID 或 case key。
+脚本会优先使用当前已加载的 CANN 环境；未加载时自动尝试标准安装位置
+`/usr/local/Ascend/cann/set_env.sh` 和 `/usr/local/Ascend/ascend-toolkit/set_env.sh`。
 
 报告使用 `msopprof` 设备侧耗时，默认 `--aic-metrics Default`。不要改为
 `BasicInfo`，否则只能得到基础耗时，不能生成完整资源明细。结果目录包含：

--- a/tests/operators/chunk_kda_fwd/README.md
+++ b/tests/operators/chunk_kda_fwd/README.md
@@ -65,17 +65,15 @@ bash scripts/benchmark_kda_main.sh \
   --work-root "$PWD/outputs/kda-main-benchmark"
 ```
 
-该入口复用 PR297 的 48 条 A5 正向用例（case ID 250 至 297）。所有用例固定为
+该入口固定运行 8 条 A5 dense 正向用例（case ID 250 至 257）。所有用例固定为
 BF16、`H=96`、`K=V=128`、`chunk_size=64`、
 `initial_state=None`、`output_final_state=False`、`use_gate_in_kernel=True`、
-`safe_gate=True`、`return_intermediate_states=False`、`state_v_first=True`，并覆盖：
+`safe_gate=True`、`return_intermediate_states=False`、`state_v_first=True`、
+`cu_seqlens=None`，并覆盖：
 
-- 总 token 数：1024、1536、2048、4096、8192、16384；
-- 单序列：全部 token 属于一个序列；
-- 8 个近似等长序列：将全部 token 尽量平均分给 8 个序列；
-- 8 个带不同尾块的序列：序列长度刻意不按 64 对齐，用于覆盖完整 chunk 与尾 chunk 混合执行；
-- 每个序列 64 个 token：一个序列恰好占一个完整 chunk；
-- `disable_recompute=False` 和 `disable_recompute=True` 两种模式。
+- dense 序列长度：1024、8192、16384、65536；
+- 每种长度覆盖启用重计算和关闭重计算两种模式，即底层
+  `disable_recompute=False/True`。
 
 可先查看固定矩阵，或只运行部分 ATK case ID / case key：
 
@@ -86,12 +84,13 @@ bash scripts/benchmark_kda_main.sh \
   --soc ascend950 \
   --device 0 \
   --work-root "$PWD/outputs/kda-main-benchmark" \
-  --cases 282,283,290,291
+  --cases 252,253,254,255
 ```
 
 为兼容旧的一键命令，`--decode-step 1` 会被接受但不参与 KDA 正向测试；旧 case 名
 `prefill_fwd_b1_s1024`、`prefill_fwd_b1_s8192`、`prefill_fwd_b1_s16384`
-分别映射到 ATK case 250、282、290。新增测试应直接使用 ATK case ID 或 case key。
+分别映射到 case 250、252、254；`prefill_fwd_b1_s65536` 映射到 case 256。
+新增测试应直接使用 case ID 或 case key。
 脚本会优先使用当前已加载的 CANN 环境；未加载时自动尝试标准安装位置
 `/usr/local/Ascend/cann/set_env.sh` 和 `/usr/local/Ascend/ascend-toolkit/set_env.sh`。
 每次运行会将 CANN 应用日志重定向到当前 `run_*/ascend_logs/`，避免继续写入默认
@@ -107,12 +106,12 @@ kernel replay 均由 msopprof 在同一个 application 进程内完成，不会�
 
 | 文件 | 内容 |
 | --- | --- |
-| `case_matrix.csv` | 48 条固定用例及 `cu_seqlens`、序列数、chunk 数、随机种子和功能属性 |
+| `case_matrix.csv` | 8 条固定 dense 用例及序列长度、chunk 数、重计算开关、随机种子和功能属性 |
 | `results.csv` / `results.md` | 每条用例的端到端 kernel 聚合耗时和执行状态 |
-| `kernel_detail.xlsx` | 48 个 case sheet；每个 sheet 保存该用例的 kernel、replay、block/sub-block 完整性能明细 |
+| `kernel_detail.xlsx` | 8 个 case sheet；每个 sheet 保存该用例的 kernel、replay、block/sub-block 完整性能明细 |
 | `results.json` | 环境元数据、用例汇总和 kernel 耗时分解 |
 
-`kernel_detail.xlsx` 固定包含 `case_250` 至 `case_297` 共 48 个 sheet，每个 sheet
+`kernel_detail.xlsx` 固定包含 `case_250` 至 `case_257` 共 8 个 sheet，每个 sheet
 提供 Cube、MAC、Vector、MTE1、MTE2、MTE3、Fixpipe、
 Scalar 的时间、占比和带宽列，并保留 `PipeUtilization`、`ArithmeticUtilization`、
 `Memory`、`MemoryL0`、`MemoryUB`、`L2Cache`、`ResourceConflictRatio` 和

--- a/tests/operators/chunk_kda_fwd/README.md
+++ b/tests/operators/chunk_kda_fwd/README.md
@@ -54,6 +54,65 @@ FLA_NPU_RUN_OPERATOR_TESTS=1 pytest -q tests/operators/chunk_kda_fwd/st/test_exa
 cd examples/fast_kernel_launch_example && FAST_KERNEL_OP_NAME=chunk_kda_fwd pytest -q tests/chunk_kda_fwd
 ```
 
+`scripts/benchmark_kda_main.sh` 提供独立 wheel 构建、安装、打包 API 自检和 `msopprof`
+报告聚合入口。默认直接使用当前
+checkout，不访问远端仓库；需要验证远端 ref 时才同时传入 `--repo-url` 和 `--ref`：
+
+```bash
+bash scripts/benchmark_kda_main.sh \
+  --soc ascend950 \
+  --device 0 \
+  --work-root "$PWD/outputs/kda-main-benchmark"
+```
+
+该入口复用 PR297 的 48 条 A5 正向用例（case ID 250 至 297）。所有用例固定为
+BF16、`H=96`、`K=V=128`、`chunk_size=64`、
+`initial_state=None`、`output_final_state=False`、`use_gate_in_kernel=True`、
+`safe_gate=True`、`return_intermediate_states=False`、`state_v_first=True`，并覆盖：
+
+- 总 token 数：1024、1536、2048、4096、8192、16384；
+- 单序列：全部 token 属于一个序列；
+- 8 个近似等长序列：将全部 token 尽量平均分给 8 个序列；
+- 8 个带不同尾块的序列：序列长度刻意不按 64 对齐，用于覆盖完整 chunk 与尾 chunk 混合执行；
+- 每个序列 64 个 token：一个序列恰好占一个完整 chunk；
+- `disable_recompute=False` 和 `disable_recompute=True` 两种模式。
+
+可先查看固定矩阵，或只运行部分 ATK case ID / case key：
+
+```bash
+python scripts/benchmark_kda_matrix.py --list-cases
+
+bash scripts/benchmark_kda_main.sh \
+  --soc ascend950 \
+  --device 0 \
+  --work-root "$PWD/outputs/kda-main-benchmark" \
+  --cases 282,283,290,291
+```
+
+为兼容旧的一键命令，`--decode-step 1` 会被接受但不参与 KDA 正向测试；旧 case 名
+`prefill_fwd_b1_s1024`、`prefill_fwd_b1_s8192`、`prefill_fwd_b1_s16384`
+分别映射到 ATK case 250、282、290。新增测试应直接使用 ATK case ID 或 case key。
+
+报告使用 `msopprof` 设备侧耗时，默认 `--aic-metrics Default`。不要改为
+`BasicInfo`，否则只能得到基础耗时，不能生成完整资源明细。结果目录包含：
+
+| 文件 | 内容 |
+| --- | --- |
+| `case_matrix.csv` | 48 条固定用例及 `cu_seqlens`、序列数、chunk 数、随机种子和功能属性 |
+| `results.csv` / `results.md` | 每条用例的端到端 kernel 聚合耗时和执行状态 |
+| `kernel_detail.xlsx` | 48 个 case sheet；每个 sheet 保存该用例的 kernel、replay、block/sub-block 完整性能明细 |
+| `results.json` | 环境元数据、用例汇总和 kernel 耗时分解 |
+
+`kernel_detail.xlsx` 固定包含 `case_250` 至 `case_297` 共 48 个 sheet，每个 sheet
+提供 Cube、MAC、Vector、MTE1、MTE2、MTE3、Fixpipe、
+Scalar 的时间、占比和带宽列，并保留 `PipeUtilization`、`ArithmeticUtilization`、
+`Memory`、`MemoryL0`、`MemoryUB`、`L2Cache`、`ResourceConflictRatio` 和
+`OpBasicInfo` 中出现的全部原始字段。`mac_time_us` 是 profiler
+`aic_cube_time(us)` 的易读别名，原始字段仍会保留。AIC 与 AIV 的 MTE 指标分别记录，
+不合并为单一数值。使用 `Default` 时若缺少任一资源表，该 case 会判为 `ERROR` 并保留诊断。
+
+任一 case 出现 `ERROR`、`OOM` 或 `TIMEOUT` 时，入口返回非零状态并保留逐 case 诊断。
+
 A5 PR264 一键构建、隔离安装和基础验收：
 
 ```bash

--- a/tests/operators/chunk_kda_fwd/README.md
+++ b/tests/operators/chunk_kda_fwd/README.md
@@ -94,6 +94,8 @@ bash scripts/benchmark_kda_main.sh \
 分别映射到 ATK case 250、282、290。新增测试应直接使用 ATK case ID 或 case key。
 脚本会优先使用当前已加载的 CANN 环境；未加载时自动尝试标准安装位置
 `/usr/local/Ascend/cann/set_env.sh` 和 `/usr/local/Ascend/ascend-toolkit/set_env.sh`。
+每次运行会将 CANN 应用日志重定向到当前 `run_*/ascend_logs/`，避免继续写入默认
+`$HOME/ascend/log`；preflight 和 profiler 输出同时实时显示在终端并保存到结果日志。
 
 报告使用 `msopprof` 设备侧耗时，默认 `--aic-metrics Default`。不要改为
 `BasicInfo`，否则只能得到基础耗时，不能生成完整资源明细。结果目录包含：

--- a/tests/operators/chunk_kda_fwd/README.md
+++ b/tests/operators/chunk_kda_fwd/README.md
@@ -131,6 +131,44 @@ python scripts/benchmark_kda_matrix.py \
 
 任一 case 出现 `ERROR`、`OOM` 或 `TIMEOUT` 时，入口返回非零状态并保留逐 case 诊断。
 
+### B200 FLA Triton 性能对比
+
+`scripts/benchmark_kda_b200_triton.py` 在单张 NVIDIA B200 上直接调用当前 Python
+环境已经安装的 `flash-linear-attention==0.5.2`，不会拉取 fla-org 仓库，也不会执行
+`pip install`。脚本使用与 A5 完全相同的 case 250 至 257、输入 shape、随机种子和功能属性，
+并强制关闭 FlashKDA、TileLang 等可选后端分发，确保执行 FLA 默认 Triton 实现。
+
+在已经安装 FLA 0.5.2 的 B200 环境中一键执行：
+
+```bash
+python scripts/benchmark_kda_b200_triton.py --device 0
+```
+
+默认每条 case 预热 5 次，随后正式执行 10 次。每次使用 CUDA event 记录完整低层
+`chunk_kda_fwd` 前向耗时并同步，最终取 10 次的算术平均值。输入生成、首次 Triton 编译、
+自动调优和预热耗时不计入正式结果。可显式写出默认参数或指定部分 case：
+
+```bash
+python scripts/benchmark_kda_b200_triton.py \
+  --device 0 \
+  --warmup 5 \
+  --runs 10 \
+  --cases 250,251,252,253,254,255,256,257 \
+  --output-dir "$PWD/output/kda-b200-triton"
+```
+
+结果目录包含：
+
+| 文件 | 内容 |
+| --- | --- |
+| `results.md` | B200 平均耗时、MFU、A5 耗时和 A5/B200 耗时比汇总表 |
+| `results.csv` | 每条 case 的平均值、中位数、最小值、最大值、标准差和峰值显存 |
+| `timings.csv` | 每条 case 的 10 次原始 CUDA event 耗时 |
+| `results.json` | GPU、PyTorch、Triton、FLA 版本、FLA 安装位置校验状态和完整结果 |
+
+脚本默认按单张 B200 的 BF16 dense 峰值 `2250 TFLOPS` 计算 MFU。若测试环境采用其他
+功耗或频率口径，可通过 `--peak-tflops <value>` 覆盖；耗时本身不受该参数影响。
+
 A5 PR264 一键构建、隔离安装和基础验收：
 
 ```bash

--- a/tests/operators/chunk_kda_fwd/README.md
+++ b/tests/operators/chunk_kda_fwd/README.md
@@ -115,6 +115,16 @@ Scalar 的时间、占比和带宽列，并保留 `PipeUtilization`、`Arithmeti
 `aic_cube_time(us)` 的易读别名，原始字段仍会保留。AIC 与 AIV 的 MTE 指标分别记录，
 不合并为单一数值。使用 `Default` 时若缺少任一资源表，该 case 会判为 `ERROR` 并保留诊断。
 
+若已有运行目录只需重新生成 `kernel_detail.xlsx`，无需重跑 NPU profiling：
+
+```bash
+python scripts/benchmark_kda_matrix.py \
+  --repair-workbook /path/to/run_YYYYMMDD_HHMMSS_PID/results
+```
+
+该命令读取原有 `results.json` 及其中记录的 msopprof CSV，覆盖结果目录内的
+`kernel_detail.xlsx`，不会启动算子或修改其他报告文件。
+
 任一 case 出现 `ERROR`、`OOM` 或 `TIMEOUT` 时，入口返回非零状态并保留逐 case 诊断。
 
 A5 PR264 一键构建、隔离安装和基础验收：

--- a/tests/operators/chunk_kda_fwd/performance/test_benchmark_kda_b200_triton.py
+++ b/tests/operators/chunk_kda_fwd/performance/test_benchmark_kda_b200_triton.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+RUNNER_PATH = REPO_ROOT / "scripts" / "benchmark_kda_b200_triton.py"
+
+
+def load_runner():
+    spec = importlib.util.spec_from_file_location(
+        "benchmark_kda_b200_triton", RUNNER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_b200_matrix_matches_the_eight_dense_atk_cases():
+    runner = load_runner()
+    assert [case.case_id for case in runner.CASES] == list(range(250, 258))
+    assert [case.total_tokens for case in runner.CASES] == [
+        1024,
+        1024,
+        8192,
+        8192,
+        16384,
+        16384,
+        65536,
+        65536,
+    ]
+    assert [case.recompute_enabled for case in runner.CASES] == [
+        True,
+        False,
+        True,
+        False,
+        True,
+        False,
+        True,
+        False,
+    ]
+    assert [case.chunk_count for case in runner.CASES] == [
+        16,
+        16,
+        128,
+        128,
+        256,
+        256,
+        1024,
+        1024,
+    ]
+    assert runner.select_cases("250,257") == [runner.CASES[0], runner.CASES[-1]]
+
+
+def test_default_run_count_is_ten(monkeypatch):
+    runner = load_runner()
+    monkeypatch.setattr(sys, "argv", [str(RUNNER_PATH)])
+    args = runner.parse_args()
+    assert args.warmup == 5
+    assert args.runs == 10
+
+
+def test_summary_uses_the_arithmetic_mean_of_all_measurements():
+    runner = load_runner()
+    timings = [float(value) for value in range(1, 11)]
+    summary = runner.summarize_timings(
+        runner.CASES[0], timings, peak_tflops=2250.0
+    )
+    assert summary["mean_us"] == 5.5
+    assert summary["median_us"] == 5.5
+    assert summary["min_us"] == 1.0
+    assert summary["max_us"] == 10.0
+    assert summary["a5_over_b200"] == runner.CASES[0].a5_us / 5.5
+
+
+def test_invoke_passes_the_fixed_dense_fla_arguments():
+    runner = load_runner()
+    captured = {}
+
+    def operation(**kwargs):
+        captured.update(kwargs)
+        return (None,) * 12
+
+    inputs = {
+        "q": object(),
+        "k": object(),
+        "v": object(),
+        "g": object(),
+        "beta": object(),
+        "A_log": object(),
+        "dt_bias": object(),
+    }
+    case = runner.CASES[1]
+    runner.invoke(operation, inputs, case)
+
+    assert captured["initial_state"] is None
+    assert captured["output_final_state"] is False
+    assert captured["cu_seqlens"] is None
+    assert captured["chunk_indices"] is None
+    assert captured["chunk_size"] == 64
+    assert captured["safe_gate"] is True
+    assert captured["lower_bound"] == -5.0
+    assert captured["use_gate_in_kernel"] is True
+    assert captured["disable_recompute"] is True
+    assert captured["return_intermediate_states"] is False
+    assert captured["state_v_first"] is True
+
+
+def test_runner_uses_installed_fla_without_install_or_clone_commands():
+    source = RUNNER_PATH.read_text(encoding="utf-8")
+    assert 'metadata.distribution("flash-linear-attention")' in source
+    assert 'import_module("fla.ops.kda.chunk_fwd")' in source
+    assert 'os.environ["FLA_DISABLE_BACKEND_DISPATCH"] = "1"' in source
+    assert "subprocess" not in source
+    assert "pip install" not in source
+    assert "git clone" not in source

--- a/tests/operators/chunk_kda_fwd/performance/test_benchmark_kda_b200_triton.py
+++ b/tests/operators/chunk_kda_fwd/performance/test_benchmark_kda_b200_triton.py
@@ -69,10 +69,10 @@ def test_summary_uses_the_arithmetic_mean_of_all_measurements():
     summary = runner.summarize_timings(
         runner.CASES[0], timings, peak_tflops=2250.0
     )
-    assert summary["mean_us"] == 5.5
-    assert summary["median_us"] == 5.5
-    assert summary["min_us"] == 1.0
-    assert summary["max_us"] == 10.0
+    assert summary["device_mean_us"] == 5.5
+    assert summary["device_median_us"] == 5.5
+    assert summary["device_min_us"] == 1.0
+    assert summary["device_max_us"] == 10.0
     assert summary["a5_over_b200"] == runner.CASES[0].a5_us / 5.5
 
 

--- a/tests/operators/chunk_kda_fwd/performance/test_benchmark_kda_matrix.py
+++ b/tests/operators/chunk_kda_fwd/performance/test_benchmark_kda_matrix.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import csv
+import importlib.util
+import sys
+import zipfile
+from argparse import Namespace
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+RUNNER_PATH = REPO_ROOT / "scripts" / "benchmark_kda_matrix.py"
+
+
+def load_runner():
+    spec = importlib.util.spec_from_file_location("benchmark_kda_matrix", RUNNER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_metric(path: Path, header: list[str], row: list[str]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(header)
+        writer.writerow(row)
+
+
+def write_default_metrics(directory: Path) -> None:
+    directory.mkdir(parents=True)
+    tables = {
+        "OpBasicInfo": (
+            ["Op Name", "Op Type", "Task Duration(us)"],
+            ["ChunkKdaFwd", "mix", "12.5"],
+        ),
+        "PipeUtilization": (
+            [
+                "block_id",
+                "sub_block_id",
+                "aic_cube_time(us)",
+                "aic_mte2_time(us)",
+                "aic_mte3_time(us)",
+                "aic_fixpipe_time(us)",
+                "aiv_vec_time(us)",
+            ],
+            ["0", "cube0", "8.0", "3.0", "2.0", "1.0", "4.0"],
+        ),
+        "ArithmeticUtilization": (
+            ["block_id", "sub_block_id", "aic_cube_ratio", "aiv_vec_ratio"],
+            ["0", "cube0", "0.8", "0.6"],
+        ),
+        "Memory": (
+            ["block_id", "sub_block_id", "aic_main_mem_read_bw(GB/s)"],
+            ["0", "cube0", "1"],
+        ),
+        "MemoryL0": (
+            ["block_id", "sub_block_id", "aic_l0a_read_bw(GB/s)"],
+            ["0", "cube0", "2"],
+        ),
+        "MemoryUB": (
+            ["block_id", "sub_block_id", "aiv_ub_read_bw_vector(GB/s)"],
+            ["0", "cube0", "3"],
+        ),
+        "L2Cache": (
+            ["block_id", "sub_block_id", "aic_read_hit_rate(%)"],
+            ["0", "cube0", "4"],
+        ),
+        "ResourceConflictRatio": (
+            ["block_id", "sub_block_id", "aic_cube_wait_ratio"],
+            ["0", "cube0", "5"],
+        ),
+    }
+    for name, (header, row) in tables.items():
+        write_metric(directory / f"{name}_sample.csv", header, row)
+
+
+def test_pr297_case_matrix_contract():
+    runner = load_runner()
+    assert len(runner.CASES) == 48
+    assert [case.atk_case_id for case in runner.CASES] == list(range(250, 298))
+    assert {case.sequence for case in runner.CASES} == {
+        1024,
+        1536,
+        2048,
+        4096,
+        8192,
+        16384,
+    }
+    assert {case.distribution for case in runner.CASES} == {
+        "single",
+        "balanced8",
+        "mixed_tail",
+        "short64",
+    }
+    for case in runner.CASES:
+        assert case.cu_seqlens[0] == 0
+        assert case.cu_seqlens[-1] == case.sequence
+        assert case.case_key.startswith("ascend950_h96_")
+    assert runner.selected_cases("prefill_fwd_b1_s16384") == [runner.CASE_BY_ID["290"]]
+
+
+def test_flat_default_metrics_are_merged_and_aliased(tmp_path):
+    runner = load_runner()
+    profile_dir = tmp_path / "OPPROF_flat"
+    write_default_metrics(profile_dir)
+
+    rows = runner.read_kernel_detail_rows(profile_dir)
+
+    assert len(rows) == 1
+    assert set(rows[0]["metric_file_types"].split(",")) == set(
+        runner.PROFILE_METRIC_NAMES
+    )
+    result = {
+        **runner.asdict(runner.CASES[0]),
+        "sequence_count": 1,
+        "chunk_count": 16,
+        "status": "PASS",
+        "profile_mode": "application_mstx",
+        "aic_metrics": "Default",
+        "_kernel_detail": rows,
+    }
+    detail = runner.build_kernel_detail_rows([result])[0]
+    assert detail["mac_time_us"] == "8.0"
+    assert detail["aic_mte2_time_us"] == "3.0"
+    assert detail["aic_mte3_time_us"] == "2.0"
+    assert detail["aic_fixpipe_time_us"] == "1.0"
+    assert detail["vec_time_us"] == "4.0"
+    assert detail["aic_main_mem_read_bw(GB/s)"] == "1"
+
+
+def test_hierarchical_default_metrics_are_merged(tmp_path):
+    runner = load_runner()
+    profile_dir = tmp_path / "profile"
+    write_default_metrics(profile_dir / "kernel_0" / "0")
+
+    rows = runner.read_kernel_detail_rows(profile_dir)
+
+    assert len(rows) == 1
+    assert rows[0]["kernel_instance"] == "kernel_0"
+    assert rows[0]["replay"] == "0"
+    assert rows[0]["block_id"] == "0"
+    assert rows[0]["sub_block_id"] == "cube0"
+
+
+def test_workbook_has_one_sheet_per_pr297_case(tmp_path):
+    runner = load_runner()
+    result = {
+        **runner.asdict(runner.CASES[0]),
+        "sequence_count": 1,
+        "chunk_count": 16,
+        "status": "PASS",
+        "profile_mode": "application_mstx",
+        "aic_metrics": "Default",
+        "_kernel_detail": [
+            {
+                "metric_file_types": ",".join(runner.PROFILE_METRIC_NAMES),
+                "source_csvs": "OPPROF/PipeUtilization.csv",
+                "kernel_instance": "OPPROF",
+                "replay": "0",
+                "block_id": "0",
+                "sub_block_id": "cube0",
+                "Op Name": "ChunkKdaFwd",
+                "Op Type": "mix",
+                "aic_cube_time(us)": "8.0",
+                "aic_mte2_time(us)": "3.0",
+                "aiv_vec_time(us)": "4.0",
+            }
+        ],
+    }
+    runner.write_kernel_detail_workbook(Namespace(output_dir=tmp_path), [result])
+
+    workbook_path = tmp_path / "kernel_detail.xlsx"
+    with zipfile.ZipFile(workbook_path) as workbook:
+        namespace = {
+            "x": "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+        }
+        tree = ElementTree.fromstring(workbook.read("xl/workbook.xml"))
+        names = [sheet.attrib["name"] for sheet in tree.findall(".//x:sheet", namespace)]
+        assert names == [f"case_{case_id}" for case_id in range(250, 298)]
+        assert len(names) == 48
+        first_sheet = workbook.read("xl/worksheets/sheet1.xml").decode("utf-8")
+        assert "mac_time_us" in first_sheet
+        assert "aic_mte2_time_us" in first_sheet
+        assert "vec_time_us" in first_sheet
+        assert "ChunkKdaFwd" in first_sheet

--- a/tests/operators/chunk_kda_fwd/performance/test_benchmark_kda_matrix.py
+++ b/tests/operators/chunk_kda_fwd/performance/test_benchmark_kda_matrix.py
@@ -101,6 +101,21 @@ def test_pr297_case_matrix_contract():
     assert runner.selected_cases("prefill_fwd_b1_s16384") == [runner.CASE_BY_ID["290"]]
 
 
+def test_profile_uses_one_application_launch(tmp_path):
+    runner = load_runner()
+    args = Namespace(aic_metrics="Default", launch_count=1, warm_up=5)
+    worker = ["python", "benchmark_kda_matrix.py", "--worker", "250"]
+
+    attempts = runner.profile_attempts(args, runner.CASES[0], tmp_path, worker)
+
+    assert len(attempts) == 1
+    command = attempts[0]["command"]
+    assert "--launch-count=1" in command
+    assert "--warm-up=5" in command
+    assert "--replay-mode=kernel" in command
+    assert "--replay-mode=application" not in command
+
+
 def test_flat_default_metrics_are_merged_and_aliased(tmp_path):
     runner = load_runner()
     profile_dir = tmp_path / "OPPROF_flat"

--- a/tests/operators/chunk_kda_fwd/performance/test_benchmark_kda_matrix.py
+++ b/tests/operators/chunk_kda_fwd/performance/test_benchmark_kda_matrix.py
@@ -76,29 +76,24 @@ def write_default_metrics(directory: Path) -> None:
         write_metric(directory / f"{name}_sample.csv", header, row)
 
 
-def test_pr297_case_matrix_contract():
+def test_dense_case_matrix_contract():
     runner = load_runner()
-    assert len(runner.CASES) == 48
-    assert [case.atk_case_id for case in runner.CASES] == list(range(250, 298))
+    assert len(runner.CASES) == 8
+    assert [case.atk_case_id for case in runner.CASES] == list(range(250, 258))
     assert {case.sequence for case in runner.CASES} == {
         1024,
-        1536,
-        2048,
-        4096,
         8192,
         16384,
+        65536,
     }
-    assert {case.distribution for case in runner.CASES} == {
-        "single",
-        "balanced8",
-        "mixed_tail",
-        "short64",
-    }
+    assert {case.distribution for case in runner.CASES} == {"dense"}
+    assert {case.disable_recompute for case in runner.CASES} == {False, True}
     for case in runner.CASES:
-        assert case.cu_seqlens[0] == 0
-        assert case.cu_seqlens[-1] == case.sequence
+        assert case.cu_seqlens is None
+        assert runner.case_chunk_count(case) == case.sequence // runner.CHUNK_SIZE
         assert case.case_key.startswith("ascend950_h96_")
-    assert runner.selected_cases("prefill_fwd_b1_s16384") == [runner.CASE_BY_ID["290"]]
+    assert runner.selected_cases("prefill_fwd_b1_s16384") == [runner.CASE_BY_ID["254"]]
+    assert runner.selected_cases("prefill_fwd_b1_s65536") == [runner.CASE_BY_ID["256"]]
 
 
 def test_profile_uses_one_application_launch(tmp_path):
@@ -132,7 +127,7 @@ def test_flat_default_metrics_are_merged_and_aliased(tmp_path):
         "sequence_count": 1,
         "chunk_count": 16,
         "status": "PASS",
-        "profile_mode": "application_mstx",
+        "profile_mode": "kernel_filter",
         "aic_metrics": "Default",
         "_kernel_detail": rows,
     }
@@ -159,14 +154,14 @@ def test_hierarchical_default_metrics_are_merged(tmp_path):
     assert rows[0]["sub_block_id"] == "cube0"
 
 
-def test_workbook_has_one_sheet_per_pr297_case(tmp_path):
+def test_workbook_has_one_sheet_per_dense_case(tmp_path):
     runner = load_runner()
     result = {
         **runner.asdict(runner.CASES[0]),
         "sequence_count": 1,
         "chunk_count": 16,
         "status": "PASS",
-        "profile_mode": "application_mstx",
+        "profile_mode": "kernel_filter",
         "aic_metrics": "Default",
         "_kernel_detail": [
             {
@@ -194,8 +189,8 @@ def test_workbook_has_one_sheet_per_pr297_case(tmp_path):
         }
         tree = ElementTree.fromstring(workbook.read("xl/workbook.xml"))
         names = [sheet.attrib["name"] for sheet in tree.findall(".//x:sheet", namespace)]
-        assert names == [f"case_{case_id}" for case_id in range(250, 298)]
-        assert len(names) == 48
+        assert names == [f"case_{case_id}" for case_id in range(250, 258)]
+        assert len(names) == 8
         first_sheet = workbook.read("xl/worksheets/sheet1.xml").decode("utf-8")
         sheet_tree = ElementTree.fromstring(first_sheet)
         child_names = [node.tag.rsplit("}", 1)[-1] for node in sheet_tree]

--- a/tests/operators/chunk_kda_fwd/performance/test_benchmark_kda_matrix.py
+++ b/tests/operators/chunk_kda_fwd/performance/test_benchmark_kda_matrix.py
@@ -163,6 +163,7 @@ def test_workbook_has_one_sheet_per_pr297_case(tmp_path):
                 "sub_block_id": "cube0",
                 "Op Name": "ChunkKdaFwd",
                 "Op Type": "mix",
+                "diagnostic": "valid\x00text",
                 "aic_cube_time(us)": "8.0",
                 "aic_mte2_time(us)": "3.0",
                 "aiv_vec_time(us)": "4.0",
@@ -181,7 +182,40 @@ def test_workbook_has_one_sheet_per_pr297_case(tmp_path):
         assert names == [f"case_{case_id}" for case_id in range(250, 298)]
         assert len(names) == 48
         first_sheet = workbook.read("xl/worksheets/sheet1.xml").decode("utf-8")
+        sheet_tree = ElementTree.fromstring(first_sheet)
+        child_names = [node.tag.rsplit("}", 1)[-1] for node in sheet_tree]
+        assert "autoFilter" not in child_names
+        assert child_names.index("sheetData") < child_names.index("mergeCells")
         assert "mac_time_us" in first_sheet
         assert "aic_mte2_time_us" in first_sheet
         assert "vec_time_us" in first_sheet
         assert "ChunkKdaFwd" in first_sheet
+        assert "validtext" in first_sheet
+
+
+def test_repair_workbook_reuses_existing_profile_data(tmp_path):
+    runner = load_runner()
+    profile_dir = tmp_path / "profile"
+    write_default_metrics(profile_dir)
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+    result = {
+        **runner.asdict(runner.CASES[0]),
+        "sequence_count": 1,
+        "chunk_count": 16,
+        "status": "PASS",
+        "profile_mode": "application_kernel_filter",
+        "aic_metrics": "Default",
+        "selected_profile_dir": str(profile_dir),
+    }
+    (results_dir / "results.json").write_text(
+        runner.json.dumps({"results": [result]}), encoding="utf-8"
+    )
+
+    workbook_path = runner.repair_kernel_detail_workbook(results_dir)
+
+    assert workbook_path == results_dir / "kernel_detail.xlsx"
+    with zipfile.ZipFile(workbook_path) as workbook:
+        first_sheet = workbook.read("xl/worksheets/sheet1.xml").decode("utf-8")
+        assert "ChunkKdaFwd" in first_sheet
+        assert "12.5" in first_sheet


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: 无；本 PR 仅新增测试性质脚本，不修改算子实现或公开接口。
- 背景与目标: 在 PR #276 方案基础上，基于最新 `main` 重提 KDA 正向一键性能测试入口，从源码拉取、隔离构建安装 wheel 到输出 `msopprof` 报告形成闭环。
- 本 PR 解决的问题: 统一 `chunk_kda_fwd` prefill 和 `recurrent_kda` decode case、设备计时口径、decode 稳态推进语义、错误分类和结果格式，并保证失败 case 通过非零退出码反馈给调用方。

## 变更类型

- [ ] Bug 修复
- [x] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `chunk_kda_fwd`、`recurrent_kda`（仅性能测试入口）
- 涉及目录 / 文件: `scripts/benchmark_kda_main.sh`、`scripts/benchmark_kda_matrix.py`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: prefill 覆盖 `B=1,S=1024/8192/16384/65536,H=96,K=V=128`；decode 覆盖 `B=1/4/16/64,S=8192,H=96,K=V=128`，单次 `decode_step=1/2/4/8`，Q/K/V 为 BF16，state 为 BF16 V-first。
- 明确不包含的范围: 不修改算子实现、公共 API、精度逻辑或 backward；不使用 Python wall time 作为性能结论。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无，仅新增独立脚本。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

静态与纯逻辑验证：

```sh
bash -n scripts/benchmark_kda_main.sh
python3 -m py_compile scripts/benchmark_kda_matrix.py
bash scripts/benchmark_kda_main.sh --help
git diff --check
```

A2/A3/A5 一键性能验证：

```sh
bash scripts/benchmark_kda_main.sh \
  --soc <ascend910b|ascend910_93|ascend950> \
  --device 0 \
  --work-root <work_dir> \
  --cases all \
  --decode-step 1
```

通过标准：wheel 构建安装和打包 API 自检通过；所有 case 生成 `msopprof` Default 完整指标结果（包含 OpBasicInfo 及硬件利用率、访存等 CSV）；报告中无 `ERROR`、`OOM` 或 `TIMEOUT`，命令退出码为 0。

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未验证 | 一键脚本 | 未执行 | 当前未提供对应 CANN/NPU 环境 |
| A3 | `ascend910_93` | 未验证 | 一键脚本 | 未执行 | 当前未提供对应 CANN/NPU 环境 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未验证 | 一键脚本 | 未执行 | 当前未提供对应 CANN/NPU 环境 |
| A3 | `ascend910_93` | 未验证 | 一键脚本 | 未执行 | 当前未提供对应 CANN/NPU 环境 |
| A5 | `ascend950` | 未验证 | 一键脚本 | 未执行 | 当前未提供对应 CANN/NPU 环境 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 一键脚本 | 未执行 | 当前未提供对应 CANN/NPU 环境 |
| A3 | `ascend910_93` | 一键脚本 | 未执行 | 当前未提供对应 CANN/NPU 环境 |
| A5 | `ascend950` | 一键脚本 | 未执行 | 当前未提供对应 CANN/NPU 环境 |

- 精度对比: 不涉及精度实现变更。
- 性能对比: 尚未执行设备测试，不提供性能数字。
- 边界 / 异常场景: Python 最低版本、SOC、decode step、case 超时和失败退出码已覆盖无设备验证。
- 未覆盖风险: A2/A3/A5 实际 wheel 构建、算子执行和不同 `msopprof` 版本输出格式需要由对应平台补齐。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 仅新增独立性能脚本，不修改 example 或算子实现 |
| A3 | `ascend910_93` | 同上 | 未执行 | 当前未提供对应 CANN/NPU 环境 |
| A5 | `ascend950` | 同上 | 未执行 | 当前未提供对应 CANN/NPU 环境 |

- 端到端场景说明: 不涉及端到端行为变更。
- 与本 PR 修改算子的关联: 仅新增 `chunk_kda_fwd`/`recurrent_kda` 性能测试入口。
- 未覆盖原因及补充计划: 合入前由对应平台或 NPU CI 补齐必要验证。

</details>

## 兼容性、风险与回退

- 兼容性说明: Python 最低版本与主线保持为 3.9；SOC、设备、CANN 环境、conda 环境、源码地址、引用和工作目录均参数化；A5 使用 `--soc ascend950`。
- 风险点: 不同 CANN/`msopprof` 版本的输出目录或 CSV 字段可能变化；decode 总耗时按稳态单次设备 kernel 时间外推，不包含 Python launch wall time。
- 回退方案: 删除新增的两个脚本即可，不影响任何已有接口或运行路径。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 本地已通过 Shell 语法、Python 编译、CLI help/非法 decode step、case 选择、decode 稳态聚合、失败退出码和 `git diff --check` 验证。
- `shellcheck` 未执行，原因是当前环境未安装该工具。
- 设备性能以 `msopprof` 结果为准；本 PR 不提供未验证的 A2/A3/A5 性能结论。
- 相比 PR #276，补充 Python 3.9 前置校验，将 decode step 公开取值与 8192 整除约束对齐，并保证存在失败 case 时命令返回非零状态。