### PR TITLE
fix: 修复 A2 变长场景 fwd_h v_new 精度回归

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
@@ -160,8 +160,7 @@ public:
         bool isFinalState,
         bool storeFinalState,
         bool useInitialState,
-        bool isPing,
-        bool cube2AlreadyWaited
+        bool isPing
     )
     {
         static constexpr uint32_t ROW_TILE = 16;
@@ -177,9 +176,7 @@ public:
             rowEnd = mActual;
         }
         if (rowBegin >= mActual) {
-            if (!cube2AlreadyWaited) {
-                Arch::CrossCoreWaitFlag(cube2Done);
-            }
+            Arch::CrossCoreWaitFlag(cube2Done);
             return;
         }
 
@@ -196,7 +193,7 @@ public:
         AscendC::LocalTensor<float> glastUbTensor = isPing ? glastUbTensor_ping : glastUbTensor_pong;
         AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0 + pingpongFlag);
         AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID2 + pingpongFlag);
-        bool useFp32StateUpdate = storeFinalState && std::is_same<FinalStateElement, float>::value &&
+        bool useFp32Recurrence = storeFinalState && std::is_same<FinalStateElement, float>::value &&
                                  (!isInitialState || useInitialState);
 
         float muls = 1.0f;
@@ -244,7 +241,7 @@ public:
                 AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
             }
             if constexpr (std::is_same<FinalStateElement, float>::value) {
-                if (useFp32StateUpdate) {
+                if (useFp32Recurrence) {
                     if (isInitialState) {
                         AscendC::DataCopy(calcUbTensor, initialState[rowBegin * outputStride],
                                           mActualThisSubBlock * nActual);
@@ -263,7 +260,7 @@ public:
             AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
             AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
 
-            if (!useFp32StateUpdate) {
+            if (!useFp32Recurrence) {
                 AscendC::Cast(calcUbTensor, hUbTensor, AscendC::RoundMode::CAST_NONE,
                               mActualThisSubBlock * nActual);
                 AscendC::PipeBarrier<PIPE_V>();
@@ -305,9 +302,7 @@ public:
                 AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
             }
 
-            if (!cube2AlreadyWaited) {
-                Arch::CrossCoreWaitFlag(cube2Done);
-            }
+            Arch::CrossCoreWaitFlag(cube2Done);
 
             if constexpr (kGated) {
                 AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
@@ -369,9 +364,7 @@ public:
             return;
         }
 
-        if (!cube2AlreadyWaited) {
-            Arch::CrossCoreWaitFlag(cube2Done);
-        }
+        Arch::CrossCoreWaitFlag(cube2Done);
 
         bool waitHFromV = storeFinalState && isInitialState && std::is_same<FinalStateElement, float>::value;
         bool waitUpdateFromMte3 = false;
@@ -394,7 +387,7 @@ public:
                 AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pingpongFlag);
             }
             if constexpr (std::is_same<FinalStateElement, float>::value) {
-                if (useFp32StateUpdate) {
+                if (useFp32Recurrence) {
                     if (isInitialState) {
                         CopyGmToUb(calcUbTensor, initialState[rowStart * outputStride],
                                    rowsThisTile, nActual, outputStride);
@@ -412,7 +405,7 @@ public:
             AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
             AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
 
-            if (!useFp32StateUpdate) {
+            if (!useFp32Recurrence) {
                 AscendC::Cast(calcUbTensor, hUbTensor, AscendC::RoundMode::CAST_NONE, rowsThisTile * nActual);
                 AscendC::PipeBarrier<PIPE_V>();
             }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
@@ -235,16 +235,15 @@ public:
         if (rowEnd > mActual) {
             rowEnd = mActual;
         }
-        uint32_t pingpongFlag = isPing ? 0 : pongBaseEvent;
         if (rowBegin >= mActual) {
-            Arch::CrossCoreWaitFlag(cube1Done);
-            // A zero-row AIV lane still owns the EVENT0 hand-off consumed by V2.
             if (waitWsFromMte3) {
+                uint32_t pingpongFlag = isPing ? 0 : pongBaseEvent;
                 AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(
                     EVENT_ID0 + pingpongFlag);
                 AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(
                     EVENT_ID0 + pingpongFlag);
             }
+            Arch::CrossCoreWaitFlag(cube1Done);
             Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vec1Done);
             return;
         }
@@ -252,6 +251,7 @@ public:
 
         AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
 
+        uint32_t pingpongFlag = isPing ? 0 : pongBaseEvent;
         AscendC::LocalTensor<UElementInput> uUbTensor = isPing ? uUbTensor_ping : uUbTensor_pong;
         AscendC::LocalTensor<float> wsUbTensor = isPing ? wsUbTensor_ping : wsUbTensor_pong;
         AscendC::LocalTensor<float> gUbTensor = isPing ? gUbTensor_ping : gUbTensor_pong;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
@@ -211,27 +211,19 @@ struct BlockSchedulerGdnFwdH {
         vBlockSize = vHeadDim;
         taskNum = batch * vNumHead;
         headGroups = vNumHead / kNumHead;
-        InitTaskWave(0);
-
-    }
-
-    CATLASS_DEVICE
-    void InitTaskWave(uint32_t waveIdx) {
-        uint32_t firstTaskIdx = waveIdx * cubeCoreNum + cubeCoreIdx;
-        taskStride = taskNum;
+        // A short final chunk can retire one AIV subcore before its partner. Keep one task stream
+        // per core until the two-stream protocol has a reverse credit for that asymmetric tail.
+        uint32_t maxTaskCntPerLoop = 1;
+        taskStride = cubeCoreNum * maxTaskCntPerLoop;
         for (uint32_t streamId = 0; streamId < PING_PONG_STAGES; ++streamId) {
             auto& stream = runningQ.streams[streamId];
-            stream.nextTaskIdx = streamId == 0 ? firstTaskIdx : taskNum;
+            stream.nextTaskIdx = (streamId < maxTaskCntPerLoop) ? (cubeCoreIdx * maxTaskCntPerLoop + streamId) : taskNum;
             stream.chunkIdx = 0;
             stream.batchChunks = 0;
             stream.active = false;
         }
-        isRunning = firstTaskIdx < taskNum;
-    }
+        isRunning = cubeCoreIdx * maxTaskCntPerLoop < taskNum;
 
-    CATLASS_DEVICE
-    uint32_t GetTaskWaveCount() const {
-        return CeilDiv(taskNum, cubeCoreNum);
     }
 
     CATLASS_DEVICE

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -267,177 +267,6 @@ public:
         }
     }
 
-    template <typename Element>
-    __aicore__ inline float LoadScalarAsFloat(
-        AscendC::GlobalTensor<Element> tensor, uint32_t offset) const
-    {
-        Element value = tensor.GetValue(offset);
-        if constexpr (std::is_same<Element, bfloat16_t>::value) {
-            return AscendC::ToFloat(value);
-        }
-        return static_cast<float>(value);
-    }
-
-    __aicore__ inline void ComputeTailVWorkspace(const GDNFwdHOffsets& offsets)
-    {
-        uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
-        uint32_t subBlockNum = AscendC::GetSubBlockNum();
-        uint32_t rowsPerSubBlock = CeilDiv(offsets.blockTokens, subBlockNum);
-        uint32_t rowBegin = subBlockIdx * rowsPerSubBlock;
-        uint32_t rowEnd = Min(rowBegin + rowsPerSubBlock, offsets.blockTokens);
-        if (rowBegin >= rowEnd) {
-            return;
-        }
-
-        constexpr uint32_t TAIL_INPUT_OFFSET = 166 * 1024;
-        constexpr uint32_t TAIL_FLOAT_OFFSET = 167 * 1024;
-        constexpr uint32_t TAIL_ACCUM_OFFSET = 168 * 1024;
-        AscendC::LocalTensor<ElementH> inputUb =
-            resource.ubBuf.template GetBufferByByte<ElementH>(TAIL_INPUT_OFFSET);
-        AscendC::LocalTensor<float> floatUb =
-            resource.ubBuf.template GetBufferByByte<float>(TAIL_FLOAT_OFFSET);
-        AscendC::LocalTensor<float> accumUb =
-            resource.ubBuf.template GetBufferByByte<float>(TAIL_ACCUM_OFFSET);
-
-        for (uint32_t tokenRow = rowBegin; tokenRow < rowEnd; ++tokenRow) {
-            AscendC::Duplicate(accumUb, 0.0f, offsets.vBlockDim);
-            AscendC::PipeBarrier<PIPE_V>();
-            for (uint32_t kIdx = 0; kIdx < kHeadDim; ++kIdx) {
-                AscendC::DataCopy(
-                    inputUb, gmH[offsets.hSrcOffset + kIdx * vHeadDim],
-                    offsets.vBlockDim);
-                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID7);
-                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID7);
-                AscendC::Cast(
-                    floatUb, inputUb, AscendC::RoundMode::CAST_NONE,
-                    offsets.vBlockDim);
-                AscendC::PipeBarrier<PIPE_V>();
-                float weight = LoadScalarAsFloat(
-                    gmW, offsets.wOffset + tokenRow * kHeadDim + kIdx);
-                AscendC::Muls(floatUb, floatUb, weight, offsets.vBlockDim);
-                AscendC::PipeBarrier<PIPE_V>();
-                AscendC::Add(accumUb, accumUb, floatUb, offsets.vBlockDim);
-                AscendC::PipeBarrier<PIPE_V>();
-            }
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID7);
-            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID7);
-            AscendC::DataCopy(
-                gmVWorkspace[offsets.vWorkOffset + tokenRow * offsets.vBlockDim],
-                accumUb, offsets.vBlockDim);
-            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID7);
-            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID7);
-        }
-    }
-
-    __aicore__ inline void ComputeTailHWorkspace(const GDNFwdHOffsets& offsets)
-    {
-        uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
-        uint32_t subBlockNum = AscendC::GetSubBlockNum();
-        uint32_t rowsPerSubBlock = CeilDiv(kHeadDim, subBlockNum);
-        uint32_t rowBegin = subBlockIdx * rowsPerSubBlock;
-        uint32_t rowEnd = Min(rowBegin + rowsPerSubBlock, kHeadDim);
-
-        constexpr uint32_t TAIL_INPUT_OFFSET = 166 * 1024;
-        constexpr uint32_t TAIL_FLOAT_OFFSET = 167 * 1024;
-        constexpr uint32_t TAIL_ACCUM_OFFSET = 168 * 1024;
-        AscendC::LocalTensor<ElementV> inputUb =
-            resource.ubBuf.template GetBufferByByte<ElementV>(TAIL_INPUT_OFFSET);
-        AscendC::LocalTensor<float> floatUb =
-            resource.ubBuf.template GetBufferByByte<float>(TAIL_FLOAT_OFFSET);
-        AscendC::LocalTensor<float> accumUb =
-            resource.ubBuf.template GetBufferByByte<float>(TAIL_ACCUM_OFFSET);
-
-        for (uint32_t kRow = rowBegin; kRow < rowEnd; ++kRow) {
-            AscendC::Duplicate(accumUb, 0.0f, offsets.vBlockDim);
-            AscendC::PipeBarrier<PIPE_V>();
-            for (uint32_t tokenRow = 0; tokenRow < offsets.blockTokens; ++tokenRow) {
-                AscendC::DataCopy(
-                    inputUb,
-                    gmVUpdateWorkspace[offsets.vWorkOffset + tokenRow * offsets.vBlockDim],
-                    offsets.vBlockDim);
-                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID7);
-                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID7);
-                AscendC::Cast(
-                    floatUb, inputUb, AscendC::RoundMode::CAST_NONE,
-                    offsets.vBlockDim);
-                AscendC::PipeBarrier<PIPE_V>();
-                float weight = LoadScalarAsFloat(
-                    gmKDecayWorkspace,
-                    offsets.kDecayWorkOffset + tokenRow * kHeadDim + kRow);
-                AscendC::Muls(floatUb, floatUb, weight, offsets.vBlockDim);
-                AscendC::PipeBarrier<PIPE_V>();
-                AscendC::Add(accumUb, accumUb, floatUb, offsets.vBlockDim);
-                AscendC::PipeBarrier<PIPE_V>();
-            }
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID7);
-            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID7);
-            AscendC::DataCopy(
-                gmHWorkspace[offsets.hWorkOffset + kRow * offsets.vBlockDim],
-                accumUb, offsets.vBlockDim);
-            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID7);
-            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID7);
-        }
-    }
-
-    __aicore__ inline void PresetVectorPipelineEvents()
-    {
-        constexpr uint32_t pongBaseEvent = 4;
-        if (storeFinalState && std::is_same<ElementFinalState, float>::value) {
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pongBaseEvent);
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2);
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pongBaseEvent);
-        } else {
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pongBaseEvent);
-            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2);
-            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pongBaseEvent);
-        }
-        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
-        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pongBaseEvent);
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3);
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pongBaseEvent);
-        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0);
-        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0 + pongBaseEvent);
-        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID2);
-        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID2 + pongBaseEvent);
-    }
-
-    __aicore__ inline void DrainVectorPipelineEvents(
-        const bool (&event0FromMte3)[PING_PONG_STAGES],
-        const bool (&event2FromMte3)[PING_PONG_STAGES])
-    {
-        constexpr uint32_t pongBaseEvent = 4;
-        if (storeFinalState && std::is_same<ElementFinalState, float>::value) {
-            for (uint32_t streamId = 0; streamId < PING_PONG_STAGES; ++streamId) {
-                uint32_t eventOffset = streamId * pongBaseEvent;
-                if (event0FromMte3[streamId]) {
-                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + eventOffset);
-                } else {
-                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + eventOffset);
-                }
-                if (event2FromMte3[streamId]) {
-                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + eventOffset);
-                } else {
-                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + eventOffset);
-                }
-            }
-        } else {
-            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
-            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pongBaseEvent);
-            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2);
-            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pongBaseEvent);
-        }
-        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pongBaseEvent);
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3);
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pongBaseEvent);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0 + pongBaseEvent);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID2);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID2 + pongBaseEvent);
-    }
-
     __aicore__ inline void Process() {
         if (isVariedLen) {
             AscendC::SyncAll<false>();
@@ -447,6 +276,9 @@ public:
             uint32_t coreIdx = AscendC::GetBlockIdx();
             uint32_t coreNum = AscendC::GetBlockNum();
 
+            BlockMmadWH blockMmadWH(resource);
+            BlockMmadKV blockMmadKV(resource);
+
             auto wLayout = tla::MakeLayout<ElementW, LayoutW>(shapeBatch * kNumHead * cubeBlockScheduler.totalTokens, kHeadDim);
             auto hLayout = tla::MakeLayout<ElementH, LayoutH>(shapeBatch * vNumHead * cubeBlockScheduler.totalChunks * kHeadDim, vHeadDim);
             auto vLayout = tla::MakeLayout<ElementVWork, LayoutV>(coreNum * chunkSize * PING_PONG_STAGES, cubeBlockScheduler.vBlockSize);
@@ -454,17 +286,10 @@ public:
             auto kLayout = tla::MakeLayout<ElementK, LayoutK>(kHeadDim, shapeBatch * kNumHead * cubeBlockScheduler.totalTokens);
             auto vworkLayout = tla::MakeLayout<ElementV, LayoutV>(coreNum * chunkSize * PING_PONG_STAGES, cubeBlockScheduler.vBlockSize);
             auto hworkLayout = tla::MakeLayout<ElementHWork, LayoutH>(coreNum * kHeadDim * PING_PONG_STAGES, cubeBlockScheduler.vBlockSize);
-            uint32_t taskWaveCount = cubeBlockScheduler.GetTaskWaveCount();
-            for (uint32_t waveIdx = 0; waveIdx < taskWaveCount; ++waveIdx) {
-                BlockMmadWH blockMmadWH(resource);
-                BlockMmadKV blockMmadKV(resource);
-                BlockMmadWH blockMmadWHTail(resource);
-                BlockMmadKV blockMmadKVTail(resource);
-                AscendC::SyncAll<false>();
-                cubeBlockScheduler.InitTaskWave(waveIdx);
-                uint32_t currStage = 0; // 0: C1, 1: C2
-                while (cubeBlockScheduler.isRunning) {
-                    if (currStage == 0) {
+            AscendC::SyncAll<false>();
+            uint32_t currStage = 0; // 0: C1, 1: C2
+            while (cubeBlockScheduler.isRunning) {
+                if (currStage == 0) {
                     /* C1: v_work = w @ h[i] */
                     cubeBlockScheduler.InitTasks();
                     for (uint32_t i = 0; i < PING_PONG_STAGES; ++i) {
@@ -476,11 +301,6 @@ public:
 
                         const GDNFwdHOffsets& cube1Offsets = cubeBlockScheduler.GetCurTaskOffsets(stream);
                         Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[streamId]);
-                        if (cube1Offsets.blockTokens < 16) {
-                            Arch::CrossCoreSetFlag<0x2, PIPE_MTE2>(
-                                cubeBlockScheduler.cube1Done[streamId]);
-                            continue;
-                        }
                         int64_t cube1OffsetW = cube1Offsets.wOffset;
                         int64_t cube1OffsetH = cube1Offsets.hSrcOffset;
                         int64_t cube1OffsetVwork = cube1Offsets.vWorkOffset;
@@ -491,22 +311,13 @@ public:
                         auto tensorBlockW = GetTile(tensorW, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.k()));
                         auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.k(), cube1Shape.n()));
                         auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.n()));
-                        if (cube1Offsets.blockTokens < chunkSize) {
-                            blockMmadWHTail.preSetFlags();
-                            blockMmadWHTail(
-                                tensorBlockW, tensorBlockH, tensorBlockV,
-                                cube1Shape, EmptyClass{}, true);
-                            blockMmadWHTail.finalWaitFlags();
-                        } else {
-                            blockMmadWH.preSetFlags();
-                            blockMmadWH(
-                                tensorBlockW, tensorBlockH, tensorBlockV, cube1Shape);
-                            blockMmadWH.finalWaitFlags();
-                        }
+                        blockMmadWH.preSetFlags();
+                        blockMmadWH(tensorBlockW, tensorBlockH, tensorBlockV, cube1Shape);
+                        blockMmadWH.finalWaitFlags();
                         AscendC::PipeBarrier<PIPE_ALL>();
                         Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done[streamId]);
                     }
