### PR TITLE
fix(gdn): 修复 KKT MMAD 同步事件重复复用

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_scaled_dot_kkt/op_host/CMakeLists.txt
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_scaled_dot_kkt/op_host/CMakeLists.txt
@@ -8,6 +8,9 @@ if (BUILD_OPEN_PROJECT)
     target_sources(op_host_aclnn PRIVATE
         chunk_scaled_dot_kkt_def.cpp
     )
+    target_compile_definitions(op_host_aclnn PRIVATE
+        ASCEND_SOC_VERSION="${ASCEND_COMPUTE_UNIT}"
+    )
 endif()
 
 add_modules_sources(OPTYPE chunk_scaled_dot_kkt ACLNNTYPE aclnn)

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_scaled_dot_kkt/op_host/chunk_scaled_dot_kkt_def.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_scaled_dot_kkt/op_host/chunk_scaled_dot_kkt_def.cpp
@@ -46,7 +46,11 @@ public:
             .ExtendCfgInfo("opFile.value", "chunk_scaled_dot_kkt");
         this->AICore().AddConfig("ascend910b", aicoreConfig);
         this->AICore().AddConfig("ascend910_93", aicoreConfig);
-        this->AICore().AddConfig("ascend950", aicoreConfig);
+#ifdef ASCEND_SOC_VERSION
+        if (std::string(ASCEND_SOC_VERSION) == "ascend950") {
+            this->AICore().AddConfig("ascend950", aicoreConfig);
+        }
+#endif
     }
 };
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_scaled_dot_kkt/op_kernel/chunk_scaled_dot_kkt.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_scaled_dot_kkt/op_kernel/chunk_scaled_dot_kkt.h
@@ -403,6 +403,11 @@ private:
         using BlockMmad = Catlass::Gemm::Block::BlockMmadTla<KktScoreDispatchPolicy, L1TileShape, L0TileShape, KType,
                                                               KType, float, void, TileCopy>;
 
+        Catlass::Arch::Resource<KktArchTag> resource;
+        BlockMmad blockMmad(resource);
+        // Keep one event lifecycle while preserving task boundaries before L0 buffers are reused.
+        blockMmad.preSetFlags();
+
         int64_t scoreGroupSeq = 0;
         // Score blocks are computed once per key head; epilogue fans each block out to hvPerHk value heads.
         const int64_t scoreBlockTaskNum = B_ * NT_ * Hk_ * ScoreRowBlockCount();
@@ -414,7 +419,6 @@ private:
             if (scoreGroupSeq >= SCORE_WORKSPACE_BUFFER_NUM) {
                 Catlass::Arch::CrossCoreWaitFlag(scoreDoneFlag_[scoreSlot]);
             }
-            Catlass::Arch::Resource<KktArchTag> resource;
             for (int64_t batchIdx = 0; batchIdx < scoreGroupBatch; ++batchIdx) {
                 const int64_t scoreBlockTask = scoreGroupBase + batchIdx * usedAicNum_;
                 if (scoreBlockTask >= scoreBlockTaskNum) {
@@ -428,14 +432,13 @@ private:
                     continue;
                 }
                 const int64_t scoreOffset = GetScoreOffset(cubeIdx, scoreSlot, batchIdx);
-                BlockMmad blockMmad(resource);
-                blockMmad.preSetFlags();
                 ComputeCatlassScoreBlock(meta, rowBegin, rowCount, colCount, scoreOffset, blockMmad);
-                blockMmad.finalWaitFlags();
+                AscendC::PipeBarrier<PIPE_ALL>();
             }
             Catlass::Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(scoreReadyFlag_[scoreSlot]);
             ++scoreGroupSeq;
         }
