### PR TITLE
test: 增加 chunk_kda_fwd A5 dense 性能一键测试

### DIFF
--- a/tests/atk/README.md
+++ b/tests/atk/README.md
@@ -83,6 +83,7 @@ npu-smi info
 | `DC_LOOP_NUMS`         | 确定性循环次数，默认`50`                                                             |
 | `DC_TIMEOUT`           | 确定性阶段超时时间，默认`3600`                                                       |
 | `PERFORMANCE_TIMEOUT`  | 性能阶段超时时间，默认`2000`                                                         |
+| `PERFORMANCE_CASE_FILE` | 性能阶段用例 JSON；默认优先使用算子目录下的`atk_<op>_performance.json`             |
 | `MSS_TOOL`             | mssanitizer 工具，默认`memcheck`                                                     |
 | `MSS_LOG_PATH`         | ATK`-msl` 日志路径；默认 `${ATK_OUTPUT_ROOT}/mssanitizer_<op>_<时间戳>.log`        |
 
@@ -147,7 +148,8 @@ bash tests/atk/run_test_cpu.sh -op=causal_conv1d
 bash tests/atk/run_test_cpu.sh -op=<op_name> -scope=accuracy
 ```
 
-性能测试使用 ATK `performance_device`：
+性能测试使用 ATK `performance_device`；如果算子目录存在
+`atk_<op_name>_performance.json`，脚本会优先使用该性能子集：
 
 ```bash
 bash tests/atk/run_test_cpu.sh -op=<op_name> -scope=performance

--- a/tests/atk/chunk_kda_fwd/README.md
+++ b/tests/atk/chunk_kda_fwd/README.md
@@ -130,15 +130,18 @@ A2 mixed-tail 1K 用例的保存输出复检稳定复现 NaN/Inf；`ct viz` 显�
 
 ## 2. A5 性能四用例
 
-`atk_chunk_kda_fwd_performance.json` 是从主矩阵固定抽取的 4 条性能用例，避免性能
-scope 误跑精度矩阵或依赖 CPU/GPU 远端节点：
+`atk_chunk_kda_fwd_performance.json` 基于主矩阵的模型输入配置提供 4 条 dense BSND
+性能用例，避免性能 scope 误跑精度矩阵或依赖 CPU/GPU 远端节点：
 
-| 用例 | H/ HV | T | K/V | chunk | `disable_recompute` |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| `id=266` | 96/96（无 GVA） | 2048 | 128/128 | 64 | `false` |
-| `id=267` | 96/96（无 GVA） | 2048 | 128/128 | 64 | `true` |
-| `id=282` | 96/96（无 GVA） | 8192 | 128/128 | 64 | `false` |
-| `id=283` | 96/96（无 GVA） | 8192 | 128/128 | 64 | `true` |
+| 用例 | layout | H/HV | T | K/V | chunk | `disable_recompute` |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| `id=266` | BSND dense | 96/96（无 GVA） | 2048 | 128/128 | 64 | `false` |
+| `id=267` | BSND dense | 96/96（无 GVA） | 2048 | 128/128 | 64 | `true` |
+| `id=282` | BSND dense | 96/96（无 GVA） | 8192 | 128/128 | 64 | `false` |
+| `id=283` | BSND dense | 96/96（无 GVA） | 8192 | 128/128 | 64 | `true` |
+
+四条用例均不传 `cu_seqlens` 和 `chunk_indices`，A5 BF16、chunk=64、K=V=128
+场景会命中 dense 对齐快路径，一次 API 调用只提交一次物理 `ChunkKdaFwd` 主 kernel。
 
 性能阶段固定使用本地 `npu` backend。ATK 26.7.8 的 `pyaclnn` 性能任务会要求
 remote comparison node；公共 runner 已将性能 backend 与精度双标杆 backend

--- a/tests/atk/chunk_kda_fwd/README.md
+++ b/tests/atk/chunk_kda_fwd/README.md
@@ -128,9 +128,9 @@ A2 mixed-tail 1K 用例的保存输出复检稳定复现 NaN/Inf；`ct viz` 显�
 `attn_out` 存在成片非有限值及数量级异常，而 CPU FP64 golden 和 CPU 同精度对照
 保持有限，属于结构性输出错误，不是小值域相对误差放大。
 
-## 2. A5 性能四用例
+## 2. A5 性能十用例
 
-`atk_chunk_kda_fwd_performance.json` 基于主矩阵的模型输入配置提供 4 条 dense BSND
+`atk_chunk_kda_fwd_performance.json` 基于主矩阵的模型输入配置提供 10 条 dense BSND
 性能用例，避免性能 scope 误跑精度矩阵或依赖 CPU/GPU 远端节点：
 
 | 用例 | layout | H/HV | T | K/V | chunk | `disable_recompute` |
@@ -139,8 +139,14 @@ A2 mixed-tail 1K 用例的保存输出复检稳定复现 NaN/Inf；`ct viz` 显�
 | `id=267` | BSND dense | 96/96（无 GVA） | 2048 | 128/128 | 64 | `true` |
 | `id=282` | BSND dense | 96/96（无 GVA） | 8192 | 128/128 | 64 | `false` |
 | `id=283` | BSND dense | 96/96（无 GVA） | 8192 | 128/128 | 64 | `true` |
+| `id=290` | BSND dense | 96/96（无 GVA） | 16384 | 128/128 | 64 | `false` |
+| `id=291` | BSND dense | 96/96（无 GVA） | 16384 | 128/128 | 64 | `true` |
+| `id=298` | BSND dense | 96/96（无 GVA） | 32768 | 128/128 | 64 | `false` |
+| `id=299` | BSND dense | 96/96（无 GVA） | 32768 | 128/128 | 64 | `true` |
+| `id=300` | BSND dense | 96/96（无 GVA） | 65536 | 128/128 | 64 | `false` |
+| `id=301` | BSND dense | 96/96（无 GVA） | 65536 | 128/128 | 64 | `true` |
 
-四条用例均不传 `cu_seqlens` 和 `chunk_indices`，A5 BF16、chunk=64、K=V=128
+十条用例均不传 `cu_seqlens` 和 `chunk_indices`，A5 BF16、chunk=64、K=V=128
 场景会命中 dense 对齐快路径，一次 API 调用只提交一次物理 `ChunkKdaFwd` 主 kernel。
 
 性能阶段固定使用本地 `npu` backend。ATK 26.7.8 的 `pyaclnn` 性能任务会要求