-                    } else {
+                } else {
                     /* C2: h[i+1] = k.T @ v_work */
                     for (uint32_t i = 0; i < PING_PONG_STAGES; ++i) {
                         uint32_t streamId = cubeBlockScheduler.GetStreamId(i);
@@ -518,11 +329,6 @@ public:
                         Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done[streamId]);
 
                         if (cubeBlockScheduler.NeedProcessStage2(stream)) {
-                            if (cube2Offsets.blockTokens < 16) {
-                                Arch::CrossCoreSetFlag<0x2, PIPE_MTE2>(
-                                    cubeBlockScheduler.cube2Done[streamId]);
-                                continue;
-                            }
                             // step 3: h[i+1] = k.T @ v_work
                             int64_t cube2OffsetKwork = kGated ? cube2Offsets.kDecayWorkOffset : cube2Offsets.wkOffset;
                             int64_t cube2OffsetVwork = cube2Offsets.vWorkOffset;
@@ -536,29 +342,18 @@ public:
                             auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.k()));
                             auto tensorBlockVwork = GetTile(tensorVwork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.k(), cube2Shape.n()));
                             auto tensorBlockHwork = GetTile(tensorHwork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.n()));
-                            if (cube2Offsets.blockTokens < chunkSize) {
-                                blockMmadKVTail.preSetFlags();
-                                blockMmadKVTail(
-                                    tensorBlockK, tensorBlockVwork, tensorBlockHwork,
-                                    cube2Shape, EmptyClass{}, true);
-                                blockMmadKVTail.finalWaitFlags();
-                            } else {
-                                blockMmadKV.preSetFlags();
-                                blockMmadKV(
-                                    tensorBlockK, tensorBlockVwork, tensorBlockHwork,
-                                    cube2Shape);
-                                blockMmadKV.finalWaitFlags();
-                            }
+                            blockMmadKV.preSetFlags();
+                            blockMmadKV(tensorBlockK, tensorBlockVwork, tensorBlockHwork, cube2Shape);
+                            blockMmadKV.finalWaitFlags();
                             AscendC::PipeBarrier<PIPE_ALL>();
                         }
                         Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube2Done[streamId]);
                     }
