### PR TITLE
fix(runtime): 隔离 FLA 与 CANN opapi 动态符号

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,12 @@ python -m pip install --force-reinstall --no-cache-dir --no-deps "$WHEEL_PATH"
 
 方式 A wheel 不安装或执行 shell 环境钩子。无论使用系统 Python、Conda、venv
 还是 Docker，每次进入新的 shell 后都需要先按 Step 1 手工 source CANN 的
-`set_env.sh`。调用 `fla_npu.ops.ascendc` 算子时会在当前 Python 进程内定位并加载
-wheel 内嵌 OPP；wheel 通过绝对路径加载 `libcust_opapi.so`，不会再生成或加载
-可能覆盖 CANN 运行库的自定义 `libopapi.so`。如果旧版 run 包曾在 wheel 中遗留该别名，
+`set_env.sh`。`import fla_npu` 会先局部加载 CANN 的 `libopapi.so`，再通过绝对路径
+局部加载当前 Python 包
+`opp/vendors/fla_npu_transformer/op_api/lib/libcust_opapi.so`。这个绝对路径从已导入
+模块的 `__file__` 推导，不受 CANN vendor 或环境变量重定向。符号查找按 custom、
+CANN 的顺序逐句柄进行，同名 `aclnn*` 优先使用 custom 实现；两个库都不会被发布
+到进程全局符号域。如果旧版 run 包曾在 wheel 中遗留自定义 `libopapi.so` 别名，
 新 runtime 会在首次加载 OPP 时删除它；目录不可写时会给出明确的手工清理提示。
 
 #### 方式 B 产物安装
@@ -117,8 +120,8 @@ wheel 内嵌 OPP；wheel 通过绝对路径加载 `libcust_opapi.so`，不会再
 # 或等价写法
 ./build_out/fla-npu-*.run --full
 
-# 如需装到 CANN OPP 目录（ASCEND_CUSTOM_OPP_PATH / ASCEND_OPP_PATH），
-# 使用 --cann 或 --install-path=<绝对路径>
+# 如需供独立 aclnn/CANN OPP 流程使用，可安装到 CANN OPP 目录；
+# fla_npu Python runtime 不会从该目录加载 libcust_opapi.so
 # ./build_out/fla-npu-*.run --cann
 
 # 如果 Python wrapper 也有修改，再安装单独编译出的 wheel
@@ -130,14 +133,25 @@ run 包覆盖完成后会重写幂等的 `set_env.bash`，并把实际 OPP 文�
 的 `RECORD`。因此重复覆盖同一个 run 包不会累积环境变量或文件记录，后续
 `pip --force-reinstall` 也能先清理 run 包增加的文件，再安装新 wheel。
 
-`import fla_npu` 会定位 OPP 并加载 `libcust_opapi.so`。执行前必须先 source CANN
-的 `set_env.sh`；CANN 环境未初始化、OPP 不完整或动态库加载失败时，import 会直接
-报错。该过程不会自动导入 `torch` / `torch_npu`，也不会注册 `torch.ops.npu`。
+`import fla_npu` 会从当前 `site-packages/fla_npu/opp` 定位 custom OPP，并加载
+CANN `libopapi.so` 和包内 `libcust_opapi.so`。执行前必须先 source CANN 的
+`set_env.sh`；CANN 环境未初始化、包内 OPP 不完整或动态库加载失败时，import 会
+直接报错。该过程不会自动导入 `torch` / `torch_npu`，也不会注册 `torch.ops.npu`。
 默认 wheel 通过 Python ctypes 直调 aclnn/opapi，推荐使用 `fla_npu.ops.ascendc`；
 只有用 `FLA_NPU_BUILD_LEGACY_EXTENSION=1` 额外编出 legacy 扩展时，才可显式调用
 `fla_npu.load_legacy_torch_ops()` 兼容旧 `torch.ops.npu.*`。
 
-`fla_npu.ops.ascendc` 调用会优先使用 wheel 内嵌 OPP，找不到时会继续从 `FLA_NPU_OPP_PATH`、`ASCEND_CUSTOM_OPP_PATH` 和 `ASCEND_OPP_PATH` 查找已安装 OPP。外部 OPP 的 `op_api/lib` 目录同样不得包含自定义 `libopapi.so`；runtime 会先尝试删除旧版本遗留的别名，目录不可写时再明确报错并要求手工清理。
+`fla_npu.ops.ascendc` 只使用当前 Python 包内嵌的 custom OPP，不会从
+`FLA_NPU_OPP_PATH`、`ASCEND_CUSTOM_OPP_PATH`、`ASCEND_OPP_PATH` 或 CANN 的
+`vendors` 目录回退查找其他 `libcust_opapi.so`。单独构建的 run 包应使用默认
+`--install` / `--full` 流程覆盖当前 wheel 内的 OPP。
+
+包内 `libcust_opapi.so` 保持原有标准安装位置，安装流程不移动该文件，也不新增
+私有动态库目录。FLA 不把包内 `op_api/lib` 加入 `LD_LIBRARY_PATH`，只对固定绝对
+路径执行 `RTLD_LOCAL` 加载；`torch_npu.ops.*` 或 `cann-ops-transformer.ops.*` 因而
+仍按各自已 source 的 CANN vendor 环境查找并局部加载自己的 `libcust_opapi.so`。
+该隔离规则要求同进程内的 opapi 使用方都遵守局部加载；不支持预先用
+`RTLD_GLOBAL` 发布 custom opapi 符号的用法。
 
 ### Step 4. 测试安装成功
 

