### PR TITLE
fix(test): 修复 chunk_bwd_dv_local GQA Golden 头映射

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/README.md
@@ -277,6 +277,14 @@ if __name__ == "__main__":
     test_chunk_bwd_dv_local_varlen()
 ```
 
+### 5.3 GQA Golden 回归覆盖
+
+共享 CPU 双标杆在定长和变长模式下均遍历全部 `H_do`，并按
+`qkHead = doHead // hRatio` 复用对应的 Q/K head。定长回归覆盖
+`H_qk=4`、`H_do=16`、`T=198`、`chunkSize=64` 的 BF16 场景，变长回归覆盖
+`H_qk=4`、`H_do=16` 的 FP16 场景。精度检查使用与算子测试一致的同精度标杆和
+高精度标杆，不通过放宽阈值规避误差。
+
 ---
 
 ## 6. 目录结构

--- a/torch_custom/fla_npu/test/golden.py
+++ b/torch_custom/fla_npu/test/golden.py
@@ -16,16 +16,22 @@ def prepare_chunk_indices(
     return torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(cu_seqlens)
 
 def chunk_bwd_dv_local_fix(
-    q: torch.Tensor,  # [B, H, T, K]
-    k: torch.Tensor,  # [B, H, T, K]
-    do: torch.Tensor, # [B, H, T, V]
-    g: torch.Tensor,  # [B, H, T]
+    q: torch.Tensor,  # [B, H_qk, T, K]
+    k: torch.Tensor,  # [B, H_qk, T, K]
+    do: torch.Tensor, # [B, H_do, T, V]
+    g: torch.Tensor,  # [B, H_do, T]
     scale: Optional[float],
     cu_seqlens: torch.LongTensor,  # [batch_size+1]
-    chunk_size: int = 64
+    chunk_size: int = 64,
+    high_precision: bool = False
 ) -> torch.Tensor:
-    B, H, T, K = k.shape
+    B, H_qk, T, K = k.shape
+    H_do = do.shape[1]
+    qkv_type = q.dtype
+    accumulator_type = torch.float64 if high_precision else torch.float32
     V = do.shape[3]
+    assert H_do % H_qk == 0, f"H_do ({H_do}) must be divisible by H_qk ({H_qk})"
+    h_ratio = H_do // H_qk
     if scale is None:
         scale = 1.0 / math.sqrt(K)
     if cu_seqlens is not None:
@@ -33,7 +39,7 @@ def chunk_bwd_dv_local_fix(
     BT = min(chunk_size, max(16, 2 ** math.ceil(math.log2(T)))) # 有风险，T至少要>=64,否则会计算错误
     chunk_per_T = (T + chunk_size -1)// chunk_size
     NT = chunk_per_T * B
-    dv = torch.zeros_like(do).to(torch.float32)
+    dv = torch.zeros_like(do).to(accumulator_type)
     g_t = g
     for chunk_idx in range(NT):
         i_n = chunk_idx // chunk_per_T # 序列编号
@@ -45,21 +51,25 @@ def chunk_bwd_dv_local_fix(
         chunk_len = chunk_end_token - chunk_start_token # 当前chunk的有效token数
         if chunk_len <= 0:
             continue
-        for i_h in range(H):
-            b_A = torch.zeros(BT, BT, device=q.device, dtype=torch.float32)
+        for do_head in range(H_do):
+            qk_head = do_head // h_ratio
+            b_A = torch.zeros(BT, BT, device=q.device, dtype=accumulator_type)
             BK = 128  # 与Triton保持一致
             BK = min(BK, K)  # 确保不超过K
             for i_k in range(0, K, BK):
                 k_end = min(i_k + BK, K)
-                b_k = k[batch_idx, i_h, chunk_start_token:chunk_start_token+chunk_len, i_k:k_end].to(torch.float32) # [chunk_len, BK]
-                q_normal = q[batch_idx, i_h, chunk_start_token:chunk_start_token+chunk_len, i_k:k_end].to(torch.float32)  # [chunk_len, BK]
+                b_k = k[batch_idx, qk_head, chunk_start_token:chunk_start_token+chunk_len, i_k:k_end]
+                q_normal = q[batch_idx, qk_head, chunk_start_token:chunk_start_token+chunk_len, i_k:k_end]
+                if high_precision:
+                    b_k = b_k.to(torch.float32)
+                    q_normal = q_normal.to(torch.float32)
                 b_q = q_normal.transpose(0, 1)  # [BK, chunk_len]
                 if chunk_len == 1:
                     matmul_result = torch.sum(b_k * q_normal)
                     b_A[:chunk_len, :chunk_len] += matmul_result
                 else:
                     b_A[:chunk_len, :chunk_len] += torch.matmul(b_k, b_q)# [BT,BT]
-            b_g = g_t[batch_idx, i_h, chunk_start_token:chunk_start_token+chunk_len] # g_t [B, H, T_max] → b_g [chunk_len]
+            b_g = g_t[batch_idx, do_head, chunk_start_token:chunk_start_token+chunk_len].to(accumulator_type) # g_t [B, H_do, T_max] → b_g [chunk_len]
             o_t = i_t * BT + torch.arange(0, BT) # [BT] chunk内的token序号
             m_t = o_t < T # [BT] bool掩码：是否是有效token
             o_t_col = o_t.unsqueeze(1)  # [BT, 1]
@@ -76,28 +86,36 @@ def chunk_bwd_dv_local_fix(
             b_A_gated[:chunk_len, :chunk_len] = b_A[:chunk_len, :chunk_len] * g_factor # [BT, BT] 门控缩放后的注意力核矩阵
             # 应用掩码
             b_A_masked = torch.where(m_A, b_A_gated, torch.zeros_like(b_A_gated)) # 只保留掩码为 True 的位置的 b_A_gated 值，其余置 0
-            b_A_masked = b_A_masked.to(torch.float32) # [BT, BT]
+            b_A_masked = b_A_masked.to(torch.float32 if high_precision else qkv_type) # [BT, BT]
             BV = 128  # 与Triton保持一致
             BV = min(BV, V)  # 确保不超过V
             for i_v in range(0, V, BV):
                 v_end = min(i_v + BV, V)
                 v_width = v_end - i_v
-                b_do = do[batch_idx, i_h, chunk_start_token:chunk_start_token+chunk_len, i_v:v_end].to(torch.float32) # do [B, T_max, H, V] → b_do [chunk_len, BV]
+                b_do = do[batch_idx, do_head, chunk_start_token:chunk_start_token+chunk_len, i_v:v_end]
+                if high_precision:
+                    b_do = b_do.to(torch.float32)
                 b_dv = torch.matmul(b_A_masked[:chunk_len, :chunk_len], b_do) # b_A_masked 这个 [BT, BT] 的矩阵，只有左上角 [chunk_len, chunk_len] 区域有非 0 值，其余所有区域全是 0
-                dv[batch_idx, i_h, chunk_start_token:chunk_start_token+chunk_len, i_v:v_end] += b_dv
+                dv[batch_idx, do_head, chunk_start_token:chunk_start_token+chunk_len, i_v:v_end] += b_dv
     return dv
 
 def chunk_bwd_dv_local_variable(
-    q: torch.Tensor,  # [B, H, T_max, K]
-    k: torch.Tensor,  # [B, H, T_max, K]
-    do: torch.Tensor, # [B, H, T_max, V]
-    g: torch.Tensor,  # [B, H, T_max]
+    q: torch.Tensor,  # [B, H_qk, T_max, K]
+    k: torch.Tensor,  # [B, H_qk, T_max, K]
+    do: torch.Tensor, # [B, H_do, T_max, V]
+    g: torch.Tensor,  # [B, H_do, T_max]
     scale: Optional[float],
     cu_seqlens: torch.LongTensor,  # [batch_size+1]
-    chunk_size: int = 64
+    chunk_size: int = 64,
+    high_precision: bool = False
 ) -> torch.Tensor:
-    B, H, T, K = k.shape
+    B, H_qk, T, K = k.shape
+    H_do = do.shape[1]
+    qkv_type = q.dtype
+    accumulator_type = torch.float64 if high_precision else torch.float32
     V = do.shape[3]
+    assert H_do % H_qk == 0, f"H_do ({H_do}) must be divisible by H_qk ({H_qk})"
+    h_ratio = H_do // H_qk
     if scale is None:
         scale = 1.0 / math.sqrt(K)
     if cu_seqlens is not None:
@@ -106,7 +124,7 @@ def chunk_bwd_dv_local_variable(
     chunk_indices = chunk_indices.view(-1)
     BT = min(chunk_size, max(16, 2 ** math.ceil(math.log2(T)))) # 有风险，T至少要>=64,否则会计算错误
     NT = len(chunk_indices) // 2 
-    dv = torch.zeros_like(do).to(torch.float32)
+    dv = torch.zeros_like(do).to(accumulator_type)
     g_t = g
     for chunk_idx in range(NT):
         i_n = chunk_indices[chunk_idx * 2].item() # 序列编号
@@ -120,21 +138,25 @@ def chunk_bwd_dv_local_variable(
         if chunk_len <= 0:
             continue
         global_start = bos + chunk_start_token # 当前chunk在T中开始的位置
-        for i_h in range(H):
-            b_A = torch.zeros(BT, BT, device=q.device, dtype=torch.float32)
+        for do_head in range(H_do):
+            qk_head = do_head // h_ratio
+            b_A = torch.zeros(BT, BT, device=q.device, dtype=accumulator_type)
             BK = 128  # 与Triton保持一致
             BK = min(BK, K)  # 确保不超过K
             for i_k in range(0, K, BK):
                 k_end = min(i_k + BK, K)
-                b_k = k[batch_idx, i_h, global_start:global_start+chunk_len, i_k:k_end].to(torch.float32) # [chunk_len, BK]
-                q_normal = q[batch_idx, i_h, global_start:global_start+chunk_len, i_k:k_end].to(torch.float32)  # [chunk_len, BK]
+                b_k = k[batch_idx, qk_head, global_start:global_start+chunk_len, i_k:k_end]
+                q_normal = q[batch_idx, qk_head, global_start:global_start+chunk_len, i_k:k_end]
+                if high_precision:
+                    b_k = b_k.to(torch.float32)
+                    q_normal = q_normal.to(torch.float32)
                 b_q = q_normal.transpose(0, 1)  # [BK, chunk_len]
                 if chunk_len == 1:
                     matmul_result = torch.sum(b_k * q_normal)
                     b_A[:chunk_len, :chunk_len] += matmul_result
                 else:
                     b_A[:chunk_len, :chunk_len] += torch.matmul(b_k, b_q)# [BT,BT]
-            b_g = g_t[batch_idx, i_h, global_start:global_start+chunk_len] # g_t [B, H, T_max] → b_g [chunk_len]
+            b_g = g_t[batch_idx, do_head, global_start:global_start+chunk_len].to(accumulator_type) # g_t [B, H_do, T_max] → b_g [chunk_len]
             o_t = i_t * BT + torch.arange(0, BT) # [BT] chunk内的token序号
             m_t = o_t < T # [BT] bool掩码：是否是有效token
             o_t_col = o_t.unsqueeze(1)  # [BT, 1]
@@ -160,13 +182,37 @@ def chunk_bwd_dv_local_variable(
             # for i in range(b_A_masked.shape[0]):
             #     row_str = ', '.join([f"{b_A_masked[i, j].item():.6f}" for j in range(b_A_masked.shape[1])])
             #     print(row_str)
-            b_A_masked = b_A_masked.to(torch.float32) # [BT, BT]
+            b_A_masked = b_A_masked.to(torch.float32 if high_precision else qkv_type) # [BT, BT]
             BV = 128  # 与Triton保持一致
             BV = min(BV, V)  # 确保不超过V
             for i_v in range(0, V, BV):
                 v_end = min(i_v + BV, V)
                 v_width = v_end - i_v
-                b_do = do[batch_idx, i_h, global_start:global_start+chunk_len, i_v:v_end].to(torch.float32) # do [B, T_max, H, V] → b_do [chunk_len, BV]
+                b_do = do[batch_idx, do_head, global_start:global_start+chunk_len, i_v:v_end]
+                if high_precision:
+                    b_do = b_do.to(torch.float32)
                 b_dv = torch.matmul(b_A_masked[:chunk_len, :chunk_len], b_do) # b_A_masked 这个 [BT, BT] 的矩阵，只有左上角 [chunk_len, chunk_len] 区域有非 0 值，其余所有区域全是 0
-                dv[batch_idx, i_h, global_start:global_start+chunk_len, i_v:v_end] += b_dv
+                dv[batch_idx, do_head, global_start:global_start+chunk_len, i_v:v_end] += b_dv
     return dv
+
+def chunk_bwd_dv_local_fix_high_precision(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    do: torch.Tensor,
+    g: torch.Tensor,
+    scale: Optional[float],
+    cu_seqlens: torch.LongTensor,
+    chunk_size: int = 64
+) -> torch.Tensor:
+    return chunk_bwd_dv_local_fix(q, k, do, g, scale, cu_seqlens, chunk_size, high_precision=True)
+
+def chunk_bwd_dv_local_variable_high_precision(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    do: torch.Tensor,
+    g: torch.Tensor,
+    scale: Optional[float],
+    cu_seqlens: torch.LongTensor,
+    chunk_size: int = 64
+) -> torch.Tensor:
+    return chunk_bwd_dv_local_variable(q, k, do, g, scale, cu_seqlens, chunk_size, high_precision=True)

--- a/torch_custom/fla_npu/test/test_npu_chunk_bwd_dv_local.py
+++ b/torch_custom/fla_npu/test/test_npu_chunk_bwd_dv_local.py
@@ -13,7 +13,13 @@ import os
 from typing import Optional
 import math
 import hashlib
-from golden import chunk_bwd_dv_local_fix, chunk_bwd_dv_local_variable, prepare_chunk_indices
+from golden import (
+    chunk_bwd_dv_local_fix,
+    chunk_bwd_dv_local_fix_high_precision,
+    chunk_bwd_dv_local_variable,
+    chunk_bwd_dv_local_variable_high_precision,
+    prepare_chunk_indices,
+)
 from utils import generate_cu_seqlens, compare_tensors_by_ratio, create_incremental_tensor, create_tensor, bool_matrix_to_uint8, get_tensor_md5, compare_tensors_md5
 import ct
 from fla_npu.ops import ascendc as ascendc_ops
@@ -24,18 +30,18 @@ torch.npu.set_compile_mode(jit_compile=False)
 torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", 0)))
 
 def test_variable():
-    B, H, T, K, V = 1, 32, 128, 128, 128
+    B, H_qk, H_do, T, K, V = 1, 4, 16, 128, 128, 128
     chunk_size= 64
     scale = 0.011
     cu_seqlens_len = 2
 
-    q = create_tensor((B, H, T, K), dtype=torch.float16)
+    q = create_tensor((B, H_qk, T, K), dtype=torch.float16)
     print(f"==== q.shape = {q.shape} ")
-    k = create_tensor((B, H, T, K), dtype=torch.float16)
+    k = create_tensor((B, H_qk, T, K), dtype=torch.float16)
     print(f"==== k.shape = {k.shape} ")
-    d_o = create_tensor((B, H, T, V), dtype=torch.float16)
+    d_o = create_tensor((B, H_do, T, V), dtype=torch.float16)
     print(f"==== d_o.shape = {d_o.shape} ")
-    g = torch.arange(B * H * T, 0, -1).reshape((B, H, T)).to(torch.float16)
+    g = torch.arange(B * H_do * T, 0, -1).reshape((B, H_do, T)).to(torch.float16)
     print(f"==== g.shape = {g.shape} ")
 
     cu_seqlens = generate_cu_seqlens(cu_seqlens_len, T)
@@ -43,7 +49,11 @@ def test_variable():
     print(f"==== cu_seqlens.shape = {cu_seqlens.shape} ",cu_seqlens)
 
     dv_golden = chunk_bwd_dv_local_variable(q, k, d_o, g, scale, cu_seqlens, chunk_size)
+    dv_golden_high_precision = chunk_bwd_dv_local_variable_high_precision(
+        q, k, d_o, g, scale, cu_seqlens, chunk_size
+    )
     print(f"==== dv_golden.shape = {dv_golden.shape} ")
+    assert torch.all(dv_golden.abs().sum(dim=(0, 2, 3)) > 0)
 
     q_npu = q.npu()
     k_npu = k.npu()
@@ -54,35 +64,42 @@ def test_variable():
     chunk_indices_list = chunk_indices.flatten().tolist()
 
     dv = ascendc_ops.npu_chunk_bwd_dv_local(q_npu, k_npu, d_o_npu, g_npu, scale=scale, chunk_size=chunk_size, g_gamma=None, A=None, cu_seqlens=cu_seqlens_list, chunk_indices=chunk_indices_list)
-    ct.single(dv.cpu(), dv_golden)
+    result = ct.dual(dv.cpu(), dv_golden, dv_golden_high_precision)
+    assert result["success"] is True
 
 
 def test_fix():
-    B=2
-    H=2
-    T=65
+    B=4
+    H_qk=4
+    H_do=16
+    T=198
     K=128
     V=128
     chunk_size=64
     scale=0.0625
 
-    q = create_tensor((B, H, T, K), dtype=torch.float16)
+    q = create_tensor((B, H_qk, T, K), dtype=torch.bfloat16)
     print(f"==== q.shape = {q.shape} ")
-    k = create_tensor((B, H, T, K), dtype=torch.float16)
+    k = create_tensor((B, H_qk, T, K), dtype=torch.bfloat16)
     print(f"==== k.shape = {k.shape} ")
-    d_o = create_tensor((B, H, T, V), dtype=torch.float16)
+    d_o = create_tensor((B, H_do, T, V), dtype=torch.bfloat16)
     print(f"==== d_o.shape = {d_o.shape} ")
-    g = torch.arange(B * H * T, 0, -1).reshape((B, H, T)).to(torch.float16)
+    g = torch.arange(B * H_do * T, 0, -1).reshape((B, H_do, T)).to(torch.bfloat16)
     print(f"==== g.shape = {g.shape} ")
     cu_seqlens = None
     dv_golden =  chunk_bwd_dv_local_fix(q, k, d_o, g, scale, cu_seqlens, chunk_size)
+    dv_golden_high_precision = chunk_bwd_dv_local_fix_high_precision(
+        q, k, d_o, g, scale, cu_seqlens, chunk_size
+    )
+    assert torch.all(dv_golden.abs().sum(dim=(0, 2, 3)) > 0)
 
     q_npu = q.npu()
     k_npu = k.npu()
     d_o_npu = d_o.npu()
     g_npu = g.npu()
     dv = ascendc_ops.npu_chunk_bwd_dv_local(q_npu, k_npu, d_o_npu, g_npu, scale=scale, chunk_size=chunk_size, g_gamma=None, A=None, cu_seqlens=None, chunk_indices=None)
-    ct.single(dv.cpu(), dv_golden)
+    result = ct.dual(dv.cpu(), dv_golden, dv_golden_high_precision)
+    assert result["success"] is True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建后，当前 head commit 仍需由仓库 Admin 触发 NPU CI，并满足分支保护要求的 2 个 approval；本 PR 不以本地 A2 验证替代仓库合入门禁。

## 关联 Issue / 背景

- 关联 Issue: Fixes #305
- 背景与目标: `chunk_bwd_dv_local` 的共享 Golden 在 GQA 场景中没有区分 Q/K 头数与 dO/dV 头数。
- 本 PR 解决的问题: 让定长和变长 Golden 遍历全部 `H_do`，并按 `qk_head = do_head // h_ratio` 映射 Q/K 头；增加 Issue 原始 shape 与变长场景回归。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `chunk_bwd_dv_local`
- 涉及目录 / 文件: 共享 Golden、`torch_custom` 单算子测试、算子 README
- 责任人 / 提交人: @chen-linxin
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [x] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 回归覆盖 BF16/FP16、定长/变长、`H_do / H_qk = 4`；定向回归同时覆盖 `hRatio=2`、`V=256`。
- 明确不包含的范围: 不修改算子运行时、tiling、kernel、接口和 ABI。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1 | `FLA_NPU_SOC=ascend910b python3 -m pip wheel --no-build-isolation --no-deps . -w dist` | 通过 | 完整 wheel 构建、安装与打包 API 检查通过 |
| A3 | `ascend910_93` | - | - | 未执行 | 本轮按 Issue 要求仅验证 A2，待仓库 CI 补齐 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1 | `FLA_NPU_SOC=ascend910b python3 -m pip wheel --no-build-isolation --no-deps . -w dist` | 通过 | 完整 wheel 构建、安装与打包 API 检查通过 |
| A3 | `ascend910_93` | - | - | 未执行 | 本轮按 Issue 要求仅验证 A2，待仓库 CI 补齐 |
| A5 | `ascend950` | - | - | 未执行 | 本轮按 Issue 要求仅验证 A2，待仓库 CI 补齐 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 torch_custom/fla_npu/test/test_npu_chunk_bwd_dv_local.py` | 通过 | 定长 Issue shape、变长 GQA dual benchmark 通过；16/16 输出头非零 |
| A2 | `ascend910b` | Fast-Kernel-Launch `chunk_bwd_dv_local` pytest | 通过 | 13/13 通过，覆盖定长/变长、`hRatio=1/2/4`、BF16/FP16 |
| A3 | `ascend910_93` | - | 未执行 | 待仓库 CI 补齐 |
| A5 | `ascend950` | - | 未执行 | 待仓库 CI 补齐 |

- 精度对比: 共享定长/变长与 3 组定向 dual benchmark 均通过，未放宽既有阈值。
- 性能对比: 运行时与 kernel 无修改；同一产物复测 2748.775 us / 2747.135 us，差异约 0.06%，未观察到回退。
- 边界 / 异常场景: 覆盖 `T=198` 非整 chunk、变长序列、`hRatio=2/4`、`V=128/256`。
- 未覆盖风险: A3/A5 尚未执行；需要仓库 NPU CI 补齐。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 examples/flash_gated_delta_rule.py --device 0` | 通过 | 前向、反向执行成功，输出与梯度均为有限值 |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未通过 | `case1_current_default` 严格 allclose 未通过；cosine=0.999954917，运行时路径未被本 PR 修改，待官方环境 NPU CI 复核 |
| A3 | `ascend910_93` | - | 未执行 | 待仓库 CI 补齐 |
| A5 | `ascend950` | - | 未执行 | 待仓库 CI 补齐 |

- 端到端场景说明: 直接 GDN 前向/反向示例通过。
- 与本 PR 修改算子的关联: 本 PR 仅修改 Golden、测试和 README，不修改端到端运行时代码。
- 未覆盖原因及补充计划: A3/A5 需仓库 CI；A2 全量 runner 的既有严格精度现象需在模板指定 wheel 环境复核。

</details>

## 兼容性、风险与回退

- 兼容性说明: 仅为 Golden 增加尾部可选参数和高精度包装函数，现有调用保持兼容。
- 风险点: 共享 Golden 的低精度路径现在显式模拟 BF16/FP16 中间结果舍入；需要关注其他复用该 Golden 的测试预期。
- 回退方案: 回退本 PR 单个提交即可恢复旧 Golden 和用例。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 根因位于共享 Golden：旧实现以 `H_qk` 为输出头循环上界，并用同一个 head 下标访问 `q/k/g/d_o/d_v`。算子 tiling 与 kernel 已按 `hRatio` 支持 GQA，因此没有修改底层实现。
- `H_qk=4, H_do=16` 的正确映射为输出头 0-3 -> Q/K 头 0、4-7 -> 1、8-11 -> 2、12-15 -> 3。
- 提交: `467f6a7`。