### PR TITLE
fix(kda): 修复 A5 chunk_kda_fwd 前向精度不稳定

### DIFF
--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_fwd_h.h
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_fwd_h.h
@@ -11,16 +11,19 @@ namespace KdaForward::arch35 {
 
 using namespace AscendC;
 
-// Prepare is fully drained before FwdH starts. Keep FwdH mode-2
+// The direct UB is shared by one AIC and its two AIV subblocks. Mode 4
+// addresses each subblock explicitly: the second AIV uses flag + 16.
+constexpr uint64_t KDA_FWD_H_DIRECT_FREE_FLAG = 6;
+constexpr uint64_t KDA_FWD_H_DIRECT_READY_FLAG = 7;
+constexpr uint64_t KDA_FWD_H_SUBBLOCK_FLAG_OFFSET = 16;
+// Prepare is fully drained before FwdH starts. Keep FwdH mode-2 L1
 // traffic outside Matmul's possible 0..7 range and SyncAll's 11..14 range.
-constexpr uint64_t KDA_FWD_H_DIRECT_FREE_FLAG = 8;
-constexpr uint64_t KDA_FWD_H_DIRECT_READY_FLAG = 8;
 constexpr uint64_t KDA_FWD_H_L1_FREE_FLAG = 9;
 constexpr uint64_t KDA_FWD_H_L1_READY_FLAG = 9;
 constexpr uint64_t KDA_FWD_H_STATE_FREE_FLAG = KDA_FWD_H_L1_FREE_FLAG;
-constexpr uint64_t KDA_FWD_H_VNEW_FREE_FLAG = KDA_FWD_H_L1_FREE_FLAG;
 constexpr uint64_t KDA_FWD_H_STATE_READY_FLAG = KDA_FWD_H_L1_READY_FLAG;
-constexpr uint64_t KDA_FWD_H_VNEW_READY_FLAG = KDA_FWD_H_L1_READY_FLAG;
+constexpr uint64_t KDA_FWD_H_VNEW_FREE_FLAG = 10;
+constexpr uint64_t KDA_FWD_H_VNEW_READY_FLAG = 10;
 
 constexpr TEventID KDA_FWD_H_MTE_W_EVENT = 0;
 constexpr TEventID KDA_FWD_H_MTE_Q_EVENT = 1;
@@ -126,8 +129,6 @@ public:
         statePublishCount_[1] = 0;
         vnewPublishCount_[0] = 0;
         vnewPublishCount_[1] = 0;
-        wPublishCount_[0] = 0;
-        wPublishCount_[1] = 0;
     }
 
     __aicore__ inline void Process()
@@ -164,6 +165,30 @@ private:
     __aicore__ inline void WaitL1SlotReadyMte1(uint64_t readyFlag)
     {
         CrossCoreWaitFlag(readyFlag);
+    }
+
+    __aicore__ inline void WaitDirectFreeAic()
+    {
+        CrossCoreWaitFlag<0x4, PIPE_FIX>(KDA_FWD_H_DIRECT_FREE_FLAG);
+        CrossCoreWaitFlag<0x4, PIPE_FIX>(
+            KDA_FWD_H_DIRECT_FREE_FLAG + KDA_FWD_H_SUBBLOCK_FLAG_OFFSET);
+    }
+
+    __aicore__ inline void SetDirectReadyAic()
+    {
+        CrossCoreSetFlag<0x4, PIPE_FIX>(KDA_FWD_H_DIRECT_READY_FLAG);
+        CrossCoreSetFlag<0x4, PIPE_FIX>(
+            KDA_FWD_H_DIRECT_READY_FLAG + KDA_FWD_H_SUBBLOCK_FLAG_OFFSET);
+    }
+
+    __aicore__ inline void WaitDirectReadyAiv()
+    {
+        CrossCoreWaitFlag<0x4, PIPE_V>(KDA_FWD_H_DIRECT_READY_FLAG);
+    }
+
+    __aicore__ inline void SetDirectFreeAiv()
+    {
+        CrossCoreSetFlag<0x4, PIPE_V>(KDA_FWD_H_DIRECT_FREE_FLAG);
     }
 
     __aicore__ inline uint64_t MatrixOffset(uint64_t b, uint64_t hv, uint64_t t) const
