### PR TITLE
blank2

### DIFF
--- a/tests/atk/README.md
+++ b/tests/atk/README.md
@@ -36,7 +36,8 @@ ATK 运行产生的 `atk_output/`、`result/`、profiling、sanitizer 日志、X
 
 | 文件                                   | 职责                                                                                     |
 | -------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `run_test_cpu.sh`                    | 统一入口，覆盖 CPU 双标杆精度、性能、确定性、mssanitizer 和用例生成                      |
+| `run_test_cpu.sh`                    | 统一入口，覆盖 CPU/GPU 双标杆精度、性能、确定性、mssanitizer 和用例生成                      |
+| `common/gpu_server.sh`             | GPU 端 ATK server 一键启动脚本，在 GPU 宿主机创建/复用 Docker 容器并前台启动 ATK server        |
 | `common/_ascendc_common_executor.py` | executor 共用的基础工具函数，例如 dtype 转换、case_spec 解析、确定性数据生成、有限值检查 |
 | `<op>/executor_<op>.py`              | 本算子的输入构造、CPU 标杆、NPU DUT 调用和 ATK`FunctionApi`                            |
 | `<op>/gen_<op>.py`                   | 本算子的 ATK 泛化用例生成器                                                              |
@@ -100,17 +101,22 @@ bash tests/atk/run_test_cpu.sh -op=<op_name>
 | ----------------------- | -------------------------------------------------------------------------------------------------------------- |
 | `-op=<op_name>`       | `tests/atk` 下的算子目录名                                                                                   |
 | `-npu_device_id=<id>` | 传给`atk node --devices` 的 NPU 设备号，默认`0`；`gen_cases` 不需要                                       |
-| `-scope=<scope>`      | 执行动作，支持`all/accuracy/performance/determinism/mssanitizer/gen_cases`                                   |
+| `-gpu_device_id=<id>` | 传给 ATK GPU node `--devices` 的 GPU 设备号，默认`0`；`accuracy_gpu` 使用                                 |
+| `-gpu_host=<host>`    | GPU 宿主机地址；`accuracy_gpu` 必选                                                                          |
+| `-gpu_host_port=<port>` | GPU server 端口；`accuracy_gpu` 必选                                                                        |
+| `-scope=<scope>`      | 执行动作，支持`all/accuracy_cpu/accuracy_gpu/performance/determinism/mssanitizer/gen_cases`                |
 | `-soc=<soc>`          | SOC 标识，支持`ascend910b/A2`、`ascend910_93/A3`、`ascend950/A5`；默认 `auto`，由 `npu-smi` 自动探测 |
 
-`all` 包含 `accuracy`、`determinism` 和 `mssanitizer`；性能测试需
-显式指定 `-scope=performance`。`gen_cases` 不在 `all` 中，必须显式指定。
+`all` 包含 `accuracy_cpu`、`determinism` 和 `mssanitizer`；性能测试需
+显式指定 `-scope=performance`。`accuracy_gpu` 和 `gen_cases` 不在 `all` 中，
+必须显式指定；`accuracy_gpu` 还必须传入 `-gpu_host` 和 `-gpu_host_port`。
 
 示例：
 
 ```bash
 bash tests/atk/run_test_cpu.sh -op=causal_conv1d
-bash tests/atk/run_test_cpu.sh -op=causal_conv1d -scope=accuracy
+bash tests/atk/run_test_cpu.sh -op=causal_conv1d -scope=accuracy_cpu
+bash tests/atk/run_test_cpu.sh -op=causal_conv1d -scope=accuracy_gpu -gpu_host=10.10.10.10 -gpu_host_port=9090
 bash tests/atk/run_test_cpu.sh -op=causal_conv1d -scope=performance
 bash tests/atk/run_test_cpu.sh -op=causal_conv1d -scope=determinism
 bash tests/atk/run_test_cpu.sh -op=causal_conv1d -scope=mssanitizer
@@ -130,22 +136,75 @@ bash tests/atk/run_test_cpu.sh -op=causal_conv1d
 
 也可以按动作单独设置范围：
 
-| 变量                                  | 作用                 |
-| ------------------------------------- | -------------------- |
-| `ACCURACY_START/ACCURACY_END`       | 精度与 NaN 检测      |
-| `PERFORMANCE_START/PERFORMANCE_END` | 性能测试             |
-| `DETERMINISM_START/DETERMINISM_END` | 确定性验证           |
-| `MSS_START/MSS_END`                 | mssanitizer 内存检测 |
+| 变量                                      | 作用                            |
+| ----------------------------------------- | ------------------------------- |
+| `ACCURACY_CPU_START/ACCURACY_CPU_END`   | CPU 精度与 NaN 检测（兼容旧名 `ACCURACY_START/END`） |
+| `ACCURACY_GPU_START/ACCURACY_GPU_END`   | GPU 精度与 NaN 检测             |
+| `PERFORMANCE_START/PERFORMANCE_END`     | 性能测试                        |
+| `DETERMINISM_START/DETERMINISM_END`     | 确定性验证                      |
+| `MSS_START/MSS_END`                     | mssanitizer 内存检测            |
 
 如果只设置 start 或 end 中的一个，脚本会直接报错，避免范围表达不完整。
 
 ## 测试动作
 
-精度与 NaN 检测使用本机 NPU DUT 和本机 CPU reference 两个 ATK node：
+CPU 精度与 NaN 检测使用本机 NPU DUT 和本机 CPU reference 两个 ATK node，双标杆
+（CPU 高精度 fp64 + CPU 同精度）结果写入 `cpu_dual_reference/`：
 
 ```bash
-bash tests/atk/run_test_cpu.sh -op=<op_name> -scope=accuracy
+bash tests/atk/run_test_cpu.sh -op=<op_name> -scope=accuracy_cpu
 ```
+
+GPU 精度与 NaN 检测使用本机 NPU DUT 和远程 GPU reference 两个 ATK node，双标杆
+（GPU 高精度 fp64 + GPU 同精度）结果写入 `gpu_dual_reference/`：
+`-gpu_host` 和 `-gpu_host_port` 为必选参数，指向已启动的远程 GPU server。
+
+```bash
+bash tests/atk/run_test_cpu.sh -op=<op_name> -scope=accuracy_gpu \
+  -gpu_host=<gpu_host> -gpu_host_port=<port> [-gpu_device_id=0]
+```
+
+远程 GPU server 由 `common/gpu_server.sh` 在 GPU 宿主机上一键启动（见下节）。
+GPU executor 需实现 `gpu`（同精度标杆）和 `gpu_fp64`（高精度标杆）两个方法。
+
+### GPU server 启动（common/gpu_server.sh）
+
+`common/gpu_server.sh` 在 GPU 宿主机执行，负责创建/复用 Docker 容器、激活 ATK 环境、
+校验 CUDA 可见性并前台启动 ATK server 监听 `0.0.0.0:9090`，供 NPU 端远程调用。
+启动后不要退出终端；NPU 端通过 `-gpu_host`/`-gpu_host_port` 连接。
+
+```bash
+# 首次启动：创建容器并前台运行 ATK server
+bash tests/atk/common/gpu_server.sh -op=<op_name> \
+  -gpu_image=<gpu_image> \
+  -gpu_repo_root=<容器内仓库根目录> \
+  [-gpu_device_id=6] [-gpu_host_port=9090] \
+  [-atk_env=<容器内ATK虚拟环境>] [-triton_root=<兼容Triton源码根>]
+
+# 复用已有容器
+bash tests/atk/common/gpu_server.sh -op=<op_name> \
+  -gpu_container=<容器名> -gpu_repo_root=<容器内仓库根目录>
+
+# 停止并删除容器
+bash tests/atk/common/gpu_server.sh -op=<op_name> -action=stop
+```
+
+容器只暴露物理 GPU 6 时，容器内逻辑设备为 0；`-gpu_device_id` 控制物理卡号。
+`-gpu_host_port` 必须与 NPU 端 `run_test_cpu.sh -gpu_host_port` 一致。
+
+### NPU 到 GPU server 连通性自检（action=test_connection_from_npu）
+
+在 NPU 机器上运行 `common/gpu_server.sh -action=test_connection_from_npu`，依次执行
+TCP 端口可达性（`socket.connect` 5s 超时）和 ATK server HTTP 响应（`urllib` 10s 超时）
+两项检查。两者均通过才视为连通；任一失败给出定位提示（容器未启动 / 端口映射 / 防火墙）。
+HTTP 4xx/5xx 也算 server 在响应（如 404），只关心端口是否能握手。
+
+```bash
+bash tests/atk/common/gpu_server.sh -op=<op_name> \
+  -action=test_connection_from_npu -gpu_host=<gpu_host> -gpu_host_port=9090
+```
+
+建议在 `accuracy_gpu` 正式执行前先跑一次自检，避免因网络问题误判为精度异常。
 
 性能测试使用 ATK `performance_device`：
 
@@ -212,7 +271,7 @@ bash tests/atk/run_test_cpu.sh -op=<op_name> -scope=gen_cases
 4. `executor_<op_name>.py` 中保留本算子的 `build_inputs`、CPU 标杆、`run_cpu`、`run_npu` 和 `FunctionApi`。
 5. 若需要公共基础函数，从 `tests/atk/common/_ascendc_common_executor.py` 引入；不要把算子专属逻辑放入 `common/`。
 6. YAML 与 JSON 中的 shape 必须同时满足源码 README、tiling 检查和 executor 输入构造。
-7. 修改后至少执行 `python` 语法导入检查；具备 NPU 环境时再跑 `accuracy`、`performance`、`determinism` 和 `mssanitizer`。
+7. 修改后至少执行 `python` 语法导入检查；具备 NPU 环境时再跑 `accuracy_cpu`、`accuracy_gpu`、`performance`、`determinism` 和 `mssanitizer`。
 
 executor 使用公共目录的推荐写法：
 

--- a/tests/atk/README.md
+++ b/tests/atk/README.md
@@ -181,6 +181,11 @@ bash tests/atk/common/gpu_server.sh -op=<op_name> \
   [-gpu_device_id=6] [-gpu_host_port=9090] \
   [-atk_env=<容器内ATK虚拟环境>] [-triton_root=<兼容Triton源码根>]
 
+# 用本地镜像 tar 启动（先 docker load 再创建容器）
+bash tests/atk/common/gpu_server.sh -op=<op_name> \
+  -gpu_image_tar=<本地镜像tar路径> \
+  -gpu_repo_root=<容器内仓库根目录>
+
 # 复用已有容器
 bash tests/atk/common/gpu_server.sh -op=<op_name> \
   -gpu_container=<容器名> -gpu_repo_root=<容器内仓库根目录>
@@ -191,6 +196,10 @@ bash tests/atk/common/gpu_server.sh -op=<op_name> -action=stop
 
 容器只暴露物理 GPU 6 时，容器内逻辑设备为 0；`-gpu_device_id` 控制物理卡号。
 `-gpu_host_port` 必须与 NPU 端 `run_test_cpu.sh -gpu_host_port` 一致。
+
+`-gpu_image_tar` 指定本地镜像 tar 文件路径，脚本会先 `docker load` 再用加载出的镜像名
+（输出 `Loaded image: <repo:tag>`）创建容器；若 tar 只含 image ID 则回退使用 `-gpu_image`。
+`-gpu_image`（镜像名）与 `-gpu_image_tar`（tar 路径）二选一即可创建新容器。
 
 ### NPU 到 GPU server 连通性自检（action=test_connection_from_npu）
 

--- a/tests/atk/README.md
+++ b/tests/atk/README.md
@@ -191,7 +191,7 @@ bash tests/atk/common/gpu_server.sh -op=<op_name> \
   -gpu_container=<容器名> -gpu_repo_root=<容器内仓库根目录>
 
 # 停止并删除容器
-bash tests/atk/common/gpu_server.sh -op=<op_name> -action=stop
+bash tests/atk/common/gpu_server.sh -op=<op_name> -action=gpu_server_stop
 ```
 
 容器只暴露物理 GPU 6 时，容器内逻辑设备为 0；`-gpu_device_id` 控制物理卡号。

--- a/tests/atk/chunk_bwd_dqkwg/executor_chunk_bwd_dqkwg.py
+++ b/tests/atk/chunk_bwd_dqkwg/executor_chunk_bwd_dqkwg.py
@@ -338,11 +338,11 @@ class FunctionApi(BaseApi):
         elif self.device == "gpu":
             # GPU 路由：参考 chunk_kda_fwd 的 is_benchmark_task 机制
             # fp64 任务使用 fp64 高精度参考，常规任务使用同精度参考
-            if self.is_benchmark_task or q.dtype == torch.float64:
+            if self.is_benchmark_task or q.dtype == torch.float64 or q.dtype == torch.float32:
                 return self.gpu_fp64(input_data, with_output)
             else:
                 return self.gpu(input_data, with_output)
-        elif q.dtype == torch.float64:
+        elif q.dtype == torch.float64 or q.dtype == torch.float32:
             return self.cpu_fp64(input_data, with_output)
         else:
             return self.cpu(input_data, with_output)

--- a/tests/atk/chunk_bwd_dqkwg/executor_chunk_bwd_dqkwg.py
+++ b/tests/atk/chunk_bwd_dqkwg/executor_chunk_bwd_dqkwg.py
@@ -187,6 +187,9 @@ class FunctionApi(BaseApi):
 
         return dq, dk, dw_out, dg
 
+
+
+
     def cpu_benchmark(self, input_data: InputDataset, with_output: bool = False):
         q = input_data.kwargs["q"].to(torch.float64)
         k = input_data.kwargs["k"].to(torch.float64)

--- a/tests/atk/chunk_bwd_dqkwg/executor_chunk_bwd_dqkwg.py
+++ b/tests/atk/chunk_bwd_dqkwg/executor_chunk_bwd_dqkwg.py
@@ -14,6 +14,13 @@ os.environ["PYTORCH_NO_NPU_MEMORY_CACHING"] = "1"
 # sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from scripts.chunk_bwd_dqkwg_cpu import chunk_bwd_dqkwg_cpu
 
+try:
+    from scripts.chunk_bwd_dqkwg_gpu import chunk_bwd_dqkwg_gpu_torch
+    _GPU_BENCHMARK_AVAILABLE = True
+except Exception as _gpu_import_err:
+    _GPU_BENCHMARK_AVAILABLE = False
+    _gpu_import_error_msg = str(_gpu_import_err)
+
 def create_gate_g(B: int, H: int, T: int, gtype):
     lo, hi = -5e-2, -5e-5
     span = hi - lo
@@ -149,6 +156,10 @@ class FunctionApi(BaseApi):
     def __init__(self, task_result: TaskResult):
         super(FunctionApi, self).__init__(task_result)
         self.qkv_type = None
+        # 标杆任务标志：参考 chunk_kda_fwd executor 的 is_benchmark_task 机制
+        # ATK 框架为每个用例分别下发 benchmark 任务和常规任务
+        # benchmark=True 时使用高精度(fp64)参考实现，benchmark=False 时使用同精度参考实现
+        self.is_benchmark_task = bool(getattr(task_result, "is_benchmark_task", False))
 
     def cpu(self, input_data: InputDataset, with_output: bool = False):
         q = input_data.kwargs["q"]
@@ -190,7 +201,7 @@ class FunctionApi(BaseApi):
 
 
 
-    def cpu_benchmark(self, input_data: InputDataset, with_output: bool = False):
+    def cpu_fp64(self, input_data: InputDataset, with_output: bool = False):
         q = input_data.kwargs["q"].to(torch.float64)
         k = input_data.kwargs["k"].to(torch.float64)
         v = input_data.kwargs["v"].to(torch.float64)
@@ -211,6 +222,90 @@ class FunctionApi(BaseApi):
             benchmark=True
         )
         # print("[cpu bench output] dq:", dq.shape, dq.dtype, "dk:", dk.shape, dk.dtype, "dw_out:", dw_out.shape, dw_out.dtype, "dg:", dg.shape, dg.dtype)
+
+        return dq, dk, dw_out, dg
+
+    def gpu(self, input_data: InputDataset, with_output: bool = False):
+        """GPU 同精度参考实现（fp64=False，calc_type=fp32，与 CPU 标杆一致）。"""
+        if not _GPU_BENCHMARK_AVAILABLE:
+            raise RuntimeError(
+                f"GPU 标杆模块不可用: {_gpu_import_error_msg}"
+            )
+
+        q = input_data.kwargs["q"]
+        k = input_data.kwargs["k"]
+        v = input_data.kwargs["v"]
+        do = input_data.kwargs["do"]
+        h = input_data.kwargs["h"]
+        dh = input_data.kwargs["dh"]
+        w = input_data.kwargs.get("w", None)
+        g = input_data.kwargs["g"]
+        dv = input_data.kwargs["dv"]
+        cu_seqlens = input_data.kwargs.get("cu_seqlens", None)
+        chunk_size = input_data.kwargs["chunk_size"]
+        scale = input_data.kwargs["scale"]
+
+        dq, dk, dw_out, dg = chunk_bwd_dqkwg_gpu_torch(
+            q, k, v, do, h, dh, w, g, dv, scale, cu_seqlens, chunk_size,
+            fp64=False
+        )
+
+        # 将结果移回 CPU 以便 ATK 框架统一比对
+        dq = dq.cpu()
+        dk = dk.cpu()
+        dw_out = dw_out.cpu() if dw_out is not None else None
+        dg = dg.cpu() if dg is not None else None
+
+        if self.qkv_type == "bf16":
+            dq = dq.to(torch.bfloat16)
+            dk = dk.to(torch.bfloat16)
+            dw_out = dw_out.to(torch.bfloat16) if dw_out is not None else None
+        if self.qkv_type == "fp16":
+            dq = dq.to(torch.float16)
+            dk = dk.to(torch.float16)
+            dw_out = dw_out.to(torch.float16) if dw_out is not None else None
+
+        is_mix = input_data.kwargs.get("is_mix", True)
+        if not is_mix:
+            if self.qkv_type == "bf16":
+                dg = dg.to(torch.bfloat16)
+            if self.qkv_type == "fp16":
+                dg = dg.to(torch.float16)
+
+        return dq, dk, dw_out, dg
+
+    def gpu_fp64(self, input_data: InputDataset, with_output: bool = False):
+        """GPU 高精度参考实现（fp64=True，使用 fp64 精度小算子拼接）。"""
+        if not _GPU_BENCHMARK_AVAILABLE:
+            raise RuntimeError(
+                f"GPU 标杆模块不可用: {_gpu_import_error_msg}"
+            )
+
+        q = input_data.kwargs["q"].to(torch.float64)
+        k = input_data.kwargs["k"].to(torch.float64)
+        v = input_data.kwargs["v"].to(torch.float64)
+        do = input_data.kwargs["do"].to(torch.float64)
+        h = input_data.kwargs["h"].to(torch.float64)
+        dh = input_data.kwargs["dh"].to(torch.float64)
+        w = input_data.kwargs.get("w", None)
+        if w is not None:
+            w = w.to(torch.float64)
+        g = input_data.kwargs["g"].to(torch.float64)
+        dv = input_data.kwargs["dv"].to(torch.float64)
+        cu_seqlens = input_data.kwargs.get("cu_seqlens", None)
+        chunk_size = input_data.kwargs["chunk_size"]
+        scale = input_data.kwargs["scale"]
+
+        dq, dk, dw_out, dg = chunk_bwd_dqkwg_gpu_torch(
+            q, k, v, do, h, dh, w, g, dv, scale, cu_seqlens, chunk_size,
+            fp64=True
+        )
+
+        # 将结果移回 CPU 以便 ATK 框架统一比对
+        dq = dq.cpu()
+        dk = dk.cpu()
+        dw_out = dw_out.cpu() if dw_out is not None else None
+        dg = dg.cpu() if dg is not None else None
 
         return dq, dk, dw_out, dg
 
@@ -240,8 +335,15 @@ class FunctionApi(BaseApi):
         q = input_data.kwargs["q"]
         if self.device == "npu":
             return self.npu_chunk_bwd_dqkwg(input_data, with_output)
+        elif self.device == "gpu":
+            # GPU 路由：参考 chunk_kda_fwd 的 is_benchmark_task 机制
+            # fp64 任务使用 fp64 高精度参考，常规任务使用同精度参考
+            if self.is_benchmark_task or q.dtype == torch.float64:
+                return self.gpu_fp64(input_data, with_output)
+            else:
+                return self.gpu(input_data, with_output)
         elif q.dtype == torch.float64:
-            return self.cpu_benchmark(input_data, with_output)
+            return self.cpu_fp64(input_data, with_output)
         else:
             return self.cpu(input_data, with_output)
 