@@ -155,7 +161,7 @@ bash tests/atk/run_test_cpu.sh \
   -scope=performance
 ```
 
-默认输出 `atk_output/perf`，性能阶段只运行上表 4 条用例。需要临时替换性能 JSON
+默认输出 `atk_output/perf`，性能阶段只运行上表 10 条用例。需要临时替换性能 JSON
 或覆盖 backend 时，可设置 `PERFORMANCE_CASE_FILE`、`PERFORMANCE_BACKEND`。
 
 ## 3. GPU 分布式拓扑

--- a/tests/atk/chunk_kda_fwd/README.md
+++ b/tests/atk/chunk_kda_fwd/README.md
@@ -128,7 +128,34 @@ A2 mixed-tail 1K 用例的保存输出复检稳定复现 NaN/Inf；`ct viz` 显�
 `attn_out` 存在成片非有限值及数量级异常，而 CPU FP64 golden 和 CPU 同精度对照
 保持有限，属于结构性输出错误，不是小值域相对误差放大。
 
-## 2. GPU 分布式拓扑
+## 2. A5 性能四用例
+
+`atk_chunk_kda_fwd_performance.json` 是从主矩阵固定抽取的 4 条性能用例，避免性能
+scope 误跑精度矩阵或依赖 CPU/GPU 远端节点：
+
+| 用例 | H/ HV | T | K/V | chunk | `disable_recompute` |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `id=266` | 96/96（无 GVA） | 2048 | 128/128 | 64 | `false` |
+| `id=267` | 96/96（无 GVA） | 2048 | 128/128 | 64 | `true` |
+| `id=282` | 96/96（无 GVA） | 8192 | 128/128 | 64 | `false` |
+| `id=283` | 96/96（无 GVA） | 8192 | 128/128 | 64 | `true` |
+
+性能阶段固定使用本地 `npu` backend。ATK 26.7.8 的 `pyaclnn` 性能任务会要求
+remote comparison node；公共 runner 已将性能 backend 与精度双标杆 backend
+分开，因此不需要启动远端节点。A5 上一键执行：
+
+```bash
+bash tests/atk/run_test_cpu.sh \
+  -op=chunk_kda_fwd \
+  -npu_device_id=<physical_npu_device> \
+  -soc=ascend950 \
+  -scope=performance
+```
+
+默认输出 `atk_output/perf`，性能阶段只运行上表 4 条用例。需要临时替换性能 JSON
+或覆盖 backend 时，可设置 `PERFORMANCE_CASE_FILE`、`PERFORMANCE_BACKEND`。
+
+## 3. GPU 分布式拓扑
 
 ```text
 A5 host
@@ -147,7 +174,7 @@ GPU 宿主机可达地址和宿主机映射端口，不要填写容器内部 IP�
 NPU 运行时和 `fla_npu.ops.ascendc`；GPU 容器只需要 CUDA Torch、Triton 和配置的
 KDA Triton callable，不需要安装 CANN 或 NPU wheel。
 
-## 3. 固定变量
+## 4. 固定变量
 
 后续命令使用以下占位符：
 
@@ -164,7 +191,7 @@ export TRITON_KDA_ROOT=<fla_org_or_compatible_triton_source_root>
 推荐在两边都把仓库放到各自固定路径；路径本身不要求相同。ATK server 与 A5 发起命令
 都从各自仓库的 `test/chunk_kda_fwd` 目录启动，输出路径使用相对路径。
 
-## 4. GPU Docker 准备
+## 5. GPU Docker 准备
 
 优先在 Docker 边界只暴露物理 GPU 6，并将容器 9090 映射到宿主机端口：
 
@@ -190,7 +217,7 @@ docker exec "$GPU_CONTAINER" nvidia-smi -L
 容器只暴露物理 GPU 6 时，它在容器内是逻辑设备 0。若容器仍能看到所有卡，则先设置
 `CUDA_VISIBLE_DEVICES=6`，ATK 中仍使用重新编号后的 `--devices 0`。
 
-## 5. GPU 容器环境与服务
+## 6. GPU 容器环境与服务
 
 进入容器后，激活 ATK 26.7.8 环境并检查 CUDA/Triton：
 
@@ -229,7 +256,7 @@ atk server \
 不要退出这个终端。日志应显示监听 `0.0.0.0:9090`，而不是只监听
 `127.0.0.1:9090`。
 
-## 6. A5 环境
+## 7. A5 环境
 
 在 A5 上加载 ATK、CANN、当前构建的 OPP 和仓内 Python 包。这里只暴露物理 NPU 6，
 所以后续 ATK 使用逻辑设备 0：
@@ -253,7 +280,7 @@ npu-smi info -i 6
 若没有设置 `ASCEND_RT_VISIBLE_DEVICES=6`，则 `node --devices` 必须传物理编号 6；两种
 写法只能选一种，不要设置可见卡后仍传 6。
 
-## 7. 两端一致性与网络预检
+## 8. 两端一致性与网络预检
 
 在 A5 和 GPU 容器内分别执行，结果必须一致：
 
@@ -276,7 +303,7 @@ curl -fsS "http://${GPU_HOST}:${GPU_HOST_PORT}/openapi.json" >/dev/null
 端口不可达时依次检查：容器内 server 是否仍在运行、是否监听 `0.0.0.0:9090`、
 `docker port` 是否存在、宿主机防火墙和 A5 到 GPU 宿主机的路由。
 
-## 8. 单 case 三路烟测
+## 9. 单 case 三路烟测
 
 在 A5 的 `test/chunk_kda_fwd` 目录执行。远端 GPU 不与 A5 共享文件系统，因此
 `--syc_dataset` 必须保留；分布式任务不要使用 `-sp`，使用 `-mt 1` 限制并发和显存：
@@ -323,7 +350,7 @@ GPU control: benchmark=False high_precision=False triton_control=True
 `gpu_benchmark` 目录保存 Torch FP64 真值；普通 `gpu_*` 目录保存同输入 dtype 的 Triton
 对照；`npu_*` 目录保存 A5 DUT 输出。
 
-## 9. 全量和单 case 定位
+## 10. 全量和单 case 定位
 
 A5 正向范围为 `250-449`，ATK 的 `-e` 是开区间：
 
