### PR TITLE
fix: package Triton sources in root wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,19 @@ python scripts/check_npu_env.py --build-only
 
 ```sh
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
-FLA_NPU_SOC=ascend910b python -m pip wheel --no-build-isolation --no-deps . -w dist
+FLA_NPU_SOC=ascend910b python scripts/build_wheel.py
 ```
+
+脚本内部仍使用 `pip wheel --no-build-isolation --no-deps` 完成构建，并在成功后打印本轮
+wheel 的绝对路径和可直接复制执行的强制覆盖安装命令。可通过 `--wheel-dir` 修改默认的
+`dist/` 输出目录。
 
 修改任何源码或适配后，重新执行同一条命令做全量构建。构建流程会清理上一轮
 `build/`、`build_out/` 和 `output/` 中间产物，不依赖 Git diff 或旧 CMake 状态决定
 编译范围：
 
 ```sh
-FLA_NPU_SOC=ascend910b python -m pip wheel --no-build-isolation --no-deps . -w dist
+FLA_NPU_SOC=ascend910b python scripts/build_wheel.py
 ```
 
 构建完成后，wheel 仍统一输出到 `dist/`。该目录可能同时存在不同版本或构建标签

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -1,0 +1,69 @@
+"""Build the root wheel and print its exact installation command."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from fla_npu_artifacts import get_wheel_filename  # noqa: E402
+
+
+def _resolve_output_dir(value: str) -> Path:
+    output_dir = Path(value).expanduser()
+    if not output_dir.is_absolute():
+        output_dir = REPO_ROOT / output_dir
+    return output_dir.resolve()
+
+
+def _install_command(wheel_path: Path) -> str:
+    return (
+        f"{shlex.quote(sys.executable)} -m pip install "
+        "--force-reinstall --no-cache-dir --no-deps "
+        f"{shlex.quote(str(wheel_path))}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--wheel-dir",
+        default="dist",
+        help="wheel output directory relative to the repository root (default: dist)",
+    )
+    args = parser.parse_args()
+
+    wheel_dir = _resolve_output_dir(args.wheel_dir)
+    wheel_dir.mkdir(parents=True, exist_ok=True)
+    wheel_path = wheel_dir / get_wheel_filename(REPO_ROOT)
+
+    command = [
+        sys.executable,
+        "-m",
+        "pip",
+        "wheel",
+        "--no-build-isolation",
+        "--no-deps",
+        ".",
+        "-w",
+        str(wheel_dir),
+    ]
+    subprocess.run(command, cwd=REPO_ROOT, check=True)
+
+    if not wheel_path.is_file():
+        raise RuntimeError(f"Expected wheel was not produced: {wheel_path}")
+
+    print(f"[fla-npu build] Wheel: {wheel_path}", flush=True)
+    print("[fla-npu build] Install command:", flush=True)
+    print(_install_command(wheel_path), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_packaged_wheel_api.py
+++ b/scripts/check_packaged_wheel_api.py
@@ -43,6 +43,15 @@ TRITON_NAMES = (
     "l2norm",
     "solve_tril",
 )
+REQUIRED_TRITON_SOURCES = (
+    "__init__.py",
+    "causal_conv1d.py",
+    "chunk_scaled_dot_kkt.py",
+    "cumsum.py",
+    "l2norm.py",
+    "solve_tril_fast.py",
+    "utils.py",
+)
 REQUIRED_ASCENDC_CONFIGS = (
     "recompute_w_u_fwd.json",
 )
@@ -86,6 +95,21 @@ def _require_packaged_opp_configs(fla_npu_module) -> None:
         raise AssertionError(
             "packaged OPP kernel configs still contain deprecated aliases: "
             + ", ".join(unexpected)
+        )
+
+
+def _require_packaged_triton_sources(fla_npu_module) -> None:
+    package_root = Path(fla_npu_module.__file__).resolve().parent
+    triton_core = package_root / "ops" / "triton" / "triton_core"
+    missing = [
+        source_name
+        for source_name in REQUIRED_TRITON_SOURCES
+        if not (triton_core / source_name).is_file()
+    ]
+    if missing:
+        raise AssertionError(
+            "packaged Triton sources are missing from "
+            f"{triton_core}: {', '.join(missing)}"
         )
 
 
@@ -170,6 +194,7 @@ def main() -> int:
 
     _require_packaged_opp_configs(fla_npu)
     _require_safe_packaged_opapi(fla_npu)
+    _require_packaged_triton_sources(fla_npu)
 
     if ascendc.BACKWARD_OPS.get("causal_conv1d") != "causal_conv1d_bwd":
         raise AssertionError("causal_conv1d backward binding metadata is missing")

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ except Exception:
 REPO_ROOT = Path(__file__).resolve().parent
 TORCH_EXTENSION_DIR = REPO_ROOT / "torch_custom" / "fla_npu"
 FLA_NPU_PACKAGE_DIR = TORCH_EXTENSION_DIR / "fla_npu"
+TRITON_CORE_PACKAGE = "fla_npu.ops.triton.triton_core"
+TRITON_CORE_SOURCE = REPO_ROOT / "fla" / "ops" / "triton" / "triton_core"
 
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 from fla_npu_artifacts import get_package_version, get_wheel_build_tag  # noqa: E402
@@ -71,6 +73,27 @@ def _read_requirements():
         if line and not line.startswith("#"):
             deps.append(line)
     return deps
+
+
+def _packages():
+    packages = find_packages(
+        where=str(TORCH_EXTENSION_DIR),
+        include=["fla_npu", "fla_npu.*"],
+    )
+    if not TRITON_CORE_SOURCE.is_dir():
+        raise FileNotFoundError(
+            f"Triton source directory is missing: {TRITON_CORE_SOURCE}"
+        )
+    if TRITON_CORE_PACKAGE not in packages:
+        packages.append(TRITON_CORE_PACKAGE)
+    return packages
+
+
+def _package_dir():
+    return {
+        "fla_npu": str(FLA_NPU_PACKAGE_DIR.relative_to(REPO_ROOT)),
+        TRITON_CORE_PACKAGE: str(TRITON_CORE_SOURCE.relative_to(REPO_ROOT)),
+    }
 
 
 def _env_flag(name):
@@ -567,13 +590,8 @@ setup(
     description="High-performance linear attention operators for Ascend NPU",
     long_description=(REPO_ROOT / "README.md").read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
-    packages=(
-        find_packages(
-            where=str(TORCH_EXTENSION_DIR),
-            include=["fla_npu", "fla_npu.*"],
-        )
-    ),
-    package_dir={"fla_npu": str(FLA_NPU_PACKAGE_DIR.relative_to(REPO_ROOT))},
+    packages=_packages(),
+    package_dir=_package_dir(),
     package_data={"fla_npu": ["opp/**/*"]},
     include_package_data=True,
     license_files=[


### PR DESCRIPTION
## 关联 Issue / 背景

- 关联 Issue: Closes #315
- 背景与目标: 根目录一键构建的 wheel 包含 `fla_npu.ops.triton` 入口，但遗漏位于另一棵源码目录下的 `triton_core` Python 源码，导致 wheel-only 安装后公开入口导入失败。
- 本 PR 解决的问题: 将 Triton 核心源码显式映射到 `fla_npu.ops.triton.triton_core`，并在默认 wheel API 棚栏中检查必需源码文件。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `fla_npu.ops.triton` 下现有 Triton 算子
- 涉及目录 / 文件: `setup.py`、`scripts/check_packaged_wheel_api.py`
- 责任人 / 提交人: @Ensley0304
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [x] `Triton` 算子打包
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不变。
- 明确不包含的范围: 不修改 Triton 算子实现、公开函数签名、JIT 行为、Ascend C Kernel 或 OPP 内容。
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [x] 是，影响根目录一键 wheel 的 Python 包内容；仅补齐此前遗漏的源码，不改变现有接口。
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无 ABI 变更。

## 修改说明

1. 根目录 `setup.py` 显式注册 `fla_npu.ops.triton.triton_core`，并将其映射到唯一源码目录 `fla/ops/triton/triton_core`。
2. 源码目录缺失时在打包阶段直接失败，避免生成结构不完整但可安装的 wheel。
3. `scripts/check_packaged_wheel_api.py` 默认检查 7 个必需的 Triton Python 源文件，防止问题再次被常规打包验收漏过。
4. 新增 `scripts/build_wheel.py` 作为推荐的一键编包入口；构建成功后打印本轮 wheel 的绝对路径和可直接复制的强制覆盖安装命令，并同步更新 README。

## 验证结果

### 静态检查

```text
python -m py_compile setup.py scripts/check_packaged_wheel_api.py scripts/build_wheel.py
git diff --check
```

结果：通过。

### 编包完成提示

- 使用 mock wheel 产物验证构建命令参数、准确产物识别和安装命令输出：通过。
- `python scripts/build_wheel.py --help`：通过。
- 完整 A2 / A5 wheel 验证仍由脚本内部复用的原 `pip wheel --no-build-isolation --no-deps` 流程完成。

### A5 / `ascend950` 完整 wheel 验证

- 完整一键 wheel 构建：通过。
- wheel 内容检查：包含 `fla_npu/ops/triton/triton_core` 下 7 个必需 Python 文件。
- 隔离环境 wheel 安装：通过。
- `python scripts/check_packaged_wheel_api.py --check-triton`：通过。
- 从仓库外临时目录执行 `from fla_npu.ops.triton import causal_conv1d`：通过，模块来源为已安装 wheel 的 `site-packages`。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0 | 根目录完整 `pip wheel` 构建及隔离安装检查 | 通过 | wheel、源码清单及公开入口导入均通过 |
| A3 | `ascend910_93` | 未执行 | 未执行 | 未执行 | 本 PR 为 Python 打包映射变更 |
| A5 | `ascend950` | 9.1.0 | 根目录完整 `pip wheel` 构建及隔离安装检查 | 通过 | wheel、源码清单及公开入口导入均通过 |

### 未覆盖说明

- 本 PR 只修复源码漏包；不以本次验证声明所有 Triton 算子的运行时 JIT 兼容性。

## 兼容性、风险与回退

- 兼容性说明: 保持 `fla_npu.ops.triton` 公开入口不变，不新增顶层 `fla` 运行时依赖。
- 风险点: 根 wheel 与子工程 wheel 各自维护相同映射，后续目录调整时需同步更新。
- 回退方案: 回退本 PR 提交即可恢复原打包行为。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [x] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [x] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成与本次 Python 打包改动直接相关的 wheel 构建、隔离安装和导入验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用（本次无需文档变更）
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

请仓库维护者在当前 head commit 上触发 NPU CI；本 PR 为 Draft，待 CI 与评审意见完成后再转 Ready for review。