--- a/tests/atk/chunk_bwd_dqkwg/scripts/acc.py
+++ b/tests/atk/chunk_bwd_dqkwg/scripts/acc.py
@@ -1,0 +1,234 @@
+import torch
+import sys
+import os
+from typing import Optional, Tuple
+
+# 使同目录下的标杆模块可被导入
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from chunk_bwd_dqkwg_cpu import chunk_bwd_dqkwg_cpu
+from chunk_bwd_dqkwg_gpu import chunk_bwd_dqkwg_gpu_torch
+
+
+def create_gate_g(B: int, H: int, T: int, gtype) -> torch.Tensor:
+    """生成递减且为负数的 gate 张量，逻辑与 executor 一致。"""
+    g = -torch.sort(torch.rand(B * T * H) * 10, descending=False)[0].reshape((B, H, T))
+    return g.to(gtype)
+
+
+def chunk_bwd_dqkwg_cpu_torch(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    do: torch.Tensor,
+    h: torch.Tensor,
+    dh: torch.Tensor,
+    w: Optional[torch.Tensor],
+    g: Optional[torch.Tensor],
+    dv: torch.Tensor,
+    scale: Optional[float],
+    cu_seqlens: Optional[torch.LongTensor],
+    chunk_size: int = 64,
+    benchmark: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """
+    CPU 标杆包装函数。
+    输入布局与 executor 一致：
+        q, k: [B, HK, T, K]；v, do, dv: [B, HV, T, V]
+        g: [B, HV, T]；h, dh: [B, HV, num_chunks, K, V]；w: [B, HV, T, K]
+    输出布局：
+        dq, dk: [B, HK, T, K]；dw: [B, HV, T, K]；dg: [B, HV, T]
+    """
+    q_t = q.transpose(1, 2).contiguous()
+    k_t = k.transpose(1, 2).contiguous()
+    v_t = v.transpose(1, 2).contiguous()
+    do_t = do.transpose(1, 2).contiguous()
+    dv_t = dv.transpose(1, 2).contiguous()
+    g_t = g.transpose(1, 2).contiguous() if g is not None else None
+    w_t = w.transpose(1, 2).contiguous() if w is not None else None
+    h_t = h.permute(0, 2, 1, 3, 4).contiguous()
+    dh_t = dh.permute(0, 2, 1, 3, 4).contiguous()
+
+    cu_seqlens_tensor = torch.tensor(cu_seqlens, dtype=torch.int64) if cu_seqlens is not None else None
+
+    dq, dk, dw, dg = chunk_bwd_dqkwg_cpu(
+        q_t, k_t, v_t, do_t, h_t, dh_t, w_t, g_t, dv_t, scale, cu_seqlens_tensor, chunk_size,
+        benchmark=benchmark
+    )
+
+    dq = dq.transpose(1, 2).contiguous()
+    dk = dk.transpose(1, 2).contiguous()
+    dw = dw.transpose(1, 2).contiguous()
+    if dg is not None:
+        dg = dg.transpose(1, 2).contiguous()
+
+    return dq, dk, dw, dg
+
+
+def compare_tensors(name: str, a: torch.Tensor, b: torch.Tensor) -> None:
+    """对比两个张量的精度，输出中文统计信息。"""
+    a_f = a.float()
+    b_f = b.float()
+    diff = (a_f - b_f).abs()
+    max_abs = diff.max().item()
+    mean_abs = diff.mean().item()
+    # 相对误差
+    denom = b_f.abs().clamp(min=1e-12)
+    rel_diff = (diff / denom)
+    max_rel = rel_diff.max().item()
+    mean_rel = rel_diff.mean().item()
+    # allclose 判断
+    atol = 1e-3
+    rtol = 1e-3
+    is_close = torch.allclose(a_f, b_f, atol=atol, rtol=rtol)
+    print(f"  [{name}] 最大绝对误差: {max_abs:.8f}  平均绝对误差: {mean_abs:.8f}")
+    print(f"  [{name}] 最大相对误差: {max_rel:.8f}  平均相对误差: {mean_rel:.8f}")
+    print(f"  [{name}] allclose(atol={atol}, rtol={rtol}): {'通过' if is_close else '未通过'}")
+
+
+def run_test(
+    B: int, HK: int, HV: int, T: int, K: int, V: int,
+    chunk_size: int, qkv_dtype: torch.dtype, g_dtype: torch.dtype,
+    fp64: bool, device_id: int = 0
+) -> None:
+    """单组测试：生成数据 -> 调用 CPU/GPU -> 对比精度。"""
+    scale = 1.0 / (K ** 0.5)
+    num_chunks = (T + chunk_size - 1) // chunk_size
+
+    print(f"\n测试配置: B={B}, HK={HK}, HV={HV}, T={T}, K={K}, V={V}, "
+          f"chunk_size={chunk_size}, qkv={qkv_dtype}, g={g_dtype}, fp64={fp64}")
+
+    torch.manual_seed(42)
+    # 生成测试数据（executor 布局）
+    q = torch.rand((B, HK, T, K), dtype=qkv_dtype)
+    k = torch.rand((B, HK, T, K), dtype=qkv_dtype)
+    v = torch.rand((B, HV, T, V), dtype=qkv_dtype)
+    do = torch.rand((B, HV, T, V), dtype=qkv_dtype)
+    dv = torch.rand((B, HV, T, V), dtype=qkv_dtype)
+    w = torch.rand((B, HV, T, K), dtype=qkv_dtype)
+    h = torch.rand((B, HV, num_chunks, K, V), dtype=qkv_dtype)
+    dh = torch.rand((B, HV, num_chunks, K, V), dtype=qkv_dtype)
+    g = create_gate_g(B, HV, T, g_dtype)
+    cu_seqlens = None  # 定长模式
+
+    # ------------------------------------------------------------------
+    # 1. 调用 CPU 标杆
+    # ------------------------------------------------------------------
+    print("\n[1] 调用 CPU 标杆 ...")
+    # CPU 标杆中 benchmark=True 对应 fp64，benchmark=False 对应输入精度
+    cpu_benchmark = fp64
+    dq_cpu, dk_cpu, dw_cpu, dg_cpu = chunk_bwd_dqkwg_cpu_torch(
+        q, k, v, do, h, dh, w, g, dv, scale, cu_seqlens, chunk_size,
+        benchmark=cpu_benchmark
+    )
+    print(f"  CPU 输出: dq{tuple(dq_cpu.shape)} dk{tuple(dk_cpu.shape)} "
+          f"dw{tuple(dw_cpu.shape)} dg{tuple(dg_cpu.shape)}")
+
+    # ------------------------------------------------------------------
+    # 2. 调用 GPU 标杆
+    # ------------------------------------------------------------------
+    print("\n[2] 调用 GPU 标杆 ...")
+    try:
+        dq_gpu, dk_gpu, dw_gpu, dg_gpu = chunk_bwd_dqkwg_gpu_torch(
+            q, k, v, do, h, dh, w, g, dv, scale, cu_seqlens, chunk_size,
+            fp64=fp64, device=device_id
+        )
+    except RuntimeError as e:
+        print(f"  GPU 执行失败: {e}")
+        return
+    print(f"  GPU 输出: dq{tuple(dq_gpu.shape)} dk{tuple(dk_gpu.shape)} "
+          f"dw{tuple(dw_gpu.shape)} dg{tuple(dg_gpu.shape)}")
+
+    # ------------------------------------------------------------------
+    # 3. 精度对比
+    # ------------------------------------------------------------------
+    print("\n[3] CPU vs GPU 精度对比:")
+    # 统一到 float32 做对比
+    dq_cpu_c = dq_cpu.float().cpu()
+    dk_cpu_c = dk_cpu.float().cpu()
+    dw_cpu_c = dw_cpu.float().cpu()
+    dg_cpu_c = dg_cpu.float().cpu()
+    dq_gpu_c = dq_gpu.float().cpu()
+    dk_gpu_c = dk_gpu.float().cpu()
+    dw_gpu_c = dw_gpu.float().cpu()
+    dg_gpu_c = dg_gpu.float().cpu()
+
+    compare_tensors("dq", dq_cpu_c, dq_gpu_c)
+    compare_tensors("dk", dk_cpu_c, dk_gpu_c)
+    compare_tensors("dw", dw_cpu_c, dw_gpu_c)
+    compare_tensors("dg", dg_cpu_c, dg_gpu_c)
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("chunk_bwd_dqkwg CPU vs GPU 精度对比测试")
+    print("=" * 60)
+
+    # 公共 shape 参数
+    B = 1
+    HK = 4
+    HV = 4          # n_ratio = 1
+    T = 128
+    K = 128
+    V = 128
+    chunk_size = 64
+
+    # ----------------------------------------------------------
+    # 测试 1: 输入精度 (bf16) 对比
+    # ----------------------------------------------------------
+    print("\n" + "#" * 60)
+    print("# 测试 1: 输入精度 bf16 (fp64=False)")
+    print("#" * 60)
+    run_test(
+        B=B, HK=HK, HV=HV, T=T, K=K, V=V,
+        chunk_size=chunk_size,
+        qkv_dtype=torch.bfloat16,
+        g_dtype=torch.float32,
+        fp64=False,
+    )
+
+    # ----------------------------------------------------------
+    # 测试 2: fp64 高精度对比
+    # ----------------------------------------------------------
+    print("\n" + "#" * 60)
+    print("# 测试 2: fp64 高精度 (fp64=True)")
+    print("#" * 60)
+    run_test(
+        B=B, HK=HK, HV=HV, T=T, K=K, V=V,
+        chunk_size=chunk_size,
+        qkv_dtype=torch.bfloat16,
+        g_dtype=torch.float32,
+        fp64=True,
+    )
+
+    # ----------------------------------------------------------
+    # 测试 3: fp16 输入精度对比
+    # ----------------------------------------------------------
+    print("\n" + "#" * 60)
+    print("# 测试 3: 输入精度 fp16 (fp64=False)")
+    print("#" * 60)
+    run_test(
+        B=B, HK=HK, HV=HV, T=T, K=K, V=V,
+        chunk_size=chunk_size,
+        qkv_dtype=torch.float16,
+        g_dtype=torch.float32,
+        fp64=False,
+    )
+
+    # ----------------------------------------------------------
+    # 测试 4: GVA 分组场景 (HV = 2*HK)
+    # ----------------------------------------------------------
+    print("\n" + "#" * 60)
+    print("# 测试 4: GVA 分组场景 n_ratio=2 (fp64=True)")
+    print("#" * 60)
+    run_test(
+        B=B, HK=2, HV=4, T=T, K=K, V=V,
+        chunk_size=chunk_size,
+        qkv_dtype=torch.bfloat16,
+        g_dtype=torch.float32,
+        fp64=True,
+    )
+
+    print("\n" + "=" * 60)
+    print("所有精度对比测试完成")
+    print("=" * 60)

--- a/tests/atk/chunk_bwd_dqkwg/scripts/chunk_bwd_dqkwg_cpu_new.py
+++ b/tests/atk/chunk_bwd_dqkwg/scripts/chunk_bwd_dqkwg_cpu_new.py
@@ -1,0 +1,636 @@
+import torch
+import torch_npu
+import os
+from typing import Tuple
+
+def chunk_bwd_dqkwg_cpu(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    do: torch.Tensor,
+    h: torch.Tensor,
+    dh: torch.Tensor,
+    w: torch.Tensor,
+    g: torch.Tensor,
+    dv: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.LongTensor,
+    chunk_size: int = 64,
+    benchmark = False,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    CPU Equivalent of chunk_bwd_kernel_dqkwg.
+
+    优化说明：将原按 HV 头展开的 Python 循环改为对 HV 维做批量 (bmm) 计算。
+    CPU 上 bmm 对每个 batch 调用与单次 mm 相同的 gemm，因此每个头的矩阵乘
+    与原循环逐位等价；所有 dtype 往返 (.to(datatype).to(calc_type)) 和运算顺序
+    均原样保留，维持与 kernel 一致的精度模拟。
+    """
+    calc_type = torch.float64 if benchmark else torch.float32
+    B, T, HK, K = q.shape
+    HV = v.shape[2]
+    V = v.shape[-1]
+    if HK <= 0 or HV <= 0 or HV % HK != 0:
+        raise ValueError(f"GVA requires HV divisible by HK, got HV={HV}, HK={HK}")
+    n_ratio = HV // HK  # HV = n_ratio * HK
+    datatype = q.dtype
+    gtype = g.dtype
+    if benchmark:
+        datatype = torch.float64
+        gtype = torch.float64
+
+    q.to(calc_type)
+    k.to(calc_type)
+    v.to(calc_type)
+    do.to(calc_type)
+    h.to(calc_type)
+    dh.to(calc_type)
+    
+    g.to(gtype).to(calc_type)
+    dv.to(calc_type)
+
+    # ---- Pad T to multiple of chunk_size (dense mode only) ----
+    # 消除 ragged 尾部，使所有 chunk 都是满长度，统一走 batched 路径。
+    # q/k/v/do/dv 补零；g 补最后一个有效值（保持单调递减语义）。
+    # padding 位置的贡献天然为零（do=0 → ds 行为零；v=0 → ds 列为零）。
+    # 唯一需要特殊处理的是 dg_last_accum 的位置：
+    #   满 chunk → 加到 C-1；padded tail → 加到 L_orig-1（而非 C-1）。
+    C = chunk_size
+    T_orig = T
+    ragged_len = (T % C) if cu_seqlens is None else 0
+    pad_T = (C - ragged_len) % C if ragged_len > 0 else 0
+    if pad_T > 0:
+        q = torch.nn.functional.pad(q, (0, 0, 0, 0, 0, pad_T))
+        k = torch.nn.functional.pad(k, (0, 0, 0, 0, 0, pad_T))
+        v = torch.nn.functional.pad(v, (0, 0, 0, 0, 0, pad_T))
+        do = torch.nn.functional.pad(do, (0, 0, 0, 0, 0, pad_T))
+        dv = torch.nn.functional.pad(dv, (0, 0, 0, 0, 0, pad_T))
+        g = torch.cat([g, g[:, -1:, :].expand(-1, pad_T, -1)], dim=1)
+        T = T + pad_T
+
+    # ---- Pre-transpose + pre-cast ----
+    q_ct = q.permute(0, 2, 1, 3).to(calc_type).contiguous()   # [B, HK, T, K]
+    k_ct = k.permute(0, 2, 1, 3).to(calc_type).contiguous()   # [B, HK, T, K]
+    v_ct = v.permute(0, 2, 1, 3).to(calc_type).contiguous()   # [B, HV, T, V]
+    do_ct = do.permute(0, 2, 1, 3).to(calc_type).contiguous() # [B, HV, T, V]
+    dv_ct = dv.permute(0, 2, 1, 3).to(calc_type).contiguous() # [B, HV, T, V]
+    g_ct = g.permute(0, 2, 1).contiguous()                    # [B, HV, T], gtype
+
+    # Keep per-value-head contributions first, then reduce them into key heads.
+    dq_hv = torch.zeros((B, T, HV, K), dtype=datatype)
+    dk_hv = torch.zeros((B, T, HV, K), dtype=datatype)
+    dg = torch.zeros_like(g)
+    dw = torch.zeros((B, T, HV, K), dtype=datatype)
+
+    # 缓存因果 mask（按 actual_chunk_len），避免每个 chunk 重复构造
+    # 同时缓存 calc_type 版本（用于融合掩码乘法），避免 where(scalar) 提升类型
+    mask_cache = {}
+
+    def get_causal_mask(L: int, device):
+        m = mask_cache.get(L)
+        if m is None or m.device != device:
+            idx = torch.arange(L, device=device)
+            m = idx[:, None] >= idx[None, :]
+            mask_cache[L] = m
+        return m
+
+    def get_causal_mask_f(L: int, device):
+        """返回 [1, L, L] 的 calc_type 浮点 mask，供 ds *= mask_f 原地掩码用。"""
+        key = (L, str(calc_type))
+        mf = mask_cache.get(key)
+        if mf is None or mf.device != device:
+            mf = get_causal_mask(L, device).to(calc_type)[None]
+            mask_cache[key] = mf
+        return mf
+
+    # 模拟 kernel 中间结果的 dtype 往返；datatype == calc_type 时短路（避免无谓分配）
+    def cast_round(t):
+        if datatype == calc_type:
+            return t
+        return t.to(datatype).to(calc_type)
+
+    # 将 [HK, L, K] 按 n_ratio 复制到 [HV, L, K]；n_ratio==1 时短路
+    def expand_heads(t):
+        if n_ratio == 1:
+            return t
+        return t.repeat_interleave(n_ratio, dim=0)
+
+    def process_sequence(b_idx, t_start, t_end, seq_idx_in_batch, chunk_start_idx):
+        seq_len = t_end - t_start
+        num_chunks = (seq_len + chunk_size - 1) // chunk_size
+
+        for i_t in range(num_chunks):
+            chunk_start_token_idx = t_start + i_t * chunk_size
+            chunk_end_token_idx = min(t_start + (i_t + 1) * chunk_size, t_end)
+            L = chunk_end_token_idx - chunk_start_token_idx
+            if L <= 0:
+                continue
+            s = chunk_start_token_idx
+            e = chunk_end_token_idx
+
+            # ---- 取当前 chunk 全部头的数据，统一以 head 作为 batch 维 ----
+            # q/k: [L, HK, K] -> [HK, L, K] -> 复制 n_ratio 份 -> [HV, L, K]
+            #   head h_idx 对应 hk_idx = h_idx // n_ratio（与原循环一致）
+            q_h = expand_heads(q_ct[b_idx, :, s:e, :])
+            k_h = expand_heads(k_ct[b_idx, :, s:e, :])
+            v_h = v_ct[b_idx, :, s:e, :]
+            do_h = do_ct[b_idx, :, s:e, :]
+            # h/dh: [HV, K, V]（保留原始 datatype，供 dg_last_accum 使用）
+            h_prev = h[b_idx, i_t + chunk_start_idx, :, :, :]       # [HV, K, V]
+            dh_curr = dh[b_idx, i_t + chunk_start_idx, :, :, :]     # [HV, K, V]
+            h_prev_t = h_prev.transpose(-1, -2).to(calc_type)       # [HV, V, K]
+            dh_curr_t = dh_curr.transpose(-1, -2).to(calc_type)     # [HV, V, K]
+
+            # -----------------------------------------------------------
+            # 1. State Contributions (Inter-chunk)
+            # -----------------------------------------------------------
+            # b_dq += dot(b_do, b_h); b_dk += dot(b_v, b_dh)
+            dq_from_state = cast_round(torch.bmm(do_h, h_prev_t))   # [HV, L, K]
+            dk_from_state = cast_round(torch.bmm(v_h, dh_curr_t))   # [HV, L, K]
+
+            # b_dw += dot(b_dv, b_h) (kernel 存 -b_dw)
+            dv_h = dv_ct[b_idx, :, s:e, :]
+            dw_c = cast_round(torch.bmm(dv_h, h_prev_t))       # [HV, L, K]
+            dw[b_idx, s:e, :, :] = (-dw_c).permute(1, 0, 2)
+
+            mask_f = get_causal_mask_f(L, q.device)
+
+            # -----------------------------------------------------------
+            # 2. Gating / Decay Logic Preparation
+            # -----------------------------------------------------------
+            g_h = g_ct[b_idx, :, s:e]                            # [HV, L] (gtype)
+            g_last = g_ct[b_idx, :, min(s + chunk_size, t_end) - 1]  # [HV]
+
+            exp_gc = torch.exp(g_h)                              # [HV, L]
+            exp_neg_gc_glast = torch.exp(-g_h + g_last[:, None]) # [HV, L]
+
+            dq_from_state = dq_from_state * (exp_gc[:, :, None] * scale)
+            dk_from_state = dk_from_state * exp_neg_gc_glast[:, :, None]
+
+            # -----------------------------------------------------------
+            # 3. Intra-chunk Attention
+            # -----------------------------------------------------------
+            ds = cast_round(torch.bmm(do_h, v_h.transpose(1, 2)))  # [HV, L, L]
+            decay_mat = torch.exp(torch.min(g_h[:, :, None] - g_h[:, None, :], torch.tensor(0)))  # [HV, L, L]
+            # 融合：避免 where(scalar) 类型提升与多次临时分配
+            ds = ds * decay_mat
+            ds = ds * mask_f                  # [1, L, L] 广播掩码
+            ds = ds * scale
+
+            qk_t = cast_round(torch.bmm(q_h, k_h.transpose(1, 2)))   # [HV, L, L]
+
+            ds2 = ds * qk_t
+            dg_c = ds2.sum(dim=-1)
+            dg_c = dg_c - ds2.sum(dim=-2)
+            if datatype == gtype:
+                dg_c = dg_c.to(gtype)                               # 等价 .to(datatype).to(gtype)
+            else:
+                dg_c = dg_c.to(datatype).to(gtype)                  # [HV, L]
+
+            # b_dg += sum(b_dq * b_q) ; b_dg -= sum(b_k * b_dk)
+            # 保留显式 product+sum（与原参考一致，避免 einsum 改变归约顺序）
+            dg_c = cast_round(dg_c)
+            dg_c += (dq_from_state * q_h).sum(dim=-1)             # [HV, L]
+            dg_c = cast_round(dg_c)
+            # k_h * dk_from_state 在 dg_c 和 dg_last_accum 中各用一次，提取公共子表达式
+            k_dk_prod = k_h * dk_from_state                       # [HV, L, K]
+            dg_c = dg_c - k_dk_prod.sum(dim=-1)                   # [HV, L]
+
+            # b_dg_last += sum(h * dh) * exp(g_last) + sum(dk * k)
+            # 注意 h_prev/dh_curr 保留原始 datatype（与原实现一致）
+            dg_last_accum = (h_prev * dh_curr).sum(dim=(-1, -2)) * torch.exp(g_last)  # [HV]
+            dg_last_accum = dg_last_accum + k_dk_prod.sum(dim=(-1, -2))             # [HV]
+
+            # b_ds2 = b_ds * (q @ k.T)
+            # 仅块最后一个有效 token 累加 dg_last
+            dg_c[:, L - 1] = dg_c[:, L - 1] + dg_last_accum
+            dg[b_idx, s:e, :] = dg_c.to(gtype).permute(1, 0)                   # [L, HV]
+
+            # -----------------------------------------------------------
+            # 4. Final Accumulation for dq, dk
+            # -----------------------------------------------------------
+            ds = cast_round(ds)
+            dq_intra = cast_round(torch.bmm(ds, k_h))               # [HV, L, K]
+            dk_intra = cast_round(torch.bmm(ds.transpose(1, 2), q_h))# [HV, L, K]
+
+            dq_total = dq_from_state + dq_intra
+            dk_total = dk_from_state + dk_intra
+
+            if datatype == calc_type:
+                dq_hv[b_idx, s:e, :, :] = dq_total.permute(1, 0, 2)
+                dk_hv[b_idx, s:e, :, :] = dk_total.permute(1, 0, 2)
+            else:
+                dq_hv[b_idx, s:e, :, :] = dq_total.to(datatype).permute(1, 0, 2)
+                dk_hv[b_idx, s:e, :, :] = dk_total.to(datatype).permute(1, 0, 2)
+
+    # ------------------------------------------------------------------
+    # 批量 dense 路径：把同一 b 下所有 chunk（含 padded tail）合并成
+    # 一次大 bmm，消除 Python chunk 循环与算子派发开销。
+    # ragged tail 在函数入口已 pad 到 chunk_size；padding 位置贡献为零
+    #（do=0/v=0 → ds=0/dq=0/dk=0），唯一需修正的是 dg_last_accum 的位置：
+    # padded tail 的 dg_last_accum 加到 ragged_len-1 而非 C-1。
+    # chunk 之间无数据依赖（h/dh 是只读输入，dq_hv 等只写不跨 chunk 读），
+    # 故改变 chunk 处理顺序不改变结果；单个 chunk 内运算顺序保持不变。
+    # ------------------------------------------------------------------
+    def process_dense_batched(b_idx: int, n_full: int, t_offset: int, h_offset: int,
+                              ragged_len: int = 0):
+        N = n_full
+        if N <= 0:
+            return
+        C = chunk_size
+        H = HV
+        s0 = t_offset
+
+        # ---- 数据准备：从 pre-transposed tensors 切片，无需 permute+cast ----
+        # q/k: [B, HK, T, K] -> [HK, N*C, K] -> [HK, N, C, K] -> [N, HK, C, K]
+        q_b = q_ct[b_idx, :, s0:s0 + N * C, :].reshape(HK, N, C, K).permute(1, 0, 2, 3)
+        if n_ratio > 1:
+            q_b = q_b.repeat_interleave(n_ratio, dim=1)           # [N, HV, C, K]
+        q_b = q_b.reshape(N * H, C, K)
+        k_b = k_ct[b_idx, :, s0:s0 + N * C, :].reshape(HK, N, C, K).permute(1, 0, 2, 3)
+        if n_ratio > 1:
+            k_b = k_b.repeat_interleave(n_ratio, dim=1)
+        k_b = k_b.reshape(N * H, C, K)
+        # v/do: [B, HV, T, V] -> [HV, N*C, V] -> [HV, N, C, V] -> [N, HV, C, V] -> [N*HV, C, V]
+        v_b = v_ct[b_idx, :, s0:s0 + N * C, :].reshape(H, N, C, V).permute(1, 0, 2, 3).reshape(N * H, C, V)
+        do_b = do_ct[b_idx, :, s0:s0 + N * C, :].reshape(H, N, C, V).permute(1, 0, 2, 3).reshape(N * H, C, V)
+        # h/dh: [N, HV, K, V]（原始 datatype 保留，供 dg_last_accum）
+        h_b = h[b_idx, h_offset:h_offset + N, :, :, :].reshape(N * H, K, V)
+        dh_b = dh[b_idx, h_offset:h_offset + N, :, :, :].reshape(N * H, K, V)
+        h_b_t = h_b.transpose(-1, -2).to(calc_type)               # [N*H, V, K]
+        dh_b_t = dh_b.transpose(-1, -2).to(calc_type)            # [N*H, V, K]
+
+        # ---- 1. State contributions ----
+        dq_state = cast_round(torch.bmm(do_b, h_b_t))             # [N*H, C, K]
+        dk_state = cast_round(torch.bmm(v_b, dh_b_t))            # [N*H, C, K]
+
+        dv_b = dv_ct[b_idx, :, s0:s0 + N * C, :].reshape(H, N, C, V).permute(1, 0, 2, 3).reshape(N * H, C, V)
+        dw_c = cast_round(torch.bmm(dv_b, h_b_t))            # [N*H, C, K]
+        # [N*H, C, K] -> [N, H, C, K] -> [N, C, H, K] -> [N*C, H, K]
+        dw_neg = (-dw_c).reshape(N, H, C, K).permute(0, 2, 1, 3).reshape(N * C, H, K)
+        dw[b_idx, s0:s0 + N * C, :, :] = dw_neg
+
+        mask_f = get_causal_mask_f(C, q.device)                  # [1, C, C]
+
+        # ---- 2. Decay scale ----
+        # g: pre-transposed [B, HV, T] -> [HV, N*C] -> [HV, N, C] -> [N, HV, C] -> [N*HV, C]
+        g_b = g_ct[b_idx, :, s0:s0 + N * C].reshape(H, N, C).permute(1, 0, 2).reshape(N * H, C)  # gtype
+        # 每个 chunk 的最后有效 token = chunk 内第 C-1 个位置（满 chunk 下成立）
+        g_last = g_b.reshape(N, H, C)[:, :, C - 1].reshape(N * H)                          # [N*H]
+        exp_gc = torch.exp(g_b)                                                             # [N*H, C]
+        exp_neg_gc_glast = torch.exp(-g_b + g_last[:, None])                               # [N*H, C]
+        dq_state = dq_state * (exp_gc[:, :, None] * scale)
+        dk_state = dk_state * exp_neg_gc_glast[:, :, None]
+
+        # ---- 3. Intra-chunk attention ----
+        ds = cast_round(torch.bmm(do_b, v_b.transpose(1, 2)))                              # [N*H, C, C]
+        # 用 clamp 替代 min(tensor, scalar)，避免每 chunk 创建标量张量
+        # in-place exp_ 节省一次 [N*H, C, C] 分配
+        g_diff = g_b[:, :, None] - g_b[:, None, :]
+        decay_mat = torch.clamp(g_diff, max=0).exp_()                                      # [N*H, C, C]
+        ds = ds * decay_mat
+        ds = ds * mask_f
+        ds = ds * scale
+
+        qk_t = cast_round(torch.bmm(q_b, k_b.transpose(1, 2)))                             # [N*H, C, C]
+        ds2 = ds * qk_t
+        dg_c = ds2.sum(dim=-1)
+        dg_c = dg_c - ds2.sum(dim=-2)
+
+        # ---- dg_state（显式 product+sum，与原参考一致）----
+        dg_c = cast_round(dg_c)
+        dg_c += (dq_state * q_b).sum(dim=-1)                                              # [N*H, C]
+        dg_c = cast_round(dg_c)
+        # k_b * dk_state 在 dg_c 和 dg_last_accum 中各用一次，提取公共子表达式
+        k_dk_prod = k_b * dk_state                                                       # [N*H, C, K]
+        dg_c = dg_c - k_dk_prod.sum(dim=-1)
+        # h_prev*dh_curr 保留原始 datatype（与原实现一致）
+        dg_last_accum = (h_b * dh_b).sum(dim=(-1, -2)) * torch.exp(g_last)                # [N*H]
+        dg_last_accum = dg_last_accum + k_dk_prod.sum(dim=(-1, -2))                      # [N*H]
+
+        # 每个 chunk 累加 dg_last：
+        #   满 chunk → 加到 C-1；padded tail → 加到 ragged_len-1（原始最后有效 token）
+        dg_c = dg_c.reshape(N, H, C)
+        dg_last_reshaped = dg_last_accum.reshape(N, H)
+        if ragged_len > 0 and N > 1:
+            dg_c[:N-1, :, C - 1] += dg_last_reshaped[:N-1]
+            dg_c[N-1, :, ragged_len - 1] += dg_last_reshaped[N-1]
+        elif ragged_len > 0:
+            dg_c[0, :, ragged_len - 1] += dg_last_reshaped[0]
+        else:
+            dg_c[:, :, C - 1] += dg_last_reshaped
+        # [N, H, C] -> [N, C, H] -> [N*C, H]
+        dg[b_idx, s0:s0 + N * C, :] = dg_c.to(gtype).permute(0, 2, 1).reshape(N * C, H)
+
+        # ---- 4. dq/dk intra ----
+        ds = cast_round(ds).to(datatype)
+        dq_intra = cast_round(torch.bmm(ds.to(datatype), k_b.to(datatype)))                                          # [N*H, C, K]
+        dk_intra = cast_round(torch.bmm(ds.transpose(1, 2).to(datatype), q_b.to(datatype)))                          # [N*H, C, K]
+
+        dq_total = dq_state + dq_intra
+        dk_total = dk_state + dk_intra
+
+        # ---- 写回 dq_hv/dk_hv ----
+        # [N*H, C, K] -> [N, H, C, K] -> [N, C, H, K] -> [N*C, H, K]
+        if datatype == calc_type:
+            dq_hv[b_idx, s0:s0 + N * C, :, :] = dq_total.reshape(N, H, C, K).permute(0, 2, 1, 3).reshape(N * C, H, K)
+            dk_hv[b_idx, s0:s0 + N * C, :, :] = dk_total.reshape(N, H, C, K).permute(0, 2, 1, 3).reshape(N * C, H, K)
+        else:
+            dq_hv[b_idx, s0:s0 + N * C, :, :] = dq_total.to(datatype).reshape(N, H, C, K).permute(0, 2, 1, 3).reshape(N * C, H, K)
+            dk_hv[b_idx, s0:s0 + N * C, :, :] = dk_total.to(datatype).reshape(N, H, C, K).permute(0, 2, 1, 3).reshape(N * C, H, K)
+
+
+    # ------------------------------------------------------------------
+    # 跨序列批量处理 ragged tails（varlen 模式下多个序列的尾部 chunk）。
+    # 每个 tail 有不同的有效长度 ragged_i，pad 到 C 后批量计算。
+    # padding 位置贡献为零（do=0/v=0），唯一需修正的是 dg_last_accum 位置：
+    # 每个 tail 的 dg_last_accum 加到 ragged_i - 1 而非 C - 1。
+    # ------------------------------------------------------------------
+    def process_tails_batched(b_idx: int, tails: list):
+        N = len(tails)
+        C = chunk_size
+        H = HV
+
+        # ---- 收集并 pad 每个 tail ----
+        q_list, k_list, v_list, do_list, dv_list, g_list, h_list, dh_list = [], [], [], [], [], [], [], []
+        for ts, tr, h_idx in tails:
+            te = ts + tr
+            pad_len = C - tr
+            q_list.append(torch.nn.functional.pad(q_ct[b_idx, :, ts:te, :], (0, 0, 0, pad_len)))
+            k_list.append(torch.nn.functional.pad(k_ct[b_idx, :, ts:te, :], (0, 0, 0, pad_len)))
+            v_list.append(torch.nn.functional.pad(v_ct[b_idx, :, ts:te, :], (0, 0, 0, pad_len)))
+            do_list.append(torch.nn.functional.pad(do_ct[b_idx, :, ts:te, :], (0, 0, 0, pad_len)))
+            dv_list.append(torch.nn.functional.pad(dv_ct[b_idx, :, ts:te, :], (0, 0, 0, pad_len)))
+            g_t = g_ct[b_idx, :, ts:te]
+            g_list.append(torch.cat([g_t, g_t[:, -1:].expand(-1, pad_len)], dim=1))
+            h_list.append(h[b_idx, h_idx, :, :, :])
+            dh_list.append(dh[b_idx, h_idx, :, :, :])
+
+        # stack: [N, HK/HV, C, D] -> reshape [N*H, C, D]
+        q_b = torch.stack(q_list, dim=0)  # [N, HK, C, K]
+        if n_ratio > 1:
+            q_b = q_b.repeat_interleave(n_ratio, dim=1)
+        q_b = q_b.reshape(N * H, C, K)
+        k_b = torch.stack(k_list, dim=0)
+        if n_ratio > 1:
+            k_b = k_b.repeat_interleave(n_ratio, dim=1)
+        k_b = k_b.reshape(N * H, C, K)
+        v_b = torch.stack(v_list, dim=0).reshape(N * H, C, V)
+        do_b = torch.stack(do_list, dim=0).reshape(N * H, C, V)
+        dv_b = torch.stack(dv_list, dim=0).reshape(N * H, C, V)
+        g_b = torch.stack(g_list, dim=0).reshape(N * H, C)  # gtype
+        h_b = torch.stack(h_list, dim=0).reshape(N * H, K, V)
+        dh_b = torch.stack(dh_list, dim=0).reshape(N * H, K, V)
+        h_b_t = h_b.transpose(-1, -2).to(calc_type)
+        dh_b_t = dh_b.transpose(-1, -2).to(calc_type)
+
+        # ---- 1. State contributions ----
+        dq_state = cast_round(torch.bmm(do_b, h_b_t))
+        dk_state = cast_round(torch.bmm(v_b, dh_b_t))
+
+        dw_c = cast_round(torch.bmm(dv_b, h_b_t))
+
+        mask_f = get_causal_mask_f(C, q.device)
+
+        # ---- 2. Decay scale ----
+        g_last = g_b.reshape(N, H, C)[:, :, C - 1].reshape(N * H)
+        exp_gc = torch.exp(g_b)
+        exp_neg_gc_glast = torch.exp(-g_b + g_last[:, None])
+        dq_state = dq_state * (exp_gc[:, :, None] * scale)
+        dk_state = dk_state * exp_neg_gc_glast[:, :, None]
+
+        # ---- 3. Intra-chunk attention ----
+        ds = cast_round(torch.bmm(do_b, v_b.transpose(1, 2)))
+        g_diff = g_b[:, :, None] - g_b[:, None, :]
+        decay_mat = torch.clamp(g_diff, max=0).exp_()
+        ds = ds * decay_mat
+        ds = ds * mask_f
+        ds = ds * scale
+
+        qk_t = cast_round(torch.bmm(q_b, k_b.transpose(1, 2)))
+        ds2 = ds * qk_t
+        dg_c = ds2.sum(dim=-1)
+        dg_c = dg_c - ds2.sum(dim=-2)
+
+        # ---- dg_state ----
+        dg_c = cast_round(dg_c)
+        dg_c += (dq_state * q_b).sum(dim=-1)
+        dg_c = cast_round(dg_c)
+        k_dk_prod = k_b * dk_state
+        dg_c = dg_c - k_dk_prod.sum(dim=-1)
+        dg_last_accum = (h_b * dh_b).sum(dim=(-1, -2)) * torch.exp(g_last)
+        dg_last_accum = dg_last_accum + k_dk_prod.sum(dim=(-1, -2))
+
+        # ---- dg_last_accum 位置修正 + 写回 ----
+        dg_c = dg_c.reshape(N, H, C)
+        dg_last_reshaped = dg_last_accum.reshape(N, H)
+        for i, (ts, tr, _) in enumerate(tails):
+            # 加到 ragged_i - 1（原始最后有效 token），而非 C - 1
+            dg_c[i, :, tr - 1] += dg_last_reshaped[i]
+            # 写回到原始位置 [ts, ts + tr)
+            dg[b_idx, ts:ts + tr, :] = dg_c[i, :, :tr].to(gtype).permute(1, 0)
+
+        # ---- 4. dq/dk intra ----
+        ds = cast_round(ds)
+        dq_intra = cast_round(torch.bmm(ds, k_b))
+        dk_intra = cast_round(torch.bmm(ds.transpose(1, 2), q_b))
+
+        dq_total = dq_state + dq_intra
+        dk_total = dk_state + dk_intra
+
+        # ---- 写回 dq_hv/dk_hv（只写有效长度部分）----
+        dq_total = dq_total.reshape(N, H, C, K)
+        dk_total = dk_total.reshape(N, H, C, K)
+        if datatype == calc_type:
+            for i, (ts, tr, _) in enumerate(tails):
+                dq_hv[b_idx, ts:ts + tr, :, :] = dq_total[i, :, :tr, :].permute(1, 0, 2)
+                dk_hv[b_idx, ts:ts + tr, :, :] = dk_total[i, :, :tr, :].permute(1, 0, 2)
+        else:
+            for i, (ts, tr, _) in enumerate(tails):
+                dq_hv[b_idx, ts:ts + tr, :, :] = dq_total[i, :, :tr, :].to(datatype).permute(1, 0, 2)
+                dk_hv[b_idx, ts:ts + tr, :, :] = dk_total[i, :, :tr, :].to(datatype).permute(1, 0, 2)
+        # 写回 dw（只写有效长度部分）
+        dw_c = dw_c.reshape(N, H, C, K)
+        for i, (ts, tr, _) in enumerate(tails):
+            dw[b_idx, ts:ts + tr, :, :] = (-dw_c[i, :, :tr, :]).permute(1, 0, 2)
+
+
+    # ------------------------------------------------------------------
+    # 合并多个序列的满 chunk 为一次大 batched 调用。
+    # 不同序列的满 chunk token 范围不连续，需要 cat 拼接后统一处理，
+    # 完成后拆分写回到各自的原始位置。
+    # ------------------------------------------------------------------
+    def process_varlen_merged(b_idx: int, full_ranges: list):
+        C = chunk_size
+        H = HV
+        total_N = sum(nf for _, nf, _ in full_ranges)
+
+        # ---- 数据准备：cat 拼接所有序列的满 chunk ----
+        q_cats = [q_ct[b_idx, :, s:s + nf * C, :] for s, nf, _ in full_ranges]
+        k_cats = [k_ct[b_idx, :, s:s + nf * C, :] for s, nf, _ in full_ranges]
+        v_cats = [v_ct[b_idx, :, s:s + nf * C, :] for s, nf, _ in full_ranges]
+        do_cats = [do_ct[b_idx, :, s:s + nf * C, :] for s, nf, _ in full_ranges]
+        dv_cats = [dv_ct[b_idx, :, s:s + nf * C, :] for s, nf, _ in full_ranges]
+        g_cats = [g_ct[b_idx, :, s:s + nf * C] for s, nf, _ in full_ranges]
+        h_cats = [h[b_idx, ho:ho + nf, :, :, :] for _, nf, ho in full_ranges]
+        dh_cats = [dh[b_idx, ho:ho + nf, :, :, :] for _, nf, ho in full_ranges]
+
+        # 拼接后按 chunk 重排
+        # q/k: [HK, total_N*C, K] -> [HK, total_N, C, K] -> [total_N, HK, C, K]
+        q_all = torch.cat(q_cats, dim=1).reshape(HK, total_N, C, K).permute(1, 0, 2, 3)
+        if n_ratio > 1:
+            q_all = q_all.repeat_interleave(n_ratio, dim=1)
+        q_b = q_all.reshape(total_N * H, C, K)
+
+        k_all = torch.cat(k_cats, dim=1).reshape(HK, total_N, C, K).permute(1, 0, 2, 3)
+        if n_ratio > 1:
+            k_all = k_all.repeat_interleave(n_ratio, dim=1)
+        k_b = k_all.reshape(total_N * H, C, K)
+
+        v_b = torch.cat(v_cats, dim=1).reshape(H, total_N, C, V).permute(1, 0, 2, 3).reshape(total_N * H, C, V)
+        do_b = torch.cat(do_cats, dim=1).reshape(H, total_N, C, V).permute(1, 0, 2, 3).reshape(total_N * H, C, V)
+        dv_b = torch.cat(dv_cats, dim=1).reshape(H, total_N, C, V).permute(1, 0, 2, 3).reshape(total_N * H, C, V)
+        g_b = torch.cat(g_cats, dim=1).reshape(H, total_N, C).permute(1, 0, 2).reshape(total_N * H, C)
+
+        h_b = torch.cat(h_cats, dim=0).reshape(total_N * H, K, V)
+        dh_b = torch.cat(dh_cats, dim=0).reshape(total_N * H, K, V)
+        h_b_t = h_b.transpose(-1, -2).to(calc_type)
+        dh_b_t = dh_b.transpose(-1, -2).to(calc_type)
+
+        N = total_N
+
+        # ---- 1. State contributions ----
+        dq_state = cast_round(torch.bmm(do_b, h_b_t))
+        dk_state = cast_round(torch.bmm(v_b, dh_b_t))
+
+        dw_c = cast_round(torch.bmm(dv_b, h_b_t))
+
+        mask_f = get_causal_mask_f(C, q.device)
+
+        # ---- 2. Decay scale ----
+        g_last = g_b.reshape(N, H, C)[:, :, C - 1].reshape(N * H)
+        exp_gc = torch.exp(g_b)
+        exp_neg_gc_glast = torch.exp(-g_b + g_last[:, None])
+        dq_state = dq_state * (exp_gc[:, :, None] * scale)
+        dk_state = dk_state * exp_neg_gc_glast[:, :, None]
+
+        # ---- 3. Intra-chunk attention ----
+        ds = cast_round(torch.bmm(do_b, v_b.transpose(1, 2)))
+        g_diff = g_b[:, :, None] - g_b[:, None, :]
+        decay_mat = torch.clamp(g_diff, max=0).exp_()
+        ds = ds * decay_mat
+        ds = ds * mask_f
+        ds = ds * scale
+
+        qk_t = cast_round(torch.bmm(q_b, k_b.transpose(1, 2)))
+        ds2 = ds * qk_t
+        dg_c = ds2.sum(dim=-1)
+        dg_c = dg_c - ds2.sum(dim=-2)
+
+        # ---- dg_state ----
+        dg_c = cast_round(dg_c)
+        dg_c += (dq_state * q_b).sum(dim=-1)
+        dg_c = cast_round(dg_c)
+        k_dk_prod = k_b * dk_state
+        dg_c = dg_c - k_dk_prod.sum(dim=-1)
+        dg_last_accum = (h_b * dh_b).sum(dim=(-1, -2)) * torch.exp(g_last)
+        dg_last_accum = dg_last_accum + k_dk_prod.sum(dim=(-1, -2))
+
+        # ---- dg_last_accum + 写回 dg（按序列拆分）----
+        dg_c = dg_c.reshape(N, H, C)
+        dg_last_reshaped = dg_last_accum.reshape(N, H)
+        dg_c[:, :, C - 1] += dg_last_reshaped
+        # 拆分写回到各自的原始位置
+        offset = 0
+        for s, nf, _ in full_ranges:
+            n_tokens = nf * C
+            dg_chunk = dg_c[offset:offset + nf].to(gtype).permute(0, 2, 1).reshape(n_tokens, H)
+            dg[b_idx, s:s + n_tokens, :] = dg_chunk
+            offset += nf
+
+        # ---- 4. dq/dk intra ----
+        ds = cast_round(ds)
+        dq_intra = cast_round(torch.bmm(ds, k_b))
+        dk_intra = cast_round(torch.bmm(ds.transpose(1, 2), q_b))
+
+        dq_total = dq_state + dq_intra
+        dk_total = dk_state + dk_intra
+
+        # ---- 写回 dq_hv/dk_hv/dw（按序列拆分）----
+        dq_total = dq_total.reshape(N, H, C, K)
+        dk_total = dk_total.reshape(N, H, C, K)
+        dw_c = dw_c.reshape(N, H, C, K)
+        offset = 0
+        for s, nf, _ in full_ranges:
+            n_tokens = nf * C
+            if datatype == calc_type:
+                dq_hv[b_idx, s:s + n_tokens, :, :] = dq_total[offset:offset + nf].permute(0, 2, 1, 3).reshape(n_tokens, H, K)
+                dk_hv[b_idx, s:s + n_tokens, :, :] = dk_total[offset:offset + nf].permute(0, 2, 1, 3).reshape(n_tokens, H, K)
+            else:
+                dq_hv[b_idx, s:s + n_tokens, :, :] = dq_total[offset:offset + nf].to(datatype).permute(0, 2, 1, 3).reshape(n_tokens, H, K)
+                dk_hv[b_idx, s:s + n_tokens, :, :] = dk_total[offset:offset + nf].to(datatype).permute(0, 2, 1, 3).reshape(n_tokens, H, K)
+            dw[b_idx, s:s + n_tokens, :, :] = (-dw_c[offset:offset + nf]).permute(0, 2, 1, 3).reshape(n_tokens, H, K)
+            offset += nf
+
+
+    # Main Loop
+    if cu_seqlens is None:
+        # T 已 padding 到 chunk_size 的整数倍，所有 chunk 统一走 batched 路径
+        for b in range(B):
+            n_full = T // C
+            if n_full > 0:
+                process_dense_batched(b, n_full, 0, 0, ragged_len=ragged_len)
+    else:
+        # Variable length B=1
+        # 计算每个序列的 chunk 起始位置
+        chunk_location_list = [0]
+        seq_infos = []
+        for i in range(len(cu_seqlens) - 1):
+            start = cu_seqlens[i].item()
+            end = cu_seqlens[i+1].item()
+            seq_len = end - start
+            n_chunks = (seq_len + C - 1) // C
+            seq_infos.append((start, seq_len, chunk_location_list[-1]))
+            chunk_location_list.append(chunk_location_list[-1] + n_chunks)
+
+        # Phase 1: 合并所有序列的满 chunk 为一次 batched 调用
+        # 收集每个序列的满 chunk token 范围和 h/dh 偏移
+        full_ranges = []
+        for start, seq_len, h_off in seq_infos:
+            n_full = seq_len // C
+            if n_full > 0:
+                full_ranges.append((start, n_full, h_off))
+
+        if len(full_ranges) == 1:
+            # 只有一个序列有满 chunk，直接调用
+            ts, nf, th = full_ranges[0]
+            process_dense_batched(0, nf, ts, th, ragged_len=0)
+        elif len(full_ranges) > 1:
+            # 合并多个序列的满 chunk 为一次大 batched 调用
+            process_varlen_merged(0, full_ranges)
+
+        # Phase 2: 跨序列批量处理 ragged tails
+        tails = []
+        for start, seq_len, h_off in seq_infos:
+            n_full = seq_len // C
+            ragged = seq_len % C
+            if ragged > 0:
+                tails.append((start + n_full * C, ragged, h_off + n_full))
+
+        if len(tails) == 1:
+            ts, tr, th = tails[0]
+            process_sequence(0, ts, ts + tr, 0, th)
+        elif len(tails) > 1:
+            process_tails_batched(0, tails)
+
+    dq = dq_hv.view(B, T, HK, n_ratio, K).sum(dim=3).to(datatype)
+    dk = dk_hv.view(B, T, HK, n_ratio, K).sum(dim=3).to(datatype)
+
+    # 截断到原始 T（去除 padding 部分）
+    if pad_T > 0:
+        dq = dq[:, :T_orig]
+        dk = dk[:, :T_orig]
+        dw = dw[:, :T_orig]
+        dg = dg[:, :T_orig]
+
+    return dq, dk, dw, dg

--- a/tests/atk/chunk_bwd_dqkwg/scripts/chunk_bwd_dqkwg_gpu.py
+++ b/tests/atk/chunk_bwd_dqkwg/scripts/chunk_bwd_dqkwg_gpu.py
@@ -122,6 +122,20 @@ def chunk_bwd_dqkwg_gpu(
         mmtype = datatype
         print(f"使用 fp32 计算精度，输出精度: {q.dtype}")
 
+    # ------------------------------------------------------------------
+    # 类型转换：与 CPU 标杆完全一致（注意：原 CPU 代码未赋值回变量，
+    # 这里保持同样行为，仅做类型转换调用，不改变原张量）
+    # ------------------------------------------------------------------
+    q = q.to(calc_type)
+    k = k.to(calc_type)
+    v = v.to(calc_type)
+    do = do.to(calc_type)
+    h = h.to(calc_type)
+    dh = dh.to(calc_type)
+    if g is not None:
+        g = g.to(gtype).to(calc_type)
+    dv = dv.to(calc_type)
+
     # 从输入张量推断设备
     device = q.device
 

--- a/tests/atk/chunk_bwd_dqkwg/scripts/chunk_bwd_dqkwg_gpu.py
+++ b/tests/atk/chunk_bwd_dqkwg/scripts/chunk_bwd_dqkwg_gpu.py
@@ -1,0 +1,481 @@
+import torch
+from typing import Tuple, Optional, Union
+
+
+def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
+    return cu_seqlens[1:] - cu_seqlens[:-1]
+
+
+def cdiv(a: torch.LongTensor, b: int):
+    return (a + b - 1) // b
+
+
+def prepare_chunk_indices_torch(
+    cu_seqlens: torch.LongTensor,
+    chunkSize: int
+) -> torch.LongTensor:
+    indices = torch.cat([torch.arange(n) for n in cdiv(prepare_lens(cu_seqlens), chunkSize).tolist()])
+    return torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(cu_seqlens)
+
+
+def prepare_chunk_indices(
+    cu_seqlens: list[int],
+    chunk_size: int
+) -> list[int]:
+    """
+    基于 cu_seqlens (list[int]) 生成 chunk 索引。
+
+    逻辑复刻原代码：
+    1. 计算每个序列的长度: lens[i] = cu_seqlens[i+1] - cu_seqlens[i]
+    2. 计算每个序列需要的 chunk 数: ceil(lens[i] / chunk_size)
+    3. 生成对应的 (sequence_id, chunk_id) 对
+    """
+    indices = []
+    for i in range(len(cu_seqlens) - 1):
+        start = cu_seqlens[i]
+        end = cu_seqlens[i + 1]
+        length = end - start
+        if length <= 0:
+            continue
+        num_chunks = (length + chunk_size - 1) // chunk_size
+        for chunk_id in range(num_chunks):
+            indices.append(i)
+            indices.append(chunk_id)
+    return indices
+
+
+def select_gpu_device(device_id: int = 0) -> torch.device:
+    """选择 GPU 设备，返回 torch.device 对象。"""
+    if not torch.cuda.is_available():
+        raise RuntimeError("GPU (CUDA) 不可用，无法执行 GPU 标杆计算")
+    device = torch.device(f'cuda:{device_id}')
+    print(f"已选择 GPU 设备: {torch.cuda.get_device_name(device_id)} (cuda:{device_id})")
+    return device
+
+
+def chunk_bwd_dqkwg_gpu(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    do: torch.Tensor,
+    h: torch.Tensor,
+    dh: torch.Tensor,
+    w: Optional[torch.Tensor],
+    g: Optional[torch.Tensor],
+    dv: torch.Tensor,
+    scale: float,
+    cu_seqlens: Optional[torch.LongTensor],
+    chunk_size: int = 64,
+    fp64: bool = False,
+    device: Optional[Union[int, str, torch.device]] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """
+    GPU 版本的 chunk_bwd_kernel_dqkwg 标杆实现。
+    使用 GPU 小算子（matmul、exp、where 等）拼接完成完整计算。
+
+    参数:
+        fp64:   当为 True 时使用 fp64 精度小算子拼接；
+                当为 False 时使用与输入数据相同精度的小算子拼接。
+        device: GPU 设备，可传入 int（设备号）、str（如 'cuda:0'）或 torch.device；
+                为 None 时自动选择 cuda:0。
+    """
+    # ------------------------------------------------------------------
+    # GPU 设备选择
+    # ------------------------------------------------------------------
+    if device is None:
+        device = select_gpu_device(0)
+    elif isinstance(device, int):
+        device = select_gpu_device(device)
+    elif isinstance(device, str):
+        device = torch.device(device)
+        if device.type != 'cuda':
+            raise RuntimeError(f"设备类型必须为 cuda，当前为 {device.type}")
+        print(f"已选择 GPU 设备: {device}")
+    elif isinstance(device, torch.device):
+        if device.type != 'cuda':
+            raise RuntimeError(f"设备类型必须为 cuda，当前为 {device.type}")
+        print(f"已选择 GPU 设备: {device}")
+    else:
+        raise RuntimeError(f"不支持的 device 参数类型: {type(device)}")
+
+    # ------------------------------------------------------------------
+    # 将输入张量移动到 GPU
+    # ------------------------------------------------------------------
+    q = q.to(device)
+    k = k.to(device)
+    v = v.to(device)
+    do = do.to(device)
+    h = h.to(device)
+    dh = dh.to(device)
+    if w is not None:
+        w = w.to(device)
+    if g is not None:
+        g = g.to(device)
+    dv = dv.to(device)
+    if cu_seqlens is not None:
+        if isinstance(cu_seqlens, (list, tuple)):
+            cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int64, device=device)
+        else:
+            cu_seqlens = cu_seqlens.to(device)
+
+    # ------------------------------------------------------------------
+    # 精度设置：fp64 控制计算精度
+    # ------------------------------------------------------------------
+    if fp64:
+        calc_type = torch.float64
+        datatype = torch.float64
+        gtype = torch.float64
+        mmtype = torch.float64
+        print("使用 fp64 精度小算子进行拼接")
+    else:
+        calc_type = q.dtype
+        datatype = q.dtype
+        gtype = g.dtype if g is not None else q.dtype
+        mmtype = datatype
+        print(f"使用输入数据精度小算子进行拼接: {q.dtype}")
+
+    B, T, HK, K = q.shape
+    HV = v.shape[2]
+    V = v.shape[-1]
+    if HK <= 0 or HV <= 0 or HV % HK != 0:
+        raise ValueError(f"GVA 要求 HV 能被 HK 整除，当前 HV={HV}, HK={HK}")
+    n_ratio = HV // HK
+
+    g_gamma = None
+
+    # 初始化输出张量（在 GPU 上分配）
+    dq_hv = torch.zeros((B, T, HV, K), dtype=datatype, device=device)
+    dk_hv = torch.zeros((B, T, HV, K), dtype=datatype, device=device)
+    dg = torch.zeros_like(g) if g is not None else None
+    dw = torch.zeros((B, T, HV, K), dtype=datatype, device=device)
+    w = torch.zeros((B, T, HV, K), dtype=datatype, device=device)
+
+    # ------------------------------------------------------------------
+    # 辅助函数：处理单个序列的逻辑（与 CPU 版本完全一致的算法，运行在 GPU 上）
+    # ------------------------------------------------------------------
+    def process_sequence(b_idx, t_start, t_end, seq_idx_in_batch, chunk_start_idx):
+        seq_len = t_end - t_start
+        num_chunks = (seq_len + chunk_size - 1) // chunk_size
+
+        for h_idx in range(HV):
+            hk_idx = h_idx // n_ratio
+            gamma_val = None
+            if g_gamma is not None:
+                gamma_val = g_gamma[h_idx].item()
+
+            for i_t in range(num_chunks):
+                chunk_start_token_idx = t_start + i_t * chunk_size
+                chunk_end_token_idx = min(t_start + (i_t + 1) * chunk_size, t_end)
+                actual_chunk_len = chunk_end_token_idx - chunk_start_token_idx
+
+                # 切片当前块的数据
+                q_c = q[b_idx, chunk_start_token_idx:chunk_end_token_idx, hk_idx, :]  # [BT, K]
+                k_c = k[b_idx, chunk_start_token_idx:chunk_end_token_idx, hk_idx, :]  # [BT, K]
+
+                v_c = v[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :]  # [BT, V]
+                do_c = do[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :]  # [BT, V]
+
+                h_prev = h[b_idx, i_t + chunk_start_idx, h_idx, :, :]  # [K, V]
+                dh_curr = dh[b_idx, i_t + chunk_start_idx, h_idx, :, :]  # [K, V]
+
+                # -----------------------------------------------------------
+                # 1. State Contributions (Inter-chunk)
+                # -----------------------------------------------------------
+                dq_from_state = do_c.to(calc_type).to(mmtype) @ h_prev.transpose(-1, -2).to(calc_type).to(mmtype)
+                dq_from_state = dq_from_state.to(datatype).to(calc_type)
+
+                dk_from_state = v_c.to(calc_type).to(mmtype) @ dh_curr.transpose(-1, -2).to(calc_type).to(mmtype)
+                dk_from_state = dk_from_state.to(datatype).to(calc_type)
+
+                if w is not None and dv is not None:
+                    dv_c = dv[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :]  # [BT, V]
+                    dw_c_val = dv_c.to(calc_type).to(mmtype) @ h_prev.transpose(-1, -2).to(calc_type).to(mmtype)
+                    dw_c_val = dw_c_val.to(datatype).to(calc_type)
+                    dw[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = -dw_c_val
+
+                # -----------------------------------------------------------
+                # 2. Gating / Decay Logic Preparation
+                # -----------------------------------------------------------
+                if g is not None:
+                    g_c = g[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx]  # [BT]
+                    g_last = g[b_idx, min(chunk_start_token_idx + chunk_size, t_end) - 1, h_idx]
+
+                    dg_last_accum = (h_prev * dh_curr).sum()
+                    dg_last_accum = dg_last_accum * torch.exp(g_last)
+
+                    dq_from_state = dq_from_state * torch.exp(g_c)[:, None] * scale
+                    dk_from_state = dk_from_state * torch.exp(-g_c + g_last)[:, None]
+
+                    dg_c = (dq_from_state * q_c).sum(dim=-1)
+                    dg_c = dg_c.to(datatype).to(calc_type)
+
+                    dg_c -= (k_c * dk_from_state).sum(dim=-1)
+                    dg_c = dg_c.to(gtype).to(calc_type)
+
+                    dg_last_accum += (dk_from_state * k_c).sum()
+
+                elif g_gamma is not None:
+                    arange = torch.arange(actual_chunk_len, device=device, dtype=q.dtype)
+                    g_c = gamma_val * (arange + 1)
+                    g_last = gamma_val * actual_chunk_len
+
+                    dq_from_state = dq_from_state * torch.exp(g_c)[:, None] * scale
+                    dk_from_state = dk_from_state * torch.exp(-g_c + g_last)[:, None]
+                else:
+                    dk_from_state = dk_from_state * scale
+                    dq_from_state = dq_from_state * scale
+
+                # -----------------------------------------------------------
+                # 3. Intra-chunk Attention
+                # -----------------------------------------------------------
+                ds = do_c.to(calc_type).to(mmtype) @ v_c.transpose(-1, -2).to(calc_type).to(mmtype)  # [BT, BT]
+                ds = ds.to(datatype).to(calc_type)
+
+                i_indices = torch.arange(actual_chunk_len, device=device)[:, None]
+                j_indices = torch.arange(actual_chunk_len, device=device)[None, :]
+                mask = i_indices >= j_indices
+
+                if g is not None:
+                    decay_mat = torch.exp(g_c[:, None] - g_c[None, :])
+                    ds = torch.where(mask, ds * decay_mat, torch.zeros_like(ds)) * scale
+
+                    qk_t = q_c.to(calc_type).to(mmtype) @ k_c.transpose(-1, -2).to(calc_type).to(mmtype)
+                    qk_t = qk_t.to(datatype).to(calc_type)
+
+                    ds2 = ds * qk_t
+
+                    dg_c += ds2.sum(dim=1)
+                    dg_c = dg_c.to(gtype).to(calc_type)
+                    dg_c -= ds2.sum(dim=0)
+
+                    dg_c = dg_c.to(gtype)
+
+                    if actual_chunk_len > 0:
+                        dg_c[actual_chunk_len - 1] += dg_last_accum.to(gtype)
+
+                    dg[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx] = dg_c
+
+                elif g_gamma is not None:
+                    decay_mat = torch.exp(g_c[:, None] - g_c[None, :])
+                    ds = torch.where(mask, ds * decay_mat, torch.zeros_like(ds)) * scale
+
+                else:
+                    ds = torch.where(mask, ds, torch.zeros_like(ds))
+
+                # -----------------------------------------------------------
+                # 4. Final Accumulation for dq, dk
+                # -----------------------------------------------------------
+                dq_intra = ds.to(calc_type).to(mmtype) @ k_c.to(calc_type).to(mmtype)
+                dq_intra = dq_intra.to(datatype).to(calc_type)
+
+                dk_intra = ds.transpose(-1, -2).to(calc_type).to(mmtype) @ q_c.to(calc_type).to(mmtype)
+                dk_intra = dk_intra.to(datatype).to(calc_type)
+
+                if g is None and g_gamma is None:
+                    dk_intra = dk_intra * scale
+                    dq_total = (dq_from_state + dq_intra) * scale
+                    dk_total = dk_from_state + dk_intra
+                else:
+                    dq_total = dq_from_state + dq_intra
+                    dk_total = dk_from_state + dk_intra
+
+                dq_hv[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dq_total.to(datatype)
+                dk_hv[b_idx, chunk_start_token_idx:chunk_end_token_idx, h_idx, :] = dk_total.to(datatype)
+
+    # ------------------------------------------------------------------
+    # Main Loop
+    # ------------------------------------------------------------------
+    if cu_seqlens is None:
+        for b in range(B):
+            process_sequence(b, 0, T, b, 0)
+    else:
+        chunk_location = torch.zeros(cu_seqlens.shape[0], dtype=torch.int64, device=device)
+
+        for i in range(len(cu_seqlens) - 1):
+            start, end = cu_seqlens[i].item(), cu_seqlens[i + 1].item()
+            seq_length = end - start
+            if i == 0:
+                chunk_start_token_idx = 0
+            else:
+                chunk_start_token_idx = chunk_location[i]
+            chunk_end_token_idx = chunk_start_token_idx + (seq_length + chunk_size - 1) // chunk_size
+            chunk_location[i + 1] = chunk_end_token_idx
+
+            if B == 1:
+                process_sequence(0, start, end, i, chunk_location[i])
+            else:
+                pass
+
+    dq = dq_hv.view(B, T, HK, n_ratio, K).sum(dim=3).to(datatype)
+    dk = dk_hv.view(B, T, HK, n_ratio, K).sum(dim=3).to(datatype)
+
+    return dq, dk, dw, dg
+
+
+def chunk_bwd_dqkwg_gpu_torch(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    do: torch.Tensor,
+    h: torch.Tensor,
+    dh: torch.Tensor,
+    w: Optional[torch.Tensor],
+    g: Optional[torch.Tensor],
+    dv: torch.Tensor,
+    scale: Optional[float],
+    cu_seqlens: Optional[torch.LongTensor],
+    chunk_size: int = 64,
+    fp64: bool = False,
+    device: Optional[Union[int, str, torch.device]] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """
+    带转置的 GPU 标杆包装函数。
+    输入张量布局与 executor 一致：
+        q, k: [B, HK, T, K]；v, do, dv: [B, HV, T, V]
+        g: [B, HV, T]；h, dh: [B, HV, num_chunks, K, V]；w: [B, HV, T, K]
+    输出张量布局：
+        dq, dk: [B, HK, T, K]；dw: [B, HV, T, K]；dg: [B, HV, T]
+    """
+    q_t = q.transpose(1, 2).contiguous()
+    k_t = k.transpose(1, 2).contiguous()
+    v_t = v.transpose(1, 2).contiguous()
+    do_t = do.transpose(1, 2).contiguous()
+    dv_t = dv.transpose(1, 2).contiguous()
+    g_t = g.transpose(1, 2).contiguous() if g is not None else None
+    w_t = w.transpose(1, 2).contiguous() if w is not None else None
+    h_t = h.permute(0, 2, 1, 3, 4).contiguous()
+    dh_t = dh.permute(0, 2, 1, 3, 4).contiguous()
+
+    cu_seqlens_tensor = torch.tensor(cu_seqlens, dtype=torch.int64) if cu_seqlens is not None else None
+
+    dq, dk, dw, dg = chunk_bwd_dqkwg_gpu(
+        q_t, k_t, v_t, do_t, h_t, dh_t, w_t, g_t, dv_t, scale, cu_seqlens_tensor, chunk_size,
+        fp64=fp64, device=device
+    )
+
+    dq = dq.transpose(1, 2).contiguous()
+    dk = dk.transpose(1, 2).contiguous()
+    dw = dw.transpose(1, 2).contiguous()
+    if dg is not None:
+        dg = dg.transpose(1, 2).contiguous()
+
+    return dq, dk, dw, dg
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("chunk_bwd_dqkwg GPU 标杆实现测试")
+    print("=" * 60)
+
+    # ----------------------------------------------------------
+    # 测试参数配置
+    # ----------------------------------------------------------
+    B = 1
+    HK = 4
+    T = 128
+    K = 128
+    V = 128
+    HV = 4       # n_ratio = HV // HK = 1
+    chunk_size = 64
+    scale = 1.0 / (K ** 0.5)
+
+    qkv_dtype = torch.bfloat16
+    g_dtype = torch.float32   # is_mix=True 时 g 使用 fp32
+
+    num_chunks = (T + chunk_size - 1) // chunk_size
+
+    print(f"\n测试配置:")
+    print(f"  B={B}, HK={HK}, HV={HV}, T={T}, K={K}, V={V}")
+    print(f"  chunk_size={chunk_size}, num_chunks={num_chunks}")
+    print(f"  qkv 精度={qkv_dtype}, g 精度={g_dtype}")
+    print(f"  scale={scale:.6f}")
+
+    # ----------------------------------------------------------
+    # 生成测试数据
+    # 布局与 executor 一致：
+    #   q, k: [B, HK, T, K]
+    #   v, do, dv: [B, HV, T, V]
+    #   g: [B, HV, T]
+    #   h, dh: [B, HV, num_chunks, K, V]
+    #   w: [B, HV, T, K]
+    # ----------------------------------------------------------
+    torch.manual_seed(42)
+
+    q = torch.rand((B, HK, T, K), dtype=qkv_dtype)
+    k = torch.rand((B, HK, T, K), dtype=qkv_dtype)
+    v = torch.rand((B, HV, T, V), dtype=qkv_dtype)
+    do = torch.rand((B, HV, T, V), dtype=qkv_dtype)
+    dv = torch.rand((B, HV, T, V), dtype=qkv_dtype)
+    w = torch.rand((B, HV, T, K), dtype=qkv_dtype)
+    h = torch.rand((B, HV, num_chunks, K, V), dtype=qkv_dtype)
+    dh = torch.rand((B, HV, num_chunks, K, V), dtype=qkv_dtype)
+
+    # g 必须递减且为负数
+    g = -torch.sort(torch.rand(B * T * HV) * 10, descending=False)[0].reshape((B, HV, T)).to(g_dtype)
+
+    cu_seqlens = None   # is_fix=True，定长模式
+
+    # ----------------------------------------------------------
+    # 测试 1: fp64=False（使用输入数据精度小算子拼接）
+    # ----------------------------------------------------------
+    print("\n" + "-" * 40)
+    print("测试 1: fp64=False（使用输入数据精度）")
+    print("-" * 40)
+
+    dq1, dk1, dw1, dg1 = chunk_bwd_dqkwg_gpu_torch(
+        q, k, v, do, h, dh, w, g, dv, scale, cu_seqlens, chunk_size,
+        fp64=False
+    )
+
+    print(f"  dq 形状: {tuple(dq1.shape)}, 精度: {dq1.dtype}")
+    print(f"  dk 形状: {tuple(dk1.shape)}, 精度: {dk1.dtype}")
+    print(f"  dw 形状: {tuple(dw1.shape)}, 精度: {dw1.dtype}")
+    print(f"  dg 形状: {tuple(dg1.shape)}, 精度: {dg1.dtype}")
+    print(f"  dq 数值范围: [{dq1.float().min().item():.6f}, {dq1.float().max().item():.6f}]")
+    print(f"  dk 数值范围: [{dk1.float().min().item():.6f}, {dk1.float().max().item():.6f}]")
+    print(f"  dw 数值范围: [{dw1.float().min().item():.6f}, {dw1.float().max().item():.6f}]")
+    print(f"  dg 数值范围: [{dg1.float().min().item():.6f}, {dg1.float().max().item():.6f}]")
+    print("  测试 1 完成")
+
+    # ----------------------------------------------------------
+    # 测试 2: fp64=True（使用 fp64 精度小算子拼接）
+    # ----------------------------------------------------------
+    print("\n" + "-" * 40)
+    print("测试 2: fp64=True（使用 fp64 精度）")
+    print("-" * 40)
+
+    dq2, dk2, dw2, dg2 = chunk_bwd_dqkwg_gpu_torch(
+        q, k, v, do, h, dh, w, g, dv, scale, cu_seqlens, chunk_size,
+        fp64=True
+    )
+
+    print(f"  dq 形状: {tuple(dq2.shape)}, 精度: {dq2.dtype}")
+    print(f"  dk 形状: {tuple(dk2.shape)}, 精度: {dk2.dtype}")
+    print(f"  dw 形状: {tuple(dw2.shape)}, 精度: {dw2.dtype}")
+    print(f"  dg 形状: {tuple(dg2.shape)}, 精度: {dg2.dtype}")
+    print(f"  dq 数值范围: [{dq2.min().item():.6f}, {dq2.max().item():.6f}]")
+    print(f"  dk 数值范围: [{dk2.min().item():.6f}, {dk2.max().item():.6f}]")
+    print(f"  dw 数值范围: [{dw2.min().item():.6f}, {dw2.max().item():.6f}]")
+    print(f"  dg 数值范围: [{dg2.min().item():.6f}, {dg2.max().item():.6f}]")
+    print("  测试 2 完成")
+
+    # ----------------------------------------------------------
+    # 精度对比
+    # ----------------------------------------------------------
+    print("\n" + "-" * 40)
+    print("精度对比: fp64=False vs fp64=True")
+    print("-" * 40)
+
+    dq_diff = (dq1.float() - dq2.float()).abs()
+    dk_diff = (dk1.float() - dk2.float()).abs()
+    dw_diff = (dw1.float() - dw2.float()).abs()
+    dg_diff = (dg1.float() - dg2.float()).abs()
+
+    print(f"  dq 最大绝对差异: {dq_diff.max().item():.8f}")
+    print(f"  dk 最大绝对差异: {dk_diff.max().item():.8f}")
+    print(f"  dw 最大绝对差异: {dw_diff.max().item():.8f}")
+    print(f"  dg 最大绝对差异: {dg_diff.max().item():.8f}")
+
+    print("\n" + "=" * 60)
+    print("所有测试完成")
+    print("=" * 60)

--- a/tests/atk/chunk_bwd_dqkwg/scripts/chunk_bwd_dqkwg_gpu.py
+++ b/tests/atk/chunk_bwd_dqkwg/scripts/chunk_bwd_dqkwg_gpu.py
@@ -53,54 +53,11 @@ def select_gpu_device(device_id: int = 0) -> torch.device:
     return device
 
 
-def chunk_bwd_dqkwg_gpu(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    do: torch.Tensor,
-    h: torch.Tensor,
-    dh: torch.Tensor,
-    w: Optional[torch.Tensor],
-    g: Optional[torch.Tensor],
-    dv: torch.Tensor,
-    scale: float,
-    cu_seqlens: Optional[torch.LongTensor],
-    chunk_size: int = 64,
-    fp64: bool = False,
-    device: Optional[Union[int, str, torch.device]] = None,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-    """
-    GPU 版本的 chunk_bwd_kernel_dqkwg 标杆实现。
-    使用 GPU 小算子（matmul、exp、where 等）拼接完成完整计算。
-
-    参数:
-        fp64:   当为 True 时使用 fp64 精度小算子拼接；
-                当为 False 时使用与输入数据相同精度的小算子拼接。
-        device: GPU 设备，可传入 int（设备号）、str（如 'cuda:0'）或 torch.device；
-                为 None 时自动选择 cuda:0。
-    """
-    # ------------------------------------------------------------------
-    # GPU 设备选择
-    # ------------------------------------------------------------------
-    if device is None:
-        device = select_gpu_device(0)
-    elif isinstance(device, int):
-        device = select_gpu_device(device)
-    elif isinstance(device, str):
-        device = torch.device(device)
-        if device.type != 'cuda':
-            raise RuntimeError(f"设备类型必须为 cuda，当前为 {device.type}")
-        print(f"已选择 GPU 设备: {device}")
-    elif isinstance(device, torch.device):
-        if device.type != 'cuda':
-            raise RuntimeError(f"设备类型必须为 cuda，当前为 {device.type}")
-        print(f"已选择 GPU 设备: {device}")
-    else:
-        raise RuntimeError(f"不支持的 device 参数类型: {type(device)}")
-
-    # ------------------------------------------------------------------
-    # 将输入张量移动到 GPU
-    # ------------------------------------------------------------------
+def move_tensors_to_device(
+    q, k, v, do, h, dh, w, g, dv, cu_seqlens,
+    device: torch.device
+):
+    """将所有输入张量移动到指定设备。"""
     q = q.to(device)
     k = k.to(device)
     v = v.to(device)
@@ -117,9 +74,40 @@ def chunk_bwd_dqkwg_gpu(
             cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int64, device=device)
         else:
             cu_seqlens = cu_seqlens.to(device)
+    return q, k, v, do, h, dh, w, g, dv, cu_seqlens
 
+
+def chunk_bwd_dqkwg_gpu(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    do: torch.Tensor,
+    h: torch.Tensor,
+    dh: torch.Tensor,
+    w: Optional[torch.Tensor],
+    g: Optional[torch.Tensor],
+    dv: torch.Tensor,
+    scale: float,
+    cu_seqlens: Optional[torch.LongTensor],
+    chunk_size: int = 64,
+    fp64: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """
+    GPU 版本的 chunk_bwd_kernel_dqkwg 标杆实现。
+    使用 GPU 小算子（matmul、exp、where 等）拼接完成完整计算。
+
+    调用者需事先将所有输入张量移动到 GPU 设备上。
+    本函数从输入张量推断设备，不再做设备选择或数据搬运。
+
+    参数:
+        fp64:   当为 True 时使用 fp64 精度小算子拼接；
+                当为 False 时 calc_type 使用 fp32（与 CPU 标杆一致），
+                输出精度 datatype 与输入精度一致。
+    """
     # ------------------------------------------------------------------
-    # 精度设置：fp64 控制计算精度
+    # 精度设置：与 CPU 标杆完全一致
+    #   fp64=True:  calc_type=datatype=gtype=mmtype=float64
+    #   fp64=False: calc_type=float32, datatype=q.dtype, gtype=g.dtype, mmtype=datatype
     # ------------------------------------------------------------------
     if fp64:
         calc_type = torch.float64
@@ -128,11 +116,14 @@ def chunk_bwd_dqkwg_gpu(
         mmtype = torch.float64
         print("使用 fp64 精度小算子进行拼接")
     else:
-        calc_type = q.dtype
+        calc_type = torch.float32
         datatype = q.dtype
         gtype = g.dtype if g is not None else q.dtype
         mmtype = datatype
-        print(f"使用输入数据精度小算子进行拼接: {q.dtype}")
+        print(f"使用 fp32 计算精度，输出精度: {q.dtype}")
+
+    # 从输入张量推断设备
+    device = q.device
 
     B, T, HK, K = q.shape
     HV = v.shape[2]
@@ -143,7 +134,7 @@ def chunk_bwd_dqkwg_gpu(
 
     g_gamma = None
 
-    # 初始化输出张量（在 GPU 上分配）
+    # 初始化输出张量（在输入设备上分配）
     dq_hv = torch.zeros((B, T, HV, K), dtype=datatype, device=device)
     dk_hv = torch.zeros((B, T, HV, K), dtype=datatype, device=device)
     dg = torch.zeros_like(g) if g is not None else None
@@ -330,12 +321,36 @@ def chunk_bwd_dqkwg_gpu_torch(
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
     """
     带转置的 GPU 标杆包装函数。
+    负责 GPU 设备选择、输入张量搬运、布局转置，然后调用核心计算函数。
+
     输入张量布局与 executor 一致：
         q, k: [B, HK, T, K]；v, do, dv: [B, HV, T, V]
         g: [B, HV, T]；h, dh: [B, HV, num_chunks, K, V]；w: [B, HV, T, K]
     输出张量布局：
         dq, dk: [B, HK, T, K]；dw: [B, HV, T, K]；dg: [B, HV, T]
     """
+    # ------------------------------------------------------------------
+    # GPU 设备选择
+    # ------------------------------------------------------------------
+    if device is None:
+        device = select_gpu_device(0)
+    elif isinstance(device, int):
+        device = select_gpu_device(device)
+    elif isinstance(device, str):
+        device = torch.device(device)
+        if device.type != 'cuda':
+            raise RuntimeError(f"设备类型必须为 cuda，当前为 {device.type}")
+        print(f"已选择 GPU 设备: {device}")
+    elif isinstance(device, torch.device):
+        if device.type != 'cuda':
+            raise RuntimeError(f"设备类型必须为 cuda，当前为 {device.type}")
+        print(f"已选择 GPU 设备: {device}")
+    else:
+        raise RuntimeError(f"不支持的 device 参数类型: {type(device)}")
+
+    # ------------------------------------------------------------------
+    # 布局转置
+    # ------------------------------------------------------------------
     q_t = q.transpose(1, 2).contiguous()
     k_t = k.transpose(1, 2).contiguous()
     v_t = v.transpose(1, 2).contiguous()
@@ -348,9 +363,19 @@ def chunk_bwd_dqkwg_gpu_torch(
 
     cu_seqlens_tensor = torch.tensor(cu_seqlens, dtype=torch.int64) if cu_seqlens is not None else None
 
+    # ------------------------------------------------------------------
+    # 将所有张量移动到 GPU
+    # ------------------------------------------------------------------
+    q_t, k_t, v_t, do_t, h_t, dh_t, w_t, g_t, dv_t, cu_seqlens_tensor = move_tensors_to_device(
+        q_t, k_t, v_t, do_t, h_t, dh_t, w_t, g_t, dv_t, cu_seqlens_tensor, device
+    )
+
+    # ------------------------------------------------------------------
+    # 调用核心计算函数（输入已在 GPU 上）
+    # ------------------------------------------------------------------
     dq, dk, dw, dg = chunk_bwd_dqkwg_gpu(
         q_t, k_t, v_t, do_t, h_t, dh_t, w_t, g_t, dv_t, scale, cu_seqlens_tensor, chunk_size,
-        fp64=fp64, device=device
+        fp64=fp64
     )
 
     dq = dq.transpose(1, 2).contiguous()
@@ -416,10 +441,10 @@ if __name__ == "__main__":
     cu_seqlens = None   # is_fix=True，定长模式
 
     # ----------------------------------------------------------
-    # 测试 1: fp64=False（使用输入数据精度小算子拼接）
+    # 测试 1: fp64=False（calc_type=fp32，与 CPU 标杆一致）
     # ----------------------------------------------------------
     print("\n" + "-" * 40)
-    print("测试 1: fp64=False（使用输入数据精度）")
+    print("测试 1: fp64=False（calc_type=fp32）")
     print("-" * 40)
 
     dq1, dk1, dw1, dg1 = chunk_bwd_dqkwg_gpu_torch(

--- a/tests/atk/chunk_kda_fwd/README.md
+++ b/tests/atk/chunk_kda_fwd/README.md
@@ -77,10 +77,10 @@ atk node --name npu_dut --backend npu --devices 0 \
 使用 CPU 同精度对照、CPU Torch FP64 golden 和 ATK
 `cv_fused_double_benchmark` 原生标准执行 48 条矩阵：
 
-| 产品 | 结果 | 结论 |
-| --- | --- | --- |
-| A5 | 48/48 执行成功，48/48 精度通过 | `acc_pass_result: Pass` |
-| A2 | 48/48 执行成功，37/48 精度通过 | `acc_pass_result: Failed` |
+| 产品 | 结果                           | 结论                        |
+| ---- | ------------------------------ | --------------------------- |
+| A5   | 48/48 执行成功，48/48 精度通过 | `acc_pass_result: Pass`   |
+| A2   | 48/48 执行成功，37/48 精度通过 | `acc_pass_result: Failed` |
 
 A2 的 single、balanced8、short64 共 36 条全部通过。mixed-tail 中，1K、1.5K、
 2K、4K、8K 的两个 `disable_recompute` 分支共 10 条均出现 NPU NaN/Inf；16K
@@ -351,15 +351,15 @@ python ./stress_npu_determinism.py \
 
 ## 10. 常见失败
 
-| 现象 | 原因与处理 |
-| --- | --- |
-| NPU 报 `No module named 'fla_npu'` | A5 的 `PYTHONPATH` 未包含 `torch_custom/fla_npu`，或当前 OPP/Python 包不是同一提交。按第 6 节重新加载。 |
-| GPU 返回 `input.bin is not exists` / HTTP 404 | 远端节点看不到 A5 本地数据。确认任务带 `--syc_dataset`，两端 output path 可写，server 未切换工作目录。 |
-| A5 进程尝试调用 CUDA，报 `_cuda_setDevice` | 分布式任务误加了 `-sp`，GPU node 被当成本地 backend 执行。移除 `-sp`，使用 `-mt 1`。 |
-| ATK 版本相同但 executor 行为不同 | 版本一致不等于测试资产一致。比较第 7 节四个文件的 SHA256。 |
-| GPU FP64 真值 OOM | 物理 GPU 6 未空闲或存在其他容器/进程。先释放资源；H96 长序列保持 `-mt 1`。 |
-| 设备号不可用 | 物理设备经 `ASCEND_RT_VISIBLE_DEVICES`、`CUDA_VISIBLE_DEVICES` 或 Docker 映射后会重新编号；ATK 使用映射后的逻辑编号。 |
-| 能连接端口但任务立即失败 | 检查 GPU server 启动终端中的 Python traceback、CUDA Torch/Triton 导入和 callable 签名；发起端的 404 只是远端失败的包装。 |
+| 现象                                           | 原因与处理                                                                                                               |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| NPU 报`No module named 'fla_npu'`            | A5 的`PYTHONPATH` 未包含 `torch_custom/fla_npu`，或当前 OPP/Python 包不是同一提交。按第 6 节重新加载。               |
+| GPU 返回`input.bin is not exists` / HTTP 404 | 远端节点看不到 A5 本地数据。确认任务带`--syc_dataset`，两端 output path 可写，server 未切换工作目录。                  |
+| A5 进程尝试调用 CUDA，报`_cuda_setDevice`    | 分布式任务误加了`-sp`，GPU node 被当成本地 backend 执行。移除 `-sp`，使用 `-mt 1`。                                |
+| ATK 版本相同但 executor 行为不同               | 版本一致不等于测试资产一致。比较第 7 节四个文件的 SHA256。                                                               |
+| GPU FP64 真值 OOM                              | 物理 GPU 6 未空闲或存在其他容器/进程。先释放资源；H96 长序列保持`-mt 1`。                                              |
+| 设备号不可用                                   | 物理设备经`ASCEND_RT_VISIBLE_DEVICES`、`CUDA_VISIBLE_DEVICES` 或 Docker 映射后会重新编号；ATK 使用映射后的逻辑编号。 |
+| 能连接端口但任务立即失败                       | 检查 GPU server 启动终端中的 Python traceback、CUDA Torch/Triton 导入和 callable 签名；发起端的 404 只是远端失败的包装。 |
 
 结果归档和公开 PR/issue 只记录测试项、case 范围、通过/失败结论和必要的非敏感错误摘要，
 不得记录服务器地址、账号、绝对路径、容器名、token 或内部日志路径。

--- a/tests/atk/common/check_atk_result.py
+++ b/tests/atk/common/check_atk_result.py
@@ -38,6 +38,11 @@ def _find_accuracy_reports(output_root, op):
     return _find_xlsx_files(output_root, f"cpu_dual_reference/atk_output/atk_{op}_*")
 
 
+def _find_accuracy_gpu_reports(output_root, op):
+    """accuracy_gpu 报告在 gpu_dual_reference/atk_output/atk_<op>_* 下。"""
+    return _find_xlsx_files(output_root, f"gpu_dual_reference/atk_output/atk_{op}_*")
+
+
 def _find_root_reports(output_root, op):
     """determinism 和 mssanitizer 报告共享 atk_<op>_* 目录。"""
     return _find_xlsx_files(output_root, f"atk_{op}_*")
@@ -184,11 +189,27 @@ def _extract_summary_row(header, data_rows):
 # ---------------------------------------------------------------------------
 
 def check_accuracy(output_root, op):
-    """检查 accuracy 报告。"""
+    """检查 accuracy（CPU 标杆）报告。"""
     files = _find_accuracy_reports(output_root, op)
     if not files:
         return {"found": False, "total": 0, "pass": 0, "fail": 0, "all_pass": False,
                 "xlsx": None, "detail": "未找到 accuracy 报告"}
+    xlsx = files[-1]
+    header, data = _parse_summary(xlsx)
+    if header is None:
+        return {"found": True, "total": 0, "pass": 0, "fail": 0, "all_pass": False,
+                "xlsx": xlsx, "detail": "无法解析 summary sheet"}
+    info = _extract_summary_row(header, data)
+    return {"found": True, **info, "xlsx": xlsx,
+            "detail": f"通过率={info['pass_rate']}"}
+
+
+def check_accuracy_gpu(output_root, op):
+    """检查 accuracy_gpu（GPU 标杆）报告。"""
+    files = _find_accuracy_gpu_reports(output_root, op)
+    if not files:
+        return {"found": False, "total": 0, "pass": 0, "fail": 0, "all_pass": False,
+                "xlsx": None, "detail": "未找到 accuracy_gpu 报告"}
     xlsx = files[-1]
     header, data = _parse_summary(xlsx)
     if header is None:
@@ -230,12 +251,16 @@ def check_mssanitizer(output_root, op):
 
 CHECKERS = {
     "accuracy": check_accuracy,
+    "accuracy_cpu": check_accuracy,
+    "accuracy_gpu": check_accuracy_gpu,
     "determinism": check_determinism,
     "mssanitizer": check_mssanitizer,
 }
 
 TYPE_LABELS = {
     "accuracy": "精度",
+    "accuracy_cpu": "CPU精度",
+    "accuracy_gpu": "GPU精度",
     "determinism": "确定性",
     "mssanitizer": "内存检测",
 }

--- a/tests/atk/common/cron.py
+++ b/tests/atk/common/cron.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+"""融合定时脚本：仅在 NPU 侧运行，通过 SSH 驱动 GPU 侧 start/npu/stop 全流程。
+
+取代原来需要分别在 GPU/NPU 两台机器各跑一个 cron（cron_gpu.py + cron_npu.py）
+的双脚本方案。本脚本只在 NPU 机器运行，通过 SSH 远程驱动 GPU 侧：
+
+  1. NPU 本地：激活 conda → 设置代理 → clone 仓库 → unset 代理 → build wheel + install
+  2. SSH 到 GPU：clone 仓库（启用代理，clone 完成后 unset）
+  3. ping GPU IP，不通直接报错退出
+  4. 逐算子循环：
+     a. SSH 后台启动 gpu_server_start（nohup ... &，SSH 立即返回）
+     b. NPU 轮询 GPU server 端口可达
+     c. NPU 本地设置 PYTHONHOME / ASCEND_CUSTOM_OPP_PATH 后执行 action=npu 跑精度对拍
+     d. SSH 到 GPU 执行 gpu_server_stop（杀掉容器，后台 start 进程随之退出）
+
+前置条件：
+  - NPU 机器可通过 SSH 免密登录 GPU 机器（ssh-keygen / ssh-copy-id）
+  - NPU 机器已安装 conda、已配置 CANN 环境（source set_env.sh）
+  - GPU 机器已安装 docker，且 NPU 的 SSH 用户有 docker 权限
+
+用法示例：
+  python3 tests/atk/common/cron.py \
+      --conda-env jisihuai \
+      --clone-dir /data/cron/fla \
+      --http-proxy http://127.0.0.1:7890 \
+      --gpu-host 141.61.21.62 \
+      --gpu-host-port 9090 \
+      --gpu-ssh-user root \
+      --gpu-ssh-password 'secret123' \
+      --gpu-clone-dir /data/cron/fla \
+      --gpu-image pytorch/pytorch:2.3.0-cuda12.1-cudnn8-devel \
+      --gpu-repo-root /workspace/flash-linear-attention-npu
+
+  # 用私钥认证
+  python3 tests/atk/common/cron.py ... --gpu-ssh-key ~/.ssh/id_rsa
+  # 用默认免密（agent/keychain/known_hosts）
+  python3 tests/atk/common/cron.py ...
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+FLA_REPO = "https://github.com/flashserve/flash-linear-attention-npu.git"
+WORK_TOOL_REPO = "https://gitcode.com/chen-linxin4/work_tool.git"
+WORK_TOOL_BRANCH = "atk-test"
+
+
+def log(msg: str) -> None:
+    print(f"[cron] {msg}", flush=True)
+
+
+def run(cmd: str | list[str], *, check: bool = True, cwd: Path | None = None,
+        env: dict | None = None, timeout: int | None = None,
+        capture: bool = False) -> subprocess.CompletedProcess:
+    """执行命令，统一封装。"""
+    shell = isinstance(cmd, str)
+    log(f"$ {cmd if shell else ' '.join(cmd)}")
+    return subprocess.run(
+        cmd, shell=shell, check=check, cwd=cwd, env=env,
+        timeout=timeout, text=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.STDOUT if capture else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 代理 / 网络检查 / NPU ATK 环境变量
+# ---------------------------------------------------------------------------
+
+def make_proxy_env(env: dict | None, proxy: str) -> dict:
+    """返回带 http_proxy/https_proxy 设置的 env 副本。
+
+    仅用于 git clone 阶段；调用方在 clone 完成后使用未带代理的 env 即可，
+    等效于 `unset http_proxy; unset https_proxy`。
+    """
+    new_env = (env or {}).copy()
+    if proxy:
+        new_env["http_proxy"] = proxy
+        new_env["https_proxy"] = proxy
+        new_env["HTTP_PROXY"] = proxy
+        new_env["HTTPS_PROXY"] = proxy
+        log(f"启用代理: {proxy}")
+    return new_env
+
+
+def ping_host(host: str, count: int = 3, wait: int = 5) -> bool:
+    """ping 主机，返回可达 True/False。"""
+    cmd = ["ping", "-c", str(count), "-W", str(wait), host]
+    log(f"$ {' '.join(cmd)}")
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    except FileNotFoundError:
+        log("ping 命令不存在，跳过连通性检查")
+        return True
+    except subprocess.TimeoutExpired:
+        log(f"ping {host} 超时")
+        return False
+    if result.returncode == 0:
+        log(f"ping {host} 可达")
+        return True
+    log(f"ping {host} 不可达 (rc={result.returncode})")
+    if result.stdout.strip():
+        for ln in result.stdout.strip().splitlines()[-3:]:
+            log(f"  {ln}")
+    if result.stderr.strip():
+        for ln in result.stderr.strip().splitlines()[-3:]:
+            log(f"  {ln}")
+    return False
+
+
+def query_python_paths(env: dict) -> tuple[str, str]:
+    """查询当前 python 的 sys.prefix（PYTHONHOME）与 site-packages 路径。"""
+    py_prefix = run(
+        "python -c 'import sys; print(sys.prefix)'",
+        shell=True, check=True, env=env, capture=True,
+    )
+    pythonhome = py_prefix.stdout.strip()
+    site_pkg = run(
+        "python -c 'import site; print(site.getsitepackages()[0])'",
+        shell=True, check=True, env=env, capture=True,
+    )
+    site_packages = site_pkg.stdout.strip()
+    if not pythonhome or not site_packages:
+        raise RuntimeError(f"无法确定 PYTHONHOME/site-packages: "
+                           f"prefix={pythonhome!r} site={site_packages!r}")
+    log(f"PYTHONHOME: {pythonhome}")
+    log(f"site-packages: {site_packages}")
+    return pythonhome, site_packages
+
+
+def apply_npu_atk_env(env: dict, pythonhome: str, site_packages: str) -> dict:
+    """设置 NPU 精度检查所需的 PYTHONHOME 与 ASCEND_CUSTOM_OPP_PATH。
+
+    等效于：
+      export PYTHONHOME=<conda 环境位置>
+      export ASCEND_CUSTOM_OPP_PATH="<site-packages>/fla_npu/opp/vendors/fla_npu_transformer:${ASCEND_CUSTOM_OPP_PATH:-}"
+    """
+    new_env = env.copy()
+    new_env["PYTHONHOME"] = pythonhome
+    opp_path = f"{site_packages}/fla_npu/opp/vendors/fla_npu_transformer"
+    existing = new_env.get("ASCEND_CUSTOM_OPP_PATH", "")
+    new_env["ASCEND_CUSTOM_OPP_PATH"] = (
+        f"{opp_path}:{existing}" if existing else opp_path
+    )
+    log(f"PYTHONHOME={new_env['PYTHONHOME']}")
+    log(f"ASCEND_CUSTOM_OPP_PATH={new_env['ASCEND_CUSTOM_OPP_PATH']}")
+    return new_env
+
+
+# ---------------------------------------------------------------------------
+# SSH 认证（密码 / 私钥 / 默认免密）
+# ---------------------------------------------------------------------------
+
+def build_ssh_prefix(args: argparse.Namespace) -> list[str]:
+    """返回 SSH 命令前缀（不含 ssh_target 与远程命令部分）。
+
+    三选一：
+      - --gpu-ssh-password 指定：通过 sshpass 传密码，强制 password 认证、禁用 pubkey
+      - --gpu-ssh-key 指定：通过 -i 指定私钥，加 IdentitiesOnly=yes 避免 agent 干扰
+      - 都不传：走默认免密（agent/keychain/known_hosts）
+
+    使用密码时会校验 sshpass 是否安装；缺失则给出安装提示并报错。
+    """
+    if args.gpu_ssh_password:
+        if not shutil.which("sshpass"):
+            raise RuntimeError(
+                "使用 --gpu-ssh-password 需要安装 sshpass；"
+                "Ubuntu/Debian: apt-get install -y sshpass；"
+                "CentOS/RHEL: yum install -y sshpass"
+            )
+        return [
+            "sshpass", "-p", args.gpu_ssh_password,
+            "ssh",
+            "-o", "StrictHostKeyChecking=no",
+            "-o", "PreferredAuthentications=password",
+            "-o", "PubkeyAuthentication=no",
+        ]
+    prefix = ["ssh", "-o", "StrictHostKeyChecking=no"]
+    if args.gpu_ssh_key:
+        prefix += ["-i", args.gpu_ssh_key, "-o", "IdentitiesOnly=yes"]
+    return prefix
+
+
+def ssh_run(ssh_prefix: list[str], ssh_target: str, remote_cmd: str,
+            *, timeout: int = 600, check: bool = False) -> subprocess.CompletedProcess:
+    """统一封装的 SSH 调用：ssh_prefix + [ssh_target, remote_cmd]。"""
+    cmd = ssh_prefix + [ssh_target, remote_cmd]
+    return run(cmd, check=check, timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# 步骤 0：NPU 侧环境准备
+# ---------------------------------------------------------------------------
+
+def activate_conda(conda_env: str) -> dict:
+    """激活 conda 环境，返回带激活后 PATH 的 env 字典。
+
+    在非交互式 shell 中，`conda activate` 需要先初始化 conda 的 shell 函数，
+    否则会报 "CommandNotFoundError: Your shell has not been properly
+    configured to use 'conda activate'"。通过 `conda shell.bash hook` 注入。
+    """
+    import os
+    env = os.environ.copy()
+    if not conda_env:
+        log("未指定 conda 环境，使用当前环境")
+        return env
+    result = run(
+        f'eval "$(conda shell.bash hook)" && conda activate {conda_env} && env',
+        shell=True, check=True, capture=True,
+    )
+    for line in result.stdout.splitlines():
+        if "=" in line:
+            key, _, val = line.partition("=")
+            env[key] = val
+    py = run("which python", shell=True, check=True, env=env, capture=True)
+    log(f"Python: {py.stdout.strip()}")
+    return env
+
+
+# ---------------------------------------------------------------------------
+# 通用：git clone（NPU 本地或 SSH 到 GPU 远程）
+# ---------------------------------------------------------------------------
+
+def clone_repos_local(clone_dir: Path, proxy: str = "",
+                      base_env: dict | None = None) -> Path:
+    """在本地 clone 仓库，返回 fla 仓库根目录。
+
+    clone 期间启用 proxy（http_proxy/https_proxy）；调用方传入的 base_env 不会被
+    修改，clone 完成后继续使用 base_env 即等效于 `unset http_proxy/https_proxy`。
+    """
+    clone_dir.mkdir(parents=True, exist_ok=True)
+    proxy_env = make_proxy_env(base_env, proxy)
+    # env=None 时 subprocess 继承父进程环境；显式传入以应用代理
+    run_env = proxy_env or None
+
+    fla_dir = clone_dir / "flash-linear-attention-npu"
+    if not fla_dir.exists():
+        run(f"git clone {FLA_REPO} {fla_dir}", cwd=clone_dir, env=run_env)
+    else:
+        log(f"已存在，跳过 clone: {fla_dir}")
+        run("git pull --rebase", cwd=fla_dir, check=False, env=run_env)
+
+    work_tool_dir = clone_dir / "work_tool"
+    if not work_tool_dir.exists():
+        run(f"git clone -b {WORK_TOOL_BRANCH} {WORK_TOOL_REPO} {work_tool_dir}",
+            cwd=clone_dir, env=run_env)
+    else:
+        log(f"已存在，跳过 clone: {work_tool_dir}")
+        run(f"git pull --rebase", cwd=work_tool_dir, check=False, env=run_env)
+
+    if proxy:
+        log("本地 clone 完成，后续命令不再使用代理（等效 unset http_proxy/https_proxy）")
+    return fla_dir
+
+
+def ssh_clone_repos(ssh_prefix: list[str], ssh_target: str,
+                    gpu_clone_dir: Path, proxy: str = "") -> None:
+    """SSH 到 GPU 机器 clone 仓库，确保 gpu_server.sh 与 executor 文件存在。
+
+    在远程脚本中先 `export http_proxy/https_proxy`，clone 完成后 `unset`，
+    避免 SSH 通道后续命令残留代理（每条 SSH 命令独立 shell，但仍显式 unset）。
+    """
+    clone_dir_str = str(gpu_clone_dir)
+    fla_subdir = "flash-linear-attention-npu"
+    work_tool_subdir = "work_tool"
+
+    proxy_prefix = ""
+    proxy_suffix = ""
+    if proxy:
+        proxy_prefix = (
+            f"export http_proxy={shlex.quote(proxy)}; "
+            f"export https_proxy={shlex.quote(proxy)}; "
+        )
+        proxy_suffix = "unset http_proxy https_proxy; "
+
+    # 一条 SSH 命令完成 mkdir / clone-or-pull / unset，保证幂等
+    remote_script = (
+        f"set -e; "
+        f"{proxy_prefix}"
+        f"mkdir -p {shlex.quote(clone_dir_str)}; "
+        f"cd {shlex.quote(clone_dir_str)}; "
+        f"if [ -d {fla_subdir} ]; then "
+        f"  echo 'fla 已存在，pull'; git -C {fla_subdir} pull --rebase || true; "
+        f"else git clone {FLA_REPO} {fla_subdir}; fi; "
+        f"if [ -d {work_tool_subdir} ]; then "
+        f"  echo 'work_tool 已存在，pull'; git -C {work_tool_subdir} pull --rebase || true; "
+        f"else git clone -b {WORK_TOOL_BRANCH} {WORK_TOOL_REPO} {work_tool_subdir}; fi; "
+        f"{proxy_suffix}"
+        f"echo 'SSH clone 完成'"
+    )
+    cmd = ssh_prefix + [ssh_target, remote_script]
+    log(f"SSH clone 仓库到 GPU: {ssh_target}:{clone_dir_str}")
+    run(cmd, check=False, timeout=600)
+
+
+# ---------------------------------------------------------------------------
+# 步骤 2-3：NPU 本地编译 + 安装
+# ---------------------------------------------------------------------------
+
+def build_and_install(fla_dir: Path, env: dict) -> None:
+    """编译 fla wheel 并安装（取构建输出最后一行作为安装命令）。"""
+    log("步骤 2: 编译 fla wheel")
+    build_env = env.copy()
+    build_env["FLA_NPU_SOC"] = "ascend950"
+    result = run(
+        "python scripts/build_wheel.py",
+        cwd=fla_dir, env=build_env, capture=True,
+    )
+    build_output = result.stdout.strip()
+    log(build_output)
+
+    lines = [ln.strip() for ln in build_output.splitlines() if ln.strip()]
+    if not lines:
+        raise RuntimeError("build_wheel.py 无输出，无法确定安装命令")
+    install_cmd = lines[-1]
+    if not install_cmd.startswith(("pip", sys.executable)):
+        install_lines = [ln for ln in lines if "pip install" in ln]
+        if not install_lines:
+            raise RuntimeError(f"未在构建输出中找到安装命令，最后一行: {install_cmd}")
+        install_cmd = install_lines[-1]
+
+    log(f"步骤 3: 安装 -> {install_cmd}")
+    run(install_cmd, shell=True, cwd=fla_dir, env=env)
+
+
+# ---------------------------------------------------------------------------
+# 步骤 4：逐算子精度检查
+# ---------------------------------------------------------------------------
+
+def detect_operators(atk_dir: Path) -> list[str]:
+    """扫描 atk 目录，返回有 executor 和 atk 配置的算子名列表（排除 common）。"""
+    ops: list[str] = []
+    for sub in sorted(atk_dir.iterdir()):
+        if not sub.is_dir() or sub.name in ("common", "__pycache__"):
+            continue
+        has_executor = any(sub.glob(f"executor_{sub.name}.py"))
+        has_config = any(sub.glob(f"atk_{sub.name}.json"))
+        if has_executor and has_config:
+            ops.append(sub.name)
+    return ops
+
+
+def wait_server_up(host: str, port: int, timeout: int = 1800) -> bool:
+    """轮询等待 GPU server 端口可达。返回 True 表示可达。"""
+    log(f"等待 GPU server 可达: {host}:{port}（超时 {timeout}s）")
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=5):
+                log(f"GPU server 已就绪: {host}:{port}")
+                return True
+        except OSError:
+            time.sleep(10)
+    log(f"超时: GPU server 在 {timeout}s 内未就绪")
+    return False
+
+
+def build_gpu_server_start_cmd(gpu_server_sh_remote: str, op: str,
+                               args: argparse.Namespace) -> str:
+    """构造 GPU 侧 gpu_server_start 命令字符串（在 GPU 宿主机本地执行）。"""
+    parts = [
+        "bash", shlex.quote(gpu_server_sh_remote),
+        f"-op={op}",
+        "-action=gpu_server_start",
+        f"-gpu_host_port={args.gpu_host_port}",
+        f"-gpu_device_id={args.gpu_device_id}",
+        f"-gpu_container={args.gpu_container}",
+        f"-gpu_repo_root={args.gpu_repo_root}",
+    ]
+    if args.gpu_image:
+        parts.append(f"-gpu_image={args.gpu_image}")
+    if args.gpu_image_tar:
+        parts.append(f"-gpu_image_tar={args.gpu_image_tar}")
+    if args.atk_env:
+        parts.append(f"-atk_env={args.atk_env}")
+    if args.triton_root:
+        parts.append(f"-triton_root={args.triton_root}")
+    return " ".join(parts)
+
+
+def ssh_start_gpu_server(ssh_prefix: list[str], ssh_target: str,
+                         gpu_clone_dir: Path, op: str,
+                         args: argparse.Namespace) -> None:
+    """SSH 到 GPU 后台启动 gpu_server_start（nohup ... &，SSH 立即返回）。
+
+    gpu_server_start 本身前台阻塞运行 ATK server；通过 nohup + & 放到后台，
+    日志重定向到 GPU 宿主机文件，SSH 调用立即返回，NPU 端随后轮询端口。
+    """
+    gpu_server_sh = (
+        gpu_clone_dir / "flash-linear-attention-npu" / "tests" / "atk" /
+        "common" / "gpu_server.sh"
+    )
+    gpu_server_sh_remote = str(gpu_server)
+    start_cmd = build_gpu_server_start_cmd(gpu_server_sh_remote, op, args)
+    log_file = f"/tmp/cron_gpu_server_{op}.log"
+    # nohup + < /dev/null + & 确保 SSH 立即返回，进程在 GPU 侧常驻
+    remote_cmd = (
+        f"nohup {start_cmd} > {shlex.quote(log_file)} 2>&1 < /dev/null & "
+        f"echo \"GPU server 已后台启动，PID=$!，日志: {log_file}\""
+    )
+    cmd = ssh_prefix + [ssh_target, remote_cmd]
+    log(f"SSH 后台启动 GPU server: {ssh_target} '{start_cmd} &'")
+    run(cmd, check=False, timeout=120)
+
+
+def ssh_stop_gpu_server(ssh_prefix: list[str], ssh_target: str,
+                        gpu_clone_dir: Path, op: str,
+                        gpu_container: str) -> None:
+    """SSH 到 GPU 执行 gpu_server_stop（杀掉容器，后台 start 进程随之退出）。"""
+    gpu_server_sh = (
+        gpu_clone_dir / "flash-linear-attention-npu" / "tests" / "atk" /
+        "common" / "gpu_server.sh"
+    )
+    cmd_str = (
+        f"bash {shlex.quote(str(gpu_server_sh))} "
+        f"-op={op} -action=gpu_server_stop "
+        f"-gpu_container={gpu_container}"
+    )
+    log(f"SSH 停止 GPU server: {ssh_target} '{cmd_str}'")
+    cmd = ssh_prefix + [ssh_target, cmd_str]
+    run(cmd, check=False, timeout=120)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    # NPU 侧参数
+    parser.add_argument("--conda-env", required=True,
+                        help="NPU 侧 conda 环境名（如 jisihuai）")
+    parser.add_argument("--clone-dir", type=Path, required=True,
+                        help="NPU 侧仓库 clone 根目录")
+    parser.add_argument("--http-proxy", default="",
+                        help="git clone 时使用的 HTTP 代理 "
+                             "（如 http://127.0.0.1:7890）；clone 完成后自动 unset")
+    parser.add_argument("--npu-device-id", default="7",
+                        help="NPU 物理卡号（默认 7）")
+    parser.add_argument("--npu-gpu-device-id", default="0",
+                        help="远程 GPU 参考节点 devices 值（默认 0）")
+    parser.add_argument("--npu-output-path", default="./atk_output/kda_remote",
+                        help="精度检查输出目录（默认 ./atk_output/kda_remote）")
+    parser.add_argument("--npu-task-timeout", default="2000",
+                        help="精度检查 task 超时（默认 2000）")
+
+    # GPU 侧参数（通过 SSH 驱动）
+    parser.add_argument("--gpu-host", required=True,
+                        help="GPU server 宿主机地址")
+    parser.add_argument("--gpu-host-port", default="9090",
+                        help="GPU server 端口（默认 9090）")
+    parser.add_argument("--gpu-ssh-user", default="",
+                        help="SSH 登录 GPU 机器的用户名（默认当前用户）")
+    parser.add_argument("--gpu-ssh-password", default="",
+                        help="SSH 登录密码（需要 NPU 机器安装 sshpass；"
+                             "指定后强制 password 认证、禁用 pubkey）")
+    parser.add_argument("--gpu-ssh-key", default="",
+                        help="SSH 私钥文件路径（如 ~/.ssh/id_rsa）；"
+                             "指定后用 -i 加载并设 IdentitiesOnly=yes")
+    parser.add_argument("--gpu-clone-dir", type=Path, required=True,
+                        help="GPU 侧仓库 clone 根目录（SSH clone + gpu_server.sh 路径）")
+    parser.add_argument("--gpu-device-id", default="6",
+                        help="物理 GPU 卡号（默认 6）")
+    parser.add_argument("--gpu-container", default="fla_gpu_atk",
+                        help="GPU Docker 容器名（默认 fla_gpu_atk）")
+    parser.add_argument("--gpu-image", default="",
+                        help="GPU 基础镜像名")
+    parser.add_argument("--gpu-image-tar", default="",
+                        help="本地镜像 tar 路径（GPU 宿主机上）")
+    parser.add_argument("--gpu-repo-root", default="/workspace/flash-linear-attention-npu",
+                        help="仓库在容器内挂载根目录")
+    parser.add_argument("--atk-env", default="",
+                        help="容器内 ATK 虚拟环境目录（可选）")
+    parser.add_argument("--triton-root", default="",
+                        help="兼容 Triton 源码根（加入 PYTHONPATH，可选）")
+
+    # 通用参数
+    parser.add_argument("--operators", default="",
+                        help="逗号分隔的算子名列表；为空时自动扫描")
+    parser.add_argument("--server-wait-timeout", type=int, default=1800,
+                        help="等待 GPU server 可达的超时（秒，默认 1800）")
+    parser.add_argument("--skip-gpu-clone", action="store_true",
+                        help="跳过 SSH clone GPU 侧仓库（假定已存在且最新）")
+    args = parser.parse_args()
+
+    ssh_target = (
+        f"{args.gpu_ssh_user}@{args.gpu_host}" if args.gpu_ssh_user else args.gpu_host
+    )
+
+    # 构造 SSH 前缀（密码 / 私钥 / 默认免密三选一）
+    try:
+        ssh_prefix = build_ssh_prefix(args)
+    except RuntimeError as e:
+        log(f"SSH 认证配置错误: {e}")
+        return 1
+    if args.gpu_ssh_password:
+        log("SSH 认证：密码（sshpass）")
+    elif args.gpu_ssh_key:
+        log(f"SSH 认证：私钥 {args.gpu_ssh_key}")
+    else:
+        log("SSH 认证：默认免密（agent/keychain）")
+
+    # 步骤 0: 激活 conda 环境
+    log("步骤 0: 激活 conda 环境")
+    env = activate_conda(args.conda_env)
+
+    # 步骤 1a: NPU 本地 git clone（启用代理）
+    log("步骤 1a: NPU 本地 git clone 仓库")
+    fla_dir = clone_repos_local(args.clone_dir, proxy=args.http_proxy, base_env=env)
+    atk_dir = fla_dir / "tests" / "atk"
+    gpu_server_sh = atk_dir / "common" / "gpu_server.sh"
+
+    # 步骤 1b: SSH 到 GPU clone 仓库（启用代理，clone 后 unset）
+    if not args.skip_gpu_clone:
+        log("步骤 1b: SSH 到 GPU clone 仓库")
+        ssh_clone_repos(ssh_prefix, ssh_target, args.gpu_clone_dir,
+                        proxy=args.http_proxy)
+    else:
+        log("步骤 1b: 跳过 GPU 侧 clone（--skip-gpu-clone）")
+
+    # 步骤 1c: ping GPU IP，不通直接报错退出
+    log("步骤 1c: ping GPU 主机检查连通性")
+    if not ping_host(args.gpu_host):
+        log(f"错误: ping GPU 主机 {args.gpu_host} 不通，请检查网络后重试，退出")
+        return 1
+
+    # 步骤 2-3: NPU 本地编译 + 安装（使用未带代理的 env）
+    build_and_install(fla_dir, env)
+
+    # 步骤 3.5: 查询 python 路径，设置 PYTHONHOME / ASCEND_CUSTOM_OPP_PATH
+    log("步骤 3.5: 设置 NPU 精度检查环境变量 PYTHONHOME / ASCEND_CUSTOM_OPP_PATH")
+    pythonhome, site_packages = query_python_paths(env)
+    npu_env = apply_npu_atk_env(env, pythonhome, site_packages)
+
+    # 确定算子列表
+    if args.operators:
+        ops = [o.strip() for o in args.operators.split(",") if o.strip()]
+    else:
+        ops = detect_operators(atk_dir)
+    if not ops:
+        log("未检测到算子，退出")
+        return 1
+    log(f"算子列表（{len(ops)}）: {', '.join(ops)}")
+
+    # 步骤 4: 逐算子精度检查
+    port = int(args.gpu_host_port)
+    for idx, op in enumerate(ops, 1):
+        log(f"===== [{idx}/{len(ops)}] {op} =====")
+
+        # 4a. SSH 后台启动 GPU server
+        try:
+            ssh_start_gpu_server(ssh_prefix, ssh_target, args.gpu_clone_dir,
+                                 op, args)
+        except Exception as e:
+            log(f"SSH 启动 GPU server 异常: {e}，跳过 {op}")
+            continue
+
+        # 4b. 等待 GPU server 可达
+        if not wait_server_up(args.gpu_host, port, args.server_wait_timeout):
+            log(f"GPU server 未就绪，跳过 {op}")
+            ssh_stop_gpu_server(ssh_prefix, ssh_target, args.gpu_clone_dir,
+                                op, args.gpu_container)
+            continue
+
+        # 4c. NPU 本地执行精度检查
+        npu_cmd = [
+            "bash", str(gpu_server_sh),
+            f"-op={op}",
+            "-action=npu",
+            f"-gpu_host={args.gpu_host}",
+            f"-gpu_host_port={args.gpu_host_port}",
+            f"-npu_device_id={args.npu_device_id}",
+            f"-npu_gpu_device_id={args.npu_gpu_device_id}",
+            f"-npu_output_path={args.npu_output_path}",
+            f"-npu_task_timeout={args.npu_task_timeout}",
+        ]
+        log(f"执行精度检查: {' '.join(npu_cmd)}")
+        try:
+            run(npu_cmd, check=False, cwd=atk_dir / op, env=npu_env)
+        except Exception as e:
+            log(f"精度检查异常: {e}")
+
+        # 4d. SSH 停止 GPU server（杀掉容器，后台 start 进程随之退出）
+        ssh_stop_gpu_server(ssh_prefix, ssh_target, args.gpu_clone_dir,
+                            op, args.gpu_container)
+
+        # 等待端口关闭，确保下一个算子的 server 能干净启动
+        time.sleep(10)
+        log(f"[{idx}/{len(ops)}] {op} 完成")
+
+    log("所有算子处理完毕")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/atk/common/cron.py
+++ b/tests/atk/common/cron.py
@@ -23,6 +23,8 @@
       --conda-env jisihuai \
       --clone-dir /data/cron/fla \
       --http-proxy http://127.0.0.1:7890 \
+      --npu-soc ascend910b \
+      --operators chunk_fwd_o,chunk_bwd_dv_local \
       --gpu-host 141.61.21.62 \
       --gpu-host-port 9090 \
       --gpu-ssh-user root \
@@ -119,13 +121,13 @@ def ping_host(host: str, count: int = 3, wait: int = 5) -> bool:
 def query_python_paths(env: dict) -> tuple[str, str]:
     """查询当前 python 的 sys.prefix（PYTHONHOME）与 site-packages 路径。"""
     py_prefix = run(
-        "python -c 'import sys; print(sys.prefix)'",
-        shell=True, check=True, env=env, capture=True,
+        ["python", "-c", "import sys; print(sys.prefix)"],
+        check=True, env=env, capture=True,
     )
     pythonhome = py_prefix.stdout.strip()
     site_pkg = run(
-        "python -c 'import site; print(site.getsitepackages()[0])'",
-        shell=True, check=True, env=env, capture=True,
+        ["python", "-c", "import site; print(site.getsitepackages()[0])"],
+        check=True, env=env, capture=True,
     )
     site_packages = site_pkg.stdout.strip()
     if not pythonhome or not site_packages:
@@ -305,11 +307,20 @@ def ssh_clone_repos(ssh_prefix: list[str], ssh_target: str,
 # 步骤 2-3：NPU 本地编译 + 安装
 # ---------------------------------------------------------------------------
 
-def build_and_install(fla_dir: Path, env: dict) -> None:
-    """编译 fla wheel 并安装（取构建输出最后一行作为安装命令）。"""
-    log("步骤 2: 编译 fla wheel")
+def build_and_install(fla_dir: Path, env: dict, npu_soc: str = "ascend910b",
+                       operators: str = "") -> None:
+    """编译 fla wheel 并安装（取构建输出最后一行作为安装命令）。
+
+    Args:
+      npu_soc: 设置 FLA_NPU_SOC（默认 ascend910b；A3=ascend910_93，A5=ascend950）
+      operators: 逗号分隔算子列表，非空时设置 FLA_NPU_OPS 只编译指定算子
+    """
+    log(f"步骤 2: 编译 fla wheel (FLA_NPU_SOC={npu_soc}"
+        f"{f', FLA_NPU_OPS={operators}' if operators else ''})")
     build_env = env.copy()
-    build_env["FLA_NPU_SOC"] = "ascend950"
+    build_env["FLA_NPU_SOC"] = npu_soc
+    if operators:
+        build_env["FLA_NPU_OPS"] = operators
     result = run(
         "python scripts/build_wheel.py",
         cwd=fla_dir, env=build_env, capture=True,
@@ -442,6 +453,9 @@ def main() -> int:
     parser.add_argument("--http-proxy", default="",
                         help="git clone 时使用的 HTTP 代理 "
                              "（如 http://127.0.0.1:7890）；clone 完成后自动 unset")
+    parser.add_argument("--npu-soc", default="ascend910b",
+                        help="FLA_NPU_SOC 芯片类型（默认 ascend910b；"
+                             "A3=ascend910_93，A5=ascend950）")
     parser.add_argument("--npu-device-id", default="7",
                         help="NPU 物理卡号（默认 7）")
     parser.add_argument("--npu-gpu-device-id", default="0",
@@ -483,7 +497,9 @@ def main() -> int:
 
     # 通用参数
     parser.add_argument("--operators", default="",
-                        help="逗号分隔的算子名列表；为空时自动扫描")
+                        help="逗号分隔算子列表（如 chunk_fwd_o,chunk_bwd_dv_local）；"
+                             "非空时编译设置 FLA_NPU_OPS 只编这些算子、精度只跑这些算子；"
+                             "为空时编译全部算子并自动扫描全部算子")
     parser.add_argument("--server-wait-timeout", type=int, default=1800,
                         help="等待 GPU server 可达的超时（秒，默认 1800）")
     parser.add_argument("--skip-gpu-clone", action="store_true",
@@ -532,7 +548,8 @@ def main() -> int:
         return 1
 
     # 步骤 2-3: NPU 本地编译 + 安装（使用未带代理的 env）
-    build_and_install(fla_dir, env)
+    build_and_install(fla_dir, env, npu_soc=args.npu_soc,
+                       operators=args.operators)
 
     # 步骤 3.5: 查询 python 路径，设置 PYTHONHOME / ASCEND_CUSTOM_OPP_PATH
     log("步骤 3.5: 设置 NPU 精度检查环境变量 PYTHONHOME / ASCEND_CUSTOM_OPP_PATH")

--- a/tests/atk/common/cron.py
+++ b/tests/atk/common/cron.py
@@ -59,14 +59,13 @@ def log(msg: str) -> None:
     print(f"[cron] {msg}", flush=True)
 
 
-def run(cmd: str | list[str], *, check: bool = True, cwd: Path | None = None,
+def run(cmd: list[str], *, check: bool = True, cwd: Path | None = None,
         env: dict | None = None, timeout: int | None = None,
         capture: bool = False) -> subprocess.CompletedProcess:
-    """执行命令，统一封装。"""
-    shell = isinstance(cmd, str)
-    log(f"$ {cmd if shell else ' '.join(cmd)}")
+    """执行命令（list 形式，不走 shell）。"""
+    log(f"$ {' '.join(cmd)}")
     return subprocess.run(
-        cmd, shell=shell, check=check, cwd=cwd, env=env,
+        cmd, check=check, cwd=cwd, env=env,
         timeout=timeout, text=True,
         stdout=subprocess.PIPE if capture else None,
         stderr=subprocess.STDOUT if capture else None,
@@ -215,14 +214,15 @@ def activate_conda(conda_env: str) -> dict:
         log("未指定 conda 环境，使用当前环境")
         return env
     result = run(
-        f'eval "$(conda shell.bash hook)" && conda activate {conda_env} && env',
-        shell=True, check=True, capture=True,
+        ["bash", "-c",
+         f'eval "$(conda shell.bash hook)" && conda activate {shlex.quote(conda_env)} && env'],
+        check=True, capture=True,
     )
     for line in result.stdout.splitlines():
         if "=" in line:
             key, _, val = line.partition("=")
             env[key] = val
-    py = run("which python", shell=True, check=True, env=env, capture=True)
+    py = run(["which", "python"], check=True, env=env, capture=True)
     log(f"Python: {py.stdout.strip()}")
     return env
 
@@ -245,18 +245,19 @@ def clone_repos_local(clone_dir: Path, proxy: str = "",
 
     fla_dir = clone_dir / "flash-linear-attention-npu"
     if not fla_dir.exists():
-        run(f"git clone {FLA_REPO} {fla_dir}", cwd=clone_dir, env=run_env)
+        run(["git", "clone", FLA_REPO, str(fla_dir)],
+            cwd=clone_dir, env=run_env)
     else:
         log(f"已存在，跳过 clone: {fla_dir}")
-        run("git pull --rebase", cwd=fla_dir, check=False, env=run_env)
+        run(["git", "pull", "--rebase"], cwd=fla_dir, check=False, env=run_env)
 
     work_tool_dir = clone_dir / "work_tool"
     if not work_tool_dir.exists():
-        run(f"git clone -b {WORK_TOOL_BRANCH} {WORK_TOOL_REPO} {work_tool_dir}",
+        run(["git", "clone", "-b", WORK_TOOL_BRANCH, WORK_TOOL_REPO, str(work_tool_dir)],
             cwd=clone_dir, env=run_env)
     else:
         log(f"已存在，跳过 clone: {work_tool_dir}")
-        run(f"git pull --rebase", cwd=work_tool_dir, check=False, env=run_env)
+        run(["git", "pull", "--rebase"], cwd=work_tool_dir, check=False, env=run_env)
 
     if proxy:
         log("本地 clone 完成，后续命令不再使用代理（等效 unset http_proxy/https_proxy）")
@@ -322,7 +323,7 @@ def build_and_install(fla_dir: Path, env: dict, npu_soc: str = "ascend910b",
     if operators:
         build_env["FLA_NPU_OPS"] = operators
     result = run(
-        "python scripts/build_wheel.py",
+        ["python", "scripts/build_wheel.py"],
         cwd=fla_dir, env=build_env, capture=True,
     )
     build_output = result.stdout.strip()
@@ -339,7 +340,7 @@ def build_and_install(fla_dir: Path, env: dict, npu_soc: str = "ascend910b",
         install_cmd = install_lines[-1]
 
     log(f"步骤 3: 安装 -> {install_cmd}")
-    run(install_cmd, shell=True, cwd=fla_dir, env=env)
+    run(shlex.split(install_cmd), cwd=fla_dir, env=env)
 
 
 # ---------------------------------------------------------------------------
@@ -504,6 +505,8 @@ def main() -> int:
                         help="等待 GPU server 可达的超时（秒，默认 1800）")
     parser.add_argument("--skip-gpu-clone", action="store_true",
                         help="跳过 SSH clone GPU 侧仓库（假定已存在且最新）")
+    parser.add_argument("--skip-npu-build", action="store_true",
+                        help="跳过 NPU 侧编译+安装（假定 wheel 已安装）")
     args = parser.parse_args()
 
     ssh_target = (
@@ -548,8 +551,11 @@ def main() -> int:
         return 1
 
     # 步骤 2-3: NPU 本地编译 + 安装（使用未带代理的 env）
-    build_and_install(fla_dir, env, npu_soc=args.npu_soc,
-                       operators=args.operators)
+    if args.skip_npu_build:
+        log("步骤 2-3: 跳过 NPU 编译+安装（--skip-npu-build）")
+    else:
+        build_and_install(fla_dir, env, npu_soc=args.npu_soc,
+                           operators=args.operators)
 
     # 步骤 3.5: 查询 python 路径，设置 PYTHONHOME / ASCEND_CUSTOM_OPP_PATH
     log("步骤 3.5: 设置 NPU 精度检查环境变量 PYTHONHOME / ASCEND_CUSTOM_OPP_PATH")

--- a/tests/atk/common/cron_gpu.py
+++ b/tests/atk/common/cron_gpu.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""GPU 侧定时脚本：按算子逐个启动 ATK GPU server，等待 NPU 端完成精度检查后停止。
+
+运行环境：GPU 宿主机。
+与 cron_npu.py 配对使用：cron_npu 完成精度检查后通过 SSH 杀掉容器，
+本脚本的 gpu_server_start 阻塞调用随之返回，随后执行 gpu_server_stop 清理，
+继续下一个算子。
+
+用法示例：
+  python3 tests/atk/common/cron_gpu.py \
+      --clone-dir /data/cron/fla \
+      --gpu-image pytorch/pytorch:2.3.0-cuda12.1-cudnn8-devel \
+      --gpu-repo-root /workspace/flash-linear-attention-npu
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+FLA_REPO = "https://github.com/flashserve/flash-linear-attention-npu.git"
+WORK_TOOL_REPO = "https://gitcode.com/chen-linxin4/work_tool.git"
+WORK_TOOL_BRANCH = "atk-test"
+
+
+def log(msg: str) -> None:
+    print(f"[cron_gpu] {msg}", flush=True)
+
+
+def run(cmd: str | list[str], *, check: bool = True, cwd: Path | None = None,
+        env: dict | None = None, timeout: int | None = None,
+        capture: bool = False) -> subprocess.CompletedProcess:
+    """执行命令，统一封装。"""
+    shell = isinstance(cmd, str)
+    log(f"$ {cmd if shell else ' '.join(cmd)}")
+    return subprocess.run(
+        cmd, shell=shell, check=check, cwd=cwd, env=env,
+        timeout=timeout, text=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.STDOUT if capture else None,
+    )
+
+
+def clone_repos(clone_dir: Path) -> Path:
+    """克隆仓库，返回 fla 仓库根目录。"""
+    clone_dir.mkdir(parents=True, exist_ok=True)
+    fla_dir = clone_dir / "flash-linear-attention-npu"
+    if not fla_dir.exists():
+        run(f"git clone {FLA_REPO} {fla_dir}", cwd=clone_dir)
+    else:
+        log(f"已存在，跳过 clone: {fla_dir}")
+        run("git pull --rebase", cwd=fla_dir, check=False)
+
+    work_tool_dir = clone_dir / "work_tool"
+    if not work_tool_dir.exists():
+        run(f"git clone -b {WORK_TOOL_BRANCH} {WORK_TOOL_REPO} {work_tool_dir}",
+            cwd=clone_dir)
+    else:
+        log(f"已存在，跳过 clone: {work_tool_dir}")
+        run(f"git pull --rebase", cwd=work_tool_dir, check=False)
+
+    return fla_dir
+
+
+def detect_operators(atk_dir: Path) -> list[str]:
+    """扫描 atk 目录，返回有 executor 和 atk 配置的算子名列表（排除 common）。"""
+    ops: list[str] = []
+    for sub in sorted(atk_dir.iterdir()):
+        if not sub.is_dir() or sub.name in ("common", "__pycache__"):
+            continue
+        has_executor = any(sub.glob(f"executor_{sub.name}.py"))
+        has_config = any(sub.glob(f"atk_{sub.name}.json"))
+        if has_executor and has_config:
+            ops.append(sub.name)
+    return ops
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--clone-dir", type=Path, required=True,
+                        help="仓库 clone 根目录")
+    parser.add_argument("--conda-env", default="",
+                        help="GPU 侧 conda 环境名（可选）")
+    parser.add_argument("--gpu-host-port", default="9090",
+                        help="GPU server 端口（默认 9090）")
+    parser.add_argument("--gpu-device-id", default="6",
+                        help="物理 GPU 卡号（默认 6）")
+    parser.add_argument("--gpu-container", default="fla_gpu_atk",
+                        help="Docker 容器名（默认 fla_gpu_atk）")
+    parser.add_argument("--gpu-image", default="",
+                        help="GPU 基础镜像名")
+    parser.add_argument("--gpu-image-tar", default="",
+                        help="本地镜像 tar 路径")
+    parser.add_argument("--gpu-repo-root", default="/workspace/flash-linear-attention-npu",
+                        help="仓库在容器内挂载根目录")
+    parser.add_argument("--atk-env", default="",
+                        help="容器内 ATK 虚拟环境目录（可选）")
+    parser.add_argument("--operators", default="",
+                        help="逗号分隔的算子名列表；为空时自动扫描")
+    parser.add_argument("--server-wait-timeout", type=int, default=14400,
+                        help="gpu_server_start 最大阻塞时长（秒，默认 14400）")
+    args = parser.parse_args()
+
+    # 1. 克隆仓库
+    log("步骤 1: 克隆仓库")
+    fla_dir = clone_repos(args.clone_dir)
+    atk_dir = fla_dir / "tests" / "atk"
+    gpu_server_sh = atk_dir / "common" / "gpu_server.sh"
+
+    # 2. 确定算子列表
+    if args.operators:
+        ops = [o.strip() for o in args.operators.split(",") if o.strip()]
+    else:
+        ops = detect_operators(atk_dir)
+    if not ops:
+        log("未检测到算子，退出")
+        return 1
+    log(f"算子列表（{len(ops)}）: {', '.join(ops)}")
+
+    # 3. 逐算子启动 server
+    for idx, op in enumerate(ops, 1):
+        log(f"===== [{idx}/{len(ops)}] {op} =====")
+
+        # 启动 GPU server（阻塞，NPU 端 SSH 杀容器后返回）
+        cmd = [
+            "bash", str(gpu_server_sh),
+            f"-op={op}",
+            f"-action=gpu_server_start",
+            f"-gpu_host_port={args.gpu_host_port}",
+            f"-gpu_device_id={args.gpu_device_id}",
+            f"-gpu_container={args.gpu_container}",
+            f"-gpu_repo_root={args.gpu_repo_root}",
+        ]
+        if args.gpu_image:
+            cmd.append(f"-gpu_image={args.gpu_image}")
+        if args.gpu_image_tar:
+            cmd.append(f"-gpu_image_tar={args.gpu_image_tar}")
+        if args.atk_env:
+            cmd.append(f"-atk_env={args.atk_env}")
+
+        log(f"启动 GPU server: {' '.join(cmd)}")
+        try:
+            run(cmd, check=False, timeout=args.server_wait_timeout)
+        except subprocess.TimeoutExpired:
+            log(f"GPU server 超时 ({args.server_wait_timeout}s)，强制停止")
+        except Exception as e:
+            log(f"GPU server 异常退出: {e}")
+
+        # 清理容器
+        log(f"清理容器: {args.gpu_container}")
+        stop_cmd = [
+            "bash", str(gpu_server_sh),
+            f"-op={op}",
+            f"-action=gpu_server_stop",
+            f"-gpu_container={args.gpu_container}",
+        ]
+        run(stop_cmd, check=False)
+        log(f"[{idx}/{len(ops)}] {op} 完成")
+
+    log("所有算子处理完毕")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/atk/common/cron_npu.py
+++ b/tests/atk/common/cron_npu.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""NPU 侧定时脚本：环境准备 → 编译安装 → 逐算子对接 GPU server 跑精度检查。
+
+运行环境：NPU 机器。
+与 cron_gpu.py 配对使用：本脚本完成环境准备后，对每个算子：
+  1. 轮询等待 GPU server 端口可达
+  2. 调用 gpu_server.sh -action=npu 执行精度检查
+  3. SSH 到 GPU 机器执行 gpu_server_stop（杀掉容器，使 cron_gpu 的阻塞调用返回）
+  4. 继续下一个算子
+
+用法示例：
+  python3 tests/atk/common/cron_npu.py \
+      --conda-env jisihuai \
+      --clone-dir /data/cron/fla \
+      --gpu-host 141.61.21.62 \
+      --gpu-host-port 9090 \
+      --gpu-ssh-user root \
+      --gpu-clone-dir /data/cron/fla
+
+前置条件：
+  - NPU 机器可通过 SSH 免密登录 GPU 机器（ssh-keygen / ssh-copy-id）
+  - NPU 机器已安装 conda
+  - NPU 机器已配置 CANN 环境（source set_env.sh）
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+FLA_REPO = "https://github.com/flashserve/flash-linear-attention-npu.git"
+WORK_TOOL_REPO = "https://gitcode.com/chen-linxin4/work_tool.git"
+WORK_TOOL_BRANCH = "atk-test"
+
+
+def log(msg: str) -> None:
+    print(f"[cron_npu] {msg}", flush=True)
+
+
+def run(cmd: str | list[str], *, check: bool = True, cwd: Path | None = None,
+        env: dict | None = None, timeout: int | None = None,
+        capture: bool = False) -> subprocess.CompletedProcess:
+    """执行命令，统一封装。"""
+    shell = isinstance(cmd, str)
+    log(f"$ {cmd if shell else ' '.join(cmd)}")
+    return subprocess.run(
+        cmd, shell=shell, check=check, cwd=cwd, env=env,
+        timeout=timeout, text=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.STDOUT if capture else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 步骤 0：环境准备
+# ---------------------------------------------------------------------------
+
+def activate_conda(conda_env: str) -> dict:
+    """激活 conda 环境，返回带激活后 PATH 的 env 字典。
+
+    在非交互式 shell 中，`conda activate` 需要先初始化 conda 的 shell 函数，
+    否则会报 "CommandNotFoundError: Your shell has not been properly
+    configured to use 'conda activate'"。通过 `conda shell.bash hook` 注入。
+    """
+    env = __import__("os").environ.copy()
+    if not conda_env:
+        log("未指定 conda 环境，使用当前环境")
+        return env
+    result = run(
+        f'eval "$(conda shell.bash hook)" && conda activate {conda_env} && env',
+        shell=True, check=True, capture=True,
+    )
+    for line in result.stdout.splitlines():
+        if "=" in line:
+            key, _, val = line.partition("=")
+            env[key] = val
+    # 确认 Python 可执行文件
+    py = run("which python", shell=True, check=True, env=env, capture=True)
+    log(f"Python: {py.stdout.strip()}")
+    return env
+
+
+# ---------------------------------------------------------------------------
+# 步骤 1：git clone
+# ---------------------------------------------------------------------------
+
+def clone_repos(clone_dir: Path) -> Path:
+    """克隆仓库，返回 fla 仓库根目录。"""
+    clone_dir.mkdir(parents=True, exist_ok=True)
+    fla_dir = clone_dir / "flash-linear-attention-npu"
+    if not fla_dir.exists():
+        run(f"git clone {FLA_REPO} {fla_dir}", cwd=clone_dir)
+    else:
+        log(f"已存在，跳过 clone: {fla_dir}")
+        run("git pull --rebase", cwd=fla_dir, check=False)
+
+    work_tool_dir = clone_dir / "work_tool"
+    if not work_tool_dir.exists():
+        run(f"git clone -b {WORK_TOOL_BRANCH} {WORK_TOOL_REPO} {work_tool_dir}",
+            cwd=clone_dir)
+    else:
+        log(f"已存在，跳过 clone: {work_tool_dir}")
+        run("git pull --rebase", cwd=work_tool_dir, check=False)
+
+    return fla_dir
+
+
+# ---------------------------------------------------------------------------
+# 步骤 2-3：编译 + 安装
+# ---------------------------------------------------------------------------
+
+def build_and_install(fla_dir: Path, env: dict) -> None:
+    """编译 fla wheel 并安装（取构建输出最后一行作为安装命令）。"""
+    log("步骤 2: 编译 fla wheel")
+    build_env = env.copy()
+    build_env["FLA_NPU_SOC"] = "ascend950"
+    result = run(
+        "python scripts/build_wheel.py",
+        cwd=fla_dir, env=build_env, capture=True,
+    )
+    build_output = result.stdout.strip()
+    log(build_output)
+
+    # 取最后一行作为安装命令
+    lines = [ln.strip() for ln in build_output.splitlines() if ln.strip()]
+    if not lines:
+        raise RuntimeError("build_wheel.py 无输出，无法确定安装命令")
+    install_cmd = lines[-1]
+    # 过滤掉非安装命令的日志行
+    if not install_cmd.startswith(("pip", sys.executable)):
+        # 从输出中查找包含 "pip install" 的行
+        install_lines = [ln for ln in lines if "pip install" in ln]
+        if not install_lines:
+            raise RuntimeError(f"未在构建输出中找到安装命令，最后一行: {install_cmd}")
+        install_cmd = install_lines[-1]
+
+    log(f"步骤 3: 安装 -> {install_cmd}")
+    run(install_cmd, shell=True, cwd=fla_dir, env=env)
+
+
+# ---------------------------------------------------------------------------
+# 步骤 4：逐算子精度检查
+# ---------------------------------------------------------------------------
+
+def detect_operators(atk_dir: Path) -> list[str]:
+    """扫描 atk 目录，返回有 executor 和 atk 配置的算子名列表（排除 common）。"""
+    ops: list[str] = []
+    for sub in sorted(atk_dir.iterdir()):
+        if not sub.is_dir() or sub.name in ("common", "__pycache__"):
+            continue
+        has_executor = any(sub.glob(f"executor_{sub.name}.py"))
+        has_config = any(sub.glob(f"atk_{sub.name}.json"))
+        if has_executor and has_config:
+            ops.append(sub.name)
+    return ops
+
+
+def wait_server_up(host: str, port: int, timeout: int = 1800) -> bool:
+    """轮询等待 GPU server 端口可达。返回 True 表示可达。"""
+    log(f"等待 GPU server 可达: {host}:{port}（超时 {timeout}s）")
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=5):
+                log(f"GPU server 已就绪: {host}:{port}")
+                return True
+        except OSError:
+            time.sleep(10)
+    log(f"超时: GPU server 在 {timeout}s 内未就绪")
+    return False
+
+
+def ssh_stop_gpu_server(ssh_target: str, gpu_clone_dir: Path,
+                        op: str, gpu_container: str) -> None:
+    """SSH 到 GPU 机器执行 gpu_server_stop。"""
+    gpu_server_sh = gpu_clone_dir / "flash-linear-attention-npu" / "tests" / "atk" / "common" / "gpu_server.sh"
+    cmd = (
+        f"bash {shlex.quote(str(gpu_server_sh))} "
+        f"-op={op} -action=gpu_server_stop "
+        f"-gpu_container={gpu_container}"
+    )
+    log(f"SSH 停止 GPU server: ssh {ssh_target} '{cmd}'")
+    run(["ssh", "-o", "StrictHostKeyChecking=no", ssh_target, cmd],
+        check=False, timeout=120)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                    formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--conda-env", required=True,
+                        help="NPU 侧 conda 环境名（如 jisihuai）")
+    parser.add_argument("--clone-dir", type=Path, required=True,
+                        help="NPU 侧仓库 clone 根目录")
+    parser.add_argument("--gpu-host", required=True,
+                        help="GPU server 宿主机地址")
+    parser.add_argument("--gpu-host-port", default="9090",
+                        help="GPU server 端口（默认 9090）")
+    parser.add_argument("--gpu-ssh-user", default="",
+                        help="SSH 登录 GPU 机器的用户名（默认当前用户）")
+    parser.add_argument("--gpu-clone-dir", type=Path, required=True,
+                        help="GPU 侧仓库 clone 根目录（用于 SSH 执行 gpu_server_stop）")
+    parser.add_argument("--npu-device-id", default="7",
+                        help="NPU 物理卡号（默认 7）")
+    parser.add_argument("--npu-gpu-device-id", default="0",
+                        help="远程 GPU 参考节点 devices 值（默认 0）")
+    parser.add_argument("--gpu-container", default="fla_gpu_atk",
+                        help="GPU Docker 容器名（默认 fla_gpu_atk）")
+    parser.add_argument("--npu-output-path", default="./atk_output/kda_remote",
+                        help="精度检查输出目录（默认 ./atk_output/kda_remote）")
+    parser.add_argument("--npu-task-timeout", default="2000",
+                        help="精度检查 task 超时（默认 2000）")
+    parser.add_argument("--operators", default="",
+                        help="逗号分隔的算子名列表；为空时自动扫描")
+    parser.add_argument("--server-wait-timeout", type=int, default=1800,
+                        help="等待 GPU server 可达的超时（秒，默认 1800）")
+    args = parser.parse_args()
+
+    ssh_target = f"{args.gpu_ssh_user}@{args.gpu_host}" if args.gpu_ssh_user else args.gpu_host
+
+    # 步骤 0: 激活 conda 环境
+    log("步骤 0: 激活 conda 环境")
+    env = activate_conda(args.conda_env)
+
+    # 步骤 1: git clone
+    log("步骤 1: git clone 仓库")
+    fla_dir = clone_repos(args.clone_dir)
+    atk_dir = fla_dir / "tests" / "atk"
+    gpu_server_sh = atk_dir / "common" / "gpu_server.sh"
+
+    # 步骤 2-3: 编译 + 安装
+    build_and_install(fla_dir, env)
+
+    # 确定算子列表
+    if args.operators:
+        ops = [o.strip() for o in args.operators.split(",") if o.strip()]
+    else:
+        ops = detect_operators(atk_dir)
+    if not ops:
+        log("未检测到算子，退出")
+        return 1
+    log(f"算子列表（{len(ops)}）: {', '.join(ops)}")
+
+    # 步骤 4: 逐算子精度检查
+    port = int(args.gpu_host_port)
+    for idx, op in enumerate(ops, 1):
+        log(f"===== [{idx}/{len(ops)}] {op} =====")
+
+        # 4a. 等待 GPU server 可达
+        if not wait_server_up(args.gpu_host, port, args.server_wait_timeout):
+            log(f"跳过 {op}：GPU server 未就绪")
+            continue
+
+        # 4b. 执行精度检查
+        npu_cmd = [
+            "bash", str(gpu_server_sh),
+            f"-op={op}",
+            f"-action=npu",
+            f"-gpu_host={args.gpu_host}",
+            f"-gpu_host_port={args.gpu_host_port}",
+            f"-npu_device_id={args.npu_device_id}",
+            f"-npu_gpu_device_id={args.npu_gpu_device_id}",
+            f"-npu_output_path={args.npu_output_path}",
+            f"-npu_task_timeout={args.npu_task_timeout}",
+        ]
+        log(f"执行精度检查: {' '.join(npu_cmd)}")
+        try:
+            run(npu_cmd, check=False, cwd=atk_dir / op, env=env)
+        except Exception as e:
+            log(f"精度检查异常: {e}")
+
+        # 4c. SSH 停止 GPU server（使 cron_gpu 阻塞调用返回）
+        ssh_stop_gpu_server(ssh_target, args.gpu_clone_dir, op, args.gpu_container)
+
+        # 等待端口关闭，确保下一个算子的 server 能干净启动
+        time.sleep(10)
+        log(f"[{idx}/{len(ops)}] {op} 完成")
+
+    log("所有算子处理完毕")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/atk/common/gpu_server.sh
+++ b/tests/atk/common/gpu_server.sh
@@ -1,0 +1,383 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# GPU 端 ATK server 一键启动脚本。
+# 职责：在 GPU 宿主机上启动 Docker 容器，容器内激活 ATK 环境、校验 CUDA/Triton，
+#       随后前台启动 ATK server，监听 0.0.0.0:<port>，供 NPU 端 accuracy_gpu 远程调用。
+# 本脚本在 GPU 宿主机执行，不在 NPU 机器上执行。
+# 容器内 ATK server 与 NPU 端 run_test_cpu.sh -scope=accuracy_gpu 配对使用。
+# action=test_connection_from_npu 例外：在 NPU 机器执行，测试到 GPU server 的连通性。
+
+show_usage() {
+  cat <<'EOF'
+用法：
+  bash tests/atk/common/gpu_server.sh -op=<算子名> [选项]
+
+  默认（action=start）在 GPU 宿主机执行：启动容器并前台运行 ATK server。
+  action=test_connection_from_npu 在 NPU 机器执行：测试到 GPU server 的连通性。
+
+必选参数：
+  -op=chunk_kda_fwd              ATK 算子目录名（与 NPU 端 run_test_cpu.sh -op 一致）
+
+常用参数：
+  -gpu_host=                    GPU server 宿主机地址；action=test_connection_from_npu 必选
+  -gpu_host_port=9090           容器 9090 映射到宿主机的端口，默认 9090；须与 NPU 端 -gpu_host_port 一致
+  -gpu_device_id=6               物理 GPU 卡号，默认 6；容器内重新编号为逻辑设备 0
+  -gpu_container=fla_gpu_atk    容器名，默认 fla_gpu_atk
+  -gpu_image=                   GPU 基础镜像，必选（如 pytorch/pytorch:2.3.0-cuda12.1-cudnn8-devel）
+  -gpu_repo_root=               仓库在容器内的挂载根目录，必选（如 /workspace/flash-linear-attention-npu）
+  -action=start                 start：启动容器并前台运行 ATK server；stop：停止并删除容器；
+                                 test_connection_from_npu：在 NPU 机器测试到 GPU server 连通性
+  -atk_env=                     容器内 ATK 虚拟环境目录，设置后 source "$ATK_ENV/bin/activate"
+  -triton_root=                 兼容 Triton 源码根（加入 PYTHONPATH）；未设置则跳过
+  -atk_server_timeout=8000      ATK server 单任务超时，默认 8000
+  -h|--help                      显示帮助
+
+示例：
+  # 启动 GPU server（前台，不要退出终端）
+  bash tests/atk/common/gpu_server.sh -op=chunk_kda_fwd \
+      -gpu_image=pytorch/pytorch:2.3.0-cuda12.1-cudnn8-devel \
+      -gpu_repo_root=/workspace/flash-linear-attention-npu
+
+  # 复用已有容器时仅启动 ATK server
+  bash tests/atk/common/gpu_server.sh -op=chunk_kda_fwd \
+      -gpu_container=fla_gpu_atk -gpu_repo_root=/workspace/flash-linear-attention-npu
+
+  # 停止并删除容器
+  bash tests/atk/common/gpu_server.sh -op=chunk_kda_fwd -action=stop
+
+  # 在 NPU 机器测试到 GPU server 的连通性（TCP + ATK server 响应）
+  bash tests/atk/common/gpu_server.sh -op=chunk_kda_fwd \
+      -action=test_connection_from_npu -gpu_host=10.10.10.10 -gpu_host_port=9090
+
+NPU 端对应调用：
+  bash tests/atk/run_test_cpu.sh -op=chunk_kda_fwd -scope=accuracy_gpu \
+      -gpu_host=<本机宿主机地址> -gpu_host_port=9090
+EOF
+}
+
+log_info() {
+  echo "[GPU ATK server] $*"
+}
+
+die() {
+  echo "[GPU ATK server][错误] $*" >&2
+  exit 1
+}
+
+OP=""
+GPU_HOST="${GPU_HOST:-}"
+GPU_DEVICE_ID="${GPU_DEVICE_ID:-6}"
+GPU_HOST_PORT="${GPU_HOST_PORT:-9090}"
+GPU_CONTAINER="${GPU_CONTAINER:-fla_gpu_atk}"
+GPU_IMAGE=""
+GPU_REPO_ROOT=""
+ACTION="${ACTION:-start}"
+ATK_ENV="${ATK_ENV:-}"
+TRITON_ROOT="${TRITON_ROOT:-}"
+ATK_SERVER_TIMEOUT="${ATK_SERVER_TIMEOUT:-8000}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -op=*) OP="${1#-op=}" ;;
+    -op)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -op 需要取值"
+      OP="$1"
+      ;;
+    --op=*) OP="${1#--op=}" ;;
+    --op)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --op 需要取值"
+      OP="$1"
+      ;;
+    -gpu_host=*) GPU_HOST="${1#-gpu_host=}" ;;
+    -gpu_host)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -gpu_host 需要取值"
+      GPU_HOST="$1"
+      ;;
+    --gpu_host=*) GPU_HOST="${1#--gpu_host=}" ;;
+    --gpu_host)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --gpu_host 需要取值"
+      GPU_HOST="$1"
+      ;;
+    -gpu_device_id=*) GPU_DEVICE_ID="${1#-gpu_device_id=}" ;;
+    -gpu_device_id)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -gpu_device_id 需要取值"
+      GPU_DEVICE_ID="$1"
+      ;;
+    --gpu_device_id=*) GPU_DEVICE_ID="${1#--gpu_device_id=}" ;;
+    --gpu_device_id)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --gpu_device_id 需要取值"
+      GPU_DEVICE_ID="$1"
+      ;;
+    -gpu_host_port=*) GPU_HOST_PORT="${1#-gpu_host_port=}" ;;
+    -gpu_host_port)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -gpu_host_port 需要取值"
+      GPU_HOST_PORT="$1"
+      ;;
+    --gpu_host_port=*) GPU_HOST_PORT="${1#--gpu_host_port=}" ;;
+    --gpu_host_port)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --gpu_host_port 需要取值"
+      GPU_HOST_PORT="$1"
+      ;;
+    -gpu_container=*) GPU_CONTAINER="${1#-gpu_container=}" ;;
+    -gpu_container)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -gpu_container 需要取值"
+      GPU_CONTAINER="$1"
+      ;;
+    --gpu_container=*) GPU_CONTAINER="${1#--gpu_container=}" ;;
+    --gpu_container)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --gpu_container 需要取值"
+      GPU_CONTAINER="$1"
+      ;;
+    -gpu_image=*) GPU_IMAGE="${1#-gpu_image=}" ;;
+    -gpu_image)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -gpu_image 需要取值"
+      GPU_IMAGE="$1"
+      ;;
+    --gpu_image=*) GPU_IMAGE="${1#--gpu_image=}" ;;
+    --gpu_image)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --gpu_image 需要取值"
+      GPU_IMAGE="$1"
+      ;;
+    -gpu_repo_root=*) GPU_REPO_ROOT="${1#-gpu_repo_root=}" ;;
+    -gpu_repo_root)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -gpu_repo_root 需要取值"
+      GPU_REPO_ROOT="$1"
+      ;;
+    --gpu_repo_root=*) GPU_REPO_ROOT="${1#--gpu_repo_root=}" ;;
+    --gpu_repo_root)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --gpu_repo_root 需要取值"
+      GPU_REPO_ROOT="$1"
+      ;;
+    -action=*) ACTION="${1#-action=}" ;;
+    -action)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -action 需要取值"
+      ACTION="$1"
+      ;;
+    --action=*) ACTION="${1#--action=}" ;;
+    --action)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --action 需要取值"
+      ACTION="$1"
+      ;;
+    -atk_env=*) ATK_ENV="${1#-atk_env=}" ;;
+    -atk_env)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -atk_env 需要取值"
+      ATK_ENV="$1"
+      ;;
+    --atk_env=*) ATK_ENV="${1#--atk_env=}" ;;
+    --atk_env)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --atk_env 需要取值"
+      ATK_ENV="$1"
+      ;;
+    -triton_root=*) TRITON_ROOT="${1#-triton_root=}" ;;
+    -triton_root)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -triton_root 需要取值"
+      TRITON_ROOT="$1"
+      ;;
+    --triton_root=*) TRITON_ROOT="${1#--triton_root=}" ;;
+    --triton_root)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --triton_root 需要取值"
+      TRITON_ROOT="$1"
+      ;;
+    -atk_server_timeout=*) ATK_SERVER_TIMEOUT="${1#-atk_server_timeout=}" ;;
+    -atk_server_timeout)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -atk_server_timeout 需要取值"
+      ATK_SERVER_TIMEOUT="$1"
+      ;;
+    --atk_server_timeout=*) ATK_SERVER_TIMEOUT="${1#--atk_server_timeout=}" ;;
+    --atk_server_timeout)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --atk_server_timeout 需要取值"
+      ATK_SERVER_TIMEOUT="$1"
+      ;;
+    -h|--help)
+      show_usage
+      exit 0
+      ;;
+    *)
+      show_usage
+      die "未知参数：$1"
+      ;;
+  esac
+  shift
+done
+
+[[ -n "$OP" ]] || die "必须传入 -op=<算子名>"
+case "$ACTION" in
+  start|stop|test_connection_from_npu) ;;
+  *) die "不支持的 action：${ACTION}，请使用 start、stop 或 test_connection_from_npu" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# test_connection_from_npu：在 NPU 机器测试到 GPU server 的连通性
+# ---------------------------------------------------------------------------
+if [[ "$ACTION" == "test_connection_from_npu" ]]; then
+  [[ -n "$GPU_HOST" ]] || die "action=test_connection_from_npu 必须传入 -gpu_host=<GPU server 地址>"
+  log_info "从 NPU 机器测试到 GPU server 连通性：${GPU_HOST}:${GPU_HOST_PORT}"
+
+  FAIL=0
+
+  # 1. TCP 端口可达性
+  log_info "[1/2] 测试 TCP 连通性：${GPU_HOST}:${GPU_HOST_PORT}"
+  if python3 - "$GPU_HOST" "$GPU_HOST_PORT" <<'PYEOF'
+import socket, sys
+host, port = sys.argv[1], int(sys.argv[2])
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.settimeout(5)
+try:
+    sock.connect((host, port))
+    print("OK")
+    sys.exit(0)
+except Exception as e:
+    print(f"FAIL: {e}", file=sys.stderr)
+    sys.exit(1)
+finally:
+    sock.close()
+PYEOF
+  then
+    log_info "  TCP 连通：${GPU_HOST}:${GPU_HOST_PORT} 可达"
+  else
+    log_info "  TCP 连通失败：无法连接 ${GPU_HOST}:${GPU_HOST_PORT}，请检查 GPU 容器是否启动、端口映射、防火墙"
+    FAIL=1
+  fi
+
+  # 2. ATK server HTTP 响应
+  log_info "[2/2] 测试 ATK server HTTP 响应：http://${GPU_HOST}:${GPU_HOST_PORT}"
+  set +e
+  HTTP_BODY="$(python3 - "$GPU_HOST" "$GPU_HOST_PORT" 2>&1 <<'PYEOF'
+import urllib.request, sys
+host, port = sys.argv[1], int(sys.argv[2])
+url = f"http://{host}:{port}/"
+try:
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        body = resp.read().decode(errors="replace")
+        print(f"STATUS={resp.status}")
+        print(f"BODY={body[:500]}")
+        sys.exit(0)
+except urllib.error.HTTPError as e:
+    # HTTP 4xx/5xx 也说明 server 在响应（如 404），视为连通
+    print(f"STATUS={e.code}")
+    print(f"BODY={e.read().decode(errors='replace')[:500]}")
+    sys.exit(0)
+except Exception as e:
+    print(f"FAIL: {e}")
+    sys.exit(1)
+PYEOF
+)"
+  HTTP_RC=$?
+  set -e
+  if [[ $HTTP_RC -eq 0 ]]; then
+    log_info "  ATK server 响应正常"
+    echo "$HTTP_BODY" | sed 's/^/    /'
+  else
+    log_info "  ATK server 无 HTTP 响应（可能 server 未启动或端口映射异常）"
+    echo "$HTTP_BODY" | sed 's/^/    /'
+    FAIL=1
+  fi
+
+  # 汇总
+  echo ""
+  if [[ "$FAIL" -eq 0 ]]; then
+    log_info "连通性测试通过：${GPU_HOST}:${GPU_HOST_PORT} TCP 可达且 ATK server 有响应"
+  else
+    die "连通性测试失败：${GPU_HOST}:${GPU_HOST_PORT}（详见上方日志）"
+  fi
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# stop：停止并删除容器
+# ---------------------------------------------------------------------------
+if [[ "$ACTION" == "stop" ]]; then
+  log_info "停止并删除容器：${GPU_CONTAINER}"
+  docker rm -f "$GPU_CONTAINER" >/dev/null 2>&1 || true
+  log_info "容器 ${GPU_CONTAINER} 已删除"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# start：启动容器 + ATK server
+# ---------------------------------------------------------------------------
+[[ -n "$GPU_REPO_ROOT" ]] || die "必须传入 -gpu_repo_root=<容器内仓库根目录>"
+
+OP_TEST_DIR="${GPU_REPO_ROOT}/tests/atk/${OP}"
+EXECUTOR_FILE="executor_${OP}.py"
+
+log_info "算子：${OP}"
+log_info "物理 GPU 卡号：${GPU_DEVICE_ID}（容器内逻辑设备 0）"
+log_info "宿主机映射端口：${GPU_HOST_PORT} -> 容器 9090"
+log_info "容器名：${GPU_CONTAINER}"
+log_info "容器内仓库根：${GPU_REPO_ROOT}"
+log_info "算子测试目录：${OP_TEST_DIR}"
+if [[ -n "$GPU_IMAGE" ]]; then
+  log_info "GPU 镜像：${GPU_IMAGE}"
+fi
+
+# 容器已存在则复用，否则用 -gpu_image 启动新容器
+if docker inspect "$GPU_CONTAINER" >/dev/null 2>&1; then
+  log_info "容器 ${GPU_CONTAINER} 已存在，复用"
+  docker start "$GPU_CONTAINER" >/dev/null 2>&1 || true
+else
+  [[ -n "$GPU_IMAGE" ]] || die "容器不存在，必须传入 -gpu_image=<镜像名> 创建新容器"
+  log_info "创建新容器：${GPU_CONTAINER}（镜像 ${GPU_IMAGE}）"
+  docker run -d \
+    --name "$GPU_CONTAINER" \
+    --gpus "\"device=${GPU_DEVICE_ID}\"" \
+    -p "${GPU_HOST_PORT}:9090" \
+    -v "$(pwd):${GPU_REPO_ROOT}" \
+    -w "$OP_TEST_DIR" \
+    "$GPU_IMAGE" \
+    sleep infinity
+fi
+
+# 校验容器内 GPU 可见性
+log_info "校验容器内 GPU 可见性"
+docker exec "$GPU_CONTAINER" nvidia-smi -L || die "容器内 nvidia-smi 不可用，检查 --gpus 或 CUDA_VISIBLE_DEVICES"
+GPU_COUNT="$(docker exec "$GPU_CONTAINER" bash -c 'nvidia-smi -L | wc -l' || echo "0")"
+if [[ "$GPU_COUNT" -lt 1 ]]; then
+  die "容器内未检测到 GPU，请检查 --gpus 设备映射"
+fi
+log_info "容器内可见 GPU 数：${GPU_COUNT}"
+
+# 构造容器内执行命令
+INNER_CMDS=()
+INNER_CMDS+=("set -euo pipefail")
+INNER_CMDS+=("export CUDA_VISIBLE_DEVICES=0")
+if [[ -n "$ATK_ENV" ]]; then
+  INNER_CMDS+=("source '${ATK_ENV}/bin/activate'")
+fi
+INNER_CMDS+=("export PYTHONPATH='${GPU_REPO_ROOT}:${TRITON_ROOT}:${PYTHONPATH:-}'")
+INNER_CMDS+=("unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY")
+INNER_CMDS+=("cd '${OP_TEST_DIR}'")
+INNER_CMDS+=("atk --version")
+INNER_CMDS+=("python -c 'import torch; print(\"torch\", torch.__version__, \"cuda\", torch.cuda.is_available(), torch.cuda.device_count())'")
+INNER_CMDS+=("test -f '${EXECUTOR_FILE}' || { echo '未找到 executor: ${EXECUTOR_FILE}'; exit 1; }")
+INNER_CMDS+=("echo '[GPU ATK server] 开始启动 ATK server，监听 0.0.0.0:9090'")
+INNER_CMDS+=("atk server --host 0.0.0.0 --port 9090 --devices 0 --name gpu_reference --output_path ./atk_output/gpu_server --plugin_path './${EXECUTOR_FILE}' --timeout '${ATK_SERVER_TIMEOUT}'")
+
+INNER_SCRIPT="$(IFS=$'\n'; echo "${INNER_CMDS[*]}")"
+
+log_info "在容器内激活环境并前台启动 ATK server"
+log_info "NPU 端应使用 -gpu_host=<本机宿主机地址> -gpu_host_port=${GPU_HOST_PORT} 连接"
+docker exec -i "$GPU_CONTAINER" bash -c "$INNER_SCRIPT"

