### PR TITLE
fix(v26.6.0): 排除 torchnpugen 聚合生成源码

### DIFF
--- a/torch_custom/fla_npu/setup.py
+++ b/torch_custom/fla_npu/setup.py
@@ -37,10 +37,14 @@ def get_sources():
                 if file.endswith(".cpp") or file.endswith(".cc"):
                     sources.append(os.path.join(root, file))
 
-    BUILD_EXCLUDE_LIST = [f"{aten_dir}/VariableTypeEverything.cpp",
-        f"{aten_dir}/ADInplaceOrViewTypeEverything.cpp",
-        f"{aten_dir}/python_functionsEverything.cpp",
-        f"{aten_dir}/RegisterFunctionalizationEverything.cpp"]
+    BUILD_EXCLUDE_LIST = [
+        os.path.join(aten_dir, "VariableTypeEverything.cpp"),
+        os.path.join(aten_dir, "ADInplaceOrViewTypeEverything.cpp"),
+        os.path.join(aten_dir, "python_functionsEverything.cpp"),
+        os.path.join(aten_dir, "RegisterFunctionalizationEverything.cpp"),
+        os.path.join(ops_dir, "OpInterfaceEverything.cpp"),
+        os.path.join(ops_dir, "ops", "opapi", "StructKernelNpuOpApiEverything.cpp"),
+    ]
 
     sources_new = [cur_file for cur_file in sources if cur_file not in BUILD_EXCLUDE_LIST]
     print("====sources_new:", sources_new)


### PR DESCRIPTION
## 关联 Issue / 背景

- Closes #323
- 在较新 `torchnpugen` 环境中，legacy C++ extension 会同时生成 `Everything.cpp` 聚合源码和分片源码。
- `torch_custom/fla_npu/setup.py` 原先递归收集全部 `.cpp/.cc`，导致同一批函数同时进入聚合对象和分片对象，最终在链接阶段报 `multiple definition`。

## 修改内容

- 从 legacy extension 编译源中排除：
  - `op_plugin/OpInterfaceEverything.cpp`
  - `op_plugin/ops/opapi/StructKernelNpuOpApiEverything.cpp`
- 将原有排除路径统一改为 `os.path.join`，确保选源逻辑在 Linux/Windows 下保持一致。

## 影响范围

- 仅调整 `v26.6.0` legacy C++ extension 的编译源选择。
- 不修改算子接口、kernel、tiling、动态库加载逻辑或调用方式。

## 验证

- 本地：`python -m py_compile torch_custom/fla_npu/setup.py` 通过。
- A5 `wys_gdn`（`torch_npu 2.7.1.post5`）：legacy extension 完成 14 个对象编译和最终 `.so` 链接，`torch.ops.load_library` 动态加载通过。

说明：A5 当前 `wys_gdn` 的旧版生成器不会生成 Issue #323 中新版 `torchnpugen` 的两份 op-plugin `Everything.cpp`，因此完整构建用于兼容性验证。