--- a/cmake/custom_build.cmake
+++ b/cmake/custom_build.cmake
@@ -98,6 +98,7 @@ if (BUILD_OPEN_PROJECT)
     )
     set_target_properties(cust_opapi PROPERTIES OUTPUT_NAME
             cust_opapi
+            NO_SONAME ON
     )
     if (NOT ENABLE_BUILT_IN)
         install(TARGETS cust_opapi

--- a/cmake/symbol.cmake
+++ b/cmake/symbol.cmake
@@ -180,7 +180,10 @@ endfunction()
 
 function(gen_cust_opapi_symbol)
   #op_api
-  set_target_properties(${OPAPI_NAME} PROPERTIES OUTPUT_NAME "cust_opapi")
+  set_target_properties(${OPAPI_NAME} PROPERTIES
+    OUTPUT_NAME "cust_opapi"
+    NO_SONAME ON
+  )
 
   install(TARGETS ${OPAPI_NAME}
     LIBRARY DESTINATION ${ACLNN_LIB_INSTALL_DIR}

--- a/docs/agents/torch-npu-decoupled-architecture.md
+++ b/docs/agents/torch-npu-decoupled-architecture.md
@@ -108,7 +108,7 @@ legacy `torch.ops.npu.*` 兼容路径仍可通过 `FLA_NPU_BUILD_LEGACY_EXTENSIO
 | CANN 构建 | SoC、kernel 二进制、op_host、tiling、op_api C ABI、host 架构 | 目标环境的 torch、torch_npu、Python minor 和 C++ ABI |
 | wheel 组装 | 包版本、Python wrapper、Triton 源码映射、内嵌 OPP vendor 树 | torch / torch_npu C++ 头文件和 dispatcher 生成代码 |
 | `pip install` | `python_requires`、安装目标 `site-packages`、wheel 内容落盘 | torch 与 torch_npu 是否配套、NPU 是否可执行 |
-| `import fla_npu` | OPP root、`libcust_opapi.so` 路径、必需动态符号 | 具体 tensor、device、stream 和 autograd 行为 |
+| `import fla_npu` | CANN 环境、包内 OPP、CANN/custom opapi 句柄和必需动态符号 | 具体 tensor、device、stream 和 autograd 行为 |
 | 首次 Ascend C 调用 | tensor metadata、目标 device、device guard、current stream、workspace、mutation 清单 | 构建机器上的 torch / torch_npu 版本 |
 | 首次 autograd / 图编译 | forward/backward 语义、版本计数、可选 `torch.library`、FakeTensor 和 compiler 能力 | torch_npu derivatives 生成和 C++ dispatcher ABI |
 | 发布验证 | 声明支持的 Python、torch、torch_npu、host 和 SoC 组合 | 未实际验证的理论兼容组合 |
@@ -117,16 +117,19 @@ legacy `torch.ops.npu.*` 兼容路径仍可通过 `FLA_NPU_BUILD_LEGACY_EXTENSIO
 
 一次 `from fla_npu.ops.ascendc import op` 调用按以下顺序执行：
 
-1. 公共入口选择 raw ctypes wrapper 或高层 autograd wrapper。
-2. wrapper 根据 `aclnn_*.h` 组织参数并分配输出 tensor。
-3. runtime 从输出 tensor 确定目标 NPU device，并检查所有输入输出位于同一 device。
-4. runtime 进入 `torch.npu.device(target_device)` device guard。
-5. runtime 从 tensor 读取 data pointer、shape、stride、dtype、storage offset 和 format，创建 ACL descriptor。
-6. ctypes 调用 `<aclnnOp>GetWorkspaceSize(...)`，取得 workspace 大小和 executor。
-7. runtime 在目标 device 上分配 workspace。
-8. runtime 读取 `torch.npu.current_stream(target_device)` 的底层 stream pointer。
-9. ctypes 调用 `<aclnnOp>(workspace, size, executor, stream)`，将 kernel enqueue 到 current stream。
-10. runtime 销毁 descriptor；workspace 和 helper tensor 在同一 current stream 上交回 PyTorch NPU allocator，并在退出 device guard 时恢复调用方原 device。
+1. root import 验证 CANN 环境，只从当前 Python 包固定路径定位 custom OPP。
+2. runtime 以 `RTLD_LOCAL | RTLD_NOW | RTLD_NODELETE` 先加载 CANN `libopapi.so`，再通过绝对路径加载包内 `libcust_opapi.so`。
+3. runtime 保存 `[custom, CANN]` 两个句柄，后续逐句柄查找符号；同名 `aclnn*` 命中 custom，custom 没有的基础符号回退到 CANN。
+4. 公共入口选择 raw ctypes wrapper 或高层 autograd wrapper。
+5. wrapper 根据 `aclnn_*.h` 组织参数并分配输出 tensor。
+6. runtime 从输出 tensor 确定目标 NPU device，并检查所有输入输出位于同一 device。
+7. runtime 进入 `torch.npu.device(target_device)` device guard。
+8. runtime 从 tensor 读取 data pointer、shape、stride、dtype、storage offset 和 format，创建 ACL descriptor。
+9. ctypes 调用 `<aclnnOp>GetWorkspaceSize(...)`，取得 workspace 大小和 executor。
+10. runtime 在目标 device 上分配 workspace。
+11. runtime 读取 `torch.npu.current_stream(target_device)` 的底层 stream pointer。
+12. ctypes 调用 `<aclnnOp>(workspace, size, executor, stream)`，将 kernel enqueue 到 current stream。
+13. runtime 销毁 descriptor；workspace 和 helper tensor 在同一 current stream 上交回 PyTorch NPU allocator，并在退出 device guard 时恢复调用方原 device。
 
 这条默认链路没有 `torch.ops.load_library()`，不查找 `torch.ops.npu.<op>`，也不加载 `custom_aclnn_extension_lib*.so`。
 
@@ -150,22 +153,44 @@ site-packages/
         fla_npu_transformer/
           bin/set_env.bash
           op_api/lib/libcust_opapi.so
+          op_api/include/...
           op_impl/ai_core/tbe/op_host/...
           op_impl/ai_core/tbe/op_tiling/...
           op_impl/ai_core/tbe/kernel/...
           op_proto/...
 ```
 
-`fla_npu` 按以下顺序选择 OPP：
+`fla_npu` 不在多个 OPP 中做运行时选择。custom OPP 的唯一合法位置是当前导入包的
+`fla_npu/opp/vendors/fla_npu_transformer`，FLA opapi 保持在该 vendor 的标准
+`op_api/lib/libcust_opapi.so` 位置。runtime 从当前导入模块的 `__file__` 推导并校验
+包内绝对路径，再直接加载该文件。`FLA_NPU_OPP_PATH`、
+`ASCEND_CUSTOM_OPP_PATH`、`ASCEND_OPP_PATH` 以及 CANN 的 `vendors` 目录都不能改变
+FLA custom opapi 句柄来源。
 
-1. 用户显式设置的 `FLA_NPU_OPP_PATH`。
-2. wheel 内嵌的 `fla_npu/opp`。
-3. `ASCEND_CUSTOM_OPP_PATH` 或 `ASCEND_OPP_PATH` 中唯一匹配的 vendor。
+root import 只把包内 OPP root/vendor 前置到 `ASCEND_CUSTOM_OPP_PATH`，供 FLA
+host、tiling 和 kernel 发现；不把包内 `op_api/lib` 加入 `LD_LIBRARY_PATH`，也不改写
+调用方已有的 CANN 动态库搜索路径。因此 `torch_npu.ops.*`、
+`cann-ops-transformer.ops.*` 等通用入口继续从调用方 source 的 CANN vendor 环境
+选择自己的库，不会通过通用动态库搜索命中 FLA 包内文件。
+`FLA_NPU_OP_API_LIB` 只记录 FLA 实际加载的包内绝对路径，用于诊断，不参与定位。
 
-选中后，包会把 vendor root 前置到 `ASCEND_CUSTOM_OPP_PATH`，把 `op_api/lib` 前置到 `LD_LIBRARY_PATH`，并用 `FLA_NPU_OP_API_LIB` 记录实际加载的 `libcust_opapi.so`。
-`import fla_npu` 会立即完成上述选择并加载 `libcust_opapi.so`。调用方必须先 source
-CANN `set_env.sh`；CANN 环境、OPP 或动态库不满足要求时，import 直接失败。root
+`import fla_npu` 会先验证调用方已经 source CANN `set_env.sh`，再加载 CANN 和包内
+custom opapi。CANN 环境、包内 OPP 或动态库不满足要求时，import 直接失败。root
 import 不会因此导入 `torch`、`torch_npu` 或注册 legacy dispatcher。
+
+加载顺序与符号优先级是两个独立概念：CANN 句柄先创建，确保基础 runtime 先完成
+初始化；符号解析时却按 custom、CANN 的句柄顺序查找，保证同名 `aclnn*` 使用 custom
+实现。两个库均使用 `RTLD_LOCAL`，不会把内部 C++/STL 符号放进进程全局符号域，
+从而避免另一个 opapi 库错误绑定这些同名实现。
+
+该设计以“同进程内所有 opapi 使用方都遵守 `RTLD_LOCAL`”为前提。如果其他组件
+预先用 `RTLD_GLOBAL` 加载 custom opapi，符号已经进入全局域，局部句柄无法撤销其
+影响；这种非局部加载不在本方案支持范围内。
+
+包内 `libcust_opapi.so` 保留标准文件名，但构建时不写 ELF `DT_SONAME`。这样 FLA
+通过绝对路径加载后，动态链接器不会把它登记成通用的 `libcust_opapi.so`；后续
+`torch_npu` 或 CANN 入口按自己的 vendor 路径加载同名库时，不会复用 FLA 的对象。
+外部程序继续可以用 `-lcust_opapi` 链接，生成的 `DT_NEEDED` 仍是标准文件名。
 自定义 OPP 不得提供 `libopapi.so`，该名字属于 CANN runtime。runtime 会删除旧版本
 安装器遗留且与 `libcust_opapi.so` 相邻的别名；如果目录不可写，则停止加载并提示
 手工清理，避免动态链接器命中错误的自定义库。
@@ -405,20 +430,21 @@ wrapper 的原则是“透传描述，不自行解释私有 layout”。默认�
 
 ### 6.3 run 包覆盖 wheel 内嵌 OPP
 
-run 包 `--install` / `--full` 会把 `packages/vendors/fla_npu_transformer` 合并覆盖到当前环境的 `site-packages/fla_npu/opp/vendors/fla_npu_transformer`。覆盖可能同时替换共享 `libcust_opapi.so`、tiling 和 proto，因此安装前必须列出：
+run 包 `--install` / `--full` 会把 `packages/vendors/fla_npu_transformer` 合并覆盖到当前环境的 `site-packages/fla_npu/opp/vendors/fla_npu_transformer`。生成的 `op_api/lib/libcust_opapi.so` 保持在标准 vendor 位置，不迁移文件，也不创建额外动态库目录。覆盖会同时替换 op_api、tiling 和 proto，因此安装前必须列出：
 
 - run 包包含的算子。
 - 覆盖后仍可使用的算子。
-- 因共享库被替换而不可用的算子。
+- 因 op_api 被替换而不可用的算子。
 - aclnn header 的 added / modified / removed 变化。
 
-覆盖结束后，安装器会删除自定义 `libopapi.so` 别名、重写可重复 source 的
-`set_env.bash`，并用当前 OPP 文件和摘要原子刷新 wheel `RECORD`。同一个 run 包
+覆盖结束后，安装器会删除自定义 `libopapi.so` 别名、保留标准 vendor 目录中的
+`libcust_opapi.so`、重写可重复 source 的 `set_env.bash`，并用当前 OPP 文件摘要
+原子刷新 wheel `RECORD`。同一个 run 包
 重复覆盖后的文件清单必须一致；后续 wheel 强制重装依赖该 `RECORD` 清理 run 包
 增加的文件。每轮 wheel 构建也必须先清理旧 `build_lib/fla_npu`，避免已删除或
 重命名的 Python 适配从上一次构建目录混入新 wheel。
 
-runtime 会缓存 CDLL 和符号，并使用 `RTLD_NODELETE`。覆盖 OPP 后必须重启 Python 进程，不能期待当前进程自动卸载旧 so。
+runtime 会缓存两个局部 CDLL 句柄和已解析符号，并使用 `RTLD_NODELETE`。覆盖 OPP 后必须重启 Python 进程，不能期待当前进程自动卸载旧 so。
 
 ### 6.4 修改红线
 
@@ -586,7 +612,9 @@ fla_npu 默认不会主动 import、链接或注册 torch_npu dispatcher；目�
 | TorchDispatchMode | 临时拦截和改写 PyTorch dispatcher 调用的 Python 机制 | raw ctypes 默认不可见，需要 custom-op 适配 |
 | AOT | Ahead-Of-Time，在实际执行前提前捕获或编译计算图 | `opcheck` 会检查 custom op 的 AOT/functionalization 行为 |
 | fullgraph | 要求 `torch.compile` 把整个函数捕获为一个图、不允许 graph break 的模式 | 未适配 ctypes side effect 的算子不能宣称支持 |
-| CDLL | ctypes 对一个已加载 C 动态库的 Python 对象 | runtime 缓存它以复用 `libcust_opapi.so` 符号 |
+| CDLL | ctypes 对一个已加载 C 动态库的 Python 对象 | runtime 缓存 custom 和 CANN opapi 句柄，并显式控制符号查找顺序 |
+| `RTLD_LOCAL` | 动态库符号只对当前加载组可见，不进入进程全局符号域 | 隔离 custom 与 CANN opapi 的内部同名 C++ 符号 |
+| `DT_SONAME` | ELF 动态库在装载器中的逻辑名字；同名请求可能复用已加载对象 | FLA 包内 opapi 不设置它，避免占用通用 `libcust_opapi.so` 身份 |
 | `RTLD_NOW` | 加载动态库时立即解析依赖符号的模式 | 让缺库或缺符号尽早失败 |
 | `RTLD_NODELETE` | 进程内不真正卸载动态库映射的模式 | run 包覆盖后必须重启 Python 才能可靠使用新 so |
 | helper tensor | wrapper 为传参临时创建、用户通常看不到的 tensor | 异步 launch 时也必须保活 |

--- a/scripts/check_install_workflows.py
+++ b/scripts/check_install_workflows.py
@@ -148,12 +148,22 @@ def _assert_record_covers_opp(package_dir: Path) -> None:
 
 def _assert_opp_layout(package_dir: Path, *, require_runtime: bool) -> None:
     vendor_dir = package_dir / "opp" / "vendors" / VENDOR_DIR
-    custom_opapi = vendor_dir / "op_api" / "lib" / "libcust_opapi.so"
-    conflicting_alias = custom_opapi.with_name("libopapi.so")
+    packaged_opapi = vendor_dir / "op_api" / "lib" / "libcust_opapi.so"
+    conflicting_alias = packaged_opapi.with_name("libopapi.so")
     if conflicting_alias.exists() or conflicting_alias.is_symlink():
         raise AssertionError(f"Installed wheel contains conflicting alias: {conflicting_alias}")
-    if require_runtime and not custom_opapi.is_file():
-        raise AssertionError(f"Installed wheel is missing custom op_api: {custom_opapi}")
+    if require_runtime and not packaged_opapi.is_file():
+        raise AssertionError(f"Installed wheel is missing packaged op_api: {packaged_opapi}")
+    if require_runtime:
+        dynamic = subprocess.check_output(
+            ["readelf", "-d", str(packaged_opapi)],
+            encoding="utf-8",
+            errors="replace",
+        )
+        if "(SONAME)" in dynamic:
+            raise AssertionError(
+                "Packaged FLA op_api must not claim the generic libcust_opapi.so SONAME"
+            )
 
 
 def _assert_set_env_idempotent(package_dir: Path, env: dict[str, str], cwd: Path) -> None:
@@ -167,7 +177,7 @@ set -euo pipefail
 unset ASCEND_CUSTOM_OPP_PATH LD_LIBRARY_PATH FLA_NPU_OPP_PATH FLA_NPU_OP_API_LIB
 source "$1"
 source "$1"
-printf '%s\n' "$ASCEND_CUSTOM_OPP_PATH" "$LD_LIBRARY_PATH" "$FLA_NPU_OPP_PATH" "$FLA_NPU_OP_API_LIB"
+printf '%s\n' "$ASCEND_CUSTOM_OPP_PATH" "${LD_LIBRARY_PATH-}" "$FLA_NPU_OPP_PATH" "$FLA_NPU_OP_API_LIB"
 '''
     output = subprocess.check_output(
         ["bash", "-c", check, "check-set-env", str(set_env)],
@@ -177,7 +187,7 @@ printf '%s\n' "$ASCEND_CUSTOM_OPP_PATH" "$LD_LIBRARY_PATH" "$FLA_NPU_OPP_PATH" "
     ).splitlines()
     expected = [
         f"{vendor_dir.parent.parent}:{vendor_dir}",
-        str(vendor_dir / "op_api" / "lib"),
+        "",
         str(vendor_dir.parent.parent),
         str(vendor_dir / "op_api" / "lib" / "libcust_opapi.so"),
     ]
@@ -194,6 +204,7 @@ def _assert_runtime(
     child_env = env.copy()
     child_env["FLA_NPU_EXPECT_OPS"] = ",".join(expected_ops)
     code = r'''
+import ctypes
 import os
 from pathlib import Path
 
@@ -208,6 +219,8 @@ first = fla_npu.load_ascendc_opapi_libraries()
 second = fla_npu.load_ascendc_opapi_libraries()
 if first is not second or not first:
     raise AssertionError("Ascend C op_api loading is not idempotent")
+if len(first) != 2:
+    raise AssertionError(f"expected custom and CANN op_api handles, got {len(first)}")
 
 package_dir = Path(fla_npu.__file__).resolve().parent
 expected = (
@@ -226,6 +239,14 @@ if configured != expected:
 maps = Path("/proc/self/maps").read_text(encoding="utf-8", errors="replace")
 if str(expected) not in maps:
     raise AssertionError("packaged libcust_opapi.so is not mapped into the process")
+if "/libopapi.so" not in maps:
+    raise AssertionError("CANN libopapi.so is not mapped into the process")
+if "custom_aclnn_extension_lib" in maps:
+    raise AssertionError("default import unexpectedly loaded the legacy C++ extension")
+
+# Regression for issue #310: importing fla_npu and then opening CANN opapi must
+# leave the subprocess able to finish normal interpreter teardown.
+ctypes.CDLL("libopapi.so")
 '''
     _run([str(python), "-c", code], env=child_env, cwd=cwd)
 
@@ -239,7 +260,7 @@ def _check_stale_alias_recovery(
     expected_ops: Iterable[str],
 ) -> None:
     package_dir = _find_package_dir(python, env, cwd)
-    custom_opapi = (
+    packaged_opapi = (
         package_dir
         / "opp"
         / "vendors"
@@ -248,8 +269,17 @@ def _check_stale_alias_recovery(
         / "lib"
         / "libcust_opapi.so"
     )
-    stale_alias = custom_opapi.with_name("libopapi.so")
-    shutil.copy2(custom_opapi, stale_alias)
+    stale_alias = (
+        package_dir
+        / "opp"
+        / "vendors"
+        / VENDOR_DIR
+        / "op_api"
+        / "lib"
+        / "libopapi.so"
+    )
+    stale_alias.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(packaged_opapi, stale_alias)
 
     _assert_runtime(
         python,

--- a/scripts/check_packaged_wheel_api.py
+++ b/scripts/check_packaged_wheel_api.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -91,33 +92,35 @@ def _require_packaged_opp_configs(fla_npu_module) -> None:
 
 def _require_safe_packaged_opapi(fla_npu_module) -> None:
     package_root = Path(fla_npu_module.__file__).resolve().parent
-    vendor_dirs = list((package_root / "opp" / "vendors").glob("*"))
-    if not vendor_dirs:
-        raise AssertionError("packaged OPP vendor directory is missing")
+    vendor_dir = package_root / "opp" / "vendors" / "fla_npu_transformer"
+    packaged_library = vendor_dir / "op_api" / "lib" / "libcust_opapi.so"
+    if not packaged_library.is_file():
+        raise AssertionError(
+            "packaged OPP must preserve libcust_opapi.so in the standard vendor "
+            f"layout: {packaged_library}"
+        )
 
-    custom_libraries = [
-        vendor_dir / "op_api" / "lib" / "libcust_opapi.so"
-        for vendor_dir in vendor_dirs
-    ]
-    if not any(path.is_file() for path in custom_libraries):
-        raise AssertionError("packaged libcust_opapi.so is missing")
-
-    conflicting_libraries = []
-    for vendor_dir in vendor_dirs:
-        candidate = vendor_dir / "op_api" / "lib" / "libopapi.so"
-        if candidate.exists() or candidate.is_symlink():
-            conflicting_libraries.append(candidate)
-    if conflicting_libraries:
+    conflicting_library = packaged_library.with_name("libopapi.so")
+    if conflicting_library.exists() or conflicting_library.is_symlink():
         raise AssertionError(
             "packaged custom OPP must not contain CANN library alias libopapi.so: "
-            + ", ".join(str(path) for path in conflicting_libraries)
+            f"{conflicting_library}"
+        )
+
+    dynamic_section = subprocess.check_output(
+        ["readelf", "-d", str(packaged_library)],
+        encoding="utf-8",
+        errors="replace",
+    )
+    if "(SONAME)" in dynamic_section:
+        raise AssertionError(
+            "packaged libcust_opapi.so must not define a SONAME; otherwise "
+            "later CANN vendor loading can reuse the FLA library by name: "
+            f"{packaged_library}"
         )
 
     configured_library = Path(os.environ.get("FLA_NPU_OP_API_LIB", "")).resolve()
-    packaged_libraries = {
-        path.resolve() for path in custom_libraries if path.is_file()
-    }
-    if configured_library not in packaged_libraries:
+    if configured_library != packaged_library.resolve():
         raise AssertionError(
             "FLA_NPU_OP_API_LIB must point to the packaged libcust_opapi.so"
         )

--- a/scripts/collect_public_env.py
+++ b/scripts/collect_public_env.py
@@ -296,6 +296,10 @@ def _has_opp(root: Path) -> bool:
 
 
 def _has_op_api(root: Path) -> bool:
+    configured_op_api = os.environ.get("FLA_NPU_OP_API_LIB", "").strip()
+    if configured_op_api and Path(configured_op_api).is_file():
+        return True
+
     candidates = [
         root / "op_api" / "lib" / "libcust_opapi.so",
         root / "op_api" / "lib" / "libopapi.so",

--- a/scripts/package/ops_transformer/scripts/finalize_wheel_opp.py
+++ b/scripts/package/ops_transformer/scripts/finalize_wheel_opp.py
@@ -53,7 +53,6 @@ def _write_set_env(vendor_dir: Path) -> None:
                 "}",
                 '_fla_npu_prepend_path ASCEND_CUSTOM_OPP_PATH "${_FLA_NPU_VENDOR_DIR}"',
                 '_fla_npu_prepend_path ASCEND_CUSTOM_OPP_PATH "${_FLA_NPU_OPP_ROOT}"',
-                '_fla_npu_prepend_path LD_LIBRARY_PATH "${_FLA_NPU_VENDOR_DIR}/op_api/lib"',
                 'export FLA_NPU_OPP_PATH="${_FLA_NPU_OPP_ROOT}"',
                 'export FLA_NPU_OP_API_LIB="${_FLA_NPU_VENDOR_DIR}/op_api/lib/libcust_opapi.so"',
                 "unset -f _fla_npu_prepend_path",
@@ -88,19 +87,24 @@ def _find_record(package_dir: Path) -> Path:
 def _refresh_record(package_dir: Path) -> Path:
     record = _find_record(package_dir)
     site_root = package_dir.parent.resolve()
-    opp_root = package_dir / "opp"
-    opp_prefix = f"{package_dir.name}/opp/"
+    package_roots = (package_dir / "opp",)
+    package_prefixes = (f"{package_dir.name}/opp/",)
 
     with record.open("r", encoding="utf-8", newline="") as handle:
         rows = list(csv.reader(handle))
 
-    rows = [row for row in rows if row and not row[0].startswith(opp_prefix)]
-    for path in sorted(opp_root.rglob("*")):
-        if not (path.is_file() or path.is_symlink()):
-            continue
-        relative = path.relative_to(site_root).as_posix()
-        digest, size = _record_digest(path)
-        rows.append([relative, digest, size])
+    rows = [
+        row
+        for row in rows
+        if row and not row[0].startswith(package_prefixes)
+    ]
+    for package_root in package_roots:
+        for path in sorted(package_root.rglob("*")):
+            if not (path.is_file() or path.is_symlink()):
+                continue
+            relative = path.relative_to(site_root).as_posix()
+            digest, size = _record_digest(path)
+            rows.append([relative, digest, size])
 
     record_mode = stat.S_IMODE(record.stat().st_mode)
     temp_name = ""
@@ -132,7 +136,7 @@ def finalize_wheel_opp(package_dir: Path, vendor_name: str = DEFAULT_VENDOR_DIR)
     vendor_dir = package_dir / "opp" / "vendors" / vendor_name
     custom_opapi = vendor_dir / "op_api" / "lib" / "libcust_opapi.so"
     if not custom_opapi.is_file():
-        raise RuntimeError(f"Wheel OPP is missing custom op_api library: {custom_opapi}")
+        raise RuntimeError(f"Wheel is missing packaged custom op_api: {custom_opapi}")
 
     conflicting_alias = custom_opapi.with_name("libopapi.so")
     if conflicting_alias.exists() or conflicting_alias.is_symlink():

--- a/setup.py
+++ b/setup.py
@@ -382,7 +382,6 @@ def _rewrite_set_env(vendor_dir):
                 "}",
                 '_fla_npu_prepend_path ASCEND_CUSTOM_OPP_PATH "${_FLA_NPU_VENDOR_DIR}"',
                 '_fla_npu_prepend_path ASCEND_CUSTOM_OPP_PATH "${_FLA_NPU_OPP_ROOT}"',
-                '_fla_npu_prepend_path LD_LIBRARY_PATH "${_FLA_NPU_VENDOR_DIR}/op_api/lib"',
                 'export FLA_NPU_OPP_PATH="${_FLA_NPU_OPP_ROOT}"',
                 'export FLA_NPU_OP_API_LIB="${_FLA_NPU_VENDOR_DIR}/op_api/lib/libcust_opapi.so"',
                 "unset -f _fla_npu_prepend_path",

--- a/tests/test_wheel_environment.py
+++ b/tests/test_wheel_environment.py
@@ -4,6 +4,7 @@ import csv
 import importlib
 import os
 import runpy
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -39,6 +40,13 @@ if not hasattr(importlib, "metadata"):
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_SOURCE = (
+    REPO_ROOT
+    / "torch_custom"
+    / "fla_npu"
+    / "fla_npu"
+    / "__init__.py"
+)
 
 
 def _load_setup() -> tuple[dict[str, object], dict[str, object]]:
@@ -102,6 +110,18 @@ def _create_minimal_vendor(vendor_dir: Path, *, include_alias: bool = False) -> 
         (vendor_dir / "op_api" / "lib" / "libopapi.so").write_bytes(b"unsafe")
 
 
+def _create_runtime_package(site_root: Path) -> tuple[Path, Path, Path]:
+    package_dir = site_root / "fla_npu"
+    package_dir.mkdir(parents=True)
+    runtime_path = package_dir / "__init__.py"
+    shutil.copy2(RUNTIME_SOURCE, runtime_path)
+    vendor_dir = package_dir / "opp" / "vendors" / "fla_npu_transformer"
+    packaged_opapi = vendor_dir / "op_api" / "lib" / "libcust_opapi.so"
+    packaged_opapi.parent.mkdir(parents=True)
+    packaged_opapi.write_bytes(b"packaged-test")
+    return runtime_path, vendor_dir, packaged_opapi
+
+
 class WheelEnvironmentTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -131,6 +151,16 @@ class WheelEnvironmentTest(unittest.TestCase):
             )
             self.assertTrue((lib_dir / "libcust_opapi.so").is_file())
             self.assertFalse((lib_dir / "libopapi.so").exists())
+            self.assertFalse((opp_root.parent / "_lib").exists())
+
+            custom_build = (REPO_ROOT / "cmake" / "custom_build.cmake").read_text(
+                encoding="utf-8"
+            )
+            symbol_build = (REPO_ROOT / "cmake" / "symbol.cmake").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("NO_SONAME ON", custom_build)
+            self.assertIn("NO_SONAME ON", symbol_build)
 
     def test_package_build_always_starts_from_clean_outputs(self) -> None:
         setup_source = (REPO_ROOT / "setup.py").read_text(encoding="utf-8")
@@ -158,7 +188,7 @@ unset ASCEND_CUSTOM_OPP_PATH LD_LIBRARY_PATH FLA_NPU_OPP_PATH FLA_NPU_OP_API_LIB
 source {set_env!s}
 source {set_env!s}
 [[ "${{ASCEND_CUSTOM_OPP_PATH}}" == "{vendor_dir.parent.parent}:{vendor_dir}" ]]
-[[ "${{LD_LIBRARY_PATH}}" == "{vendor_dir}/op_api/lib" ]]
+[[ -z "${{LD_LIBRARY_PATH-}}" ]]
 [[ "${{FLA_NPU_OPP_PATH}}" == "{vendor_dir.parent.parent}" ]]
 [[ "${{FLA_NPU_OP_API_LIB}}" == "{vendor_dir}/op_api/lib/libcust_opapi.so" ]]
 """
@@ -239,6 +269,7 @@ source {set_env!s}
             self.assertTrue(
                 (vendor_dir / "op_api" / "lib" / "libcust_opapi.so").is_file()
             )
+            self.assertFalse((package_dir / "_lib").exists())
             self.assertFalse(
                 (vendor_dir / "op_api" / "lib" / "libopapi.so").exists()
             )
@@ -264,7 +295,7 @@ unset ASCEND_CUSTOM_OPP_PATH LD_LIBRARY_PATH FLA_NPU_OPP_PATH FLA_NPU_OP_API_LIB
 source {set_env!s}
 source {set_env!s}
 [[ "${{ASCEND_CUSTOM_OPP_PATH}}" == "{vendor_dir.parent.parent}:{vendor_dir}" ]]
-[[ "${{LD_LIBRARY_PATH}}" == "{vendor_dir}/op_api/lib" ]]
+[[ -z "${{LD_LIBRARY_PATH-}}" ]]
 [[ "${{FLA_NPU_OPP_PATH}}" == "{vendor_dir.parent.parent}" ]]
 [[ "${{FLA_NPU_OP_API_LIB}}" == "{vendor_dir}/op_api/lib/libcust_opapi.so" ]]
 """
@@ -328,54 +359,193 @@ source {set_env!s}
         )
         self.assertIn("finalize_wheel_opp.py", custom_build)
 
-    def test_import_requires_cann_environment(self) -> None:
-        runtime_path = (
-            REPO_ROOT
-            / "torch_custom"
-            / "fla_npu"
-            / "fla_npu"
-            / "__init__.py"
+    def test_legacy_extension_rpath_keeps_standard_vendor_layout(self) -> None:
+        setup_source = (
+            REPO_ROOT / "torch_custom" / "fla_npu" / "setup.py"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn("-Wl,-rpath,$ORIGIN/_lib", setup_source)
+        self.assertIn(
+            "-Wl,-rpath,$ORIGIN/opp/vendors/fla_npu_transformer/op_api/lib",
+            setup_source,
         )
-        with mock.patch.dict(os.environ, {}, clear=True):
-            with self.assertRaisesRegex(RuntimeError, "CANN environment is not initialized"):
-                runpy.run_path(str(runtime_path))
 
-    def test_import_loads_runtime_and_removes_stale_libopapi_alias(self) -> None:
-        runtime_path = (
-            REPO_ROOT
-            / "torch_custom"
-            / "fla_npu"
-            / "fla_npu"
-            / "__init__.py"
-        )
+    def test_public_environment_diagnostic_recognizes_packaged_opapi(self) -> None:
+        collector = runpy.run_path(str(REPO_ROOT / "scripts" / "collect_public_env.py"))
+        has_op_api = collector["_has_op_api"]
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            vendor_dir = (
+            packaged_opapi = (
                 Path(temp_dir)
+                / "fla_npu"
                 / "opp"
                 / "vendors"
                 / "fla_npu_transformer"
+                / "op_api"
+                / "lib"
+                / "libcust_opapi.so"
             )
-            _create_minimal_vendor(vendor_dir, include_alias=True)
+            packaged_opapi.parent.mkdir(parents=True)
+            packaged_opapi.write_bytes(b"packaged-test")
+            with mock.patch.dict(
+                os.environ,
+                {"FLA_NPU_OP_API_LIB": str(packaged_opapi)},
+                clear=True,
+            ):
+                self.assertTrue(has_op_api(Path(temp_dir) / "empty-opp"))
+
+    def test_import_requires_cann_environment(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(RuntimeError, "CANN environment is not initialized"):
+                runpy.run_path(str(RUNTIME_SOURCE))
+
+    def test_import_loads_runtime_and_removes_stale_libopapi_alias(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_path, vendor_dir, packaged_opapi = _create_runtime_package(
+                Path(temp_dir) / "site-packages"
+            )
+            stale_alias = vendor_dir / "op_api" / "lib" / "libopapi.so"
+            stale_alias.parent.mkdir(parents=True, exist_ok=True)
+            stale_alias.write_bytes(b"unsafe")
+            external_vendor = Path(temp_dir) / "cann" / "vendors" / "other"
+            _create_minimal_vendor(external_vendor)
 
             with mock.patch.dict(
                 os.environ,
                 {
                     "ASCEND_HOME_PATH": "/fake/cann",
-                    "FLA_NPU_OPP_PATH": str(vendor_dir),
+                    "FLA_NPU_OPP_PATH": str(external_vendor),
+                    "ASCEND_CUSTOM_OPP_PATH": str(external_vendor),
+                    "ASCEND_OPP_PATH": str(external_vendor.parent.parent),
                 },
                 clear=True,
             ):
-                with mock.patch("ctypes.CDLL", return_value=mock.sentinel.custom_opapi):
+                def fake_cdll(path, *, mode):
+                    del mode
+                    if str(path) == "libopapi.so":
+                        return mock.sentinel.cann_opapi
+                    return mock.sentinel.custom_opapi
+
+                with mock.patch("ctypes.CDLL", side_effect=fake_cdll) as cdll:
                     with self.assertWarnsRegex(RuntimeWarning, "Removed a stale"):
                         runtime_globals = runpy.run_path(str(runtime_path))
                     first = runtime_globals["load_ascendc_opapi_libraries"]()
                     second = runtime_globals["load_ascendc_opapi_libraries"]()
                     self.assertIs(first, second)
-                    self.assertEqual(first, [mock.sentinel.custom_opapi])
+                    self.assertEqual(
+                        first,
+                        [mock.sentinel.custom_opapi, mock.sentinel.cann_opapi],
+                    )
+
+                    self.assertEqual(len(cdll.call_args_list), 2)
+                    cann_call, custom_call = cdll.call_args_list
+                    cann_args, cann_kwargs = cann_call
+                    custom_args, custom_kwargs = custom_call
+                    self.assertEqual(cann_args, ("libopapi.so",))
+                    self.assertEqual(
+                        custom_args,
+                        (str(packaged_opapi),),
+                    )
+                    expected_mode = (
+                        getattr(os, "RTLD_LOCAL", 0)
+                        | getattr(os, "RTLD_NOW", 0)
+                        | getattr(os, "RTLD_NODELETE", 0)
+                    )
+                    self.assertEqual(cann_kwargs["mode"], expected_mode)
+                    self.assertEqual(custom_kwargs["mode"], expected_mode)
+                    self.assertEqual(
+                        expected_mode & getattr(os, "RTLD_GLOBAL", 0),
+                        0,
+                    )
+                    self.assertEqual(
+                        os.environ["ASCEND_CUSTOM_OPP_PATH"],
+                        os.pathsep.join(
+                            [
+                                str(vendor_dir.parent.parent),
+                                str(vendor_dir),
+                                str(external_vendor),
+                            ]
+                        ),
+                    )
+                    self.assertEqual(
+                        os.environ["ASCEND_OPP_PATH"],
+                        str(external_vendor.parent.parent),
+                    )
+                    self.assertNotIn("LD_LIBRARY_PATH", os.environ)
+                    self.assertEqual(
+                        os.environ["FLA_NPU_OP_API_LIB"],
+                        str(packaged_opapi),
+                    )
             self.assertFalse(
                 (vendor_dir / "op_api" / "lib" / "libopapi.so").exists()
             )
+
+    def test_import_reports_missing_cann_opapi(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_path, _, _ = _create_runtime_package(Path(temp_dir) / "site-packages")
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "ASCEND_HOME_PATH": "/fake/cann",
+                },
+                clear=True,
+            ):
+                with mock.patch("ctypes.CDLL", side_effect=OSError("not found")):
+                    with self.assertRaisesRegex(
+                        RuntimeError,
+                        r"Unable to load the CANN op_api library.*source.*CANN set_env\.sh",
+                    ):
+                        runpy.run_path(str(runtime_path))
+
+    def test_import_accepts_packaged_opapi_in_standard_vendor_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_path, _, packaged_opapi = _create_runtime_package(
+                Path(temp_dir) / "site-packages"
+            )
+
+            with mock.patch.dict(
+                os.environ,
+                {"ASCEND_HOME_PATH": "/fake/cann"},
+                clear=True,
+            ):
+                with mock.patch(
+                    "ctypes.CDLL",
+                    side_effect=(mock.sentinel.cann_opapi, mock.sentinel.custom_opapi),
+                ) as cdll:
+                    runtime_globals = runpy.run_path(str(runtime_path))
+                    self.assertEqual(
+                        runtime_globals["load_ascendc_opapi_libraries"](),
+                        [mock.sentinel.custom_opapi, mock.sentinel.cann_opapi],
+                    )
+                    self.assertEqual(
+                        Path(cdll.call_args_list[1][0][0]).resolve(),
+                        packaged_opapi.resolve(),
+                    )
+
+    def test_import_does_not_fallback_to_external_custom_opp(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_path, _, packaged_opapi = _create_runtime_package(
+                Path(temp_dir) / "site-packages"
+            )
+            packaged_opapi.unlink()
+            external_vendor = Path(temp_dir) / "cann" / "vendors" / "external"
+            _create_minimal_vendor(external_vendor)
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "ASCEND_HOME_PATH": "/fake/cann",
+                    "FLA_NPU_OPP_PATH": str(external_vendor),
+                    "ASCEND_CUSTOM_OPP_PATH": str(external_vendor),
+                    "ASCEND_OPP_PATH": str(external_vendor.parent.parent),
+                },
+                clear=True,
+            ):
+                with self.assertRaisesRegex(
+                    FileNotFoundError,
+                    r"packaged FLA NPU op_api library",
+                ):
+                    runpy.run_path(str(runtime_path))
 
 if __name__ == "__main__":
     unittest.main()

--- a/torch_custom/fla_npu/README.md
+++ b/torch_custom/fla_npu/README.md
@@ -14,14 +14,17 @@ out = ascendc_ops.npu_chunk_fwd_o(...)
 from fla_npu.ops.ascendc import chunk_fwd_o
 ```
 
-默认路径通过 Python `ctypes` 直调已安装 OPP 里的 `libcust_opapi.so`，不依赖 PyTorch dispatcher 注册，也不会默认编译或加载 `torch_npu` 自定义扩展。旧的 `torch.ops.npu.*` / `torch_npu.ops.*` 兼容路径仍可做，但只作为迁移期可选能力，不推荐新增代码使用，也不会默认使能。
+默认路径通过 Python `ctypes` 直调当前 `fla_npu` 包内 OPP 的
+`libcust_opapi.so`，不依赖 PyTorch dispatcher 注册，也不会默认编译或加载
+`torch_npu` 自定义扩展。旧的 `torch.ops.npu.*` / `torch_npu.ops.*` 兼容路径仍可做，
+但只作为迁移期可选能力，不推荐新增代码使用，也不会默认使能。
 
-`import fla_npu` 会立即加载 OPP 中的 `libcust_opapi.so`。导入前必须先 source CANN
-的 `set_env.sh`；使用方式 B standalone wheel 时，还必须先安装算子 run 包，或设置
-`FLA_NPU_OPP_PATH` 指向已有 OPP root / vendor 目录。CANN 环境未初始化、OPP 不完整
-或动态库加载失败时，import 会直接报错。FLA 自定义 op_api 只使用
-`libcust_opapi.so`，不要在 custom OPP 的 `op_api/lib` 目录创建会遮蔽 CANN 运行库
-的 `libopapi.so` 别名。
+`import fla_npu` 会立即局部加载 CANN `libopapi.so` 和当前包内 OPP 的
+`libcust_opapi.so`。导入前必须先 source CANN 的 `set_env.sh`；使用方式 B standalone
+wheel 时，还必须先用 run 包默认安装流程补齐 wheel 内的 OPP。CANN 环境未初始化、
+包内 OPP 不完整或动态库加载失败时，import 会直接报错。FLA 自定义 op_api 只使用
+包内 `libcust_opapi.so`，不会从 CANN 或环境变量指向的 vendor 目录回退加载其他副本。
+不要在 custom OPP 的 `op_api/lib` 目录创建会遮蔽 CANN 运行库的 `libopapi.so` 别名。
 
 ## 默认交付件
 
@@ -51,10 +54,16 @@ fla_npu/opp/vendors/fla_npu_transformer
 
 关键产物包括：
 
-- `op_api/lib/libcust_opapi.so`：自定义 aclnn op_api 动态库。
+- `opp/vendors/fla_npu_transformer/op_api/lib/libcust_opapi.so`：保持标准 vendor
+  安装位置，由 `fla_npu` 从当前模块的 `__file__` 推导绝对路径并局部加载。
+- `opp/vendors/fla_npu_transformer/op_api/include`：aclnn 头文件。
 - `op_api/include/aclnnop/aclnn_*.h`：Python ctypes ABI 对齐依据。
 - `op_impl/ai_core/tbe/op_host/...`、`op_tiling/...`、`op_proto/...`：host、tiling、proto 动态库。
 - `op_impl/ai_core/tbe/kernel/...`：AI Core kernel `.o` 和 config。
+
+包内 `op_api/lib` 不加入 `LD_LIBRARY_PATH`，因此不会改变 `torch_npu` 或其他 CANN
+算子包的通用动态库搜索路径。各 opapi 使用方都以 `RTLD_LOCAL` 加载自己的库时，
+彼此不会向全局符号域发布内部符号；该方案不支持 `RTLD_GLOBAL` custom opapi。
 
 ## 推荐调用方式
 

--- a/torch_custom/fla_npu/fla_npu/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/__init__.py
@@ -21,54 +21,42 @@ def _prepend_env_path(name: str, value: pathlib.Path) -> None:
         os.environ[name] = os.pathsep.join([value_str, *parts])
 
 
-def _candidate_vendor_names() -> list[str]:
-    return [_DEFAULT_VENDOR_DIR]
-
-
-def _candidate_opp_roots() -> list[pathlib.Path]:
-    roots: list[pathlib.Path] = []
-    override = os.environ.get("FLA_NPU_OPP_PATH", "").strip()
-    if override:
-        roots.append(pathlib.Path(override).expanduser())
-
-    roots.append(_PACKAGE_DIR / "opp")
-
-    for env_name in ("ASCEND_CUSTOM_OPP_PATH", "ASCEND_OPP_PATH"):
-        for part in os.environ.get(env_name, "").split(os.pathsep):
-            if part:
-                roots.append(pathlib.Path(part).expanduser())
-
-    return list(dict.fromkeys(roots))
-
-
-def _has_custom_opapi(vendor_dir: pathlib.Path) -> bool:
-    return (vendor_dir / "op_api" / "lib" / "libcust_opapi.so").exists()
-
-
 def _resolve_vendor_dir() -> pathlib.Path:
-    for root in _candidate_opp_roots():
-        if _has_custom_opapi(root):
-            return root.resolve()
-
-        vendors_root = root / "vendors"
-        for name in _candidate_vendor_names():
-            vendor_dir = vendors_root / name
-            if _has_custom_opapi(vendor_dir):
-                return vendor_dir.resolve()
-
-        if vendors_root.exists():
-            vendor_dirs = [
-                path for path in vendors_root.iterdir() if path.is_dir() and _has_custom_opapi(path)
-            ]
-            if len(vendor_dirs) == 1:
-                return vendor_dirs[0].resolve()
+    package_dir = _PACKAGE_DIR.resolve()
+    vendor_dir = package_dir / "opp" / "vendors" / _DEFAULT_VENDOR_DIR
+    if vendor_dir.is_dir():
+        resolved_vendor_dir = vendor_dir.resolve()
+        try:
+            resolved_vendor_dir.relative_to(package_dir)
+        except ValueError:
+            pass
+        else:
+            return resolved_vendor_dir
 
     raise FileNotFoundError(
-        "Unable to find FLA NPU custom OPP. Expected "
-        f"{_PACKAGE_DIR / 'opp' / 'vendors' / _DEFAULT_VENDOR_DIR}. "
-        "If you installed it separately, source the custom OPP set_env.bash, "
-        "or set FLA_NPU_OPP_PATH to either the OPP root containing vendors/ "
-        "or the vendor directory itself."
+        "Unable to find the FLA NPU custom OPP embedded in this Python package. "
+        f"Expected a regular package-local OPP at {vendor_dir}. Reinstall the "
+        "complete wheel, or overlay the "
+        "matching run package into the installed fla_npu package. External CANN "
+        "vendor directories are not used as a fallback."
+    )
+
+
+def _resolve_packaged_opapi(vendor_dir: pathlib.Path) -> pathlib.Path:
+    package_dir = _PACKAGE_DIR.resolve()
+    op_api_lib = (vendor_dir / "op_api" / "lib" / "libcust_opapi.so").resolve()
+    try:
+        op_api_lib.relative_to(package_dir)
+    except ValueError:
+        pass
+    else:
+        if op_api_lib.is_file():
+            return op_api_lib
+    raise FileNotFoundError(
+        "Unable to find the packaged FLA NPU op_api library. Expected "
+        f"{vendor_dir / 'op_api' / 'lib' / 'libcust_opapi.so'}. Reinstall the "
+        "complete wheel, or overlay the matching run package into the installed "
+        "fla_npu package."
     )
 
 
@@ -80,11 +68,9 @@ def _prepare_embedded_opp() -> pathlib.Path:
         )
 
     vendor_dir = _resolve_vendor_dir()
-    opp_root = vendor_dir.parent.parent if vendor_dir.parent.name == "vendors" else vendor_dir
-    op_api_lib = vendor_dir / "op_api" / "lib" / "libcust_opapi.so"
-    if not op_api_lib.exists():
-        raise FileNotFoundError(f"Embedded custom op_api library not found: {op_api_lib}")
-    op_api_alias = op_api_lib.with_name("libopapi.so")
+    public_op_api_dir = vendor_dir / "op_api" / "lib"
+    op_api_lib = _resolve_packaged_opapi(vendor_dir)
+    op_api_alias = public_op_api_dir / "libopapi.so"
     if op_api_alias.exists() or op_api_alias.is_symlink():
         try:
             op_api_alias.unlink()
@@ -102,24 +88,19 @@ def _prepare_embedded_opp() -> pathlib.Path:
             stacklevel=2,
         )
 