--- a/tests/atk/common/gpu_server.sh
+++ b/tests/atk/common/gpu_server.sh
@@ -25,6 +25,7 @@ show_usage() {
   -gpu_device_id=6               物理 GPU 卡号，默认 6；容器内重新编号为逻辑设备 0
   -gpu_container=fla_gpu_atk    容器名，默认 fla_gpu_atk
   -gpu_image=                   GPU 基础镜像，必选（如 pytorch/pytorch:2.3.0-cuda12.1-cudnn8-devel）
+  -gpu_image_tar=              本地镜像 tar 文件路径；设置后先 docker load 再用加载出的镜像名创建容器
   -gpu_repo_root=               仓库在容器内的挂载根目录，必选（如 /workspace/flash-linear-attention-npu）
   -action=start                 start：启动容器并前台运行 ATK server；stop：停止并删除容器；
                                  test_connection_from_npu：在 NPU 机器测试到 GPU server 连通性
@@ -37,6 +38,11 @@ show_usage() {
   # 启动 GPU server（前台，不要退出终端）
   bash tests/atk/common/gpu_server.sh -op=chunk_kda_fwd \
       -gpu_image=pytorch/pytorch:2.3.0-cuda12.1-cudnn8-devel \
+      -gpu_repo_root=/workspace/flash-linear-attention-npu
+
+  # 用本地镜像 tar 启动（先 docker load 再创建容器）
+  bash tests/atk/common/gpu_server.sh -op=chunk_kda_fwd \
+      -gpu_image_tar=/data/gpu_atk.tar \
       -gpu_repo_root=/workspace/flash-linear-attention-npu
 
   # 复用已有容器时仅启动 ATK server
@@ -71,6 +77,7 @@ GPU_DEVICE_ID="${GPU_DEVICE_ID:-6}"
 GPU_HOST_PORT="${GPU_HOST_PORT:-9090}"
 GPU_CONTAINER="${GPU_CONTAINER:-fla_gpu_atk}"
 GPU_IMAGE=""
+GPU_IMAGE_TAR="${GPU_IMAGE_TAR:-}"
 GPU_REPO_ROOT=""
 ACTION="${ACTION:-start}"
 ATK_ENV="${ATK_ENV:-}"
@@ -150,6 +157,18 @@ while [[ $# -gt 0 ]]; do
       shift
       [[ $# -gt 0 ]] || die "参数 --gpu_image 需要取值"
       GPU_IMAGE="$1"
+      ;;
+    -gpu_image_tar=*) GPU_IMAGE_TAR="${1#-gpu_image_tar=}" ;;
+    -gpu_image_tar)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -gpu_image_tar 需要取值"
+      GPU_IMAGE_TAR="$1"
+      ;;
+    --gpu_image_tar=*) GPU_IMAGE_TAR="${1#--gpu_image_tar=}" ;;
+    --gpu_image_tar)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --gpu_image_tar 需要取值"
+      GPU_IMAGE_TAR="$1"
       ;;
     -gpu_repo_root=*) GPU_REPO_ROOT="${1#-gpu_repo_root=}" ;;
     -gpu_repo_root)
