### PR TITLE
fix: 统一 bwd dhu 的 L0A ping-pong 流水

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_cube.h
@@ -83,8 +83,6 @@ public:
         cachedKResidentValid_ = false;
         cachedKResidentBase_ = 0;
         cachedKResidentSlot_ = 0;
-        cachedL0KValid_ = false;
-        cachedL0KBase_ = 0;
     }
 
     __aicore__ inline void Process()
@@ -151,7 +149,6 @@ public:
 
                 cachedKResidentValid_ = false;
                 nextKResidentSlot_ = 0;
-                cachedL0KValid_ = false;
                 for (int64_t headOffset = 0; headOffset < headCnt; ++headOffset) {
                     const int64_t hv = hvBase + headOffset;
                     const int64_t workspaceSlot = windowStartSlot + headOffset;
@@ -191,17 +188,13 @@ public:
                                             termQWorkspaceOffset_);
 
                     auto tensorK = tla::MakeTensor(gmK, layoutK, Catlass::Arch::PositionGM{});
-                    constexpr bool useL0KResident = std::is_same<DT, bfloat16_t>::value && V_DIM == 128;
-                    const bool needLoadKResident = useL0KResident ?
-                                                       (!cachedL0KValid_ || cachedL0KBase_ != kBase) :
-                                                       (!cachedKResidentValid_ || cachedKResidentBase_ != kBase);
+                    const bool needLoadKResident = !cachedKResidentValid_ || cachedKResidentBase_ != kBase;
                     if (needLoadKResident) {
                         if (cachedKResidentValid_) {
                             AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(KResidentEvent(cachedKResidentSlot_));
                             cachedKResidentValid_ = false;
                         }
                         cachedKResidentBase_ = kBase;
-                        cachedL0KBase_ = kBase;
                         cachedKResidentSlot_ = nextKResidentSlot_;
                         cachedKResidentValid_ = true;
                         nextKResidentSlot_ ^= 1U;
@@ -300,20 +293,15 @@ public:
                                     tla::MakeTensor(l0A[l0Slot], layoutL0A, Catlass::Arch::PositionL0A{});
                                 auto tensorTileL1A = tla::GetTile(
                                     tensorL1K, tla::MakeCoord(0, kOffset), tla::MakeShape(mActual, curK));
-                                if (!useL0KResident || needLoadKResident) {
-                                    if (waitKReady) {
-                                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(kResidentEvent);
-                                        waitKReady = false;
-                                    }
-                                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0AEvent);
-                                    copyL1ToL0A_DvState(tensorL0A, tensorTileL1A);
-                                    if (lastK && (releaseKAfterUse || useL0KResident)) {
-                                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(kResidentEvent);
-                                        cachedKResidentValid_ = false;
-                                    }
-                                    if (lastK && useL0KResident) {
-                                        cachedL0KValid_ = true;
-                                    }
+                                if (waitKReady) {
+                                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(kResidentEvent);
+                                    waitKReady = false;
+                                }
+                                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0AEvent);
+                                copyL1ToL0A_DvState(tensorL0A, tensorTileL1A);
+                                if (lastK && releaseKAfterUse) {
+                                    AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(kResidentEvent);
+                                    cachedKResidentValid_ = false;
                                 }
 
                                 auto layoutL0B = tla::MakeLayout<DT, LayoutTagL0B_DvState>(
@@ -333,9 +321,7 @@ public:
                                     AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(stateScratchEvent);
                                 }
                                 AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(l0ReadyEvent);
-                                if (!useL0KResident) {
-                                    curL0_ ^= 1U;
-                                }
+                                curL0_ ^= 1U;
 
                                 AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(l0ReadyEvent);
                                 if (firstK) {
@@ -343,12 +329,7 @@ public:
                                 }
                                 const uint8_t unitFlag = lastK ? 0b11 : 0b10;
                                 tileMmadDvState(tensorTileL0C, tensorL0A, tensorL0B, firstK, unitFlag);
-                                if (!useL0KResident || releaseKAfterUse) {
-                                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0AEvent);
-                                    if (useL0KResident) {
-                                        cachedL0KValid_ = false;
-                                    }
-                                }
+                                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0AEvent);
                                 AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0BEvent);
                                 if (lastK) {
                                     AscendC::SetFlag<AscendC::HardEvent::M_FIX>(l0CEvent);
@@ -395,7 +376,7 @@ public:
                             static_cast<uint32_t>(chunkInfo.chunkLen), static_cast<uint32_t>(V_DIM),
                             static_cast<uint32_t>(K_));
                     }
-                    if (releaseKAfterUse && !useL0KResident) {
+                    if (releaseKAfterUse) {
                         cachedKResidentValid_ = false;
                     }
 
@@ -415,9 +396,6 @@ public:
                     }
                     auto tensorL1QGT =
                         tla::MakeTensor(l1AScratch[qgScratchSlot], L1A_LAYOUT_QGT, Catlass::Arch::PositionL1{});
