### PR TITLE
fix(kda): 修复 A5 ChunkKdaFwd 多 chunk 执行超时

### DIFF
--- a/fla/ops/ascendc/kda/chunk_kda_fwd/README.md
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/README.md
@@ -3,7 +3,8 @@
 ## 功能
 
 `ChunkKdaFwd` 对齐不涉及 CP 切分的 FLA `chunk_kda_fwd` 顶层语义。公共接口接收 raw gate 或已激活的
-自然对数 gate，在 L2 内调用 `KdaGateCumsum`，再依次发射 Prepare、PostWu、FwdH 和 Finalize。
+自然对数 gate。Gate、Prepare、PostWu、FwdH 和 Finalize 复用同一个私有 L0；A5 的非对齐多 chunk
+场景按四个阶段依次提交，其他场景保持单次提交。该内部调度不改变 ACLNN 或 Python 公共接口。
 
 Shape 符号与布局约定见 [KDA 模型符号表](../README.md#model-shape-symbols)。
 

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/docs/design.md
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/docs/design.md
@@ -16,9 +16,11 @@ raw g -> ChunkKdaFwd[
 ] -> attn_out
 ```
 
-`aclnnChunkKdaFwd` 做公开 layout 的连续化和必要视图转换，然后只启动一个物理
-`ChunkKdaFwd` L0。Gate、Prepare、Post-WU、FwdH 和 Finalize 均是该 L0 内部阶段，不再注册或
-启动私有阶段 L0。选择所需信息均由既有输入、shape 和属性推导，不增加公开属性或接口字段。
+`aclnnChunkKdaFwd` 做公开 layout 的连续化和必要视图转换。A5 的 BF16、chunk=64、K=V=128
+dense 对齐快路径保持单次物理 `ChunkKdaFwd` L0；A5 其他多 chunk 场景将同一个私有 L0 按
+Gate/Prepare、Post-WU、FwdH、Finalize 四个阶段依次提交，使阶段间通过物理 launch 边界重置事件状态。
+A2/A3 和单 chunk 场景仍使用单次物理 L0。阶段选择仅使用私有 `stage` 属性，不增加公开属性、
+接口字段或独立算子原型。
 
 ## 阶段职责
 
@@ -84,9 +86,10 @@ sequence-major，并按 `state_v_first` 决定末两维顺序。`final_state` �
 ## 重计算策略
 
 L2 不理解 autograd 重计算策略。`final_state/gk/w/u/qg/kg/v_new/h` 是相互独立的
-`OPTIONAL_OUTPUT`；非空指针表示导出，空指针表示不公开该结果。arch35 快路径为隐藏输出传递
-固定 ABI 占位，并由 tiling 在 kernel workspace 中承接实际中间结果；通用路径使用同一规则。
-公开输出存在时直接作为内部目标使用。
+`OPTIONAL_OUTPUT`；非空指针表示导出，空指针表示不公开该结果。单 launch 路径为隐藏输出传递
+固定 ABI 占位，并由 tiling 在 kernel workspace 中承接实际中间结果。A5 四段 launch 路径将
+阶段间依赖的 `gk/w/u/qg/kg/v_new/h/final_state` 和私有 `qg_scaled/u_seed` 物化为 executor 内部张量，
+使后续 launch 不依赖前一 launch 的 kernel workspace。公开输出存在时直接作为内部目标使用。
 
 Python/legacy 包装层对齐 fla-org `chunk_kda_fwd` 提交
 `0f0f0c97af39343855b43bbbaddcedfda5cb9d77`：
@@ -98,27 +101,29 @@ Python/legacy 包装层对齐 fla-org `chunk_kda_fwd` 提交
 - `final_state` 只在 `output_final_state=true` 时创建公开输出。
 
 内部 `hCompute` 与公开 `hOut` 是两个生命周期：`hCompute` 是 FwdH 到 Finalize 的必需
-head-major 阶段结果，`hOut` 为空时由 kernel workspace 承接；`hOut` 非空时，L2 提供 head-major
-临时输出并在导出边界转为 sequence-major。该规则对齐非 CP 的低层 12 返回值接口；
+head-major 阶段结果；`hOut` 为空时，单 launch 路径由 kernel workspace 承接，四段路径由 executor
+内部张量承接。`hOut` 非空时，L2 提供 head-major 临时输出并在导出边界转为 sequence-major。
+该规则对齐非 CP 的低层 12 返回值接口；
 第 12 项 `initial_state` 由 Python 层原对象透传。
 
 ## 模板化方案与 tiling key
 
-物理 `ChunkKdaFwd` 只有一个外层 `op_kernel/chunk_kda_fwd.cpp` 入口。A5 实现位于
+`ChunkKdaFwd` 只有一个外层 `op_kernel/chunk_kda_fwd.cpp` 入口和一个私有 L0 类型。A5 实现位于
 `op_kernel/arch35/*.h`，host 侧 A5 模板选择位于 `op_host/arch35/*.h`。Prepare、Post-WU、
 Finalize 的内部实现头与统一 kernel 入口同属 `chunk_kda_fwd/op_kernel/`，不存在对应的独立 L0
-原型或 `.cpp` 入口。
+原型或 `.cpp` 入口。A5 四段路径只是用不同私有 `stage` 属性连续调用该入口。
 
 - `tiling key=1`：非 chunk=64、K=V=128 场景的通用模板族。
 - `tiling key=2`：chunk=64、K=V=128 模板族，包括 dense、tail 和 varlen。
 
-两个 key 是同一物理 L0 的编译期场景变体，不是平台编号、独立算子或独立接口。A2/A3/A5
+两个 key 是同一 L0 的编译期场景变体，不是平台编号、独立算子或独立接口。A2/A3/A5
 均生成两个 key；同一个 key 内再由编译架构选择根目录通用实现或 `arch35/` 实现。host 的
 `SetTilingKey` 只检查 chunk、K、V，不检查 SoC。
 
-在 arch35 上，key2 的完整 64 行 chunk 使用 Prepare/Post-WU 成批融合流水；tail 使用同一物理
-L0 内的边界实现。dense 对齐场景使用 arch35 FwdH；tail/varlen 内嵌共享 FwdH。其他架构在
-同一 key2 下使用其对应实现。tiling key 不改变算子原型、输出契约或数学定义。
+在 arch35 上，key2 的 dense 对齐场景使用单 launch 融合流水和 arch35 FwdH。A5 多 chunk 的
+tail/varlen 以及 key1 泛化场景使用四段 launch，并在 FwdH 阶段复用共享实现。其他架构在同一
+key2 下使用其对应单 launch 实现。tiling key 和私有 `stage` 均不改变公开算子原型、输出契约
+或数学定义。
 
 ## 性能设计
 

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/chunk_kda_fwd_def.cpp
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/chunk_kda_fwd_def.cpp
@@ -67,6 +67,8 @@ public:
         this->Output("kg").ParamType(OPTIONAL).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
         this->Output("v_new").ParamType(OPTIONAL).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
         this->Output("h").ParamType(OPTIONAL).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Output("qg_scaled").ParamType(OPTIONAL).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Output("u_seed").ParamType(OPTIONAL).DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
 
         this->Attr("layout").AttrType(OPTIONAL).String("BSND");
         this->Attr("scale").AttrType(REQUIRED).Float(1.0);
@@ -75,6 +77,7 @@ public:
         this->Attr("lower_bound").AttrType(OPTIONAL).Float(-5.0);
         this->Attr("use_gate_in_kernel").AttrType(REQUIRED).Bool(false);
         this->Attr("state_v_first").AttrType(OPTIONAL).Bool(false);
+        this->Attr("stage").AttrType(OPTIONAL).Int(-1);
 
         OpAICoreConfig config;
         config.DynamicCompileStaticFlag(true)

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/chunk_kda_fwd_tiling.cpp
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/chunk_kda_fwd_tiling.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include "platform/soc_spec.h"
 #include <register/op_impl_registry.h>
 #include "arch35/chunk_kda_fwd_tiling_impl.h"
 #include "tiling/platform/platform_ascendc.h"

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/chunk_kda_fwd_tiling.cpp
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/chunk_kda_fwd_tiling.cpp
@@ -207,7 +207,7 @@ ge::graphStatus Tiling4ChunkKdaFwd(gert::TilingContext *context)
     const auto platform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
     const uint32_t blockDim = std::max<uint32_t>(platform.GetCoreNumAic(), 1);
     const bool isAscend950 =
-        platform.GetSocVersion() == platform_ascendc::SocVersion::ASCEND950;
+        platform.GetCurNpuArch() == NpuArch::DAV_3510;
     const bool useChunk64K128V128Template =
         chunkSize == 64 && shape.kDim == 128 && shape.vDim == 128;
     const auto arch35Options = arch35::ConfigureChunkKdaFwdArch35(

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/chunk_kda_fwd_tiling.cpp
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/chunk_kda_fwd_tiling.cpp
@@ -33,6 +33,9 @@ constexpr size_t ATTR_CHUNK_SIZE_IDX = 2;
 constexpr size_t ATTR_SAFE_GATE_IDX = 3;
 constexpr size_t ATTR_LOWER_BOUND_IDX = 4;
 constexpr size_t ATTR_USE_GATE_IDX = 5;
+constexpr size_t ATTR_STAGE_IDX = 7;
+constexpr int64_t KDA_STAGE_FULL = -1;
+constexpr int64_t KDA_STAGE_FINALIZE = 3;
 
 constexpr uint64_t KDA_ALIGN = 512;
 constexpr uint64_t KDA_SOLVE_SCRATCH_SLOTS = 5;
@@ -171,7 +174,9 @@ ge::graphStatus Tiling4ChunkKdaFwd(gert::TilingContext *context)
     const bool safeGate = *attrs->GetAttrPointer<bool>(ATTR_SAFE_GATE_IDX);
     const float lowerBound = *attrs->GetAttrPointer<float>(ATTR_LOWER_BOUND_IDX);
     const bool useGateInKernel = *attrs->GetAttrPointer<bool>(ATTR_USE_GATE_IDX);
-    if (chunkSize <= 0) {
+    const int64_t stage = *attrs->GetAttrPointer<int64_t>(ATTR_STAGE_IDX);
+    if (chunkSize <= 0 || stage < KDA_STAGE_FULL ||
+        stage > KDA_STAGE_FINALIZE) {
         return ge::GRAPH_FAILED;
     }
 
@@ -328,6 +333,7 @@ ge::graphStatus Tiling4ChunkKdaFwd(gert::TilingContext *context)
     tiling.set_storeKg(storeKg);
     tiling.set_storeVNew(storeVNew);
     tiling.set_storeH(storeH);
+    tiling.set_stage(stage);
     tiling.set_gateDataType(gDesc->GetDataType() == ge::DT_FLOAT ? 2 :
         (gDesc->GetDataType() == ge::DT_BF16 ? 1 : 0));
     tiling.set_gateUsedCoreNum(static_cast<int64_t>(blockDim) * 2);

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/chunk_kda_fwd_tiling.h
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/chunk_kda_fwd_tiling.h
@@ -37,6 +37,7 @@ TILING_DATA_FIELD_DEF(bool, storeQG);
 TILING_DATA_FIELD_DEF(bool, storeKg);
 TILING_DATA_FIELD_DEF(bool, storeVNew);
 TILING_DATA_FIELD_DEF(bool, storeH);
+TILING_DATA_FIELD_DEF(int64_t, stage);
 
 TILING_DATA_FIELD_DEF(int64_t, gateDataType);
 TILING_DATA_FIELD_DEF(int64_t, gateUsedCoreNum);

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/aclnn_chunk_kda_fwd.cpp
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/aclnn_chunk_kda_fwd.cpp
@@ -32,6 +32,9 @@ extern "C" {
 namespace {
 constexpr int64_t MAX_KDA_K_DIM = 256;
 constexpr int64_t MAX_KDA_HEAD_NUM = 128;
+constexpr int64_t KDA_STAGE_FULL = -1;
+constexpr int64_t KDA_STAGE_GATE_PREPARE = 0;
+constexpr int64_t KDA_STAGE_COUNT = 4;
 
 constexpr int64_t MAX_KDA_VARLEN_SEQUENCES = 1024;
 
@@ -513,6 +516,12 @@ const aclTensor *AsRank4(const aclTensor *tensor, const op::Shape &shape, aclOpE
 {
     return l0op::Reshape(tensor, shape, executor);
 }
+
+bool IsAscend950()
+{
+    const char *socName = aclrtGetSocName();
+    return socName != nullptr && std::strstr(socName, "Ascend950") != nullptr;
+}
 } // namespace
 
 aclnnStatus aclnnChunkKdaFwdGetWorkspaceSize(
@@ -613,13 +622,21 @@ aclnnStatus aclnnChunkKdaFwdGetWorkspaceSize(
     const op::Shape stateShape4 =
         MakeShape({info.seqNum, info.hvNum, info.kDim, info.vDim});
     const op::Shape placeholderShape = MakeShape({1});
+    const bool useDenseA5FastPath =
+        params.cuSeqlensOptional == nullptr && params.q->GetDataType() == DataType::DT_BF16 &&
+        params.chunkSize == 64 && info.kDim == 128 && info.vDim == 128 &&
+        info.seqlen % params.chunkSize == 0;
+    const bool splitStages =
+        IsAscend950() && info.totalChunks > 1 && !useDenseA5FastPath;
 
     const aclTensor *gkCompute = params.gkOut;
     if (gkCompute != nullptr && info.isRank3) {
         gkCompute = AsRank4(gkCompute, gkShape4, executorPtr);
     }
     if (gkCompute == nullptr) {
-        gkCompute = AllocTensor(executorPtr, placeholderShape, DataType::DT_FLOAT);
+        gkCompute = AllocTensor(
+            executorPtr, splitStages ? gkShape4 : placeholderShape,
+            DataType::DT_FLOAT);
     }
     CHECK_RET(gkCompute != nullptr, ACLNN_ERR_INNER_NULLPTR);
 
@@ -657,22 +674,27 @@ aclnnStatus aclnnChunkKdaFwdGetWorkspaceSize(
         akkCompute = AllocTensor(executorPtr, matrixShape4, params.q->GetDataType());
     }
     const aclTensor *wCompute = wExport == nullptr
-        ? AllocTensor(executorPtr, placeholderShape, params.q->GetDataType())
+        ? AllocTensor(executorPtr, splitStages ? kShape4 : placeholderShape,
+                      params.q->GetDataType())
         : wExport;
     const aclTensor *uCompute = uExport == nullptr
-        ? AllocTensor(executorPtr, placeholderShape, params.q->GetDataType())
+        ? AllocTensor(executorPtr, splitStages ? vShape4 : placeholderShape,
+                      params.q->GetDataType())
         : uExport;
     const aclTensor *qgCompute = qgExport == nullptr
-        ? AllocTensor(executorPtr, placeholderShape, params.q->GetDataType())
+        ? AllocTensor(executorPtr, splitStages ? kShape4 : placeholderShape,
+                      params.q->GetDataType())
         : qgExport;
     const aclTensor *kgCompute = kgExport == nullptr
-        ? AllocTensor(executorPtr, placeholderShape, params.q->GetDataType())
+        ? AllocTensor(executorPtr, splitStages ? kShape4 : placeholderShape,
+                      params.q->GetDataType())
         : kgExport;
     const aclTensor *vNewCompute = vNewExport == nullptr
-        ? AllocTensor(executorPtr, placeholderShape, params.q->GetDataType())
+        ? AllocTensor(executorPtr, splitStages ? vShape4 : placeholderShape,
+                      params.q->GetDataType())
         : vNewExport;
     const aclTensor *hCompute = AllocTensor(
-        executorPtr, hExport == nullptr ? placeholderShape : hShape5,
+        executorPtr, hExport == nullptr && !splitStages ? placeholderShape : hShape5,
         params.q->GetDataType());
     CHECK_RET(aqkCompute != nullptr && akkCompute != nullptr && wCompute != nullptr &&
                   uCompute != nullptr && qgCompute != nullptr && kgCompute != nullptr &&
@@ -686,7 +708,7 @@ aclnnStatus aclnnChunkKdaFwdGetWorkspaceSize(
     }
     const bool outputFinalState = params.finalStateOut != nullptr;
     const aclTensor *finalStateCompute = AllocTensor(
-        executorPtr, outputFinalState ? stateShape4 : placeholderShape,
+        executorPtr, outputFinalState || splitStages ? stateShape4 : placeholderShape,
         DataType::DT_FLOAT);
     CHECK_RET(finalStateCompute != nullptr, ACLNN_ERR_INNER_NULLPTR);
 
@@ -697,16 +719,42 @@ aclnnStatus aclnnChunkKdaFwdGetWorkspaceSize(
         CHECK_RET(attnCompute != nullptr, ACLNN_ERR_INNER_NULLPTR);
     }
 
-    auto result = l0op::KdaChunkForward(
-        qHead, kHead, vHead, gHead, betaHead, params.aLogOptional,
-        params.dtBiasOptional, initialStateCompute, params.cuSeqlensOptional,
-        params.chunkIndicesOptional, params.scale, params.chunkSize, params.safeGate,
-        parsedLayout == KdaFwdLayout::BSND, params.useGateInKernel,
-        params.lowerBound, attnCompute, finalStateCompute, gkCompute,
-        aqkCompute, akkCompute, wCompute, uCompute, qgCompute,
-        kgCompute, vNewCompute, hCompute, executorPtr);
-    for (const aclTensor *tensor : result) {
-        CHECK_RET(tensor != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    const aclTensor *qgScaledCompute = AllocTensor(
+        executorPtr, splitStages ? kShape4 : placeholderShape,
+        params.q->GetDataType());
+    const aclTensor *uSeedCompute = AllocTensor(
+        executorPtr, splitStages ? vShape4 : placeholderShape,
+        params.q->GetDataType());
+    CHECK_RET(qgScaledCompute != nullptr && uSeedCompute != nullptr,
+              ACLNN_ERR_INNER_NULLPTR);
+
+    auto launchStage = [&](int64_t stage) {
+        return l0op::KdaChunkForward(
+            qHead, kHead, vHead, gHead, betaHead, params.aLogOptional,
+            params.dtBiasOptional, initialStateCompute, params.cuSeqlensOptional,
+            params.chunkIndicesOptional, params.scale, params.chunkSize,
+            params.safeGate, parsedLayout == KdaFwdLayout::BSND,
+            params.useGateInKernel, params.lowerBound, attnCompute,
+            finalStateCompute, gkCompute, aqkCompute, akkCompute, wCompute,
+            uCompute, qgCompute, kgCompute, vNewCompute, hCompute,
+            qgScaledCompute, uSeedCompute, stage, executorPtr);
+    };
+    l0op::KdaCoreOutputs result{};
+    if (splitStages) {
+        // Physical launch boundaries reset the A5 event state between the
+        // prepare, post-WU, recurrent, and output pipelines.
+        for (int64_t stage = KDA_STAGE_GATE_PREPARE; stage < KDA_STAGE_COUNT;
+             ++stage) {
+            result = launchStage(stage);
+            for (const aclTensor *tensor : result) {
+                CHECK_RET(tensor != nullptr, ACLNN_ERR_INNER_NULLPTR);
+            }
+        }
+    } else {
+        result = launchStage(KDA_STAGE_FULL);
+        for (const aclTensor *tensor : result) {
+            CHECK_RET(tensor != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        }
     }
 
     if (outputFinalState) {

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/chunk_kda_fwd.cpp
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/chunk_kda_fwd.cpp
@@ -46,13 +46,17 @@ KdaCoreOutputs KdaChunkForward(
     const aclTensor *kgOut,
     const aclTensor *vNewOut,
     const aclTensor *hOut,
+    const aclTensor *qgScaledOut,
+    const aclTensor *uSeedOut,
+    int64_t stage,
     aclOpExecutor *executor)
 {
     L0_DFX(KdaChunkForward, q, k, v, g, beta, aLogOptional, dtBiasOptional,
            initialStateOptional, cuSeqlensOptional, chunkIndicesOptional,
            scale, chunkSize, safeGate, inputSequenceMajor, useGateInKernel,
            lowerBound, attnOut, finalStateOut, gkOut, aqkOut, akkOut,
-           wOut, uOut, qgOut, kgOut, vNewOut, hOut);
+           wOut, uOut, qgOut, kgOut, vNewOut, hOut, qgScaledOut, uSeedOut,
+           stage);
 
     const aclTensor *actualCuSeqlens = nullptr;
     if (cuSeqlensOptional != nullptr) {
@@ -79,17 +83,17 @@ KdaCoreOutputs KdaChunkForward(
         OP_INPUT(q, k, v, g, beta, aLogOptional, dtBiasOptional,
                  initialStateOptional, actualCuSeqlens, actualChunkIndices),
         OP_OUTPUT(attnOut, finalStateOut, gkOut, aqkOut, akkOut, wOut, uOut,
-                  qgOut, kgOut, vNewOut, hOut),
+                  qgOut, kgOut, vNewOut, hOut, qgScaledOut, uSeedOut),
         OP_ATTR(inputSequenceMajor ? "BSND" : "BNSD", scale, chunkSize,
                 safeGate, static_cast<float>(lowerBound), useGateInKernel,
-                false));
+                false, stage));
     if (ret != ACLNN_SUCCESS) {
         OP_LOGE(ACLNN_ERR_PARAM_INVALID,
                 "ADD_TO_LAUNCHER_LIST_AICORE ChunkKdaFwd failed.");
         return {};
     }
     return {attnOut, finalStateOut, gkOut, aqkOut, akkOut, wOut, uOut,
-            qgOut, kgOut, vNewOut, hOut};
+            qgOut, kgOut, vNewOut, hOut, qgScaledOut, uSeedOut};
 }
 
 } // namespace l0op

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/chunk_kda_fwd.h
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_host/op_api/chunk_kda_fwd.h
@@ -13,7 +13,7 @@
 #include "opdev/op_executor.h"
 
 namespace l0op {
-using KdaCoreOutputs = std::array<const aclTensor *, 11>;
+using KdaCoreOutputs = std::array<const aclTensor *, 13>;
 
 KdaCoreOutputs KdaChunkForward(
     const aclTensor *q, const aclTensor *k, const aclTensor *v, const aclTensor *g, const aclTensor *beta,
@@ -24,7 +24,9 @@ KdaCoreOutputs KdaChunkForward(
     const aclTensor *attnOut,
     const aclTensor *finalStateOut, const aclTensor *gkOut, const aclTensor *aqkOut,
     const aclTensor *akkOut, const aclTensor *wOut, const aclTensor *uOut, const aclTensor *qgOut,
-    const aclTensor *kgOut, const aclTensor *vNewOut, const aclTensor *hOut, aclOpExecutor *executor);
+    const aclTensor *kgOut, const aclTensor *vNewOut, const aclTensor *hOut,
+    const aclTensor *qgScaledOut, const aclTensor *uSeedOut, int64_t stage,
+    aclOpExecutor *executor);
 } // namespace l0op
 
 #endif

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/chunk_kda_fwd.cpp
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/chunk_kda_fwd.cpp
@@ -12,6 +12,91 @@
 
 namespace KdaForward {
 
+constexpr int64_t KDA_STAGE_FULL = -1;
+constexpr int64_t KDA_STAGE_GATE_PREPARE = 0;
+constexpr int64_t KDA_STAGE_POST_WU = 1;
+constexpr int64_t KDA_STAGE_FWD_H = 2;
+constexpr int64_t KDA_STAGE_FINALIZE = 3;
+
+template <bool SAFE_GATE, typename T, typename BETA_T, typename TilingData,
+          uint32_t COMPILE_BT, uint32_t COMPILE_K, uint32_t COMPILE_V>
+__aicore__ inline void DispatchStage(
+    GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR beta,
+    GM_ADDR aLog, GM_ADDR dtBias, GM_ADDR initialState,
+    GM_ADDR cuSeqlens, GM_ADDR chunkIndices, GM_ADDR attnOut,
+    GM_ADDR finalState, GM_ADDR gk, GM_ADDR aqk, GM_ADDR akk,
+    GM_ADDR w, GM_ADDR u, GM_ADDR qg, GM_ADDR kg, GM_ADDR vNew, GM_ADDR h,
+    GM_ADDR qgScaled, GM_ADDR uSeed, GM_ADDR userWorkspace,
+    const TilingData &tiling)
+{
+    auto addresses = ResolveAddresses(
+        finalState, gk, w, u, qg, kg, vNew, h, userWorkspace, tiling);
+    addresses.qgScaled = qgScaled;
+    if (tiling.stage == KDA_STAGE_GATE_PREPARE) {
+        RunGateCumsum(g, aLog, dtBias, cuSeqlens, addresses.gk, tiling);
+        if (!tiling.computeGateInPrepare) {
+            SyncAll<false>();
+        }
+        TPipe pipe;
+        KdaPrepare::RunChunkKdaPrepare<SAFE_GATE, T, float, BETA_T,
+            TilingData,
+            COMPILE_BT, COMPILE_K, COMPILE_V>(
+            q, k, v, addresses.gk, g, aLog, dtBias, beta, initialState,
+            cuSeqlens, chunkIndices, aqk, akk, addresses.qg,
+            addresses.qgScaled, addresses.w, uSeed, addresses.kg,
+            userWorkspace, tiling, pipe, tiling.storeQG);
+    } else if (tiling.stage == KDA_STAGE_POST_WU) {
+        TPipe pipe;
+        KdaPostWu::RunChunkKdaPostWu<T, float, BETA_T>(
+            q, k, v, addresses.gk, beta, initialState, cuSeqlens,
+            chunkIndices, addresses.w, akk, uSeed, addresses.w,
+            addresses.u, addresses.kg, addresses.vNew, userWorkspace,
+            tiling, pipe);
+    } else if (tiling.stage == KDA_STAGE_FWD_H) {
+        if (tiling.vHeadDim > 128) {
+            RunFwdH<T, Catlass::Gemm::Kernel::GDNFwdHTileShapes256>(
+                initialState, cuSeqlens, chunkIndices, addresses,
+                userWorkspace, tiling);
+        } else {
+            RunFwdH<T, Catlass::Gemm::Kernel::GDNFwdHTileShapes128>(
+                initialState, cuSeqlens, chunkIndices, addresses,
+                userWorkspace, tiling);
+        }
+    } else if (tiling.stage == KDA_STAGE_FINALIZE) {
+        TPipe pipe;
+        KdaFinalize::RunChunkKdaOutput<T, float, BETA_T>(
+            q, k, v, addresses.gk, beta, initialState, cuSeqlens,
+            chunkIndices, addresses.qgScaled, aqk, addresses.vNew,
+            addresses.h, attnOut, userWorkspace, tiling, pipe);
+    }
+}
+
+template <typename T, typename BETA_T, typename TilingData,
+          uint32_t COMPILE_BT, uint32_t COMPILE_K, uint32_t COMPILE_V>
+__aicore__ inline void DispatchStageSafeGate(
+    GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR beta,
+    GM_ADDR aLog, GM_ADDR dtBias, GM_ADDR initialState,
+    GM_ADDR cuSeqlens, GM_ADDR chunkIndices, GM_ADDR attnOut,
+    GM_ADDR finalState, GM_ADDR gk, GM_ADDR aqk, GM_ADDR akk,
+    GM_ADDR w, GM_ADDR u, GM_ADDR qg, GM_ADDR kg, GM_ADDR vNew, GM_ADDR h,
+    GM_ADDR qgScaled, GM_ADDR uSeed, GM_ADDR userWorkspace,
+    const TilingData &tiling)
+{
+    if (tiling.safeGate) {
+        DispatchStage<true, T, BETA_T, TilingData,
+            COMPILE_BT, COMPILE_K, COMPILE_V>(
+            q, k, v, g, beta, aLog, dtBias, initialState, cuSeqlens,
+            chunkIndices, attnOut, finalState, gk, aqk, akk, w, u, qg,
+            kg, vNew, h, qgScaled, uSeed, userWorkspace, tiling);
+    } else {
+        DispatchStage<false, T, BETA_T, TilingData,
+            COMPILE_BT, COMPILE_K, COMPILE_V>(
+            q, k, v, g, beta, aLog, dtBias, initialState, cuSeqlens,
+            chunkIndices, attnOut, finalState, gk, aqk, akk, w, u, qg,
+            kg, vNew, h, qgScaled, uSeed, userWorkspace, tiling);
+    }
+}
+
 template <bool SAFE_GATE, typename T, typename BETA_T, typename TilingData,
           uint32_t COMPILE_BT, uint32_t COMPILE_K, uint32_t COMPILE_V>
 __aicore__ inline void DispatchGeneric(
@@ -103,7 +188,7 @@ extern "C" __global__ __aicore__ void chunk_kda_fwd(
     GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR attn_out,
     GM_ADDR final_state, GM_ADDR gk, GM_ADDR aqk, GM_ADDR akk,
     GM_ADDR w, GM_ADDR u, GM_ADDR qg, GM_ADDR kg, GM_ADDR v_new, GM_ADDR h,
-    GM_ADDR workspace, GM_ADDR tiling)
+    GM_ADDR qg_scaled, GM_ADDR u_seed, GM_ADDR workspace, GM_ADDR tiling)
 {
     KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
     KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
@@ -111,12 +196,30 @@ extern "C" __global__ __aicore__ void chunk_kda_fwd(
     GM_ADDR userWorkspace = AscendC::GetUserWorkspace(workspace);
     GET_TILING_DATA_WITH_STRUCT(ChunkKdaFwdTilingData, tilingData, tiling);
     if (TILING_KEY_IS(1)) {
+        if (tilingData.stage != KdaForward::KDA_STAGE_FULL) {
+            KdaForward::DispatchStageSafeGate<DTYPE_Q, DTYPE_BETA,
+                ChunkKdaFwdTilingData, 0, 0, 0>(
+                q, k, v, g, beta, a_log, dt_bias, initial_state, cu_seqlens,
+                chunk_indices, attn_out, final_state, gk, aqk, akk, w, u,
+                qg, kg, v_new, h, qg_scaled, u_seed, userWorkspace,
+                tilingData);
+            return;
+        }
         KdaForward::DispatchGenericSafeGate<DTYPE_Q, DTYPE_BETA,
             ChunkKdaFwdTilingData, 0, 0, 0>(
             q, k, v, g, beta, a_log, dt_bias, initial_state, cu_seqlens,
             chunk_indices, attn_out, final_state, gk, aqk, akk, w, u, qg,
             kg, v_new, h, userWorkspace, tilingData);
     } else if (TILING_KEY_IS(2)) {
+        if (tilingData.stage != KdaForward::KDA_STAGE_FULL) {
+            KdaForward::DispatchStageSafeGate<DTYPE_Q, DTYPE_BETA,
+                ChunkKdaFwdTilingData, 64, 128, 128>(
+                q, k, v, g, beta, a_log, dt_bias, initial_state, cu_seqlens,
+                chunk_indices, attn_out, final_state, gk, aqk, akk, w, u,
+                qg, kg, v_new, h, qg_scaled, u_seed, userWorkspace,
+                tilingData);
+            return;
+        }
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
         KdaForward::DispatchArch35SafeGate<DTYPE_Q, DTYPE_BETA,
             ChunkKdaFwdTilingData, 64, 128, 128>(

--- a/torch_custom/fla_npu/test/test_npu_chunk_kda_a5_staging.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_kda_a5_staging.py
@@ -1,0 +1,391 @@
+# Copyright (c) 2026 Tianjin University, Ltd.
+
+"""A5 regression coverage for staged ChunkKdaFwd launches."""
+
+from __future__ import annotations
+
+import gc
+import math
+
+import pytest
+import torch
+
+torch_npu = pytest.importorskip("torch_npu")
+
+from fla_npu.ops.ascendc import chunk_kda_fwd  # noqa: E402
+
+
+OUTPUT_NAMES = (
+    "attn_out",
+    "final_state",
+    "gk",
+    "Aqk",
+    "Akk",
+    "w",
+    "u",
+    "qg",
+    "kg",
+    "v_new",
+    "h",
+    "initial_state",
+)
+
+
+def _is_ascend950() -> bool:
+    try:
+        return "950" in torch.npu.get_device_name(0)
+    except Exception:
+        return False
+
+
+def _l2norm(x: torch.Tensor) -> torch.Tensor:
+    dtype = x.dtype
+    x_float = x.float()
+    return (x_float * torch.rsqrt(x_float.square().sum(dim=-1, keepdim=True) + 1e-6)).to(dtype)
+
+
+def _chunk_indices(cu_seqlens: tuple[int, ...], chunk_size: int) -> tuple[int, ...]:
+    return tuple(
+        value
+        for seq_id, (start, end) in enumerate(zip(cu_seqlens, cu_seqlens[1:]))
+        for chunk_id in range(math.ceil((end - start) / chunk_size))
+        for value in (seq_id, chunk_id)
+    )
+
+
+def _chunked_reference(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state_vk: torch.Tensor,
+    cu_seqlens: tuple[int, ...],
+) -> tuple[torch.Tensor, ...]:
+    q, k, v, gate, beta, initial_state_vk = (
+        tensor.detach().cpu()
+        for tensor in (q, k, v, gate, beta, initial_state_vk)
+    )
+    batch, tokens, heads, head_dim = q.shape
+    assert batch == 1
+    chunk_size = 64
+    total_chunks = sum(
+        math.ceil((end - start) / chunk_size)
+        for start, end in zip(cu_seqlens, cu_seqlens[1:])
+    )
+    dtype = q.dtype
+    scale = head_dim**-0.5
+
+    out = torch.empty_like(v)
+    final_state_vk = torch.empty_like(initial_state_vk, dtype=torch.float32)
+    gk = torch.empty((1, heads, tokens, head_dim), dtype=torch.float32)
+    aqk = torch.zeros((1, heads, tokens, chunk_size), dtype=dtype)
+    akk = torch.zeros_like(aqk)
+    w = torch.empty((1, heads, tokens, head_dim), dtype=dtype)
+    u = torch.empty_like(w)
+    qg = torch.empty_like(w)
+    kg = torch.empty_like(w)
+    v_new = torch.empty_like(w)
+    h = torch.empty((1, total_chunks, heads, head_dim, head_dim), dtype=dtype)
+
+    global_chunk = 0
+    for seq_id, (seq_start, seq_end) in enumerate(zip(cu_seqlens, cu_seqlens[1:])):
+        state_kv = initial_state_vk[seq_id].float().transpose(-1, -2).contiguous()
+        chunk_offset = 0
+        for start in range(seq_start, seq_end, chunk_size):
+            end = min(start + chunk_size, seq_end)
+            length = end - start
+            causal = torch.ones((length, length), dtype=torch.bool).tril()
+            strict_causal = torch.ones_like(causal).tril(diagonal=-1)
+            eye = torch.eye(length, dtype=torch.float32).expand(heads, -1, -1)
+            q_block = q[0, start:end].float().transpose(0, 1)
+            k_block = k[0, start:end].float().transpose(0, 1)
+            v_block = v[0, start:end].float().transpose(0, 1)
+            beta_block = beta[0, start:end].float().transpose(0, 1)
+            gk_block = (
+                torch.cumsum(gate[0, start:end].float(), dim=0) / math.log(2.0)
+            ).transpose(0, 1)
+            relative_gate = gk_block[:, :, None, :] - gk_block[:, None, :, :]
+            gate_factor = torch.exp2(
+                relative_gate.masked_fill(~causal[None, :, :, None], 0.0)
+            )
+            qk = torch.einsum("hik,hjk,hijk->hij", q_block, k_block, gate_factor) * scale
+            kk = torch.einsum("hik,hjk,hijk->hij", k_block, k_block, gate_factor)
+            aqk_block = torch.where(causal[None], qk, 0.0)
+            strict_kk = torch.where(strict_causal[None], kk * beta_block[:, :, None], 0.0)
+            akk_block = torch.linalg.solve_triangular(eye + strict_kk, eye, upper=False)
+            w_block = torch.bmm(
+                akk_block,
+                k_block * beta_block[:, :, None] * torch.exp2(gk_block),
+            )
+            u_block = torch.bmm(akk_block, v_block * beta_block[:, :, None])
+            qg_block = q_block * torch.exp2(gk_block)
+            kg_block = k_block * torch.exp2(gk_block[:, -1, None, :] - gk_block)
+            v_new_block = u_block - torch.bmm(w_block, state_kv)
+
+            gk[0, :, start:end] = gk_block
+            aqk[0, :, start:end, :length] = aqk_block.to(dtype)
+            akk[0, :, start:end, :length] = akk_block.to(dtype)
+            w[0, :, start:end] = w_block.to(dtype)
+            u[0, :, start:end] = u_block.to(dtype)
+            qg[0, :, start:end] = qg_block.to(dtype)
+            kg[0, :, start:end] = kg_block.to(dtype)
+            v_new[0, :, start:end] = v_new_block.to(dtype)
+            h[0, global_chunk + chunk_offset] = state_kv.transpose(-1, -2).to(dtype)
+            out[0, start:end] = (
+                torch.bmm(qg_block, state_kv) * scale
+                + torch.bmm(aqk_block, v_new_block)
+            ).transpose(0, 1).to(dtype)
+            state_kv = (
+                torch.exp2(gk_block[:, -1])[:, :, None] * state_kv
+                + torch.bmm(kg_block.transpose(1, 2), v_new_block)
+            )
+            chunk_offset += 1
+        final_state_vk[seq_id] = state_kv.transpose(-1, -2)
+        global_chunk += chunk_offset
+
+    return (
+        out,
+        final_state_vk,
+        gk,
+        aqk,
+        akk,
+        w,
+        u,
+        qg,
+        kg,
+        v_new,
+        h,
+        initial_state_vk,
+    )
+
+
+def _for_layout(tensor: torch.Tensor, layout: str) -> torch.Tensor:
+    if layout == "BSND":
+        return tensor.contiguous()
+    assert layout == "TND"
+    return tensor.squeeze(0).contiguous()
+
+
+def _expected_for_layout(outputs: tuple[torch.Tensor, ...], layout: str) -> tuple[torch.Tensor, ...]:
+    if layout == "BSND":
+        return outputs
+    rank3_indices = {0, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+    return tuple(output.squeeze(0) if index in rank3_indices else output for index, output in enumerate(outputs))
+
+
+def _expected_output_shapes(
+    layout: str,
+    tokens: int,
+    heads: int,
+    head_dim: int,
+    cu_seqlens: tuple[int, ...],
+) -> tuple[tuple[int, ...], ...]:
+    seq_num = len(cu_seqlens) - 1
+    total_chunks = sum(
+        math.ceil((end - start) / 64)
+        for start, end in zip(cu_seqlens, cu_seqlens[1:])
+    )
+    sequence_shape = (1, tokens, heads, head_dim)
+    head_shape = (1, heads, tokens, head_dim)
+    matrix_shape = (1, heads, tokens, 64)
+    state_shape = (seq_num, heads, head_dim, head_dim)
+    chunk_state_shape = (1, total_chunks, heads, head_dim, head_dim)
+    if layout == "TND":
+        sequence_shape = sequence_shape[1:]
+        head_shape = head_shape[1:]
+        matrix_shape = matrix_shape[1:]
+        chunk_state_shape = chunk_state_shape[1:]
+    return (
+        sequence_shape,
+        state_shape,
+        head_shape,
+        matrix_shape,
+        matrix_shape,
+        head_shape,
+        head_shape,
+        head_shape,
+        head_shape,
+        head_shape,
+        chunk_state_shape,
+        state_shape,
+    )
+
+
+def _assert_outputs(actual, expected, retained: set[int]) -> None:
+    assert len(actual) == len(expected) == len(OUTPUT_NAMES)
+    for index, (name, expected_output) in enumerate(zip(OUTPUT_NAMES, expected)):
+        if index not in retained:
+            assert actual[index] is None, f"{name} must not be retained"
+            continue
+        assert actual[index] is not None, f"{name} must be retained"
+        torch.testing.assert_close(
+            actual[index].detach().cpu(),
+            expected_output,
+            rtol=3e-2,
+            atol=3e-2,
+            msg=name,
+        )
+
+
+@pytest.mark.parametrize(
+    ("layout", "tokens", "heads", "cu_seqlens"),
+    [
+        pytest.param("BSND", 131, 6, (0, 131), id="BSND-T131-H6"),
+        pytest.param("TND", 191, 6, (0, 63, 131, 191), id="TND-varlen"),
+    ],
+)
+@torch.inference_mode()
+def test_chunk_kda_fwd_a5_multichunk_all_outputs(layout, tokens, heads, cu_seqlens):
+    if not _is_ascend950():
+        pytest.skip("requires an Ascend 950 device")
+
+    torch.manual_seed(20260819)
+    device = torch.device("npu:0")
+    torch.npu.set_device(0)
+    head_dim = 128
+    q_bsnd = _l2norm(torch.randn(1, tokens, heads, head_dim, dtype=torch.bfloat16, device=device))
+    k_bsnd = _l2norm(torch.randn_like(q_bsnd))
+    v_bsnd = torch.randn_like(q_bsnd) * 0.05
+    raw_gate_bsnd = torch.randn(
+        1, tokens, heads, head_dim, dtype=torch.float32, device=device
+    ) * 0.1
+    beta_bsnd = torch.rand(1, tokens, heads, dtype=torch.float32, device=device).sigmoid()
+    a_log = torch.randn(heads, dtype=torch.float32, device=device) * 0.05
+    dt_bias = torch.randn(heads * head_dim, dtype=torch.float32, device=device) * 0.05
+    initial_state_vk = torch.randn(
+        len(cu_seqlens) - 1,
+        heads,
+        head_dim,
+        head_dim,
+        dtype=torch.float32,
+        device=device,
+    ) * 0.01
+    indices = _chunk_indices(cu_seqlens, 64)
+    args = (
+        _for_layout(q_bsnd, layout),
+        _for_layout(k_bsnd, layout),
+        _for_layout(v_bsnd, layout).contiguous(),
+        _for_layout(raw_gate_bsnd, layout).contiguous(),
+        _for_layout(beta_bsnd, layout).contiguous(),
+        head_dim**-0.5,
+        64,
+    )
+    kwargs = {
+        "layout": layout,
+        "initial_state": initial_state_vk,
+        "output_final_state": True,
+        "cu_seqlens": cu_seqlens,
+        "chunk_indices": indices,
+        "safe_gate": True,
+        "lower_bound": -5.0,
+        "use_gate_in_kernel": True,
+        "A_log": a_log,
+        "dt_bias": dt_bias,
+        "state_v_first": True,
+    }
+
+    retained_outputs = chunk_kda_fwd(
+        *args,
+        **kwargs,
+        disable_recompute=True,
+        return_intermediate_states=True,
+    )
+    torch.npu.synchronize()
+
+    safe_gate = -5.0 * torch.sigmoid(
+        (raw_gate_bsnd.float() + dt_bias.view(1, 1, heads, head_dim))
+        * a_log.exp().view(1, 1, heads, 1)
+    )
+    expected = _expected_for_layout(
+        _chunked_reference(
+            q_bsnd,
+            k_bsnd,
+            v_bsnd,
+            safe_gate,
+            beta_bsnd,
+            initial_state_vk,
+            cu_seqlens,
+        ),
+        layout,
+    )
+    _assert_outputs(retained_outputs, expected, set(range(len(OUTPUT_NAMES))))
+    assert retained_outputs[11] is initial_state_vk
+
+    del retained_outputs, expected
+    gc.collect()
+    torch.npu.empty_cache()
+
+
+@pytest.mark.parametrize(
+    ("layout", "cu_seqlens"),
+    [
+        pytest.param("BSND", (0, 8191), id="BSND-model-shape"),
+        pytest.param("TND", (0, 2047, 4096, 8191), id="TND-varlen-model-shape"),
+    ],
+)
+@torch.inference_mode()
+def test_chunk_kda_fwd_a5_t8191_all_outputs_are_finite(layout, cu_seqlens):
+    if not _is_ascend950():
+        pytest.skip("requires an Ascend 950 device")
+
+    device = torch.device("npu:0")
+    torch.npu.set_device(0)
+    tokens, heads, head_dim = 8191, 12, 128
+    q_bsnd = torch.full(
+        (1, tokens, heads, head_dim),
+        head_dim**-0.5,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    k_bsnd = torch.full_like(q_bsnd, head_dim**-0.5)
+    v_bsnd = torch.zeros_like(q_bsnd)
+    raw_gate_bsnd = torch.zeros(
+        (1, tokens, heads, head_dim), dtype=torch.float32, device=device
+    )
+    beta_bsnd = torch.full(
+        (1, tokens, heads), 0.5, dtype=torch.float32, device=device
+    )
+    initial_state_vk = torch.zeros(
+        (len(cu_seqlens) - 1, heads, head_dim, head_dim),
+        dtype=torch.float32,
+        device=device,
+    )
+    outputs = chunk_kda_fwd(
+        _for_layout(q_bsnd, layout),
+        _for_layout(k_bsnd, layout),
+        _for_layout(v_bsnd, layout).contiguous(),
+        _for_layout(raw_gate_bsnd, layout).contiguous(),
+        _for_layout(beta_bsnd, layout).contiguous(),
+        head_dim**-0.5,
+        64,
+        layout=layout,
+        initial_state=initial_state_vk,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=_chunk_indices(cu_seqlens, 64),
+        safe_gate=True,
+        lower_bound=-5.0,
+        use_gate_in_kernel=True,
+        A_log=torch.zeros(heads, dtype=torch.float32, device=device),
+        dt_bias=torch.zeros(heads * head_dim, dtype=torch.float32, device=device),
+        disable_recompute=True,
+        return_intermediate_states=True,
+        state_v_first=True,
+    )
+    torch.npu.synchronize()
+
+    expected_shapes = _expected_output_shapes(
+        layout, tokens, heads, head_dim, cu_seqlens
+    )
+    assert len(outputs) == len(OUTPUT_NAMES) == len(expected_shapes)
+    for name, output, shape in zip(OUTPUT_NAMES, outputs, expected_shapes):
+        assert output is not None, f"{name} must be retained"
+        assert tuple(output.shape) == shape, name
+    finite = torch.stack([torch.isfinite(output).all() for output in outputs])
+    assert finite.all().item()
+    assert outputs[11] is initial_state_vk
+
+    del outputs
+    gc.collect()
+    torch.npu.empty_cache()


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> 本 PR 创建后将在当前 head commit 上触发 NPU CI；如后续更新 commit，需要重新触发。

## 关联 Issue / 背景

- 关联 Issue: Closes #337
- 背景与目标: A5 上 `ChunkKdaFwd` 的多 chunk 场景可能在单次物理 launch 内跨 Gate/Prepare、Post-WU、FwdH 和 Finalize 复用事件状态，长序列执行时可能触发 device task timeout。
- 本 PR 解决的问题: 将 A5 非对齐多 chunk 路径拆为四次物理 launch，通过 launch 边界重置事件状态；同时把跨阶段中间结果物化为 executor 内部张量，避免后续阶段读取前一 kernel workspace。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `chunk_kda_fwd`
- 涉及目录 / 文件: `fla/ops/ascendc/kda/chunk_kda_fwd/`、`torch_custom/fla_npu/test/test_npu_chunk_kda_a5_staging.py`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [x] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [x] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不改变既有 BSND/BNSD/TND/NTD、dtype、chunk size、gate、initial state 和 12 项返回值语义；新增回归覆盖 BSND/TND、BF16、chunk=64、K=V=128、多 chunk 和 `state_v_first=true`。
- 明确不包含的范围: 不修改数学算法、公开 Python/ACLNN 函数签名、输入 range 或精度阈值；不包含性能优化结论。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [x] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 私有 `ChunkKdaFwd` L0 增加 `stage` 属性以及 `qg_scaled`、`u_seed` 两个内部输出，需要重新编译配套 OPP；公共 ACLNN 与 Python 接口、入参和返回值保持不变。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

```sh
bash build.sh --pkg --soc=ascend950 --ops=chunk_kda_fwd --vendor_name=fla_npu
python -m pytest -q -s torch_custom/fla_npu/test/test_npu_chunk_kda_a5_staging.py
git diff --check
```

A5 测试覆盖模型长序列 BSND、同规模 TND packed varlen、`T=131/H=6` 精度回归及全部 12 个输出。精度失败输出使用 `ct viz` 按 0.1 采样率检查。

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未验证 | 定向构建 `chunk_kda_fwd` | 未执行 | 待 NPU CI 补齐 |
| A3 | `ascend910_93` | 未验证 | 定向构建 `chunk_kda_fwd` | 未执行 | 待 NPU CI 补齐 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未验证 | 定向构建 `chunk_kda_fwd` | 未执行 | 待 NPU CI 补齐 |
| A3 | `ascend910_93` | 未验证 | 定向构建 `chunk_kda_fwd` | 未执行 | 待 NPU CI 补齐 |
| A5 | `ascend950` | CANN 9.1.0 | 定向构建 `chunk_kda_fwd` | 未完成 | 首次依赖编译未在本次限时验证窗口内完成，待 CI 补齐 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `test_npu_chunk_kda_a5_staging.py` | 未执行 | 该文件为 A5 定向回归；A2 待 CI |
| A3 | `ascend910_93` | `test_npu_chunk_kda_a5_staging.py` | 未执行 | 该文件为 A5 定向回归；A3 待 CI |
| A5 | `ascend950` | BSND/TND 定向真实设备回归 | 部分通过 | BSND/TND `T=8191/H=12` 的 12 个输出 shape、有限值和 initial state 身份通过；TND `T=191/H=6` 的 12 个输出完整性通过 |

- 精度对比: `T=131/H=6` BSND 与 `T=191/H=6` TND 的全部 12 输出 CPU 参考测试已加入；本地完整 pytest 未在 30 秒限时窗口内完成，待 CI 补齐。与本提交核心实现逐文件一致的已编译 OPP 已完成 `T=131/H=6` 输出检查，`ct viz` 采样率 0.1 未发现结构性异常。
- 性能对比: 未执行；本 PR 不声明性能收益。
- 边界 / 异常场景: 覆盖非 64 对齐尾块、单序列与 packed varlen、多 chunk、raw gate、`A_log`、`dt_bias`、`safe_gate`、`state_v_first=true` 及全部 12 个返回位。
- 未覆盖风险: 当前分支完整 A2/A3/A5 编译、A2/A3 运行、完整 CPU 精度对比、sanitizer 和性能仍待 CI 或后续验证。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI |

- 端到端场景说明: GDN/KDA 前向调用链。
- 与本 PR 修改算子的关联: 端到端模型会调用 `chunk_kda_fwd` 多 chunk 路径。
- 未覆盖原因及补充计划: PR 创建后触发 NPU CI quick 补齐。

</details>

## 兼容性、风险与回退

- 兼容性说明: A2/A3、A5 单 chunk 和 A5 BF16/chunk=64/K=V=128 的 dense 对齐快路径保持单 launch；A5 其他多 chunk 场景使用四阶段 launch。公共接口和返回顺序不变。
- 风险点: 私有 L0 ABI 变化要求 op host、op api 与 kernel 配套编译；跨阶段中间张量会增加 A5 非对齐多 chunk 路径的临时显存占用。
- 回退方案: 回退本 PR 单提交即可恢复原单 launch 路径；保留新增真实设备回归用例用于后续定位。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 根因: A5 多 chunk 的融合执行在 Gate/Prepare、Post-WU、FwdH 和 Finalize 之间复用有限的事件状态，长序列下可能发生事件计数状态异常并导致 device task timeout。四次物理 launch 为阶段间提供明确边界。
- 实现只新增私有 L0 属性和内部输出，不增加公开算子或公开参数。
- 提交: `19886f310198cc1326fbf8b887cd8bf7c544a8cb`