-                    }
-                    currStage ^= 0x01;
                 }
-                Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[0]);
-                Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[1]);
+                currStage ^= 0x01;
             }
+            Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[0]);
+            Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[1]);
 
         }
 
@@ -569,6 +364,8 @@ public:
             uint32_t coreNum = AscendC::GetBlockNum();
             uint32_t taskCount =
                 (isVariedLen ? vecBlockScheduler.tokenBatch : shapeBatch) * vNumHead;
+            uint32_t tasksPerCore = 1;
+            uint32_t taskStride = coreNum * tasksPerCore;
             uint32_t rowsPerSubBlock = (kHeadDim + subBlockNum - 1) / subBlockNum;
             uint32_t rowBegin = subBlockIdx * rowsPerSubBlock;
             uint32_t rowEnd = Min(rowBegin + rowsPerSubBlock, kHeadDim);
@@ -579,6 +376,7 @@ public:
             uint32_t totalChunks =
                 isVariedLen ? vecBlockScheduler.totalChunks : ((seqlen + chunkSize - 1) / chunkSize);
             uint32_t stateBlockSize = kHeadDim * vHeadDim;
+            uint32_t pingpongFlag = 1;
             AscendC::LocalTensor<ElementInitialState> stateUbTensorPing =
                 resource.ubBuf.template GetBufferByByte<ElementInitialState>(0);
             AscendC::LocalTensor<ElementInitialState> stateUbTensorPong =
