### PR TITLE
docs: clarify ChunkGatedDeltaRuleBwdDhu K/V limits

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/README.md
@@ -98,8 +98,8 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhu(
 - `h0Optional`、`dhtOptional` 的形状必须为 `[B, HV, K, V]`（若提供）。
 - `dhOut` 的形状必须为 `[B, HV, NT, K, V]`。
 - **GVA 约束**：`HV % HK == 0`；读 `q`/`k` 时使用 `hq = hv / (HV / HK)`，读/写 `w`/`dO`/`dv`/`g`/`dh`/`dv2` 使用 value head 索引 `hv`。
-- 当前实现要求 `K ≤ 128`。
-- 当前实现要求 `V ≤ 256`（Cube tile 原生按 `V` 上限 256 设计，**无**按 V 维切换的 TilingKey）。
+- 当前实现仅支持 `K = 128`；其他 `K` 尺寸会在 tiling 阶段被拒绝。
+- 当前实现仅支持 `V = 128` 或 `V = 256`；其他 `V` 尺寸会在 tiling 阶段被拒绝（Cube tile 原生按 `V` 上限 256 设计，**无**按 V 维切换的 TilingKey）。
 - **TilingKey**：`g` 与 `q` 同 dtype 时为 Key=1，`g` 为 FP32 时为 Key=2（与 V 维无关）。
 - `chunkSize` 当前仅支持 `64` 或 `128`。
 - 当启用变长模式时，`cuSeqlensOptional` 和 `chunkIndicesOptional` 须同时提供，且仅支持 `B = 1`。
@@ -135,8 +135,8 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhu(
 
 额外限制：
 
-- `K ≤ 128`
-- `V ≤ 256`（支持 `V = 256`）
+- `K = 128`
+- `V ∈ {128, 256}`
 - `chunkSize ∈ {64, 128}`
 
 ---


### PR DESCRIPTION
## Summary
- 将 `ChunkGatedDeltaRuleBwdDhu` 的公开文档更新为实际支持范围：`K=128`，`V=128/256`。
- 明确其他 K/V 尺寸会在 tiling 阶段被拒绝，避免按旧文档使用任意小尺寸。
- 与当前主干已存在的 tiling 校验保持一致。

Fixes #313

## Validation
- `git diff --check`
- 静态核对 README 与 `ChunkGatedDeltaRuleBwdDhu` tiling 校验条件一致。
- 仅文档修改，未运行 A2/NPU 测试。