+    # CANN still needs the package OPP for host/tiling/kernel discovery. Do not
+    # add op_api/lib to LD_LIBRARY_PATH: FLA opens this exact package-local file
+    # by absolute path, while other RTLD_LOCAL consumers keep their own search.
     _prepend_env_path("ASCEND_CUSTOM_OPP_PATH", vendor_dir)
-    _prepend_env_path("ASCEND_CUSTOM_OPP_PATH", opp_root)
-    _prepend_env_path("LD_LIBRARY_PATH", op_api_lib.parent)
+    _prepend_env_path("ASCEND_CUSTOM_OPP_PATH", vendor_dir.parent.parent)
     os.environ["FLA_NPU_OP_API_LIB"] = str(op_api_lib)
 
     return vendor_dir
 
 
-def _load_shared_library(path_or_name) -> Optional[ctypes.CDLL]:
-    try:
-        return _load_shared_library_required(path_or_name)
-    except OSError:
-        return None
-
-
 def _load_shared_library_required(path_or_name) -> ctypes.CDLL:
     mode = (
-        getattr(os, "RTLD_GLOBAL", 0)
+        getattr(os, "RTLD_LOCAL", 0)
         | getattr(os, "RTLD_NOW", 0)
         | getattr(os, "RTLD_NODELETE", 0)
     )