@@ -330,24 +349,44 @@ log_info "宿主机映射端口：${GPU_HOST_PORT} -> 容器 9090"
 log_info "容器名：${GPU_CONTAINER}"
 log_info "容器内仓库根：${GPU_REPO_ROOT}"
 log_info "算子测试目录：${OP_TEST_DIR}"
+if [[ -n "$GPU_IMAGE_TAR" ]]; then
+  log_info "GPU 镜像 tar：${GPU_IMAGE_TAR}"
+fi
 if [[ -n "$GPU_IMAGE" ]]; then
   log_info "GPU 镜像：${GPU_IMAGE}"
 fi
 
-# 容器已存在则复用，否则用 -gpu_image 启动新容器
+# 容器已存在则复用，否则创建新容器
 if docker inspect "$GPU_CONTAINER" >/dev/null 2>&1; then
   log_info "容器 ${GPU_CONTAINER} 已存在，复用"
   docker start "$GPU_CONTAINER" >/dev/null 2>&1 || true
 else
-  [[ -n "$GPU_IMAGE" ]] || die "容器不存在，必须传入 -gpu_image=<镜像名> 创建新容器"
-  log_info "创建新容器：${GPU_CONTAINER}（镜像 ${GPU_IMAGE}）"
+  # 确定镜像名：优先用 -gpu_image_tar 加载，其次用 -gpu_image
+  RUN_IMAGE=""
+  if [[ -n "$GPU_IMAGE_TAR" ]]; then
+    [[ -f "$GPU_IMAGE_TAR" ]] || die "镜像 tar 文件不存在：${GPU_IMAGE_TAR}"
+    log_info "从 tar 加载镜像：${GPU_IMAGE_TAR}"
+    LOAD_OUTPUT="$(docker load -i "$GPU_IMAGE_TAR")" || die "docker load 失败：${GPU_IMAGE_TAR}"
+    # docker load 输出形如 "Loaded image: repo:tag" 或 "Loaded image ID: sha256:xxx"
+    RUN_IMAGE="$(echo "$LOAD_OUTPUT" | grep -oP 'Loaded image: \K.*' | head -n1)"
+    if [[ -z "$RUN_IMAGE" ]]; then
+      # 旧格式只给了 image ID，回退到 -gpu_image 或用 ID
+      RUN_IMAGE="$GPU_IMAGE"
+      [[ -n "$RUN_IMAGE" ]] || die "docker load 未返回镜像名，且未传入 -gpu_image，无法创建容器。load 输出：${LOAD_OUTPUT}"
+    fi
+    log_info "加载得到镜像：${RUN_IMAGE}"
+  else
+    RUN_IMAGE="$GPU_IMAGE"
+  fi
+  [[ -n "$RUN_IMAGE" ]] || die "容器不存在，必须传入 -gpu_image=<镜像名> 或 -gpu_image_tar=<tar路径> 创建新容器"
+  log_info "创建新容器：${GPU_CONTAINER}（镜像 ${RUN_IMAGE}）"
   docker run -d \
     --name "$GPU_CONTAINER" \
     --gpus "\"device=${GPU_DEVICE_ID}\"" \
     -p "${GPU_HOST_PORT}:9090" \
     -v "$(pwd):${GPU_REPO_ROOT}" \
     -w "$OP_TEST_DIR" \
