### PR TITLE
fix(kda): 修复 ChunkKdaFwd 尾块 bitwise determinism

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
@@ -218,7 +218,8 @@ public:
         bool isFinalState,
         bool storeFinalState,
         bool waitWsFromMte3,
-        bool isPing
+        bool isPing,
+        bool cube1AlreadyWaited
     )
     {
         static constexpr uint32_t ROW_TILE = 16;
@@ -237,7 +238,9 @@ public:
         }
         uint32_t pingpongFlag = isPing ? 0 : pongBaseEvent;
         if (rowBegin >= mActual) {
-            Arch::CrossCoreWaitFlag(cube1Done);
+            if (!cube1AlreadyWaited) {
+                Arch::CrossCoreWaitFlag(cube1Done);
+            }
             // A zero-row AIV lane still owns the EVENT0 hand-off consumed by V2.
             if (waitWsFromMte3) {
                 AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(
@@ -285,7 +288,9 @@ public:
             } else {
                 AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
             }
-            Arch::CrossCoreWaitFlag(cube1Done);
+            if (!cube1AlreadyWaited) {
+                Arch::CrossCoreWaitFlag(cube1Done);
+            }
 
             if (waitWsFromMte3) {
                 AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
@@ -353,7 +358,9 @@ public:
         } else {
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pingpongFlag);
         }
-        Arch::CrossCoreWaitFlag(cube1Done);
+        if (!cube1AlreadyWaited) {
+            Arch::CrossCoreWaitFlag(cube1Done);
+        }
 
         bool waitWsThisTileFromMte3 = waitWsFromMte3;
         for (uint32_t rowStart = rowBegin; rowStart < rowEnd;) {

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -278,7 +278,8 @@ public:
         return static_cast<float>(value);
     }
 
-    __aicore__ inline void ComputeTailVWorkspace(const GDNFwdHOffsets& offsets)
+    __aicore__ inline void ComputeTailVWorkspace(
+        const GDNFwdHOffsets& offsets, uint32_t tailEventId)
     {
         uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
         uint32_t subBlockNum = AscendC::GetSubBlockNum();
@@ -288,6 +289,8 @@ public:
         if (rowBegin >= rowEnd) {
             return;
         }
+        AscendC::ResetMask();
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(tailEventId);
 
         constexpr uint32_t TAIL_INPUT_OFFSET = 166 * 1024;
         constexpr uint32_t TAIL_FLOAT_OFFSET = 167 * 1024;
@@ -298,44 +301,70 @@ public:
             resource.ubBuf.template GetBufferByByte<float>(TAIL_FLOAT_OFFSET);
         AscendC::LocalTensor<float> accumUb =
             resource.ubBuf.template GetBufferByByte<float>(TAIL_ACCUM_OFFSET);
+        AscendC::LocalTensor<ElementW> weightInputUb =
+            resource.ubBuf.template GetBufferByByte<ElementW>(169 * 1024);
+        AscendC::LocalTensor<float> weightFloatUb =
+            resource.ubBuf.template GetBufferByByte<float>(170 * 1024);
 
         for (uint32_t tokenRow = rowBegin; tokenRow < rowEnd; ++tokenRow) {
+            AscendC::DataCopy(
+                weightInputUb,
+                gmW[offsets.wOffset + tokenRow * kHeadDim],
+                kHeadDim);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(tailEventId);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(tailEventId);
+            AscendC::Cast(
+                weightFloatUb, weightInputUb, AscendC::RoundMode::CAST_NONE,
+                kHeadDim);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::SetFlag<AscendC::HardEvent::V_S>(tailEventId);
+            AscendC::WaitFlag<AscendC::HardEvent::V_S>(tailEventId);
+
             AscendC::Duplicate(accumUb, 0.0f, offsets.vBlockDim);
             AscendC::PipeBarrier<PIPE_V>();
             for (uint32_t kIdx = 0; kIdx < kHeadDim; ++kIdx) {
                 AscendC::DataCopy(
                     inputUb, gmH[offsets.hSrcOffset + kIdx * vHeadDim],
                     offsets.vBlockDim);
-                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID7);
-                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID7);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(tailEventId);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(tailEventId);
                 AscendC::Cast(
                     floatUb, inputUb, AscendC::RoundMode::CAST_NONE,
                     offsets.vBlockDim);
                 AscendC::PipeBarrier<PIPE_V>();
-                float weight = LoadScalarAsFloat(
-                    gmW, offsets.wOffset + tokenRow * kHeadDim + kIdx);
+                float weight = weightFloatUb.GetValue(kIdx);
+                AscendC::SetFlag<AscendC::HardEvent::S_V>(tailEventId);
+                AscendC::WaitFlag<AscendC::HardEvent::S_V>(tailEventId);
                 AscendC::Muls(floatUb, floatUb, weight, offsets.vBlockDim);
                 AscendC::PipeBarrier<PIPE_V>();
                 AscendC::Add(accumUb, accumUb, floatUb, offsets.vBlockDim);
                 AscendC::PipeBarrier<PIPE_V>();
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(tailEventId);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(tailEventId);
             }
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID7);
-            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID7);
+            AscendC::SetFlag<AscendC::HardEvent::S_MTE2>(tailEventId);
+            AscendC::WaitFlag<AscendC::HardEvent::S_MTE2>(tailEventId);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(tailEventId);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(tailEventId);
             AscendC::DataCopy(
                 gmVWorkspace[offsets.vWorkOffset + tokenRow * offsets.vBlockDim],
                 accumUb, offsets.vBlockDim);
-            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID7);
-            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID7);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(tailEventId);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(tailEventId);
         }
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(tailEventId);
     }
 
-    __aicore__ inline void ComputeTailHWorkspace(const GDNFwdHOffsets& offsets)
+    __aicore__ inline void ComputeTailHWorkspace(
+        const GDNFwdHOffsets& offsets, uint32_t tailEventId)
     {
         uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
         uint32_t subBlockNum = AscendC::GetSubBlockNum();
         uint32_t rowsPerSubBlock = CeilDiv(kHeadDim, subBlockNum);
         uint32_t rowBegin = subBlockIdx * rowsPerSubBlock;
         uint32_t rowEnd = Min(rowBegin + rowsPerSubBlock, kHeadDim);
+        AscendC::ResetMask();
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(tailEventId);
 
         constexpr uint32_t TAIL_INPUT_OFFSET = 166 * 1024;
         constexpr uint32_t TAIL_FLOAT_OFFSET = 167 * 1024;
@@ -346,37 +375,58 @@ public:
             resource.ubBuf.template GetBufferByByte<float>(TAIL_FLOAT_OFFSET);
         AscendC::LocalTensor<float> accumUb =
             resource.ubBuf.template GetBufferByByte<float>(TAIL_ACCUM_OFFSET);
+        AscendC::LocalTensor<ElementK> weightInputUb =
+            resource.ubBuf.template GetBufferByByte<ElementK>(169 * 1024);
+        AscendC::LocalTensor<float> weightFloatUb =
+            resource.ubBuf.template GetBufferByByte<float>(170 * 1024);
 
         for (uint32_t kRow = rowBegin; kRow < rowEnd; ++kRow) {
             AscendC::Duplicate(accumUb, 0.0f, offsets.vBlockDim);
             AscendC::PipeBarrier<PIPE_V>();
             for (uint32_t tokenRow = 0; tokenRow < offsets.blockTokens; ++tokenRow) {
                 AscendC::DataCopy(
+                    weightInputUb,
+                    gmKDecayWorkspace[offsets.kDecayWorkOffset + tokenRow * kHeadDim],
+                    kHeadDim);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(tailEventId);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(tailEventId);
+                AscendC::Cast(
+                    weightFloatUb, weightInputUb, AscendC::RoundMode::CAST_NONE,
+                    kHeadDim);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::SetFlag<AscendC::HardEvent::V_S>(tailEventId);
+                AscendC::WaitFlag<AscendC::HardEvent::V_S>(tailEventId);
+                AscendC::DataCopy(
                     inputUb,
                     gmVUpdateWorkspace[offsets.vWorkOffset + tokenRow * offsets.vBlockDim],
                     offsets.vBlockDim);
-                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID7);
-                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID7);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(tailEventId);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(tailEventId);
                 AscendC::Cast(
                     floatUb, inputUb, AscendC::RoundMode::CAST_NONE,
                     offsets.vBlockDim);
                 AscendC::PipeBarrier<PIPE_V>();
-                float weight = LoadScalarAsFloat(
-                    gmKDecayWorkspace,
-                    offsets.kDecayWorkOffset + tokenRow * kHeadDim + kRow);
+                float weight = weightFloatUb.GetValue(kRow);
+                AscendC::SetFlag<AscendC::HardEvent::S_V>(tailEventId);
+                AscendC::WaitFlag<AscendC::HardEvent::S_V>(tailEventId);
                 AscendC::Muls(floatUb, floatUb, weight, offsets.vBlockDim);
                 AscendC::PipeBarrier<PIPE_V>();
                 AscendC::Add(accumUb, accumUb, floatUb, offsets.vBlockDim);
                 AscendC::PipeBarrier<PIPE_V>();
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(tailEventId);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(tailEventId);
+                AscendC::SetFlag<AscendC::HardEvent::S_MTE2>(tailEventId);
+                AscendC::WaitFlag<AscendC::HardEvent::S_MTE2>(tailEventId);
             }
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID7);
-            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID7);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(tailEventId);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(tailEventId);
             AscendC::DataCopy(
                 gmHWorkspace[offsets.hWorkOffset + kRow * offsets.vBlockDim],
                 accumUb, offsets.vBlockDim);