@@ -127,15 +108,23 @@ def _load_shared_library_required(path_or_name) -> ctypes.CDLL:
 
 
 def load_ascendc_opapi_libraries() -> list[ctypes.CDLL]:
-    """Load embedded custom op_api and CANN aclnn libraries for ctypes calls."""
+    """Load CANN and custom op_api libraries for custom-first symbol lookup."""
 
     global _ASCENDC_OPAPI_LIBRARIES
     if _ASCENDC_OPAPI_LIBRARIES is not None:
         return _ASCENDC_OPAPI_LIBRARIES
 
     vendor_dir = _prepare_embedded_opp()
-    op_api_dir = vendor_dir / "op_api" / "lib"
-    custom_opapi = op_api_dir / "libcust_opapi.so"
+    custom_opapi = _resolve_packaged_opapi(vendor_dir)
+
+    try:
+        cann_library = _load_shared_library_required("libopapi.so")
+    except OSError as exc:
+        raise RuntimeError(
+            "Unable to load the CANN op_api library libopapi.so. Please source "
+            "the matching CANN set_env.sh before importing fla_npu. "
+            f"Dynamic loader error: {exc}"
+        ) from exc
 
     try:
         custom_library = _load_shared_library_required(custom_opapi)
@@ -144,7 +133,9 @@ def load_ascendc_opapi_libraries() -> list[ctypes.CDLL]:
             f"Unable to load embedded FLA NPU custom op_api library: {custom_opapi}. "
             f"Dynamic loader error: {exc}"
         ) from exc