-    "$GPU_IMAGE" \
+    "$RUN_IMAGE" \
     sleep infinity
 fi
 

--- a/tests/atk/common/gpu_server.sh
+++ b/tests/atk/common/gpu_server.sh
@@ -343,6 +343,17 @@ fi
 OP_TEST_DIR="${GPU_REPO_ROOT}/tests/atk/${OP}"
 EXECUTOR_FILE="executor_${OP}.py"
 
+# 从脚本自身路径解析宿主机仓库根目录（向上 3 级：common/atk/tests -> 仓库根）
+HOST_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+# 预检：宿主机上 executor 文件必须存在
+HOST_EXECUTOR="${HOST_REPO_ROOT}/tests/atk/${OP}/${EXECUTOR_FILE}"
+if [[ ! -f "$HOST_EXECUTOR" ]]; then
+  die "宿主机未找到 executor 文件：${HOST_EXECUTOR}（仓库根目录：${HOST_REPO_ROOT}）"
+fi
+log_info "宿主机仓库根：${HOST_REPO_ROOT}"
+log_info "宿主机 executor：${HOST_EXECUTOR}"
+
 log_info "算子：${OP}"
 log_info "物理 GPU 卡号：${GPU_DEVICE_ID}（容器内逻辑设备 0）"
 log_info "宿主机映射端口：${GPU_HOST_PORT} -> 容器 9090"
