### PR TITLE
fix: probe legacy build capabilities by import

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ source $INSTALL_PATH/ascend-toolkit/set_env.sh
 
 #### 方式 A：【推荐】源码一键编译并生成 wheel
 
-在已完成 CANN、PyTorch、torch-npu、torchnpugen、triton-ascend 环境准备后，推荐直接在仓库根目录生成单 wheel。默认目标芯片为 `ascend910b`，A3/A5 机器需要显式指定 `FLA_NPU_SOC`。本仓不会自动安装 `torch`、`torch_npu`、`torchnpugen` 或 `triton-ascend`，因为这些包必须和 CANN、Python、`torch_npu` 可用版本匹配；在新的 conda 环境中请先安装匹配依赖，再执行预检：
+默认 Python-only wheel 构建只要求准备 CANN 和根目录 `requirements.txt` 中的 Python 依赖，不会导入 `torch`、`torch_npu`、`torchnpugen` 或 `torch.utils.cpp_extension`。默认目标芯片为 `ascend910b`，A3/A5 机器需要显式指定 `FLA_NPU_SOC`。在新的 conda 环境中先执行默认构建预检：
 
 ```sh
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
@@ -40,7 +40,13 @@ python -m pip install -r requirements.txt
 python scripts/check_npu_env.py --build-only
 ```
 