-    libraries = [custom_library]
+    # Load CANN first so its runtime is initialized independently, but search
+    # the explicit handles custom-first when an aclnn symbol exists in both.
+    libraries = [custom_library, cann_library]
 
     _ASCENDC_OPAPI_LIBRARIES = libraries
     return libraries

--- a/torch_custom/fla_npu/fla_npu/install_opp.py
+++ b/torch_custom/fla_npu/fla_npu/install_opp.py
@@ -75,6 +75,9 @@ def install_opp(install_path: Path, force: bool = False) -> None:
                 raise FileExistsError(f"{vendor_dst} already exists. Use --force to replace it.")
             shutil.rmtree(vendor_dst)
         shutil.copytree(vendor_src, vendor_dst)
+        custom_opapi = vendor_dst / "op_api" / "lib" / "libcust_opapi.so"
+        if not custom_opapi.is_file():
+            raise FileNotFoundError(f"Custom op_api library not found: {custom_opapi}")
         op_api_alias = vendor_dst / "op_api" / "lib" / "libopapi.so"
         if op_api_alias.exists() or op_api_alias.is_symlink():
             op_api_alias.unlink()
@@ -87,7 +90,11 @@ def install_opp(install_path: Path, force: bool = False) -> None:
 
     for vendor_dir in copied:
         print(f"Installed OPP vendor: {vendor_dir}")
