### PR TITLE
fix(build): prefer vendored opbase inc/src in OP_TILING_INCLUDE

### DIFF
--- a/cmake/variables.cmake
+++ b/cmake/variables.cmake
@@ -157,6 +157,8 @@ else()
 endif()
 
 set(OP_TILING_INCLUDE
+  ${OPBASE_SOURCE_PATH}/pkg_inc
+  ${OPBASE_SOURCE_PATH}/include
   ${C_SEC_INCLUDE}
   ${PLATFORM_INC_DIRS}
   ${METADEF_INCLUDE_DIRS}


### PR DESCRIPTION
## Summary
When building with a commercial CANN 9.2.0 package on Ascend, tiling sources vendored in
`third_party/opbase/src/...` (e.g. `elewise_tiling.cpp`, `reduce_tiling.cpp`) fail to compile
with:

```
error: no declaration matches 'void ...ElewiseBaseTiling::AdaptEleBaseTilingData(...)'
note: candidate is: 'void ...AdaptEleBaseTilingData(...) const'
```

The root cause is a **header/source mismatch**: the CANN-installed `pkg_inc` opbase headers are
newer than (or differ in `const`-qualifier signatures from) the vendored opbase revision that this
project actually compiles. `OP_TILING_INCLUDE` resolves the installed CANN header first, so the
compiler sees a declaration that does not match the vendored definition.

This change prepends the vendored opbase include directories (`${OPBASE_SOURCE_PATH}/pkg_inc` and
`${OPBASE_SOURCE_PATH}/include`) to `OP_TILING_INCLUDE`, so opbase tiling sources resolve their
headers from the **same** vendored opbase revision instead of the CANN-installed one, guaranteeing
header/source 同源 (same source) and eliminating the mismatch.

## How it was tested
- Applies cleanly on top of `main`.
- With the patch, the build that previously failed on commercial CANN 9.2.0 compiles successfully.

Made with [Cursor](https://cursor.com)