@@ -285,11 +310,11 @@ private:
             typename DirectTileCopy::template CopyL0CToDst<decltype(tensorUb)>;
         CopyL0CToDst copyL0CToDst;
 
-        CrossCoreWaitFlag(KDA_FWD_H_DIRECT_FREE_FLAG);
+        WaitDirectFreeAic();
         SetFlag<HardEvent::M_FIX>(mToFixEvent);
         WaitFlag<HardEvent::M_FIX>(mToFixEvent);
         copyL0CToDst(tensorUb, tensorL0C);
-        CrossCoreSetFlag<0x2, PIPE_FIX>(KDA_FWD_H_DIRECT_READY_FLAG);
+        SetDirectReadyAic();
         SetFlag<HardEvent::FIX_M>(fixToMEvent);
     }
 
@@ -540,9 +565,6 @@ private:
             l0C, KDA_FWD_H_CHUNK, KDA_FWD_H_DIM,
             aicMToFixEvent_, aicFixToMEvent_);
         SetL1SlotFlagAicToAiv<PIPE_FIX>(KDA_FWD_H_STATE_FREE_FLAG);
-        if (fusePostWuIntoFwdH_) {
-            SetL1SlotFlagAicToAiv<PIPE_FIX>(KDA_FWD_H_STATE_FREE_FLAG);
-        }
 
         WaitFlag<HardEvent::M_MTE1>(stateL0FreeEvent_);
         WaitFlag<HardEvent::FIX_M>(aicFixToMEvent_);
@@ -678,15 +700,12 @@ private:
                     ComputePostWuAic(chunk);
                 }
                 WaitL1SlotReadyMte1(KDA_FWD_H_STATE_READY_FLAG);
-                if (fusePostWuIntoFwdH_) {
-                    WaitL1SlotReadyMte1(KDA_FWD_H_STATE_READY_FLAG);
-                }
                 ComputeStateProductsAic(b, hv, chunk, fusePostWuIntoFwdH_);
                 WaitL1SlotReadyMte1(KDA_FWD_H_VNEW_READY_FLAG);
                 ComputeVnewProductsAic(
                     b, hv, chunk, chunk + 1 < totalChunks_);
             }
