### PR TITLE
fix: allocate fwd_h final_state as fp32 when initial_state is absent (v26.6.0)

### DIFF
--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -346,7 +346,11 @@ at::Tensor npu_chunk_fwd_o(
     at::Tensor final_state_out;
     if (output_final_state_) {
         int N = cu_seqlens.has_value() ? cu_seqlens->size() - 1 : B;
-        auto state_options = initial_state.has_value() ? initial_state->options() : h_out.options();
+        // Kernel tiling uses fp32 state when initial_state is absent. Allocating
+        // bf16 here made V2 write float into a half-size buffer → NaN/Inf.
+        auto state_options = initial_state.has_value()
+            ? initial_state->options()
+            : h_out.options().dtype(at::kFloat);
         final_state_out = at::empty({N, HV, K, V}, state_options);
     } else {
         final_state_out = at::empty({1}, k.options());


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> 当前 head commit 已被标记为 `NPU CI / 手动验证 pending`。合入前需要仓库 Admin 权限账号触发 `NPU CI / 手动验证`（`/run-npu-ci quick` 或 GitHub Actions `NPU CI` workflow），并满足分支保护的 2 个 approval。

## 关联 Issue / 背景

- 关联 Issue: 无（问题来自 v26.6.0 实机复现，未关联 issue）
- 背景与目标: `npu_chunk_gated_delta_rule_fwd_h` 在合法 GDN `g`（全负、无 exp 溢出）输入下，`final_state` 输出出现 NaN/Inf，并污染 `v_new` 首 token（偏差约 1e37）。根因是 host 侧 `final_state_out` 分配 dtype 与 kernel tiling 期望不一致。
- 本 PR 解决的问题:
  - 根因: 当 `initial_state=None` 时，kernel tiling 固定使用 fp32 state，但 host 在 `torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp` 中用 `h_out.options()`（bf16）分配 `final_state_out`，导致 V2 把 float 值写入半尺寸缓冲区，产生 NaN/Inf。
  - 修复: `initial_state=None` 时改用 `h_out.options().dtype(at::kFloat)` 分配 `final_state_out`，与 fast-kernel launch 示例和 `main` 分支行为保持一致。

## 变更类型

- [x] Bug 修复

## 算子责任范围

- 涉及算子名称: `npu_chunk_gated_delta_rule_fwd_h`（`aclnnChunkGatedDeltaRuleFwdH`）
- 涉及目录 / 文件:
  - `torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp`
- 责任人 / 提交人: @Coding-Pangolin
- 修改范围:
  - [x] `torch_custom` 适配（host 侧输出 tensor 分配 dtype）
- 输入 / 输出 / shape / dtype / format 支持范围:
  - 仅影响 `output_final_state=True` 且 `initial_state=None` 时 `final_state` 的输出分配：由 bf16（错误）改为 fp32（与 kernel 一致）
- 明确不包含的范围: 不改 kernel、tiling、InferShape、aclnn 接口定义；不涉及 ABI 变更
- 是否影响公共模块或其他算子:
  - [x] 否
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化

## 验证方法

### 1. 环境确认

- CANN 版本: Ascend Toolkit（含 fwd_h OPP 的 26.6.0 配套版本）
- 产品 / 芯片类型: A2 / `ascend910b`
- 机器或 CI 链接: 本机 NPU 验证（未跑 CI）

### 2. 编译验证

```sh
bash build.sh --pkg --soc=ascend910b --ops=chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu
cd torch_custom/fla_npu && bash build.sh
```

通过标准: 命令退出码 0，编译日志无 ERROR；本机重建后已成功加载 `custom_aclnn_extension_lib.so`。

### 3. 修改算子 test 验证

```sh
python3 repro_fwd_h_legal_g.py --T 64
python3 repro_fwd_h_legal_g.py --T 2771
```

### 4. 整体 example ST 验证

未执行（本 PR 为最小化 host 侧修复，未改动 kernel/example；如需可在 CI 上触发 `/run-npu-ci quick`）。

## 修改算子测试

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 repro_fwd_h_legal_g.py --T 64` | 通过 | 见下 |
| A2 | `ascend910b` | `python3 repro_fwd_h_legal_g.py --T 2771` | 通过 | 见下 |

- 精度对比（NPU 输出 vs CPU golden `forward_h_trans_cpu`）:
  - `T=64`（单 chunk）: `h` / `v_new` 逐位一致；`final_state` max_abs ≈ 4e-3，全部有限
  - `T=2771`（含尾 chunk 19 token）: `h` / `v_new` 逐位一致；`final_state` max_abs ≈ 6e-4，全部有限
  - 修复前 `final_state` 存在 NaN/Inf，`v_new` 首 token 偏差约 1e37；修复后均为有限值
- 边界 / 异常场景: 覆盖 `initial_state=None` + `output_final_state=True` + 尾 chunk（非 64 整数倍）与整 chunk 两种场景
- 未覆盖风险: A3 / A5 未实测（本机仅 A2）；NPU CI 未触发

## 整体 Example ST 验证

未执行。本 PR 只调整 host 侧输出 tensor 分配 dtype，不改 kernel / tiling / aclnn 接口，端到端调用链不受影响；如需可在合入前触发 `/run-npu-ci quick`。

## 兼容性、风险与回退

- 兼容性说明: 仅当 `initial_state=None` 时 `final_state` 输出 dtype 由错误的 bf16 变为 fp32，与 kernel 实际写入格式一致；不改变接口签名
- 风险点: 极低。行为与 `main` 分支（PR #219 已引入相同逻辑）及 `examples/fast_kernel_launch_example` 一致
- 回退方案: 回退本 commit 即恢复原分配逻辑
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过（本机仅 A2）
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过（未执行）
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过（A2 已通过，A3 / A5 未执行）
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过（未执行）
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用（不适用）
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 复现脚本 `repro_fwd_h_legal_g.py` 使用合法 GDN `g`（全负、无 exp 溢出）构造与实机 dump 同尺度输入（`[1, 32, 2771, 128]` bf16 / `g` fp32），不依赖 dump .pt 文件即可复现问题。
- 该修复逻辑与 `upstream/main` 中 PR #219（commit `93d0c7e7`）引入的 `k.options().dtype(at::kFloat)` 完全一致，本 PR 是将其同步到 `v26.6.0`。