-            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID7);
-            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID7);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(tailEventId);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(tailEventId);
         }
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(tailEventId);
     }
 
     __aicore__ inline void PresetVectorPipelineEvents()
@@ -679,8 +729,13 @@ public:
                             continue;
                         }
                         const GDNFwdHOffsets& vec1Offsets = vecBlockScheduler.GetCurTaskOffsets(stream);
-                        if (vec1Offsets.blockTokens < 16) {
-                            ComputeTailVWorkspace(vec1Offsets);
+                        bool tailVectorPath = vec1Offsets.blockTokens < 16;
+                        if (tailVectorPath) {
+                            Arch::CrossCoreWaitFlag(
+                                vecBlockScheduler.cube1Done[streamId]);
+                            ComputeTailVWorkspace(
+                                vec1Offsets,
+                                EVENT_ID3 + (streamId == 0 ? 0 : 4));
                         }
                         bool waitWsFromMte3 = storeFinalState && std::is_same<ElementFinalState, float>::value &&
                                               event0FromMte3[streamId];
@@ -691,7 +746,7 @@ public:
                             vec1Offsets.blockTokens, kHeadDim, vec1Offsets.vBlockDim, vHeadDim,
                             vecBlockScheduler.cube1Done[streamId], vecBlockScheduler.vec1Done[streamId],
                             vec1Offsets.isInitialState, vec1Offsets.isFinalState, storeFinalState,
-                            waitWsFromMte3, (streamId == 0)
+                            waitWsFromMte3, (streamId == 0), tailVectorPath
                         );
                         AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
                         AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
