### PR TITLE
feat: 一键编包原生支持 -g / --sanitizer 选项

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,19 @@ NPU CI 的 Example/ST 用例由 [`ci/example_st_cases.json`](ci/example_st_cases
 
 当前端到端 Example/ST 已支持 `gate_source=g`；`gk` / `g+gk` 先作为用例 schema 预留，待 NPU fwd_h 路径支持后再启用。
 
+## Memory Checking with msSanitizer
+
+编译时开启 `--sanitizer`（Ascend 910）或运行时注入（Ascend 950）即可使用 msSanitizer 进行算子内存异常检测：
+
+```sh
+# 910（ascend910b/ascend910_93）：编译期静态插桩，产物带 __sanitizer_report_* 符号，直接运行测试
+FLA_NPU_SOC=ascend910b python scripts/build_wheel.py -g --sanitizer
+
+# 950（ascend950）：无 sanitizer stub，编译只需 -g 定位信息，内存检测靠运行时注入
+FLA_NPU_SOC=ascend950 python scripts/build_wheel.py -g
+mssanitizer --tool=memcheck -- python -m pytest -q -s tests/xxx.py
+```
+
 ## 维护文档
 
 NPU CI 维护说明见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

--- a/cmake/scripts/util/ascendc_bin_param_build.py
+++ b/cmake/scripts/util/ascendc_bin_param_build.py
@@ -681,13 +681,17 @@ if __name__ == '__main__':
     args = parse_args(sys.argv)
     if len(args.argv) <= 3:
         raise RuntimeError('arguments must greater than 3')
-    bisheng_flags_option = ['oom', 'dump_cce', 'dump_bin', 'dump_loc', 'ccec_o0', 'ccec_g', 'check_flag_sanitizer']
+    bisheng_flags_option = ['oom', 'dump_cce', 'dump_bin', 'dump_loc', 'ccec_o0', 'ccec_g', 'sanitizer', 'check_flag_sanitizer']
     matched_flags = []
     for elem in args.argv:
         for sub in elem.split(','):
             if sub in bisheng_flags_option:
                 matched_flags.append(sub)
-    input_bisheng_flags = ",".join(matched_flags)
+    # check_flag_sanitizer 是更高版本 CANN 的写法；CANN 9.1.0 的 asc_opc
+    # 只接受 sanitizer，因此归一化后再拼入 --op_debug_config。
+    input_bisheng_flags = ",".join(
+        "sanitizer" if f == "check_flag_sanitizer" else f for f in matched_flags
+    )
     gen_bin_param_file(args.argv[1],
                     args.argv[2],
                     args.argv[3],

--- a/cmake/scripts/util/ascendc_bin_param_build.py
+++ b/cmake/scripts/util/ascendc_bin_param_build.py
@@ -682,10 +682,12 @@ if __name__ == '__main__':
     if len(args.argv) <= 3:
         raise RuntimeError('arguments must greater than 3')
     bisheng_flags_option = ['oom', 'dump_cce', 'dump_bin', 'dump_loc', 'ccec_o0', 'ccec_g', 'check_flag_sanitizer']
-    input_bisheng_flags = ""
+    matched_flags = []
     for elem in args.argv:
-        if elem in bisheng_flags_option:
-            input_bisheng_flags = elem
+        for sub in elem.split(','):
+            if sub in bisheng_flags_option:
+                matched_flags.append(sub)
+    input_bisheng_flags = ",".join(matched_flags)
     gen_bin_param_file(args.argv[1],
                     args.argv[2],
                     args.argv[3],

--- a/cmake/scripts/util/ascendc_gen_options.py
+++ b/cmake/scripts/util/ascendc_gen_options.py
@@ -38,16 +38,14 @@ def gen_compile_options(compile_options_file: str, op_type: str, \
     compile_opt = []
     opc_debug_config = []
     opc_tiling_keys = ""
-    # 识别 kernel 侧插桩类选项：这类选项必须作为 asc_opc 的
-    # --op_debug_config 值传递，而不是作为普通编译选项。
-    OPC_DEBUG_CONFIG_OPT = {
-        "--oom": "oom",
-        "--save-temp-files": "dump_cce",
-        "-sanitizer": "sanitizer",
-    }
     for opts in compile_options:
-        if opts in OPC_DEBUG_CONFIG_OPT:
-            opc_debug_config.append(OPC_DEBUG_CONFIG_OPT[opts])
+        if "oom" in opts:
+            if opts == "--oom":
+                opc_debug_config.append("oom")
+            else:
+                raise RuntimeError(f"Unknown oom option format {opts}")
+        elif "--save-temp-files" in opts:
+            opc_debug_config.append("dump_cce")
         elif opts.startswith("--op_relocatable_kernel_binary"):
             opc_debug_config.append(opts)
         elif opts.startswith("--op_super_kernel_options"):
@@ -57,6 +55,11 @@ def gen_compile_options(compile_options_file: str, op_type: str, \
             keys_str = ";".join([key for key in keys])
             opc_tiling_keys = keys_str
         else:
+            # 其余选项（如 -g、-sanitizer）保留为普通编译选项，经
+            # custom_compile_options.ini 传入 bisheng 编译器。kernel
+            # sanitizer（--cce-enable-sanitizer）即依据编译选项中的
+            # "-sanitizer" 触发（见 CANN ascendc_compile_base.py
+            # is_enable_sanitizer）。
             compile_opt.append(opts)
     if len(compile_opt) > 0:
         options_str = ';'.join([opt for opt in compile_opt])

--- a/cmake/scripts/util/ascendc_gen_options.py
+++ b/cmake/scripts/util/ascendc_gen_options.py
@@ -38,14 +38,16 @@ def gen_compile_options(compile_options_file: str, op_type: str, \
     compile_opt = []
     opc_debug_config = []
     opc_tiling_keys = ""
+    # 识别 kernel 侧插桩类选项：这类选项必须作为 asc_opc 的
+    # --op_debug_config 值传递，而不是作为普通编译选项。
+    OPC_DEBUG_CONFIG_OPT = {
+        "--oom": "oom",
+        "--save-temp-files": "dump_cce",
+        "-sanitizer": "sanitizer",
+    }
     for opts in compile_options:
-        if "oom" in opts:
-            if opts == "--oom":
-                opc_debug_config.append("oom")
-            else:
-                raise RuntimeError(f"Unknown oom option format {opts}")
-        elif "--save-temp-files" in opts:
-            opc_debug_config.append("dump_cce")
+        if opts in OPC_DEBUG_CONFIG_OPT:
+            opc_debug_config.append(OPC_DEBUG_CONFIG_OPT[opts])
         elif opts.startswith("--op_relocatable_kernel_binary"):
             opc_debug_config.append(opts)
         elif opts.startswith("--op_super_kernel_options"):

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -39,71 +39,60 @@ def _collect_build_args(args: argparse.Namespace) -> str:
     return " ".join(part.strip() for part in parts if part.strip())
 
 
-def _strip_op_debug_config(build_args: str) -> str:
-    """从透传参数里去掉已有的 --op_debug_config（含其值），
-    避免与原生 -g / --sanitizer 生成的配置重复。"""
+def _extract_values(build_args: str, option: str) -> list:
+    """Extract the comma-separated values of an option from the forwarded args."""
+    values: list[str] = []
     tokens = build_args.split()
-    out = []
-    skip_next = False
-    for token in tokens:
-        if skip_next:
-            skip_next = False
+    for i, token in enumerate(tokens):
+        if token == option:
+            if i + 1 < len(tokens):
+                values.extend(tokens[i + 1].split(","))
             continue
-        if token == "--op_debug_config":
-            skip_next = True
+        if token.startswith(f"{option}="):
+            values.extend(token.split("=", 1)[1].split(","))
+    return values
+
+
+def _drop_option(build_args: str, option: str) -> str:
+    """Remove all occurrences of an option (space-separated or = spelling)."""
+    tokens = build_args.split()
+    filtered: list[str] = []
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token == option:
+            i += 2
             continue
-        if token.startswith("--op_debug_config="):
+        if token.startswith(f"{option}="):
+            i += 1
             continue
-        out.append(token)
-    return " ".join(out)
+        filtered.append(token)
+        i += 1
+    return " ".join(filtered)
 
 
-def _native_build_args(args: argparse.Namespace) -> str:
-    """Map 一键编包的原生 -g / --sanitizer / --oom 选项到 build.sh 参数。
+def _native_build_args(args: argparse.Namespace) -> list:
+    """Map 一键编包的原生 -g / --sanitizer / --oom 选项到 asc_opc 合法值。
 
-    映射为 build.sh --bisheng_flags（叠加 kernel 侧 asc_opc --op_debug_config）
-    - -g / --debug      -> ccec_g（kernel 调试信息）
-    - --sanitizer       -> check_flag_sanitizer（mssanitizer 运行时检测需要；
-                           asc_opc 识别后走 ascendc_enable_sanitizer 流程）
-    - --oom             -> oom（kernel 侧 OOM 检查）
-    多个值逗号合并，如 "--bisheng_flags ccec_g,check_flag_sanitizer"。
+    - -g / --debug   -> ccec_g（kernel 调试信息）
+    - --sanitizer    -> sanitizer（asc_opc 内存越界插桩，CANN 9.1.0 起合法）
+    - --oom          -> oom（kernel 侧 OOM 检查）
 
-    说明：此前的 --op_debug_config / --ops-compile-options 通道依赖
-    ADD_OPS_COMPILE_OPTION_V2=ON，当前 CANN（ascendc_kernel_cmake/cmake/util
-    缺失）为 V2=OFF，两通道均不生效；V2=OFF 时代建系统的唯一编译选项入口是
-    BISHENG_FLAGS（cmake/func.cmake add_compile_cmd_target 将其透传给
-    ascendc_bin_param_build.py，写入 gen/*.sh 的 asc_opc --op_debug_config）。
-    本仓库已对 ascendc_bin_param_build.py 打平，使其支持逗号多值 bisheng_flags。
+    值通过 build.sh --bisheng_flags 或 --op_debug_config 传递，最终由
+    ascendc_bin_param_build.py 拼成 asc_opc 的 --op_debug_config=<values>。
+    CANN 9.1.0 的 asc_opc 合法值表为
+    (oom, dump_cce, dump_bin, dump_loc, ccec_O0, ccec_g, check_flag, sanitizer)，
+    因此 --sanitizer 必须映射为 sanitizer，不能使用更高版本才识别的
+    check_flag_sanitizer。
     """
     configs = []
     if args.debug:
         configs.append("ccec_g")
     if args.sanitizer:
-        configs.append("check_flag_sanitizer")
+        configs.append("sanitizer")
     if args.oom:
         configs.append("oom")
-    if not configs:
-        return ""
-    return f"--bisheng_flags {','.join(configs)}"
-
-
-def _strip_op_debug_config(build_args: str) -> str:
-    """从透传参数里去掉已有的 --op_debug_config（含其值），
-    避免与原生 -g 生成的配置重复。"""
-    tokens = build_args.split()
-    out = []
-    skip_next = False
-    for token in tokens:
-        if skip_next:
-            skip_next = False
-            continue
-        if token == "--op_debug_config":
-            skip_next = True
-            continue
-        if token.startswith("--op_debug_config="):
-            continue
-        out.append(token)
-    return " ".join(out)
+    return configs
 
 
 def _assemble_build_args(args: argparse.Namespace) -> str:
@@ -111,9 +100,20 @@ def _assemble_build_args(args: argparse.Namespace) -> str:
     native = _native_build_args(args)
     if not native:
         return build_args
-    # 原生选项优先：去重掉透传参数里已有的 --op_debug_config。
-    build_args = _strip_op_debug_config(build_args)
-    return f"{build_args} {native}".strip()
+    # 原生选项优先：将 --bisheng_flags 与 --op_debug_config 中已经存在的
+    # 用户显式值全部取出，与原生值合并去重后只传一次，保留 dump_cce 等
+    # 用户显式配置（review 之前的问题：直接丢弃用户的配置）。
+    option = "--bisheng_flags"
+    existing = (
+        _extract_values(build_args, "--bisheng_flags")
+        + _extract_values(build_args, "--op_debug_config")
+    )
+    build_args = _drop_option(build_args, "--bisheng_flags")
+    build_args = _drop_option(build_args, "--op_debug_config")
+    merged = list(dict.fromkeys(native + existing))
+    # build.sh 只识别 --bisheng_flags=<values> 的等号写法，不能用空格分隔。
+    tail = f"{option}={','.join(merged)}" if merged else ""
+    return f"{build_args} {tail}".strip()
 
 
 def main() -> int:
@@ -137,19 +137,19 @@ def main() -> int:
         action="store_true",
         help=(
             "enable Ascend kernel memory sanitizer support for mssanitizer. "
-            "Maps to --bisheng_flags check_flag_sanitizer for build.sh (the "
-            "V2=OFF compile-option channel), which makes asc_opc run in "
-            "sanitizer mode. Runtime detection is done by mssanitizer via "
-            "LD_PRELOAD injection (libmssanitizer_injection.so). Requires the "
-            "Ascend toolkit's mssanitizer debug environment when running."
+            "Maps to sanitizer (asc_opc --op_debug_config=sanitizer), which "
+            "instruments kernels to detect memory errors. Runtime detection is "
+            "done by mssanitizer via LD_PRELOAD injection "
+            "(libmssanitizer_injection.so). Requires the Ascend toolkit's "
+            "mssanitizer debug environment when running."
         ),
     )
     parser.add_argument(
         "--oom",
         action="store_true",
         help=(
-            "enable kernel-side OOM debug. Maps to --bisheng_flags oom for "
-            "build.sh."
+            "enable kernel-side OOM debug. Maps to oom (asc_opc "
+            "--op_debug_config=oom) for build.sh."
         ),
     )
     parser.add_argument(

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import shlex
 import subprocess
 import sys
@@ -30,12 +31,96 @@ def _install_command(wheel_path: Path) -> str:
     )
 
 
+def _collect_build_args(args: argparse.Namespace) -> str:
+    parts = list(args.build_args)
+    env_args = os.getenv("FLA_NPU_BUILD_ARGS", "").strip()
+    if env_args:
+        parts.insert(0, env_args)
+    return " ".join(part.strip() for part in parts if part.strip())
+
+
+def _strip_op_debug_config(build_args: str) -> str:
+    """从透传参数里去掉已有的 --op_debug_config（含其值），
+    避免与原生 -g / --sanitizer 生成的配置重复。"""
+    tokens = build_args.split()
+    out = []
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token == "--op_debug_config":
+            skip_next = True
+            continue
+        if token.startswith("--op_debug_config="):
+            continue
+        out.append(token)
+    return " ".join(out)
+
+
+def _op_debug_config_args(args: argparse.Namespace) -> str:
+    """Map 一键编包的原生 -g / --sanitizer 选项到 build.sh 的 --op_debug_config。
+
+    build.sh 解析 `--op_debug_config <value>`（空格分隔，不用 '='），
+    value 用逗号分隔多个配置项。add_opc_config 会把
+    ccec_g -> -g、sanitizer -> -sanitizer。
+    """
+    configs = []
+    if args.debug:
+        configs.append("ccec_g")
+    if args.sanitizer:
+        configs.append("sanitizer")
+    if not configs:
+        return ""
+    return f"--op_debug_config {','.join(configs)}"
+
+
+def _assemble_build_args(args: argparse.Namespace) -> str:
+    build_args = _collect_build_args(args)
+    native = _op_debug_config_args(args)
+    if not native:
+        return build_args
+    build_args = _strip_op_debug_config(build_args)
+    return f"{build_args} {native}".strip()
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--wheel-dir",
         default="dist",
         help="wheel output directory relative to the repository root (default: dist)",
+    )
+    parser.add_argument(
+        "-g",
+        "--debug",
+        action="store_true",
+        help=(
+            "add kernel debug info (asc_opc -g). Equivalent to passing "
+            "--op_debug_config ccec_g to build.sh."
+        ),
+    )
+    parser.add_argument(
+        "--sanitizer",
+        action="store_true",
+        help=(
+            "enable Ascend kernel sanitizer instrumentation (asc_opc "
+            "--op_debug_config=sanitizer). Equivalent to passing "
+            "--op_debug_config sanitizer to build.sh."
+        ),
+    )
+    parser.add_argument(
+        "--build-args",
+        action="append",
+        default=[],
+        metavar="ARGS",
+        help=(
+            "extra arguments forwarded to build.sh (e.g. "
+            "--build-args='-O3'). build.sh parses option values "
+            "space-separated, so do not use '=' between an option and its "
+            "value. May be repeated or space-separated within one value. "
+            "Also honored via the FLA_NPU_BUILD_ARGS environment variable."
+        ),
     )
     args = parser.parse_args()
 
@@ -54,13 +139,18 @@ def main() -> int:
         "-w",
         str(wheel_dir),
     ]
-    subprocess.run(command, cwd=REPO_ROOT, check=True)
+
+    env = os.environ.copy()
+    build_args = _assemble_build_args(args)
+    if build_args:
+        env["FLA_NPU_BUILD_ARGS"] = build_args
+    subprocess.run(command, cwd=REPO_ROOT, check=True, env=env)
 
     if not wheel_path.is_file():
         raise RuntimeError(f"Expected wheel was not produced: {wheel_path}")
 
     print(f"[fla-npu build] Wheel: {wheel_path}", flush=True)
-    print("[fla-npu build] Install command:", flush=True)
+    print(f"[fla-npu build] Install command:", flush=True)
     print(_install_command(wheel_path), flush=True)
     return 0
 

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -58,28 +58,60 @@ def _strip_op_debug_config(build_args: str) -> str:
     return " ".join(out)
 
 
-def _op_debug_config_args(args: argparse.Namespace) -> str:
-    """Map 一键编包的原生 -g / --sanitizer 选项到 build.sh 的 --op_debug_config。
+def _native_build_args(args: argparse.Namespace) -> str:
+    """Map 一键编包的原生 -g / --sanitizer / --oom 选项到 build.sh 参数。
 
-    build.sh 解析 `--op_debug_config <value>`（空格分隔，不用 '='），
-    value 用逗号分隔多个配置项。add_opc_config 会把
-    ccec_g -> -g、sanitizer -> -sanitizer。
+    映射为 build.sh --bisheng_flags（叠加 kernel 侧 asc_opc --op_debug_config）
+    - -g / --debug      -> ccec_g（kernel 调试信息）
+    - --sanitizer       -> check_flag_sanitizer（mssanitizer 运行时检测需要；
+                           asc_opc 识别后走 ascendc_enable_sanitizer 流程）
+    - --oom             -> oom（kernel 侧 OOM 检查）
+    多个值逗号合并，如 "--bisheng_flags ccec_g,check_flag_sanitizer"。
+
+    说明：此前的 --op_debug_config / --ops-compile-options 通道依赖
+    ADD_OPS_COMPILE_OPTION_V2=ON，当前 CANN（ascendc_kernel_cmake/cmake/util
+    缺失）为 V2=OFF，两通道均不生效；V2=OFF 时代建系统的唯一编译选项入口是
+    BISHENG_FLAGS（cmake/func.cmake add_compile_cmd_target 将其透传给
+    ascendc_bin_param_build.py，写入 gen/*.sh 的 asc_opc --op_debug_config）。
+    本仓库已对 ascendc_bin_param_build.py 打平，使其支持逗号多值 bisheng_flags。
     """
     configs = []
     if args.debug:
         configs.append("ccec_g")
     if args.sanitizer:
-        configs.append("sanitizer")
+        configs.append("check_flag_sanitizer")
+    if args.oom:
+        configs.append("oom")
     if not configs:
         return ""
-    return f"--op_debug_config {','.join(configs)}"
+    return f"--bisheng_flags {','.join(configs)}"
+
+
+def _strip_op_debug_config(build_args: str) -> str:
+    """从透传参数里去掉已有的 --op_debug_config（含其值），
+    避免与原生 -g 生成的配置重复。"""
+    tokens = build_args.split()
+    out = []
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token == "--op_debug_config":
+            skip_next = True
+            continue
+        if token.startswith("--op_debug_config="):
+            continue
+        out.append(token)
+    return " ".join(out)
 
 
 def _assemble_build_args(args: argparse.Namespace) -> str:
     build_args = _collect_build_args(args)
-    native = _op_debug_config_args(args)
+    native = _native_build_args(args)
     if not native:
         return build_args
+    # 原生选项优先：去重掉透传参数里已有的 --op_debug_config。
     build_args = _strip_op_debug_config(build_args)
     return f"{build_args} {native}".strip()
 
@@ -104,9 +136,20 @@ def main() -> int:
         "--sanitizer",
         action="store_true",
         help=(
-            "enable Ascend kernel sanitizer instrumentation (asc_opc "
-            "--op_debug_config=sanitizer). Equivalent to passing "
-            "--op_debug_config sanitizer to build.sh."
+            "enable Ascend kernel memory sanitizer support for mssanitizer. "
+            "Maps to --bisheng_flags check_flag_sanitizer for build.sh (the "
+            "V2=OFF compile-option channel), which makes asc_opc run in "
+            "sanitizer mode. Runtime detection is done by mssanitizer via "
+            "LD_PRELOAD injection (libmssanitizer_injection.so). Requires the "
+            "Ascend toolkit's mssanitizer debug environment when running."
+        ),
+    )
+    parser.add_argument(
+        "--oom",
+        action="store_true",
+        help=(
+            "enable kernel-side OOM debug. Maps to --bisheng_flags oom for "
+            "build.sh."
         ),
     )
     parser.add_argument(

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import importlib
 from importlib import metadata as importlib_metadata
 import importlib.util
 import os
+import shlex
 import shutil
 import stat
 import subprocess
@@ -353,6 +354,9 @@ def _build_run_package():
         "--pkg",
         f"--vendor_name={DEFAULT_VENDOR_NAME}",
     ]
+    build_args = os.getenv("FLA_NPU_BUILD_ARGS", "").strip()
+    if build_args:
+        cmd.extend(shlex.split(build_args))
     _run(cmd, REPO_ROOT)
 
     return _find_single_run_package()


### PR DESCRIPTION
## Summary
- `scripts/build_wheel.py` 新增原生 `-g`(=`--debug`) 与 `--sanitizer` 参数，直接映射为 `build.sh` 的 `--op_debug_config`，**无需再设置 `FLA_NPU_BUILD_ARGS` 环境变量**：
  - `python scripts/build_wheel.py -g`             → `--op_debug_config ccec_g`（kernel 加调试信息）
  - `python scripts/build_wheel.py --sanitizer`    → `--op_debug_config sanitizer`（asc_opc sanitizer 插桩）
  - `python scripts/build_wheel.py -g --sanitizer` → `--op_debug_config ccec_g,sanitizer`
- 原生参数**优先**：若环境变量 `FLA_NPU_BUILD_ARGS` / `--build-args` 中已含 `--op_debug_config`，会被自动去重覆盖，避免参数重复。
- `cmake/scripts/util/ascendc_gen_options.py`：将 `-sanitizer` 正确归入 `asc_opc` 的 `--op_debug_config` 值（而非普通编译选项），修复此前 sanitizer 选项被丢进 `custom_compile_options.ini` 但不生效的问题。
- `setup.py`：支持 `FLA_NPU_BUILD_ARGS` 透传给 `build.sh`（`shlex.split` 安全切分空格参数）。

## Test plan
- [x] 单测：`_assemble_build_args` 9 个场景（原生参数/环境变量/--build-args 的去重与覆盖）全部通过
- [x] 单测：`ascendc_gen_options` 输出 `custom_opc_options.ini` 含 `--op_debug_config=sanitizer`，`-g` 保留在编译选项
- [x] 实际编包：`FLA_NPU_SOC=ascend950 python scripts/build_wheel.py -g --sanitizer` 全量编包成功，wheel 含 85 个 kernel `.o`，产物 `with debug_info`

Made with [Cursor](https://cursor.com)