@@ -587,15 +385,11 @@ public:
                 resource.ubBuf.template GetBufferByByte<ElementH>(64 * 1024);
             AscendC::LocalTensor<ElementH> hUbTensorPong =
                 resource.ubBuf.template GetBufferByByte<ElementH>(160 * 1024);
-            uint32_t taskWaveCount = vecBlockScheduler.GetTaskWaveCount();
-            for (uint32_t waveIdx = 0; waveIdx < taskWaveCount; ++waveIdx) {
-                EpilogueGDNFwdHVnew epilogueGDNFwdHVnew(resource);
-                EpilogueGDNFwdHUpdate epilogueGDNFwdHUpdate(resource);
-                uint32_t taskIdx = waveIdx * coreNum + coreIdx;
-                uint32_t pingpongFlag = 1;
-                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
-                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
-                if (taskIdx < taskCount) {
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
+            for (uint32_t slot = 0; slot < tasksPerCore; ++slot) {
+                for (uint32_t taskIdx = coreIdx * tasksPerCore + slot;
+                     taskIdx < taskCount; taskIdx += taskStride) {
                     uint32_t batchIdx = taskIdx / vNumHead;
                     uint32_t vHeadIdx = taskIdx % vNumHead;
                     uint32_t chunkOffset =
@@ -646,25 +440,48 @@ public:
                         pingpongFlag = 1 - pingpongFlag;
                     }
                 }
-                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
-                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
+            }
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
 
-                AscendC::SyncAll<false>();
-                vecBlockScheduler.InitTaskWave(waveIdx);
-                Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done[0]);
-                Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done[1]);
-                PresetVectorPipelineEvents();
-                uint32_t currStage = 0; // 0: V1, 1: V2
-                bool waitStageFence = false;
-                bool event0FromMte3[PING_PONG_STAGES] = {false, false};
-                bool event2FromMte3[PING_PONG_STAGES] = {
-                    !(storeFinalState && std::is_same<ElementFinalState, float>::value),
-                    !(storeFinalState && std::is_same<ElementFinalState, float>::value)};
-                while (vecBlockScheduler.isRunning) {
-                    if (waitStageFence) {
-                        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
-                    }
-                    if (currStage == 0) {
+            AscendC::SyncAll<false>();
+
+            Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done[0]);
+            Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done[1]);
+
+            EpilogueGDNFwdHVnew epilogueGDNFwdHVnew(resource);
+            EpilogueGDNFwdHUpdate epilogueGDNFwdHUpdate(resource);
+            uint32_t pongBaseEvent = 4;
+
+            if (storeFinalState && std::is_same<ElementFinalState, float>::value) {
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0); // preset v
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pongBaseEvent);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2); // preset h
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pongBaseEvent);
+            } else {
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0); // preset v
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pongBaseEvent);
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2); // preset h
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pongBaseEvent);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1); // preset u
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pongBaseEvent);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3); // preset g
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pongBaseEvent);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0); // preset h_update
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0 + pongBaseEvent);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID2); // preset h
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID2 + pongBaseEvent);
+            uint32_t currStage = 0; // 0: V1, 1: V2
+            bool waitStageFence = false;
+            bool event0FromMte3[PING_PONG_STAGES] = {false, false};
+            bool event2FromMte3[PING_PONG_STAGES] = {!(storeFinalState && std::is_same<ElementFinalState, float>::value),
+                                                      !(storeFinalState && std::is_same<ElementFinalState, float>::value)};
+            while (vecBlockScheduler.isRunning) {
+                if (waitStageFence) {
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
+                }
+                if (currStage == 0) {
                     /* V1:
                      * gmV = gmU - gmVWorkspace
                      * g_buf = gmG[-1] - gmG
@@ -679,9 +496,6 @@ public:
                             continue;
                         }
                         const GDNFwdHOffsets& vec1Offsets = vecBlockScheduler.GetCurTaskOffsets(stream);
-                        if (vec1Offsets.blockTokens < 16) {
-                            ComputeTailVWorkspace(vec1Offsets);
-                        }
                         bool waitWsFromMte3 = storeFinalState && std::is_same<ElementFinalState, float>::value &&
                                               event0FromMte3[streamId];
                         epilogueGDNFwdHVnew(
@@ -699,7 +513,7 @@ public:
                             event0FromMte3[streamId] = false;
                         }
                     }
-                    } else {
+                } else {
                     /* V2: h[i+1] += h_work if i < num_chunks - 1 else None */
                     for (uint32_t i = 0; i < PING_PONG_STAGES; ++i) {
                         uint32_t streamId = vecBlockScheduler.GetStreamId(i);
@@ -709,12 +523,6 @@ public:
                         }
                         const GDNFwdHOffsets& vec2Offsets = vecBlockScheduler.GetCurTaskOffsets(stream);
                         if (vecBlockScheduler.NeedProcessStage2(stream)) {
-                            bool tailVectorPath = vec2Offsets.blockTokens < 16;
-                            if (tailVectorPath) {
-                                Arch::CrossCoreWaitFlag(
-                                    vecBlockScheduler.cube2Done[streamId]);
-                                ComputeTailHWorkspace(vec2Offsets);
-                            }
                             if (storeFinalState && std::is_same<ElementFinalState, float>::value) {
                                 event0FromMte3[streamId] = true;
                                 event2FromMte3[streamId] = !vec2Offsets.isFinalState;
@@ -729,7 +537,7 @@ public:
                                 gmInitialState[vec2Offsets.initialStateOffset],
                                 vec2Offsets.blockTokens, kHeadDim, vec2Offsets.vBlockDim, vHeadDim, vecBlockScheduler.cube2Done[streamId],
                                 vec2Offsets.isInitialState, vec2Offsets.isFinalState, storeFinalState,
-                                useInitialState, (streamId == 0), tailVectorPath
+                                useInitialState, (streamId == 0)
                             );
                             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
                             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
@@ -738,16 +546,49 @@ public:
                         }
                         Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done[streamId]);
                     }