-    print(f"To use this external OPP location, set FLA_NPU_OPP_PATH={install_path}")
+    print(
+        "The external OPP is available to CANN/ACLNN after sourcing its "
+        "set_env.bash. The fla_npu Python runtime always loads libcust_opapi.so "
+        "from the vendor tree embedded in its installed package."
+    )
 
 
 def main() -> int:

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/_runtime.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/_runtime.py
@@ -340,7 +340,7 @@ class _CallContext:
 
 
 class _AclnnRuntime:
-    """从已打包的 custom op_api 动态库里解析并缓存符号。"""
+    """从 custom、CANN op_api 句柄中按优先级解析并缓存符号。"""
 
     def __init__(self):
         import fla_npu

--- a/torch_custom/fla_npu/test/test_runtime_device_guard.py
+++ b/torch_custom/fla_npu/test/test_runtime_device_guard.py
@@ -88,6 +88,31 @@ def fake_torch(npu: FakeNpu):
 
 
 class RuntimeDeviceGuardTest(unittest.TestCase):
+    def test_symbol_lookup_prefers_custom_library_and_caches_result(self):
+        custom_symbol = object()
+        cann_symbol = object()
+        runtime = object.__new__(RUNTIME._AclnnRuntime)
+        runtime._libraries = [
+            types.SimpleNamespace(aclnnSharedSymbol=custom_symbol),
+            types.SimpleNamespace(aclnnSharedSymbol=cann_symbol),
+        ]
+        runtime._symbols = {}
+
+        self.assertIs(runtime.symbol("aclnnSharedSymbol"), custom_symbol)
+        runtime._libraries.clear()
+        self.assertIs(runtime.symbol("aclnnSharedSymbol"), custom_symbol)
+
+    def test_symbol_lookup_falls_back_to_cann_library(self):
+        cann_symbol = object()
+        runtime = object.__new__(RUNTIME._AclnnRuntime)
+        runtime._libraries = [
+            types.SimpleNamespace(),
+            types.SimpleNamespace(aclnnCannOnlySymbol=cann_symbol),
+        ]
+        runtime._symbols = {}
+
+        self.assertIs(runtime.symbol("aclnnCannOnlySymbol"), cann_symbol)
+
     def test_device_guard_switches_to_target_and_restores_previous_device(self):
         npu = FakeNpu(current_device=0)
         with mock.patch.dict(sys.modules, {"torch": fake_torch(npu)}):


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: #310
- 背景与目标: 修复 `import fla_npu` 后再加载 CANN `libopapi.so` 时，进程退出阶段因动态符号串扰触发 double free 的问题，同时隔离 FLA 与其他 CANN vendor opapi 的加载边界。
- 本 PR 解决的问题:
  - FLA 与 CANN opapi 不再通过 `RTLD_GLOBAL` 共享内部 C++/STL 符号域。
  - 同名 `aclnn*` 符号按 FLA custom、CANN 的顺序查找，custom 缺失时回退 CANN。
  - FLA 只通过当前 Python 包推导出的绝对路径加载包内 `libcust_opapi.so`，不从外部 vendor 回退。
  - 保持 `fla_npu/opp/vendors/fla_npu_transformer/op_api/lib/libcust_opapi.so` 原标准安装位置，不移动文件、不新增动态库目录。
  - 未 source CANN 时，`import fla_npu` 立即给出明确报错。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: 所有使用 `fla_npu.ops.ascendc` 共享 runtime 的算子；未修改任何算子 kernel。