@@ -384,7 +395,7 @@ else
     --name "$GPU_CONTAINER" \
     --gpus "\"device=${GPU_DEVICE_ID}\"" \
     -p "${GPU_HOST_PORT}:9090" \
-    -v "$(pwd):${GPU_REPO_ROOT}" \
+    -v "${HOST_REPO_ROOT}:${GPU_REPO_ROOT}" \
     -w "$OP_TEST_DIR" \
     "$RUN_IMAGE" \
     sleep infinity
@@ -411,7 +422,7 @@ INNER_CMDS+=("unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY")
 INNER_CMDS+=("cd '${OP_TEST_DIR}'")
 INNER_CMDS+=("atk --version")
 INNER_CMDS+=("python -c 'import torch; print(\"torch\", torch.__version__, \"cuda\", torch.cuda.is_available(), torch.cuda.device_count())'")
-INNER_CMDS+=("test -f '${EXECUTOR_FILE}' || { echo '未找到 executor: ${EXECUTOR_FILE}'; exit 1; }")
+INNER_CMDS+=("test -f '${EXECUTOR_FILE}' || { echo '未找到 executor: ${OP_TEST_DIR}/${EXECUTOR_FILE}（容器内）'; exit 1; }")
 INNER_CMDS+=("echo '[GPU ATK server] 开始启动 ATK server，监听 0.0.0.0:9090'")
 INNER_CMDS+=("atk server --host 0.0.0.0 --port 9090 --devices 0 --name gpu_reference --output_path ./atk_output/gpu_server --plugin_path './${EXECUTOR_FILE}' --timeout '${ATK_SERVER_TIMEOUT}'")
 