-                    if constexpr (useL0KResident) {
-                        curL0_ = 1;
-                    }
                     RunResidentMmad<LayoutTagL0A_TermQ, LayoutTagL0B_TermQ>(
                         copyL1ToL0A_TermQ, copyL1ToL0B_TermQ, tileMmadTermQ, copyL0CToGm_TermQ,
                         tensorL1QGT, tensorL1DO, blockTermQ, l0A, l0B, l0C,
@@ -964,8 +942,6 @@ private:
     bool cachedKResidentValid_ = false;
     int64_t cachedKResidentBase_ = 0;
     uint32_t cachedKResidentSlot_ = 0;
-    bool cachedL0KValid_ = false;
-    int64_t cachedL0KBase_ = 0;
 };
 
 } // namespace GDN


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。

## 关联 Issue / 背景

- 关联 Issue: Fixes #351
- 背景与目标: A5 BF16、V=128 的三头任务窗口在跨阶段复用 L0A 时可能无法正常完成。
- 本 PR 解决的问题: 取消 K 的 L0A 常驻特殊状态，使 DvState、TermQ 和 TermW 统一使用同一套 L0A ping-pong 流水。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `ChunkGatedDeltaRuleBwdDhu`
- 涉及目录 / 文件: `fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_cube.h`
- 责任人 / 提交人: @zhangshuolei-hfut
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 保持现有支持范围不变。
- 明确不包含的范围: 不修改 A2/A3 kernel、host tiling、公开接口、golden 和分核策略。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无。仅调整 A5 kernel 内部 L1 K 复用和 L0A ping-pong 流水。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

### 1. 编译验证

```sh
bash build.sh --pkg --soc=ascend910b --ops=chunk_gated_delta_rule_bwd_dhu --vendor_name=fla_npu -j64
bash build.sh --pkg --soc=ascend950 --ops=chunk_gated_delta_rule_bwd_dhu --vendor_name=fla_npu -j64
```

### 2. 修改算子测试验证

使用 `fla_npu.ops.ascendc.npu_chunk_gated_delta_rule_bwd_dhu` 运行双标杆泛化测试，比较 `dh`、`dh0` 和 `dv2`。

覆盖 fixed/varlen、BF16/FP16、chunk=64/128、尾块、`Hk:Hv=1:2/1:3/1:4`、`g + use_exp2=false/true`、`gk + use_exp2=true`。

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  |  | 未执行 | 本次使用 CANN 9.0.1 验证 |
| A3 | `ascend910_93` |  |  | 未执行 | 本次未覆盖 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.0.1 | `bash build.sh --pkg --soc=ascend910b --ops=chunk_gated_delta_rule_bwd_dhu --vendor_name=fla_npu -j64` | 通过 | 单算子 run 包生成成功 |
| A3 | `ascend910_93` |  |  | 未执行 | 本次修改仅涉及 A5 arch35 kernel，待 CI 覆盖 |
| A5 | `ascend950` | 9.1.0 | `bash build.sh --pkg --soc=ascend950 --ops=chunk_gated_delta_rule_bwd_dhu --vendor_name=fla_npu -j64` | 通过 | 单算子 run 包生成成功 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 双标杆泛化测试 | 通过 | 7/7 用例通过，`dh/dh0/dv2` 均通过 |
| A3 | `ascend910_93` |  | 未执行 | 本次修改仅涉及 A5 arch35 kernel，待 CI 覆盖 |
| A5 | `ascend950` | 双标杆泛化测试 | 通过 | 6/6 用例通过，`dh/dh0/dv2` 均通过；三头任务路径正常完成 |

- 精度对比: A2、A5 双标杆泛化测试全部通过。
- 性能对比: A5 目标性能 case 中，统一 L0A ping-pong 方案为 1798.129 us；L0A 常驻方案为 1789.599 us，差异约 0.48%；四头规避方案为 1947.546 us，统一方案快约 7.67%。
- 边界 / 异常场景: 覆盖 fixed/varlen、尾块、chunk=64/128、BF16/FP16、GVA 1:2/1:3/1:4、`g`/`gk`、`use_exp2` 和 `dh0`。
- 未覆盖风险: A3 与整体 Example ST 未在本地执行，待 NPU CI 覆盖。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 未执行 | 待 NPU CI 覆盖 |
| A3 | `ascend910_93` |  | 未执行 | 待 NPU CI 覆盖 |
| A5 | `ascend950` |  | 未执行 | 待 NPU CI 覆盖 |

- 端到端场景说明: 本次仅完成修改算子的定向构建、精度和性能验证。
- 与本 PR 修改算子的关联: 修改位于 GDN 反向 `dhu` 阶段。
- 未覆盖原因及补充计划: 由 NPU CI 补充 Example ST 和 A3 回归。

</details>

## 兼容性、风险与回退

- 兼容性说明: 公开接口、ABI、输入输出、tiling 和分核策略均不变。
- 风险点: A5 BF16、V=128 路径新增每个 DvState 的 L1 到 L0A 搬运；K 仍在独立 L1 buffer 中按 query head 复用。
- 回退方案: 回退本 PR 单个提交即可恢复原行为。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

根因是 K 的 L0A 常驻特殊状态与 DvState、TermQ、TermW 的通用 ping-pong 共用槽位和事件生命周期。奇数 value head 任务窗口会使这两套状态发生冲突。修复后 K 仅在独立 L1 buffer 中复用，每个 DvState 从 L1 搬入当前 L0A slot，所有计算阶段统一通过 `curL0_` 轮转。