- 涉及目录 / 文件: `torch_custom/fla_npu/fla_npu`、wheel/run 包打包脚本、opapi CMake、共享 runtime 测试和解耦架构文档。
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [x] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不变。
- 明确不包含的范围: 不修改 kernel、tiling、算子精度、性能和公开 Python/aclnn 参数语义；不改变标准 vendor 安装布局。
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [x] 是，请说明影响面、兼容策略和回归范围: 影响所有 Ascend C 默认入口共用的 import、opapi 加载和符号查找。包内标准位置保持不变；FLA 不再把包内 `op_api/lib` 加入 `LD_LIBRARY_PATH`，只通过固定绝对路径局部加载。
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: aclnn C ABI、Python API 和动态库安装位置均不变；仅调整动态库加载作用域、显式符号查找顺序和 ELF SONAME。

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本: 9.1.0 beta.1
- 产品 / 芯片类型: A3 / `ascend910_93`
- 机器或 CI 链接: 未提供公开 CI 链接。

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

本 PR 实际执行的共享 runtime 回归:

```sh
python3 -m unittest tests.test_wheel_environment \
  torch_custom.fla_npu.test.test_runtime_device_guard \
  torch_custom.fla_npu.test.test_aclnn_ctypes_abi \
  torch_custom.fla_npu.test.test_ascendc_mutation_contract
```