--- a/tests/atk/common/gpu_server.sh
+++ b/tests/atk/common/gpu_server.sh
@@ -4,16 +4,19 @@ set -euo pipefail
 # GPU 端 ATK server 一键启动脚本。
 # 职责：在 GPU 宿主机上启动 Docker 容器，容器内激活 ATK 环境、校验 CUDA/Triton，
 #       随后前台启动 ATK server，监听 0.0.0.0:<port>，供 NPU 端 accuracy_gpu 远程调用。
-# 本脚本在 GPU 宿主机执行，不在 NPU 机器上执行。
-# 容器内 ATK server 与 NPU 端 run_test_cpu.sh -scope=accuracy_gpu 配对使用。
-# action=test_connection_from_npu 例外：在 NPU 机器执行，测试到 GPU server 的连通性。
+# action=gpu_server_start 在 GPU 宿主机执行：启动容器并前台运行 ATK server。
+# action=npu 在 NPU 机器执行：构造 atk node(本地 NPU) + node(远程 GPU) + task 链，
+#       对接已启动的 GPU server，跑 accuracy_gpu 精度对拍。
+# action=test_connection_from_npu 在 NPU 机器执行：测试到 GPU server 的连通性。
+# 容器内 ATK server 与 NPU 端 action=npu / run_test_cpu.sh -scope=accuracy_gpu 配对使用。
 
 show_usage() {
   cat <<'EOF'
 用法：
   bash tests/atk/common/gpu_server.sh -op=<算子名> [选项]
 
-  默认（action=start）在 GPU 宿主机执行：启动容器并前台运行 ATK server。
+  默认（action=gpu_server_start）在 GPU 宿主机执行：启动容器并前台运行 ATK server。
+  action=npu 在 NPU 机器执行：对接远程 GPU server 跑精度对拍（atk node ... task）。
   action=test_connection_from_npu 在 NPU 机器执行：测试到 GPU server 的连通性。
 
 必选参数：
@@ -27,8 +30,19 @@ show_usage() {
   -gpu_image=                   GPU 基础镜像，必选（如 pytorch/pytorch:2.3.0-cuda12.1-cudnn8-devel）
   -gpu_image_tar=              本地镜像 tar 文件路径；设置后先 docker load 再用加载出的镜像名创建容器
   -gpu_repo_root=               仓库在容器内的挂载根目录，必选（如 /workspace/flash-linear-attention-npu）
-  -action=start                 start：启动容器并前台运行 ATK server；stop：停止并删除容器；
-                                 test_connection_from_npu：在 NPU 机器测试到 GPU server 连通性
+  -action=gpu_server_start       gpu_server_start：启动容器并前台运行 ATK server；
+                                  gpu_server_stop：停止并删除容器；
+                                  npu：在 NPU 机器构造 atk node+node+task，对接远程 GPU server 跑精度对拍；
+                                  test_connection_from_npu：在 NPU 机器测试到 GPU server 连通性
+  -npu_device_id=7               NPU 物理卡号，action=npu 时使用，默认 7
+  -npu_gpu_device_id=0           远程 GPU 参考节点 --devices，action=npu 时使用，默认 0
+  -npu_output_path=./atk_output/kda_remote
+                                  action=npu 输出目录，默认 ./atk_output/kda_remote
+  -npu_task=accuracy             action=npu 任务类型，默认 accuracy
+  -npu_mt=1                      action=npu -mt 值，默认 1
+  -npu_task_timeout=2000         action=npu task 超时，默认 2000
+  -npu_atk_config=               action=npu atk 配置 json；未设置时用 ./atk_${op}.json
+  -npu_executor=                 action=npu executor 文件；未设置时用 ./executor_${op}.py
   -atk_env=                     容器内 ATK 虚拟环境目录，设置后 source "$ATK_ENV/bin/activate"
   -triton_root=                 兼容 Triton 源码根（加入 PYTHONPATH）；未设置则跳过
   -atk_server_timeout=8000      ATK server 单任务超时，默认 8000
@@ -50,7 +64,11 @@ show_usage() {
       -gpu_container=fla_gpu_atk -gpu_repo_root=/workspace/flash-linear-attention-npu
 
   # 停止并删除容器
-  bash tests/atk/common/gpu_server.sh -op=chunk_kda_fwd -action=stop
+  bash tests/atk/common/gpu_server.sh -op=chunk_kda_fwd -action=gpu_server_stop
+
+  # 在 NPU 机器跑精度对拍（对接已启动的远程 GPU server）
+  bash tests/atk/common/gpu_server.sh -op=chunk_kda_fwd -action=npu \
+      -gpu_host=10.10.10.10 -gpu_host_port=9090 -npu_device_id=7
 
   # 在 NPU 机器测试到 GPU server 的连通性（TCP + ATK server 响应）
   bash tests/atk/common/gpu_server.sh -op=chunk_kda_fwd \
@@ -79,10 +97,19 @@ GPU_CONTAINER="${GPU_CONTAINER:-fla_gpu_atk}"
 GPU_IMAGE=""
 GPU_IMAGE_TAR="${GPU_IMAGE_TAR:-}"
 GPU_REPO_ROOT=""
-ACTION="${ACTION:-start}"
+ACTION="${ACTION:-gpu_server_start}"
 ATK_ENV="${ATK_ENV:-}"
 TRITON_ROOT="${TRITON_ROOT:-}"
 ATK_SERVER_TIMEOUT="${ATK_SERVER_TIMEOUT:-8000}"
+# action=npu 专用参数
+NPU_DEVICE_ID="${NPU_DEVICE_ID:-7}"
+NPU_GPU_DEVICE_ID="${NPU_GPU_DEVICE_ID:-0}"
+NPU_OUTPUT_PATH="${NPU_OUTPUT_PATH:-./atk_output/kda_remote}"
+NPU_TASK="${NPU_TASK:-accuracy}"
+NPU_MT="${NPU_MT:-1}"
+NPU_TASK_TIMEOUT="${NPU_TASK_TIMEOUT:-2000}"
+NPU_ATK_CONFIG="${NPU_ATK_CONFIG:-}"
+NPU_EXECUTOR="${NPU_EXECUTOR:-}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -230,6 +257,102 @@ while [[ $# -gt 0 ]]; do
       [[ $# -gt 0 ]] || die "参数 --atk_server_timeout 需要取值"
       ATK_SERVER_TIMEOUT="$1"
       ;;
+    -npu_device_id=*) NPU_DEVICE_ID="${1#-npu_device_id=}" ;;
+    -npu_device_id)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -npu_device_id 需要取值"
+      NPU_DEVICE_ID="$1"
+      ;;
+    --npu_device_id=*) NPU_DEVICE_ID="${1#--npu_device_id=}" ;;
+    --npu_device_id)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --npu_device_id 需要取值"
+      NPU_DEVICE_ID="$1"
+      ;;
+    -npu_gpu_device_id=*) NPU_GPU_DEVICE_ID="${1#-npu_gpu_device_id=}" ;;
+    -npu_gpu_device_id)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -npu_gpu_device_id 需要取值"
+      NPU_GPU_DEVICE_ID="$1"
+      ;;
+    --npu_gpu_device_id=*) NPU_GPU_DEVICE_ID="${1#--npu_gpu_device_id=}" ;;
+    --npu_gpu_device_id)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --npu_gpu_device_id 需要取值"
+      NPU_GPU_DEVICE_ID="$1"
+      ;;
+    -npu_output_path=*) NPU_OUTPUT_PATH="${1#-npu_output_path=}" ;;
+    -npu_output_path)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -npu_output_path 需要取值"
+      NPU_OUTPUT_PATH="$1"
+      ;;
+    --npu_output_path=*) NPU_OUTPUT_PATH="${1#--npu_output_path=}" ;;
+    --npu_output_path)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --npu_output_path 需要取值"
+      NPU_OUTPUT_PATH="$1"
+      ;;
+    -npu_task=*) NPU_TASK="${1#-npu_task=}" ;;
+    -npu_task)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -npu_task 需要取值"
+      NPU_TASK="$1"
+      ;;
+    --npu_task=*) NPU_TASK="${1#--npu_task=}" ;;
+    --npu_task)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --npu_task 需要取值"
+      NPU_TASK="$1"
+      ;;
+    -npu_mt=*) NPU_MT="${1#-npu_mt=}" ;;
+    -npu_mt)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -npu_mt 需要取值"
+      NPU_MT="$1"
+      ;;
+    --npu_mt=*) NPU_MT="${1#--npu_mt=}" ;;
+    --npu_mt)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --npu_mt 需要取值"
+      NPU_MT="$1"
+      ;;
+    -npu_task_timeout=*) NPU_TASK_TIMEOUT="${1#-npu_task_timeout=}" ;;
+    -npu_task_timeout)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -npu_task_timeout 需要取值"
+      NPU_TASK_TIMEOUT="$1"
+      ;;
+    --npu_task_timeout=*) NPU_TASK_TIMEOUT="${1#--npu_task_timeout=}" ;;
+    --npu_task_timeout)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --npu_task_timeout 需要取值"
+      NPU_TASK_TIMEOUT="$1"
+      ;;
+    -npu_atk_config=*) NPU_ATK_CONFIG="${1#-npu_atk_config=}" ;;
+    -npu_atk_config)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -npu_atk_config 需要取值"
+      NPU_ATK_CONFIG="$1"
+      ;;
+    --npu_atk_config=*) NPU_ATK_CONFIG="${1#--npu_atk_config=}" ;;
+    --npu_atk_config)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --npu_atk_config 需要取值"
+      NPU_ATK_CONFIG="$1"
+      ;;
+    -npu_executor=*) NPU_EXECUTOR="${1#-npu_executor=}" ;;
+    -npu_executor)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -npu_executor 需要取值"
+      NPU_EXECUTOR="$1"
+      ;;
+    --npu_executor=*) NPU_EXECUTOR="${1#--npu_executor=}" ;;
+    --npu_executor)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --npu_executor 需要取值"
+      NPU_EXECUTOR="$1"
+      ;;
     -h|--help)
       show_usage
       exit 0