-如果依赖缺失，预检和一键编包都会在真正编译前失败，并列出缺失项，例如 `torch`、`torch_npu`、`torchnpugen.*`、`triton` 或 `triton-ascend distribution was not found`。依赖通过后再生成 wheel：
+只有显式构建 legacy PyTorch C++ extension 时，才需要准备相互匹配的 PyTorch、torch-npu、torchnpugen 和 triton-ascend，并执行：
+
+```sh
+python scripts/check_npu_env.py --build-only --legacy-extension
+```
+
+legacy 预检会真实导入构建使用的五个 `torchnpugen` 子模块以及 `BuildExtension`、`CppExtension`，并将代码生成能力与 GDN `aclnn_extension` stream 安全策略分别报告。依赖通过后再生成 wheel：
 
 ```sh
 source /usr/local/Ascend/ascend-toolkit/set_env.sh

--- a/docs/agents/torch-npu-decoupled-architecture.md
+++ b/docs/agents/torch-npu-decoupled-architecture.md
@@ -97,7 +97,9 @@ Python 用户代码
 | wheel tag 携带 `cp311`、平台和 C++ ABI 信息 | Python 层使用 `py3-none-any` tag | 同一 host/SoC wheel 可覆盖多个 Python minor 和已验证框架组合 |
 | 每次框架升级重新编译桥接扩展 | 运行时做 capability probe 和测试 | 框架升级不再天然要求重编 OPP wheel |
 
-legacy `torch.ops.npu.*` 兼容路径仍可通过 `FLA_NPU_BUILD_LEGACY_EXTENSION=1` 构建，但它是显式 opt-in，不属于默认解耦交付。
+legacy `torch.ops.npu.*` 兼容路径仍可通过 `FLA_NPU_BUILD_LEGACY_EXTENSION=1` 构建，但它是显式 opt-in，不属于默认解耦交付。legacy 预检通过真实导入构建实际使用的 `torchnpugen` 子模块和 `torch.utils.cpp_extension` 中的 `BuildExtension`、`CppExtension` 判断代码生成与编译能力；默认 Python-only 预检不执行这些 import。
+
+legacy 构建能力与 GDN `aclnn_extension` stream 安全性是两项独立约束。模块可导入只能证明代码生成或 C++ extension API 存在，不能证明 `torch_npu` 已包含 stream 修复；后者仍由独立命名的已知安全版本策略检查，直到上游提供可直接探测的 feature marker。预检必须分别报告两项结果，不能用版本号代替模块导入，也不能用模块导入代替 stream 安全检查。
 
 ### 2.4 依赖在哪个阶段确定
 

--- a/scripts/check_npu_env.py
+++ b/scripts/check_npu_env.py
@@ -4,42 +4,24 @@ from __future__ import annotations
 
 import argparse
 import importlib
-import importlib.util
 import os
-import re
 import shutil
 import sys
 from importlib import metadata
-from typing import Optional, Tuple
+from typing import Optional
 
 from packaging.version import InvalidVersion, Version
+
+from fla_npu_build_capabilities import (
+    probe_legacy_build_capabilities,
+    torch_npu_gdn_stream_fix_error,
+)
 
 
 MIN_PYTHON = (3, 9)
 MIN_TORCH = "2.6.0"
 MIN_TRITON_ASCEND = "3.2.0"
 MIN_TRITON_ASCEND_A5 = "3.2.1"
-TORCH_NPU_GDN_FIX_MINIMUMS = {
-    "2.7.1": "2.7.1.post5",
-    "2.8.0": "2.8.0.post5",
-    "2.9.0": "2.9.0.post3",
-    "2.10.0": "2.10.0.post2",
-    "2.11.0": "2.11.0rc3",
-    "2.12.0": "2.12.0rc1",
-}
-MIN_TORCH_NPU_FUTURE_FIX_FAMILY = "2.13.0"
-TORCH_NPU_GDN_FIX_RELEASE_URL = (
-    "https://gitcode.com/Ascend/pytorch/releases?"
-    "presetConfig={%22tags%22:229,%22release%22:122}"
-)
-
-TORCHNPUGEN_MODULES = (
-    "torchnpugen.gen_op_plugin_functions",
-    "torchnpugen.gen_derivatives",
-    "torchnpugen.gen_op_backend",
-    "torchnpugen.gen_backend_stubs",
-    "torchnpugen.struct.gen_struct_opapi",
-)
 
 
 def _ok(message: str) -> None:
@@ -66,18 +48,6 @@ def _import_module(failures: list[str], module_name: str):
     return module
 
 
-def _find_module(failures: list[str], module_name: str) -> None:
-    try:
-        spec = importlib.util.find_spec(module_name)
-    except Exception as exc:
-        _fail(failures, f"{module_name}: {exc}")
-        return
-    if spec is None:
-        _fail(failures, f"{module_name}: not found")
-        return
-    _ok(f"{module_name}: {spec.origin or 'namespace package'}")
-
-
 def _distribution_version(name: str) -> str:
     try:
         return metadata.version(name)
@@ -102,45 +72,6 @@ def _version_obj(value: str) -> Optional[Version]:
         return Version(value.split("+", 1)[0])
     except InvalidVersion:
         return None
-
-
-def _version_key(value: str) -> Optional[Tuple[int, int, int]]:
-    parts = re.findall(r"\d+", value.split("+", 1)[0])
-    if not parts:
-        return None
-    nums = [int(part) for part in parts[:3]]
-    while len(nums) < 3:
-        nums.append(0)
-    return tuple(nums)
-
-
-def _check_torch_npu_gdn_fix(failures: list[str], actual: str) -> None:
-    actual_version = _version_obj(actual)
-    if actual_version is None:
-        _fail(failures, f"torch_npu has unsupported version string: {actual}")
-        return
-
-    minimum = TORCH_NPU_GDN_FIX_MINIMUMS.get(actual_version.base_version)
-    if minimum and actual_version >= Version(minimum):
-        return
-
-    if actual_version >= Version(MIN_TORCH_NPU_FUTURE_FIX_FAMILY):
-        return
-
-    if minimum is None:
-        return
-
-    requirements = ", ".join(
-        f"{family}>={minimum}" for family, minimum in TORCH_NPU_GDN_FIX_MINIMUMS.items()
-    )
-    _fail(
-        failures,
-        "torch_npu must come from an Ascend PyTorch release that contains the "
-        "GDN aclnn_extension stream fix. Packages from releases before "
-        "v26.1.0-beta.1, such as v26.0.0-pytorch2.x, are rejected. "
-        f"Expected one of: {requirements}, or torch_npu>={MIN_TORCH_NPU_FUTURE_FIX_FAMILY} "
-        f"from {TORCH_NPU_GDN_FIX_RELEASE_URL}; got {actual}.",
-    )
 
 
 def _check_triton_ascend_a5_compat(failures: list[str], actual: str) -> None:
@@ -204,7 +135,10 @@ def main() -> int:
     parser.add_argument(
         "--skip-torchnpugen",
         action="store_true",
-        help="Skip torchnpugen checks. Intended only for internal maintenance builds.",
+        help=(
+            "Skip torchnpugen import checks for internal maintenance builds. "
+            "The PyTorch C++ extension capability check still runs."
+        ),
     )
     args = parser.parse_args()
 
@@ -264,13 +198,26 @@ def main() -> int:
     if torch_npu is not None:
         torch_npu_version = getattr(torch_npu, "__version__", "<unknown>")
         _ok(f"torch_npu version: {torch_npu_version}")
-        _check_torch_npu_gdn_fix(failures, torch_npu_version)
+        if args.legacy_extension:
+            stream_fix_error = torch_npu_gdn_stream_fix_error(torch_npu_version)
+            if stream_fix_error:
+                _fail(failures, stream_fix_error)
+            else:
+                _ok(
+                    "torch_npu legacy GDN stream safety: "
+                    f"{torch_npu_version}"
+                )
 
-    if args.legacy_extension and not args.skip_torchnpugen:
-        for module_name in TORCHNPUGEN_MODULES:
-            _find_module(failures, module_name)
-    elif args.skip_torchnpugen:
-        _warn("skipping torchnpugen checks")
+    if args.legacy_extension:
+        if args.skip_torchnpugen:
+            _warn("skipping torchnpugen import checks")
+        for probe in probe_legacy_build_capabilities(
+            include_torchnpugen=not args.skip_torchnpugen
+        ):
+            if probe.available:
+                _ok(f"{probe.requirement}: {probe.detail}")
+            else:
+                _fail(failures, f"{probe.requirement}: {probe.detail}")
 
     if check_runtime:
         triton = _import_module(failures, "triton")

--- a/scripts/fla_npu_build_capabilities.py
+++ b/scripts/fla_npu_build_capabilities.py
@@ -1,0 +1,156 @@
+"""Shared capability probes for the optional legacy PyTorch extension build."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from packaging.version import InvalidVersion, Version
+
+
+TORCHNPUGEN_MODULES = (
+    "torchnpugen.gen_op_plugin_functions",
+    "torchnpugen.gen_derivatives",
+    "torchnpugen.gen_op_backend",
+    "torchnpugen.gen_backend_stubs",
+    "torchnpugen.struct.gen_struct_opapi",
+)
+
+CPP_EXTENSION_MODULE = "torch.utils.cpp_extension"
+CPP_EXTENSION_SYMBOLS = ("BuildExtension", "CppExtension")
+
+KNOWN_GDN_STREAM_FIX_MINIMUMS = {
+    "2.7.1": "2.7.1.post5",
+    "2.8.0": "2.8.0.post5",
+    "2.9.0": "2.9.0.post3",
+    "2.10.0": "2.10.0.post2",
+    "2.11.0": "2.11.0rc3",
+    "2.12.0": "2.12.0rc1",
+}
+MIN_TORCH_NPU_FUTURE_STREAM_FIX_FAMILY = "2.13.0"
+TORCH_NPU_GDN_STREAM_FIX_RELEASE_URL = (
+    "https://gitcode.com/Ascend/pytorch/releases?"
+    "presetConfig={%22tags%22:229,%22release%22:122}"
+)
+
+
+@dataclass(frozen=True)
+class CapabilityProbe:
+    requirement: str
+    available: bool
+    detail: str
+
+
+def _module_origin(module) -> str:
+    return getattr(module, "__file__", None) or "built-in or namespace package"
+
+
+def _import_error(exc: Exception) -> str:
+    return f"{type(exc).__name__}: {exc}"
+
+
+def probe_legacy_build_capabilities(
+    *, include_torchnpugen: bool = True
+) -> Tuple[CapabilityProbe, ...]:
+    """Import the modules and symbols used by the legacy extension build.
+
+    The imports intentionally happen only when this function is called so the
+    default Python-only wheel build remains independent of torch, torch_npu,
+    torchnpugen, and the PyTorch C++ extension ABI.
+    """
+
+    probes = []
+
+    try:
+        cpp_extension = importlib.import_module(CPP_EXTENSION_MODULE)
+    except Exception as exc:
+        detail = f"module import failed: {_import_error(exc)}"
+        probes.extend(
+            CapabilityProbe(
+                requirement=f"{CPP_EXTENSION_MODULE}.{symbol}",
+                available=False,
+                detail=detail,
+            )
+            for symbol in CPP_EXTENSION_SYMBOLS
+        )
+    else:
+        origin = _module_origin(cpp_extension)
+        for symbol in CPP_EXTENSION_SYMBOLS:
+            if hasattr(cpp_extension, symbol):
+                probes.append(
+                    CapabilityProbe(
+                        requirement=f"{CPP_EXTENSION_MODULE}.{symbol}",
+                        available=True,
+                        detail=origin,
+                    )
+                )
+            else:
+                probes.append(
+                    CapabilityProbe(
+                        requirement=f"{CPP_EXTENSION_MODULE}.{symbol}",
+                        available=False,
+                        detail=f"required attribute is missing from {origin}",
+                    )
+                )
+
+    if include_torchnpugen:
+        for module_name in TORCHNPUGEN_MODULES:
+            try:
+                module = importlib.import_module(module_name)
+            except Exception as exc:
+                probes.append(
+                    CapabilityProbe(
+                        requirement=module_name,
+                        available=False,
+                        detail=_import_error(exc),
+                    )
+                )
+            else:
+                probes.append(
+                    CapabilityProbe(
+                        requirement=module_name,
+                        available=True,
+                        detail=_module_origin(module),
+                    )
+                )
+
+    return tuple(probes)
+
+
+def _version_obj(value: str) -> Optional[Version]:
+    try:
+        return Version(value.split("+", 1)[0])
+    except InvalidVersion:
+        return None
+
+
+def torch_npu_gdn_stream_fix_error(actual: str) -> Optional[str]:
+    """Return the legacy GDN stream-policy failure, independently of imports."""
+
+    actual_version = _version_obj(actual)
+    if actual_version is None:
+        return f"torch_npu has an unsupported version string: {actual}"
+
+    minimum = KNOWN_GDN_STREAM_FIX_MINIMUMS.get(actual_version.base_version)
+    if minimum and actual_version >= Version(minimum):
+        return None
+
+    if actual_version >= Version(MIN_TORCH_NPU_FUTURE_STREAM_FIX_FAMILY):
+        return None
+
+    if minimum is None:
+        return None
+
+    requirements = ", ".join(
+        f"{family}>={minimum}"
+        for family, minimum in KNOWN_GDN_STREAM_FIX_MINIMUMS.items()
+    )
+    return (
+        "torch_npu must come from an Ascend PyTorch release that contains the "
+        "GDN aclnn_extension stream fix. Packages from releases before "
+        "v26.1.0-beta.1, such as v26.0.0-pytorch2.x, are rejected. "
+        f"Expected one of: {requirements}, or "
+        f"torch_npu>={MIN_TORCH_NPU_FUTURE_STREAM_FIX_FAMILY} from "
+        f"{TORCH_NPU_GDN_STREAM_FIX_RELEASE_URL}; got {actual}."
+    )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ import shutil
 import stat
 import subprocess
 import sys
-import re
 import time
 from pathlib import Path
 
@@ -31,6 +30,10 @@ TRITON_CORE_PACKAGE = "fla_npu.ops.triton.triton_core"
 TRITON_CORE_SOURCE = REPO_ROOT / "fla" / "ops" / "triton" / "triton_core"
 
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from fla_npu_build_capabilities import (  # noqa: E402
+    probe_legacy_build_capabilities,
+    torch_npu_gdn_stream_fix_error,
+)
 from fla_npu_artifacts import get_package_version, get_wheel_build_tag  # noqa: E402
 
 
@@ -40,27 +43,6 @@ MIN_PYTHON = (3, 9)
 MIN_TORCH = "2.6.0"
 MIN_TRITON_ASCEND = "3.2.0"
 MIN_TRITON_ASCEND_A5 = "3.2.1"
-TORCH_NPU_GDN_FIX_MINIMUMS = {
-    "2.7.1": "2.7.1.post5",
-    "2.8.0": "2.8.0.post5",
-    "2.9.0": "2.9.0.post3",
-    "2.10.0": "2.10.0.post2",
-    "2.11.0": "2.11.0rc3",
-    "2.12.0": "2.12.0rc1",
-}
-MIN_TORCH_NPU_FUTURE_FIX_FAMILY = "2.13.0"
-TORCH_NPU_GDN_FIX_RELEASE_URL = (
-    "https://gitcode.com/Ascend/pytorch/releases?"
-    "presetConfig={%22tags%22:229,%22release%22:122}"
-)
-
-TORCHNPUGEN_MODULES = (
-    "torchnpugen.gen_op_plugin_functions",
-    "torchnpugen.gen_derivatives",
-    "torchnpugen.gen_op_backend",
-    "torchnpugen.gen_backend_stubs",
-    "torchnpugen.struct.gen_struct_opapi",
-)
 
 
 def _read_requirements():
@@ -131,44 +113,6 @@ def _version_obj(value):
         return Version(value.split("+", 1)[0])
     except InvalidVersion:
         return None
-
-
-def _version_key(value):
-    parts = re.findall(r"\d+", value.split("+", 1)[0])
-    if not parts:
-        return None
-    nums = [int(part) for part in parts[:3]]
-    while len(nums) < 3:
-        nums.append(0)
-    return tuple(nums)
-
-
-def _check_torch_npu_gdn_fix(failures, actual):
-    actual_version = _version_obj(actual)
-    if actual_version is None:
-        failures.append(f"torch_npu has an unsupported version string: {actual}")
-        return
-
-    minimum = TORCH_NPU_GDN_FIX_MINIMUMS.get(actual_version.base_version)
-    if minimum and actual_version >= Version(minimum):
-        return
-
-    if actual_version >= Version(MIN_TORCH_NPU_FUTURE_FIX_FAMILY):
-        return
-
-    if minimum is None:
-        return
-
-    requirements = ", ".join(
-        f"{family}>={minimum}" for family, minimum in TORCH_NPU_GDN_FIX_MINIMUMS.items()
-    )
-    failures.append(
-        "torch_npu must come from an Ascend PyTorch release that contains the "
-        "GDN aclnn_extension stream fix. Packages from releases before "
-        "v26.1.0-beta.1, such as v26.0.0-pytorch2.x, are rejected. "
-        f"Expected one of: {requirements}, or torch_npu>={MIN_TORCH_NPU_FUTURE_FIX_FAMILY} "
-        f"from {TORCH_NPU_GDN_FIX_RELEASE_URL}; got {actual}."
-    )
 
 
 def _check_triton_ascend_a5_compat(failures, actual):
@@ -266,7 +210,15 @@ def _check_build_environment():
         if torch is not None:
             _check_min_version(failures, "torch", getattr(torch, "__version__", ""), MIN_TORCH)
         if torch_npu is not None:
-            _check_torch_npu_gdn_fix(failures, getattr(torch_npu, "__version__", ""))
+            torch_npu_version = getattr(torch_npu, "__version__", "")
+            stream_fix_error = torch_npu_gdn_stream_fix_error(torch_npu_version)
+            if stream_fix_error:
+                failures.append(stream_fix_error)
+            else:
+                print(
+                    "[fla-npu build][OK] torch_npu legacy GDN stream safety: "
+                    f"{torch_npu_version}"
+                )
 
         triton_ascend_version = _distribution_version("triton-ascend")
         try:
@@ -284,17 +236,19 @@ def _check_build_environment():
     else:
         print("[fla-npu build][OK] Skipping torch/torch_npu build-time checks for Python-only wheel")
 
-    if build_legacy_extension and not _env_flag("FLA_NPU_SKIP_TORCH_GEN"):
-        for module in TORCHNPUGEN_MODULES:
-            try:
-                spec = importlib.util.find_spec(module)
-            except Exception as exc:
-                failures.append(f"{module}: {exc}")
-                continue
-            if spec is None:
-                failures.append(f"{module}: not found")
+    if build_legacy_extension:
+        include_torchnpugen = not _env_flag("FLA_NPU_SKIP_TORCH_GEN")
+        if not include_torchnpugen:
+            print("[fla-npu build][WARN] Skipping torchnpugen import checks")
+        for probe in probe_legacy_build_capabilities(
+            include_torchnpugen=include_torchnpugen
+        ):
+            if probe.available:
+                print(
+                    f"[fla-npu build][OK] {probe.requirement}: {probe.detail}"
+                )
             else:
-                print(f"[fla-npu build][OK] {module}: {spec.origin or 'namespace package'}")
+                failures.append(f"{probe.requirement}: {probe.detail}")
 
     print(f"[fla-npu build][OK] FLA_NPU_SOC={os.getenv('FLA_NPU_SOC', DEFAULT_SOC)}")
     print(f"[fla-npu build][OK] FLA NPU vendor={DEFAULT_VENDOR_NAME}")

--- a/tests/test_build_capabilities.py
+++ b/tests/test_build_capabilities.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import importlib
+import runpy
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+try:
+    import packaging.version  # noqa: F401
+except ImportError:
+    from pip._vendor import packaging as vendored_packaging
+    from pip._vendor.packaging import version as vendored_packaging_version
+
+    sys.modules["packaging"] = vendored_packaging
+    sys.modules["packaging.version"] = vendored_packaging_version
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import fla_npu_build_capabilities as capabilities  # noqa: E402
+
+try:
+    import setuptools
+except ImportError:
+    setuptools = None
+
+
+def _module(path: str, **attributes):
+    return types.SimpleNamespace(__file__=path, **attributes)
+
+
+class LegacyBuildCapabilityTest(unittest.TestCase):
+    def test_probes_real_modules_and_cpp_extension_symbols(self) -> None:
+        cpp_extension = _module(
+            "/fake/torch/utils/cpp_extension.py",
+            BuildExtension=object(),
+            CppExtension=object(),
+        )
+
+        def fake_import(module_name: str):
+            if module_name == capabilities.CPP_EXTENSION_MODULE:
+                return cpp_extension
+            return _module(f"/fake/{module_name.replace('.', '/')}.py")
+
+        with mock.patch.object(
+            capabilities.importlib, "import_module", side_effect=fake_import
+        ) as import_module:
+            probes = capabilities.probe_legacy_build_capabilities()
+
+        self.assertTrue(all(probe.available for probe in probes))
+        self.assertEqual(
+            [call.args[0] for call in import_module.call_args_list],
+            [capabilities.CPP_EXTENSION_MODULE, *capabilities.TORCHNPUGEN_MODULES],
+        )
+
+    def test_child_module_import_failure_is_reported_with_exception_type(self) -> None:
+        broken_module = capabilities.TORCHNPUGEN_MODULES[2]
+        cpp_extension = _module(
+            "/fake/torch/utils/cpp_extension.py",
+            BuildExtension=object(),
+            CppExtension=object(),
+        )
+
+        def fake_import(module_name: str):
+            if module_name == capabilities.CPP_EXTENSION_MODULE:
+                return cpp_extension
+            if module_name == broken_module:
+                raise ModuleNotFoundError("No module named 'missing_dependency'")
+            return _module(f"/fake/{module_name.replace('.', '/')}.py")
+
+        with mock.patch.object(
+            capabilities.importlib, "import_module", side_effect=fake_import
+        ):
+            probes = capabilities.probe_legacy_build_capabilities()
+
+        failure = next(
+            probe for probe in probes if probe.requirement == broken_module
+        )
+        self.assertFalse(failure.available)
+        self.assertEqual(
+            failure.detail,
+            "ModuleNotFoundError: No module named 'missing_dependency'",
+        )
+
+    def test_missing_cpp_extension_symbol_is_reported(self) -> None:
+        cpp_extension = _module(
+            "/fake/torch/utils/cpp_extension.py",
+            BuildExtension=object(),
+        )
+        with mock.patch.object(
+            capabilities.importlib,
+            "import_module",
+            return_value=cpp_extension,
+        ):
+            probes = capabilities.probe_legacy_build_capabilities(
+                include_torchnpugen=False
+            )
+
+        cpp_extension_probe = next(
+            probe
+            for probe in probes
+            if probe.requirement.endswith(".CppExtension")
+        )
+        self.assertFalse(cpp_extension_probe.available)
+        self.assertIn("required attribute is missing", cpp_extension_probe.detail)
+
+    def test_skipping_torchnpugen_still_checks_cpp_extension(self) -> None:
+        cpp_extension = _module(
+            "/fake/torch/utils/cpp_extension.py",
+            BuildExtension=object(),
+            CppExtension=object(),
+        )
+        with mock.patch.object(
+            capabilities.importlib,
+            "import_module",
+            return_value=cpp_extension,
+        ) as import_module:
+            probes = capabilities.probe_legacy_build_capabilities(
+                include_torchnpugen=False
+            )
+
+        self.assertEqual(
+            import_module.call_args_list,
+            [mock.call(capabilities.CPP_EXTENSION_MODULE)],
+        )
+        self.assertEqual(len(probes), len(capabilities.CPP_EXTENSION_SYMBOLS))
+        self.assertTrue(all(probe.available for probe in probes))
+
+    def test_stream_policy_is_independent_of_import_capabilities(self) -> None:
+        for family, minimum in capabilities.KNOWN_GDN_STREAM_FIX_MINIMUMS.items():
+            with self.subTest(family=family, minimum=minimum):
+                self.assertIsNone(
+                    capabilities.torch_npu_gdn_stream_fix_error(minimum)
+                )
+
+        self.assertIn(
+            "GDN aclnn_extension stream fix",
+            capabilities.torch_npu_gdn_stream_fix_error("2.7.1.post4"),
+        )
+        self.assertIn(
+            "unsupported version string",
+            capabilities.torch_npu_gdn_stream_fix_error("internal-build"),
+        )
+
+
+class CapabilityIntegrationTest(unittest.TestCase):
+    @unittest.skipIf(setuptools is None, "setuptools is required to load setup.py")
+    def test_python_only_setup_check_does_not_probe_legacy_dependencies(self) -> None:
+        setup_kwargs = {}
+
+        def capture_setup(**kwargs) -> None:
+            setup_kwargs.update(kwargs)
+
+        with mock.patch.object(setuptools, "setup", side_effect=capture_setup):
+            setup_globals = runpy.run_path(str(REPO_ROOT / "setup.py"))
+
+        check_build_environment = setup_globals["_check_build_environment"]
+        function_globals = check_build_environment.__globals__
+        legacy_probe = mock.Mock(
+            side_effect=AssertionError("legacy capability probe must not run")
+        )
+
+        with mock.patch.dict(
+            function_globals,
+            {"probe_legacy_build_capabilities": legacy_probe},
+        ), mock.patch.dict(
+            "os.environ",
+            {"ASCEND_HOME_PATH": "/fake/cann"},
+            clear=True,
+        ), mock.patch.object(
+            function_globals["shutil"], "which", return_value="/usr/bin/bash"
+        ), mock.patch.object(
+            function_globals["importlib"],
+            "import_module",
+            side_effect=AssertionError("Python-only build must not import runtime modules"),
+        ):
+            check_build_environment()
+
+        legacy_probe.assert_not_called()
+
+    def test_environment_preflight_uses_shared_probe_without_find_spec(self) -> None:
+        setup_source = (REPO_ROOT / "setup.py").read_text(encoding="utf-8")
+        preflight_source = (SCRIPTS_DIR / "check_npu_env.py").read_text(
+            encoding="utf-8"
+        )
+
+        for source in (setup_source, preflight_source):
+            self.assertIn("probe_legacy_build_capabilities", source)
+            self.assertNotIn("find_spec", source)
+            self.assertNotIn("TORCHNPUGEN_MODULES =", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 关联问题

Closes #326

将 legacy PyTorch C++ 扩展的构建能力检查与 GDN stream 修复版本校验分开。构建依赖是否可用，以实际导入结果为准；stream 修复是否满足要求，继续由独立版本策略判断。

## 修改方式

**所有环境检查集中在现有 `scripts/check_npu_env.py`，不新增脚本或测试文件。**

- `setup.py` 复用 `check_npu_env.py` 中的能力探测和 stream 版本校验函数，避免维护两套规则。导入检查脚本不会执行命令行入口或主动加载框架依赖。
- 真实导入五个 `torchnpugen` 子模块，并检查 `BuildExtension`、`CppExtension`；失败时报告具体模块、异常类型和原因。
- 按 `gen.sh` 的实际条件，探测前临时设置去掉本地后缀的 `PYTORCH_VERSION`，结束后恢复原环境。A5 实测确认，该变量缺失会使 `torchnpugen.struct.gen_struct_opapi` 导入时出现 `NoneType.split` 异常。
- 构建能力与 stream 版本策略分别报告；模块可导入不等于包含 stream 修复。例如 `2.7.1.post5.dev20260618` 即使通过能力检查，仍不满足当前 stream 版本下限。
- 保留当前工具链、CANN 9.x 预检，以及默认 stable ABI 启动库和纯 ctypes 编包路径。默认非 legacy 路径不执行 legacy 专用能力探测和 stream 校验。
- 必要的回归用例并入现有 `tests/test_wheel_environment.py`。移除先前新增的 `scripts/fla_npu_build_capabilities.py` 和 `tests/test_build_capabilities.py`。

`--skip-torchnpugen` / `FLA_NPU_SKIP_TORCH_GEN` 仅跳过代码生成模块检查，legacy 构建仍检查 PyTorch C++ 扩展接口。

## 使用方式

按 README，统一使用原有入口：

```bash
# 完整环境预检
python scripts/check_npu_env.py

