### PR TITLE
fix(fast-launch): correct non-contiguous state handling in recurrent …

### DIFF
--- a/examples/fast_kernel_launch_example/cmake/ascend.cmake
+++ b/examples/fast_kernel_launch_example/cmake/ascend.cmake
@@ -55,8 +55,12 @@ set(ASCEND_INCLUDE_DIRS
     ${ASCEND_DIR}/include/op_common
     ${ASCEND_DIR}/${SYSTEM_PREFIX}/include
     ${ASCEND_DIR}/${SYSTEM_PREFIX}/include/op_common
+    ${ASCEND_DIR}/${SYSTEM_PREFIX}/include/op_common/op_host
     ${ASCEND_DIR}/pkg_inc
     ${ASCEND_DIR}/pkg_inc/op_common
+    ${ASCEND_DIR}/${SYSTEM_PREFIX}/pkg_inc
+    ${ASCEND_DIR}/${SYSTEM_PREFIX}/pkg_inc/op_common
+    ${ASCEND_DIR}/${SYSTEM_PREFIX}/pkg_inc/op_common/op_host
     ${ASCEND_DIR}/${SYSTEM_PREFIX}/pkg_inc/base
     ${ASCEND_DIR}/include/hcomm
     ${ASCEND_DIR}/compiler/tikcpp/include

--- a/examples/fast_kernel_launch_example/csrc/recurrent_gated_delta_rule/ascend910b/CMakeLists.txt
+++ b/examples/fast_kernel_launch_example/csrc/recurrent_gated_delta_rule/ascend910b/CMakeLists.txt
@@ -9,3 +9,7 @@
 # ----------------------------------------------------------------------------
 
 add_sources("--npu-arch=dav-2201")
+
+target_include_directories(recurrent_gated_delta_rule_obj PRIVATE
+    ${ASCEND_DIR}/${SYSTEM_PREFIX}/include/op_common/op_host
+)

--- a/examples/fast_kernel_launch_example/csrc/recurrent_gated_delta_rule/ascend910b/recurrent_gated_delta_rule.cpp
+++ b/examples/fast_kernel_launch_example/csrc/recurrent_gated_delta_rule/ascend910b/recurrent_gated_delta_rule.cpp
@@ -12,8 +12,9 @@
  * \brief Recurrent gated delta rule operator with fast kernel launch (<<<>>>).
  */
 
-#include <vector>
+#include <limits>
 #include <tuple>
+#include <vector>
 #include <ATen/Operators.h>
 #include <torch/all.h>
 #include <torch/library.h>
@@ -90,7 +91,7 @@ std::tuple<at::Tensor, at::Tensor> recurrent_gated_delta_rule_functional_meta(
     TORCH_CHECK(state.dim() == 4, "initial_state dim should be 4");
     c10::SmallVector<int64_t, 3> outShape = {value.size(0), value.size(1), value.size(2)};
     at::Tensor out = at::empty(outShape, value.options().dtype(at::ScalarType::BFloat16));
-    at::Tensor stateOut = at::empty_like(state);
+    at::Tensor stateOut = at::empty_strided(state.sizes(), state.strides(), state.options());
     return std::make_tuple(out, stateOut);
 }
 
@@ -106,6 +107,33 @@ static ge::DataType ToGeStateDtype(at::ScalarType dtype)
         return ge::DT_FLOAT;
     }
     return ge::DT_BF16;