@@ -349,7 +376,7 @@ python ./stress_npu_determinism.py \
   --repeats 100
 ```
 
-## 10. 常见失败
+## 11. 常见失败
 
 | 现象 | 原因与处理 |
 | --- | --- |

--- a/tests/atk/chunk_kda_fwd/atk_chunk_kda_fwd_performance.json
+++ b/tests/atk/chunk_kda_fwd/atk_chunk_kda_fwd_performance.json
@@ -55,7 +55,7 @@
         "required": true,
         "dtype": "non_param",
         "shape": null,
-        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":2048,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t2048_c64_packed_single_recompute\",\"chunk_size\":64,\"cu_seqlens\":\"0,2048\",\"data_profile\":\"model_h96\",\"disable_recompute\":false,\"distribution\":\"single\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=True,disable_recompute=False\",\"output_final_state\":false,\"profile\":\"a5_accuracy\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260820,\"shape_spec\":\"B=1,H=96,HV=96,T=2048,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"accuracy,model_target,regression,boundary,varlen\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
+        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":2048,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t2048_c64_dense_bsnd_recompute\",\"chunk_size\":64,\"cu_seqlens\":\"\",\"data_profile\":\"model_h96\",\"disable_recompute\":false,\"distribution\":\"dense\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=False,disable_recompute=False\",\"output_final_state\":false,\"profile\":\"a5_performance\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260820,\"shape_spec\":\"B=1,H=96,HV=96,T=2048,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"performance,model_target,regression\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
         "backward": false
       },
       {
@@ -199,7 +199,7 @@
         "required": true,
         "dtype": "bool",
         "shape": null,
-        "range_values": true,
+        "range_values": false,
         "backward": false
       },
       {
@@ -324,7 +324,7 @@
         "required": true,
         "dtype": "non_param",
         "shape": null,
-        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":2048,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t2048_c64_packed_single_export\",\"chunk_size\":64,\"cu_seqlens\":\"0,2048\",\"data_profile\":\"model_h96\",\"disable_recompute\":true,\"distribution\":\"single\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=True,disable_recompute=True\",\"output_final_state\":false,\"profile\":\"a5_accuracy\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260820,\"shape_spec\":\"B=1,H=96,HV=96,T=2048,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"accuracy,model_target,regression,boundary,varlen\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
+        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":2048,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t2048_c64_dense_bsnd_export\",\"chunk_size\":64,\"cu_seqlens\":\"\",\"data_profile\":\"model_h96\",\"disable_recompute\":true,\"distribution\":\"dense\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=False,disable_recompute=True\",\"output_final_state\":false,\"profile\":\"a5_performance\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260820,\"shape_spec\":\"B=1,H=96,HV=96,T=2048,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"performance,model_target,regression\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
         "backward": false
       },
       {
@@ -468,7 +468,7 @@
         "required": true,
         "dtype": "bool",
         "shape": null,
-        "range_values": true,
+        "range_values": false,
         "backward": false
       },
       {
@@ -593,7 +593,7 @@
         "required": true,
         "dtype": "non_param",
         "shape": null,
-        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":8192,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t8192_c64_packed_single_recompute\",\"chunk_size\":64,\"cu_seqlens\":\"0,8192\",\"data_profile\":\"model_h96\",\"disable_recompute\":false,\"distribution\":\"single\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=True,disable_recompute=False\",\"output_final_state\":false,\"profile\":\"a5_accuracy\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260828,\"shape_spec\":\"B=1,H=96,HV=96,T=8192,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"accuracy,model_target,regression,boundary,varlen\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
+        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":8192,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t8192_c64_dense_bsnd_recompute\",\"chunk_size\":64,\"cu_seqlens\":\"\",\"data_profile\":\"model_h96\",\"disable_recompute\":false,\"distribution\":\"dense\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=False,disable_recompute=False\",\"output_final_state\":false,\"profile\":\"a5_performance\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260828,\"shape_spec\":\"B=1,H=96,HV=96,T=8192,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"performance,model_target,regression\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
         "backward": false
       },
       {
@@ -737,7 +737,7 @@
         "required": true,
         "dtype": "bool",
         "shape": null,
-        "range_values": true,
+        "range_values": false,
         "backward": false
       },
       {
@@ -862,7 +862,7 @@
         "required": true,
         "dtype": "non_param",
         "shape": null,
-        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":8192,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t8192_c64_packed_single_export\",\"chunk_size\":64,\"cu_seqlens\":\"0,8192\",\"data_profile\":\"model_h96\",\"disable_recompute\":true,\"distribution\":\"single\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=True,disable_recompute=True\",\"output_final_state\":false,\"profile\":\"a5_accuracy\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260828,\"shape_spec\":\"B=1,H=96,HV=96,T=8192,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"accuracy,model_target,regression,boundary,varlen\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
+        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":8192,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t8192_c64_dense_bsnd_export\",\"chunk_size\":64,\"cu_seqlens\":\"\",\"data_profile\":\"model_h96\",\"disable_recompute\":true,\"distribution\":\"dense\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=False,disable_recompute=True\",\"output_final_state\":false,\"profile\":\"a5_performance\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260828,\"shape_spec\":\"B=1,H=96,HV=96,T=8192,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"performance,model_target,regression\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
         "backward": false
       },
       {
@@ -1006,7 +1006,7 @@
         "required": true,
         "dtype": "bool",
         "shape": null,
-        "range_values": true,
+        "range_values": false,
         "backward": false
       },
       {

--- a/tests/atk/chunk_kda_fwd/atk_chunk_kda_fwd_performance.json
+++ b/tests/atk/chunk_kda_fwd/atk_chunk_kda_fwd_performance.json
@@ -1074,5 +1074,1619 @@
       }
     ],
     "save_name": "chunk_kda_fwd"
+  },
+  {
+    "id": 290,
+    "default_seed": 20260832,
+    "name": "chunk_kda_fwd",
+    "aclnn_name": "ChunkKdaFwd",
+    "version": "v2.1",
+    "api": "pytorch",
+    "api_type": "executor_chunk_kda_fwd",
+    "expected_error_msg": null,
+    "backward": false,
+    "standard": {
+      "acc": {
+        "cv_fused_double_benchmark": {
+          "max_re_ratio": 5,
+          "avg_re_ratio": 1.5,
+          "root_mean_squared_ratio": 1.5
+        }
+      },
+      "perf": "not_key"
+    },
+    "outputs": null,
+    "inputs": [
+      {
+        "name": "low_precision_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "bf16",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "fp32_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "fp32",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "case_spec",
+        "type": "attr",
+        "required": true,
+        "dtype": "non_param",
+        "shape": null,
+        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":16384,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t16384_c64_dense_bsnd_recompute\",\"chunk_size\":64,\"cu_seqlens\":\"\",\"data_profile\":\"model_h96\",\"disable_recompute\":false,\"distribution\":\"dense\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=False,disable_recompute=False\",\"output_final_state\":false,\"profile\":\"a5_performance\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260832,\"shape_spec\":\"B=1,H=96,HV=96,T=16384,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"performance,model_target,regression\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
+        "backward": false
+      },
+      {
+        "name": "soc",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascend950",
+        "backward": false
+      },
+      {
+        "name": "route",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascendc",
+        "backward": false
+      },
+      {
+        "name": "batch",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 1,
+        "backward": false
+      },
+      {
+        "name": "head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "value_head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "total_tokens",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 16384,
+        "backward": false
+      },
+      {
+        "name": "key_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "value_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "chunk_size",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 64,
+        "backward": false
+      },
+      {
+        "name": "layout",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "BSND",
+        "backward": false
+      },
+      {
+        "name": "q_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "g_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "fp32",
+        "backward": false
+      },
+      {
+        "name": "beta_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "initial_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "output_final_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "varlen",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "safe_gate",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "lower_bound",
+        "type": "attr",
+        "required": true,
+        "dtype": "float",
+        "shape": null,
+        "range_values": -5.0,
+        "backward": false
+      },
+      {
+        "name": "use_gate_in_kernel",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "disable_recompute",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "return_intermediate_states",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "state_v_first",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "negative_case",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      }
+    ],
+    "save_name": "chunk_kda_fwd"
+  },
+  {
+    "id": 291,
+    "default_seed": 20260832,
+    "name": "chunk_kda_fwd",
+    "aclnn_name": "ChunkKdaFwd",
+    "version": "v2.1",
+    "api": "pytorch",
+    "api_type": "executor_chunk_kda_fwd",
+    "expected_error_msg": null,
+    "backward": false,
+    "standard": {
+      "acc": {
+        "cv_fused_double_benchmark": {
+          "max_re_ratio": 5,
+          "avg_re_ratio": 1.5,
+          "root_mean_squared_ratio": 1.5
+        }
+      },
+      "perf": "not_key"
+    },
+    "outputs": null,
+    "inputs": [
+      {
+        "name": "low_precision_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "bf16",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "fp32_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "fp32",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "case_spec",
+        "type": "attr",
+        "required": true,
+        "dtype": "non_param",
+        "shape": null,
+        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":16384,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t16384_c64_dense_bsnd_export\",\"chunk_size\":64,\"cu_seqlens\":\"\",\"data_profile\":\"model_h96\",\"disable_recompute\":true,\"distribution\":\"dense\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=False,disable_recompute=True\",\"output_final_state\":false,\"profile\":\"a5_performance\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260832,\"shape_spec\":\"B=1,H=96,HV=96,T=16384,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"performance,model_target,regression\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
+        "backward": false
+      },
+      {
+        "name": "soc",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascend950",
+        "backward": false
+      },
+      {
+        "name": "route",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascendc",
+        "backward": false
+      },
+      {
+        "name": "batch",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 1,
+        "backward": false
+      },
+      {
+        "name": "head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "value_head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "total_tokens",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 16384,
+        "backward": false
+      },
+      {
+        "name": "key_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "value_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "chunk_size",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 64,
+        "backward": false
+      },
+      {
+        "name": "layout",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "BSND",
+        "backward": false
+      },
+      {
+        "name": "q_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "g_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "fp32",
+        "backward": false
+      },
+      {
+        "name": "beta_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "initial_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "output_final_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "varlen",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "safe_gate",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "lower_bound",
+        "type": "attr",
+        "required": true,
+        "dtype": "float",
+        "shape": null,
+        "range_values": -5.0,
+        "backward": false
+      },
+      {
+        "name": "use_gate_in_kernel",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "disable_recompute",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "return_intermediate_states",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "state_v_first",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "negative_case",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      }
+    ],
+    "save_name": "chunk_kda_fwd"
+  },
+  {
+    "id": 298,
+    "default_seed": 20260820,
+    "name": "chunk_kda_fwd",
+    "aclnn_name": "ChunkKdaFwd",
+    "version": "v2.1",
+    "api": "pytorch",
+    "api_type": "executor_chunk_kda_fwd",
+    "expected_error_msg": null,
+    "backward": false,
+    "standard": {
+      "acc": {
+        "cv_fused_double_benchmark": {
+          "max_re_ratio": 5,
+          "avg_re_ratio": 1.5,
+          "root_mean_squared_ratio": 1.5
+        }
+      },
+      "perf": "not_key"
+    },
+    "outputs": null,
+    "inputs": [
+      {
+        "name": "low_precision_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "bf16",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "fp32_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "fp32",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "case_spec",
+        "type": "attr",
+        "required": true,
+        "dtype": "non_param",
+        "shape": null,
+        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":32768,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t32768_c64_dense_bsnd_recompute\",\"chunk_size\":64,\"cu_seqlens\":\"\",\"data_profile\":\"model_h96\",\"disable_recompute\":false,\"distribution\":\"dense\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=False,disable_recompute=False\",\"output_final_state\":false,\"profile\":\"a5_performance\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260820,\"shape_spec\":\"B=1,H=96,HV=96,T=32768,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"performance,model_target,regression\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
+        "backward": false
+      },
+      {
+        "name": "soc",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascend950",
+        "backward": false
+      },
+      {
+        "name": "route",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascendc",
+        "backward": false
+      },
+      {
+        "name": "batch",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 1,
+        "backward": false
+      },
+      {
+        "name": "head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "value_head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "total_tokens",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 32768,
+        "backward": false
+      },
+      {
+        "name": "key_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "value_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "chunk_size",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 64,
+        "backward": false
+      },
+      {
+        "name": "layout",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "BSND",
+        "backward": false
+      },
+      {
+        "name": "q_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "g_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "fp32",
+        "backward": false
+      },
+      {
+        "name": "beta_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "initial_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "output_final_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "varlen",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "safe_gate",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "lower_bound",
+        "type": "attr",
+        "required": true,
+        "dtype": "float",
+        "shape": null,
+        "range_values": -5.0,
+        "backward": false
+      },
+      {
+        "name": "use_gate_in_kernel",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "disable_recompute",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "return_intermediate_states",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "state_v_first",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "negative_case",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      }
+    ],
+    "save_name": "chunk_kda_fwd"
+  },
+  {
+    "id": 299,
+    "default_seed": 20260820,
+    "name": "chunk_kda_fwd",
+    "aclnn_name": "ChunkKdaFwd",
+    "version": "v2.1",
+    "api": "pytorch",
+    "api_type": "executor_chunk_kda_fwd",
+    "expected_error_msg": null,
+    "backward": false,
+    "standard": {
+      "acc": {
+        "cv_fused_double_benchmark": {
+          "max_re_ratio": 5,
+          "avg_re_ratio": 1.5,
+          "root_mean_squared_ratio": 1.5
+        }
+      },
+      "perf": "not_key"
+    },
+    "outputs": null,
+    "inputs": [
+      {
+        "name": "low_precision_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "bf16",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "fp32_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "fp32",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "case_spec",
+        "type": "attr",
+        "required": true,
+        "dtype": "non_param",
+        "shape": null,
+        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":32768,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t32768_c64_dense_bsnd_export\",\"chunk_size\":64,\"cu_seqlens\":\"\",\"data_profile\":\"model_h96\",\"disable_recompute\":true,\"distribution\":\"dense\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=False,disable_recompute=True\",\"output_final_state\":false,\"profile\":\"a5_performance\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260820,\"shape_spec\":\"B=1,H=96,HV=96,T=32768,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"performance,model_target,regression\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
+        "backward": false
+      },
+      {
+        "name": "soc",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascend950",
+        "backward": false
+      },
+      {
+        "name": "route",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascendc",
+        "backward": false
+      },
+      {
+        "name": "batch",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 1,
+        "backward": false
+      },
+      {
+        "name": "head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "value_head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "total_tokens",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 32768,
+        "backward": false
+      },
+      {
+        "name": "key_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "value_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "chunk_size",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 64,
+        "backward": false
+      },
+      {
+        "name": "layout",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "BSND",
+        "backward": false
+      },
+      {
+        "name": "q_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "g_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "fp32",
+        "backward": false
+      },
+      {
+        "name": "beta_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "initial_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "output_final_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "varlen",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "safe_gate",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "lower_bound",
+        "type": "attr",
+        "required": true,
+        "dtype": "float",
+        "shape": null,
+        "range_values": -5.0,
+        "backward": false
+      },
+      {
+        "name": "use_gate_in_kernel",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "disable_recompute",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "return_intermediate_states",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "state_v_first",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "negative_case",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      }
+    ],
+    "save_name": "chunk_kda_fwd"
+  },
+  {
+    "id": 300,
+    "default_seed": 20260820,
+    "name": "chunk_kda_fwd",
+    "aclnn_name": "ChunkKdaFwd",
+    "version": "v2.1",
+    "api": "pytorch",
+    "api_type": "executor_chunk_kda_fwd",
+    "expected_error_msg": null,
+    "backward": false,
+    "standard": {
+      "acc": {
+        "cv_fused_double_benchmark": {
+          "max_re_ratio": 5,
+          "avg_re_ratio": 1.5,
+          "root_mean_squared_ratio": 1.5
+        }
+      },
+      "perf": "not_key"
+    },
+    "outputs": null,
+    "inputs": [
+      {
+        "name": "low_precision_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "bf16",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "fp32_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "fp32",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "case_spec",
+        "type": "attr",
+        "required": true,
+        "dtype": "non_param",
+        "shape": null,
+        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":65536,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t65536_c64_dense_bsnd_recompute\",\"chunk_size\":64,\"cu_seqlens\":\"\",\"data_profile\":\"model_h96\",\"disable_recompute\":false,\"distribution\":\"dense\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=False,disable_recompute=False\",\"output_final_state\":false,\"profile\":\"a5_performance\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260820,\"shape_spec\":\"B=1,H=96,HV=96,T=65536,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"performance,model_target,regression\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
+        "backward": false
+      },
+      {
+        "name": "soc",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascend950",
+        "backward": false
+      },
+      {
+        "name": "route",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascendc",
+        "backward": false
+      },
+      {
+        "name": "batch",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 1,
+        "backward": false
+      },
+      {
+        "name": "head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "value_head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "total_tokens",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 65536,
+        "backward": false
+      },
+      {
+        "name": "key_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "value_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "chunk_size",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 64,
+        "backward": false
+      },
+      {
+        "name": "layout",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "BSND",
+        "backward": false
+      },
+      {
+        "name": "q_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "g_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "fp32",
+        "backward": false
+      },
+      {
+        "name": "beta_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "initial_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "output_final_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "varlen",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "safe_gate",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "lower_bound",
+        "type": "attr",
+        "required": true,
+        "dtype": "float",
+        "shape": null,
+        "range_values": -5.0,
+        "backward": false
+      },
+      {
+        "name": "use_gate_in_kernel",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "disable_recompute",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "return_intermediate_states",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "state_v_first",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "negative_case",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      }
+    ],
+    "save_name": "chunk_kda_fwd"
+  },
+  {
+    "id": 301,
+    "default_seed": 20260820,
+    "name": "chunk_kda_fwd",
+    "aclnn_name": "ChunkKdaFwd",
+    "version": "v2.1",
+    "api": "pytorch",
+    "api_type": "executor_chunk_kda_fwd",
+    "expected_error_msg": null,
+    "backward": false,
+    "standard": {
+      "acc": {
+        "cv_fused_double_benchmark": {
+          "max_re_ratio": 5,
+          "avg_re_ratio": 1.5,
+          "root_mean_squared_ratio": 1.5
+        }
+      },
+      "perf": "not_key"
+    },
+    "outputs": null,
+    "inputs": [
+      {
+        "name": "low_precision_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "bf16",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "fp32_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "fp32",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "case_spec",
+        "type": "attr",
+        "required": true,
+        "dtype": "non_param",
+        "shape": null,
+        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":65536,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t65536_c64_dense_bsnd_export\",\"chunk_size\":64,\"cu_seqlens\":\"\",\"data_profile\":\"model_h96\",\"disable_recompute\":true,\"distribution\":\"dense\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=False,disable_recompute=True\",\"output_final_state\":false,\"profile\":\"a5_performance\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260820,\"shape_spec\":\"B=1,H=96,HV=96,T=65536,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"performance,model_target,regression\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
+        "backward": false
+      },
+      {
+        "name": "soc",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascend950",
+        "backward": false
+      },
+      {
+        "name": "route",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascendc",
+        "backward": false
+      },
+      {
+        "name": "batch",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 1,
+        "backward": false
+      },
+      {
+        "name": "head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "value_head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "total_tokens",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 65536,
+        "backward": false
+      },
+      {
+        "name": "key_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "value_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "chunk_size",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 64,
+        "backward": false
+      },
+      {
+        "name": "layout",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "BSND",
+        "backward": false
+      },
+      {
+        "name": "q_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "g_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "fp32",
+        "backward": false
+      },
+      {
+        "name": "beta_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "initial_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "output_final_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "varlen",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "safe_gate",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "lower_bound",
+        "type": "attr",
+        "required": true,
+        "dtype": "float",
+        "shape": null,
+        "range_values": -5.0,
+        "backward": false
+      },
+      {
+        "name": "use_gate_in_kernel",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "disable_recompute",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "return_intermediate_states",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "state_v_first",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "negative_case",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      }
+    ],
+    "save_name": "chunk_kda_fwd"
   }
 ]

--- a/tests/atk/chunk_kda_fwd/atk_chunk_kda_fwd_performance.json
+++ b/tests/atk/chunk_kda_fwd/atk_chunk_kda_fwd_performance.json
@@ -1,0 +1,1078 @@
+[
+  {
+    "id": 266,
+    "default_seed": 20260820,
+    "name": "chunk_kda_fwd",
+    "aclnn_name": "ChunkKdaFwd",
+    "version": "v2.1",
+    "api": "pytorch",
+    "api_type": "executor_chunk_kda_fwd",
+    "expected_error_msg": null,
+    "backward": false,
+    "standard": {
+      "acc": {
+        "cv_fused_double_benchmark": {
+          "max_re_ratio": 5,
+          "avg_re_ratio": 1.5,
+          "root_mean_squared_ratio": 1.5
+        }
+      },
+      "perf": "not_key"
+    },
+    "outputs": null,
+    "inputs": [
+      {
+        "name": "low_precision_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "bf16",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "fp32_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "fp32",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "case_spec",
+        "type": "attr",
+        "required": true,
+        "dtype": "non_param",
+        "shape": null,
+        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":2048,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t2048_c64_packed_single_recompute\",\"chunk_size\":64,\"cu_seqlens\":\"0,2048\",\"data_profile\":\"model_h96\",\"disable_recompute\":false,\"distribution\":\"single\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=True,disable_recompute=False\",\"output_final_state\":false,\"profile\":\"a5_accuracy\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260820,\"shape_spec\":\"B=1,H=96,HV=96,T=2048,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"accuracy,model_target,regression,boundary,varlen\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
+        "backward": false
+      },
+      {
+        "name": "soc",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascend950",
+        "backward": false
+      },
+      {
+        "name": "route",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascendc",
+        "backward": false
+      },
+      {
+        "name": "batch",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 1,
+        "backward": false
+      },
+      {
+        "name": "head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "value_head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "total_tokens",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 2048,
+        "backward": false
+      },
+      {
+        "name": "key_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "value_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "chunk_size",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 64,
+        "backward": false
+      },
+      {
+        "name": "layout",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "BSND",
+        "backward": false
+      },
+      {
+        "name": "q_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "g_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "fp32",
+        "backward": false
+      },
+      {
+        "name": "beta_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "initial_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "output_final_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "varlen",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "safe_gate",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "lower_bound",
+        "type": "attr",
+        "required": true,
+        "dtype": "float",
+        "shape": null,
+        "range_values": -5.0,
+        "backward": false
+      },
+      {
+        "name": "use_gate_in_kernel",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "disable_recompute",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "return_intermediate_states",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "state_v_first",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "negative_case",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      }
+    ],
+    "save_name": "chunk_kda_fwd"
+  },
+  {
+    "id": 267,
+    "default_seed": 20260820,
+    "name": "chunk_kda_fwd",
+    "aclnn_name": "ChunkKdaFwd",
+    "version": "v2.1",
+    "api": "pytorch",
+    "api_type": "executor_chunk_kda_fwd",
+    "expected_error_msg": null,
+    "backward": false,
+    "standard": {
+      "acc": {
+        "cv_fused_double_benchmark": {
+          "max_re_ratio": 5,
+          "avg_re_ratio": 1.5,
+          "root_mean_squared_ratio": 1.5
+        }
+      },
+      "perf": "not_key"
+    },
+    "outputs": null,
+    "inputs": [
+      {
+        "name": "low_precision_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "bf16",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "fp32_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "fp32",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "case_spec",
+        "type": "attr",
+        "required": true,
+        "dtype": "non_param",
+        "shape": null,
+        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":2048,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t2048_c64_packed_single_export\",\"chunk_size\":64,\"cu_seqlens\":\"0,2048\",\"data_profile\":\"model_h96\",\"disable_recompute\":true,\"distribution\":\"single\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=True,disable_recompute=True\",\"output_final_state\":false,\"profile\":\"a5_accuracy\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260820,\"shape_spec\":\"B=1,H=96,HV=96,T=2048,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"accuracy,model_target,regression,boundary,varlen\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
+        "backward": false
+      },
+      {
+        "name": "soc",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascend950",
+        "backward": false
+      },
+      {
+        "name": "route",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascendc",
+        "backward": false
+      },
+      {
+        "name": "batch",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 1,
+        "backward": false
+      },
+      {
+        "name": "head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "value_head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "total_tokens",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 2048,
+        "backward": false
+      },
+      {
+        "name": "key_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "value_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "chunk_size",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 64,
+        "backward": false
+      },
+      {
+        "name": "layout",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "BSND",
+        "backward": false
+      },
+      {
+        "name": "q_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "g_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "fp32",
+        "backward": false
+      },
+      {
+        "name": "beta_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "initial_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "output_final_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "varlen",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "safe_gate",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "lower_bound",
+        "type": "attr",
+        "required": true,
+        "dtype": "float",
+        "shape": null,
+        "range_values": -5.0,
+        "backward": false
+      },
+      {
+        "name": "use_gate_in_kernel",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "disable_recompute",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "return_intermediate_states",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "state_v_first",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "negative_case",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      }
+    ],
+    "save_name": "chunk_kda_fwd"
+  },
+  {
+    "id": 282,
+    "default_seed": 20260828,
+    "name": "chunk_kda_fwd",
+    "aclnn_name": "ChunkKdaFwd",
+    "version": "v2.1",
+    "api": "pytorch",
+    "api_type": "executor_chunk_kda_fwd",
+    "expected_error_msg": null,
+    "backward": false,
+    "standard": {
+      "acc": {
+        "cv_fused_double_benchmark": {
+          "max_re_ratio": 5,
+          "avg_re_ratio": 1.5,
+          "root_mean_squared_ratio": 1.5
+        }
+      },
+      "perf": "not_key"
+    },
+    "outputs": null,
+    "inputs": [
+      {
+        "name": "low_precision_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "bf16",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "fp32_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "fp32",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "case_spec",
+        "type": "attr",
+        "required": true,
+        "dtype": "non_param",
+        "shape": null,
+        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":8192,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t8192_c64_packed_single_recompute\",\"chunk_size\":64,\"cu_seqlens\":\"0,8192\",\"data_profile\":\"model_h96\",\"disable_recompute\":false,\"distribution\":\"single\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=True,disable_recompute=False\",\"output_final_state\":false,\"profile\":\"a5_accuracy\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260828,\"shape_spec\":\"B=1,H=96,HV=96,T=8192,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"accuracy,model_target,regression,boundary,varlen\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
+        "backward": false
+      },
+      {
+        "name": "soc",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascend950",
+        "backward": false
+      },
+      {
+        "name": "route",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascendc",
+        "backward": false
+      },
+      {
+        "name": "batch",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 1,
+        "backward": false
+      },
+      {
+        "name": "head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "value_head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "total_tokens",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 8192,
+        "backward": false
+      },
+      {
+        "name": "key_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "value_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "chunk_size",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 64,
+        "backward": false
+      },
+      {
+        "name": "layout",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "BSND",
+        "backward": false
+      },
+      {
+        "name": "q_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "g_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "fp32",
+        "backward": false
+      },
+      {
+        "name": "beta_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "initial_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "output_final_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "varlen",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "safe_gate",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "lower_bound",
+        "type": "attr",
+        "required": true,
+        "dtype": "float",
+        "shape": null,
+        "range_values": -5.0,
+        "backward": false
+      },
+      {
+        "name": "use_gate_in_kernel",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "disable_recompute",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "return_intermediate_states",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "state_v_first",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "negative_case",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      }
+    ],
+    "save_name": "chunk_kda_fwd"
+  },
+  {
+    "id": 283,
+    "default_seed": 20260828,
+    "name": "chunk_kda_fwd",
+    "aclnn_name": "ChunkKdaFwd",
+    "version": "v2.1",
+    "api": "pytorch",
+    "api_type": "executor_chunk_kda_fwd",
+    "expected_error_msg": null,
+    "backward": false,
+    "standard": {
+      "acc": {
+        "cv_fused_double_benchmark": {
+          "max_re_ratio": 5,
+          "avg_re_ratio": 1.5,
+          "root_mean_squared_ratio": 1.5
+        }
+      },
+      "perf": "not_key"
+    },
+    "outputs": null,
+    "inputs": [
+      {
+        "name": "low_precision_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "bf16",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "fp32_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "fp32",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "case_spec",
+        "type": "attr",
+        "required": true,
+        "dtype": "non_param",
+        "shape": null,
+        "range_values": "{\"B\":1,\"H\":96,\"HV\":96,\"K\":128,\"T\":8192,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"bf16\",\"beta_scale\":0.35,\"case_key\":\"ascend950_h96_t8192_c64_packed_single_export\",\"chunk_size\":64,\"cu_seqlens\":\"0,8192\",\"data_profile\":\"model_h96\",\"disable_recompute\":true,\"distribution\":\"single\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=False,varlen=True,disable_recompute=True\",\"output_final_state\":false,\"profile\":\"a5_accuracy\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":false,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":20260828,\"shape_spec\":\"B=1,H=96,HV=96,T=8192,K=128,V=128\",\"soc\":\"ascend950\",\"state_v_first\":true,\"tags\":\"accuracy,model_target,regression,boundary,varlen\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
+        "backward": false
+      },
+      {
+        "name": "soc",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascend950",
+        "backward": false
+      },
+      {
+        "name": "route",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascendc",
+        "backward": false
+      },
+      {
+        "name": "batch",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 1,
+        "backward": false
+      },
+      {
+        "name": "head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "value_head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "total_tokens",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 8192,
+        "backward": false
+      },
+      {
+        "name": "key_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "value_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "chunk_size",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 64,
+        "backward": false
+      },
+      {
+        "name": "layout",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "BSND",
+        "backward": false
+      },
+      {
+        "name": "q_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "g_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "fp32",
+        "backward": false
+      },
+      {
+        "name": "beta_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "initial_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "output_final_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "varlen",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "safe_gate",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "lower_bound",
+        "type": "attr",
+        "required": true,
+        "dtype": "float",
+        "shape": null,
+        "range_values": -5.0,
+        "backward": false
+      },
+      {
+        "name": "use_gate_in_kernel",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "disable_recompute",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "return_intermediate_states",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "state_v_first",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "negative_case",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      }
+    ],
+    "save_name": "chunk_kda_fwd"
+  }
+]

--- a/tests/atk/chunk_kda_fwd/scripts/gen_performance_cases.py
+++ b/tests/atk/chunk_kda_fwd/scripts/gen_performance_cases.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Generate the dense chunk_kda_fwd performance subset."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from pathlib import Path
+
+
+# Existing matrix entries provide the canonical input schema.  The three long
+# lengths are dense performance-only cases and are derived from the same schema.
+CASE_SPECS = (
+    (266, 266, 2048, False, "recompute"),
+    (267, 267, 2048, True, "export"),
+    (282, 282, 8192, False, "recompute"),
+    (283, 283, 8192, True, "export"),
+    (290, 290, 16384, False, "recompute"),
+    (291, 291, 16384, True, "export"),
+    (298, 266, 32768, False, "recompute"),
+    (299, 267, 32768, True, "export"),
+    (300, 266, 65536, False, "recompute"),
+    (301, 267, 65536, True, "export"),
+)
+
+
+def _input_by_name(case: dict, name: str) -> dict:
+    matches = [item for item in case["inputs"] if item["name"] == name]
+    if len(matches) != 1:
+        raise ValueError(
+            f"case {case['id']} must contain exactly one {name!r} input"
+        )
+    return matches[0]
+
+
+def _make_dense_case(
+    source_case: dict,
+    output_id: int,
+    total_tokens: int,
+    disable_recompute: bool,
+    suffix: str,
+) -> dict:
+    case = copy.deepcopy(source_case)
+    case["id"] = output_id
+    spec_input = _input_by_name(case, "case_spec")
+    spec = json.loads(spec_input["range_values"])
+    expected = {
+        "B": 1,
+        "H": 96,
+        "HV": 96,
+        "K": 128,
+        "V": 128,
+        "chunk_size": 64,
+        "layout": "BSND",
+        "q_dtype": "bf16",
+        "g_dtype": "fp32",
+        "beta_dtype": "bf16",
+        "soc": "ascend950",
+    }
+    for key, value in expected.items():
+        if spec.get(key) != value:
+            raise ValueError(
+                f"case {source_case['id']} has unexpected {key}: "
+                f"{spec.get(key)!r}, expected {value!r}"
+            )
+
+    spec.update(
+        T=total_tokens,
+        case_key=f"ascend950_h96_t{total_tokens}_c64_dense_bsnd_{suffix}",
+        cu_seqlens="",
+        distribution="dense",
+        disable_recompute=disable_recompute,
+        explicit_chunk_indices=False,
+        optional_spec=(
+            "initial=False,final=False,varlen=False,"
+            f"disable_recompute={disable_recompute}"
+        ),
+        profile="a5_performance",
+        shape_spec=(
+            f"B=1,H=96,HV=96,T={total_tokens},K=128,V=128"
+        ),
+        tags="performance,model_target,regression",
+    )
+    spec_input["range_values"] = json.dumps(
+        spec, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+    _input_by_name(case, "total_tokens")["range_values"] = total_tokens
+    _input_by_name(case, "varlen")["range_values"] = False
+    _input_by_name(case, "disable_recompute")["range_values"] = disable_recompute
+    return case
+
+
+def generate(source_path: Path) -> list[dict]:
+    source_cases = json.loads(source_path.read_text(encoding="utf-8"))
+    by_id = {case["id"]: case for case in source_cases}
+    missing = sorted({source_id for _, source_id, *_ in CASE_SPECS} - set(by_id))
+    if missing:
+        raise ValueError(f"source matrix is missing case ids: {missing}")
+    return [
+        _make_dense_case(
+            by_id[source_id], output_id, total_tokens, disable_recompute, suffix
+        )
+        for output_id, source_id, total_tokens, disable_recompute, suffix in CASE_SPECS
+    ]
+
+
+def main() -> None:
+    op_dir = Path(__file__).resolve().parent.parent
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=op_dir / "atk_chunk_kda_fwd.json")
+    parser.add_argument(
+        "--output", type=Path, default=op_dir / "atk_chunk_kda_fwd_performance.json"
+    )
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    rendered = json.dumps(generate(args.source), ensure_ascii=False, indent=2) + "\n"
+    if args.check:
+        if not args.output.is_file() or args.output.read_text(encoding="utf-8") != rendered:
+            raise SystemExit(f"performance cases are stale: {args.output}")
+        print("performance cases are up to date: 10 dense BSND cases")
+        return
+    args.output.write_text(rendered, encoding="utf-8")
+    print(f"wrote 10 dense BSND cases to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/atk/run_test_cpu.sh
+++ b/tests/atk/run_test_cpu.sh
@@ -27,6 +27,7 @@ show_usage() {
   DC_LOOP_NUMS                   确定性循环次数，默认 50（与 ATK 一致）
   DC_TIMEOUT                     确定性阶段超时，默认 3600
   PERFORMANCE_TIMEOUT            性能阶段超时，默认 2000
+  PERFORMANCE_CASE_FILE          性能阶段用例 JSON，默认优先使用算子目录下的性能子集
   CASE_START/CASE_END            通用 case 顺序范围；不设置时不传 -s/-e，ATK 执行全部用例
   ACCURACY_START/ACCURACY_END    精度与 NaN 检测 case 范围
   PERFORMANCE_START/END          性能 case 范围
@@ -274,6 +275,7 @@ RESULT_CHECK_PY="${SCRIPT_DIR}/common/check_atk_result.py"
 
 # NPU 后端固定为 npu
 CASE_FILE="${OP_DIR}/atk_${OP}.json"
+PERFORMANCE_CASE_FILE="${PERFORMANCE_CASE_FILE:-${OP_DIR}/atk_${OP}_performance.json}"
 EXECUTOR_FILE="${OP_DIR}/executor_${OP}.py"
 YAML_FILE="${OP_DIR}/${OP}.yaml"
 GEN_FILE="${OP_DIR}/gen_${OP}.py"
@@ -285,6 +287,9 @@ if should_run gen_cases; then
 else
   [[ -f "$CASE_FILE" ]] || die "找不到 ATK 用例文件：${CASE_FILE}"
   [[ -f "$EXECUTOR_FILE" ]] || die "找不到 ATK 执行器：${EXECUTOR_FILE}"
+fi
+if should_run performance && [[ ! -f "$PERFORMANCE_CASE_FILE" ]]; then
+  PERFORMANCE_CASE_FILE="${OP_DIR}/atk_${OP}_perf.json"
 fi
 
 if [[ -n "${ATK_ENV:-}" ]]; then
@@ -369,11 +374,12 @@ fi
 
 if should_run performance; then
   log_info "开始性能测试：performance_device"
+  log_info "性能用例文件：${PERFORMANCE_CASE_FILE}"
   set_case_range_args "性能测试 case 范围" "$PERFORMANCE_START" "$PERFORMANCE_END"
   "$ATK_BIN" node --name npu_dut --backend npu --devices "$NPU_DEVICE_ID" \
       --output_path "${ATK_OUTPUT_ROOT}/perf" \
     task \
-      -c "atk_${OP}_perf.json" \
+      -c "$PERFORMANCE_CASE_FILE" \
       --task performance_device \
       -p "executor_${OP}.py" \
       "${CASE_RANGE_ARGS[@]}" \


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: 无（独立的算子测试资产补充）
- 背景与目标: 为 chunk_kda_fwd 增加 A5 dense BSND 指定场景的一键性能测试，不修改 ATK 公共入口。
- 本 PR 解决的问题: 使用算子专属脚本和本地 npu backend 执行 performance_device，避免 pyaclnn 单节点性能任务要求远端比较节点。

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: chunk_kda_fwd
- 涉及目录 / 文件: `tests/atk/chunk_kda_fwd/`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: A5（ascend950），BF16，B=1，H=HV=96，无 GVA，dense BSND，T=2048/8192，K=V=128，chunk_size=64，不传变长元数据，覆盖 disable_recompute 开关。
- 明确不包含的范围: 不修改公共 ATK runner、公共 README、算子 kernel、tiling、op_host、op_api、运行时 ABI 或精度标准。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无。

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source <cann_install_path>/ascend-toolkit/set_env.sh
cat <cann_install_path>/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本: 未执行真实设备测试。
- 产品 / 芯片类型: 目标为 A5 / ascend950。
- 机器或 CI 链接: 无。

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | 未执行（仅增加 A5 算子专属测试资产） | 未执行 | 无 |
| A3 | `ascend910_93` | 未执行 | 未执行（仅增加 A5 算子专属测试资产） | 未执行 | 无 |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | 未执行（仅增加 A5 算子专属测试资产） | 未执行 | 无 |
| A3 | `ascend910_93` | 未执行 | 未执行（仅增加 A5 算子专属测试资产） | 未执行 | 无 |
| A5 | `ascend950` | 未执行 | 未执行（当前环境无 CANN/NPU） | 未执行 | 无 |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | 未执行 | 当前任务仅增加 A5 性能用例 |
| A3 | `ascend910_93` | 未执行 | 未执行 | 当前任务仅增加 A5 性能用例 |
| A5 | `ascend950` | `bash tests/atk/chunk_kda_fwd/scripts/run_performance.sh -npu_device_id=<device_id>` | 未执行 | 当前环境无 A5/CANN/NPU |

- 精度对比: 不涉及精度逻辑；4 条性能 JSON 的生成一致性和 dense 语义校验通过。
- 性能对比: fake ATK smoke 验证本地 npu backend、4 条用例加载和 4/4 汇总判定通过；真实 A5 性能未执行。
- 边界 / 异常场景: 覆盖 dense BSND、T=2048/8192 与 disable_recompute=true/false。
- 未覆盖风险: 真实 ATK、CANN 和 A5 设备上的 profile 需在目标环境补测。

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | 未执行 | 本 PR 不修改算子实现或 Example/ST |
| A3 | `ascend910_93` | 未执行 | 未执行 | 本 PR 不修改算子实现或 Example/ST |
| A5 | `ascend950` | 未执行 | 未执行 | 本 PR 不修改算子实现或 Example/ST |

- 端到端场景说明: 不涉及。
- 与本 PR 修改算子的关联: 本 PR 仅增加 chunk_kda_fwd 算子专属 ATK 性能资产。
- 未覆盖原因及补充计划: 真实 A5 性能由目标环境补测。

</details>

## 兼容性、风险与回退

- 兼容性说明: 不修改公共 runner；新增脚本只作用于 chunk_kda_fwd 的 A5 dense 性能场景。
- 风险点: 目标 ATK 版本对 npu backend 或性能汇总格式的兼容性需在 A5 环境确认。
- 回退方案: 回退本 PR 的单个提交，删除新增性能 JSON/脚本和 README 章节。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因（独立的算子测试资产补充）
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证（Shell/Python 语法、生成一致性、dense 语义、fake ATK smoke）
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

评审重点：所有改动均位于 `tests/atk/chunk_kda_fwd/`；公共 ATK runner 和公共 README 无改动。性能脚本使用本地 npu backend，并且只有 ATK 汇总精确为 4/4 时才返回成功。

真实 A5/CANN 性能测试尚未执行，合入前需在目标环境运行算子 README 中的一键命令并检查 profile。