@@ -713,7 +768,9 @@ public:
                             if (tailVectorPath) {
                                 Arch::CrossCoreWaitFlag(
                                     vecBlockScheduler.cube2Done[streamId]);
-                                ComputeTailHWorkspace(vec2Offsets);
+                                ComputeTailHWorkspace(
+                                    vec2Offsets,
+                                    EVENT_ID3 + (streamId == 0 ? 0 : 4));
                             }
                             if (storeFinalState && std::is_same<ElementFinalState, float>::value) {
                                 event0FromMte3[streamId] = true;

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/docs/design.md
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/docs/design.md
@@ -120,10 +120,10 @@ Finalize 的内部实现头与统一 kernel 入口同属 `chunk_kda_fwd/op_kerne
 均生成两个 key；同一个 key 内再由编译架构选择根目录通用实现或 `arch35/` 实现。host 的
 `SetTilingKey` 只检查 chunk、K、V，不检查 SoC。
 
-在 arch35 上，key2 的 dense 对齐场景使用单 launch 融合流水和 arch35 FwdH。A5 多 chunk 的
-tail/varlen 以及 key1 泛化场景使用四段 launch，并在 FwdH 阶段复用共享实现。其他架构在同一
-key2 下使用其对应单 launch 实现。tiling key 和私有 `stage` 均不改变公开算子原型、输出契约
-或数学定义。
+在 arch35 上，key2 的 dense 对齐场景使用单 launch 和 arch35 FwdH；融合 score 写回在跳过
+共享 PostWU 时会额外物化以块尾 gate 为参考的最终 `kg`，供 FwdH 和可选公开输出共同使用。
+A5 多 chunk 的 tail/varlen 以及 key1 泛化场景使用四段 launch。其他架构在同一 key 下使用其
+对应单 launch 实现。tiling key 和私有 `stage` 均不改变公开算子原型、输出契约或数学定义。
 
 ## 性能设计
 

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_finalize.h
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_finalize.h
@@ -256,7 +256,6 @@ private:
         mte3ToVEvent_ = pipe_->AllocEventID<HardEvent::MTE3_V>();
         mte2ToMte3Event_ = pipe_->AllocEventID<HardEvent::MTE2_MTE3>();
         mte3ToMte2Event_ = pipe_->AllocEventID<HardEvent::MTE3_MTE2>();
-        vToSEvent_ = pipe_->AllocEventID<HardEvent::V_S>();
         sToVEvent_ = pipe_->AllocEventID<HardEvent::S_V>();
         sToMte2Event_ = pipe_->AllocEventID<HardEvent::S_MTE2>();
         vectorEventsAllocated_ = true;
@@ -273,7 +272,6 @@ private:
         pipe_->ReleaseEventID<HardEvent::MTE3_V>(mte3ToVEvent_);
         pipe_->ReleaseEventID<HardEvent::MTE2_MTE3>(mte2ToMte3Event_);
         pipe_->ReleaseEventID<HardEvent::MTE3_MTE2>(mte3ToMte2Event_);
-        pipe_->ReleaseEventID<HardEvent::V_S>(vToSEvent_);
         pipe_->ReleaseEventID<HardEvent::S_V>(sToVEvent_);
         pipe_->ReleaseEventID<HardEvent::S_MTE2>(sToMte2Event_);
         vectorEventsAllocated_ = false;
@@ -514,9 +512,9 @@ private:
             Cast(
                 coefficients, coefficientTyped, RoundMode::CAST_NONE,
                 static_cast<uint32_t>(curT));
-            PipeBarrier<PIPE_V>();
-            SetFlag<HardEvent::V_S>(vToSEvent_);
-            WaitFlag<HardEvent::V_S>(vToSEvent_);
+            // Earlier megakernel stages reuse V_S event IDs. Drain the cast
+            // before the first scalar coefficient read in this tail row.
+            PipeBarrier<PIPE_ALL>();
             Duplicate(dstRow, 0.0f, static_cast<uint32_t>(V_));
             PipeBarrier<PIPE_V>();
             for (uint64_t j = 0; j < curT; ++j) {
@@ -554,9 +552,9 @@ private:
             Cast(
                 coefficients, coefficientTyped, RoundMode::CAST_NONE,
                 static_cast<uint32_t>(K_));
-            PipeBarrier<PIPE_V>();
-            SetFlag<HardEvent::V_S>(vToSEvent_);
-            WaitFlag<HardEvent::V_S>(vToSEvent_);
+            // Earlier megakernel stages reuse V_S event IDs. Drain the cast
+            // before the first scalar coefficient read in this tail row.
+            PipeBarrier<PIPE_ALL>();
             Duplicate(dstRow, 0.0f, static_cast<uint32_t>(V_));
             PipeBarrier<PIPE_V>();
             for (uint64_t d = 0; d < K_; ++d) {
@@ -1380,7 +1378,6 @@ private:
     TEventID mte3ToVEvent_ = 0;
     TEventID mte2ToMte3Event_ = 0;
     TEventID mte3ToMte2Event_ = 0;
-    TEventID vToSEvent_ = 0;
     TEventID sToVEvent_ = 0;
     TEventID sToMte2Event_ = 0;
     bool vectorEventsAllocated_ = false;

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_post_wu.h
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_post_wu.h
@@ -1491,7 +1491,7 @@ private:
     template <typename SrcTensor, typename DstTensor>
     __aicore__ inline void ComputeTailWuRow(GlobalTensor<SrcTensor> &src, GlobalTensor<DstTensor> &dst,
                                             uint64_t akkBase, uint64_t srcBase, uint64_t dstBase, uint64_t curT,
-                                            uint64_t dim)
+                                            uint64_t dim, uint64_t rowStride)
     {
         LocalTensor<float> acc = vecBuf_.Get<float>();
         LocalTensor<float> value = vecBuf_.Get<float>()[512];
@@ -1506,7 +1506,7 @@ private:
         SetFlag<HardEvent::V_S>(EXP2_EVENT_ID);
         WaitFlag<HardEvent::V_S>(EXP2_EVENT_ID);
         for (uint64_t j = 0; j < curT; ++j) {
-            LoadAsFloatVector(src, srcBase + j * dim, value, typed, dim);
+            LoadAsFloatVector(src, srcBase + j * rowStride, value, typed, dim);
             float coefficient = coefficients.GetValue(j);
             SetFlag<HardEvent::S_V>(EXP2_EVENT_ID);
             WaitFlag<HardEvent::S_V>(EXP2_EVENT_ID);
@@ -1530,15 +1530,24 @@ private:
     __aicore__ inline void ComputeTailWuVector(uint64_t b, uint64_t hv, uint64_t chunkIdx, uint64_t start,
                                                uint64_t curT, uint64_t subBlockIdx, uint64_t subBlockNum)
     {
+        // preparedQG_ and w_ alias. Each subblock owns disjoint columns and
+        // writes rows from last to first, so every lower-triangular source row
+        // remains live through its final use without desynchronizing the AIVs.
+        uint64_t colBegin = (K_ * subBlockIdx) / subBlockNum;
+        uint64_t colEnd = (K_ * (subBlockIdx + 1)) / subBlockNum;
+        for (uint64_t row = curT; row > 0; --row) {
+            uint64_t rowIdx = row - 1;
+            ComputeTailWuRow(
+                preparedQG_, w_, AOffset(b, hv, start + rowIdx, 0), KVOffset(b, hv, start, colBegin, K_),
+                KVOffset(b, hv, start + rowIdx, colBegin, K_), curT, colEnd - colBegin, K_);
+        }
+
         uint64_t rowBegin = (curT * subBlockIdx) / subBlockNum;
         uint64_t rowEnd = (curT * (subBlockIdx + 1)) / subBlockNum;
         for (uint64_t row = rowBegin; row < rowEnd; ++row) {
             ComputeTailWuRow(
-                preparedQG_, w_, AOffset(b, hv, start + row, 0), KVOffset(b, hv, start, 0, K_),
-                KVOffset(b, hv, start + row, 0, K_), curT, K_);
-            ComputeTailWuRow(
                 propagatedVNew_, u_, AOffset(b, hv, start + row, 0), KVOffset(b, hv, start, 0, V_),
-                KVOffset(b, hv, start + row, 0, V_), curT, V_);
+                KVOffset(b, hv, start + row, 0, V_), curT, V_, V_);
         }
     }
 #endif

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_prepare.h
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_prepare.h
@@ -414,6 +414,8 @@ static __simd_vf__ inline void PrepareKdaGateQwKgRegbase(
             RegTensor<float> directOneReg;
             RegTensor<float> finalNegZeroReg;
             RegTensor<float> finalNegOneReg;
+            RegTensor<float> finalKZeroReg;
+            RegTensor<float> finalKOneReg;
             RegTensor<float> inputZeroReg;
             RegTensor<float> inputOneReg;
             RegTensor<float> outputZeroReg;
@@ -474,6 +476,11 @@ static __simd_vf__ inline void PrepareKdaGateQwKgRegbase(
                 qOut + offset, outputZeroReg, outputOneReg, inputMask, floatMask);
 
             LoadKdaGateRegbasePair<InputT>(inputZeroReg, inputOneReg, k + offset, inputMask);
+            if constexpr (EXPORT_FINAL_KG) {
+                // wOut may alias k, and STORE_DIRECT later reuses inputZeroReg/inputOneReg for V.
+                Adds(finalKZeroReg, inputZeroReg, 0.0f, floatMask);
+                Adds(finalKOneReg, inputOneReg, 0.0f, floatMask);
+            }
             if constexpr (STORE_DIRECT || SCALE_SCORE_W) {
                 LoadAlign<float, LoadDist::DIST_BRC_B32>(betaReg, beta + row);
             }
@@ -532,8 +539,7 @@ static __simd_vf__ inline void PrepareKdaGateQwKgRegbase(
                 Maxs(finalNegOneReg, finalNegOneReg, KDA_EXP_INPUT_MIN, floatMask);
                 ExpFloatTwoReg(finalNegZeroReg, finalNegOneReg,
                                finalNegZeroReg, finalNegOneReg, floatMask);
-                LoadKdaGateRegbasePair<InputT>(inputZeroReg, inputOneReg, k + offset, inputMask);
-                MulFloatTwoReg(outputZeroReg, outputOneReg, inputZeroReg, inputOneReg,
+                MulFloatTwoReg(outputZeroReg, outputOneReg, finalKZeroReg, finalKOneReg,
                                finalNegZeroReg, finalNegOneReg, floatMask);
                 StoreKdaGateRegbasePair<InputT>(
                     finalKgOut + offset, outputZeroReg, outputOneReg, inputMask, floatMask);
@@ -904,6 +910,7 @@ public:
         isVarLen_ = tiling.isVarLen;
         inputSequenceMajor_ = tiling.inputSequenceMajor;
         fusePostWu_ = tiling.fusePostWu;
+        materializeFinalKg_ = tiling.fusePostWu || tiling.fusePostWuIntoFwdH;
         computeGateInPrepare_ = tiling.computeGateInPrepare;
         hasALog_ = tiling.hasALog;
         hasDtBias_ = tiling.hasDtBias;
@@ -1718,7 +1725,7 @@ private:
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
             bool fuseQwKg = SAFE_GATE && BT_ == 64 && K_ == 128 && V_ == 128 && subBlockNum == 1;
             if (fuseQwKg) {
-                PrepareKdaGateQwKgRegbase<T, SCORE_T, GK_T, true, true, false, true>(
+                PrepareKdaGateQwKgRegbase<T, SCORE_T, GK_T, true, true, exportFinalKg, true>(
                     (__ubuf__ T *)reinterpret_cast<uint64_t>(qTyped.GetPhyAddr()),
                     (__ubuf__ T *)reinterpret_cast<uint64_t>(kTyped.GetPhyAddr()),
                     (__ubuf__ SCORE_T *)reinterpret_cast<uint64_t>(qScore.GetPhyAddr()),
@@ -1728,26 +1735,13 @@ private:
                     (__ubuf__ T *)reinterpret_cast<uint64_t>(directW.GetPhyAddr()),
                     (__ubuf__ T *)reinterpret_cast<uint64_t>(vTyped.GetPhyAddr()),
                     (__ubuf__ T *)reinterpret_cast<uint64_t>(directV.GetPhyAddr()),
-                    nullptr,
+                    (__ubuf__ T *)reinterpret_cast<uint64_t>(vTyped.GetPhyAddr()),
                     (__ubuf__ float *)reinterpret_cast<uint64_t>(betaFp32.GetPhyAddr()),
                     (__ubuf__ GK_T *)reinterpret_cast<uint64_t>(gateTyped.GetPhyAddr()),
                     (__ubuf__ float *)reinterpret_cast<uint64_t>(refFp32.GetPhyAddr()),
-                    nullptr,
+                    (__ubuf__ float *)reinterpret_cast<uint64_t>(finalRefFp32.GetPhyAddr()),
                     static_cast<uint16_t>(tileRows), static_cast<uint16_t>(K_),
                     static_cast<uint16_t>(tileRows));
-                if constexpr (exportFinalKg) {
-                    // vTyped remains an input to the fused direct-V write. Produce finalKg only
-                    // after that call completes so its writeback cannot race the first V load.
-                    // The typed helper also keeps BF16 finalKg within the score-safe exp range.
-                    PipeBarrier<PIPE_V>();
-                    PrepareKdaGateKgRegbase<T, T, GK_T, true>(
-                        (__ubuf__ T *)reinterpret_cast<uint64_t>(vTyped.GetPhyAddr()),
-                        (__ubuf__ T *)reinterpret_cast<uint64_t>(kTyped.GetPhyAddr()),
-                        (__ubuf__ GK_T *)reinterpret_cast<uint64_t>(gateTyped.GetPhyAddr()),
-                        (__ubuf__ float *)reinterpret_cast<uint64_t>(finalRefFp32.GetPhyAddr()),
-                        static_cast<uint16_t>(tileRows), static_cast<uint16_t>(K_),
-                        static_cast<uint16_t>(tileRows));
-                }
             } else {
                 PrepareKdaGateQwRegbase<T, SCORE_T, GK_T, true>(
                     (__ubuf__ T *)reinterpret_cast<uint64_t>(qTyped.GetPhyAddr()),
@@ -1979,6 +1973,10 @@ private:
             LoadGateScoreRef(refFp32, b, hv, refToken);
         }
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+        LocalTensor<float> finalRefFp32 = exp2Buf_.Get<float>()[K_];
+        if (materializeFinalKg_) {
+            LoadGateScoreRef(finalRefFp32, b, hv, start + curT - 1);
+        }
         const bool fuseScoreWriteback =
             writeScoreScratch && useRef && K_ * 2 <= EXP2_UB_ELEMENTS;
 #endif
@@ -2073,22 +2071,42 @@ private:
             }
             if (writeScoreScratch) {
                 if (fuseScoreWriteback) {
-                    PrepareKdaGateQwKgRegbase<T, SCORE_T, GK_T, true, true, false, true>(
-                        (__ubuf__ T *)reinterpret_cast<uint64_t>(qTyped.GetPhyAddr()),
-                        (__ubuf__ T *)reinterpret_cast<uint64_t>(kTyped.GetPhyAddr()),
-                        (__ubuf__ SCORE_T *)reinterpret_cast<uint64_t>(qScore.GetPhyAddr()),
-                        (__ubuf__ SCORE_T *)reinterpret_cast<uint64_t>(wScore.GetPhyAddr()),
-                        (__ubuf__ SCORE_T *)reinterpret_cast<uint64_t>(kgScore.GetPhyAddr()),
-                        (__ubuf__ T *)reinterpret_cast<uint64_t>(directQ.GetPhyAddr()),
-                        (__ubuf__ T *)reinterpret_cast<uint64_t>(directW.GetPhyAddr()),
-                        (__ubuf__ T *)reinterpret_cast<uint64_t>(vTyped.GetPhyAddr()),
-                        (__ubuf__ T *)reinterpret_cast<uint64_t>(directV.GetPhyAddr()),
-                        nullptr,
-                        (__ubuf__ float *)reinterpret_cast<uint64_t>(betaFp32.GetPhyAddr()),
-                        (__ubuf__ GK_T *)reinterpret_cast<uint64_t>(gateTyped.GetPhyAddr()),
-                        (__ubuf__ float *)reinterpret_cast<uint64_t>(refFp32.GetPhyAddr()),
-                        nullptr,
-                        static_cast<uint16_t>(tileRows), static_cast<uint16_t>(K_), validRows);
+                    if (materializeFinalKg_) {
+                        PrepareKdaGateQwKgRegbase<T, SCORE_T, GK_T, true, true, true, true>(
+                            (__ubuf__ T *)reinterpret_cast<uint64_t>(qTyped.GetPhyAddr()),
+                            (__ubuf__ T *)reinterpret_cast<uint64_t>(kTyped.GetPhyAddr()),
+                            (__ubuf__ SCORE_T *)reinterpret_cast<uint64_t>(qScore.GetPhyAddr()),
+                            (__ubuf__ SCORE_T *)reinterpret_cast<uint64_t>(wScore.GetPhyAddr()),
+                            (__ubuf__ SCORE_T *)reinterpret_cast<uint64_t>(kgScore.GetPhyAddr()),
+                            (__ubuf__ T *)reinterpret_cast<uint64_t>(directQ.GetPhyAddr()),
+                            (__ubuf__ T *)reinterpret_cast<uint64_t>(directW.GetPhyAddr()),
+                            (__ubuf__ T *)reinterpret_cast<uint64_t>(vTyped.GetPhyAddr()),
+                            (__ubuf__ T *)reinterpret_cast<uint64_t>(directV.GetPhyAddr()),
+                            (__ubuf__ T *)reinterpret_cast<uint64_t>(vTyped.GetPhyAddr()),
+                            (__ubuf__ float *)reinterpret_cast<uint64_t>(betaFp32.GetPhyAddr()),
+                            (__ubuf__ GK_T *)reinterpret_cast<uint64_t>(gateTyped.GetPhyAddr()),
+                            (__ubuf__ float *)reinterpret_cast<uint64_t>(refFp32.GetPhyAddr()),
+                            (__ubuf__ float *)reinterpret_cast<uint64_t>(finalRefFp32.GetPhyAddr()),
+                            static_cast<uint16_t>(tileRows), static_cast<uint16_t>(K_),
+                            validRows);
+                    } else {
+                        PrepareKdaGateQwKgRegbase<T, SCORE_T, GK_T, true, true, false, true>(
+                            (__ubuf__ T *)reinterpret_cast<uint64_t>(qTyped.GetPhyAddr()),
+                            (__ubuf__ T *)reinterpret_cast<uint64_t>(kTyped.GetPhyAddr()),
+                            (__ubuf__ SCORE_T *)reinterpret_cast<uint64_t>(qScore.GetPhyAddr()),
+                            (__ubuf__ SCORE_T *)reinterpret_cast<uint64_t>(wScore.GetPhyAddr()),
+                            (__ubuf__ SCORE_T *)reinterpret_cast<uint64_t>(kgScore.GetPhyAddr()),
+                            (__ubuf__ T *)reinterpret_cast<uint64_t>(directQ.GetPhyAddr()),
+                            (__ubuf__ T *)reinterpret_cast<uint64_t>(directW.GetPhyAddr()),
+                            (__ubuf__ T *)reinterpret_cast<uint64_t>(vTyped.GetPhyAddr()),
+                            (__ubuf__ T *)reinterpret_cast<uint64_t>(directV.GetPhyAddr()),
+                            nullptr,
+                            (__ubuf__ float *)reinterpret_cast<uint64_t>(betaFp32.GetPhyAddr()),
+                            (__ubuf__ GK_T *)reinterpret_cast<uint64_t>(gateTyped.GetPhyAddr()),
+                            (__ubuf__ float *)reinterpret_cast<uint64_t>(refFp32.GetPhyAddr()),
+                            nullptr,
+                            static_cast<uint16_t>(tileRows), static_cast<uint16_t>(K_), validRows);
+                    }
                 } else {
                     PrepareKdaGateQwKgRegbase<T, SCORE_T, GK_T, true, false, false>(
                         (__ubuf__ T *)reinterpret_cast<uint64_t>(qTyped.GetPhyAddr()),
@@ -2227,6 +2245,9 @@ private:
                     StorePreparedQG(b, hv, token, directQ, elems);
                     CopyVectorOut(w_, KVOffset(b, hv, token, 0, K_), directW, elems);
                     CopyVectorOut(vNew_, KVOffset(b, hv, token, 0, V_), directV, tileRows * V_);
+                    if (materializeFinalKg_) {
+                        CopyVectorOut(finalKg_, KVOffset(b, hv, token, 0, K_), vTyped, elems);
+                    }
                 }
 #endif
             } else {
@@ -5066,6 +5087,7 @@ private:
     bool headPairMode_ = false;
     bool inputSequenceMajor_ = false;
     bool fusePostWu_ = false;
+    bool materializeFinalKg_ = false;
     bool computeGateInPrepare_ = false;
     bool hasALog_ = false;
     bool hasDtBias_ = false;

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/chunk_kda_fwd_post_wu.h
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/chunk_kda_fwd_post_wu.h
@@ -710,7 +710,7 @@ private:
     template <typename SrcTensor, typename DstTensor>
     __aicore__ inline void ComputeTailWuRow(GlobalTensor<SrcTensor> &src, GlobalTensor<DstTensor> &dst,
                                             uint64_t akkBase, uint64_t srcBase, uint64_t dstBase, uint64_t curT,
-                                            uint64_t dim)
+                                            uint64_t dim, uint64_t rowStride)
     {
         LocalTensor<float> acc = vecBuf_.Get<float>();
         LocalTensor<float> value = vecBuf_.Get<float>()[512];
@@ -725,7 +725,7 @@ private:
         SetFlag<HardEvent::V_S>(EXP2_EVENT_ID);
         WaitFlag<HardEvent::V_S>(EXP2_EVENT_ID);
         for (uint64_t j = 0; j < curT; ++j) {
-            LoadAsFloatVector(src, srcBase + j * dim, value, typed, dim);
+            LoadAsFloatVector(src, srcBase + j * rowStride, value, typed, dim);
             float coefficient = coefficients.GetValue(j);
             SetFlag<HardEvent::S_V>(EXP2_EVENT_ID);
             WaitFlag<HardEvent::S_V>(EXP2_EVENT_ID);
@@ -749,15 +749,24 @@ private:
     __aicore__ inline void ComputeTailWuVector(uint64_t b, uint64_t hv, uint64_t start, uint64_t curT,
                                                uint64_t subBlockIdx, uint64_t subBlockNum)
     {
+        // preparedQG_ and w_ alias. Each subblock owns disjoint columns and
+        // writes rows from last to first, so every lower-triangular source row
+        // remains live through its final use without desynchronizing the AIVs.
+        uint64_t colBegin = (K_ * subBlockIdx) / subBlockNum;
+        uint64_t colEnd = (K_ * (subBlockIdx + 1)) / subBlockNum;
+        for (uint64_t row = curT; row > 0; --row) {
+            uint64_t rowIdx = row - 1;
+            ComputeTailWuRow(
+                preparedQG_, w_, AOffset(b, hv, start + rowIdx, 0), KVOffset(b, hv, start, colBegin, K_),
+                KVOffset(b, hv, start + rowIdx, colBegin, K_), curT, colEnd - colBegin, K_);
+        }
+
         uint64_t rowBegin = (curT * subBlockIdx) / subBlockNum;
         uint64_t rowEnd = (curT * (subBlockIdx + 1)) / subBlockNum;
         for (uint64_t row = rowBegin; row < rowEnd; ++row) {
             ComputeTailWuRow(
-                preparedQG_, w_, AOffset(b, hv, start + row, 0), KVOffset(b, hv, start, 0, K_),
-                KVOffset(b, hv, start + row, 0, K_), curT, K_);
-            ComputeTailWuRow(
                 propagatedVNew_, u_, AOffset(b, hv, start + row, 0), KVOffset(b, hv, start, 0, V_),
-                KVOffset(b, hv, start + row, 0, V_), curT, V_);
+                KVOffset(b, hv, start + row, 0, V_), curT, V_, V_);
         }
     }
 

--- a/torch_custom/fla_npu/test/test_npu_chunk_kda_a5_staging.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_kda_a5_staging.py
@@ -41,7 +41,9 @@ def _is_ascend950() -> bool:
 def _l2norm(x: torch.Tensor) -> torch.Tensor:
     dtype = x.dtype
     x_float = x.float()
-    return (x_float * torch.rsqrt(x_float.square().sum(dim=-1, keepdim=True) + 1e-6)).to(dtype)
+    return (
+        x_float * torch.rsqrt(x_float.square().sum(dim=-1, keepdim=True) + 1e-6)
+    ).to(dtype)
 
 
 def _chunk_indices(cu_seqlens: tuple[int, ...], chunk_size: int) -> tuple[int, ...]:
@@ -63,8 +65,7 @@ def _chunked_reference(
     cu_seqlens: tuple[int, ...],
 ) -> tuple[torch.Tensor, ...]:
     q, k, v, gate, beta, initial_state_vk = (
-        tensor.detach().cpu()
-        for tensor in (q, k, v, gate, beta, initial_state_vk)
+        tensor.detach().cpu() for tensor in (q, k, v, gate, beta, initial_state_vk)
     )
     batch, tokens, heads, head_dim = q.shape
     assert batch == 1
@@ -109,10 +110,14 @@ def _chunked_reference(
             gate_factor = torch.exp2(
                 relative_gate.masked_fill(~causal[None, :, :, None], 0.0)
             )
-            qk = torch.einsum("hik,hjk,hijk->hij", q_block, k_block, gate_factor) * scale
+            qk = (
+                torch.einsum("hik,hjk,hijk->hij", q_block, k_block, gate_factor) * scale
+            )
             kk = torch.einsum("hik,hjk,hijk->hij", k_block, k_block, gate_factor)
             aqk_block = torch.where(causal[None], qk, 0.0)
-            strict_kk = torch.where(strict_causal[None], kk * beta_block[:, :, None], 0.0)
+            strict_kk = torch.where(
+                strict_causal[None], kk * beta_block[:, :, None], 0.0
+            )
             akk_block = torch.linalg.solve_triangular(eye + strict_kk, eye, upper=False)
             w_block = torch.bmm(
                 akk_block,
@@ -133,12 +138,15 @@ def _chunked_reference(
             v_new[0, :, start:end] = v_new_block.to(dtype)
             h[0, global_chunk + chunk_offset] = state_kv.transpose(-1, -2).to(dtype)
             out[0, start:end] = (
-                torch.bmm(qg_block, state_kv) * scale
-                + torch.bmm(aqk_block, v_new_block)
-            ).transpose(0, 1).to(dtype)
-            state_kv = (
-                torch.exp2(gk_block[:, -1])[:, :, None] * state_kv
-                + torch.bmm(kg_block.transpose(1, 2), v_new_block)
+                (
+                    torch.bmm(qg_block, state_kv) * scale
+                    + torch.bmm(aqk_block, v_new_block)
+                )
+                .transpose(0, 1)
+                .to(dtype)
+            )
+            state_kv = torch.exp2(gk_block[:, -1])[:, :, None] * state_kv + torch.bmm(
+                kg_block.transpose(1, 2), v_new_block
             )
             chunk_offset += 1
         final_state_vk[seq_id] = state_kv.transpose(-1, -2)
@@ -167,11 +175,16 @@ def _for_layout(tensor: torch.Tensor, layout: str) -> torch.Tensor:
     return tensor.squeeze(0).contiguous()
 
 
-def _expected_for_layout(outputs: tuple[torch.Tensor, ...], layout: str) -> tuple[torch.Tensor, ...]:
+def _expected_for_layout(
+    outputs: tuple[torch.Tensor, ...], layout: str
+) -> tuple[torch.Tensor, ...]:
     if layout == "BSND":
         return outputs
     rank3_indices = {0, 2, 3, 4, 5, 6, 7, 8, 9, 10}
-    return tuple(output.squeeze(0) if index in rank3_indices else output for index, output in enumerate(outputs))
+    return tuple(
+        output.squeeze(0) if index in rank3_indices else output
+        for index, output in enumerate(outputs)
+    )
 
 
 def _expected_output_shapes(
@@ -183,8 +196,7 @@ def _expected_output_shapes(
 ) -> tuple[tuple[int, ...], ...]:
     seq_num = len(cu_seqlens) - 1
     total_chunks = sum(
-        math.ceil((end - start) / 64)
-        for start, end in zip(cu_seqlens, cu_seqlens[1:])
+        math.ceil((end - start) / 64) for start, end in zip(cu_seqlens, cu_seqlens[1:])
     )
     sequence_shape = (1, tokens, heads, head_dim)
     head_shape = (1, heads, tokens, head_dim)
@@ -229,14 +241,17 @@ def _assert_outputs(actual, expected, retained: set[int]) -> None:
 
 
 @pytest.mark.parametrize(
-    ("layout", "tokens", "heads", "cu_seqlens"),
+    ("layout", "tokens", "heads", "cu_seqlens", "use_metadata"),
     [
-        pytest.param("BSND", 131, 6, (0, 131), id="BSND-T131-H6"),
-        pytest.param("TND", 191, 6, (0, 63, 131, 191), id="TND-varlen"),
+        pytest.param("BSND", 128, 6, (0, 128), False, id="BSND-T128-dense"),
+        pytest.param("BSND", 131, 6, (0, 131), True, id="BSND-T131-H6"),
+        pytest.param("TND", 191, 6, (0, 63, 131, 191), True, id="TND-varlen"),
     ],
 )
 @torch.inference_mode()
-def test_chunk_kda_fwd_a5_multichunk_all_outputs(layout, tokens, heads, cu_seqlens):
+def test_chunk_kda_fwd_a5_multichunk_all_outputs(
+    layout, tokens, heads, cu_seqlens, use_metadata
+):
     if not _is_ascend950():
         pytest.skip("requires an Ascend 950 device")
 
@@ -244,23 +259,31 @@ def test_chunk_kda_fwd_a5_multichunk_all_outputs(layout, tokens, heads, cu_seqle
     device = torch.device("npu:0")
     torch.npu.set_device(0)
     head_dim = 128
-    q_bsnd = _l2norm(torch.randn(1, tokens, heads, head_dim, dtype=torch.bfloat16, device=device))
+    q_bsnd = _l2norm(
+        torch.randn(1, tokens, heads, head_dim, dtype=torch.bfloat16, device=device)
+    )
     k_bsnd = _l2norm(torch.randn_like(q_bsnd))
     v_bsnd = torch.randn_like(q_bsnd) * 0.05
-    raw_gate_bsnd = torch.randn(
-        1, tokens, heads, head_dim, dtype=torch.float32, device=device
-    ) * 0.1
-    beta_bsnd = torch.rand(1, tokens, heads, dtype=torch.float32, device=device).sigmoid()
+    raw_gate_bsnd = (
+        torch.randn(1, tokens, heads, head_dim, dtype=torch.float32, device=device)
+        * 0.1
+    )
+    beta_bsnd = torch.rand(
+        1, tokens, heads, dtype=torch.float32, device=device
+    ).sigmoid()
     a_log = torch.randn(heads, dtype=torch.float32, device=device) * 0.05
     dt_bias = torch.randn(heads * head_dim, dtype=torch.float32, device=device) * 0.05
-    initial_state_vk = torch.randn(
-        len(cu_seqlens) - 1,
-        heads,
-        head_dim,
-        head_dim,
-        dtype=torch.float32,
-        device=device,
-    ) * 0.01
+    initial_state_vk = (
+        torch.randn(
+            len(cu_seqlens) - 1,
+            heads,
+            head_dim,
+            head_dim,
+            dtype=torch.float32,
+            device=device,
+        )
+        * 0.01
+    )
     indices = _chunk_indices(cu_seqlens, 64)
     args = (
         _for_layout(q_bsnd, layout),
@@ -275,8 +298,8 @@ def test_chunk_kda_fwd_a5_multichunk_all_outputs(layout, tokens, heads, cu_seqle
         "layout": layout,
         "initial_state": initial_state_vk,
         "output_final_state": True,
-        "cu_seqlens": cu_seqlens,
-        "chunk_indices": indices,
+        "cu_seqlens": cu_seqlens if use_metadata else None,
+        "chunk_indices": indices if use_metadata else None,
         "safe_gate": True,
         "lower_bound": -5.0,
         "use_gate_in_kernel": True,
@@ -312,7 +335,17 @@ def test_chunk_kda_fwd_a5_multichunk_all_outputs(layout, tokens, heads, cu_seqle
     _assert_outputs(retained_outputs, expected, set(range(len(OUTPUT_NAMES))))
     assert retained_outputs[11] is initial_state_vk
 
-    del retained_outputs, expected
+    model_outputs = chunk_kda_fwd(
+        *args,
+        **kwargs,
+        disable_recompute=False,
+        return_intermediate_states=False,
+    )
+    torch.npu.synchronize()
+    _assert_outputs(model_outputs, expected, {0, 1, 3, 4, 11})
+    assert model_outputs[11] is initial_state_vk
+
+    del retained_outputs, model_outputs, expected
     gc.collect()
     torch.npu.empty_cache()
 
@@ -343,9 +376,7 @@ def test_chunk_kda_fwd_a5_t8191_all_outputs_are_finite(layout, cu_seqlens):
     raw_gate_bsnd = torch.zeros(
         (1, tokens, heads, head_dim), dtype=torch.float32, device=device
     )
-    beta_bsnd = torch.full(
-        (1, tokens, heads), 0.5, dtype=torch.float32, device=device
-    )
+    beta_bsnd = torch.full((1, tokens, heads), 0.5, dtype=torch.float32, device=device)
     initial_state_vk = torch.zeros(
         (len(cu_seqlens) - 1, heads, head_dim, head_dim),
         dtype=torch.float32,

--- a/torch_custom/fla_npu/test/test_npu_chunk_kda_tail_determinism.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_kda_tail_determinism.py
@@ -1,0 +1,110 @@
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from fla_npu.ops.ascendc import chunk_kda_fwd
+
+
+CHUNK_SIZE = 64
+DETERMINISM_REPEATS = 20
+OUTPUT_NAMES = (
+    "attn_out",
+    "final_state",
+    "gk",
+    "Aqk",
+    "Akk",
+    "w",
+    "u",
+    "qg",
+    "kg",
+    "v_new",
+    "h",
+    "initial_state_out",
+)
+
+
+def _chunk_indices(tokens):
+    return [
+        value
+        for chunk_id in range((tokens + CHUNK_SIZE - 1) // CHUNK_SIZE)
+        for value in (0, chunk_id)
+    ]
+
+
+def _snapshot(outputs):
+    torch.npu.synchronize()
+    return tuple(
+        None if output is None else output.detach().cpu().contiguous()
+        for output in outputs
+    )
+
+
+def _assert_bitwise_equal(expected, actual, repeat):
+    assert len(expected) == len(actual) == len(OUTPUT_NAMES)
+    for name, expected_output, actual_output in zip(OUTPUT_NAMES, expected, actual):
+        if expected_output is None or actual_output is None:
+            assert expected_output is None and actual_output is None, (
+                f"repeat={repeat} output={name} changed between None and Tensor"
+            )
+            continue
+        same_metadata = (
+            expected_output.shape == actual_output.shape
+            and expected_output.dtype == actual_output.dtype
+        )
+        same_bits = same_metadata and torch.equal(
+            expected_output.view(torch.uint8), actual_output.view(torch.uint8)
+        )
+        assert same_bits, f"repeat={repeat} output={name} is not bitwise deterministic"
+
+
+@pytest.mark.parametrize(
+    ("tokens", "disable_recompute"),
+    [
+        pytest.param(15, False, id="single-tail-model-mode"),
+        pytest.param(15, True, id="single-tail-all-outputs"),
+        pytest.param(65, True, id="full-chunk-plus-tail-all-outputs"),
+    ],
+)
+@torch.inference_mode()
+def test_chunk_kda_tail_is_bitwise_deterministic(tokens, disable_recompute):
+    torch.manual_seed(20260820 + tokens + int(disable_recompute))
+    torch.npu.set_device(0)
+
+    shape = (1, tokens, 6, 128)
+    q = (torch.randn(shape) * 0.04).to(torch.bfloat16).npu()
+    k = (torch.randn(shape) * 0.04).to(torch.bfloat16).npu()
+    v = (torch.randn(shape) * 0.04).to(torch.bfloat16).npu()
+    raw_gate = (-7.0 + torch.randn(shape) * 0.03).to(torch.float32).npu()
+    beta = (torch.rand((1, tokens, 6)) * 0.2 + 0.05).to(torch.float32).npu()
+    initial_state = (torch.randn((1, 6, 128, 128)) * 0.01).to(torch.float32).npu()
+    a_log = torch.zeros(6, dtype=torch.float32, device="npu")
+    dt_bias = torch.zeros(6 * 128, dtype=torch.float32, device="npu")
+
+    def run():
+        return chunk_kda_fwd(
+            q,
+            k,
+            v,
+            raw_gate,
+            beta,
+            128**-0.5,
+            CHUNK_SIZE,
+            layout="BSND",
+            initial_state=initial_state,
+            output_final_state=True,
+            cu_seqlens=[0, tokens],
+            chunk_indices=_chunk_indices(tokens),
+            safe_gate=True,
+            lower_bound=-5.0,
+            use_gate_in_kernel=True,
+            A_log=a_log,
+            dt_bias=dt_bias,
+            disable_recompute=disable_recompute,
+            return_intermediate_states=True,
+            state_v_first=True,
+        )
+
+    run()
+    expected = _snapshot(run())
+    for repeat in range(1, DETERMINISM_REPEATS):
+        _assert_bitwise_equal(expected, _snapshot(run()), repeat)

--- a/torch_custom/fla_npu/test/test_npu_chunk_kda_tail_metadata.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_kda_tail_metadata.py
@@ -1,0 +1,265 @@
+import math
+from dataclasses import dataclass
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from fla_npu.ops.ascendc import chunk_kda_fwd
+
+
+CHUNK_SIZE = 64
+HEADS = 6
+HEAD_DIM = 128
+LOWER_BOUND = -5.0
+MAX_REASONABLE_ABS = 1.0e6
+TAIL_TEST_TOKENS = (
+    128,
+    129,
+    130,
+    131,
+    143,
+    144,
+    145,
+    159,
+    160,
+    161,
+    191,
+    192,
+    193,
+)
+OUTPUT_NAMES = (
+    "output",
+    "final_state",
+    "gk",
+    "aqk",
+    "akk",
+    "w",
+    "u",
+    "qg",
+    "kg",
+    "v_new",
+    "h",
+    "initial_state",
+)
+
+
+@dataclass
+class ChunkKdaInputs:
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    raw_gate: torch.Tensor
+    activated_gate: torch.Tensor
+    beta: torch.Tensor
+    a_log: torch.Tensor
+    dt_bias: torch.Tensor
+    initial_state: torch.Tensor
+    cu_seqlens: tuple[int, ...]
+    chunk_indices: tuple[int, ...]
+
+    def clone(self):
+        return ChunkKdaInputs(
+            q=self.q.clone(),
+            k=self.k.clone(),
+            v=self.v.clone(),
+            raw_gate=self.raw_gate.clone(),
+            activated_gate=self.activated_gate.clone(),
+            beta=self.beta.clone(),
+            a_log=self.a_log.clone(),
+            dt_bias=self.dt_bias.clone(),
+            initial_state=self.initial_state.clone(),
+            cu_seqlens=self.cu_seqlens,
+            chunk_indices=self.chunk_indices,
+        )
+
+
+def l2norm(value):
+    dtype = value.dtype
+    value_fp32 = value.float()
+    return (
+        value_fp32
+        * torch.rsqrt((value_fp32 * value_fp32).sum(dim=-1, keepdim=True) + 1e-6)
+    ).to(dtype)
+
+
+def build_inputs(tokens):
+    seed = 20260820 + tokens
+    torch.manual_seed(seed)
+    torch.npu.manual_seed_all(seed)
+
+    shape = (1, tokens, HEADS, HEAD_DIM)
+    q = l2norm(torch.randn(shape, device="npu", dtype=torch.bfloat16))
+    k = l2norm(torch.randn(shape, device="npu", dtype=torch.bfloat16))
+    v = torch.randn(shape, device="npu", dtype=torch.bfloat16) * 0.2
+    raw_gate = torch.randn(shape, device="npu", dtype=torch.bfloat16) * 2.0
+    beta = torch.sigmoid(
+        torch.randn((1, tokens, HEADS), device="npu", dtype=torch.float32)
+    )
+    a_log = torch.empty((HEADS,), device="npu", dtype=torch.float32).uniform_(-0.5, 0.8)
+    dt_bias = torch.empty(
+        (HEADS * HEAD_DIM,), device="npu", dtype=torch.float32
+    ).uniform_(-7.5, -1.5)
+    initial_state = torch.zeros(
+        (1, HEADS, HEAD_DIM, HEAD_DIM), device="npu", dtype=torch.float32
+    )
+    activated_gate = LOWER_BOUND * torch.sigmoid(
+        (raw_gate.float() + dt_bias.view(1, 1, HEADS, HEAD_DIM))
+        * a_log.exp().view(1, 1, HEADS, 1)
+    )
+    chunk_indices = tuple(
+        value
+        for chunk_index in range(math.ceil(tokens / CHUNK_SIZE))
+        for value in (0, chunk_index)
+    )
+    return ChunkKdaInputs(
+        q=q,
+        k=k,
+        v=v,
+        raw_gate=raw_gate,
+        activated_gate=activated_gate,
+        beta=beta,
+        a_log=a_log,
+        dt_bias=dt_bias,
+        initial_state=initial_state,
+        cu_seqlens=(0, tokens),
+        chunk_indices=chunk_indices,
+    )
+
+
+def final_state_reference(inputs):
+    k = inputs.k.detach().cpu()
+    v = inputs.v.detach().cpu()
+    gate = inputs.activated_gate.detach().cpu()
+    beta = inputs.beta.detach().cpu()
+    initial_state = inputs.initial_state.detach().cpu()
+    _, tokens, heads, head_dim = k.shape
+    final_state = torch.empty_like(initial_state, dtype=torch.float32)
+
+    for head_index in range(heads):
+        state_kv = initial_state[0, head_index].float().transpose(-1, -2).contiguous()
+        for start in range(0, tokens, CHUNK_SIZE):
+            end = min(start + CHUNK_SIZE, tokens)
+            chunk_tokens = end - start
+            strict_causal = torch.ones(
+                (chunk_tokens, chunk_tokens), dtype=torch.bool
+            ).tril(diagonal=-1)
+            eye = torch.eye(chunk_tokens, dtype=torch.float32)
+            k_block = k[0, start:end, head_index].float()
+            v_block = v[0, start:end, head_index].float()
+            beta_block = beta[0, start:end, head_index].float()
+            gk_block = torch.cumsum(
+                gate[0, start:end, head_index].float(), dim=0
+            ) / math.log(2.0)
+            relative_gate = gk_block[:, None, :] - gk_block[None, :, :]
+            gate_factor = torch.exp2(
+                relative_gate.masked_fill(~strict_causal[:, :, None], 0.0)
+            )
+            kk = torch.einsum("ik,jk,ijk->ij", k_block, k_block, gate_factor)
+            strict_kk = torch.where(strict_causal, kk * beta_block[:, None], 0.0)
+            akk_block = torch.linalg.solve_triangular(eye + strict_kk, eye, upper=False)
+            w_block = akk_block @ (k_block * beta_block[:, None] * torch.exp2(gk_block))
+            u_block = akk_block @ (v_block * beta_block[:, None])
+            kg_block = k_block * torch.exp2(gk_block[-1][None, :] - gk_block)
+            v_new_block = u_block - w_block @ state_kv
+            state_kv = (
+                torch.exp2(gk_block[-1])[:, None] * state_kv + kg_block.T @ v_new_block
+            )
+        final_state[0, head_index] = state_kv.transpose(-1, -2)
+    return final_state
+
+
+def run_chunk_kda(inputs, gate_mode, metadata_mode):
+    use_gate_in_kernel = gate_mode == "raw_gate"
+    gate = inputs.raw_gate if use_gate_in_kernel else inputs.activated_gate
+    use_varlen_metadata = metadata_mode == "varlen"
+    return chunk_kda_fwd(
+        inputs.q,
+        inputs.k,
+        inputs.v,
+        gate,
+        inputs.beta,
+        HEAD_DIM**-0.5,
+        CHUNK_SIZE,
+        layout="BSND",
+        initial_state=inputs.initial_state,
+        output_final_state=True,
+        cu_seqlens=inputs.cu_seqlens if use_varlen_metadata else None,
+        chunk_indices=inputs.chunk_indices if use_varlen_metadata else None,
+        safe_gate=True,
+        lower_bound=LOWER_BOUND,
+        use_gate_in_kernel=use_gate_in_kernel,
+        A_log=inputs.a_log if use_gate_in_kernel else None,
+        dt_bias=inputs.dt_bias if use_gate_in_kernel else None,
+        disable_recompute=True,
+        return_intermediate_states=False,
+        state_v_first=True,
+    )
+
+
+def snapshot(outputs):
+    torch.npu.synchronize()
+    return tuple(
+        output.detach().cpu().contiguous() if isinstance(output, torch.Tensor) else None
+        for output in outputs
+    )
+
+
+def assert_bitwise_equal(expected, actual, tokens):
+    assert len(expected) == len(actual) == len(OUTPUT_NAMES)
+    for name, first, second in zip(OUTPUT_NAMES, expected, actual):
+        if first is None or second is None:
+            assert first is None and second is None, (
+                f"tokens={tokens} output={name} changed between Tensor and None"
+            )
+            continue
+        same_metadata = first.shape == second.shape and first.dtype == second.dtype
+        same_bits = same_metadata and torch.equal(
+            first.view(torch.uint8), second.view(torch.uint8)
+        )
+        assert same_bits, f"tokens={tokens} output={name} is not bitwise equal"
+        first_fp32 = first.float()
+        second_fp32 = second.float()
+        assert torch.isfinite(first_fp32).all(), (
+            f"tokens={tokens} output={name} contains non-finite values"
+        )
+        assert torch.isfinite(second_fp32).all(), (
+            f"tokens={tokens} output={name} contains non-finite values"
+        )
+        assert first_fp32.abs().max().item() <= MAX_REASONABLE_ABS, (
+            f"tokens={tokens} output={name} has an unreasonable magnitude"
+        )
+        assert second_fp32.abs().max().item() <= MAX_REASONABLE_ABS, (
+            f"tokens={tokens} output={name} has an unreasonable magnitude"
+        )
+
+
+@pytest.mark.parametrize(
+    "tokens",
+    TAIL_TEST_TOKENS,
+    ids=lambda tokens: f"tokens_{tokens}_remainder_{tokens % CHUNK_SIZE}",
+)
+@pytest.mark.parametrize("gate_mode", ["external_gate", "raw_gate"])
+@pytest.mark.parametrize("metadata_mode", ["dense", "varlen"])
+@torch.inference_mode()
+def test_chunk_kda_tail_metadata_is_bitwise_deterministic(
+    tokens, gate_mode, metadata_mode
+):
+    inputs = build_inputs(tokens)
+    # Allocate both sets before the first launch so an out-of-bounds write from
+    # that launch cannot change tensors allocated for the second invocation.
+    first_inputs = inputs.clone()
+    second_inputs = inputs.clone()
+    first = snapshot(run_chunk_kda(first_inputs, gate_mode, metadata_mode))
+    second = snapshot(run_chunk_kda(second_inputs, gate_mode, metadata_mode))
+    torch.testing.assert_close(
+        first[1],
+        final_state_reference(inputs),
+        rtol=3e-2,
+        atol=3e-2,
+        msg=(
+            f"final_state accuracy failed for tokens={tokens}, "
+            f"gate_mode={gate_mode}, metadata_mode={metadata_mode}"
+        ),
+    )
+    assert_bitwise_equal(first, second, tokens)


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建后需在当前 head commit 上触发 NPU CI；后续更新 commit 时需要重新触发，并满足分支保护要求。

## 关联 Issue / 背景

- 关联 Issue: Closes #349
- 背景与目标: A5 上 `chunk_kda_fwd` 的不足 16 token 短尾块在随机非零 `initial_state` 下可能出现 bitwise determinism 不一致。
- 本 PR 解决的问题: 修复 A5 Finalize 系数从 VEC 交给 scalar 读取时的遗留 event 状态问题，同时修复 Post-WU workspace 别名下的跨 AIV 重叠更新，并补齐共享 FwdH 短尾块事件所有权。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `chunk_kda_fwd`、内部复用的 `chunk_gated_delta_rule_fwd_h` 尾块路径
- 涉及目录 / 文件: `fla/ops/ascendc/kda/chunk_kda_fwd/`、`fla/ops/ascendc/gdn/chunk_gdn_fwd/`、`torch_custom/fla_npu/test/test_npu_chunk_kda_tail_determinism.py`、`torch_custom/fla_npu/test/test_npu_chunk_kda_tail_metadata.py`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不改变既有 BSND/BNSD/TND/NTD、dtype、chunk size、gate、initial state、`state_v_first` 和 12 项返回值语义；新增 BSND、BF16、chunk=64、K=V=128、短尾块和跨 chunk 尾块的 bitwise 回归，并覆盖 raw/external gate 与 dense/varlen metadata。
- 明确不包含的范围: 不修改数学算法、公开 Python/ACLNN 接口、输入 range 或精度阈值；不声明性能收益。
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [x] 是，共享 FwdH 短尾块事件协议被修正；已在 A2 边界用例与 A5 KDA 回归中验证。
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无公共 ABI 变化，仅调整 kernel 内部同步和 workspace 访问顺序。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

```sh
bash build.sh --pkg --soc=ascend950 --vendor_name=fla_npu --ops=chunk_kda_fwd
python -m pytest -q torch_custom/fla_npu/test/test_npu_chunk_kda_tail_determinism.py
python -m pytest -q torch_custom/fla_npu/test/test_npu_chunk_kda_tail_metadata.py
git diff --check
```

补充执行模型形状 `S=7680/H=6/D=128`、BSND/TND 300 条精度用例，并逐项检查 12 个输出。

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未验证 | 定向构建 `chunk_kda_fwd` | 未执行 | 待 NPU CI 补齐 |
| A3 | `ascend910_93` | 未验证 | 定向构建 `chunk_kda_fwd` | 未执行 | 待 NPU CI 补齐 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.x | BSND/TND 边界单算子回归 | 通过 | 短尾块、跨 chunk 尾块和模型形状通过 |
| A3 | `ascend910_93` | 未验证 | 定向构建 `chunk_kda_fwd` | 未执行 | 待 NPU CI 补齐 |
| A5 | `ascend950` | 9.2.0 | 定向构建 `chunk_kda_fwd` | 通过 | 所有 tiling key 与安装包生成成功 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | BSND `S=15/16/65/131/7680`、TND packed varlen、用户 tail metadata 矩阵 | 通过 | 用户矩阵 52/52 通过，全部 12 个返回位 bitwise 稳定；BSND/TND 精度通过 |
| A3 | `ascend910_93` | 未执行 | 未执行 | 待 NPU CI 补齐 |
| A5 | `ascend950` | 确定性回归、用户 tail metadata 矩阵、模型形状、300 条精度 | 通过 | 用户矩阵 52/52 通过，全部 12 个返回位 bitwise 稳定；三组各 20 次 bitwise 相同；300/300 精度通过 |

- 精度对比: BSND 150 条、TND 150 条，全部 12 个输出按 `rtol=atol=3e-2` 比较，300/300 通过；全局最大绝对误差不超过 `9.765625e-4`。
- 性能对比: 未执行；新增 `PIPE_ALL` 仅位于 A5 短尾块系数交接路径，本 PR 不声明性能收益。
- 边界 / 异常场景: 覆盖 `S=15/16/65/128/129/130/131/143/144/145/159/160/161/191/192/193/7680`、随机/零 `initial_state`、raw/external gate、dense/varlen metadata、`disable_recompute` 两种模式、`state_v_first=true`、BSND/TND 和全部 12 个返回位。
- 未覆盖风险: A3、CANN 8.5 A2/A3、整体 Example ST、sanitizer 和性能仍待 CI 或后续验证。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI |

- 端到端场景说明: GDN/KDA 前向调用链。
- 与本 PR 修改算子的关联: 模型 prefill 会调用 `chunk_kda_fwd`，短尾块会进入本 PR 修复路径。
- 未覆盖原因及补充计划: PR 创建后触发 NPU CI quick 补齐。

</details>

## 兼容性、风险与回退

- 兼容性说明: 公共接口、shape、dtype、layout、输出保留策略和返回顺序不变；PR 338 已有的 `NpuArch::DAV_3510` tiling 隔离保持不变。
- 风险点: A5 短尾块增加全 pipe drain；共享 FwdH 尾块调整 event 生命周期和 scalar 权重读取顺序，需要关注低 token 场景性能及 A2/A3 回归。
- 回退方案: 回退本 PR 单提交即可恢复原 kernel 同步与 workspace 更新顺序；保留新增真实 NPU 回归用于后续定位。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 根因一: A5 Finalize 在 BF16 系数 Cast 后使用 `V_S` event 交给 scalar `GetValue`；前序 megakernel 阶段复用同一 event ID，首个 wait 可能消费遗留状态并提前读取系数。短尾块改为在首次 scalar 读取前执行 `PipeBarrier<PIPE_ALL>()`。
- 根因二: Post-WU 的 `preparedQG` 与 `w` 复用 workspace，两个 AIV 子块原先可能读写重叠行。修复后按 K 列分区，并按行逆序处理，避免覆盖仍待消费的数据。
- 共享 FwdH 短尾块补齐 CrossCore wait 所有权和 VEC/MTE/scalar event 闭环，避免重复 wait 或未完成数据被消费。
- 提交: `c63123c5d651fcd25bc82007e4a72ab035ea398d`