-                    }
-                    waitStageFence = vecBlockScheduler.isRunning;
-                    if (waitStageFence) {
-                        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
-                    }
-                    currStage ^= 0x01;
                 }
-
-                DrainVectorPipelineEvents(event0FromMte3, event2FromMte3);
+                waitStageFence = vecBlockScheduler.isRunning;
+                if (waitStageFence) {
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
+                }
+                currStage ^= 0x01;
             }
+
+            if (storeFinalState && std::is_same<ElementFinalState, float>::value) {
+                if (event0FromMte3[0]) {
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+                } else {
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+                }
+                if (event0FromMte3[1]) {
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pongBaseEvent);
+                } else {
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pongBaseEvent);
+                }
+                if (event2FromMte3[0]) {
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2);
+                } else {
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2);
+                }
+                if (event2FromMte3[1]) {
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pongBaseEvent);
+                } else {
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pongBaseEvent);
+                }
+            } else {
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0); // preset v
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pongBaseEvent);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2); // preset h
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2 + pongBaseEvent);
+            }
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1); // preset u
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1 + pongBaseEvent);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3); // preset g
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3 + pongBaseEvent);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0); // drain h_update
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0 + pongBaseEvent);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID2); // drain h
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID2 + pongBaseEvent);
 
         }
     }


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 创建后将评论 `/run-npu-ci quick`，补齐当前 head commit 的 NPU CI 状态。

