### PR TITLE
fix(gdn): bound KKT B-matrix tile by valid rows to fix varlen tail OOB

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_scaled_dot_kkt/op_kernel/chunk_scaled_dot_kkt.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_scaled_dot_kkt/op_kernel/chunk_scaled_dot_kkt.h
@@ -352,7 +352,11 @@ private:
         if (rowCount <= 0) {
             return false;
         }
-        colCount = BT_;
+        // Bound the score's N dimension by the number of valid rows: the B-matrix tile is read as K x colCount
+        // from kGm[kOffset], so an unbounded colCount would read [rowStart, rowStart + BT) even for a partial
+        // chunk. When the last chunk of the k tensor is partial (e.g. varlen tail), that read runs past the
+        // tensor end and triggers an MTE DDR out-of-range exception.
+        colCount = MinI64(BT_, meta.valid);
         return colCount > 0;
     }
 
@@ -812,12 +816,15 @@ private:
                                           int64_t rowCount,
                                           int64_t colCount)
     {
+        (void)colCount;
+        // Always copy full BT-wide rows. A partial chunk only fills colCount < BT columns of the score tile;
+        // the extra columns contain stale data but are never read by the epilogue (which stops at the valid
+        // prefix). Keeping blockLen = BT * sizeof(float) preserves the 32B alignment requirement of DataCopyPad.
         DataCopyExtParams scoreParams;
         scoreParams.blockCount = static_cast<uint16_t>(rowCount);
-        scoreParams.blockLen = static_cast<uint32_t>(colCount * static_cast<int64_t>(sizeof(float)));
-        scoreParams.srcStride = static_cast<uint32_t>((BT_ - colCount) * static_cast<int64_t>(sizeof(float)) /
-                                                      UB_ALIGN_BYTES);
-        scoreParams.dstStride = static_cast<uint32_t>((btAlign_ - colCount) * static_cast<int64_t>(sizeof(float)) /
+        scoreParams.blockLen = static_cast<uint32_t>(BT_ * static_cast<int64_t>(sizeof(float)));
+        scoreParams.srcStride = 0;
+        scoreParams.dstStride = static_cast<uint32_t>((btAlign_ - BT_) * static_cast<int64_t>(sizeof(float)) /
                                                       UB_ALIGN_BYTES);
         scoreParams.rsv = 0;
         DataCopyPadExtParams<float> padParams{false, 0, 0, 0.0f};


### PR DESCRIPTION
## Summary
- Fixes a sequence-dependent `507015` / MTE DDR out-of-range crash on Ascend 950 when a **varlen** `chunk_scaled_dot_kkt` call has a **partial last chunk** (`valid < BT`).
- Root cause: in `DecodeScoreBlockTask`, the Catlass score GEMM B-matrix `colCount` was unconditionally set to `BT_`, so the GM→L1 load of `K × BT` could read past the end of `k` when `rowStart + BT > T`.
- Fix: `colCount = min(BT_, meta.valid)`; keep `CopyScoreBlock` `blockLen = BT * sizeof(float)` for DataCopyPad 32B alignment (epilogue only consumes the valid prefix).

## Repro (before fix)
```
fixed BT128 T7168  →  varlen BT64 T65536 (partial last chunk, e.g. valid=2)
```
Isolated by `seq14` / hypothesis `baseline`. Aligned / last-chunk-full variants did not crash.

## Verification (after fix)
- baseline / seq14: pass (was crash)
- seq14 stress ×5: 5/5 pass
- aligned / lastfull / firsth / fixedtail: pass
- precision: case19 tail + fixed BT128, `max_rel ≤ 0.017`, zero-pattern OK
- sweep case09–12 → case19: pass

## Test plan
- [ ] Rebuild `chunk_scaled_dot_kkt` for ascend950 and reinstall vendor package
- [ ] Run fixed→varlen sequence (BT128 then BT64 varlen with partial tail)
- [ ] Confirm GDN generalization varlen cases still pass precision


Made with [Cursor](https://cursor.com)