+}
+
+static void FillStateStrides(const at::Tensor &state, RecurrentGatedDeltaRuleTilingData &tiling)
+{
+    TORCH_CHECK(state.dim() == 4, "state dim should be 4");
+    const auto stateStrides = state.strides();
+    const int64_t dk = state.size(3);
+    const int64_t dv = state.size(2);
+    const int64_t nv = state.size(1);
+
+    TORCH_CHECK(stateStrides[3] == 1, "state stride(3) must be 1, but got ", stateStrides[3]);
+    TORCH_CHECK(stateStrides[2] == dk, "state stride(2) must equal Dk (", dk, "), but got ", stateStrides[2]);
+    TORCH_CHECK(stateStrides[1] >= dv * stateStrides[2],
+                "state stride(1) must leave non-overlapping (Dv, Dk) matrices, but got ", stateStrides[1]);
+    TORCH_CHECK(stateStrides[0] >= nv * stateStrides[1],
+                "state stride(0) must leave non-overlapping Nv heads, but got ", stateStrides[0]);
+
+    constexpr int64_t maxTilingStride = static_cast<int64_t>(std::numeric_limits<uint32_t>::max());
+    for (int64_t dim = 0; dim < 3; ++dim) {
+        TORCH_CHECK(stateStrides[dim] >= 0 && stateStrides[dim] <= maxTilingStride,
+                    "state stride(", dim, ") must be in [0, UINT32_MAX], but got ", stateStrides[dim]);
+    }
+
+    // PyTorch strides and the kernel offsets are both measured in elements.
+    tiling.stateStride0 = static_cast<uint32_t>(stateStrides[0]);
+    tiling.stateStride1 = static_cast<uint32_t>(stateStrides[1]);
+    tiling.stateStride2 = static_cast<uint32_t>(stateStrides[2]);
 }
 
 static RecurrentGatedDeltaRuleTilingData CalcTilingParams(const at::Tensor &query, const at::Tensor &key,
@@ -157,6 +185,7 @@ static RecurrentGatedDeltaRuleTilingData CalcTilingParams(const at::Tensor &quer
     optiling::RecurrentGatedDeltaRuleTilingProcessor processor(ctx);
     TORCH_CHECK(processor.Process(tiling, blockDim, workspaceSize) == ge::GRAPH_SUCCESS,
                 "recurrent_gated_delta_rule tiling failed.");
+    FillStateStrides(state, tiling);
     return tiling;
 }
 
@@ -278,6 +307,7 @@ at::Tensor recurrent_gated_delta_rule_npu(const at::Tensor &query, const at::Ten
                                           const c10::optional<at::Tensor> &num_accepted_tokens,
                                           const c10::optional<at::Tensor> &g, const c10::optional<at::Tensor> &gk)
 {
+    const c10::OptionalDeviceGuard guard(query.device());
     TORCH_CHECK(scale.has_value(), "scale cannot be empty");
     auto out = recurrent_gated_delta_rule_meta(query, key, value, state, beta, scale, actual_seq_lengths,
                                                ssm_state_indices, num_accepted_tokens, g, gk);
@@ -293,12 +323,13 @@ std::tuple<at::Tensor, at::Tensor> recurrent_gated_delta_rule_functional_npu(
     const c10::optional<at::Tensor> &num_accepted_tokens, const c10::optional<at::Tensor> &g,
     const c10::optional<at::Tensor> &gk)
 {
+    const c10::OptionalDeviceGuard guard(query.device());
     TORCH_CHECK(scale.has_value(), "scale cannot be empty");
     auto outs = recurrent_gated_delta_rule_functional_meta(query, key, value, state, beta, scale, actual_seq_lengths,
                                                            ssm_state_indices, num_accepted_tokens, g, gk);
     at::Tensor out = std::get<0>(outs);
-    (void)std::get<1>(outs);
-    at::Tensor stateInplace = state.clone();
+    at::Tensor stateInplace = std::get<1>(outs);
+    stateInplace.copy_(state);
     RunRecurrentGatedDeltaRuleKernel(query, key, value, beta, stateInplace, actual_seq_lengths, ssm_state_indices,
                                      num_accepted_tokens, g, gk, static_cast<float>(scale.value()), out, true);
     return std::make_tuple(out, stateInplace);

--- a/examples/fast_kernel_launch_example/tests/recurrent_gated_delta_rule/test_recurrent_gated_delta_rule.py
+++ b/examples/fast_kernel_launch_example/tests/recurrent_gated_delta_rule/test_recurrent_gated_delta_rule.py
@@ -16,6 +16,7 @@ Accuracy test for npu_recurrent_gated_delta_rule.
 Compares NPU output against CPU golden reference from PTA.
 """
 
+import os
 import sys
 from pathlib import Path
 
@@ -32,6 +33,11 @@ sys.path.insert(0, str(_PTA_DIR))
 
 from golden import recurrent_gated_delta_rule_golden
 from utils import compare_tensors_by_ratio
+
+
+STATE_HEAD_PREFIX_PADDING = 16
+STATE_LAYOUTS = ("contiguous", "noncontiguous")
+API_MODES = ("functional", "mutable")
 
 
 def make_inputs(
@@ -111,51 +117,92 @@ def run_golden(inp):
     )
 
 
-def run_npu(inp):
-    """Run NPU operator and return CPU tensors."""
-    device = torch.device("npu:7")
-    torch_npu.npu.set_device(device)
-    q_npu = inp["query"].npu()
-    k_npu = inp["key"].npu()
-    v_npu = inp["value"].npu()
-    s_npu = inp["state"].clone().npu()
-    b_npu = inp["beta"].npu()
-    asl_npu = inp["actual_seq_lengths"].npu()
-    ssi_npu = inp["ssm_state_indices"].npu()
+def make_npu_state(cpu_state, device, state_layout):
+    dense_state = cpu_state.to(device)
+    if state_layout == "contiguous":
+        return dense_state, tuple(dense_state.stride())
 
-    g_npu = inp["g"].npu() if inp["g"] is not None else None
-    gk_npu = inp["gk"].npu() if inp["gk"] is not None else None
+    block_num, nv, dv, dk = cpu_state.shape
+    head_stride = dv * dk + STATE_HEAD_PREFIX_PADDING
+    padded_strides = (nv * head_stride, head_stride, dk, 1)
+    storage = torch.empty(
+        (block_num, nv, head_stride), dtype=cpu_state.dtype, device=device
+    )
+    state = storage.as_strided(
+        cpu_state.shape, padded_strides, STATE_HEAD_PREFIX_PADDING
+    )
+    state.copy_(dense_state)
+    return state, padded_strides
+
+
+def run_npu(inp, state_layout, api_mode):
+    """Run NPU operator and return CPU tensors."""
+    device = torch.device(os.getenv("FLA_NPU_TEST_DEVICE", "npu:0"))
+    torch_npu.npu.set_device(device)
+    q_npu = inp["query"].to(device)
+    k_npu = inp["key"].to(device)
+    v_npu = inp["value"].to(device)
+    s_npu, expected_state_strides = make_npu_state(
+        inp["state"], device, state_layout
+    )
+    b_npu = inp["beta"].to(device)
+    asl_npu = inp["actual_seq_lengths"].to(device)
+    ssi_npu = inp["ssm_state_indices"].to(device)
+
+    g_npu = inp["g"].to(device) if inp["g"] is not None else None
+    gk_npu = inp["gk"].to(device) if inp["gk"] is not None else None
     nat_npu = (
-        inp["num_accepted_tokens"].npu()
+        inp["num_accepted_tokens"].to(device)
         if inp["num_accepted_tokens"] is not None
         else None
     )
 
-    result = torch.ops.ascend_ops.recurrent_gated_delta_rule_functional(
-        q_npu,
-        k_npu,
-        v_npu,
-        s_npu,
-        beta=b_npu,
-        scale=inp["scale"],
-        actual_seq_lengths=asl_npu,
-        ssm_state_indices=ssi_npu,
-        num_accepted_tokens=nat_npu,
-        g=g_npu,
-        gk=gk_npu,
-    )
+    assert tuple(s_npu.stride()) == expected_state_strides
+    if state_layout == "noncontiguous":
+        assert not s_npu.is_contiguous()
+        assert s_npu.storage_offset() == STATE_HEAD_PREFIX_PADDING
+
+    # Finish asynchronous H2D/view initialization before isolating the custom
+    # kernel launch in this accuracy test.
     torch_npu.npu.synchronize()
 
-    if isinstance(result, (tuple, list)):
+    kwargs = {
+        "beta": b_npu,
+        "scale": inp["scale"],
+        "actual_seq_lengths": asl_npu,
+        "ssm_state_indices": ssi_npu,
+        "num_accepted_tokens": nat_npu,
+        "g": g_npu,
+        "gk": gk_npu,
+    }
+    if api_mode == "functional":
+        result = torch.ops.ascend_ops.recurrent_gated_delta_rule_functional(
+            q_npu, k_npu, v_npu, s_npu, **kwargs
+        )
+        torch_npu.npu.synchronize()
         attn_out = result[0].cpu()
         final_state = result[1].cpu()
+        output_state_strides = tuple(result[1].stride())
+        input_state_after = s_npu.cpu()
     else:
+        result = torch.ops.ascend_ops.recurrent_gated_delta_rule(
+            q_npu, k_npu, v_npu, s_npu, **kwargs
+        )
+        torch_npu.npu.synchronize()
         attn_out = result.cpu()
         final_state = s_npu.cpu()
+        output_state_strides = tuple(s_npu.stride())
+        input_state_after = None
 
     star_idx = int(inp["actual_seq_lengths"][0].item())
     attn_out[:star_idx] = 0
-    return attn_out, final_state
+    return (
+        attn_out,
+        final_state,
+        output_state_strides,
+        expected_state_strides,
+        input_state_after,
+    )
 
 
 def assert_compare_tensors_by_ratio(golden, actual, name, rtol=0.01, atol=0.004):
@@ -188,11 +235,13 @@ TEST_CONFIGS = [
 
 
 @pytest.mark.skipif(not torch.npu.is_available(), reason="NPU device not found")
+@pytest.mark.parametrize("state_layout", STATE_LAYOUTS)
+@pytest.mark.parametrize("api_mode", API_MODES)
 @pytest.mark.parametrize(
     "bs,mtp,nk,nv,dk,dv,use_g,use_gk,use_accepted_tokens,seed,rtol,atol",
     TEST_CONFIGS,
 )
-def test_recurrent_gated_delta_rule_functional_accuracy(
+def test_recurrent_gated_delta_rule_accuracy(
     bs,
     mtp,
     nk,
@@ -205,6 +254,8 @@ def test_recurrent_gated_delta_rule_functional_accuracy(
     seed,
     rtol,
     atol,
+    state_layout,
+    api_mode,
 ):
     inp = make_inputs(
         bs,
@@ -220,7 +271,12 @@ def test_recurrent_gated_delta_rule_functional_accuracy(
     )
 
     golden_attn, golden_state = run_golden(inp)
-    npu_attn, npu_state = run_npu(inp)
+    npu_attn, npu_state, output_strides, expected_strides, input_state_after = run_npu(
+        inp, state_layout, api_mode
+    )
 
     assert_compare_tensors_by_ratio(golden_attn, npu_attn, "attn_out", rtol=rtol, atol=atol)
     assert_compare_tensors_by_ratio(golden_state, npu_state, "final_state", rtol=rtol, atol=atol)
+    assert output_strides == expected_strides
+    if api_mode == "functional":
+        assert torch.equal(input_state_after, inp["state"])


### PR DESCRIPTION
…gated delta rule

# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @Canzovo
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