结果: 28 项测试通过。另完成 A3 一体化 wheel 构建、安装和动态加载验证，覆盖标准安装布局、无 `DT_SONAME`、custom-first 符号查找、CANN fallback、CANN vendor 同名库隔离、未 source CANN 报错，以及 Issue #310 复现顺序连续 5 次正常退出。

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未验证 | `FLA_NPU_SOC=ascend910b python -m pip wheel --no-build-isolation --no-deps . -w dist` | 未执行 | 待 CI 补齐。 |
| A3 | `ascend910_93` | 9.1.0 beta.1 | `FLA_NPU_SOC=ascend910_93 python -m pip wheel --no-build-isolation --no-deps . -w dist` | 通过 | 一体化 wheel 构建、安装和 API 自检通过。 |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未验证 | `FLA_NPU_SOC=ascend910b python -m pip wheel --no-build-isolation --no-deps . -w dist` | 未执行 | 待 CI 补齐。 |
| A3 | `ascend910_93` | 9.1.0 beta.1 | `FLA_NPU_SOC=ascend910_93 python -m pip wheel --no-build-isolation --no-deps . -w dist` | 通过 | 标准 `.so` 位置、无 SONAME 和双 custom opapi 局部共存验证通过。 |
| A5 | `ascend950` | 未验证 | `FLA_NPU_SOC=ascend950 python -m pip wheel --no-build-isolation --no-deps . -w dist` | 未执行 | 待 CI 补齐。 |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | 未执行 | 本 PR 不修改 kernel；共享 runtime 回归待 CI 补齐。 |
| A3 | `ascend910_93` | 共享 runtime 单元测试和真实动态加载验证 | 通过 | 28 项测试通过；Issue #310 复现顺序连续 5 次正常退出；未执行算子精度测试。 |
| A5 | `ascend950` | 未执行 | 未执行 | 本 PR 不修改 kernel；共享 runtime 回归待 CI 补齐。 |

- 精度对比: 未执行；本 PR 不修改计算语义和 kernel。
- 性能对比: 未执行；本 PR 不修改 kernel 性能路径。
- 边界 / 异常场景: 覆盖未 source CANN、包内库缺失、外部 vendor 不回退、旧 `libopapi.so` 别名、CANN fallback、标准安装布局和同名库局部隔离。
- 未覆盖风险: A2/A5 构建、各产品 Example ST 和真实 `torch_npu.ops.*` 算子调用待 NPU CI 补齐。

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐。 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 已完成共享加载回归，端到端 ST 待 NPU CI 补齐。 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐。 |

- 端到端场景说明: 未执行。
- 与本 PR 修改算子的关联: 本 PR 修改所有 Ascend C 算子共用的 import、符号解析和 wheel/run 包加载边界。
- 未覆盖原因及补充计划: 当前完成 A3 真实构建与动态加载验证；PR 更新后请求 NPU CI 补齐 Example ST。

</details>

## 兼容性、风险与回退

- 兼容性说明: `libcust_opapi.so` 保持原标准 vendor 安装位置。FLA 从当前包 `__file__` 推导绝对路径并使用 `RTLD_LOCAL` 加载，不把包内 `op_api/lib` 加入 `LD_LIBRARY_PATH`；其他 CANN 算子入口继续按各自 vendor 机制加载自己的库。默认路径仍不依赖 `custom_aclnn_extension_lib`。
- 风险点: 本方案要求同进程内各 opapi 使用方遵守 `RTLD_LOCAL`；不支持预先以 `RTLD_GLOBAL` 发布 custom opapi 符号的用法。A2/A5 和 Example ST 尚未执行。
- 回退方案: 回退本 PR commit，恢复上一版本 wheel/run 包。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

建议重点检视以下动态链接边界：

- CANN `libopapi.so` 先加载，FLA 包内 `libcust_opapi.so` 后加载；两个 handle 均为 `RTLD_LOCAL | RTLD_NOW | RTLD_NODELETE`。
- 句柄保存顺序为 `[custom, CANN]`，只用于显式符号查找优先级，不依赖进程全局符号抢占。
- FLA `libcust_opapi.so` 保持原标准位置，但该目录不加入 `LD_LIBRARY_PATH`，且动态库不设置 `DT_SONAME`。
- FLA custom opapi 的绝对路径只从当前导入包推导；CANN/`torch_npu` 继续使用各自的 vendor 定位流程。
