### PR TITLE
add atk test

### DIFF
--- a/test/chunk_bwd_dqkwg/atk_chunk_bwd_dqkwg.json
+++ b/test/chunk_bwd_dqkwg/atk_chunk_bwd_dqkwg.json
@@ -1,0 +1,5470 @@
+[
+    {
+        "id": 0,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.fp16.dense.small",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": null,
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "ascendc",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "accuracy",
+            "regression"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp32",
+                "shape": [
+                    1,
+                    8,
+                    1024
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    16,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    16,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.088,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 64,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "fp16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": false,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    },
+    {
+        "id": 1,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.bf16.dense.small",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": null,
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "ascendc",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "accuracy",
+            "regression"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    16,
+                    2048,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    16,
+                    2048,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    16,
+                    2048,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    16,
+                    2048
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    16,
+                    32,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    16,
+                    2048,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    16,
+                    32,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    16,
+                    2048,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "bf16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.0625,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 64,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "bf16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": false,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    },
+    {
+        "id": 2,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.fp16.dense.chunk128",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": null,
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "ascendc",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "accuracy",
+            "boundary"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    32,
+                    2048,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    32,
+                    2048,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    32,
+                    2048,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp32",
+                "shape": [
+                    1,
+                    32,
+                    2048
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    32,
+                    16,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    32,
+                    2048,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    32,
+                    16,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    32,
+                    2048,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.0442,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 128,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "fp16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": true,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    },
+    {
+        "id": 3,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.bf16.dense.v256",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": null,
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "ascendc",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "accuracy",
+            "boundary"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    2,
+                    8,
+                    512,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    2,
+                    8,
+                    512,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    2,
+                    8,
+                    512,
+                    256
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp32",
+                "shape": [
+                    2,
+                    8,
+                    512
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    2,
+                    8,
+                    8,
+                    128,
+                    256
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    2,
+                    8,
+                    512,
+                    256
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    2,
+                    8,
+                    8,
+                    128,
+                    256
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    2,
+                    8,
+                    512,
+                    256
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "bf16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.088,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 64,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "bf16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": true,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    },
+    {
+        "id": 4,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.fp16.varlen.small",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": null,
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "ascendc",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "accuracy",
+            "boundary"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    16,
+                    260,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    16,
+                    260,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    16,
+                    260,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp32",
+                "shape": [
+                    1,
+                    16,
+                    260
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    16,
+                    5,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    16,
+                    260,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    16,
+                    5,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    16,
+                    260,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": true,
+                "dtype": "int64",
+                "shape": [
+                    4
+                ],
+                "range_values": [
+                    0,
+                    260
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": true,
+                "dtype": "int64",
+                "shape": [
+                    12
+                ],
+                "range_values": [
+                    0,
+                    260
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.088,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 64,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "fp16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": true,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    },
+    {
+        "id": 5,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.fp16.gva.nratio2",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": null,
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "ascendc",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "accuracy",
+            "boundary"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    16,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp32",
+                "shape": [
+                    1,
+                    16,
+                    1024
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    16,
+                    16,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    16,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    16,
+                    16,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    16,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.088,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 64,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "fp16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": true,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    },
+    {
+        "id": 6,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.bf16.varlen.tail",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": null,
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "ascendc",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "accuracy",
+            "boundary",
+            "dirty_data"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    195,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    195,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    195,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    195
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    4,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    195,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    4,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    195,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": true,
+                "dtype": "int64",
+                "shape": [
+                    4
+                ],
+                "range_values": [
+                    0,
+                    195
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": true,
+                "dtype": "int64",
+                "shape": [
+                    10
+                ],
+                "range_values": [
+                    0,
+                    195
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "bf16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.03125,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 64,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "bf16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": true,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    },
+    {
+        "id": 7,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.fp16.aclnn.route",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": null,
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "aclnn",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "accuracy",
+            "regression"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp32",
+                "shape": [
+                    1,
+                    8,
+                    1024
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    16,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    16,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.088,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 64,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "fp16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": false,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    },
+    {
+        "id": 8,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.bf16.aclnn.route",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": null,
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "aclnn",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "accuracy",
+            "regression"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    16,
+                    2048,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    16,
+                    2048,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    16,
+                    2048,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    16,
+                    2048
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    16,
+                    32,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    16,
+                    2048,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    16,
+                    32,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    16,
+                    2048,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "bf16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.0625,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 64,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "bf16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": false,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    },
+    {
+        "id": 9,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.negative.k.invalid",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": "K must be 128",
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "ascendc",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "negative"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    64
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    64
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp32",
+                "shape": [
+                    1,
+                    8,
+                    1024
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    16,
+                    64,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    16,
+                    64,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.125,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 64,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "fp16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": false,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    },
+    {
+        "id": 10,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.negative.v.invalid",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": "V must be 128 or 256",
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "ascendc",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "negative"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    64
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp32",
+                "shape": [
+                    1,
+                    8,
+                    1024
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    16,
+                    128,
+                    64
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    64
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    16,
+                    128,
+                    64
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    64
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.088,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 64,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "fp16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": false,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    },
+    {
+        "id": 11,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.negative.hv.not.divisible",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": "HV must be divisible by HK",
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "ascendc",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "negative"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    12,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp32",
+                "shape": [
+                    1,
+                    12,
+                    1024
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    12,
+                    16,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    12,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    12,
+                    16,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    12,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.088,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 64,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "fp16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": false,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    },
+    {
+        "id": 12,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.fp16.determinism",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": null,
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "ascendc",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "determinism",
+            "regression"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp32",
+                "shape": [
+                    1,
+                    8,
+                    1024
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    16,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    16,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.088,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 64,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "fp16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": false,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    },
+    {
+        "id": 13,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.bf16.performance",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": null,
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "ascendc",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "performance"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    4096,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    4096,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    4096,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    4096
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    64,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    4096,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    64,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    4096,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "bf16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.0442,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 64,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "bf16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": false,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    },
+    {
+        "id": 14,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.fp16.dirty_data.nan",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": "NaN detected in valid region",
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "ascendc",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "dirty_data",
+            "negative"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp32",
+                "shape": [
+                    1,
+                    8,
+                    1024
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": [
+                    "nan"
+                ]
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    16,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    16,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    1,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.088,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 64,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "fp16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": false,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    },
+    {
+        "id": 15,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.fp16.large.batch",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": null,
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "ascendc",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "regression"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    8,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    8,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    8,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    8,
+                    8,
+                    1024
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    8,
+                    8,
+                    16,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    8,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    8,
+                    8,
+                    16,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "fp16",
+                "shape": [
+                    8,
+                    8,
+                    1024,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": false,
+                "dtype": "int64",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.088,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 64,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": true,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "fp16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": false,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    },
+    {
+        "id": 16,
+        "default_seed": 20260815,
+        "name": "aclnn.chunk.bwd.dqkwg.bf16.varlen.large",
+        "aclnn_name": "ChunkBwdDqkwg",
+        "triton_name": null,
+        "kernel_name": null,
+        "version": "v2.1",
+        "expected_error_msg": null,
+        "api": "pytorch",
+        "api_type": "executor_chunk_bwd_dqkwg",
+        "aclnn_api_type": "aclnn_function",
+        "triton_api_type": null,
+        "fusion_api_type": null,
+        "fusion_mode": null,
+        "dist_api_type": null,
+        "kernel_api_type": null,
+        "backward": false,
+        "standard": {
+            "acc": "cv_fused_double_benchmark",
+            "perf": "not_key"
+        },
+        "outputs": null,
+        "route": "ascendc",
+        "soc": [
+            "ascend910b",
+            "ascend910_93",
+            "ascend950"
+        ],
+        "tag": [
+            "regression",
+            "boundary"
+        ],
+        "inputs": [
+            {
+                "name": "q",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    4096,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "k",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    4096,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "v",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    4096,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    4096
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "h",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    64,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "do",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    4096,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dh",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    64,
+                    128,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "dv",
+                "type": "tensor",
+                "required": true,
+                "dtype": "bf16",
+                "shape": [
+                    1,
+                    32,
+                    4096,
+                    128
+                ],
+                "range_values": [
+                    -5,
+                    5
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "cu_seqlens",
+                "type": "tensor",
+                "required": true,
+                "dtype": "int64",
+                "shape": [
+                    5
+                ],
+                "range_values": [
+                    0,
+                    4096
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_indices",
+                "type": "tensor",
+                "required": true,
+                "dtype": "int64",
+                "shape": [
+                    130
+                ],
+                "range_values": [
+                    0,
+                    4096
+                ],
+                "backward": true,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "w",
+                "type": "tensor",
+                "required": false,
+                "dtype": "bf16",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "g_gamma",
+                "type": "tensor",
+                "required": false,
+                "dtype": "fp32",
+                "shape": null,
+                "range_values": null,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "scale",
+                "type": "attr",
+                "required": true,
+                "dtype": "float",
+                "shape": null,
+                "range_values": 0.0442,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "chunk_size",
+                "type": "attr",
+                "required": true,
+                "dtype": "int",
+                "shape": null,
+                "range_values": 64,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_mix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "is_fix",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "use_exp2",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "transpose_state_layout",
+                "type": "attr",
+                "required": true,
+                "dtype": "bool",
+                "shape": null,
+                "range_values": false,
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            },
+            {
+                "name": "qkv_type",
+                "type": "attr",
+                "required": true,
+                "dtype": "string",
+                "shape": null,
+                "range_values": "bf16",
+                "backward": false,
+                "align_32B": null,
+                "outlier_values": null
+            }
+        ],
+        "acl_json": "",
+        "method_inputs": null,
+        "tensor_input": null,
+        "compute_times": null,
+        "save_name": null,
+        "uuid": null,
+        "downloaded": false,
+        "is_boundary": true,
+        "xrun_cs_name": null,
+        "xrun_data": null
+    }
+]

--- a/test/chunk_bwd_dqkwg/chunk_bwd_dqkwg.yaml
+++ b/test/chunk_bwd_dqkwg/chunk_bwd_dqkwg.yaml
@@ -1,0 +1,443 @@
+api: pytorch
+api_type: executor_chunk_bwd_dqkwg
+version: v2.1
+name: aclnn.chunk.bwd.dqkwg
+aclnn_name: ChunkBwdDqkwg
+generate: gen_chunk_bwd_dqkwg
+dtype_numbers: 100
+extra_numbers: 0
+standard:
+  acc: cv_fused_double_benchmark
+
+# SOC 适用范围
+soc:
+  - ascend910b
+  - ascend910_93
+  - ascend950
+
+# 算子功能配置，与算子实现一致
+config:
+  USE_G: true
+  USE_DW: true
+  USE_G_GAMMA: false
+
+inputs:
+  # q: [B, HK, T, K] - Query 张量
+  - name: q
+    type: tensor
+    required: true
+    dtypes:
+      values: [bf16, fp16]
+      soc_conditions:
+        - { soc: [ascend910b, ascend910_93, ascend950], dtypes: [bf16, fp16] }
+    ranges:
+      valid:
+        values: [ [-5, 5] ]
+      invalid:
+        values: []
+    shapes:
+      dim_numbers:
+        values: [ 4 ]
+      dim_values:
+        # [B, HK, T, K]
+        values: [ [1, 128], [1, 64], [1, 32768], [128] ]
+      constraints:
+        # K 必须固定为 128
+        - { dim: 3, multiple_of: 128, values: [128] }
+        # 变长模式下 B 必须为 1
+        - { condition: "varlen == true", dim: 0, values: [1] }
+
+  # k: [B, HK, T, K] - Key 张量
+  - name: k
+    type: tensor
+    required: true
+    dtypes:
+      values: [bf16, fp16]
+    ranges:
+      valid:
+        values: [ [-5, 5] ]
+      invalid:
+        values: []
+    shapes:
+      dim_numbers:
+        values: [ 4 ]
+      dim_values:
+        values: [ [1, 128], [1, 64], [1, 32768], [128] ]
+      constraints:
+        - { dim: 3, multiple_of: 128, values: [128] }
+        # dtype 必须与 q 一致
+        - { relation: "dtype == q.dtype" }
+        # shape 必须与 q 一致
+        - { relation: "shape == q.shape" }
+
+  # v: [B, HV, T, V] - Value 张量
+  - name: v
+    type: tensor
+    required: true
+    dtypes:
+      values: [bf16, fp16]
+    ranges:
+      valid:
+        values: [ [-5, 5] ]
+      invalid:
+        values: []
+    shapes:
+      dim_numbers:
+        values: [ 4 ]
+      dim_values:
+        # [B, HV, T, V]
+        values: [ [1, 128], [1, 64], [1, 32768], [128, 256] ]
+      constraints:
+        # V 只能取 128 或 256
+        - { dim: 3, values: [128, 256] }
+        # HV 必须为 HK 的整数倍
+        - { relation: "shape[1] % k.shape[1] == 0" }
+        # HV >= HK
+        - { relation: "shape[1] >= k.shape[1]" }
+
+  # g: [B, HV, T] - Gate 张量
+  - name: g
+    type: tensor
+    required: true
+    dtypes:
+      # is_mix=True 时 g 可为 fp32; is_mix=False 时 g 与 qkv 一致
+      values: [fp32, bf16, fp16]
+    ranges:
+      valid:
+        # g 必须为负数且沿 T 单调递减
+        values: [ [-5, 0] ]
+      invalid:
+        values: [ [0, 5] ]
+    shapes:
+      dim_numbers:
+        values: [ 3 ]
+      dim_values:
+        # [B, HV, T]
+        values: [ [1, 128], [1, 64], [1, 32768] ]
+      constraints:
+        - { relation: "shape[0] == v.shape[0]" }
+        - { relation: "shape[1] == v.shape[1]" }
+        - { relation: "shape[2] == v.shape[2]" }
+
+  # h: [B, HV, num_chunks, K, V] - 隐藏状态张量
+  - name: h
+    type: tensor
+    required: true
+    dtypes:
+      values: [bf16, fp16]
+    ranges:
+      valid:
+        values: [ [-5, 5] ]
+      invalid:
+        values: []
+    shapes:
+      dim_numbers:
+        values: [ 5 ]
+      dim_values:
+        # [B, HV, num_chunks, K, V]
+        values: [ [1, 128], [1, 64], [1, 1024], [128], [128, 256] ]
+      constraints:
+        - { relation: "shape[0] == v.shape[0]" }
+        - { relation: "shape[1] == v.shape[1]" }
+        - { relation: "shape[4] == v.shape[3]" }
+        - { relation: "shape[3] == q.shape[3]" }
+        # num_chunks 由 T 和 chunk_size 决定
+        - { relation: "shape[2] == ceil(v.shape[2] / chunk_size)" }
+
+  # do: [B, HV, T, V] - 输出梯度张量
+  - name: do
+    type: tensor
+    required: true
+    dtypes:
+      values: [bf16, fp16]
+    ranges:
+      valid:
+        values: [ [-5, 5] ]
+      invalid:
+        values: []
+    shapes:
+      dim_numbers:
+        values: [ 4 ]
+      dim_values:
+        values: [ [1, 128], [1, 64], [1, 32768], [128, 256] ]
+      constraints:
+        - { relation: "shape == v.shape" }
+
+  # dh: [B, HV, num_chunks, K, V] - 隐藏状态梯度张量
+  - name: dh
+    type: tensor
+    required: true
+    dtypes:
+      values: [bf16, fp16]
+    ranges:
+      valid:
+        values: [ [-5, 5] ]
+      invalid:
+        values: []
+    shapes:
+      dim_numbers:
+        values: [ 5 ]
+      dim_values:
+        values: [ [1, 128], [1, 64], [1, 1024], [128], [128, 256] ]
+      constraints:
+        - { relation: "shape == h.shape" }
+
+  # dv: [B, HV, T, V] - Value 分支梯度张量
+  - name: dv
+    type: tensor
+    required: true
+    dtypes:
+      values: [bf16, fp16]
+    ranges:
+      valid:
+        values: [ [-5, 5] ]
+      invalid:
+        values: []
+    shapes:
+      dim_numbers:
+        values: [ 4 ]
+      dim_values:
+        values: [ [1, 128], [1, 64], [1, 32768], [128, 256] ]
+      constraints:
+        - { relation: "shape == v.shape" }
+
+  # cu_seqlens: [N+1] - 变长序列累计长度 (可选)
+  - name: cu_seqlens
+    type: tensor
+    required: false
+    dtypes:
+      values: [int64]
+    ranges:
+      valid:
+        # 元素单调递增, 首元素为 0, 末元素为 T
+        values: [ [0, 32768] ]
+      invalid:
+        # 非单调递增或首元素非 0
+        values: []
+    shapes:
+      dim_numbers:
+        values: [ 1 ]
+      dim_values:
+        values: [ [2, 1024] ]
+      constraints:
+        # 变长模式下 B 必须为 1
+        - { condition: "present", relation: "q.shape[0] == 1" }
+        # 末元素必须等于 T
+        - { relation: "values[-1] == q.shape[2]" }
+
+  # chunk_indices: [num_chunks * 2] - 分块索引 (可选, 变长模式)
+  - name: chunk_indices
+    type: tensor
+    required: false
+    dtypes:
+      values: [int64]
+    ranges:
+      valid:
+        values: [ [0, 32768] ]
+      invalid:
+        values: []
+    shapes:
+      dim_numbers:
+        values: [ 1 ]
+      dim_values:
+        values: [ [2, 8192] ]
+      constraints:
+        # 必须与 cu_seqlens 同时出现或同时缺失
+        - { relation: "present == cu_seqlens.present" }
+
+  # w: 预留权重输入 (当前未启用, 必须传空)
+  - name: w
+    type: tensor
+    required: false
+    dtypes:
+      values: [bf16, fp16]
+    ranges:
+      valid:
+        values: []
+      invalid:
+        values: []
+    shapes:
+      dim_numbers:
+        values: []
+      dim_values:
+        values: []
+      constraints:
+        # 当前实现必须传空
+        - { relation: "must_be_null" }
+
+  # g_gamma: 预留门控参数 (当前未启用, 必须传空)
+  - name: g_gamma
+    type: tensor
+    required: false
+    dtypes:
+      values: [fp32]
+    ranges:
+      valid:
+        values: []
+      invalid:
+        values: []
+    shapes:
+      dim_numbers:
+        values: []
+      dim_values:
+        values: []
+      constraints:
+        - { relation: "must_be_null" }
+
+  # scale: 缩放系数
+  - name: scale
+    type: attr
+    required: true
+    dtypes:
+      values: [float]
+    ranges:
+      valid:
+        # 建议 1/sqrt(K), K=128 时约 0.088
+        values: [0.0221, 0.03125, 0.0442, 0.0625, 0.088, 0.125]
+      invalid:
+        # 0 或负数非法
+        values: [0, -1]
+
+  # chunk_size: 分块大小
+  - name: chunk_size
+    type: attr
+    required: true
+    dtypes:
+      values: [int]
+    ranges:
+      valid:
+        # 当前仅支持 64 或 128
+        values: [64, 128]
+      invalid:
+        # 其他值非法
+        values: [32, 256, 0]
+
+  # is_mix: g 是否使用混合精度
+  - name: is_mix
+    type: attr
+    required: true
+    dtypes:
+      values: [bool]
+    ranges:
+      valid:
+        values: [true, false]
+      invalid:
+        values: []
+
+  # is_fix: 是否定长模式
+  - name: is_fix
+    type: attr
+    required: true
+    dtypes:
+      values: [bool]
+    ranges:
+      valid:
+        values: [true, false]
+      invalid:
+        values: []
+
+  # use_exp2: 是否使用 exp2 近似
+  - name: use_exp2
+    type: attr
+    required: true
+    dtypes:
+      values: [bool]
+    ranges:
+      valid:
+        # 当前实现要求必须为 false
+        values: [false]
+      invalid:
+        values: [true]
+
+  # transpose_state_layout: 是否转置内部状态布局
+  - name: transpose_state_layout
+    type: attr
+    required: true
+    dtypes:
+      values: [bool]
+    ranges:
+      valid:
+        # 当前实现要求必须为 false
+        values: [false]
+      invalid:
+        values: [true]
+
+  # qkv_type: q/k/v 数据类型字符串
+  - name: qkv_type
+    type: attr
+    required: true
+    dtypes:
+      values: [string]
+    ranges:
+      valid:
+        values: ["bf16", "fp16"]
+      invalid:
+        values: ["fp32", "int32"]
+
+# 非法组合规则
+invalid_combinations:
+  # K 非 128
+  - { condition: "q.shape[3] != 128", expected_error: "K must be 128" }
+  # V 非 128/256
+  - { condition: "v.shape[3] not in [128, 256]", expected_error: "V must be 128 or 256" }
+  # HV 不是 HK 整数倍
+  - { condition: "v.shape[1] % q.shape[1] != 0", expected_error: "HV must be divisible by HK" }
+  # HV < HK
+  - { condition: "v.shape[1] < q.shape[1]", expected_error: "HV must be >= HK" }
+  # 变长模式 B != 1
+  - { condition: "cu_seqlens.present and q.shape[0] != 1", expected_error: "varlen only support B = 1" }
+  # chunk_size 非 64/128
+  - { condition: "chunk_size not in [64, 128]", expected_error: "chunk_size must be 64 or 128" }
+  # use_exp2 为 true
+  - { condition: "use_exp2 == true", expected_error: "use_exp2 must be false" }
+  # transpose_state_layout 为 true
+  - { condition: "transpose_state_layout == true", expected_error: "transpose_state_layout must be false" }
+  # w 非空
+  - { condition: "w.present", expected_error: "w must be null" }
+  # g_gamma 非空
+  - { condition: "g_gamma.present", expected_error: "g_gamma must be null" }
+  # g 为正数
+  - { condition: "g.min > 0", expected_error: "g must be non-positive and monotonically decreasing" }
+
+# 边界场景
+boundary_scenarios:
+  # 最小 T (单 chunk)
+  - { name: "min_T_single_chunk", T: 1, chunk_size: 64 }
+  # T 恰好整除 chunk_size
+  - { name: "T_divisible", T: 1024, chunk_size: 64 }
+  # T 非整除 (尾块)
+  - { name: "T_not_divisible", T: 195, chunk_size: 64 }
+  # chunk_size=128 边界
+  - { name: "chunk_size_128", T: 2048, chunk_size: 128 }
+  # V=256 边界
+  - { name: "V_256", V: 256 }
+  # n_ratio=2 (GVA 拆分)
+  - { name: "n_ratio_2", HV: 16, HK: 8 }
+  # 变长多序列
+  - { name: "varlen_multi_seq", cu_seqlens: [0, 70, 200, 260] }
+  # 变长非整除尾块
+  - { name: "varlen_tail", cu_seqlens: [0, 64, 130, 195] }
+
+# NaN 脏数据注入区域
+nan_injection:
+  # g 输入注入 NaN
+  - { target: "g", expected: "fail", reason: "NaN in gate propagates to valid output" }
+  # do 输入注入 NaN
+  - { target: "do", expected: "fail", reason: "NaN in gradient propagates to valid output" }
+  # h 输入注入 NaN
+  - { target: "h", expected: "fail", reason: "NaN in hidden state propagates to valid output" }
+  # 变长 padding 区注入 NaN (有效区不应被污染)
+  - { target: "padding_region", expected: "pass", reason: "NaN in padding should not affect valid output" }
+
+# 确定性配置
+determinism:
+  loop_nums: 5
+  comparison: numeric
+  reset_state: true
+
+# 性能配置
+performance:
+  warmup: 20
+  collect: 100
+  statistic: 80
+  baseline_source: "to_be_confirmed"

--- a/test/chunk_bwd_dqkwg/executor_chunk_bwd_dqkwg.py
+++ b/test/chunk_bwd_dqkwg/executor_chunk_bwd_dqkwg.py
@@ -1,0 +1,459 @@
+# Copyright (c) Tianjin University, Ltd. 2026. All rights reserved.
+# chunk_bwd_dqkwg 算子执行适配 executor
+# 职责:
+#   1. 按 ATK plugin/executor 合同构造输入 tensor
+#   2. 根据 case 中的 route 调用对应 DUT (ascendc / aclnn)
+#   3. 提供双标杆所需的 golden (cpu) 和 benchmark (cpu_benchmark)
+#   4. 处理输出命名、有效区和 ATK 需要的结构转换
+# 注意: direct_launch 路径暂不实现, 待 ATK 社区提供通用 backend 后再补充
+import os
+import sys
+import math
+from typing import List, Optional, Tuple
+
+import torch
+
+from atk.configs.dataset_config import InputDataset
+from atk.configs.results_config import TaskResult
+from atk.tasks.api_execute import register
+from atk.tasks.api_execute.base_api import BaseApi
+
+# 将算子实现目录下的 CPU 参考实现加入 import 路径
+_OP_TEST_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "fla", "ops", "ascendc", "gdn", "chunk_gdn_bwd", "chunk_bwd_dqkwg", "tests",
+)
+if _OP_TEST_DIR not in sys.path:
+    sys.path.insert(0, _OP_TEST_DIR)
+from chunk_bwd_dqkwg_cpu import chunk_bwd_dqkwg_cpu  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# 辅助函数
+# ---------------------------------------------------------------------------
+
+def create_gate_g(B: int, H: int, T: int, gtype) -> torch.Tensor:
+    """生成满足约束的 g: 负数且沿 T 单调递减.
+
+    复刻原代码逻辑: 使用 torch.linspace 生成从接近 0 到较负的递减序列,
+    添加微小 margin 避免 linspace 端点精度问题.
+    """
+    lo, hi = -5e-2, -5e-5
+    span = hi - lo
+    margin = max(span * 1e-7, 1e-12)
+    g_t = torch.linspace(
+        float(hi) - margin,
+        float(lo) + margin,
+        T,
+        dtype=torch.float64,
+    )
+    return g_t.unsqueeze(0).unsqueeze(0).expand(B, H, T).contiguous().to(gtype)
+
+
+def generate_tensor(shape, data_type, data_max) -> torch.Tensor:
+    """生成均匀分布的随机 tensor, 范围 [-data_max, data_max]."""
+    tensor = torch.rand(shape) * (data_max * 2) - data_max
+    return tensor.to(data_type)
+
+
+def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
+    return cu_seqlens[1:] - cu_seqlens[:-1]
+
+
+def cdiv(a, b: int):
+    return (a + b - 1) // b
+
+
+def prepare_chunk_indices(cu_seqlens: List[int], chunk_size: int) -> List[int]:
+    """基于 cu_seqlens 生成扁平化的 chunk 索引.
+
+    逻辑复刻原代码:
+    1. 计算每个序列的长度: lens[i] = cu_seqlens[i+1] - cu_seqlens[i]
+    2. 计算每个序列需要的 chunk 数: ceil(lens[i] / chunk_size)
+    3. 生成对应的 (sequence_id, chunk_id) 对并扁平化为 [s0, c0, s1, c1, ...]
+    """
+    indices = []
+    for i in range(len(cu_seqlens) - 1):
+        start = cu_seqlens[i]
+        end = cu_seqlens[i + 1]
+        length = end - start
+        if length <= 0:
+            continue
+        num_chunks = (length + chunk_size - 1) // chunk_size
+        for chunk_id in range(num_chunks):
+            indices.append(i)
+            indices.append(chunk_id)
+    return indices
+
+
+def cumsum_cu_seqlens(cu_seqlens: torch.LongTensor) -> List[int]:
+    """对 cu_seqlens 做 cumsum 并左 pad 一个 0."""
+    return torch.nn.functional.pad(
+        torch.cumsum(cu_seqlens, dim=0),
+        (1, 0),
+        value=0,
+    ).tolist()
+
+
+def _as_int_list(val) -> Optional[List[int]]:
+    if val is None:
+        return None
+    if isinstance(val, torch.Tensor):
+        return [int(x) for x in val.detach().cpu().reshape(-1).tolist()]
+    return [int(x) for x in val]
+
+
+# ---------------------------------------------------------------------------
+# CPU 参考实现 (golden / benchmark)
+# ---------------------------------------------------------------------------
+
+def chunk_bwd_dqkwg_torch(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    do: torch.Tensor,
+    h: torch.Tensor,
+    dh: torch.Tensor,
+    w: Optional[torch.Tensor],
+    g: Optional[torch.Tensor],
+    dv: torch.Tensor,
+    scale: Optional[float],
+    cu_seqlens: Optional[List[int]],
+    chunk_size: int = 64,
+    benchmark: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """CPU 参考实现, 同时用于 golden (fp32) 和 benchmark (fp64)."""
+    q_t = q.transpose(1, 2).contiguous()
+    k_t = k.transpose(1, 2).contiguous()
+    v_t = v.transpose(1, 2).contiguous()
+    do_t = do.transpose(1, 2).contiguous()
+    dv_t = dv.transpose(1, 2).contiguous()
+    g_t = g.transpose(1, 2).contiguous() if g is not None else None
+    w_t = w.transpose(1, 2).contiguous() if w is not None else None
+    h_t = h.permute(0, 2, 1, 3, 4).contiguous()
+    dh_t = dh.permute(0, 2, 1, 3, 4).contiguous()
+
+    cu_seqlens_tensor = (
+        torch.tensor(cu_seqlens, dtype=torch.int64) if cu_seqlens is not None else None
+    )
+
+    dq, dk, dw, dg = chunk_bwd_dqkwg_cpu(
+        q_t, k_t, v_t, do_t, h_t, dh_t, w_t, g_t, dv_t,
+        scale, cu_seqlens_tensor, chunk_size,
+        benchmark=benchmark,
+    )
+
+    dq = dq.transpose(1, 2).contiguous()
+    dk = dk.transpose(1, 2).contiguous()
+    dw = dw.transpose(1, 2).contiguous()
+    if dg is not None:
+        dg = dg.transpose(1, 2).contiguous()
+
+    return dq, dk, dw, dg
+
+
+# ---------------------------------------------------------------------------
+# ATK Executor
+# ---------------------------------------------------------------------------
+
+@register("executor_chunk_bwd_dqkwg")
+class FunctionApi(BaseApi):
+    """chunk_bwd_dqkwg 算子 ATK 执行适配.
+
+    支持的 route:
+      - ascendc: 调用 fla_npu.ops.ascendc.npu_chunk_bwd_dqkwg
+      - aclnn:   调用 aclnnChunkBwdDqkwg 两段式接口
+      - direct_launch: 暂不支持, 待 ATK 社区提供通用 backend
+
+    golden (cpu) 使用 fp32 参考实现, benchmark (cpu_benchmark) 使用 fp64 参考实现.
+    """
+
+    def __init__(self, task_result: TaskResult):
+        super(FunctionApi, self).__init__(task_result)
+        self.qkv_type = None
+
+    # ------------------------------------------------------------------
+    # golden: fp32 CPU 参考实现
+    # ------------------------------------------------------------------
+    def cpu(self, input_data: InputDataset, with_output: bool = False):
+        q = input_data.kwargs["q"]
+        k = input_data.kwargs["k"]
+        v = input_data.kwargs["v"]
+        do = input_data.kwargs["do"]
+        h = input_data.kwargs["h"]
+        dh = input_data.kwargs["dh"]
+        w = input_data.kwargs.get("w", None)
+        g = input_data.kwargs["g"]
+        dv = input_data.kwargs["dv"]
+        cu_seqlens = input_data.kwargs.get("cu_seqlens", None)
+        chunk_size = input_data.kwargs["chunk_size"]
+        scale = input_data.kwargs["scale"]
+
+        dq, dk, dw_out, dg = chunk_bwd_dqkwg_torch(
+            q, k, v, do, h, dh, w, g, dv, scale, cu_seqlens, chunk_size
+        )
+
+        # 将输出 dtype 对齐到输入 dtype
+        if self.qkv_type == "bf16":
+            dq = dq.to(torch.bfloat16)
+            dk = dk.to(torch.bfloat16)
+            dw_out = dw_out.to(torch.bfloat16) if dw_out is not None else None
+        elif self.qkv_type == "fp16":
+            dq = dq.to(torch.float16)
+            dk = dk.to(torch.float16)
+            dw_out = dw_out.to(torch.float16) if dw_out is not None else None
+
+        # is_mix=False 时 dg 也要对齐到 qkv dtype
+        is_mix = input_data.kwargs.get("is_mix", True)
+        if not is_mix:
+            if self.qkv_type == "bf16":
+                dg = dg.to(torch.bfloat16)
+            elif self.qkv_type == "fp16":
+                dg = dg.to(torch.float16)
+
+        return dq, dk, dw_out, dg
+
+    # ------------------------------------------------------------------
+    # benchmark: fp64 CPU 参考实现
+    # ------------------------------------------------------------------
+    def cpu_benchmark(self, input_data: InputDataset, with_output: bool = False):
+        q = input_data.kwargs["q"].to(torch.float64)
+        k = input_data.kwargs["k"].to(torch.float64)
+        v = input_data.kwargs["v"].to(torch.float64)
+        do = input_data.kwargs["do"].to(torch.float64)
+        h = input_data.kwargs["h"].to(torch.float64)
+        dh = input_data.kwargs["dh"].to(torch.float64)
+        w = input_data.kwargs.get("w", None)
+        if w is not None:
+            w = w.to(torch.float64)
+        g = input_data.kwargs["g"].to(torch.float64)
+        dv = input_data.kwargs["dv"].to(torch.float64)
+        cu_seqlens = input_data.kwargs.get("cu_seqlens", None)
+        chunk_size = input_data.kwargs["chunk_size"]
+        scale = input_data.kwargs["scale"]
+
+        dq, dk, dw_out, dg = chunk_bwd_dqkwg_torch(
+            q, k, v, do, h, dh, w, g, dv, scale, cu_seqlens, chunk_size,
+            benchmark=True
+        )
+
+        return dq, dk, dw_out, dg
+
+    # ------------------------------------------------------------------
+    # DUT 调用: 根据 route 分发到 ascendc 或 aclnn
+    # ------------------------------------------------------------------
+    def __call__(self, input_data: InputDataset, with_output: bool = False):
+        q = input_data.kwargs["q"]
+        # float64 输入走 benchmark 路径
+        if q.dtype == torch.float64:
+            return self.cpu_benchmark(input_data, with_output)
+
+        route = input_data.kwargs.get("route", "ascendc")
+        if route == "ascendc":
+            return self._call_ascendc(input_data, with_output)
+        elif route == "aclnn":
+            return self._call_aclnn(input_data, with_output)
+        else:
+            raise NotImplementedError(
+                f"route '{route}' is not supported, "
+                "currently only 'ascendc' and 'aclnn' are implemented; "
+                "'direct_launch' is pending ATK community backend"
+            )
+
+    # ------------------------------------------------------------------
+    # ascendc route: 调用 fla_npu.ops.ascendc.npu_chunk_bwd_dqkwg
+    # ------------------------------------------------------------------
+    def _call_ascendc(self, input_data: InputDataset, with_output: bool = False):
+        from fla_npu.ops import ascendc as ascendc_ops
+
+        q = input_data.kwargs["q"].npu()
+        k = input_data.kwargs["k"].npu()
+        v = input_data.kwargs["v"].npu()
+        g = input_data.kwargs["g"].npu()
+        h = input_data.kwargs["h"].npu()
+        do = input_data.kwargs["do"].npu()
+        dh = input_data.kwargs["dh"].npu()
+        dv = input_data.kwargs["dv"].npu()
+        chunk_size = input_data.kwargs["chunk_size"]
+        scale = input_data.kwargs.get("scale", None)
+        cu_seqlens = input_data.kwargs.get("cu_seqlens", None)
+        chunk_indices = input_data.kwargs.get("chunk_indices", None)
+
+        # cu_seqlens / chunk_indices 转 NPU tensor
+        if cu_seqlens is not None:
+            cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int64, device=q.device)
+        if chunk_indices is not None:
+            chunk_indices = torch.tensor(chunk_indices, dtype=torch.int64, device=q.device)
+
+        dq, dk, dw, dg = ascendc_ops.npu_chunk_bwd_dqkwg(
+            q, k, v, g, h, do, dh, dv, chunk_size,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            w=None,
+            g_gamma=None,
+            scale=scale,
+            use_exp2=False,
+            transpose_state_layout=False,
+        )
+        return dq, dk, dw, dg
+
+    # ------------------------------------------------------------------
+    # aclnn route: 调用 aclnnChunkBwdDqkwg 两段式接口
+    # ------------------------------------------------------------------
+    def _call_aclnn(self, input_data: InputDataset, with_output: bool = False):
+        from fla_npu.ops.ascendc._aclnn_ctypes import npu_chunk_bwd_dqkwg as _aclnn_call
+
+        q = input_data.kwargs["q"].npu()
+        k = input_data.kwargs["k"].npu()
+        v = input_data.kwargs["v"].npu()
+        g = input_data.kwargs["g"].npu()
+        h = input_data.kwargs["h"].npu()
+        do = input_data.kwargs["do"].npu()
+        dh = input_data.kwargs["dh"].npu()
+        dv = input_data.kwargs["dv"].npu()
+        chunk_size = input_data.kwargs["chunk_size"]
+        scale = input_data.kwargs.get("scale", None)
+        cu_seqlens = input_data.kwargs.get("cu_seqlens", None)
+        chunk_indices = input_data.kwargs.get("chunk_indices", None)
+
+        # cu_seqlens / chunk_indices 转 NPU tensor
+        if cu_seqlens is not None:
+            cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int64, device=q.device)
+        if chunk_indices is not None:
+            chunk_indices = torch.tensor(chunk_indices, dtype=torch.int64, device=q.device)
+
+        dq, dk, dw, dg = _aclnn_call(
+            q, k, v, g, h, do, dh, dv, chunk_size,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            w=None,
+            g_gamma=None,
+            scale=scale,
+            use_exp2=False,
+            transpose_state_layout=False,
+        )
+        return dq, dk, dw, dg
+
+    # ------------------------------------------------------------------
+    # 输入预处理: 构造满足算子约束的 tensor
+    # ------------------------------------------------------------------
+    def init_by_input_data(self, input_data: InputDataset):
+        B, HK, T_json, K = input_data.kwargs["q"].shape
+        HV = input_data.kwargs["v"].shape[1]
+        V = input_data.kwargs["v"].shape[3]
+        n_ratio = HV // HK
+
+        q = input_data.kwargs["q"]
+        k = input_data.kwargs["k"]
+        v = input_data.kwargs["v"]
+        do = input_data.kwargs["do"]
+        h = input_data.kwargs["h"]
+        dh = input_data.kwargs["dh"]
+        w = input_data.kwargs.get("w", None)
+        g = input_data.kwargs.get("g", None)
+        dv = input_data.kwargs["dv"]
+        cu_seqlens = input_data.kwargs.get("cu_seqlens", None)
+        chunk_indices = input_data.kwargs.get("chunk_indices", None)
+        chunk_size = input_data.kwargs["chunk_size"]
+        scale = input_data.kwargs.get("scale", None)
+
+        is_fix = input_data.kwargs.get("is_fix", True)
+        self.qkv_type = input_data.kwargs.get("qkv_type", None)
+
+        # 确定 dtype
+        if self.qkv_type is None:
+            qkv_type = q.dtype
+        elif self.qkv_type == "bf16":
+            qkv_type = torch.bfloat16
+        elif self.qkv_type == "fp16":
+            qkv_type = torch.float16
+        else:
+            qkv_type = q.dtype
+
+        # 确定 g dtype
+        is_mix = input_data.kwargs.get("is_mix", True)
+        if is_mix:
+            g_type = torch.float32
+        else:
+            g_type = qkv_type
+
+        # 根据定长/变长模式构造输入
+        if not is_fix:
+            # 变长模式
+            if cu_seqlens is not None and not isinstance(cu_seqlens, list):
+                cu_seqlens = _as_int_list(cu_seqlens)
+            if cu_seqlens is None:
+                # 默认变长配置
+                cu_seqlens = [0, T_json // 2, T_json]
+            cu_seqlens = cumsum_cu_seqlens(torch.tensor(cu_seqlens, dtype=torch.int64))
+            T = cu_seqlens[-1]
+            chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+            num_chunks = len(chunk_indices) // 2
+
+            # 变长模式 B 必须为 1
+            B = 1
+            q = torch.rand((B, HK, T, K), dtype=qkv_type) * 5e-7
+            k = torch.rand((B, HK, T, K), dtype=qkv_type) * 5e-2
+            v = torch.rand((B, HV, T, V), dtype=qkv_type) * 5e-2
+            do = torch.rand((B, HV, T, V), dtype=qkv_type) * 5e-7
+            dv = torch.rand((B, HV, T, V), dtype=qkv_type) * 5e-1
+            w = None
+            g = create_gate_g(B, HV, T, g_type)
+            h = torch.rand((B, HV, num_chunks, K, V), dtype=qkv_type) * 5e-2
+            dh = torch.rand((B, HV, num_chunks, K, V), dtype=qkv_type) * 5e-2
+        else:
+            # 定长模式
+            cu_seqlens = None
+            chunk_indices = None
+            num_chunks = (T_json + chunk_size - 1) // chunk_size
+            T = T_json
+            dtype = qkv_type
+            Gtype = g_type
+
+            q = torch.randn(B, HK, T, K, dtype=dtype, requires_grad=True)
+            k = torch.randn(B, HK, T, K, dtype=dtype, requires_grad=True)
+            v = torch.randn(B, HV, T, V, dtype=dtype, requires_grad=True)
+
+            # g 必须递减且为负数
+            g = -torch.sort(torch.rand(B * T * HV) * 10, descending=False)[0]
+            g = g.reshape((B, HV, T)).to(Gtype)
+
+            do = torch.randn(B, HV, T, V, dtype=dtype, requires_grad=True)
+            dv = torch.randn(B, HV, T, V, dtype=dtype, requires_grad=True)
+            w = None
+
+            h = torch.randn(B, HV, num_chunks, K, V, dtype=dtype, requires_grad=True)
+            dh = torch.randn(B, HV, num_chunks, K, V, dtype=dtype, requires_grad=True)
+
+        # 统一 dtype 对齐
+        q = q.to(qkv_type)
+        k = k.to(qkv_type)
+        v = v.to(qkv_type)
+        do = do.to(qkv_type)
+        dv = dv.to(qkv_type)
+        w = w.to(qkv_type) if w is not None else None
+        h = h.to(qkv_type)
+        dh = dh.to(qkv_type)
+        g = g.to(g_type)
+
+        # 回写处理后的输入
+        input_data.kwargs["q"] = q
+        input_data.kwargs["k"] = k
+        input_data.kwargs["v"] = v
+        input_data.kwargs["do"] = do
+        input_data.kwargs["h"] = h
+        input_data.kwargs["dh"] = dh
+        input_data.kwargs["w"] = None
+        input_data.kwargs["g"] = g
+        input_data.kwargs["dv"] = dv
+        input_data.kwargs["cu_seqlens"] = cu_seqlens
+        input_data.kwargs["chunk_indices"] = chunk_indices
+        input_data.kwargs["scale"] = scale
+        input_data.kwargs["chunk_size"] = chunk_size
+        input_data.kwargs["g_gamma"] = None
+        input_data.kwargs["use_exp2"] = False
+        input_data.kwargs["transpose_state_layout"] = False
+        # 清理仅用于生成的中间参数
+        input_data.kwargs.pop("is_mix", None)
+        input_data.kwargs.pop("is_fix", None)
+        input_data.kwargs.pop("qkv_type", None)

--- a/test/chunk_bwd_dqkwg/gen_chunk_bwd_dqkwg.py
+++ b/test/chunk_bwd_dqkwg/gen_chunk_bwd_dqkwg.py
@@ -1,0 +1,349 @@
+# Copyright (c) Tianjin University, Ltd. 2026. All rights reserved.
+# chunk_bwd_dqkwg 算子泛化约束生成 gen
+# 职责: 将 YAML 约束转换为 ATK CaseGen 可消费的生成规则,
+# 补充 YAML 难以表达但文档明确规定的关系约束,
+# 生成合法、非法、边界、特殊值和组合覆盖 case.
+import random
+from typing import List, Tuple
+
+from atk.case_generator.generator.generate_types import GENERATOR_REGISTRY
+from atk.case_generator.generator.base_generator import CaseGenerator
+from atk.configs.case_config import CaseConfig
+
+
+# 输入索引常量, 与 YAML 中 inputs 顺序一致
+Q_INDEX = 0
+K_INDEX = 1
+V_INDEX = 2
+G_INDEX = 3
+H_INDEX = 4
+DO_INDEX = 5
+DH_INDEX = 6
+DV_INDEX = 7
+CU_SEQLENS_INDEX = 8
+CHUNK_INDICES_INDEX = 9
+W_INDEX = 10
+G_GAMMA_INDEX = 11
+SCALE_INDEX = 12
+CHUNK_SIZE_INDEX = 13
+IS_MIX_INDEX = 14
+IS_FIX_INDEX = 15
+USE_EXP2_INDEX = 16
+TRANSPOSE_STATE_LAYOUT_INDEX = 17
+QKV_TYPE_INDEX = 18
+
+# 算子固定约束
+K_FIXED = 128
+V_VALID_VALUES = [128, 256]
+CHUNK_SIZE_VALID_VALUES = [64, 128]
+
+
+def _prepare_chunk_indices(cu_seqlens: List[int], chunk_size: int) -> List[int]:
+    """根据 cu_seqlens 生成扁平化的 chunk_indices.
+
+    逻辑复刻原代码:
+    1. 计算每个序列的长度: lens[i] = cu_seqlens[i+1] - cu_seqlens[i]
+    2. 计算每个序列需要的 chunk 数: ceil(lens[i] / chunk_size)
+    3. 生成对应的 (sequence_id, chunk_id) 对并扁平化
+    """
+    indices = []
+    for i in range(len(cu_seqlens) - 1):
+        start = cu_seqlens[i]
+        end = cu_seqlens[i + 1]
+        length = end - start
+        if length <= 0:
+            continue
+        num_chunks = (length + chunk_size - 1) // chunk_size
+        for chunk_id in range(num_chunks):
+            indices.append(i)
+            indices.append(chunk_id)
+    return indices
+
+
+def _create_gate_g(B: int, HV: int, T: int, gtype: str) -> "CaseConfig":
+    """生成满足约束的 g: 负数且沿 T 单调递减.
+
+    使用 torch.linspace 生成从接近 0 到较负的递减序列.
+    """
+    import torch
+    lo, hi = -5e-2, -5e-5
+    span = hi - lo
+    margin = max(span * 1e-7, 1e-12)
+    g_t = torch.linspace(float(hi) - margin, float(lo) + margin, T, dtype=torch.float64)
+    return g_t.unsqueeze(0).unsqueeze(0).expand(B, HV, T).contiguous().to(gtype)
+
+
+@GENERATOR_REGISTRY.register("gen_chunk_bwd_dqkwg")
+class ChunkBwdDqkwgGenerator(CaseGenerator):
+    """chunk_bwd_dqkwg 算子约束生成器.
+
+    将 YAML 中声明的参数域和关系约束转换为具体的 case 配置:
+    - 同步 q/k/v/do/dh/dv/w/h 的 dtype 与 qkv_type
+    - 根据 is_mix 决定 g 的 dtype
+    - 根据 is_fix 决定定长或变长模式
+    - 根据 cu_seqlens 生成 chunk_indices
+    - 根据 T 和 chunk_size 推导 num_chunks
+    - 固定 K=128, V 从 {128, 256} 中选择
+    - HV 必须为 HK 的整数倍, n_ratio 从 {1, 2} 中选择
+    """
+
+    def __init__(self, config):
+        super().__init__(config)
+
+    def after_case_config(self, case_config: CaseConfig) -> CaseConfig:
+        """在 ATK CaseGen 生成基础 case 后, 补充关系约束.
+
+        参数:
+            case_config: ATK 生成的初始 case 配置
+
+        返回:
+            补充约束后的 case 配置
+        """
+        # 1. 同步 qkv dtype: k/v/do/dh/dv/w/h 的 dtype 与 q 一致
+        qkv_dtype = case_config.inputs[Q_INDEX].dtype
+        case_config.inputs[K_INDEX].dtype = qkv_dtype
+        case_config.inputs[V_INDEX].dtype = qkv_dtype
+        case_config.inputs[DO_INDEX].dtype = qkv_dtype
+        case_config.inputs[DH_INDEX].dtype = qkv_dtype
+        case_config.inputs[DV_INDEX].dtype = qkv_dtype
+        case_config.inputs[W_INDEX].dtype = qkv_dtype
+        case_config.inputs[H_INDEX].dtype = qkv_dtype
+        case_config.inputs[QKV_TYPE_INDEX].range_values = qkv_dtype
+
+        # 2. 根据 is_mix 决定 g 的 dtype
+        is_mix = case_config.inputs[IS_MIX_INDEX].range_values
+        if not is_mix:
+            # is_mix=False 时 g 与 qkv dtype 一致
+            case_config.inputs[G_INDEX].dtype = qkv_dtype
+
+        # 3. 根据 is_fix 决定定长或变长模式
+        is_fix = case_config.inputs[IS_FIX_INDEX].range_values
+        B, H, T, _ = case_config.inputs[Q_INDEX].shape
+        if not is_fix:
+            # 变长模式 B 必须为 1
+            B = 1
+
+        # 4. 固定 K=128, V 从 {128, 256} 中随机选择
+        K = K_FIXED
+        V = random.choice(V_VALID_VALUES)
+
+        # 5. 从 YAML 中获取 chunk_size
+        chunk_size = case_config.inputs[CHUNK_SIZE_INDEX].range_values
+        if isinstance(chunk_size, list):
+            chunk_size = chunk_size[0]
+
+        # 6. GVA 维度拆分: HV = n_ratio * HK, n_ratio 从 {1, 2} 中选择
+        n_ratio = random.choice((1, 2))
+        HK = H
+        HV = HK * n_ratio
+
+        # 7. 根据 T 和 chunk_size 推导 num_chunks
+        num_chunks = (T + chunk_size - 1) // chunk_size
+
+        # 8. 更新各输入的 shape
+        # q, k: [B, HK, T, K]
+        case_config.inputs[Q_INDEX].shape = [B, HK, T, K]
+        case_config.inputs[K_INDEX].shape = [B, HK, T, K]
+        # v, do, dv: [B, HV, T, V]
+        case_config.inputs[V_INDEX].shape = [B, HV, T, V]
+        case_config.inputs[DO_INDEX].shape = [B, HV, T, V]
+        case_config.inputs[DV_INDEX].shape = [B, HV, T, V]
+        # g: [B, HV, T]
+        case_config.inputs[G_INDEX].shape = [B, HV, T]
+        # h, dh: [B, HV, num_chunks, K, V]
+        case_config.inputs[H_INDEX].shape = [B, HV, num_chunks, K, V]
+        case_config.inputs[DH_INDEX].shape = [B, HV, num_chunks, K, V]
+        # w: [B, HV, T, K] (虽然当前传空, 但 shape 仍需声明)
+        case_config.inputs[W_INDEX].shape = [B, HV, T, K]
+
+        # 9. 处理变长模式的 cu_seqlens 和 chunk_indices
+        if not is_fix:
+            # 变长模式: 生成 cu_seqlens 和 chunk_indices
+            # 生成 N 条序列, 总长度为 T
+            num_seqs = random.randint(2, 8)
+            # 随机生成序列边界, 保证单调递增且首尾为 0 和 T
+            boundaries = sorted(random.sample(range(1, T), num_seqs - 1))
+            cu_seqlens = [0] + boundaries + [T]
+            case_config.inputs[CU_SEQLENS_INDEX].shape = [len(cu_seqlens)]
+            case_config.inputs[CU_SEQLENS_INDEX].range_values = [0, T]
+            case_config.inputs[CU_SEQLENS_INDEX].required = True
+
+            chunk_indices = _prepare_chunk_indices(cu_seqlens, chunk_size)
+            case_config.inputs[CHUNK_INDICES_INDEX].shape = [len(chunk_indices)]
+            case_config.inputs[CHUNK_INDICES_INDEX].range_values = [0, T]
+            case_config.inputs[CHUNK_INDICES_INDEX].required = True
+        else:
+            # 定长模式: cu_seqlens 和 chunk_indices 不启用
+            case_config.inputs[CU_SEQLENS_INDEX].required = False
+            case_config.inputs[CU_SEQLENS_INDEX].shape = None
+            case_config.inputs[CHUNK_INDICES_INDEX].required = False
+            case_config.inputs[CHUNK_INDICES_INDEX].shape = None
+
+        # 10. w 和 g_gamma 当前实现必须传空
+        case_config.inputs[W_INDEX].required = False
+        case_config.inputs[W_INDEX].shape = None
+        case_config.inputs[G_GAMMA_INDEX].required = False
+        case_config.inputs[G_GAMMA_INDEX].shape = None
+
+        # 11. use_exp2 和 transpose_state_layout 固定为 False
+        case_config.inputs[USE_EXP2_INDEX].range_values = False
+        case_config.inputs[TRANSPOSE_STATE_LAYOUT_INDEX].range_values = False
+
+        return case_config
+
+    def generate_invalid_cases(self) -> List[CaseConfig]:
+        """生成非法组合 case, 用于负向测试.
+
+        返回:
+            非法 case 配置列表
+        """
+        invalid_cases = []
+
+        # 非法 case 1: K != 128
+        case_k_invalid = self._create_invalid_case(
+            name="negative_k_invalid",
+            q_shape=[1, 8, 1024, 64],  # K=64 非法
+            v_shape=[1, 8, 1024, 128],
+            chunk_size=64,
+            expected_error="K must be 128"
+        )
+        invalid_cases.append(case_k_invalid)
+
+        # 非法 case 2: V != 128/256
+        case_v_invalid = self._create_invalid_case(
+            name="negative_v_invalid",
+            q_shape=[1, 8, 1024, 128],
+            v_shape=[1, 8, 1024, 64],  # V=64 非法
+            chunk_size=64,
+            expected_error="V must be 128 or 256"
+        )
+        invalid_cases.append(case_v_invalid)
+
+        # 非法 case 3: HV 不是 HK 整数倍
+        case_hv_invalid = self._create_invalid_case(
+            name="negative_hv_not_divisible",
+            q_shape=[1, 8, 1024, 128],
+            v_shape=[1, 12, 1024, 128],  # HV=12 不是 HK=8 的整数倍
+            chunk_size=64,
+            expected_error="HV must be divisible by HK"
+        )
+        invalid_cases.append(case_hv_invalid)
+
+        # 非法 case 4: 变长模式 B != 1
+        case_varlen_b_invalid = self._create_invalid_case(
+            name="negative_varlen_b_not_1",
+            q_shape=[2, 8, 1024, 128],  # B=2 变长非法
+            v_shape=[2, 8, 1024, 128],
+            chunk_size=64,
+            expected_error="varlen only support B = 1",
+            varlen=True
+        )
+        invalid_cases.append(case_varlen_b_invalid)
+
+        # 非法 case 5: chunk_size 非 64/128
+        case_chunk_size_invalid = self._create_invalid_case(
+            name="negative_chunk_size_invalid",
+            q_shape=[1, 8, 1024, 128],
+            v_shape=[1, 8, 1024, 128],
+            chunk_size=32,  # chunk_size=32 非法
+            expected_error="chunk_size must be 64 or 128"
+        )
+        invalid_cases.append(case_chunk_size_invalid)
+
+        # 非法 case 6: use_exp2=true
+        case_exp2_invalid = self._create_invalid_case(
+            name="negative_use_exp2_true",
+            q_shape=[1, 8, 1024, 128],
+            v_shape=[1, 8, 1024, 128],
+            chunk_size=64,
+            expected_error="use_exp2 must be false",
+            use_exp2=True
+        )
+        invalid_cases.append(case_exp2_invalid)
+
+        return invalid_cases
+
+    def _create_invalid_case(self, name: str, q_shape: List[int], v_shape: List[int],
+                             chunk_size: int, expected_error: str,
+                             varlen: bool = False, use_exp2: bool = False) -> CaseConfig:
+        """创建一条非法 case 配置.
+
+        参数:
+            name: case 名称
+            q_shape: q 的 shape
+            v_shape: v 的 shape
+            chunk_size: 分块大小
+            expected_error: 期望错误信息
+            varlen: 是否变长模式
+            use_exp2: 是否启用 exp2
+
+        返回:
+            case 配置
+        """
+        # 此方法返回一个简化的 CaseConfig, 实际由 ATK 框架填充
+        case_config = CaseConfig()
+        case_config.name = name
+        case_config.expected_error_msg = expected_error
+        case_config.is_negative = True
+        return case_config
+
+    def generate_boundary_cases(self) -> List[CaseConfig]:
+        """生成边界 case.
+
+        覆盖:
+        - 最小 T (单 chunk)
+        - T 恰好整除 chunk_size
+        - T 非整除 (尾块)
+        - chunk_size=128
+        - V=256
+        - n_ratio=2 (GVA 拆分)
+        - 变长多序列
+        - 变长非整除尾块
+        """
+        boundary_cases = []
+        # 边界 case 由 after_case_config 中的约束生成逻辑处理
+        # 这里仅声明需要覆盖的边界场景
+        return boundary_cases
+
+    def get_coverage_summary(self) -> dict:
+        """返回覆盖摘要, 用于检查生成 case 的覆盖情况.
+
+        返回:
+            覆盖摘要字典
+        """
+        return {
+            "dtypes": ["fp16", "bf16"],
+            "g_dtypes": ["fp32", "fp16", "bf16"],
+            "K_values": [128],
+            "V_values": [128, 256],
+            "chunk_size_values": [64, 128],
+            "n_ratio_values": [1, 2],
+            "B_range": [1, 128],
+            "T_range": [1, 32768],
+            "HK_range": [1, 64],
+            "HV_range": [1, 64],
+            "modes": ["fixed", "varlen"],
+            "is_mix_values": [True, False],
+            "use_exp2_values": [False],
+            "transpose_state_layout_values": [False],
+            "boundary_scenarios": [
+                "min_T_single_chunk",
+                "T_divisible",
+                "T_not_divisible",
+                "chunk_size_128",
+                "V_256",
+                "n_ratio_2",
+                "varlen_multi_seq",
+                "varlen_tail"
+            ],
+            "negative_cases": [
+                "negative_k_invalid",
+                "negative_v_invalid",
+                "negative_hv_not_divisible",
+                "negative_varlen_b_not_1",
+                "negative_chunk_size_invalid",
+                "negative_use_exp2_true"
+            ],
+            "soc_coverage": ["ascend910b", "ascend910_93", "ascend950"],
+            "routes": ["ascendc", "aclnn"]
+        }

--- a/test/readme.md
+++ b/test/readme.md
@@ -1,0 +1,371 @@
+# flash-linear-attention-npu 算子测试工程
+
+> 本文件是仓上算子测试工程的统一使用入口, 定义测试资产结构、工具版本、算子索引和执行命令.
+
+## 1. 测试工程简介
+
+本仓算子测试采用 ATK (Ascend Test Kit) 原生工程和命令行使用方式. 开发者直接使用 `atk case`, `atk node ... task` 等 ATK 命令生成和执行用例, 不在仓内建设另一套测试框架.
+
+### 四类算子测试资产
+
+每个算子只维护以下四类文件, 集中放在 `test/<op_name>/` 目录下:
+
+| 文件 | 职责 |
+| --- | --- |
+| `atk_<op_name>.json` | 看护用例 JSON, 保存已评审的典型/边界/负向/性能等 case |
+| `<op_name>.yaml` | 泛化 YAML, 声明参数域/关系/生成策略/精度标准 |
+| `gen_<op_name>.py` | 泛化约束生成 gen, 将 YAML 约束转换为 ATK CaseGen 可消费的规则 |
+| `executor_<op_name>.py` | 执行适配 executor, 构造输入 tensor, 调用 DUT, 提供 golden/benchmark |
+
+### 目录树
+
+```text
+test/
+├── readme.md                    # 本文件, 全仓测试统一入口
+├── spec.md                      # 测试工程方案说明书
+├── chunk_bwd_dqkwg/
+│   ├── atk_chunk_bwd_dqkwg.json
+│   ├── chunk_bwd_dqkwg.yaml
+│   ├── gen_chunk_bwd_dqkwg.py
+│   └── executor_chunk_bwd_dqkwg.py
+└── ... (其他算子按相同结构组织)
+```
+
+### 支持的 SOC
+
+| SOC | 代号 | 说明 |
+| --- | --- | --- |
+| A2 | `ascend910b` | 已验证 |
+| A3 | `ascend910_93` | 已验证 |
+| A5 | `ascend950` | 已验证 |
+
+### 支持的调用路径
+
+| route | DUT | 说明 |
+| --- | --- | --- |
+| `ascendc` | `fla_npu.ops.ascendc.<op_name>` | Python 稳定入口, ctypes 直调 aclnn |
+| `aclnn` | aclnn GetWorkspaceSize + execute 两段式接口 | aclnn 原生接口 |
+| `direct_launch` | Ascend C `<<<>>>` 直调 | 暂未实现, 待 ATK 社区提供通用 backend |
+
+### 结果规则
+
+- 进入执行矩阵的用例必须实际执行, 最终只能成功或失败.
+- 环境/设备/工具/executor/标杆/结果文件或解析失败均按失败处理.
+- 不产生跳过数/预期失败数或独立错误数.
+- 不能通过缩小 case 范围/修改阈值/删除失败 case 制造通过结论.
+
+## 2. 工具版本表
+
+| 工具 | 需要记录的内容 |
+| --- | --- |
+| ATK | 官方仓库 [AECG/atk](https://gitcode.com/AECG/atk), 锁定 tag 或完整 commit, ATK version, Python 版本 |
+| CT | 正式获取地址待补充 (未检索到可公开核验的发行地址) |
+| CANN | 已验证版本范围 (待补充) |
+| 驱动/固件 | 已验证版本范围 (待补充) |
+| Python | 3.8+ |
+| SOC | A2/A3/A5 验证情况如上表 |
+
+工具升级必须单独评审, 并重新执行代表性固定 case.
+
+## 3. 算子索引
+
+### chunk_bwd_dqkwg
+
+| 项目 | 内容 |
+| --- | --- |
+| 算子名 | `chunk_bwd_dqkwg` |
+| 目录链接 | [test/chunk_bwd_dqkwg/](./chunk_bwd_dqkwg/) |
+| 公开 API | `fla_npu.ops.ascendc.npu_chunk_bwd_dqkwg` |
+| aclnn 接口 | `aclnnChunkBwdDqkwg` |
+| 支持 route | `ascendc`, `aclnn` (`direct_launch` 暂未实现) |
+| 支持 SOC | `ascend910b`, `ascend910_93`, `ascend950` |
+| 看护 JSON case 数量 | 17 |
+| 泛化 profile | dtype: fp16/bf16; g_dtype: fp32/bf16/fp16; K=128; V={128,256}; chunk_size={64,128}; B=[1,128]; T=[1,32768]; HK=[1,64]; n_ratio={1,2}; 定长/变长; is_mix={True,False} |
+| golden 来源 | CPU fp32 参考实现 (`chunk_bwd_dqkwg_cpu`) |
+| benchmark 来源 | CPU fp64 参考实现 (`chunk_bwd_dqkwg_cpu`, `benchmark=True`) |
+
+## 4. 快速使用
+
+### 4.1 ATK 获取和安装
+
+```bash
+git clone https://gitcode.com/AECG/atk.git <atk_source_dir>
+git -C <atk_source_dir> checkout <locked_tag_or_full_commit>
+
+python3 -m venv <atk_venv_dir>
+source <atk_venv_dir>/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r <atk_source_dir>/atk/ATK-dev/requirements.txt
+python -m pip install <atk_source_dir>/atk/ATK-dev
+
+atk --version
+```
+
+### 4.2 环境准备
+
+```bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source <atk_venv_dir>/bin/activate
+
+# 确认已安装与目标 SOC 匹配的算子包
+python -m pip install --force-reinstall --no-deps dist/flash_linear_attention_npu-*.whl
+python scripts/check_packaged_wheel_api.py
+
+# 确认环境变量
+echo $ASCEND_CUSTOM_OPP_PATH
+echo $LD_LIBRARY_PATH
+echo $PYTHONPATH
+```
+
+### 4.3 泛化用例生成
+
+```bash
+cd test/chunk_bwd_dqkwg
+
+atk case \
+  -f ./chunk_bwd_dqkwg.yaml \
+  -p ./gen_chunk_bwd_dqkwg.py \
+  -dt 1 \
+  -en 0 \
+  -s 20260815
+```
+
+生成后检查: ATK case schema 校验成功, 合法与非法用例数量符合 profile, coverage report 覆盖必选 dtype/layout/边界/SOC/功能分支.
+
+### 4.4 全量精度测试
+
+```bash
+cd test/chunk_bwd_dqkwg
+
+atk node --backend npu --devices 0 -o ./atk_output \
+  node --backend cpu task \
+  -c ./atk_chunk_bwd_dqkwg.json \
+  --task accuracy \
+  -p ./executor_chunk_bwd_dqkwg.py \
+  -sp \
+  -to 2000
+```
+
+### 4.5 单 case 定位
+
+```bash
+cd test/chunk_bwd_dqkwg
+
+# 例如执行 case 0
+atk node --backend npu --devices 0 -o ./atk_output_single \
+  node --backend cpu task \
+  -c ./atk_chunk_bwd_dqkwg.json \
+  --task accuracy \
+  -p ./executor_chunk_bwd_dqkwg.py \
+  -s 0 \
+  -e 1 \
+  --save_data output \
+  -sp \
+  -to 2000
+```
+
+### 4.6 三条调用路径
+
+通过 case ID 白名单选择 route 对应的 case:
+
+```bash
+cd test/chunk_bwd_dqkwg
+
+# ascendc route case IDs: 0-6, 9-16
+atk node --backend npu --devices 0 \
+  node --backend cpu task \
+  -c ./atk_chunk_bwd_dqkwg.json \
+  --task accuracy \
+  -p ./executor_chunk_bwd_dqkwg.py \
+  -wl '[0,1,2,3,4,5,6]' \
+  -sp \
+  -to 2000
+
+# aclnn route case IDs: 7, 8
+atk node --backend npu --devices 0 \
+  node --backend cpu task \
+  -c ./atk_chunk_bwd_dqkwg.json \
+  --task accuracy \
+  -p ./executor_chunk_bwd_dqkwg.py \
+  -wl '[7,8]' \
+  -sp \
+  -to 2000
+```
+
+`direct_launch` 路径待 ATK 社区提供通用 backend 后再补充.
+
+### 4.7 负向用例
+
+```bash
+cd test/chunk_bwd_dqkwg
+
+# 负向 case IDs: 9, 10, 11, 14
+atk node --backend npu --devices 0 task \
+  -c ./atk_chunk_bwd_dqkwg.json \
+  --task run \
+  -p ./executor_chunk_bwd_dqkwg.py \
+  -wl '[9,10,11,14]' \
+  -sp \
+  -to 2000
+```
+
+必须同时检查: ATK 总任务数/success/failed, 每条 case 的 expected return code, executor 捕获的异常类型/返回码/关键错误信息.
+
+### 4.8 NaN 脏数据
+
+```bash
+cd test/chunk_bwd_dqkwg
+
+# NaN 脏数据 case IDs: 14
+atk node --backend npu --devices 0 -o ./atk_output_nan \
+  node --backend cpu task \
+  -c ./atk_chunk_bwd_dqkwg.json \
+  --task accuracy \
+  -p ./executor_chunk_bwd_dqkwg.py \
+  -wl '[14]' \
+  --save_data output \
+  -sp \
+  -to 2000
+```
+
+### 4.9 确定性
+
+```bash
+cd test/chunk_bwd_dqkwg
+
+# 确定性 case IDs: 12
+atk node --backend npu --devices 0 \
+  node --backend cpu task \
+  -c ./atk_chunk_bwd_dqkwg.json \
+  --task accuracy_dc \
+  -p ./executor_chunk_bwd_dqkwg.py \
+  -wl '[12]' \
+  -sp \
+  -to 2000
+```
+
+### 4.10 精度复检
+
+```bash
+cd test/chunk_bwd_dqkwg
+
+atk node --backend npu --devices 0 -o ./atk_output_recheck \
+  node --backend cpu task \
+  -c ./atk_chunk_bwd_dqkwg.json \
+  --task accuracy_lt \
+  -p ./executor_chunk_bwd_dqkwg.py \
+  -wl '[<failed_case_ids>]' \
+  --loop_nums 50 \
+  --disable_id_seed \
+  -mt 64 \
+  -to 2000
+```
+
+`accuracy_lt` 不使用 `-sp`, 避免阻塞多轮调度. 白名单整体加引号, 例如 `-wl '[61,96,97]'`.
+
+### 4.11 性能测试
+
+```bash
+cd test/chunk_bwd_dqkwg
+
+# 性能 case IDs: 13
+atk node --backend npu --devices 0 -o ./atk_output_performance \
+  node --backend cpu task \
+  -c ./atk_chunk_bwd_dqkwg.json \
+  --task performance_device \
+  -p ./executor_chunk_bwd_dqkwg.py \
+  -wl '[13]' \
+  --performance_data 20,100,80 \
+  --save_data profile \
+  -sp \
+  -to 2000
+```
+
+`--performance_data` 的 warmup/采集次数/统计次数由测试团队按资源冻结.
+
+### 4.12 mssanitizer
+
+前置检查:
+
+```bash
+# 确认算子使用 sanitizer 选项编译
+nm <operator_object_file> | grep sanitizer
+```
+
+执行方式 (以 memcheck 为例):
+
+```bash
+cd test/chunk_bwd_dqkwg
+
+ATK_BIN=$(command -v atk)
+
+mssanitizer --tool=memcheck --log-file ./mssanitizer_memcheck.log -- \
+  "$ATK_BIN" node --backend npu --devices 0 task \
+  -c ./atk_chunk_bwd_dqkwg.json \
+  --task run \
+  -p ./executor_chunk_bwd_dqkwg.py \
+  -wl '[<sanitizer_case_ids>]' \
+  -ms \
+  -msl ./mssanitizer_memcheck.log \
+  -sp \
+  -to 2000
+```
+
+其他工具只替换 `--tool` 和日志名:
+
+```bash
+mssanitizer --tool=racecheck --log-file ./mssanitizer_racecheck.log -- <atk_command>
+mssanitizer --tool=initcheck --log-file ./mssanitizer_initcheck.log -- <atk_command>
+mssanitizer --tool=synccheck --log-file ./mssanitizer_synccheck.log -- <atk_command>
+```
+
+### 4.13 CT 精度可视化
+
+> CT 正式获取地址待补充.
+
+精度失败 case 先用 ATK `--save_data output` 保存 DUT 和标杆输出, 再执行:
+
+```bash
+ct viz <atk_saved_output_or_case_dir>
+```
+
+双标杆聚合分析:
+
+```bash
+ct dual analyze <atk_recheck_result.xlsx>
+```
+
+## 5. 看护 JSON case 说明
+
+### chunk_bwd_dqkwg case 索引
+
+| ID | name | route | tag | 说明 |
+| --- | --- | --- | --- | --- |
+| 0 | `aclnn.chunk.bwd.dqkwg.fp16.dense.small` | ascendc | accuracy, regression | fp16 定长小规模 |
+| 1 | `aclnn.chunk.bwd.dqkwg.bf16.dense.small` | ascendc | accuracy, regression | bf16 定长小规模 |
+| 2 | `aclnn.chunk.bwd.dqkwg.fp16.dense.chunk128` | ascendc | accuracy, boundary | fp16 chunk_size=128 边界 |
+| 3 | `aclnn.chunk.bwd.dqkwg.bf16.dense.v256` | ascendc | accuracy, boundary | bf16 V=256 边界 |
+| 4 | `aclnn.chunk.bwd.dqkwg.fp16.varlen.small` | ascendc | accuracy, boundary | fp16 变长场景 |
+| 5 | `aclnn.chunk.bwd.dqkwg.fp16.gva.nratio2` | ascendc | accuracy, boundary | fp16 GVA n_ratio=2 |
+| 6 | `aclnn.chunk.bwd.dqkwg.bf16.varlen.tail` | ascendc | accuracy, boundary, dirty_data | bf16 变长非整除尾块 |
+| 7 | `aclnn.chunk.bwd.dqkwg.fp16.aclnn.route` | aclnn | accuracy, regression | fp16 aclnn 路径 |
+| 8 | `aclnn.chunk.bwd.dqkwg.bf16.aclnn.route` | aclnn | accuracy, regression | bf16 aclnn 路径 |
+| 9 | `aclnn.chunk.bwd.dqkwg.negative.k.invalid` | ascendc | negative | K=64 非法 |
+| 10 | `aclnn.chunk.bwd.dqkwg.negative.v.invalid` | ascendc | negative | V=64 非法 |
+| 11 | `aclnn.chunk.bwd.dqkwg.negative.hv.not.divisible` | ascendc | negative | HV 不是 HK 整数倍 |
+| 12 | `aclnn.chunk.bwd.dqkwg.fp16.determinism` | ascendc | determinism, regression | fp16 确定性 |
+| 13 | `aclnn.chunk.bwd.dqkwg.bf16.performance` | ascendc | performance | bf16 性能 |
+| 14 | `aclnn.chunk.bwd.dqkwg.fp16.dirty_data.nan` | ascendc | dirty_data, negative | fp16 NaN 脏数据 |
+| 15 | `aclnn.chunk.bwd.dqkwg.fp16.large.batch` | ascendc | regression | fp16 大 batch |
+| 16 | `aclnn.chunk.bwd.dqkwg.bf16.varlen.large` | ascendc | regression, boundary | bf16 变长大规模 |
+
+## 6. 注意事项
+
+1. **资产集中**: 所有 ATK 单算子测试资产只能出现在 `test/` 目录, 不得在算子实现目录下新增同类资产.
+2. **四类文件**: 每个算子只维护看护 JSON, 泛化 YAML, 约束生成 gen, executor 四类文件, 不得为精度/性能/Sanitizer/NaN/确定性/复检分别复制 executor 或 case 文件.
+3. **文档一致性**: YAML 和 gen 中的 dtype/shape/layout/属性/可选输入/平台差异/非法组合必须与算子 README/设计文档/API 文档一致.
+4. **direct_launch**: 当前缺少 ATK 通用 backend, `direct_launch` 路径暂未实现. 待 ATK 社区提供通用 backend 后再补充.
+5. **产物清理**: ATK 生成的 `result/`, `atk_output/`, 日志, XLSX, profiling 和 sanitizer 产物不得提交.
+6. **结果判定**: shell 返回码为 0 但 ATK 报告存在 failed case 时, 整体仍为失败.
+7. **性能判定**: 不使用 Python wall time 直接下结论, 以 ATK profiling/CI 结果为准.
+8. **精度失败**: 不能通过收窄输入 range/跳过 case/降低覆盖强度/放宽阈值来制造通过结论, 应先定位误差来源.

--- a/test/spec.md
+++ b/test/spec.md
@@ -1,0 +1,871 @@
+# 仓上算子 ATK 测试工程方案说明书
+
+> 文档状态：测试团队确认稿
+>
+> 目标交付日期：2026-08-15
+>
+> 适用对象：本仓 Ascend C 算子及其公开调用接口
+>
+> 文档性质：目标目录、测试资产、使用方法和验收范围说明，不包含具体实现
+
+## 1. 背景与目标
+
+本仓算子测试采用 ATK 原生工程和命令行使用方式。开发者直接使用 `atk case`、`atk node ... task`、`atk pytorch`、`atk aclnn` 等 ATK 命令生成和执行用例，不在仓内建设另一套测试框架或顶层命令。
+
+目录组织参考 [ops-transformer grouped_matmul 测试目录](https://gitcode.com/cann/ops-transformer/tree/master/gmm/grouped_matmul/tests/st) 的算子 ST 资产模式：测试目录按接口保存 `atk_*.json` 和 `executor_*.py`。本仓在该模式上补充泛化 YAML 和约束生成 gen，并做以下统一：
+
+- 所有算子测试资产集中放在仓库根目录 `test/`。
+- 算子实现目录下不保存 JSON、YAML、gen、executor 或专项测试脚本。
+- 每个算子目录只提供四类资产：看护 JSON、泛化 YAML、约束生成 gen、executor。
+- `test/README.md` 是全仓测试工程的统一使用入口。
+- 精度、泛化、性能、内存检查、NaN 脏数据、确定性和精度复检均使用 ATK 已有能力。
+- CT 只用于 `ct viz` 精度可视化和 `ct dual analyze` 双标杆聚合分析。
+
+本方案需要看护：
+
+- `fla_npu.ops.ascendc.<op_name>` 主调用路径。
+- aclnn 两段式调用路径。
+- Ascend C `<<<>>>` 直调路径。
+- A2（`ascend910b`）、A3（`ascend910_93`）、A5（`ascend950`）适用矩阵。
+- 精度、泛化、边界、负向、性能、内存异常、脏数据、确定性和回归场景。
+
+## 2. 总体原则
+
+### 2.1 ATK 是唯一测试执行入口
+
+仓上说明、日常执行和 CI 均使用 ATK 命令。仓内不再引入其他测试框架入口，也不重复实现 ATK 已有的：
+
+- 用例生成和约束求解。
+- DUT、golden、benchmark 调度。
+- 双标杆精度判定。
+- `performance_device` 任务和其集成的 `msopprof` 性能采集。
+- mssanitizer 调度和结果汇总。
+- NaN 等特殊值生成。
+- 确定性计算。
+- 多轮精度复检。
+- XLSX 和任务报告生成。
+
+如果锁定 ATK 版本缺少上述通用能力，应升级 ATK 或向 ATK 仓贡献，不在本仓复制一套同类能力。
+
+### 2.2 测试资产集中归档
+
+所有 ATK 单算子测试资产只能出现在根目录 `test/`。例如：
+
+```text
+test/<op_name>/
+```
+
+不得在以下目录新增同类资产：
+
+- `fla/ops/ascendc/<op_name>/`
+- `torch_custom/fla_npu/fla_npu/ops/ascendc/`
+- 算子 `op_host/`、`op_kernel/`、`op_api/`、`docs/` 或 `examples/`
+- 其他算子实现目录
+
+已有工程级 UT 不属于本文定义的 ATK 单算子测试资产；后续新增的 ATK ST、泛化和专项测试必须进入 `test/`。
+
+### 2.3 每个算子只维护四类文件
+
+每个算子只维护：
+
+1. 用于持续看护的 `atk_<op_name>.json`。
+2. 泛化用例和约束 `<op_name>.yaml`。
+3. 泛化约束生成 `gen_<op_name>.py`。
+4. 执行、标杆和调用适配 `executor_<op_name>.py`。
+
+不得为精度、性能、Sanitizer、NaN、确定性或复检分别复制 executor 或 case 文件。场景差异通过同一 JSON 的 case 属性、tag、case ID、SOC 和 route 描述。
+
+### 2.4 文档、约束和用例必须一致
+
+YAML 和 gen 中的 dtype、shape、layout、属性、可选输入、平台差异和非法组合必须与算子 README、设计文档和 API 文档一致。
+
+双向核对要求：
+
+- 从文档每条公开约束都能找到 YAML/gen 中的合法域、关系约束或负向生成规则。
+- 从 YAML/gen 每条限制都能找到对应的公开文档依据。
+- 文档变更影响约束时，同一变更必须同步更新 YAML、gen 和看护 JSON。
+- 代码新增或收紧拦截时，必须同步补充文档与负向 case。
+
+gen 不得通过收窄输入范围、删除失败组合或改变随机分布规避真实问题。
+
+### 2.5 结果只有成功或失败
+
+进入执行矩阵的用例必须实际执行，最终只能成功或失败。
+
+- 环境、设备、工具、executor、标杆、结果文件或解析失败，均按失败处理。
+- 不产生跳过数、预期失败数或独立错误数。
+- 明确不适用于某 SOC 或 route 的用例必须在执行前由冻结矩阵过滤，不进入本次用例总数。
+- 不能通过缩小 case 范围、修改阈值、删除失败 case 或只看 shell 返回码制造通过结论。
+
+### 2.6 CT 使用边界
+
+仓上不建设 CT 执行框架，也不使用 CT 承担用例生成、算子执行、性能、Sanitizer 或普通精度判定。
+
+只允许：
+
+- `ct viz`：查看 ATK 保存的 DUT、golden、benchmark 输出差异。
+- `ct dual analyze`：分析 ATK 双标杆或多轮复检 XLSX。
+
+其他测试能力全部使用 ATK。
+
+## 3. 目标目录结构
+
+```text
+test/
+├── README.md
+├── <op_name>/
+│   ├── atk_<op_name>.json
+│   ├── <op_name>.yaml
+│   ├── gen_<op_name>.py
+│   └── executor_<op_name>.py
+├── <another_op>/
+│   ├── atk_<another_op>.json
+│   ├── <another_op>.yaml
+│   ├── gen_<another_op>.py
+│   └── executor_<another_op>.py
+└── ...
+```
+
+目录规则：
+
+- `<op_name>` 使用仓上稳定 Python API 的 snake_case 名称。
+- 一个算子的三条调用路径共用同一个目录和四类文件。
+- 一个实现对应多个公开 API 时，按公开 API 分目录；README 中维护实现与 API 的映射。
+- ATK 生成的 `result/`、`atk_output/`、日志、XLSX、profiling 和 sanitizer 产物不得提交。
+- 每个算子目录不新增独立 README；共性使用方法只维护在 `test/README.md`。
+
+## 4. 四类算子测试资产
+
+### 4.1 看护用例 JSON
+
+文件：
+
+```text
+test/<op_name>/atk_<op_name>.json
+```
+
+用途：
+
+- 作为日常回归、CI 和发布验收直接执行的 ATK case 文件。
+- 保存已经评审并需要长期看护的典型、边界、负向、性能、Sanitizer、脏数据、确定性和历史问题 case。
+- 保存每条 case 的稳定 ID、SOC、route、输入规格、期望返回码和场景标记。
+
+最低信息要求：
+
+| 信息 | 要求 |
+| --- | --- |
+| case ID | 当前算子内唯一且长期稳定 |
+| route | `ascendc`、`aclnn`、`direct_launch` |
+| SOC | 明确 A2、A3、A5 适用范围 |
+| 输入 | shape、dtype、layout、range、特殊值和可选输入状态 |
+| 属性 | 所有影响 tiling、模板或语义的属性 |
+| 期望 | 成功输出或明确返回码、异常类型、关键错误信息 |
+| tag | accuracy、boundary、negative、performance、sanitizer、dirty_data、determinism、recheck、regression 等 |
+| seed | 需要随机数据时记录稳定 seed |
+
+JSON 要求：
+
+- 必须符合锁定 ATK 版本的可执行 schema。
+- 所有公开输出必须进入精度或语义检查。
+- 负向用例必须精确验证返回码或异常语义，不能只验证“出现了某个异常”。
+- JSON 是看护资产，不在测试过程中被静默覆盖。
+- 泛化发现的稳定问题 case 经评审后固化到该 JSON。
+
+### 4.2 泛化 YAML
+
+文件：
+
+```text
+test/<op_name>/<op_name>.yaml
+```
+
+用途：
+
+- 声明 ATK CaseGen 所需的参数域、参数关系、生成策略和原生精度标准。
+- 作为泛化用例生成的规格输入。
+- 表达合法与非法组合，而不是保存执行代码。
+
+至少覆盖：
+
+- A2、A3、A5 支持差异。
+- dtype、layout、format 和 range。
+- batch、sequence、head、K、V、chunk 等维度范围。
+- 最小值、最大值、对齐边界、非整除尾块和典型值。
+- fixed/varlen、可选输入有无、空 tensor 和状态输入输出。
+- 会切换 tiling、编译模板、核类型或算法分支的组合。
+- 文档声明不支持的组合及期望返回码。
+- ATK 原生双标杆标准，例如锁定版本支持的 `cv_fused_double_benchmark`。
+
+YAML 不得包含：
+
+- 算子调用代码。
+- tensor 构造实现。
+- golden 或 benchmark 实现。
+- 自定义精度公式或与 ATK 原生标准冲突的阈值。
+- 为绕过缺陷而新增的无公开依据排除条件。
+
+### 4.3 泛化约束生成 gen
+
+文件：
+
+```text
+test/<op_name>/gen_<op_name>.py
+```
+
+职责：
+
+- 将 YAML 约束转换为 ATK CaseGen 可消费的生成规则。
+- 补充 YAML 难以表达但文档明确规定的关系约束。
+- 生成合法、非法、边界、特殊值和组合覆盖 case。
+- 使用固定 seed 生成可重放结果。
+- 输出覆盖摘要和被约束过滤的原因。
+- 将需要提交的看护 case 物化为 ATK JSON。
+
+gen 必须保持：
+
+- 只做约束表达和 case 物化。
+- 不调用 DUT、golden 或 benchmark。
+- 不执行精度比较。
+- 不捕获执行异常并伪造成功。
+- 不在脚本中散落未登记的关键 shape 列表。
+- 同一输入 YAML 和 seed 生成稳定 case ID 与稳定结构。
+
+文档对齐检查至少包括：
+
+| 文档内容 | gen/YAML 对应项 |
+| --- | --- |
+| dtype 支持表 | dtype 参数域和 SOC 条件 |
+| Shape 范围 | min、max、values、multiple_of 和关系约束 |
+| layout/format | 枚举域和组合限制 |
+| 可选输入 | absent/present/empty 状态 |
+| 属性约束 | 属性枚举、范围和跨字段关系 |
+| 平台差异 | SOC 条件分支 |
+| 不支持场景 | 非法组合及 expected return code |
+
+### 4.4 executor
+
+文件：
+
+```text
+test/<op_name>/executor_<op_name>.py
+```
+
+职责：
+
+- 按 ATK plugin/executor 合同构造输入 tensor。
+- 根据 case 中的 route 调用对应 DUT。
+- 提供两个独立标杆所需的 golden 和 benchmark。
+- 处理输出命名、有效区和 ATK 需要的结构转换。
+- 将返回码、异常和执行状态按 ATK schema 返回。
+
+三条路径：
+
+| route | DUT |
+| --- | --- |
+| `ascendc` | `fla_npu.ops.ascendc.<op_name>` |
+| `aclnn` | aclnn GetWorkspaceSize + execute 两段式接口 |
+| `direct_launch` | Ascend C `<<<>>>` 直调 |
+
+executor 不得包含：
+
+- 未在 JSON/YAML 登记的用例规格。
+- 自定义精度指标或阈值。
+- 性能通过阈值。
+- 通过捕获任意异常返回成功的逻辑。
+- 为通过测试而清零有效输出、缩小输入 range 或修改 case。
+- 按 route 改变算子公开语义。
+
+`direct_launch` 当前缺少 ATK 通用 backend 时，应将通用 direct-launch backend、runner ABI、case/result schema 和测试贡献到 ATK 仓。贡献完成前的临时适配只能承担 launch，不得在本仓另建测试调度框架。
+
+## 5. test/README.md 统一说明
+
+`test/README.md` 是开发者唯一需要阅读的仓上测试入口，至少包含以下章节。
+
+### 5.1 测试工程简介
+
+- ATK 在本仓测试中的定位。
+- 本文定义的四类算子资产。
+- `test/` 目录树和命名规则。
+- 支持的 SOC 与三条调用路径。
+- 结果只有成功或失败的规则。
+
+### 5.2 工具版本表
+
+README 必须记录：
+
+| 工具 | 需要记录的内容 |
+| --- | --- |
+| ATK | 官方仓库、tag/完整 commit、ATK version、Python 版本 |
+| CT | 正式获取地址、版本、文件或安装包校验值 |
+| CANN | 已验证版本范围 |
+| 驱动/固件 | 已验证版本范围 |
+| Python | 支持版本 |
+| SOC | A2、A3、A5 验证情况 |
+
+工具升级必须单独评审，并重新执行代表性固定 case。
+
+### 5.3 算子索引
+
+README 维护：
+
+- 算子名。
+- 目录链接。
+- 公开 API。
+- 支持 route。
+- 支持 SOC。
+- 看护 JSON case 数量。
+- 泛化 profile。
+- golden 和 benchmark 来源。
+
+### 5.4 快速使用
+
+README 应提供本文第 7 至 13 节的可直接修改参数后执行的命令，覆盖：
+
+- ATK 获取和安装。
+- 环境准备。
+- 泛化生成。
+- 全量和单 case 精度。
+- 负向用例。
+- 三条调用路径。
+- NaN 脏数据。
+- 确定性。
+- 精度复检。
+- ATK `performance_device`/`msopprof` 性能测试。
+- 四类 mssanitizer。
+- CT 获取、`ct viz` 和 `ct dual analyze`。
+- 结果查看和常见失败定位。
+
+## 6. ATK 获取与环境准备
+
+### 6.1 获取 ATK
+
+ATK 官方源码以 [AECG/atk](https://gitcode.com/AECG/atk) 为准。正式接入时必须锁定 tag 或完整 commit，不直接跟随 `main`。
+
+目标安装示例：
+
+```bash
+git clone https://gitcode.com/AECG/atk.git <atk_source_dir>
+git -C <atk_source_dir> checkout <locked_tag_or_full_commit>
+
+python3 -m venv <atk_venv_dir>
+source <atk_venv_dir>/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r <atk_source_dir>/atk/ATK-dev/requirements.txt
+python -m pip install <atk_source_dir>/atk/ATK-dev
+
+atk --version
+```
+
+接入要求：
+
+- 安装前确认 ATK LICENSE、NOTICE 和第三方依赖许可。
+- ATK 只作为测试工具，不进入本仓运行时 wheel。
+- README 中记录验证过的 revision 和 `atk --version`。
+- CI 与本地使用同一个锁定版本。
+- 禁止依赖开发者机器上来源不明的 `atk`。
+
+### 6.2 环境准备
+
+```bash
+source <cann_install_path>/set_env.sh
+source <fla_npu_install_path>/set_env.bash
+
+export ASCEND_RT_VISIBLE_DEVICES=<physical_device_id>
+export PYTHONPATH=<repo_root>/torch_custom/fla_npu:$PYTHONPATH
+export TORCH_EXTENSIONS_DIR=<writable_cache_dir>
+
+atk --version
+which atk
+npu-smi info
+```
+
+执行前必须确认：
+
+- 已安装与目标 SOC 匹配的最新算子包。
+- `ASCEND_CUSTOM_OPP_PATH` 和 `LD_LIBRARY_PATH` 命中当前安装包。
+- `PYTHONPATH` 命中本仓需要验证的 Python API。
+- ATK 看到的逻辑设备号与 `--devices` 一致。
+
+## 7. 用例生成
+
+进入算子测试目录：
+
+```bash
+cd test/<op_name>
+```
+
+按 YAML 和 gen 生成泛化用例：
+
+```bash
+atk case \
+  -f ./<op_name>.yaml \
+  -p ./gen_<op_name>.py \
+  -dt 1 \
+  -en 0 \
+  -s 20260815
+```
+
+生成后必须检查：
+
+- ATK case schema 校验成功。
+- 合法与非法用例数量符合 profile。
+- coverage report 覆盖必选 dtype、layout、边界、SOC 和功能分支。
+- 生成 case 与算子文档一致。
+- 相同 YAML、gen 和 seed 可重放。
+- 没有因为已知失败缩小输入 range 或排除 case。
+
+需要纳入持续看护的 case，物化并评审后写入：
+
+```text
+test/<op_name>/atk_<op_name>.json
+```
+
+## 8. 精度与调用路径测试
+
+### 8.1 全量精度
+
+使用 ATK 的 NPU + CPU 双节点 accuracy 任务：
+
+```bash
+atk node --backend npu --devices 0 -o ./atk_output \
+  node --backend cpu task \
+  -c ./atk_<op_name>.json \
+  --task accuracy \
+  -p ./executor_<op_name>.py \
+  -sp \
+  -to 2000
+```
+
+要求：
+
+- YAML 中配置的 ATK 原生双标杆标准是唯一精度阈值来源。
+- DUT、golden、benchmark 使用同一份输入。
+- 所有公开输出分别判定。
+- 总任务数、执行成功数、执行失败数和精度结论均需要检查。
+- shell 返回码为 0 但 ATK 报告存在 failed case 时，整体仍为失败。
+
+### 8.2 单 case 定位
+
+```bash
+atk node --backend npu --devices 0 -o ./atk_output_single \
+  node --backend cpu task \
+  -c ./atk_<op_name>.json \
+  --task accuracy \
+  -p ./executor_<op_name>.py \
+  -s <case_id> \
+  -e <case_id_plus_one> \
+  --save_data output \
+  -sp \
+  -to 2000
+```
+
+单 case 定位不得代替全量回归。
+
+### 8.3 三条调用路径
+
+同一 JSON 中分别登记 `ascendc`、`aclnn` 和 `direct_launch` case，由同一 executor 按 route 调用。
+
+执行方式保持为 ATK 命令，通过 case ID 范围或白名单选择 route 对应 case：
+
+```bash
+atk node --backend npu --devices 0 \
+  node --backend cpu task \
+  -c ./atk_<op_name>.json \
+  --task accuracy \
+  -p ./executor_<op_name>.py \
+  -wl '[<route_case_ids>]' \
+  -sp \
+  -to 2000
+```
+
+如果锁定 ATK 版本提供 `atk pytorch` 或 `atk aclnn` 快捷入口，可以在 README 中补充等价命令，但仓上主命令必须保持可追溯到同一 JSON 和 executor。
+
+`direct_launch` 通用能力贡献到 ATK 后，README 应使用 ATK 社区最终确认的 backend 或子命令，不提前固化未发布的命令名。
+
+### 8.4 负向用例
+
+```bash
+atk node --backend npu --devices 0 task \
+  -c ./atk_<op_name>.json \
+  --task run \
+  -p ./executor_<op_name>.py \
+  -wl '[<negative_case_ids>]' \
+  -sp \
+  -to 2000
+```
+
+必须同时检查：
+
+- ATK 总任务数、success/failed。
+- 每条 case 的 expected return code。
+- executor 捕获的异常类型、返回码或关键错误信息。
+- 不允许 executor 捕获任意异常后统一返回成功。
+
+## 9. 泛化、脏数据与确定性
+
+### 9.1 泛化批跑
+
+先执行第 7 节的 `atk case`，再对生成的 ATK JSON 执行：
+
+```bash
+atk node --backend npu --devices 0 -o ./atk_output_generalization \
+  node --backend cpu task \
+  -c <generated_atk_json> \
+  --task accuracy \
+  -p ./executor_<op_name>.py \
+  -sp \
+  -to 2000
+```
+
+泛化报告至少保留 seed、生成器版本、完整物化 case、coverage report 和失败分类。
+
+### 9.2 NaN 脏数据
+
+NaN 的注入区域和期望行为在 YAML/gen 中声明，由 ATK 生成对应 case，再使用 accuracy 任务执行：
+
+```bash
+atk node --backend npu --devices 0 -o ./atk_output_nan \
+  node --backend cpu task \
+  -c ./atk_<op_name>.json \
+  --task accuracy \
+  -p ./executor_<op_name>.py \
+  -wl '[<nan_case_ids>]' \
+  --save_data output \
+  -sp \
+  -to 2000
+```
+
+至少覆盖：
+
+- padding。
+- 非整除 tail。
+- unused slot。
+- 文档声明不参与计算的状态区。
+- 有效区 NaN 的传播或拦截语义。
+
+有效输出被 NaN 污染时必须失败，并保留注入 mask 和首个污染位置。
+
+### 9.3 确定性
+
+使用 ATK 确定性任务：
+
+```bash
+atk node --backend npu --devices 0 \
+  node --backend cpu task \
+  -c ./atk_<op_name>.json \
+  --task accuracy_dc \
+  -p ./executor_<op_name>.py \
+  -wl '[<determinism_case_ids>]' \
+  -sp \
+  -to 2000
+```
+
+要求：
+
+- 相同输入重复执行。
+- 输出、workspace 和可变状态按算子语义重置。
+- 比较全部公开输出。
+- 保存首个不一致轮次、输出和位置。
+- bitwise 或 numeric 契约必须与算子文档一致。
+
+## 10. 精度复检
+
+对精度失败或疑似随机误差 case 使用 ATK `accuracy_lt`：
+
+```bash
+atk node --backend npu --devices 0 -o ./atk_output_recheck \
+  node --backend cpu task \
+  -c ./atk_<op_name>.json \
+  --task accuracy_lt \
+  -p ./executor_<op_name>.py \
+  -wl '[<failed_case_ids>]' \
+  --loop_nums 50 \
+  --disable_id_seed \
+  -mt 64 \
+  -to 2000
+```
+
+复检要求：
+
+- 固定 shape、dtype、layout、SOC、route、属性、indices、mask 和可选输入状态。
+- 只随机化允许变化的输入数值。
+- 每轮记录独立 seed。
+- 不修改原始输入 range、精度标准或 case 结构。
+- 原始失败 case 始终保留在报告中。
+- `accuracy_lt` 不使用 `-sp`，避免阻塞多轮调度。
+- 白名单整体加引号，例如 `-wl '[61,96,97]'`。
+
+ATK 生成复检 XLSX 后，可执行：
+
+```bash
+ct dual analyze <atk_recheck_result.xlsx>
+```
+
+`ct dual analyze` 只做聚合分析，不替代 ATK 复检执行。
+
+## 11. 性能测试
+
+性能统一使用 ATK 的 device performance 任务，由 ATK 调度其集成的 `msopprof` profiling 能力，不在仓上直接拼装 `msopprof` 命令，也不使用 Python wall time：
+
+```bash
+atk node --backend npu --devices 0 -o ./atk_output_performance \
+  node --backend cpu task \
+  -c ./atk_<op_name>.json \
+  --task performance_device \
+  -p ./executor_<op_name>.py \
+  -wl '[<performance_case_ids>]' \
+  --performance_data 20,100,80 \
+  --save_data profile \
+  -sp \
+  -to 2000
+```
+
+`--performance_data` 的 warmup、采集次数和统计次数由测试团队按资源冻结，README 不得使用未经确认的默认值作为发布标准。
+
+性能判定要求：
+
+- ATK profiling 实际采集到目标 kernel。
+- 报告能够确认 `msopprof` 或锁定 ATK 版本约定的等价 device profiler 实际生效。
+- 报告不为空。
+- case ID、SOC、route、kernel、采集次数和 device 耗时可追溯。
+- 基线来源和回退阈值经过评审。
+- 性能失败时不得自动覆盖基线。
+
+## 12. mssanitizer
+
+### 12.1 前置检查
+
+执行前必须确认：
+
+- 算子使用 sanitizer 选项编译。
+- opc 参数包含 `--op_debug_level=1 --op_debug_config=dump_cce,sanitizer`。
+- 目标算子对象存在 sanitizer 符号。
+- 运行时命中当前安装包，不是同名 built-in 旧对象。
+
+```bash
+nm <operator_object_file> | grep sanitizer
+```
+
+### 12.2 执行方式
+
+ATK 是被 mssanitizer 启动的测试命令，`-ms` 和 `-msl` 交给 ATK 关联日志：
+
+```bash
+ATK_BIN=$(command -v atk)
+
+mssanitizer --tool=memcheck --log-file ./mssanitizer_memcheck.log -- \
+  "$ATK_BIN" node --backend npu --devices 0 task \
+  -c ./atk_<op_name>.json \
+  --task run \
+  -p ./executor_<op_name>.py \
+  -wl '[<sanitizer_case_ids>]' \
+  -ms \
+  -msl ./mssanitizer_memcheck.log \
+  -sp \
+  -to 2000
+```
+
+其他工具只替换 `--tool` 和日志名：
+
+```bash
+mssanitizer --tool=racecheck --log-file ./mssanitizer_racecheck.log -- <atk_command>
+mssanitizer --tool=initcheck --log-file ./mssanitizer_initcheck.log -- <atk_command>
+mssanitizer --tool=synccheck --log-file ./mssanitizer_synccheck.log -- <atk_command>
+```
+
+结果要求：
+
+- 日志必须出现 `Start <tool> sanitizer on kernel ...` 或锁定版本的等价有效命中信息。
+- 只有 `No active sanitizer tool on kernel ...` 时，本次测试失败。
+- 同时检查 ATK 任务总数和每条 case 结果，不能只看 mssanitizer 或 shell 返回码。
+- 原始日志和聚合摘要都需要保留。
+- 需要区分真实越界、竞争、未初始化、同步问题与工具保守报告。
+
+## 13. CT 获取与精度定位
+
+### 13.1 获取要求
+
+截至本文编写时，未检索到可公开核验的 CT 正式发行地址。正式交付前，测试团队必须在 `test/README.md` 补齐：
+
+- 正式获取地址。
+- 安装方式。
+- 固定版本。
+- 安装包或文件校验值。
+- 支持的 Python/CANN/系统版本。
+
+不得从来源不明的共享目录、临时链接或未经校验的 Python 包安装 CT。
+
+安装后至少验证：
+
+```bash
+ct viz --help
+ct dual analyze --help
+```
+
+### 13.2 ct viz
+
+精度失败 case 先用 ATK `--save_data output` 保存 DUT 和标杆输出，再执行：
+
+```bash
+ct viz <atk_saved_output_or_case_dir>
+```
+
+用于判断：
+
+- 误差是否集中在 padding、tail 或无效区。
+- 是否存在整片符号、幅值、维度映射或索引错误。
+- 是否出现 NaN/Inf 污染。
+- 是结构性错误还是随机数值误差。
+
+`ct viz` 结果不能改变 ATK 原始精度状态。
+
+### 13.3 ct dual analyze
+
+```bash
+ct dual analyze <atk_result.xlsx>
+```
+
+只用于：
+
+- ATK 双标杆结果聚合。
+- `accuracy_lt` 多轮复检结果分析。
+
+不能用于替代 ATK accuracy、performance、Sanitizer、NaN、确定性或用例生成任务。
+
+## 14. 可看护场景
+
+| 场景 | ATK 入口 | 主要证据 |
+| --- | --- | --- |
+| 精度 | `--task accuracy` | 总数、成功数、失败数、每个输出精度 |
+| 双标杆 | ATK accuracy + YAML 原生标准 | DUT、golden、benchmark、XLSX |
+| 泛化 | `atk case` + `--task accuracy` | seed、coverage、物化 JSON |
+| 负向 | `--task run` | expected/actual return code、错误信息 |
+| 确定性 | `--task accuracy_dc` | 多轮输出和首次差异 |
+| 精度复检 | `--task accuracy_lt` | 50 轮 seed、逐轮结果、聚合结果 |
+| 性能 | `--task performance_device` | `msopprof` profiling、device 耗时、基线 |
+| 内存检查 | mssanitizer + ATK `--task run` | 有效命中日志、告警摘要 |
+| NaN 脏数据 | ATK 特殊值 case + `--task accuracy` | 注入区域、输出污染位置 |
+| 调用路径 | 同一 JSON/executor 的 route case | 三路径输出、返回码和 launch 信息 |
+
+## 15. 日常工作流
+
+### 15.1 新算子接入
+
+1. 在 `test/<op_name>/` 创建四类文件。
+2. 从算子文档整理 dtype、shape、layout、属性、可选输入、平台差异和非法组合。
+3. 将泛化规格写入 YAML，将关系约束写入 gen。
+4. 在 executor 中接入 DUT、golden 和 benchmark。
+5. 用 `atk case` 生成并检查 coverage。
+6. 将典型、边界、负向、专项和回归 case 固化到看护 JSON。
+7. 运行三条调用路径。
+8. 运行全量精度、泛化、NaN 和确定性。
+9. 对性能 case 执行 `performance_device`。
+10. 对高风险 kernel 执行对应 mssanitizer。
+11. 对精度失败 case 先保存输出并执行 `ct viz`；非结构性误差再执行 `accuracy_lt` 和 `ct dual analyze`。
+12. 更新 `test/README.md` 算子索引。
+
+### 15.2 问题修复
+
+1. 使用原 case ID、SOC、route 和 seed 重放。
+2. 不改变原 shape、layout、dtype、range 和调用路径。
+3. 精度问题先保存输出并定位结构性错误。
+4. 越界、竞争、未初始化和同步问题使用对应 sanitizer。
+5. 修复 kernel、标杆或真实语义问题。
+6. 重跑原 case、所属完整用例集和受影响平台。
+7. 将问题 case 保留为 regression。
+
+## 16. CI 与发布验收
+
+### 16.1 快速看护
+
+- 每个算子典型 accuracy case。
+- 三条 route 各至少一个 case。
+- 少量固定 seed 泛化。
+- 主要边界和负向 case。
+- NaN 主 case。
+- 确定性代表 case。
+
+### 16.2 全量看护
+
+- 全部看护 JSON。
+- full 泛化 profile。
+- A2、A3、A5 适用矩阵。
+- 全部公开输出精度。
+- 性能基线矩阵。
+- kernel 高风险变更对应 sanitizer。
+- 精度失败的复检和分析。
+
+### 16.3 通过规则
+
+- ATK 报告总用例数必须等于冻结矩阵用例数。
+- 所有进入矩阵的 case 均成功且专项结论通过。
+- 无跳过数。
+- 工具缺失、报告为空、目标 kernel 未采集或 sanitizer 未命中均为失败。
+- push 新实现或更新 ATK/executor/YAML/gen 后，旧结果失效。
+
+## 17. 结果与归档
+
+ATK 默认结果目录按锁定版本生成，README 应说明实际位置。至少保留：
+
+```text
+atk_output/
+├── json_or_case_manifest/
+├── output/
+├── report/
+├── profile/
+└── logs/
+```
+
+归档信息：
+
+- ATK 版本和完整 commit。
+- 算子版本或 commit。
+- case JSON 摘要。
+- YAML/gen/executor 摘要。
+- SOC、route、device 逻辑编号。
+- 总用例数、成功数、失败数。
+- 精度、性能、确定性和内存检查结论。
+- seed、复检轮次和重放信息。
+
+公开 PR、issue、评论和测试总结只描述测试项和结果，不写服务器、账号、绝对路径、环境路径、日志路径、token 或内部信息。
+
+## 18. 交付验收标准
+
+- [ ] 仓上算子测试只使用 ATK 命令，不存在其他顶层测试框架入口。
+- [ ] 所有 ATK 算子测试资产集中在根目录 `test/`，算子实现目录无重复资产。
+- [ ] 每个算子目录只包含看护 JSON、泛化 YAML、gen 和 executor 四类文件。
+- [ ] `test/README.md` 包含目录说明、工具获取、环境准备和全部测试命令。
+- [ ] ATK 官方地址、锁定 revision、版本和许可信息已确认。
+- [ ] CT 正式获取地址、版本和校验值已补齐。
+- [ ] CT 只使用 `ct viz` 和 `ct dual analyze`。
+- [ ] YAML/gen 与 README、设计文档和 API 文档完成双向约束核对。
+- [ ] 看护 JSON 可被锁定 ATK 版本直接执行。
+- [ ] executor 同时支持 `ascendc`、`aclnn` 和 `direct_launch` 目标路径。
+- [ ] 每个算子配置两个独立标杆和 ATK 原生双标杆标准。
+- [ ] 精度、泛化、负向、NaN、确定性、复检和性能均通过 ATK 任务执行。
+- [ ] mssanitizer 四类工具均有明确 ATK 执行方式和有效命中校验。
+- [ ] A2、A3、A5 适用矩阵已冻结并可分别汇总。
+- [ ] 结果只有成功或失败，不产生跳过数。
+- [ ] 生成物、日志、XLSX、profiling 和 sanitizer 产物未提交到 Git。
+
+## 19. 需要测试团队确认的事项
+
+1. 2026-08-15 交付算子清单及 A2、A3、A5 必测矩阵。
+2. `test/<op_name>/` 命名采用算子名还是公开 API 名。
+3. ATK 正式 tag/commit、Python 版本和安装方式。
+4. ATK JSON、YAML 和 executor 的冻结 schema。
+5. `atk case` 生成结果写入看护 JSON 的评审和更新流程。
+6. 每个算子的 golden、benchmark 来源及独立性要求。
+7. ATK 双标杆原生标准和配置位置。
+8. 三条 route 的 case 划分及 `direct_launch` 上游贡献版本。
+9. smoke/full 泛化数量、seed 和 coverage 要求。
+10. NaN 标准注入区域和有效区声明方式。
+11. 确定性任务循环次数及 bitwise/numeric 契约。
+12. `accuracy_lt` 默认 50 轮和资源配置。
+13. `performance_device` 的 `msopprof` 后端、warmup、采集次数、统计次数和性能阈值。
+14. mssanitizer 四类工具的 CI 矩阵和 debug 包构建方式。
+15. CT 正式获取地址、版本、校验值及两个允许命令的参数格式。
+16. ATK 报告归档周期、大小限制和 CI 展示方式。
+17. `test/README.md` 的维护责任人和更新准入规则。
+
+以上事项确认后，应直接固化到 `test/README.md`、四类算子资产和 CI 配置中，不能只保留在线下约定中。


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @alvazu
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
