### PR TITLE
feat: 为 ChunkGatedDeltaRuleBwdDhu 增加 use_exp2 参数

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/ATK/aclnn_chunk_gated_delta_rule_bwd_dhu.yaml
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/ATK/aclnn_chunk_gated_delta_rule_bwd_dhu.yaml
@@ -181,3 +181,13 @@ inputs:
         values: ["bf16", "fp16"]
       invalid:
         values: []
+  - name: use_exp2
+    type: attr
+    required: true
+    dtypes:
+      values: [bool]
+    ranges:
+      valid:
+        values: [false]
+      invalid:
+        values: []

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/ATK/executor_chunk_gated_delta_rule_bwd_dhu.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/ATK/executor_chunk_gated_delta_rule_bwd_dhu.py
@@ -67,8 +67,10 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
     cu_seqlens: Optional[List[int]] = None,
     chunk_indices: Optional[List[int]] = None,
     g: Optional[torch.Tensor] = None,
+    gK: Optional[torch.Tensor] = None,
     scale: Optional[float] = None,
     chunk_size: int = 64,
+    use_exp2: bool = False,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
     """
     PyTorch 标杆：与 flash-linear-attention-npu 中 test_chunk_gated_delta_rule_bwd_dhu.py 保持一致。
@@ -78,6 +80,10 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
     dtype = q.dtype
 
     B, H, T, K = q.shape
+    if (g is None) == (gK is None):
+        raise ValueError("Exactly one of g and gK must be provided.")
+    if gK is not None:
+        use_exp2 = True
     V = do.shape[-1]
     BT = chunk_size
 
@@ -167,8 +173,9 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
                 if g is not None:
                     bg_last = g[b, i_h, global_last_idx]
                     b_g = g[b, i_h, global_start_t:global_end_t]
-                    bg_last_exp = torch.exp(bg_last)
-                    b_g_exp = torch.exp(b_g)
+                    gate_exp = torch.exp2 if use_exp2 else torch.exp
+                    bg_last_exp = gate_exp(bg_last)
+                    b_g_exp = gate_exp(b_g)
 
                 b_do = do[b, i_h, global_start_t:global_end_t, :]
                 b_dv_existing = dv[b, i_h, global_start_t:global_end_t, :]
@@ -178,7 +185,7 @@ def chunk_gated_delta_rule_bwd_dhu_torch(
 
                 if g is not None:
                     m_t = torch.arange(block_size_t, device=device) < block_size_t
-                    gate_factor = torch.exp(bg_last - b_g).unsqueeze(-1)
+                    gate_factor = (torch.exp2 if use_exp2 else torch.exp)(bg_last - b_g).unsqueeze(-1)
                     mask_expanded = m_t.unsqueeze(-1).float()
                     b_dv *= gate_factor * mask_expanded
 
@@ -220,6 +227,8 @@ class FunctionApi(BaseApi):
         d_o = input_data.kwargs["d_o"]
         dv = input_data.kwargs["dv"]
         g = input_data.kwargs["g"]
+        gK = input_data.kwargs.get("gK")
+        use_exp2 = input_data.kwargs.get("use_exp2", gK is not None)
         cu_seqlens = input_data.kwargs["cu_seqlens"]
         chunk_indices = input_data.kwargs["chunk_indices"]
         chunk_size = input_data.kwargs["chunk_size"]
@@ -234,8 +243,10 @@ class FunctionApi(BaseApi):
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
             g=g,
+            gK=gK,
             scale=scale,
             chunk_size=chunk_size,
+            use_exp2=use_exp2,
         )
         if self.qkv_type == "bf16":
             dh = dh.to(torch.bfloat16)

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/README.md
@@ -34,7 +34,7 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhuGetWorkspaceSize(
     const aclTensor *gOptional, const aclTensor *gkOptional,
     const aclTensor *h0Optional, const aclTensor *dhtOptional,
     const aclIntArray *cuSeqlensOptional, const aclIntArray *chunkIndicesOptional,
-    double scale, int64_t chunkSize,
+    double scale, int64_t chunkSize, bool useExp2,
     const aclTensor *dhOut, const aclTensor *dh0Out, const aclTensor *dv2Out,
     uint64_t *workspaceSize, aclOpExecutor **executor);
 
@@ -73,6 +73,7 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhu(
 |---|---|---|---|---|---|---|
 | `scale` | 输入 | 可选属性，接口侧必传 | 缩放系数 | 推荐设置为 `1 / sqrt(K)` | `double` | 建议按 `1 / sqrt(K)` 设置 |
 | `chunkSize` | 输入 | 可选属性，接口侧必传 | 分块大小 | 默认值为 `64`，仅支持 `64` 或 `128` | `int64_t` | 仅支持 `64` / `128` |
+| `use_exp2` | 输入 | 可选属性，接口侧必传 | 指数门控实现 | `g` 支持 `true`/`false`；`gk` 必须为 `true` | `bool` | `true` / `false` |
 
 ### 3.3 输出参数（Outputs）
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/examples/test_aclnn_chunk_gated_delta_rule_bwd_dhu.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/examples/test_aclnn_chunk_gated_delta_rule_bwd_dhu.cpp
@@ -241,7 +241,7 @@ int main() {
   aclOpExecutor *executor;
 
   // 调用aclnnChunkGatedDeltaRuleBwdDhu第一段接口
-  ret = aclnnChunkGatedDeltaRuleBwdDhuGetWorkspaceSize(q, k, w, d_o, dv, g, nullptr, nullptr, nullptr, cuSeqlens, chunkIndices, scale, chunk_size, dh, dh0, dv2, &workspaceSize, &executor);
+  ret = aclnnChunkGatedDeltaRuleBwdDhuGetWorkspaceSize(q, k, w, d_o, dv, g, nullptr, nullptr, nullptr, cuSeqlens, chunkIndices, scale, chunk_size, false, dh, dh0, dv2, &workspaceSize, &executor);
   CHECK_RET(
       ret == ACL_SUCCESS,
       LOG_PRINT("aclnnChunkGatedDeltaRuleBwdDhuGetWorkspaceSize failed. ERROR: %d\n", ret);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/chunk_gated_delta_rule_bwd_dhu_def.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/chunk_gated_delta_rule_bwd_dhu_def.cpp
@@ -120,6 +120,7 @@ public:
 
         this->Attr("scale").AttrType(OPTIONAL).Float(1.0);
         this->Attr("chunk_size").AttrType(OPTIONAL).Int(64);
+        this->Attr("use_exp2").AttrType(OPTIONAL).Bool(false);
 
         OpAICoreConfig aicoreConfig;
         aicoreConfig.DynamicCompileStaticFlag(true)

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_api/aclnn_chunk_gated_delta_rule_bwd_dhu.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_api/aclnn_chunk_gated_delta_rule_bwd_dhu.cpp
@@ -160,7 +160,7 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhuGetWorkspaceSize(
         cuSeqlensOptional, chunkIndicesOptional, scale, chunkSize, useExp2, dhOut, dh0Out, dv2Out};
     L2_DFX_PHASE_1(aclnnChunkGatedDeltaRuleBwdDhu,
                    DFX_IN(q, k, w, dO, dv, gOptional, gkOptional, h0Optional, dhtOptional,
-                          cuSeqlensOptional, chunkIndicesOptional),
+                          cuSeqlensOptional, chunkIndicesOptional, scale, chunkSize, useExp2),
                    DFX_OUT(dhOut, dh0Out, dv2Out));
 
     auto uniqueExecutor = CREATE_EXECUTOR();

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_api/aclnn_chunk_gated_delta_rule_bwd_dhu.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_api/aclnn_chunk_gated_delta_rule_bwd_dhu.cpp
@@ -44,6 +44,7 @@ struct ChunkGatedDeltaRuleBwdDhuParams {
     const aclIntArray *chunkIndicesOptional = nullptr;
     double scale = 1.0;
     int64_t chunkSize = 64;
+    bool useExp2 = false;
     const aclTensor *dhOut = nullptr;
     const aclTensor *dh0Out = nullptr;
     const aclTensor *dv2Out = nullptr;
@@ -58,6 +59,8 @@ static aclnnStatus CheckNotNull(ChunkGatedDeltaRuleBwdDhuParams params)
     CHECK_COND(params.dv != nullptr, ACLNN_ERR_PARAM_NULLPTR, "dv must not be nullptr.");
     CHECK_COND((params.gOptional != nullptr) != (params.gkOptional != nullptr), ACLNN_ERR_PARAM_INVALID,
                "Exactly one of g and gk must be provided.");
+    CHECK_COND(params.gkOptional == nullptr || params.useExp2, ACLNN_ERR_PARAM_INVALID,
+               "use_exp2 must be true when gk is provided.");
     CHECK_COND(params.dhOut != nullptr, ACLNN_ERR_PARAM_NULLPTR, "dhOut must not be nullptr.");
     CHECK_COND(params.dv2Out != nullptr, ACLNN_ERR_PARAM_NULLPTR, "dv2Out must not be nullptr.");
     return ACLNN_SUCCESS;
@@ -145,6 +148,7 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhuGetWorkspaceSize(
     const aclIntArray *chunkIndicesOptional,
     double scale,
     int64_t chunkSize,
+    bool useExp2,
     const aclTensor *dhOut,
     const aclTensor *dh0Out,
     const aclTensor *dv2Out,
@@ -153,7 +157,7 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhuGetWorkspaceSize(
 {
     ChunkGatedDeltaRuleBwdDhuParams params{
         q, k, w, dO, dv, gOptional, gkOptional, h0Optional, dhtOptional,
-        cuSeqlensOptional, chunkIndicesOptional, scale, chunkSize, dhOut, dh0Out, dv2Out};
+        cuSeqlensOptional, chunkIndicesOptional, scale, chunkSize, useExp2, dhOut, dh0Out, dv2Out};
     L2_DFX_PHASE_1(aclnnChunkGatedDeltaRuleBwdDhu,
                    DFX_IN(q, k, w, dO, dv, gOptional, gkOptional, h0Optional, dhtOptional,
                           cuSeqlensOptional, chunkIndicesOptional),
@@ -170,7 +174,7 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhuGetWorkspaceSize(
     auto result = l0op::ChunkGatedDeltaRuleBwdDhu(
         params.q, params.k, params.w, params.dO, params.dv, params.gOptional, params.gkOptional,
         params.h0Optional, params.dhtOptional, params.cuSeqlensOptional, params.chunkIndicesOptional,
-        params.scale, params.chunkSize, params.dhOut, params.dh0Out, params.dv2Out, executorPtr);
+        params.scale, params.chunkSize, params.useExp2, params.dhOut, params.dh0Out, params.dv2Out, executorPtr);
     CHECK_RET(result[0] != nullptr, ACLNN_ERR_PARAM_NULLPTR);
     CHECK_RET(result[1] != nullptr, ACLNN_ERR_PARAM_NULLPTR);
     CHECK_RET(result[2] != nullptr, ACLNN_ERR_PARAM_NULLPTR);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_api/aclnn_chunk_gated_delta_rule_bwd_dhu.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_api/aclnn_chunk_gated_delta_rule_bwd_dhu.h
@@ -26,6 +26,7 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhuGetWorkspaceSize(
     const aclIntArray *chunkIndicesOptional,
     double scale,
     int64_t chunkSize,
+    bool useExp2,
     const aclTensor *dhOut,
     const aclTensor *dh0Out,
     const aclTensor *dv2Out,

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_api/chunk_gated_delta_rule_bwd_dhu.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_api/chunk_gated_delta_rule_bwd_dhu.cpp
@@ -63,13 +63,14 @@ const std::array<const aclTensor *, 3> ChunkGatedDeltaRuleBwdDhu(
     const aclIntArray *chunkIndicesOptional,
     double scale,
     int64_t chunkSize,
+    bool useExp2,
     const aclTensor *dhOut,
     const aclTensor *dh0Out,
     const aclTensor *dv2Out,
     aclOpExecutor *executor)
 {
     L0_DFX(ChunkGatedDeltaRuleBwdDhu, q, k, w, dO, dv, gOptional, gkOptional, h0Optional, dhtOptional,
-           cuSeqlensOptional, chunkIndicesOptional, scale, chunkSize, dhOut, dh0Out, dv2Out);
+           cuSeqlensOptional, chunkIndicesOptional, scale, chunkSize, useExp2, dhOut, dh0Out, dv2Out);
 
     const aclTensor *actualCuSeqlens = ConvertIntArrayToTensor(cuSeqlensOptional, executor);
     const aclTensor *actualChunkIndices = ConvertIntArrayToTensor(chunkIndicesOptional, executor);
@@ -93,7 +94,7 @@ const std::array<const aclTensor *, 3> ChunkGatedDeltaRuleBwdDhu(
         OP_INPUT(q, k, w, dO, dv, gOptional, gkOptional, h0Optional, dhtOptional,
                  actualCuSeqlens, actualChunkIndices),
         OP_OUTPUT(dhOut, dh0OutKernel, dv2Out),
-        OP_ATTR(scale, chunkSize));
+        OP_ATTR(scale, chunkSize, useExp2));
     if (ret != ACLNN_SUCCESS) {
         OP_LOGE(ACLNN_ERR_PARAM_INVALID, "ADD_TO_LAUNCHER_LIST_AICORE failed.");
         return {nullptr, nullptr, nullptr};

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_api/chunk_gated_delta_rule_bwd_dhu.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_api/chunk_gated_delta_rule_bwd_dhu.h
@@ -30,6 +30,7 @@ const std::array<const aclTensor *, 3> ChunkGatedDeltaRuleBwdDhu(
     const aclIntArray *chunkIndicesOptional,
     double scale,
     int64_t chunkSize,
+    bool useExp2,
     const aclTensor *dhOut,
     const aclTensor *dh0Out,
     const aclTensor *dv2Out,

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.cpp
@@ -92,6 +92,7 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleBwdDhu(gert::TilingContext *context)
 
     const double *scalePtr = attrPtr->GetAttrPointer<double>(CGDR_BWD_DHU_ATTR_SCALE_IDX);
     const int32_t *chunkSizePtr = attrPtr->GetAttrPointer<int32_t>(CGDR_BWD_DHU_ATTR_CHUNK_SIZE_IDX);
+    const bool *useExp2Ptr = attrPtr->GetAttrPointer<bool>(CGDR_BWD_DHU_ATTR_USE_EXP2_IDX);
 
     uint64_t ubSize = 0;
     ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
@@ -111,6 +112,7 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleBwdDhu(gert::TilingContext *context)
         gateDataType,
         hasG,
         hasGk,
+        useExp2Ptr != nullptr ? *useExp2Ptr : false,
         h0InputShape != nullptr,
         true,
         scalePtr != nullptr ? static_cast<double>(*scalePtr) : 1.0,

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.cpp
@@ -37,6 +37,7 @@ void ChunkGatedDeltaRuleBwdDhuTilingDataPrint(
     OP_LOGD(nodeName, "=== totalChunkNum: %ld", tiling.totalChunkNum);
     OP_LOGD(nodeName, "=== chunkTaskNum: %ld", tiling.chunkTaskNum);
     OP_LOGD(nodeName, "=== seqNum: %ld", tiling.seqNum);
+    OP_LOGD(nodeName, "=== headsPerTask: %ld", tiling.headsPerTask);
     OP_LOGD(nodeName, "=== headWindowNum: %ld", tiling.headWindowNum);
     OP_LOGD(nodeName, "=== taskNum: %ld", tiling.taskNum);
     OP_LOGD(nodeName, "=== isVariable: %ld", tiling.isVariable);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling.h
@@ -36,6 +36,7 @@ static constexpr size_t CGDR_BWD_DHU_INPUT_CU_SEQLENS_IDX = 9;
 static constexpr size_t CGDR_BWD_DHU_INPUT_CHUNK_INDICES_IDX = 10;
 static constexpr size_t CGDR_BWD_DHU_ATTR_SCALE_IDX = 0;
 static constexpr size_t CGDR_BWD_DHU_ATTR_CHUNK_SIZE_IDX = 1;
+static constexpr size_t CGDR_BWD_DHU_ATTR_USE_EXP2_IDX = 2;
 
 } // namespace optiling
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
@@ -46,6 +46,7 @@ static constexpr int64_t CHUNK_SIZE_128 = 128;
 static constexpr int64_t CHUNK_INDICES_PAIR = 2;
 static constexpr int64_t VAR_LEN_B = 1;
 static constexpr int64_t HEADS_PER_TASK = 4;
+static constexpr int64_t MAX_TASKS_PER_CORE = 4;
 static constexpr int64_t WORKSPACE_BUFFER_COUNT = 8;
 static constexpr uint64_t VECTOR_SUB_BLOCK_NUM = 2;
 static constexpr uint64_t DTYPE_SIZE_HALF = 2;
@@ -404,7 +405,6 @@ private:
             return ge::GRAPH_FAILED;
         }
         tiling_.chunkSize = chunkSize;
-        tiling_.headWindowNum = CeilDiv(tiling_.HV, HEADS_PER_TASK);
         return ge::GRAPH_SUCCESS;
     }
 
@@ -445,8 +445,16 @@ private:
 
     ge::graphStatus WorkspaceTiling()
     {
+        const uint32_t maxBlockDim = ctx_.aicCoreNum == 0 ? 1U : ctx_.aicCoreNum;
+        const int64_t totalHeadTaskNum = tiling_.seqNum * tiling_.HV;
+        tiling_.headsPerTask = std::min(
+            HEADS_PER_TASK, CeilDiv(totalHeadTaskNum, static_cast<int64_t>(maxBlockDim)));
+        tiling_.headWindowNum = CeilDiv(tiling_.HV, tiling_.headsPerTask);
         tiling_.taskNum = tiling_.seqNum * tiling_.headWindowNum;
-        blockDim_ = ctx_.aicCoreNum == 0 ? 1U : ctx_.aicCoreNum;
+        const int64_t targetTaskPerCore = std::min(
+            MAX_TASKS_PER_CORE, CeilDiv(tiling_.taskNum, static_cast<int64_t>(maxBlockDim)));
+        blockDim_ = std::min(
+            maxBlockDim, static_cast<uint32_t>(CeilDiv(tiling_.taskNum, targetTaskPerCore)));
 
         const uint64_t qSize = DtypeSize(ctx_.qDataType);
         tiling_.dh0ClearCoreNum = 0;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
@@ -79,6 +79,7 @@ struct ChunkGatedDeltaRuleBwdDhuTilingContext {
     ge::DataType gDataType;
     bool hasG;
     bool hasGk;
+    bool useExp2;
     bool hasDh0;
     bool stage0Debug;
     double scale;
@@ -385,6 +386,11 @@ private:
         tiling_.HRatio = tiling_.HV / tiling_.HK;
         tiling_.hasDh0 = ctx_.hasDh0 ? 1 : 0;
         tiling_.hasGk = ctx_.hasGk ? 1 : 0;
+        if (ctx_.hasGk && !ctx_.useExp2) {
+            OP_LOGE(ctx_.nodeName, "use_exp2 must be true when gk is provided.");
+            return ge::GRAPH_FAILED;
+        }
+        tiling_.useExp2 = ctx_.useExp2 ? 1 : 0;
 
         if (tiling_.K != K_SIZE_128) {
             return ge::GRAPH_FAILED;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_cube.h
@@ -68,6 +68,7 @@ public:
         chunkSize_ = tiling_->chunkSize;
         vecRow_ = tiling_->vecRow > 0 ? tiling_->vecRow : 8;
         totalChunkNum_ = tiling_->totalChunkNum;
+        headsPerTask_ = tiling_->headsPerTask;
         headWindowNum_ = tiling_->headWindowNum;
         taskNum_ = tiling_->taskNum;
         workspaceElemsPerSubBlock_ = tiling_->workspaceElemsPerSubBlock;
@@ -127,8 +128,8 @@ public:
         for (int64_t taskIdx = blockIdx; taskIdx < taskNum_; taskIdx += blockNum) {
             const int64_t seqIdx = taskIdx / headWindowNum_;
             const int64_t headWindowIdx = taskIdx - seqIdx * headWindowNum_;
-            const int64_t hvBase = headWindowIdx * HEADS_PER_TASK;
-            const int64_t headCnt = Min(HEADS_PER_TASK, HV_ - hvBase);
+            const int64_t hvBase = headWindowIdx * headsPerTask_;
+            const int64_t headCnt = Min(headsPerTask_, HV_ - hvBase);
             const int64_t taskRound = (taskIdx - blockIdx) / blockNum;
             const int64_t windowStartSlot = (taskRound & 1) * HEADS_PER_TASK;
             if (headCnt <= 0) {
@@ -949,6 +950,7 @@ private:
     int64_t chunkSize_ = 0;
     int64_t vecRow_ = 8;
     int64_t totalChunkNum_ = 0;
+    int64_t headsPerTask_ = 0;
     int64_t headWindowNum_ = 0;
     int64_t taskNum_ = 0;
     int64_t workspaceElemsPerSubBlock_ = 0;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_struct.h
@@ -78,6 +78,7 @@ struct ChunkGatedDeltaRuleBwdDhuTilingData {
     int64_t totalChunkNum;
     int64_t chunkTaskNum;
     int64_t seqNum;
+    int64_t headsPerTask;
     int64_t headWindowNum;
     int64_t taskNum;
     int64_t isVariable;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_struct.h
@@ -86,6 +86,7 @@ struct ChunkGatedDeltaRuleBwdDhuTilingData {
     int64_t dh0ClearElemsPerCore;
     int64_t dh0ClearTailElems;
     int64_t hasGk;
+    int64_t useExp2;
     int64_t workspaceElemsPerSubBlock;
     int64_t qgWorkspaceOffset;
     int64_t stateWorkspaceOffset;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_vector.h
@@ -217,6 +217,7 @@ public:
         HRatio_ = tiling_->HRatio;
         chunkSize_ = tiling_->chunkSize;
         totalChunkNum_ = tiling_->totalChunkNum;
+        headsPerTask_ = tiling_->headsPerTask;
         headWindowNum_ = tiling_->headWindowNum;
         taskNum_ = tiling_->taskNum;
         isVariable_ = tiling_->isVariable;
@@ -324,8 +325,8 @@ public:
         for (int64_t taskIdx = coreIdx; taskIdx < taskNum_; taskIdx += blockNum) {
             const int64_t seqIdx = taskIdx / headWindowNum_;
             const int64_t headWindowIdx = taskIdx - seqIdx * headWindowNum_;
-            const int64_t hvBase = headWindowIdx * HEADS_PER_TASK;
-            const int64_t headCnt = Min(HEADS_PER_TASK, HV_ - hvBase);
+            const int64_t hvBase = headWindowIdx * headsPerTask_;
+            const int64_t headCnt = Min(headsPerTask_, HV_ - hvBase);
             const int64_t taskRound = (taskIdx - coreIdx) / blockNum;
             const int64_t windowStartSlot = (taskRound & 1) * HEADS_PER_TASK;
             if (headCnt <= 0) {
@@ -889,6 +890,7 @@ private:
     int64_t vecRow_ = 8;
     int64_t gateElems_ = 0;
     int64_t totalChunkNum_ = 0;
+    int64_t headsPerTask_ = 0;
     int64_t headWindowNum_ = 0;
     int64_t taskNum_ = 0;
     int64_t subBlockNum_ = 1;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_vector.h
@@ -391,9 +391,16 @@ public:
                         CastGateInputRows(gateRaw, gateInputBuf_[gateIdx],
                                           static_cast<uint32_t>(chunkInfo.chunkLen), gateIdx);
                         AscendC::PipeBarrier<PIPE_V>();
-                        AscendC::Muls(gateFactor, gateRaw, tiling_->useExp2 != 0 ? LN2 : 1.0f,
-                                      static_cast<uint32_t>(chunkInfo.chunkLen));
-                        AscendC::Exp(gateFactor, gateFactor, static_cast<uint32_t>(chunkInfo.chunkLen));
+                        if (tiling_->useExp2 != 0) {
+                            AscendC::Muls(gateFactor, gateRaw, LN2,
+                                          static_cast<uint32_t>(chunkInfo.chunkLen));
+                            AscendC::PipeBarrier<PIPE_V>();
+                            AscendC::Exp(gateFactor, gateFactor,
+                                         static_cast<uint32_t>(chunkInfo.chunkLen));
+                        } else {
+                            AscendC::Exp(gateFactor, gateRaw,
+                                         static_cast<uint32_t>(chunkInfo.chunkLen));
+                        }
                         AscendC::PipeBarrier<PIPE_V>();
                     } else {
                         const int64_t lastToken = chunkInfo.tokenStart + chunkInfo.chunkLen - 1;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_vector.h
@@ -87,7 +87,7 @@ __simd_vf__ inline void FillFloatRegbase(__ubuf__ float *dst, float value, uint1
 }
 
 __simd_vf__ inline void ExpScalarSubFloatRegbase(__ubuf__ float *dst, __ubuf__ float *src,
-                                                 __ubuf__ float *scalar, uint16_t elements)
+                                                 __ubuf__ float *scalar, uint16_t elements, bool useExp2)
 {
     constexpr uint32_t ELEMS_PER_VF = AscendC::VECTOR_REG_WIDTH / sizeof(float);
     const uint16_t loopCnt = static_cast<uint16_t>((elements + ELEMS_PER_VF - 1) / ELEMS_PER_VF);
@@ -103,6 +103,9 @@ __simd_vf__ inline void ExpScalarSubFloatRegbase(__ubuf__ float *dst, __ubuf__ f
         maskLoop = UpdateMask<float>(curElems);
         LoadAlign(srcReg, src + elemOffset);
         Sub(dstReg, scalarReg, srcReg, maskLoop);
+        if (useExp2) {
+            Muls(dstReg, dstReg, 0.69314718055994530942f, maskLoop);
+        }
         Exp(dstReg, dstReg, maskLoop);
         StoreAlign(dst + elemOffset, dstReg, maskLoop);
     }
@@ -388,7 +391,9 @@ public:
                         CastGateInputRows(gateRaw, gateInputBuf_[gateIdx],
                                           static_cast<uint32_t>(chunkInfo.chunkLen), gateIdx);
                         AscendC::PipeBarrier<PIPE_V>();
-                        AscendC::Exp(gateFactor, gateRaw, static_cast<uint32_t>(chunkInfo.chunkLen));
+                        AscendC::Muls(gateFactor, gateRaw, tiling_->useExp2 != 0 ? LN2 : 1.0f,
+                                      static_cast<uint32_t>(chunkInfo.chunkLen));
+                        AscendC::Exp(gateFactor, gateFactor, static_cast<uint32_t>(chunkInfo.chunkLen));
                         AscendC::PipeBarrier<PIPE_V>();
                     } else {
                         const int64_t lastToken = chunkInfo.tokenStart + chunkInfo.chunkLen - 1;
@@ -487,7 +492,7 @@ public:
                             (__ubuf__ float *)reinterpret_cast<uint64_t>(dvGateFactor.GetPhyAddr()),
                             (__ubuf__ float *)reinterpret_cast<uint64_t>(gateRaw.GetPhyAddr()),
                             ((__ubuf__ float *)reinterpret_cast<uint64_t>(gateRaw.GetPhyAddr())) + lastRow,
-                            static_cast<uint16_t>(chunkInfo.chunkLen));
+                            static_cast<uint16_t>(chunkInfo.chunkLen), tiling_->useExp2 != 0);
                         AscendC::PipeBarrier<PIPE_V>();
                     }
                     Catlass::Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecToCubeFlag_);

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_cube.h
@@ -60,6 +60,7 @@ public:
         HRatio_ = tiling_->HRatio;
         chunkSize_ = tiling_->chunkSize;
         totalChunkNum_ = tiling_->totalChunkNum;
+        headsPerTask_ = tiling_->headsPerTask;
         headWindowNum_ = tiling_->headWindowNum;
         taskNum_ = tiling_->taskNum;
         workspaceElemsPerSubBlock_ = tiling_->workspaceElemsPerSubBlock;
@@ -113,8 +114,8 @@ public:
         for (int64_t taskIdx = blockIdx; taskIdx < taskNum_; taskIdx += blockNum) {
             const int64_t seqIdx = taskIdx / headWindowNum_;
             const int64_t headWindowIdx = taskIdx - seqIdx * headWindowNum_;
-            const int64_t hvBase = headWindowIdx * HEADS_PER_TASK;
-            const int64_t headCnt = Min(HEADS_PER_TASK, HV_ - hvBase);
+            const int64_t hvBase = headWindowIdx * headsPerTask_;
+            const int64_t headCnt = Min(headsPerTask_, HV_ - hvBase);
             const int64_t taskRound = (taskIdx - blockIdx) / blockNum;
             const int64_t windowStartSlot = (taskRound & 1) * HEADS_PER_TASK;
             if (headCnt <= 0) {
@@ -686,6 +687,7 @@ private:
     int64_t HRatio_ = 0;
     int64_t chunkSize_ = 0;
     int64_t totalChunkNum_ = 0;
+    int64_t headsPerTask_ = 0;
     int64_t headWindowNum_ = 0;
     int64_t taskNum_ = 0;
     int64_t workspaceElemsPerSubBlock_ = 0;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_struct.h
@@ -78,6 +78,7 @@ struct ChunkGatedDeltaRuleBwdDhuTilingData {
     int64_t totalChunkNum;
     int64_t chunkTaskNum;
     int64_t seqNum;
+    int64_t headsPerTask;
     int64_t headWindowNum;
     int64_t taskNum;
     int64_t isVariable;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_struct.h
@@ -86,6 +86,7 @@ struct ChunkGatedDeltaRuleBwdDhuTilingData {
     int64_t dh0ClearElemsPerCore;
     int64_t dh0ClearTailElems;
     int64_t hasGk;
+    int64_t useExp2;
     int64_t workspaceElemsPerSubBlock;
     int64_t qgWorkspaceOffset;
     int64_t stateWorkspaceOffset;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vector.h
@@ -61,6 +61,7 @@ public:
         HRatio_ = tiling_->HRatio;
         chunkSize_ = tiling_->chunkSize;
         totalChunkNum_ = tiling_->totalChunkNum;
+        headsPerTask_ = tiling_->headsPerTask;
         headWindowNum_ = tiling_->headWindowNum;
         taskNum_ = tiling_->taskNum;
         isVariable_ = tiling_->isVariable;
@@ -153,8 +154,8 @@ public:
         for (int64_t taskIdx = coreIdx; taskIdx < taskNum_; taskIdx += blockNum) {
             const int64_t seqIdx = taskIdx / headWindowNum_;
             const int64_t headWindowIdx = taskIdx - seqIdx * headWindowNum_;
-            const int64_t hvBase = headWindowIdx * HEADS_PER_TASK;
-            const int64_t headCnt = Min(HEADS_PER_TASK, HV_ - hvBase);
+            const int64_t hvBase = headWindowIdx * headsPerTask_;
+            const int64_t headCnt = Min(headsPerTask_, HV_ - hvBase);
             const int64_t taskRound = (taskIdx - coreIdx) / blockNum;
             const int64_t windowStartSlot = (taskRound & 1) * HEADS_PER_TASK;
             if (headCnt <= 0) {
@@ -699,6 +700,7 @@ private:
     int64_t vecRow_ = 8;
     int64_t gateElems_ = 0;
     int64_t totalChunkNum_ = 0;
+    int64_t headsPerTask_ = 0;
     int64_t headWindowNum_ = 0;
     int64_t taskNum_ = 0;
     int64_t subBlockNum_ = 1;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vector.h
@@ -216,9 +216,16 @@ public:
                         CastGateInputRows(gateRaw, gateInputBuf_[gateIdx],
                                           static_cast<uint32_t>(chunkInfo.chunkLen), gateIdx);
                         AscendC::PipeBarrier<PIPE_V>();
-                        AscendC::Muls(gateFactor, gateRaw, tiling_->useExp2 != 0 ? LN2 : 1.0f,
-                                      static_cast<uint32_t>(chunkInfo.chunkLen));
-                        AscendC::Exp(gateFactor, gateFactor, static_cast<uint32_t>(chunkInfo.chunkLen));
+                        if (tiling_->useExp2 != 0) {
+                            AscendC::Muls(gateFactor, gateRaw, LN2,
+                                          static_cast<uint32_t>(chunkInfo.chunkLen));
+                            AscendC::PipeBarrier<PIPE_V>();
+                            AscendC::Exp(gateFactor, gateFactor,
+                                         static_cast<uint32_t>(chunkInfo.chunkLen));
+                        } else {
+                            AscendC::Exp(gateFactor, gateRaw,
+                                         static_cast<uint32_t>(chunkInfo.chunkLen));
+                        }
                         AscendC::PipeBarrier<PIPE_V>();
                         const int64_t lastRow = chunkInfo.chunkLen - 1;
                         const int64_t lastRowBase = (lastRow / BRCB_GROUP_ROWS) * BRCB_GROUP_ROWS;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vector.h
@@ -216,7 +216,9 @@ public:
                         CastGateInputRows(gateRaw, gateInputBuf_[gateIdx],
                                           static_cast<uint32_t>(chunkInfo.chunkLen), gateIdx);
                         AscendC::PipeBarrier<PIPE_V>();
-                        AscendC::Exp(gateFactor, gateRaw, static_cast<uint32_t>(chunkInfo.chunkLen));
+                        AscendC::Muls(gateFactor, gateRaw, tiling_->useExp2 != 0 ? LN2 : 1.0f,
+                                      static_cast<uint32_t>(chunkInfo.chunkLen));
+                        AscendC::Exp(gateFactor, gateFactor, static_cast<uint32_t>(chunkInfo.chunkLen));
                         AscendC::PipeBarrier<PIPE_V>();
                         const int64_t lastRow = chunkInfo.chunkLen - 1;
                         const int64_t lastRowBase = (lastRow / BRCB_GROUP_ROWS) * BRCB_GROUP_ROWS;
@@ -322,6 +324,11 @@ public:
                                          gBrcb[lastLane * BRCB_ROW_FLOAT_ELEMS], cur, 1, {1, 1, 0, 8, 8, 1});
                         }
                         AscendC::PipeBarrier<PIPE_V>();
+                        if (tiling_->useExp2 != 0) {
+                            AscendC::Muls(dvGateFactor, dvGateFactor, LN2,
+                                          static_cast<uint32_t>(chunkInfo.chunkLen));
+                            AscendC::PipeBarrier<PIPE_V>();
+                        }
                         AscendC::Exp(dvGateFactor, dvGateFactor, static_cast<uint32_t>(chunkInfo.chunkLen));
                         AscendC::PipeBarrier<PIPE_V>();
                     }

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
@@ -74,6 +74,27 @@ _GET_WORKSPACE_ARGTYPES = {
         ctypes.POINTER(ctypes.c_uint64),  # workspaceSize
         ctypes.POINTER(ctypes.c_void_p),  # executor
     ],
+    "aclnnChunkGatedDeltaRuleBwdDhu": [
+        ctypes.c_void_p,  # q
+        ctypes.c_void_p,  # k
+        ctypes.c_void_p,  # w
+        ctypes.c_void_p,  # dO
+        ctypes.c_void_p,  # dv
+        ctypes.c_void_p,  # gOptional
+        ctypes.c_void_p,  # gkOptional
+        ctypes.c_void_p,  # h0Optional
+        ctypes.c_void_p,  # dhtOptional
+        ctypes.c_void_p,  # cuSeqlensOptional
+        ctypes.c_void_p,  # chunkIndicesOptional
+        ctypes.c_double,  # scale
+        ctypes.c_int64,  # chunkSize
+        ctypes.c_bool,  # useExp2
+        ctypes.c_void_p,  # dhOut
+        ctypes.c_void_p,  # dh0Out
+        ctypes.c_void_p,  # dv2Out
+        ctypes.POINTER(ctypes.c_uint64),  # workspaceSize
+        ctypes.POINTER(ctypes.c_void_p),  # executor
+    ],
     "aclnnSolveTri": [
         ctypes.c_void_p,
         ctypes.c_void_p,

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
@@ -326,6 +326,8 @@ def npu_chunk_gated_delta_rule_bwd_dhu(
     Hv, V = dv_shape[1], dv_shape[3]
     if (g is None) == (gK is None):
         raise ValueError("Exactly one of g and gK must be provided.")
+    if gK is not None and not _optional_bool(use_exp2, True):
+        raise ValueError("use_exp2 must be true when gK is provided.")
     if any(tensor.dtype != q.dtype for tensor in (k, w, d_o, dv)):
         raise ValueError("q, k, w, d_o and dv must have the same dtype.")
     gate = g if g is not None else gK
@@ -362,6 +364,7 @@ def npu_chunk_gated_delta_rule_bwd_dhu(
             ctx.int_array(chunk_indices),
             ctypes.c_double(float(scale)),
             ctypes.c_int64(int(chunk_size)),
+            ctypes.c_bool(_optional_bool(use_exp2, gK is not None)),
             logical_tensor(ctx, dh, "dh"),
             logical_tensor(ctx, dh0, "dh0"),
             logical_tensor(ctx, dv2, "dv2"),

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -306,7 +306,7 @@ bool ResolveChunkLocalCumsumOutputDtype(
         q, k, w, d_o, dv,
         g_, gK_, h0_, dht_,
         cu_seqlens, chunk_indices,
-        scale, chunk_size,
+        scale, chunk_size, static_cast<bool>(use_exp2.value_or(gK_.defined())),
         dh, dh0, dv2
     );
     return std::make_tuple(dh, dh0, dv2);

--- a/torch_custom/fla_npu/test/test_aclnn_ctypes_abi.py
+++ b/torch_custom/fla_npu/test/test_aclnn_ctypes_abi.py
@@ -46,15 +46,17 @@ ACLNN_CTYPES = load_aclnn_ctypes_module()
 
 
 class FakeTensor:
-    def __init__(self, shape):
+    def __init__(self, shape, dtype=None):
         self.shape = tuple(shape)
+        self.dtype = dtype
 
 
 class FakeCallContext:
     def __init__(self):
         self.descriptor_names = []
 
-    def tensor(self, tensor, name):
+    def tensor(self, tensor, name, **kwargs):
+        del kwargs
         del tensor
         self.descriptor_names.append(name)
         return ctypes.c_void_p(0x1000 + len(self.descriptor_names))
@@ -66,6 +68,62 @@ class FakeCallContext:
 
 
 class AclnnCtypesAbiTest(unittest.TestCase):
+    def test_chunk_gated_delta_rule_bwd_dhu_signature_and_default_use_exp2(self):
+        import inspect
+
+        import torch
+
+        expected_argtypes = [
+            *([ctypes.c_void_p] * 11),
+            ctypes.c_double,
+            ctypes.c_int64,
+            ctypes.c_bool,
+            *([ctypes.c_void_p] * 3),
+            ctypes.POINTER(ctypes.c_uint64),
+            ctypes.POINTER(ctypes.c_void_p),
+        ]
+        self.assertEqual(
+            ACLNN_CTYPES._GET_WORKSPACE_ARGTYPES["aclnnChunkGatedDeltaRuleBwdDhu"],
+            expected_argtypes,
+        )
+        self.assertIs(
+            inspect.signature(ACLNN_CTYPES.npu_chunk_gated_delta_rule_bwd_dhu)
+            .parameters["use_exp2"]
+            .default,
+            False,
+        )
+
+        captured = {}
+
+        def fake_empty(shape, like, **kwargs):
+            return FakeTensor(shape, kwargs.get("dtype", like.dtype))
+
+        def fake_empty_like(tensor, **kwargs):
+            return FakeTensor(tensor.shape, kwargs.get("dtype", tensor.dtype))
+
+        def fake_call_aclnn(name, build_args, outputs):
+            context = FakeCallContext()
+            captured["name"] = name
+            captured["args"] = build_args(context)
+            return outputs
+
+        dtype = torch.float16
+        q = FakeTensor((1, 2, 64, 128), dtype)
+        state = FakeTensor((1, 2, 64, 128), dtype)
+        g = FakeTensor((1, 2, 64), torch.float32)
+        with mock.patch.object(ACLNN_CTYPES, "_empty", side_effect=fake_empty):
+            with mock.patch.object(ACLNN_CTYPES, "_empty_like", side_effect=fake_empty_like):
+                with mock.patch.object(ACLNN_CTYPES, "_call_aclnn", side_effect=fake_call_aclnn):
+                    ACLNN_CTYPES.npu_chunk_gated_delta_rule_bwd_dhu(
+                        q, q, q, state, state, scale=0.125, chunk_size=64, g=g
+                    )
+
+        operator_argtypes = expected_argtypes[:-2]
+        self.assertEqual(captured["name"], "aclnnChunkGatedDeltaRuleBwdDhu")
+        self.assertEqual(len(captured["args"]), len(operator_argtypes))
+        self.assertEqual([type(arg) for arg in captured["args"]], operator_argtypes)
+        self.assertFalse(captured["args"][13].value)
+
     def test_recurrent_gated_delta_rule_requires_at_least_one_gate_before_launch(self):
         with mock.patch.object(ACLNN_CTYPES, "_call_aclnn") as call_aclnn:
             with self.assertRaisesRegex(

--- a/torch_custom/fla_npu/test/test_bwd_dhu.py
+++ b/torch_custom/fla_npu/test/test_bwd_dhu.py
@@ -73,6 +73,7 @@ def chunk_gated_delta_rule_bwd_dhu_cpu(
     scale: Optional[float] = None,
     chunk_size: int = 64,
     golden_mode: str = "fp32",
+    use_exp2: bool = False,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
     """GVA 形状 CPU 标杆。golden_mode: fp64 / npu / fp32。"""
     del dht
@@ -200,7 +201,8 @@ def chunk_gated_delta_rule_bwd_dhu_cpu(
             if g is not None:
                 bg_last = g[:, :, global_last_idx].to(torch.float32)
                 b_g = g[:, :, gs:ge].to(torch.float32)
-                gate_factor = _gate_exp(bg_last.unsqueeze(-1) - b_g).unsqueeze(-1)
+                gate_exp = _gate_exp2 if use_exp2 else _gate_exp
+                gate_factor = gate_exp(bg_last.unsqueeze(-1) - b_g).unsqueeze(-1)
                 m_t = torch.arange(block_size_t, device=device, dtype=torch.float32) < float(block_size_t)
                 b_dv = b_dv * gate_factor * m_t.view(1, 1, block_size_t, 1)
 
@@ -210,8 +212,8 @@ def chunk_gated_delta_rule_bwd_dhu_cpu(
             b_q_t = q_blk.transpose(-1, -2)
             b_w_t = w_blk.transpose(-1, -2)
             if g is not None:
-                bg_last_exp = _gate_exp(bg_last)
-                b_g_exp = _gate_exp(b_g)
+                bg_last_exp = gate_exp(bg_last)
+                b_g_exp = gate_exp(b_g)
                 b_dh_for_update = b_dh * bg_last_exp.unsqueeze(-1).unsqueeze(-1)
                 b_q_gated = b_q_t * b_g_exp.unsqueeze(-2)
             elif gK is not None:
@@ -253,7 +255,8 @@ def chunk_gated_delta_rule_bwd_dhu_cpu(
             if g is not None:
                 bg_last = g[:, :, global_last_idx].to(torch.float32)
                 b_g = g[:, :, gs:ge].to(torch.float32)
-                gate_factor = _gate_exp(bg_last.unsqueeze(-1) - b_g).unsqueeze(-1)
+                gate_exp = _gate_exp2 if use_exp2 else _gate_exp
+                gate_factor = gate_exp(bg_last.unsqueeze(-1) - b_g).unsqueeze(-1)
                 m_t = torch.arange(block_size_t, device=device, dtype=torch.float32) < float(block_size_t)
                 b_dv = b_dv * gate_factor * m_t.view(1, 1, block_size_t, 1)
 
@@ -263,8 +266,8 @@ def chunk_gated_delta_rule_bwd_dhu_cpu(
             b_q_t = q_blk.transpose(-1, -2)
             b_w_t = w_blk.transpose(-1, -2)
             if g is not None:
-                bg_last_exp = _gate_exp(bg_last)
-                b_g_exp = _gate_exp(b_g)
+                bg_last_exp = gate_exp(bg_last)
+                b_g_exp = gate_exp(b_g)
                 b_dh_for_update = b_dh * bg_last_exp.unsqueeze(-1).unsqueeze(-1)
                 b_q_gated = b_q_t * b_g_exp.unsqueeze(-2)
             elif gK is not None:


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: #343

Closes #343
- 背景与目标: 为 `ChunkGatedDeltaRuleBwdDhu` 增加可控的指数门控实现参数。
- 本 PR 解决的问题: `g` 支持 `exp/exp2` 选择，`gk` 强制使用 `exp2`，并保证 ACLNN、tiling、kernel、torch_custom、golden 与 ATK 语义一致。

## 变更类型

- [ ] Bug 修复
- [x] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: `ChunkGatedDeltaRuleBwdDhu`
- 涉及目录 / 文件: `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu`、`torch_custom/fla_npu`
- 责任人 / 提交人: @zhangshuolei-hfut
- 修改范围:
  - [x] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [x] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 保持原有输入输出、shape、dtype、format 范围；新增可选布尔属性 `use_exp2`。
- 明确不包含的范围: 不改变算子输出数量、shape、数据类型和非门控计算路径。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: ACLNN 接口新增 `use_exp2` 参数，默认值为 `false`；需要 ABI 责任人检视并重新编译调用链。

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source <CANN_ROOT>/ascend-toolkit/set_env.sh
cat <CANN_ROOT>/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | `bash build.sh --pkg --soc=ascend910b --ops=chunk_gated_delta_rule_bwd_dhu --vendor_name=fla_npu -j64` | 未执行 | 当前环境未提供 CANN 编译环境 |
| A3 | `ascend910_93` | 未执行 | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_gated_delta_rule_bwd_dhu --vendor_name=fla_npu -j64` | 未执行 | 当前环境未提供 CANN 编译环境 |
| A5 | `ascend950` | 未执行 | `bash build.sh --pkg --soc=ascend950 --ops=chunk_gated_delta_rule_bwd_dhu --vendor_name=fla_npu -j64` | 未执行 | 当前环境未提供 CANN 编译环境 |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | 未执行 | 当前环境未提供 NPU 运行环境 |
| A3 | `ascend910_93` | 未执行 | 未执行 | 当前环境未提供 NPU 运行环境 |
| A5 | `ascend950` | 未执行 | 未执行 | 当前环境未提供 NPU 运行环境 |

- 精度对比: 未执行 NPU 精度测试；golden 已覆盖 `g` 的两种指数模式，`gk` 保持 `exp2`。
- 性能对比: 未执行。
- 边界 / 异常场景: host/tiling 对 `gk + use_exp2=false` 拒绝；Python wrapper 同步校验。
- 未覆盖风险: 需要在 A2/A3/A5 完成编译、运行和精度回归。

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明: 未执行整体 Example ST。
- 与本 PR 修改算子的关联: 该 PR 修改 ACLNN 入参和 kernel tiling 数据布局，需要重新编译后验证。
- 未覆盖原因及补充计划: 当前环境未提供 CANN/NPU；由 CI 或目标设备补充验证。

</details>

## 兼容性、风险与回退

- 兼容性说明: 默认 `use_exp2=false` 保持 `g` 原有标准 `exp` 行为；`gk` 统一使用 `exp2`。
- 风险点: ACLNN 入参新增布尔参数，需 ABI 责任人检视。
- 回退方案: 回退本 PR commit 即可恢复原接口和 kernel 行为。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