# 基础编包环境预检
python scripts/check_npu_env.py --build-only

# 显式构建 legacy 扩展时的预检
python scripts/check_npu_env.py --build-only --legacy-extension
```

默认 stable ABI 启动库仍需要 PyTorch；`--build-only` 不代表整个默认编包过程完全不需要 PyTorch。未启用 legacy 扩展时，可设置 `FLA_NPU_BUILD_STABLE_ABI=0` 使用纯 ctypes 路径。

## 变更范围

- [x] 问题修复
- [x] 构建与环境预检
- [x] 文档与回归测试

相对主线仅修改 5 个已有文件：`scripts/check_npu_env.py`、`setup.py`、`tests/test_wheel_environment.py`、`README.md` 和解耦架构说明。无算子 kernel、tiling、公开算子接口或 aclnn ABI 变更。提交人：Ensley0304。

## 验证结果

环境：A5 / Ascend950，CANN 9.1.0，Python 3.10.20，PyTorch 2.7.1+cpu，torch_npu 2.7.1.post5，triton-ascend 3.2.1。

### 本次主线冲突解决后复测

提交 `fd406b4f` 已合并主线 `45838919`，保留新增的算子名称校验及其他主线功能，并精简架构说明：

| 项目 | 结果 |
| --- | --- |
| `python -m unittest discover -s tests -p test_wheel_environment.py -v` | 27 项全部通过 |
| `python scripts/check_npu_env.py --build-only` | 通过 |
| `python scripts/check_npu_env.py --build-only --legacy-extension` | 通过，包含真实模块导入与独立 stream 校验 |
| 主线算子过滤及编包函数语法树比对 | 与主线一致；合法算子通过、非法名称被拒绝 |
| Python 语法检查与差异空白检查 | 通过 |

原有测试中的文件组织断言已移除，其余 8 项能力与行为回归用例并入现有的 19 项 wheel 环境测试。

### 前一版本完成的实际编包与运行验证

提交 `58e61722` 已完成默认 stable ABI 启动库 + 全量 OPP 的 A5 编包、wheel 隔离安装及仓库自带 API 检查。安装后执行 SolveTri：fp16、BSND、形状 `[1,64,1,64]`，零输入的输出严格等于单位矩阵，`rtol=0, atol=0`。

产物：`flash_linear_attention_npu-26.7.0.dev0-950.x86_64-py3-none-linux_x86_64.whl`。

最终 SHA256：`d506c85897b2cf7e1b97b0e84876aedb114732f7854e0a0d1f88cb053b8859bf`。

本次合并主线并精简文档，已复测上述检查入口，未重新执行全量 kernel 编译或 NPU 算子运行；前一版本的产物不标记为当前提交的新产物。

验证使用 `PYTHONNOUSERSITE=1`、取消 `PYTHONPATH`、设置 `TORCH_DEVICE_BACKEND_AUTOLOAD=0`；legacy 预检仍显式导入 torch_npu。环境中的 conda CMake 启动脚本存在旧解释器路径问题，通过临时 PATH 使用系统 CMake 3.28.3，未更改环境安装。

## 待完成与合入要求

- 当前提交仍需正式 A2+A5 NPU CI 和全部必需检查，并满足 2 个审核批准；旧提交的 CI 结果不能替代当前提交的门禁。
- legacy 路径已完成真实依赖预检，尚未执行完整 legacy 扩展 wheel 编包。
- 人工验证未覆盖 A2/A3 编包与完整 GDN 端到端精度回归；SolveTri 仅用于安装后的基本加载与执行验证。
- 可整体回退本 PR，无算子 ABI 或数据格式迁移。
