### PR TITLE
fix(build): explicitly include soc_spec.h in tiling sources

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_host/op_tiling/prepare_wy_repr_bwd_da_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_host/op_tiling/prepare_wy_repr_bwd_da_tiling.cpp
@@ -15,6 +15,7 @@
 #include "prepare_wy_repr_bwd_da_tiling.h"
 #include "arch35/prepare_wy_repr_bwd_da_tiling_a5.h"
 #include <register/op_impl_registry.h>
+#include "platform/soc_spec.h"
 #include "platform/platform_ascendc.h"
 
 namespace optiling {

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/prepare_wy_repr_bwd_full_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/prepare_wy_repr_bwd_full_tiling.cpp
@@ -15,6 +15,7 @@
 #include "prepare_wy_repr_bwd_full_tiling.h"
 #include "arch35/prepare_wy_repr_bwd_full_tiling_a5.h"
 #include <register/op_impl_registry.h>
+#include "platform/soc_spec.h"
 #include "platform/platform_ascendc.h"
 
 namespace optiling {

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_local_cumsum/op_host/chunk_local_cumsum_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_local_cumsum/op_host/chunk_local_cumsum_tiling.cpp
@@ -17,6 +17,7 @@
 #include <cstring>
 #include <cstdint>
 #include "register/op_impl_registry.h"
+#include "platform/soc_spec.h"
 #include "tiling/platform/platform_ascendc.h"
 #include "log/log.h"
 #include "err/ops_err.h"

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_scaled_dot_kkt/op_host/chunk_scaled_dot_kkt_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_scaled_dot_kkt/op_host/chunk_scaled_dot_kkt_tiling.cpp
@@ -6,6 +6,7 @@
 
 #include "../op_kernel/chunk_scaled_dot_kkt_common.h"
 #include "register/op_impl_registry.h"
+#include "platform/soc_spec.h"
 #include "tiling/platform/platform_ascendc.h"
 
 namespace optiling {

--- a/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_host/causal_conv1d_bwd_tiling.cpp
+++ b/fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_host/causal_conv1d_bwd_tiling.cpp
@@ -18,6 +18,7 @@
 #include "register/op_def_registry.h"
 #include "tiling_base/tiling_templates_registry.h"
 #include "tiling_base/tiling_util.h"
+#include "platform/soc_spec.h"
 #include "log/log.h"
 #include "util/math_util.h"
 #include "platform/platform_info.h"


### PR DESCRIPTION
## 关联 Issue / 背景

- 关联 Issue: 无（构建修复，无需 Issue）
- 背景与目标: CANN 8.5.2 下 `python scripts/build_wheel.py` / `bash build.sh --pkg` 全量编译失败，报错 `'DAV_2201'/'DAV_3510' is not a member of 'NpuArch'`。
- 本 PR 解决的问题: 让工程在 CANN 8.5.2 下可以完整编译通过，同时不影响 CANN 9.0+。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 变更内容

根因：CANN 8.5.2 的 `tiling/platform/platform_ascendc.h`（`aarch64-linux/ascendc/include/highlevel_api/tiling/platform/`）**去掉了 `#include "platform/soc_spec.h"`**，导致 `NpuArch` 仅剩前向声明，枚举成员（如 `DAV_2201`、`DAV_3510`）未定义。对比 CANN 9.1.0 同一头文件第 21 行仍保留该 include。

修复：在以下 5 个使用 `NpuArch::DAV_*` 的 tiling 编译单元补上显式 `#include "platform/soc_spec.h"`，与现有 `chunk_kda_fwd_tiling.cpp` 的写法保持一致：

- `fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_local_cumsum/op_host/chunk_local_cumsum_tiling.cpp`
- `fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_scaled_dot_kkt/op_host/chunk_scaled_dot_kkt_tiling.cpp`
- `fla/ops/ascendc/gdn/gdn_preprocess/causal_conv1d_bwd/op_host/causal_conv1d_bwd_tiling.cpp`
- `fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_da/op_host/op_tiling/prepare_wy_repr_bwd_da_tiling.cpp`
- `fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd_full/op_host/op_tiling/prepare_wy_repr_bwd_full_tiling.cpp`

不改变任何算子行为、接口或 ABI；纯头文件 include 补充。

## 算子责任范围

- 涉及算子名称: chunk_local_cumsum, chunk_scaled_dot_kkt, causal_conv1d_bwd, prepare_wy_repr_bwd_da, prepare_wy_repr_bwd_full
- 涉及目录 / 文件: 见上（5 个 op_host/op_tiling 源文件，各 +1 行 include）
- 修改范围:
  - [x] `Tiling` 策略（仅 include 修复，无逻辑变化）
- 输入 / 输出 / shape / dtype / format 支持范围: 不变
- 明确不包含的范围: 无算子逻辑、接口、kernel 变更
- 是否影响公共模块或其他算子:
  - [x] 否
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化

## 验证

### 编译验证（CANN 8.5.2）

在 `/data/wnc/cann/cann-8.5.2/cann-8.5.2/set_env.sh` 环境下执行：

```sh
FLA_NPU_SOC=ascend910b python scripts/build_wheel.py
```

结果：**通过**（exit 0），正常产出 wheel：

```text
dist/flash_linear_attention_npu-26.7.0.dev0+main.9bd5e18-910b.aarch64-py3-none-any.whl
```

修复前基线：同样命令在未加 include 时失败（`DAV_2201/DAV_3510 is not a member of NpuArch`，gmake Error 2）；已确认与 `cmake/variables.cmake` 的 vendored opbase include 优先级补丁无关（去掉该补丁基线复现同一错误）。

### 未执行项

- A3 (`ascend910_93`) / A5 (`ascend950`) 编译、单算子测试与 Example ST 未执行（本机仅具备 ascend910b + CANN 8.5.2 环境）。修改仅为额外 include，理论上不随 SOC 变化，但建议由 NPU CI 覆盖 A2/A3/A5。

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因（构建修复，无需 Issue）
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过（未执行，无对应环境）
- [ ] 已验证修改算子的对应 test 通过（未执行）
- [ ] 已验证整体 example ST 通过（未执行）
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录（如适用）
- [x] PR 标题已使用合适类型标签（`fix(build):`）
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退