## 关联 Issue / 背景

- 关联 Issue: Closes #367
- 背景与目标: A2 `chunk_gated_delta_rule_fwd_h` 在变长 TND 的非整 chunk 尾部会产生错误的 `v_new`，导致 GDN 整体精度回归。
- 本 PR 解决的问题: 恢复 A2 每核连续任务调度，使 EventID、跨核 flag 与 MMAD/epilogue 资源在完整任务流内保持单一生命周期，消除 wave 边界的同步时序错误。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: `chunk_gated_delta_rule_fwd_h`
- 涉及目录 / 文件: `fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/` 下 A2 的 kernel、scheduler 和两个 epilogue 文件
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不变；仍支持现有 FP16/BF16、dense/varlen TND、初始状态与最终状态组合。
- 明确不包含的范围: 不修改 op_host、tiling、op_api、Python 接口、测试阈值、用例输入范围及 A5 `arch35` kernel。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无 ABI 变化。

<details>
<summary>版本与产品编译矩阵</summary>

当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

### 1. 编译验证

```sh
bash build.sh --pkg --soc=ascend910b --ops=chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu
```

### 2. 原问题 Example ST 验证

```sh
python3 ci/run_example_st_cases.py \
  --device 0 \
  --cases-file ci/example_st_cases.json \
  --case-filter case1_current_default
```

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0-beta.1 | `bash build.sh --pkg --soc=ascend910b --ops=chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu` | 通过 | 两组 kernel binary 及 `.run` 包生成，日志无 ERROR/FAILED |
| A3 | `ascend910_93` | 9.1.0-beta.1 | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu` | 通过 | 两组 kernel binary 及 `.run` 包生成，日志无 ERROR/FAILED |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0-beta.1 | `bash build.sh --pkg --soc=ascend910b --ops=chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu` | 通过 | 两组 kernel binary 及 `.run` 包生成，日志无 ERROR/FAILED |
| A3 | `ascend910_93` | 9.1.0-beta.1 | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu` | 通过 | 两组 kernel binary 及 `.run` 包生成，日志无 ERROR/FAILED |
| A5 | `ascend950` | 9.1.0-beta.1 | `bash build.sh --pkg --soc=ascend950 --ops=chunk_gated_delta_rule_fwd_h --vendor_name=fla_npu` | 通过 | 两组 kernel binary 及 `.run` 包生成，日志无 ERROR/FAILED |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 原问题通过整体 Example ST 验证 | 未单独执行 | 原问题调用链已直接覆盖修改算子 |
| A3 | `ascend910_93` |  | 未执行 | 无对应硬件，待 NPU CI 补齐 |
| A5 | `ascend950` |  | 未执行 | 无对应硬件，待 NPU CI 补齐；本 PR 未修改 `arch35` 路径 |