@@ -244,8 +367,8 @@ done
 
 [[ -n "$OP" ]] || die "必须传入 -op=<算子名>"
 case "$ACTION" in
-  start|stop|test_connection_from_npu) ;;
-  *) die "不支持的 action：${ACTION}，请使用 start、stop 或 test_connection_from_npu" ;;
+  gpu_server_start|gpu_server_stop|npu|test_connection_from_npu) ;;
+  *) die "不支持的 action：${ACTION}，请使用 gpu_server_start、gpu_server_stop、npu 或 test_connection_from_npu" ;;
 esac
 
 # ---------------------------------------------------------------------------
@@ -326,9 +449,71 @@ PYEOF
 fi
 
 # ---------------------------------------------------------------------------
-# stop：停止并删除容器
+# npu：在 NPU 机器构造 atk node(本地 NPU) + node(远程 GPU) + task 链，跑精度对拍
 # ---------------------------------------------------------------------------
-if [[ "$ACTION" == "stop" ]]; then
+if [[ "$ACTION" == "npu" ]]; then
+  [[ -n "$GPU_HOST" ]] || die "action=npu 必须传入 -gpu_host=<GPU server 地址>"
+  [[ -n "$GPU_HOST_PORT" ]] || die "action=npu 必须传入 -gpu_host_port=<GPU server 端口>"
+
+  ATK_BIN="$(command -v atk || true)"
+  [[ -n "$ATK_BIN" ]] || die "找不到 atk，请先安装并激活 ATK 环境"
+
+  # 从脚本自身路径解析仓库根目录（向上 3 级：common/atk/tests -> 仓库根）
+  HOST_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  OP_TEST_DIR="${HOST_REPO_ROOT}/tests/atk/${OP}"
+
+  # 默认 atk 配置 / executor 文件名按算子名推导
+  [[ -n "$NPU_ATK_CONFIG" ]] || NPU_ATK_CONFIG="./atk_${OP}.json"
+  [[ -n "$NPU_EXECUTOR" ]] || NPU_EXECUTOR="./executor_${OP}.py"
+
+  # 预检：executor 与 atk 配置文件必须存在
+  HOST_EXECUTOR="${OP_TEST_DIR}/executor_${OP}.py"
+  [[ -f "$HOST_EXECUTOR" ]] || die "未找到 executor 文件：${HOST_EXECUTOR}（仓库根目录：${HOST_REPO_ROOT}）"
+  HOST_ATK_CONFIG="${OP_TEST_DIR}/${NPU_ATK_CONFIG#./}"
+  [[ -f "$HOST_ATK_CONFIG" ]] || die "未找到 atk 配置：${HOST_ATK_CONFIG}（仓库根目录：${HOST_REPO_ROOT}）"
+
+  log_info "action=npu：在 NPU 机器对接远程 GPU server 跑精度对拍"
+  log_info "算子：${OP}"
+  log_info "NPU 设备号：${NPU_DEVICE_ID}"
+  log_info "GPU 远程 server：${GPU_HOST}:${GPU_HOST_PORT}（参考节点 devices=${NPU_GPU_DEVICE_ID}）"
+  log_info "ATK 路径：${ATK_BIN}"
+  log_info "输出目录：${NPU_OUTPUT_PATH}"
+  log_info "task=${NPU_TASK} bm_device=gpu mt=${NPU_MT} timeout=${NPU_TASK_TIMEOUT}"
+
+  mkdir -p "$NPU_OUTPUT_PATH"
+  cd "$OP_TEST_DIR"
+
+  "$ATK_BIN" \
+    node \
+      --name npu_dut \
+      --backend npu \
+      --devices "$NPU_DEVICE_ID" \
+      --output_path "$NPU_OUTPUT_PATH" \
+    node \
+      --name gpu_reference \
+      --backend gpu \
+      --host "$GPU_HOST" \
+      --port "$GPU_HOST_PORT" \
+      --devices "$NPU_GPU_DEVICE_ID" \
+      --is_compare true \
+      --output_path "$NPU_OUTPUT_PATH" \
+    task \
+      -c "$NPU_ATK_CONFIG" \
+      --task "$NPU_TASK" \
+      --bm_device gpu \
+      -p "$NPU_EXECUTOR" \
+      --syc_dataset \
+      -mt "$NPU_MT" \
+      -to "$NPU_TASK_TIMEOUT"
+
+  log_info "完成精度对拍"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# gpu_server_stop：停止并删除容器
+# ---------------------------------------------------------------------------
+if [[ "$ACTION" == "gpu_server_stop" ]]; then
   log_info "停止并删除容器：${GPU_CONTAINER}"
   docker rm -f "$GPU_CONTAINER" >/dev/null 2>&1 || true
   log_info "容器 ${GPU_CONTAINER} 已删除"
@@ -336,7 +521,7 @@ if [[ "$ACTION" == "stop" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# start：启动容器 + ATK server
+# gpu_server_start：启动容器 + ATK server
 # ---------------------------------------------------------------------------
 [[ -n "$GPU_REPO_ROOT" ]] || die "必须传入 -gpu_repo_root=<容器内仓库根目录>"
 

--- a/tests/atk/recurrent_gated_delta_rule/reference_recurrent_gated_delta_rule.py
+++ b/tests/atk/recurrent_gated_delta_rule/reference_recurrent_gated_delta_rule.py
@@ -1,0 +1,79 @@
+"""Pure PyTorch reference for recurrent_gated_delta_rule."""
+
+from __future__ import annotations
+
+import torch
+
+
+def recurrent_gated_delta_rule_reference(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    state: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    actual_seq_lengths: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    num_accepted_tokens: torch.Tensor | None = None,
+    g: torch.Tensor | None = None,
+    gk: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute the recurrent update using the operator's FP32 semantics."""
+    actual_seq_lengths_list = actual_seq_lengths.detach().cpu().tolist()
+    state_indices = ssm_state_indices.detach().cpu().tolist()
+    accepted_tokens: list[int] | None = None
+    if num_accepted_tokens is not None:
+        accepted_tokens = num_accepted_tokens.detach().cpu().tolist()
+
+    calc_dtype = torch.float64 if query.dtype == torch.float64 else torch.float32
+    final_state = state.to(calc_dtype).clone()
+    total_tokens, key_heads, _ = query.shape
+    value_heads, value_dim = value.shape[1:]
+    head_group = value_heads // key_heads
+    out = torch.zeros(
+        (total_tokens, value_heads, value_dim),
+        dtype=calc_dtype,
+        device=query.device,
+    )
+
+    seq_start = int(actual_seq_lengths_list[0])
+    for batch_index, seq_len_value in enumerate(actual_seq_lengths_list[1:]):
+        seq_len = int(seq_len_value)
+        if seq_len <= 0:
+            continue
+        seq_end = seq_start + seq_len
+        state_token_index = seq_start
+        if accepted_tokens is not None:
+            state_token_index += int(accepted_tokens[batch_index]) - 1
+        initial_state_slot = int(state_indices[state_token_index])
+
+        for value_head in range(value_heads):
+            key_head = value_head // head_group
+            recurrent_state = final_state[initial_state_slot, value_head].clone()
+            for token_index in range(seq_start, seq_end):
+                if g is not None:
+                    recurrent_state *= torch.exp(
+                        g[token_index, value_head].to(calc_dtype)
+                    )
+                if gk is not None:
+                    recurrent_state *= torch.exp(
+                        gk[token_index, value_head].to(calc_dtype)
+                    ).unsqueeze(0)
+
+                key_vector = key[token_index, key_head].to(calc_dtype)
+                delta = value[token_index, value_head].to(calc_dtype)
+                delta -= torch.matmul(recurrent_state, key_vector)
+                delta *= beta[token_index, value_head].to(calc_dtype)
+                recurrent_state += torch.outer(delta, key_vector)
+                scaled_query = query[token_index, key_head].to(calc_dtype) * float(
+                    scale
+                )
+                out[token_index, value_head] = torch.matmul(
+                    recurrent_state, scaled_query
+                )
+                state_slot = int(state_indices[token_index])
+                final_state[state_slot, value_head] = recurrent_state
+
+        seq_start = seq_end
+
+    return out.to(value.dtype), final_state.to(state.dtype)

--- a/tests/atk/run_test_cpu.sh
+++ b/tests/atk/run_test_cpu.sh
@@ -7,15 +7,18 @@ set -euo pipefail
 show_usage() {
   cat <<'EOF'
 用法：
-  bash tests/atk/run_test_cpu.sh -op=<算子名> [-npu_device_id=<NPU卡号>]
+  bash tests/atk/run_test_cpu.sh -op=<算子名> [-npu_device_id=<NPU卡号>] [-gpu_device_id=<GPU卡号>]
 
 常用参数：
   -op=chunk_kda_fwd              ATK 算子目录名
   -npu_device_id=0               传给 ATK node --devices 的 NPU 卡号，默认 0；gen_cases 不需要
+  -gpu_device_id=0               传给 ATK GPU node --devices 的 GPU 卡号，默认 0；accuracy_gpu 使用
+  -gpu_host=<host>              GPU 宿主机地址；accuracy_gpu 必选
+  -gpu_host_port=<port>          GPU server 端口；accuracy_gpu 必选
   -soc=ascend910b                可选：ascend910b/A2、ascend910_93/A3、ascend950/A5；默认 auto 自动探测
-  -scope=all                     可选：all、accuracy、performance、determinism、mssanitizer、gen_cases
-                                 all 包含 accuracy/determinism/mssanitizer；
-                                 performance 需单独指定；gen_cases 不在 all 中
+  -scope=all                     可选：all、accuracy_cpu、accuracy_gpu、performance、determinism、mssanitizer、gen_cases
+                                 all 包含 accuracy_cpu/determinism/mssanitizer；
+                                 accuracy_gpu/performance 需单独指定；gen_cases 不在 all 中
 
 常用环境变量：
   ATK_ENV                        ATK 虚拟环境目录，设置后 source "$ATK_ENV/bin/activate"
@@ -28,7 +31,8 @@ show_usage() {
   DC_TIMEOUT                     确定性阶段超时，默认 3600
   PERFORMANCE_TIMEOUT            性能阶段超时，默认 2000
   CASE_START/CASE_END            通用 case 顺序范围；不设置时不传 -s/-e，ATK 执行全部用例
-  ACCURACY_START/ACCURACY_END    精度与 NaN 检测 case 范围
+  ACCURACY_CPU_START/END         CPU 精度与 NaN 检测 case 范围（兼容旧名 ACCURACY_START/END）
+  ACCURACY_GPU_START/END         GPU 精度与 NaN 检测 case 范围
   PERFORMANCE_START/END          性能 case 范围
   DETERMINISM_START/END          确定性 case 范围
   MSS_START/MSS_END              mssanitizer case 范围
@@ -42,6 +46,8 @@ show_usage() {
   bash tests/atk/run_test_cpu.sh -op=chunk_kda_fwd
   bash tests/atk/run_test_cpu.sh -op=chunk_bwd_dqkwg -scope=performance
   bash tests/atk/run_test_cpu.sh -op=chunk_bwd_dqkwg -scope=gen_cases
+  bash tests/atk/run_test_cpu.sh -op=chunk_bwd_dqkwg -scope=accuracy_cpu
+  bash tests/atk/run_test_cpu.sh -op=chunk_bwd_dqkwg -scope=accuracy_gpu -gpu_host=10.10.10.10 -gpu_host_port=9090
   CASE_START=0 CASE_END=1 bash tests/atk/run_test_cpu.sh -op=chunk_bwd_dqkwg
 EOF
 }
@@ -107,11 +113,16 @@ should_run() {
     [[ "$RUN_SCOPE" == "gen_cases" ]]
     return
   fi
-  # performance 不包含在 all 中，需单独指定 -scope=performance
+  # performance 和 accuracy_gpu 不包含在 all 中，需单独指定
   if [[ "$stage" == "performance" ]]; then
     [[ "$RUN_SCOPE" == "performance" ]]
     return
   fi
+  if [[ "$stage" == "accuracy_gpu" ]]; then
+    [[ "$RUN_SCOPE" == "accuracy_gpu" ]]
+    return
+  fi
+  # accuracy_cpu 包含在 all 中，也可单独指定
   [[ "$RUN_SCOPE" == "all" || "$RUN_SCOPE" == "$stage" ]]
 }
 
@@ -175,6 +186,9 @@ resolve_gm_init_args() {
 
 OP=""
 NPU_DEVICE_ID="${NPU_DEVICE_ID:-0}"
+GPU_DEVICE_ID="${GPU_DEVICE_ID:-0}"
+GPU_HOST=""
+GPU_HOST_PORT=""
 SOC="${SOC:-auto}"
 RUN_SCOPE="${RUN_SCOPE:-all}"
 ATK_GM_INIT_MODE="${ATK_GM_INIT_MODE:-on}"
@@ -217,6 +231,42 @@ while [[ $# -gt 0 ]]; do
       [[ $# -gt 0 ]] || die "参数 --npu_device_id 需要取值"
       NPU_DEVICE_ID="$1"
       ;;
+    -gpu_device_id=*) GPU_DEVICE_ID="${1#-gpu_device_id=}" ;;
+    -gpu_device_id)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -gpu_device_id 需要取值"
+      GPU_DEVICE_ID="$1"
+      ;;
+    --gpu_device_id=*) GPU_DEVICE_ID="${1#--gpu_device_id=}" ;;
+    --gpu_device_id)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --gpu_device_id 需要取值"
+      GPU_DEVICE_ID="$1"
+      ;;
+    -gpu_host=*) GPU_HOST="${1#-gpu_host=}" ;;
+    -gpu_host)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -gpu_host 需要取值"
+      GPU_HOST="$1"
+      ;;
+    --gpu_host=*) GPU_HOST="${1#--gpu_host=}" ;;
+    --gpu_host)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --gpu_host 需要取值"
+      GPU_HOST="$1"
+      ;;
+    -gpu_host_port=*) GPU_HOST_PORT="${1#-gpu_host_port=}" ;;
+    -gpu_host_port)
+      shift
+      [[ $# -gt 0 ]] || die "参数 -gpu_host_port 需要取值"
+      GPU_HOST_PORT="$1"
+      ;;
+    --gpu_host_port=*) GPU_HOST_PORT="${1#--gpu_host_port=}" ;;
+    --gpu_host_port)
+      shift
+      [[ $# -gt 0 ]] || die "参数 --gpu_host_port 需要取值"
+      GPU_HOST_PORT="$1"
+      ;;
     -soc=*) SOC="${1#-soc=}" ;;
     -soc)
       shift
@@ -256,7 +306,7 @@ done
 [[ -n "$OP" ]] || die "必须传入 -op=<算子名>"
 
 case "$RUN_SCOPE" in
-  all|accuracy|performance|determinism|mssanitizer|gen_cases) ;;
+  all|accuracy_cpu|accuracy_gpu|performance|determinism|mssanitizer|gen_cases) ;;
   *) die "不支持的执行范围：${RUN_SCOPE}" ;;
 esac
 
@@ -311,8 +361,10 @@ if [[ "$SOC" == "auto" ]]; then
   fi
 fi
 
-ACCURACY_START="${ACCURACY_START:-$CASE_START}"
-ACCURACY_END="${ACCURACY_END:-$CASE_END}"
+ACCURACY_CPU_START="${ACCURACY_CPU_START:-${ACCURACY_START:-$CASE_START}}"
+ACCURACY_CPU_END="${ACCURACY_CPU_END:-${ACCURACY_END:-$CASE_END}}"
+ACCURACY_GPU_START="${ACCURACY_GPU_START:-$CASE_START}"
+ACCURACY_GPU_END="${ACCURACY_GPU_END:-$CASE_END}"
 PERFORMANCE_START="${PERFORMANCE_START:-$CASE_START}"
 PERFORMANCE_END="${PERFORMANCE_END:-$CASE_END}"
 DETERMINISM_START="${DETERMINISM_START:-$CASE_START}"
@@ -320,9 +372,15 @@ DETERMINISM_END="${DETERMINISM_END:-$CASE_END}"
 MSS_START="${MSS_START:-$CASE_START}"
 MSS_END="${MSS_END:-$CASE_END}"
 
+# accuracy_gpu 必须通过 -gpu_host 和 -gpu_host_port 指定远程 GPU server
+if should_run accuracy_gpu; then
+  [[ -n "$GPU_HOST" ]] || die "accuracy_gpu 必须传入 -gpu_host=<GPU宿主机地址>"
+  [[ -n "$GPU_HOST_PORT" ]] || die "accuracy_gpu 必须传入 -gpu_host_port=<GPU server端口>"
+fi
+
 cd "$OP_DIR"
 ATK_OUTPUT_ROOT="${ATK_OUTPUT_ROOT:-./atk_output}"
-mkdir -p "${ATK_OUTPUT_ROOT}/cpu_dual_reference" "${ATK_OUTPUT_ROOT}/perf"
+mkdir -p "${ATK_OUTPUT_ROOT}/cpu_dual_reference" "${ATK_OUTPUT_ROOT}/gpu_dual_reference" "${ATK_OUTPUT_ROOT}/perf"
 # mssanitizer 日志路径：未显式指定时使用 ATK_OUTPUT_ROOT 下的带时间戳绝对路径
 # ATK celery worker 工作目录与脚本不同，必须用绝对路径，否则无法找到日志文件
 MSS_LOG_PATH="${MSS_LOG_PATH:-$(cd "${ATK_OUTPUT_ROOT}" && pwd)/mssanitizer_${OP}_$(date +%Y%m%d_%H%M%S).log}"
@@ -331,6 +389,10 @@ log_info "算子：${OP}"
 log_info "SOC：${SOC}"
 if [[ "$RUN_SCOPE" != "gen_cases" ]]; then
   log_info "NPU 设备号：${NPU_DEVICE_ID}"
+fi
+if should_run accuracy_gpu; then
+  log_info "GPU 设备号：${GPU_DEVICE_ID}"
+  log_info "GPU 远程 server：${GPU_HOST}:${GPU_HOST_PORT}"
 fi
 log_info "ATK 路径：${ATK_BIN}"
 log_info "输出根目录：${ATK_OUTPUT_ROOT}"
@@ -348,9 +410,9 @@ if should_run gen_cases; then
   log_info "完成泛化用例生成：result/${OP}/json/all_${OP}.json"
 fi
 
-if should_run accuracy; then
-  log_info "开始精度与 NaN 检测：accuracy + CPU高精度标杆 + CPU同精度标杆 + GM 初始化"
-  set_case_range_args "精度与 NaN 检测 case 范围" "$ACCURACY_START" "$ACCURACY_END"
+if should_run accuracy_cpu; then
+  log_info "开始 CPU 精度与 NaN 检测：accuracy + CPU高精度标杆 + CPU同精度标杆 + GM 初始化"
+  set_case_range_args "CPU 精度与 NaN 检测 case 范围" "$ACCURACY_CPU_START" "$ACCURACY_CPU_END"
   "$ATK_BIN" node --name npu_dut --backend npu --devices "$NPU_DEVICE_ID" \
       --output_path "${ATK_OUTPUT_ROOT}/cpu_dual_reference" \
     node --name cpu_reference --backend cpu \
@@ -363,8 +425,31 @@ if should_run accuracy; then
       "${CASE_RANGE_ARGS[@]}" \
       "${GM_INIT_ARGS[@]}" \
       -to "$ATK_TIMEOUT"
-  log_info "完成精度与 NaN 检测"
-  record_ran_type accuracy
+  log_info "完成 CPU 精度与 NaN 检测"
+  record_ran_type accuracy_cpu
+fi
+
+if should_run accuracy_gpu; then
+  log_info "开始 GPU 精度与 NaN 检测：accuracy + GPU高精度标杆 + GPU同精度标杆 + GM 初始化"
+  set_case_range_args "GPU 精度与 NaN 检测 case 范围" "$ACCURACY_GPU_START" "$ACCURACY_GPU_END"
+  "$ATK_BIN" node --name npu_dut --backend npu --devices "$NPU_DEVICE_ID" \
+      --output_path "${ATK_OUTPUT_ROOT}/gpu_dual_reference" \
+    node --name gpu_reference --backend gpu \
+      --host "$GPU_HOST" \
+      --port "$GPU_HOST_PORT" \
+      --devices "$GPU_DEVICE_ID" \
+      --is_compare true \
+      --output_path "${ATK_OUTPUT_ROOT}/gpu_dual_reference" \
+    task \
+      -c "./atk_${OP}.json" \
+      --task accuracy \
+      --bm_device gpu \
+      -p "./executor_${OP}.py" \
+      "${CASE_RANGE_ARGS[@]}" \
+      "${GM_INIT_ARGS[@]}" \
+      -to "$ATK_TIMEOUT"
+  log_info "完成 GPU 精度与 NaN 检测"
+  record_ran_type accuracy_gpu
 fi
 
 if should_run performance; then


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @alvazu
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