+        blockMmad.finalWaitFlags();
         const int64_t pendingSlots = MinI64(scoreGroupSeq, static_cast<int64_t>(SCORE_WORKSPACE_BUFFER_NUM));
         for (int64_t slot = 0; slot < pendingSlots; ++slot) {
             Catlass::Arch::CrossCoreWaitFlag(scoreDoneFlag_[slot]);


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> 本 PR 创建后需由仓库 Admin 触发当前 head commit 的 NPU CI，并在合入前满足 2 个 approval；若后续更新 commit，需要重新触发 NPU CI。

## 关联 Issue / 背景

- 关联 Issue: Closes #360
- 背景与目标: GDN 接入网络后存在同步超时风险，排查定位到 `ChunkScaledDotKkt` 的 AIC MMAD 硬事件生命周期。
- 本 PR 解决的问题: 消除 score task 间重复初始化 M/MTE1 硬事件导致的冗余 `set_flag`，同时避免 L0 缓冲跨任务复用产生数据竞争。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `ChunkScaledDotKkt`
- 涉及目录 / 文件: `fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_scaled_dot_kkt/op_kernel/chunk_scaled_dot_kkt.h`
- 责任人 / 提交人: @Coding-Pangolin
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 保持现有支持范围不变；已回归固定长/变长、FP16/BF16、BT64/BT128、`Hv/Hk=1/2/4`。
- 明确不包含的范围: 不修改 Tiling、Host、OpApi、Torch 接口、跨核 score workspace ready/done 协议和其他 GDN 算子。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无。

### 实现说明

1. 将 `Resource` 和 `BlockMmad` 从每个 score group/task 提升到单个 AIC 任务序列，只执行一次 `preSetFlags()` 和一次 `finalWaitFlags()`，使硬事件初始化与回收成对且生命周期唯一。
2. 在每个 score task 后增加 `PipeBarrier<PIPE_ALL>()`，确保下一任务复用 L0A/L0B 前，当前 MMAD 及搬运流水已经完成。
3. 保持 score workspace 的 CrossCore ready/done 槽位协议不变。

## 修改算子测试

### 版本与产品编译矩阵

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 结论 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0 | `bash build.sh --build-type=Release --pkg --soc=ascend910b --ops=chunk_scaled_dot_kkt --vendor_name=fla_npu -j1` | 通过 | 生成安装包，无 ERROR/FAILED |
| A3 | `ascend910_93` | 9.1.0 | `bash build.sh --build-type=Release --pkg --soc=ascend910_93 --ops=chunk_scaled_dot_kkt --vendor_name=fla_npu -j1` | 通过 | 生成安装包，无 ERROR/FAILED |
| A5 | `ascend950` | 9.1.0 | `bash build.sh --build-type=Release --pkg --soc=ascend950 --ops=chunk_scaled_dot_kkt --vendor_name=fla_npu -j1` | 通过 | 生成安装包，无 ERROR/FAILED |

### 单算子测试结果

| 产品 | `--soc` | 实际执行方式 | 结果 | 精度 / 稳定性结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 当前无对应运行设备 | 未执行 | 待 NPU CI 补齐 |
| A3 | `ascend910_93` | 当前无对应运行设备 | 未执行 | 待 NPU CI 补齐 |
| A5 | `ascend950` | 调用仓内 KKT test 的 6 组有效矩阵，并执行重复调用与 Sanitizer | 通过 | 6/6；最大绝对误差 `8.35e-7` |

- 精度对比: 固定长/变长、FP16/BF16、K64/K128、BT64/BT128 全部通过。
- 性能对比: 本 PR 聚焦同步正确性，未进行正式性能对比。
- 边界 / 异常场景: 固定长和变长各 100 次一次性排队后同步均完成；输出有限。
- Sanitizer: `synccheck` 的冗余 `set_flag` 从 1936 条降为 0；16 次 KKT 调用均无错误。`racecheck` 16 次调用为 0 hazard。
- 未覆盖风险: A2/A3 仅完成交叉编译，运行时和整体 Example/ST 待 NPU CI 补齐。

## 整体 Example ST 验证

| 产品 | `--soc` | 实际执行命令 | 结果 | 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json --case-filter case1_current_default` | 通过 | `allclose=True`，cosine `0.999996`，max abs `6.71e-4` |

- 端到端场景说明: 12 段非均匀 TND 变长输入；另完成 100 次整网延迟同步和 4 流并发 20 轮，输出均有限。
- 与本 PR 修改算子的关联: 整体 GDN 前向链路会调用本 PR 修改的 KKT。
- 未覆盖原因及补充计划: 当前仅有 A5 运行环境，A2/A3 由仓库 NPU CI 补齐。

## 兼容性、风险与回退

- 兼容性说明: 算子接口、shape/dtype 支持范围和 workspace 跨核协议均不变。
- 风险点: score task 间新增全流水 barrier，可能带来少量串行化开销；范围仅限 KKT AIC score 计算。
- 回退方案: 回退本 PR 的单个提交即可恢复原实现。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

修复选择“一次事件生命周期 + task 间显式流水边界”，原因是仅合并事件生命周期会被 `racecheck` 检出跨 task 的 L0A/L0B WAR hazard，而恢复每 task 的 `preSetFlags()`/`finalWaitFlags()` 又会复现同步超时。当前实现同时满足 `synccheck` 和 `racecheck`。