- 精度对比: A2 原问题用例 `finite=True`、`allclose=True`、`bad_frac=0`，`max_abs=0.000670794`，`cosine=0.999996157`。
- 性能对比: 未执行；本 PR 以恢复错误引入前的 A2 连续调度为修复边界，不对性能作结论。
- 边界 / 异常场景: 覆盖 12 段不均匀变长序列、多个非整 chunk 尾部及 1-token 尾序列。
- 未覆盖风险: A3/A5 运行时精度和性能待 NPU CI 补齐。

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json --case-filter case1_current_default` | 通过 | 1/1 执行成功且精度通过；输出有限、allclose 通过、无坏点 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json --case-filter case1_current_default` | 未执行 | 无对应硬件，待 NPU CI 补齐 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json --case-filter case1_current_default` | 未执行 | 无对应硬件，待 NPU CI 补齐 |

- 端到端场景说明: BF16、TND varlen、`T=4087`、12 段不均匀序列，包含非整 chunk 和 1-token 尾序列。
- 与本 PR 修改算子的关联: 该用例经过完整 GDN 前向链路，回归态由 `fwd_h` 的 `v_new` 错误导致最终 `o` 精度失败；修复后最终输出满足现有标准。
- 未覆盖原因及补充计划: 当前仅有 A2 运行硬件；PR 创建后触发 `/run-npu-ci quick` 补齐仓库门禁。

</details>

## 兼容性、风险与回退

- 兼容性说明: 公共接口、ABI、tiling、shape、dtype、format 和返回值均不变；A5 `arch35` 路径不变。
- 风险点: A2 恢复连续任务流后会改变 kernel 调度行为，需由 NPU CI 继续覆盖其他 dense/varlen 和初始状态组合；性能未在本 PR 中下结论。
- 回退方案: 回退本 PR 单个提交可恢复原调度，但会重新引入 A2 变长尾部精度问题；如需回退应先阻断受影响版本并另行修复 wave 边界同步协议。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 回归引入提交: `c8a9ac66`。
- 修复提交: `81382008`。
- 根因证据: Stage0 MMAD 单独验证正确，错误只在按 wave 重建 MMAD/epilogue 资源后的生产路径出现；恢复完整任务流内单一 EventID/flag 生命周期后，原始用例通过。
- 本 PR 不新增重复用例：`ci/example_st_cases.json` 中已启用的 `case1_current_default` 就是原问题 shape、seed 和 `cu_seqlens`。