-            CrossCoreWaitFlag(KDA_FWD_H_DIRECT_FREE_FLAG);
+            WaitDirectFreeAic();
         }
         WaitFlag<HardEvent::M_MTE1>(stateL0FreeEvent_);
         for (uint32_t slot = 0; slot < KDA_FWD_H_L1_STAGING_DEPTH; ++slot) {
@@ -760,10 +779,12 @@ private:
         stateCopyParams.srcGap = 0;
         stateCopyParams.dstGap = KDA_FWD_H_DIM - KDA_FWD_H_SUB_DIM;
         DataCopy(l1State[rowBegin * 16], stateTyped, stateCopyParams);
-        SetL1SlotFlagAivToAic<PIPE_MTE3>(KDA_FWD_H_STATE_READY_FLAG);
-        ++statePublishCount_[subBlockIdx];
         SetFlag<HardEvent::MTE3_V>(aivMte3ToVEvent_);
         WaitFlag<HardEvent::MTE3_V>(aivMte3ToVEvent_);
+        if (!fusePostWuIntoFwdH_) {
+            SetL1SlotFlagAivToAic<PIPE_MTE3>(KDA_FWD_H_STATE_READY_FLAG);
+        }
+        ++statePublishCount_[subBlockIdx];
     }
 
     __aicore__ inline void ProcessChunkAiv(
@@ -777,19 +798,17 @@ private:
         const uint32_t stateRowBegin = subBlockIdx * KDA_FWD_H_SUB_DIM;
         StoreCurrentStateAiv(b, hv, chunk, stateRowBegin, state, stateTyped);
 
-        CrossCoreWaitFlag(KDA_FWD_H_DIRECT_READY_FLAG);
+        WaitDirectReadyAiv();
         WaitFlag<HardEvent::MTE3_MTE2>(aivMte3ToMte2Event_);
         if (fusePostWuIntoFwdH_) {
             Cast(ioTyped, direct, RoundMode::CAST_RINT, KDA_FWD_H_TOKEN_SUB_ELEMS);
             PipeBarrier<PIPE_V>();
-            CrossCoreSetFlag<0x2, PIPE_V>(KDA_FWD_H_DIRECT_FREE_FLAG);
+            SetDirectFreeAiv();
 
             SetFlag<HardEvent::V_MTE3>(aivVToMte3Event_);
             WaitFlag<HardEvent::V_MTE3>(aivVToMte3Event_);
             LocalTensor<T> l1W = resource_.l1Buf.template GetBufferByByte<T>(
                 L1WOffset(chunk & 3));
-            WaitL1SlotFreeMte3(
-                KDA_FWD_H_STATE_FREE_FLAG, wPublishCount_[subBlockIdx]);
             DataCopyParams wCopyParams;
             wCopyParams.blockCount = KDA_FWD_H_SUB_CHUNK;
             wCopyParams.blockLen = 1;
@@ -803,15 +822,14 @@ private:
             SetFlag<HardEvent::MTE3_V>(aivMte3ToVEvent_);
             WaitFlag<HardEvent::MTE3_V>(aivMte3ToVEvent_);
             SetL1SlotFlagAivToAic<PIPE_MTE3>(KDA_FWD_H_STATE_READY_FLAG);
-            ++wPublishCount_[subBlockIdx];
 
-            CrossCoreWaitFlag(KDA_FWD_H_DIRECT_READY_FLAG);
+            WaitDirectReadyAiv();
             Cast(ioTyped, direct, RoundMode::CAST_RINT, KDA_FWD_H_TOKEN_SUB_ELEMS);
             PipeBarrier<PIPE_V>();
             Cast(vnew, ioTyped, RoundMode::CAST_NONE, KDA_FWD_H_TOKEN_SUB_ELEMS);
             PipeBarrier<PIPE_V>();
-            CrossCoreSetFlag<0x2, PIPE_V>(KDA_FWD_H_DIRECT_FREE_FLAG);
-            CrossCoreWaitFlag(KDA_FWD_H_DIRECT_READY_FLAG);
+            SetDirectFreeAiv();
+            WaitDirectReadyAiv();
         } else {
             DataCopy(ioTyped, u_[ChunkMatrixOffset(b, hv, chunk, tokenBegin)],
                      KDA_FWD_H_TOKEN_SUB_ELEMS);
@@ -822,7 +840,7 @@ private:
         }
         Sub(vnew, vnew, direct, KDA_FWD_H_TOKEN_SUB_ELEMS);
         PipeBarrier<PIPE_V>();
-        CrossCoreSetFlag<0x2, PIPE_V>(KDA_FWD_H_DIRECT_FREE_FLAG);
+        SetDirectFreeAiv();
         if (storeVNew_) {
             Cast(ioTyped, vnew, RoundMode::CAST_RINT, KDA_FWD_H_TOKEN_SUB_ELEMS);
             PipeBarrier<PIPE_V>();
@@ -861,12 +879,12 @@ private:
         SetL1SlotFlagAivToAic<PIPE_MTE3>(KDA_FWD_H_VNEW_READY_FLAG);
         ++vnewPublishCount_[subBlockIdx];
 
-        CrossCoreWaitFlag(KDA_FWD_H_DIRECT_READY_FLAG);
+        WaitDirectReadyAiv();
         Adds(out1, direct, 0.0f, KDA_FWD_H_TOKEN_SUB_ELEMS);
         PipeBarrier<PIPE_V>();
-        CrossCoreSetFlag<0x2, PIPE_V>(KDA_FWD_H_DIRECT_FREE_FLAG);
+        SetDirectFreeAiv();
 
-        CrossCoreWaitFlag(KDA_FWD_H_DIRECT_READY_FLAG);
+        WaitDirectReadyAiv();
         DataCopy(gate, gk_[ChunkMatrixOffset(b, hv, chunk, KDA_FWD_H_CHUNK - 1) +
                            stateRowBegin], KDA_FWD_H_SUB_DIM);
         SetFlag<HardEvent::MTE2_V>(aivMte2ToVEvent_);
@@ -885,8 +903,8 @@ private:
         Adds(state, direct, 0.0f, KDA_FWD_H_STATE_SUB_ELEMS);
         PipeBarrier<PIPE_V>();
 
-        CrossCoreSetFlag<0x2, PIPE_V>(KDA_FWD_H_DIRECT_FREE_FLAG);
-        CrossCoreWaitFlag(KDA_FWD_H_DIRECT_READY_FLAG);
+        SetDirectFreeAiv();
+        WaitDirectReadyAiv();
         Add(direct, direct, out1, KDA_FWD_H_TOKEN_SUB_ELEMS);
         PipeBarrier<PIPE_V>();
         Cast(ioTyped, direct, RoundMode::CAST_RINT, KDA_FWD_H_TOKEN_SUB_ELEMS);
@@ -896,7 +914,7 @@ private:
         CopyOutputRows(
             b, hv, chunk * KDA_FWD_H_CHUNK + tokenBegin,
             ioTyped, KDA_FWD_H_SUB_CHUNK);
-        CrossCoreSetFlag<0x2, PIPE_V>(KDA_FWD_H_DIRECT_FREE_FLAG);
+        SetDirectFreeAiv();
         SetFlag<HardEvent::MTE3_MTE2>(aivMte3ToMte2Event_);
     }
 
@@ -927,7 +945,7 @@ private:
             const uint64_t hv = task % heads_;
             const uint32_t stateRowBegin = subBlockIdx * KDA_FWD_H_SUB_DIM;
             InitializeStateAiv(b, hv, stateRowBegin, state);
-            CrossCoreSetFlag<0x2, PIPE_V>(KDA_FWD_H_DIRECT_FREE_FLAG);
+            SetDirectFreeAiv();
             for (uint32_t chunk = 0;
                  chunk < static_cast<uint32_t>(totalChunks_); ++chunk) {
                 ProcessChunkAiv(
@@ -962,7 +980,6 @@ private:
     GlobalTensor<T> h_;
     uint32_t statePublishCount_[2] = {0, 0};
     uint32_t vnewPublishCount_[2] = {0, 0};
-    uint32_t wPublishCount_[2] = {0, 0};
     TEventID aicMte2ToMte1Event_ = KDA_FWD_H_MTE_W_EVENT;
     TEventID aicL1ReuseEvents_[KDA_FWD_H_L1_STAGING_DEPTH] = {0, 1, 2, 3};
     TEventID stateL0FreeEvent_ = KDA_FWD_H_M_EVENT;

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_prepare.h
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_prepare.h
@@ -1718,7 +1718,7 @@ private:
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
             bool fuseQwKg = SAFE_GATE && BT_ == 64 && K_ == 128 && V_ == 128 && subBlockNum == 1;
             if (fuseQwKg) {
-                PrepareKdaGateQwKgRegbase<T, SCORE_T, GK_T, true, true, exportFinalKg, true>(
+                PrepareKdaGateQwKgRegbase<T, SCORE_T, GK_T, true, true, false, true>(
                     (__ubuf__ T *)reinterpret_cast<uint64_t>(qTyped.GetPhyAddr()),
                     (__ubuf__ T *)reinterpret_cast<uint64_t>(kTyped.GetPhyAddr()),
                     (__ubuf__ SCORE_T *)reinterpret_cast<uint64_t>(qScore.GetPhyAddr()),
@@ -1728,13 +1728,26 @@ private:
                     (__ubuf__ T *)reinterpret_cast<uint64_t>(directW.GetPhyAddr()),
                     (__ubuf__ T *)reinterpret_cast<uint64_t>(vTyped.GetPhyAddr()),
                     (__ubuf__ T *)reinterpret_cast<uint64_t>(directV.GetPhyAddr()),
-                    (__ubuf__ T *)reinterpret_cast<uint64_t>(vTyped.GetPhyAddr()),
+                    nullptr,
                     (__ubuf__ float *)reinterpret_cast<uint64_t>(betaFp32.GetPhyAddr()),
                     (__ubuf__ GK_T *)reinterpret_cast<uint64_t>(gateTyped.GetPhyAddr()),
                     (__ubuf__ float *)reinterpret_cast<uint64_t>(refFp32.GetPhyAddr()),
-                    (__ubuf__ float *)reinterpret_cast<uint64_t>(finalRefFp32.GetPhyAddr()),
+                    nullptr,
                     static_cast<uint16_t>(tileRows), static_cast<uint16_t>(K_),
                     static_cast<uint16_t>(tileRows));
+                if constexpr (exportFinalKg) {
+                    // vTyped remains an input to the fused direct-V write. Produce finalKg only
+                    // after that call completes so its writeback cannot race the first V load.
+                    // The typed helper also keeps BF16 finalKg within the score-safe exp range.
+                    PipeBarrier<PIPE_V>();
+                    PrepareKdaGateKgRegbase<T, T, GK_T, true>(
+                        (__ubuf__ T *)reinterpret_cast<uint64_t>(vTyped.GetPhyAddr()),
+                        (__ubuf__ T *)reinterpret_cast<uint64_t>(kTyped.GetPhyAddr()),
+                        (__ubuf__ GK_T *)reinterpret_cast<uint64_t>(gateTyped.GetPhyAddr()),
+                        (__ubuf__ float *)reinterpret_cast<uint64_t>(finalRefFp32.GetPhyAddr()),
+                        static_cast<uint16_t>(tileRows), static_cast<uint16_t>(K_),
+                        static_cast<uint16_t>(tileRows));
+                }
             } else {
                 PrepareKdaGateQwRegbase<T, SCORE_T, GK_T, true>(
                     (__ubuf__ T *)reinterpret_cast<uint64_t>(qTyped.GetPhyAddr()),


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> 本 PR 当前为草稿。合入前需在当前 head commit 上完成仓库要求的 NPU CI 和评审门禁；后续如更新 commit，需要重新触发验证。

## 关联 Issue / 背景

- 关联 Issue: 无；按本次提交拆分要求，不创建 Issue，精度修复代码独立提交。
- 背景与目标: `chunk_kda_fwd` 在 A5 的 `H=96`、`T=8192`、`chunk_size=64` 场景中存在跨核同步和 final kg 写回竞争，可能从第二个 chunk 开始产生头部离群值，并表现为重复执行结果不稳定。
- 本 PR 解决的问题:
  - direct UB 由一个 AIC 与两个 AIV subblock 共享时，旧的 mode-2 单 flag 握手不能分别约束两个 AIV，可能提前复用缓冲区。
  - state 与 vnew 共用 L1 flag，且 fused 分支存在重复 set/wait，可能破坏生产者/消费者计数。
  - fused QWKG 在 direct-V 首次读取前把 final kg 写回 `vTyped`，可能覆盖仍在使用的 V 输入。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `chunk_kda_fwd`
- 涉及目录 / 文件:
  - `fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_fwd_h.h`
  - `fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_prepare.h`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不改变现有公开支持范围；本次原问题验证集中在 BF16、`head=96`、`chunk_size=64`、`T=8192/16384` 及 packed varlen 场景。
- 明确不包含的范围: ATK/诊断/压测脚本、测试断言更新、varlen workspace 调整、direct-launch 示例适配和性能优化；测试内容将单独提交 PR。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

1. 对 `chunk_kda_fwd` 构建 A5 算子包并安装验证。
2. 在 A5 复现原始 `H=96`、`T=8192`、`chunk_size=64` 精度问题，固定输入重复执行 100 次，比较输出二进制稳定性。
3. 在 A2/A5 运行 `T=8192/16384`、`chunk_size=64`、recompute 开关及典型 packed varlen 分布的精度矩阵。
4. 执行仓内 kernel 静态合同测试，并运行 `git diff --check`。

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 配套环境版本 | 本 PR 未单独重编译 | 未执行 | 修改仅位于 arch35；已完成 A2 精度回归 |
| A3 | `ascend910_93` | - | - | 未执行 | 待 NPU CI 补齐 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 配套环境版本 | 本 PR 未单独重编译 | 未执行 | 修改仅位于 arch35；已完成 A2 精度回归 |
| A3 | `ascend910_93` | - | - | 未执行 | 待 NPU CI 补齐 |
| A5 | `ascend950` | 配套环境版本 | `bash build.sh --pkg --soc=ascend950 --ops=chunk_kda_fwd --vendor_name=fla_npu` | 通过 | 算子包构建、安装和调用通过 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 单算子精度矩阵 | 通过 | 小规模 FP32 参考及代表性场景通过 |
| A3 | `ascend910_93` | - | 未执行 | 待 NPU CI 补齐 |
| A5 | `ascend950` | 单算子精度与稳定性矩阵 | 通过 | 原问题消失；固定输入重复 100 次输出稳定；`T=8192/16384` 结果满足 BF16 精度要求 |

- 精度对比: 覆盖 `initial_state=None`、`output_final_state=false`、`use_gate_in_kernel=true`、`safe_gate=true`、`disable_recompute=true/false`、`return_intermediate_states=false`、`state_v_first=true`，并覆盖 single、balanced、mixed-tail、short-sequence 等 packed varlen 分布。
- 性能对比: 本 PR 仅拆分精度修复，不包含性能优化或性能测试脚本。
- 边界 / 异常场景: 覆盖 `T=8192/16384`、`chunk_size=64` 和多种 packed varlen 分段。
- 未覆盖风险: A3 尚未验证；GPU 分布式 benchmark 环境不可用，未执行 GPU 对照。仓内 54 条 kernel 静态合同测试中 53 条通过，1 条旧实现字符串断言需要在独立测试 PR 中随实现语义更新。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐 |

- 端到端场景说明: 本次先验证原问题单算子精度和稳定性，整体 Example ST 留给 NPU CI。
- 与本 PR 修改算子的关联: `chunk_kda_fwd` 是 KDA 前向链路的核心算子。
- 未覆盖原因及补充计划: PR 当前为草稿，合入前补齐仓库要求的 NPU CI。

</details>

## 兼容性、风险与回退

- 兼容性说明: 仅调整 A5 arch35 kernel 内部同步与 UB 写回顺序，不改变接口、tiling key、shape、dtype 或输出语义。
- 风险点: mode-4 跨核 flag 与 L1 flag 分配需保持成对；后续修改流水时需避免复用本 PR 使用的 flag。
- 回退方案: 回退本 PR 单个提交即可恢复原实现。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 本 PR 只包含精度修复代码。ATK、诊断、稳定性压测和静态断言更新将通过独立测试 PR 提交。
- 评审重点: direct UB 的一对二 mode-4 握手、state/vnew 独立 L1 flag，以及 fused QWKG 延迟 final kg 写回后的数据生命周期。
