### PR TITLE
fix(chunk_fwd_o): skip empty AIV tail sub-blocks

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/epilogue/block/block_epilogue_gdn_fwdo_output.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/epilogue/block/block_epilogue_gdn_fwdo_output.hpp
@@ -292,6 +292,12 @@ public:
         uint32_t blockIdx = AscendC::GetBlockIdx();
         uint32_t mActualPerSubBlock = CeilDiv(mActual, subBlockNum);
         uint32_t mActualThisSubBlock = (subBlockIdx == 0) ? mActualPerSubBlock : (mActual - mActualPerSubBlock);
+        // For a one-token tail, the second AIV sub-block owns no rows.  Do
+        // not form its GM row pointer (one full output row past the tensor)
+        // or issue a zero-length DataCopy from it.
+        if (mActualThisSubBlock == 0) {
+            return;
+        }
         uint32_t mOffset = subBlockIdx * mActualPerSubBlock;
         uint32_t nOffset = 0;
         int64_t offsetA = mOffset * nActual + nOffset;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/epilogue/block/block_epilogue_gdn_fwdo_qkmask.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/epilogue/block/block_epilogue_gdn_fwdo_qkmask.hpp
@@ -132,6 +132,11 @@ public:
         uint32_t blockIdx = AscendC::GetBlockIdx();
         uint32_t mActualPerSubBlock = CeilDiv(mActual, subBlockNum);
         uint32_t mActualThisSubBlock = (subBlockIdx == 0) ? mActualPerSubBlock : (mActual - mActualPerSubBlock);
+        // For a one-token tail, the second AIV sub-block owns no rows. Avoid
+        // issuing zero-length data movement and event operations for it.
+        if (mActualThisSubBlock == 0) {
+            return;
+        }
         uint32_t mOffset = subBlockIdx * mActualPerSubBlock;
         uint32_t nOffset = 0;
         int64_t offsetA = mOffset * nActual + nOffset;


### PR DESCRIPTION
## 背景

当尾 chunk 只有 1 个 token 时，AIV 双子块划分后的第二个子块没有有效行。原实现仍会构造越过张量末尾一行的 GM 指针，并执行零长度数据搬运和事件操作，可能导致算子卡住或内存访问异常。

## 修改

在 qk-mask 和 output 两个 epilogue 中，当 `mActualThisSubBlock == 0` 时直接返回，跳过空 AIV 子块。

## 验证

相同 Kernel 修复已在 A2、A5 上完成 200 条 ATK 精度、确定性和 MSS 验证，结果均通过。