### PR TITLE
fix(run): backport wheel OPP overlay to v26.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ FLA_NPU_SOC=ascend910b FLA_NPU_INCREMENTAL_BUILD=1 python -m pip wheel --no-buil
 
 增量构建仅建议用于本地反复调试。构建完成后，wheel 会输出到 `dist/` 目录，按 Step 3 安装即可。
 
+如果当前 Python 环境已经安装过一次完整 wheel，且后续只修改 Ascend C 算子实现，
+无需再次生成完整 wheel。可以只编译对应算子的 run 包并覆盖 wheel 内嵌 OPP，
+具体命令见 Step 3 的“推荐：首次安装 wheel，后续增量安装 run 包”。
+
 方式 A 编译可用环境变量：
 
 | 环境变量 | 可选范围 | 作用 / 建议 | 默认 |
@@ -141,18 +145,47 @@ python -m pip install --force-reinstall --no-deps dist/flash_linear_attention_np
 wheel 通过绝对路径加载 `libcust_opapi.so`，不会再生成或加载可能覆盖 CANN
 运行库的自定义 `libopapi.so`。
 
-#### 方式 B 产物安装
+#### 推荐：首次安装 wheel，后续增量安装 run 包
 
-先安装 run 包，再安装 torch_custom wheel。运行 Python 前需要 source custom OPP 的 `set_env.bash`，或设置 `FLA_NPU_OPP_PATH` 指向 OPP root / vendor 目录。
+首次使用时，按方式 A 编译并安装一次完整 wheel。后续如果只修改 Ascend C
+算子实现，在同一个 Python/Conda 环境中只编译对应算子的 run 包：
 
 ```sh
-export FLA_NPU_OPP_INSTALL_PATH=/path/to/fla_npu_opp
-./build_out/fla-npu-*.run --quiet --install-path=${FLA_NPU_OPP_INSTALL_PATH}
-source ${FLA_NPU_OPP_INSTALL_PATH}/vendors/fla_npu_transformer/bin/set_env.bash
-python -m pip install --force-reinstall --no-deps torch_custom/fla_npu/dist/fla_npu-*.whl
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+bash build.sh --soc=ascend910b --pkg --vendor_name=fla_npu --ops=<op_name>
+./build_out/fla-npu-fla_npu_linux-*.run --install
 ```
 
-`import fla_npu` 会优先使用 wheel 内嵌 OPP，找不到时会继续从 `FLA_NPU_OPP_PATH`、`ASCEND_CUSTOM_OPP_PATH` 和 `ASCEND_OPP_PATH` 查找已安装 OPP。外部 OPP 的 `op_api/lib` 目录同样不得包含自定义 `libopapi.so`；如果残留该文件并可能遮蔽 CANN 运行库，导入会明确报错并要求清理旧别名。
+`--install` 会把本次 run 包中的 OPP 增量合并到当前 Python 环境已安装 wheel 的
+`fla_npu/opp`，无参数运行或使用 `--full` 与之等价。安装完成后请重新启动 Python
+进程；不需要设置 `FLA_NPU_OPP_PATH` 或 source wheel 内的 `set_env.bash`。进入新 shell
+时仍需 source CANN 的 `set_env.sh`。
+
+按算子构建的 run 包仍会整体替换 `libcust_opapi.so`、tiling so、proto so 等共享产物。
+安装器会列出当前 run 包包含的算子，并用 `WARNING` 标出覆盖后可能不可用的其他算子。
+这条路径适合只调试当前算子的开发环境；需要同时使用完整算子集时，应重新安装完整
+wheel，或构建包含全部所需算子的 run 包。
+
+如果 Python wrapper、公开接口或打包配置也有修改，仍需重新编译并安装完整 wheel，
+不能只安装 run 包。
+
+#### 可选：安装到外部 CANN OPP
+
+只有需要独立调试外部 OPP 时，才使用 `--cann`，或者通过 `--install-path` 指定绝对路径：
+
+```sh
+# 使用 ASCEND_CUSTOM_OPP_PATH / ASCEND_OPP_PATH
+./build_out/fla-npu-fla_npu_linux-*.run --cann
+
+# 或安装到指定目录
+export FLA_NPU_OPP_INSTALL_PATH=/path/to/fla_npu_opp
+./build_out/fla-npu-fla_npu_linux-*.run --install-path=${FLA_NPU_OPP_INSTALL_PATH}
+source ${FLA_NPU_OPP_INSTALL_PATH}/vendors/fla_npu_transformer/bin/set_env.bash
+```
+
+外部 OPP 模式不会更新 wheel 内嵌 OPP。`import fla_npu` 会优先使用 wheel 内嵌 OPP，
+找不到时才继续从 `FLA_NPU_OPP_PATH`、`ASCEND_CUSTOM_OPP_PATH` 和
+`ASCEND_OPP_PATH` 查找外部 OPP。
 
 ### Step 4. 测试安装成功
 

--- a/cmake/custom_build.cmake
+++ b/cmake/custom_build.cmake
@@ -1030,21 +1030,32 @@ if (ENABLE_OPS_KERNEL)
 endif ()
 
 if (NOT ENABLE_BUILT_IN AND BUILD_OPEN_PROJECT)
+    set(FLA_NPU_WHEEL_OPP_FINALIZER
+            ${CMAKE_SOURCE_DIR}/scripts/package/ops_transformer/scripts/finalize_wheel_opp.py)
     add_custom_target(modify_vendor ALL
-            DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/scripts/install.sh ${CMAKE_CURRENT_BINARY_DIR}/scripts/upgrade.sh
+            DEPENDS
+            ${CMAKE_CURRENT_BINARY_DIR}/scripts/install.sh
+            ${CMAKE_CURRENT_BINARY_DIR}/scripts/upgrade.sh
+            ${CMAKE_CURRENT_BINARY_DIR}/scripts/finalize_wheel_opp.py
     )
 
     # modify VENDOR_NAME in install.sh and upgrade.sh
-    if (EXISTS ${ASCEND_PROJECT_DIR}/fwk_modules/scripts)
-        set(ASCEND_PROJECT_DIR_SCRIPTS_PATH ${ASCEND_PROJECT_DIR}/fwk_modules/scripts)
-    else()
-        set(ASCEND_PROJECT_DIR_SCRIPTS_PATH ${CMAKE_SOURCE_DIR}/cmake/scripts/custom)
-    endif()
-    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/scripts/install.sh ${CMAKE_CURRENT_BINARY_DIR}/scripts/upgrade.sh
+    # Use the repository-owned custom package scripts so scoped wheel-OPP
+    # replacement behavior is deterministic across CANN releases.
+    set(ASCEND_PROJECT_DIR_SCRIPTS_PATH ${CMAKE_SOURCE_DIR}/cmake/scripts/custom)
+    add_custom_command(OUTPUT
+            ${CMAKE_CURRENT_BINARY_DIR}/scripts/install.sh
+            ${CMAKE_CURRENT_BINARY_DIR}/scripts/upgrade.sh
+            ${CMAKE_CURRENT_BINARY_DIR}/scripts/finalize_wheel_opp.py
             COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/scripts
             COMMAND cp -r ${ASCEND_PROJECT_DIR_SCRIPTS_PATH}/* ${CMAKE_CURRENT_BINARY_DIR}/scripts/
+            COMMAND cp ${FLA_NPU_WHEEL_OPP_FINALIZER} ${CMAKE_CURRENT_BINARY_DIR}/scripts/
             COMMAND chmod +w ${CMAKE_CURRENT_BINARY_DIR}/scripts/*
             COMMAND sed -i "s/vendor_name=customize/vendor_name=${VENDOR_NAME}_transformer/g" ${CMAKE_CURRENT_BINARY_DIR}/scripts/*
+            DEPENDS
+            ${ASCEND_PROJECT_DIR_SCRIPTS_PATH}/install.sh
+            ${ASCEND_PROJECT_DIR_SCRIPTS_PATH}/upgrade.sh
+            ${FLA_NPU_WHEEL_OPP_FINALIZER}
     )
 
     install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/scripts/

--- a/cmake/scripts/custom/help.info
+++ b/cmake/scripts/custom/help.info
@@ -1,2 +1,7 @@
-  --install-path                    Install operator package to specific dir path
+  --install                         Merge this run package into the active Python flash-linear-attention-npu wheel OPP
+  --full                            Same as --install (default behavior)
+                                    Lists package operators, support status, and scoped aclnn ABI changes
+  --cann                            Install into the CANN OPP layout (ASCEND_CUSTOM_OPP_PATH / ASCEND_OPP_PATH)
+  --install-path                    Install operator package to specific dir path (CANN layout)
   --install-for-all                 Allow other users to use the operator package
+  --quiet                           Quiet install mode

--- a/cmake/scripts/custom/install.sh
+++ b/cmake/scripts/custom/install.sh
@@ -15,8 +15,10 @@ target_custom=0
 sourcedir=$PWD/packages
 vendordir=vendors/$vendor_name
 
-QUIET="y"
+QUIET="n"
 INSTALL_FOR_ALL="n"
+WHEEL_INSTALL="y"
+MODE_SET="n"
 
 
 while true
@@ -26,9 +28,25 @@ do
         QUIET="y"
         shift
     ;;
+    --full|--install)
+        WHEEL_INSTALL="y"
+        MODE_SET="y"
+        shift
+    ;;
+    --cann)
+        WHEEL_INSTALL="n"
+        MODE_SET="y"
+        shift
+    ;;
     --install-path=*)
         INSTALL_PATH=$(echo $1 | cut -d"=" -f2-)
         INSTALL_PATH=${INSTALL_PATH%*/}
+        # An explicit install path targets the CANN OPP layout, unless a
+        # wheel/cann install mode was already requested explicitly.
+        if [ "${MODE_SET}" = "n" ]; then
+            WHEEL_INSTALL="n"
+            MODE_SET="y"
+        fi
         shift
     ;;
     --install-for-all)
@@ -46,9 +64,388 @@ done
 
 log() {
     cur_date=`date +"%Y-%m-%d %H:%M:%S"`
-    echo "[ops_custom] [$cur_date] "$1
+    printf '[ops_custom] [%s] %s\n' "${cur_date}" "$1"
 }
 
+get_python_bin() {
+    local candidate
+    for candidate in python python3; do
+        if command -v "${candidate}" >/dev/null 2>&1 && "${candidate}" -c 'import sys; raise SystemExit(0 if sys.version_info[0] >= 3 else 1)' >/dev/null 2>&1; then
+            command -v "${candidate}"
+            return
+        fi
+    done
+    echo ""
+}
+
+get_wheel_opp_root() {
+    local python_bin
+    python_bin=$(get_python_bin)
+    if [ -z "${python_bin}" ]; then
+        log "[WARNING] python is required to locate the installed fla_npu wheel OPP."
+        return 1
+    fi
+
+    "${python_bin}" - <<'PY'
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.find_spec("fla_npu")
+if spec is None or spec.origin is None:
+    print("fla_npu is not importable. Install flash-linear-attention-npu wheel first.", file=sys.stderr)
+    raise SystemExit(1)
+
+package_dir = Path(spec.origin).resolve().parent
+print(package_dir / "opp")
+PY
+}
+
+to_snake_name() {
+    echo "$1" | sed -E 's/([A-Z]+)([A-Z][a-z])/\1_\2/g; s/([a-z0-9])([A-Z])/\1_\2/g' | tr '[:upper:]' '[:lower:]'
+}
+
+support_status_tag() {
+    local status="$1"
+
+    case "${status}" in
+        warning)
+            printf 'WARNING'
+            ;;
+        notice)
+            printf 'NOTICE'
+            ;;
+        ok)
+            printf 'OK'
+            ;;
+        *)
+            printf 'INFO'
+            ;;
+    esac
+}
+
+collect_vendor_op_names() {
+    local vendor_dir="$1"
+    local abi_dir="${vendor_dir}/op_api/include/aclnnop"
+    local kernel_root="${vendor_dir}/op_impl/ai_core/tbe/kernel"
+
+    (
+        if [ -d "${abi_dir}" ]; then
+            while IFS= read -r header_file; do
+                local file_name
+                file_name=$(basename "${header_file}")
+                case "${file_name}" in
+                    aclnn_ops_transformer*.h)
+                        continue
+                        ;;
+                    aclnn_*.h)
+                        echo "${file_name}" | sed -E 's/^aclnn_(.*)\.h$/\1/'
+                        ;;
+                esac
+            done < <(find "${abi_dir}" -type f -name 'aclnn_*.h' | sort)
+        fi
+
+        if [ -d "${kernel_root}" ]; then
+            while IFS= read -r src_op_dir; do
+                local rel_dir="${src_op_dir#${kernel_root}/}"
+                case "${rel_dir}" in
+                    config/*)
+                        continue
+                        ;;
+                esac
+                to_snake_name "$(basename "${src_op_dir}")"
+            done < <(find "${kernel_root}" -mindepth 2 -maxdepth 2 -type d | sort)
+        fi
+    ) | sort -u
+}
+
+collect_op_aclnn_abi_changes() {
+    local src_vendor="$1"
+    local dst_vendor="$2"
+    local op_name="$3"
+    local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
+    local dst_abi_dir="${dst_vendor}/op_api/include/aclnnop"
+    local rel_file
+
+    for rel_file in "aclnn_${op_name}.h" "level2/aclnn_${op_name}.h"; do
+        if [ -f "${src_abi_dir}/${rel_file}" ] && [ ! -f "${dst_abi_dir}/${rel_file}" ]; then
+            echo "ADDED ${rel_file}"
+        elif [ -f "${src_abi_dir}/${rel_file}" ] && [ -f "${dst_abi_dir}/${rel_file}" ] && ! cmp -s "${src_abi_dir}/${rel_file}" "${dst_abi_dir}/${rel_file}"; then
+            echo "MODIFIED ${rel_file}"
+        elif [ ! -f "${src_abi_dir}/${rel_file}" ] && [ -f "${dst_abi_dir}/${rel_file}" ]; then
+            echo "DELETED ${rel_file}"
+        fi
+    done
+}
+
+op_has_source_aclnn_header() {
+    local src_vendor="$1"
+    local op_name="$2"
+    local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
+
+    [ -f "${src_abi_dir}/aclnn_${op_name}.h" ] || [ -f "${src_abi_dir}/level2/aclnn_${op_name}.h" ]
+}
+
+format_change_summary() {
+    local change_file="$1"
+    local summary=""
+    local line
+
+    while IFS= read -r line; do
+        if [ -z "${summary}" ]; then
+            summary="${line}"
+        else
+            summary="${summary}; ${line}"
+        fi
+    done <"${change_file}"
+    echo "${summary}"
+}
+
+log_op_status() {
+    local level="$1"
+    local status="$2"
+    local op_name="$3"
+    local reason="$4"
+    local tag
+
+    tag=$(support_status_tag "${status}")
+    log "[${level}]   $(printf '%-7s %-36s - %s' "${tag}" "${op_name}" "${reason}")"
+}
+
+log_op_scope_file() {
+    local title="$1"
+    local op_file="$2"
+    local level="$3"
+    local op_name
+
+    log "[${level}] ${title}"
+    if [ ! -s "${op_file}" ]; then
+        log "[${level}]   (none detected)"
+        return
+    fi
+
+    while IFS= read -r op_name; do
+        log "[${level}]   ${op_name}"
+    done <"${op_file}"
+}
+
+log_included_op_status() {
+    local src_vendor="$1"
+    local dst_vendor="$2"
+    local op_name="$3"
+    local changes_file
+    local summary
+
+    changes_file=$(mktemp)
+    collect_op_aclnn_abi_changes "${src_vendor}" "${dst_vendor}" "${op_name}" >"${changes_file}"
+    summary=$(format_change_summary "${changes_file}")
+
+    if grep -qE '^(MODIFIED|DELETED) ' "${changes_file}"; then
+        log_op_status "WARNING" "warning" "${op_name}" "unsupported after install because aclnn ABI changed: ${summary}"
+    elif grep -q '^ADDED ' "${changes_file}"; then
+        log_op_status "WARNING" "notice" "${op_name}" "included in run package, but aclnn ABI is new in the installed wheel: ${summary}"
+    elif ! op_has_source_aclnn_header "${src_vendor}" "${op_name}"; then
+        log_op_status "WARNING" "notice" "${op_name}" "included in run package, but no aclnn ABI header was found to compare"
+    else
+        log_op_status "INFO" "ok" "${op_name}" "included in run package and aclnn ABI is unchanged"
+    fi
+
+    rm -f "${changes_file}"
+}
+
+confirm_partial_shared_lib_impact() {
+    local src_vendor="$1"
+    local dst_vendor="$2"
+    local src_ops_file
+    local dst_ops_file
+    local unavailable_ops_file
+    local op_name
+
+    src_ops_file=$(mktemp)
+    dst_ops_file=$(mktemp)
+    unavailable_ops_file=$(mktemp)
+
+    collect_vendor_op_names "${src_vendor}" >"${src_ops_file}"
+    collect_vendor_op_names "${dst_vendor}" >"${dst_ops_file}"
+    comm -23 "${dst_ops_file}" "${src_ops_file}" >"${unavailable_ops_file}"
+
+    log_op_scope_file "This run package contains operators:" "${src_ops_file}" "INFO"
+    log "[INFO] Operator support status after installing this run package:"
+    log "[INFO]   $(printf '%-7s %s' "$(support_status_tag "warning")" "unsupported after install")"
+    log "[INFO]   $(printf '%-7s %s' "$(support_status_tag "notice")" "requires manual attention")"
+    log "[INFO]   $(printf '%-7s %s' "$(support_status_tag "ok")" "supported after install")"
+
+    while IFS= read -r op_name; do
+        log_included_op_status "${src_vendor}" "${dst_vendor}" "${op_name}"
+    done <"${src_ops_file}"
+
+    if [ -s "${unavailable_ops_file}" ]; then
+        log "[WARNING] Installing this run package replaces shared opapi/tiling/proto libraries in the wheel with the scoped build from this package."
+        log "[WARNING] The following installed operators are not included in this run package and will not be usable after replacement:"
+        while IFS= read -r op_name; do
+            log_op_status "WARNING" "warning" "${op_name}" "not included in this run package; shared opapi/tiling/proto libraries will be replaced"
+        done <"${unavailable_ops_file}"
+    fi
+
+    rm -f "${src_ops_file}" "${dst_ops_file}" "${unavailable_ops_file}"
+
+    if [ "${QUIET}" = "y" ]; then
+        log "[WARNING] --quiet is set, treating scoped run package replacement impact as confirmed."
+        return
+    fi
+
+    log "[INFO] Continue to replace the installed wheel OPP with this scoped run package? [y/n]"
+    while true; do
+        read yn
+        if [ "${yn}" = "y" ]; then
+            return
+        elif [ "${yn}" = "n" ]; then
+            log "[INFO] Exit without installing run package."
+            exit 0
+        else
+            log "[WARNING] Input error, please input y or n to choose!"
+        fi
+    done
+}
+
+remove_deleted_aclnn_headers() {
+    local src_vendor="$1"
+    local dst_vendor="$2"
+    local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
+    local dst_abi_dir="${dst_vendor}/op_api/include/aclnnop"
+    local op_name
+    local rel_file
+
+    if [ ! -d "${src_abi_dir}" ] || [ ! -d "${dst_abi_dir}" ]; then
+        return
+    fi
+
+    while IFS= read -r op_name; do
+        for rel_file in "aclnn_${op_name}.h" "level2/aclnn_${op_name}.h"; do
+            if [ -f "${dst_abi_dir}/${rel_file}" ] && [ ! -f "${src_abi_dir}/${rel_file}" ]; then
+                rm -f "${dst_abi_dir}/${rel_file}"
+            fi
+        done
+    done < <(collect_vendor_op_names "${src_vendor}")
+}
+
+merge_vendor_to_wheel_opp() {
+    local src_vendor="$1"
+    local dst_vendor="$2"
+    local src_kernel_root="${src_vendor}/op_impl/ai_core/tbe/kernel"
+    local dst_kernel_root="${dst_vendor}/op_impl/ai_core/tbe/kernel"
+    local src_op_dir
+    local rel_dir
+    local dst_op_dir
+
+    mkdir -p "${dst_vendor}"
+
+    if [ -d "${src_kernel_root}" ]; then
+        while IFS= read -r src_op_dir; do
+            rel_dir="${src_op_dir#${src_kernel_root}/}"
+            case "${rel_dir}" in
+                config/*)
+                    continue
+                    ;;
+            esac
+            dst_op_dir="${dst_kernel_root}/${rel_dir}"
+            if [ -d "${dst_op_dir}" ]; then
+                rm -rf "${dst_op_dir}"
+            fi
+        done < <(find "${src_kernel_root}" -mindepth 2 -maxdepth 2 -type d)
+    fi
+
+    remove_deleted_aclnn_headers "${src_vendor}" "${dst_vendor}"
+
+    if command -v rsync >/dev/null 2>&1; then
+        rsync -a --checksum "${src_vendor}/" "${dst_vendor}/"
+    else
+        cp -a "${src_vendor}/." "${dst_vendor}/"
+    fi
+
+}
+
+finalize_wheel_opp() {
+    local wheel_opp_root="$1"
+    local python_bin
+    local script_dir
+    python_bin=$(get_python_bin)
+    script_dir=$(dirname "$(readlink -f "$0")")
+    if [ -z "${python_bin}" ]; then
+        log "[ERROR] python is required to finalize the installed wheel OPP."
+        exit 1
+    fi
+
+    if ! "${python_bin}" "${script_dir}/finalize_wheel_opp.py" \
+        --package-dir "$(dirname "${wheel_opp_root}")" \
+        --vendor-name "${vendor_name}"; then
+        log "[ERROR] Failed to finalize the installed wheel OPP and refresh wheel RECORD."
+        exit 1
+    fi
+}
+
+update_wheel_vendors_config() {
+    local vendors_root="$1"
+    local config_file="${vendors_root}/config.ini"
+    local existing=""
+    local merged="${vendor_name}"
+    local item
+
+    mkdir -p "${vendors_root}"
+    if [ -f "${config_file}" ]; then
+        existing=$(grep -w "load_priority" "${config_file}" | tail -n 1 | cut --only-delimited -d"=" -f2-)
+    fi
+
+    IFS=',' read -ra vendor_items <<< "${existing}"
+    for item in "${vendor_items[@]}"; do
+        item=$(echo "${item}" | xargs)
+        if [ -n "${item}" ] && [ "${item}" != "${vendor_name}" ]; then
+            merged="${merged},${item}"
+        fi
+    done
+    echo "load_priority=${merged}" >"${config_file}"
+}
+
+install_wheel_opp_package() {
+    local src_vendor="${sourcedir}/${vendordir}"
+    local wheel_opp_root
+    local dst_vendor
+
+    if [ ! -d "${src_vendor}" ]; then
+        log "[ERROR] The run package does not contain ${src_vendor}."
+        exit 1
+    fi
+
+    wheel_opp_root=$(get_wheel_opp_root)
+    if [ -z "${wheel_opp_root}" ]; then
+        log "[WARNING] fla_npu wheel is not importable, falling back to CANN OPP install."
+        return 1
+    fi
+    wheel_opp_root="${wheel_opp_root%/}"
+    dst_vendor="${wheel_opp_root}/${vendordir}"
+
+    if [ ! -d "${dst_vendor}" ]; then
+        log "[ERROR] Target wheel OPP vendor not found: ${dst_vendor}. Install the full flash-linear-attention-npu wheel first."
+        exit 1
+    fi
+
+    log "[INFO] Merge FLA NPU run package into installed wheel OPP root: ${wheel_opp_root}"
+    log "[INFO] Source vendor ${src_vendor}"
+    log "[INFO] Target vendor ${dst_vendor}"
+
+    confirm_partial_shared_lib_impact "${src_vendor}" "${dst_vendor}"
+    merge_vendor_to_wheel_opp "${src_vendor}" "${dst_vendor}"
+    update_wheel_vendors_config "${wheel_opp_root}/vendors"
+    finalize_wheel_opp "${wheel_opp_root}"
+
+    log "[INFO] FLA NPU wheel OPP update completed. Restart Python processes to load the new libcust_opapi.so and kernels."
+    echo "SUCCESS"
+    exit 0
+}
+
+if [ "${WHEEL_INSTALL}" = "y" ]; then
+    install_wheel_opp_package
+fi
 if [ -n "${INSTALL_PATH}" ]; then
     if [[ ! "${INSTALL_PATH}" = /* ]]; then
         log "[ERROR] use absolute path for --install-path argument"

--- a/scripts/package/ops_transformer/scripts/finalize_wheel_opp.py
+++ b/scripts/package/ops_transformer/scripts/finalize_wheel_opp.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Finalize an OPP overlay inside an installed fla_npu wheel."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import hashlib
+import os
+import stat
+import tempfile
+from pathlib import Path
+
+
+DIST_INFO_GLOB = "flash_linear_attention_npu-*.dist-info"
+DEFAULT_VENDOR_DIR = "fla_npu_transformer"
+
+
+def _write_set_env(vendor_dir: Path) -> None:
+    bin_dir = vendor_dir / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    set_env = bin_dir / "set_env.bash"
+    set_env.write_text(
+        "\n".join(
+            [
+                "#!/bin/bash",
+                '_FLA_NPU_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"',
+                '_FLA_NPU_VENDOR_DIR="$(cd "${_FLA_NPU_SCRIPT_DIR}/.." && pwd)"',
+                '_FLA_NPU_OPP_ROOT="$(cd "${_FLA_NPU_VENDOR_DIR}/../.." && pwd)"',
+                "_fla_npu_prepend_path() {",
+                '    local name="$1"',
+                '    local value="$2"',
+                '    local current=""',
+                '    if [[ -v "${name}" ]]; then',
+                '        current="${!name}"',
+                "    fi",
+                '    case ":${current}:" in',
+                '        *":${value}:"*) return 0 ;;',
+                "    esac",
+                '    printf -v "${name}" "%s" "${value}${current:+:${current}}"',
+                '    export "${name}"',
+                "}",
+                '_fla_npu_prepend_path ASCEND_CUSTOM_OPP_PATH "${_FLA_NPU_VENDOR_DIR}"',
+                '_fla_npu_prepend_path ASCEND_CUSTOM_OPP_PATH "${_FLA_NPU_OPP_ROOT}"',
+                '_fla_npu_prepend_path LD_LIBRARY_PATH "${_FLA_NPU_VENDOR_DIR}/op_api/lib"',
+                'export FLA_NPU_OPP_PATH="${_FLA_NPU_OPP_ROOT}"',
+                'export FLA_NPU_OP_API_LIB="${_FLA_NPU_VENDOR_DIR}/op_api/lib/libcust_opapi.so"',
+                "unset -f _fla_npu_prepend_path",
+                "unset _FLA_NPU_SCRIPT_DIR _FLA_NPU_VENDOR_DIR _FLA_NPU_OPP_ROOT",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    set_env.chmod(0o755)
+
+
+def _record_digest(path: Path) -> tuple[str, str]:
+    content = path.read_bytes()
+    digest = base64.urlsafe_b64encode(hashlib.sha256(content).digest()).rstrip(b"=").decode("ascii")
+    return f"sha256={digest}", str(len(content))
+
+
+def _find_record(package_dir: Path) -> Path:
+    dist_infos = sorted(package_dir.parent.glob(DIST_INFO_GLOB))
+    if len(dist_infos) != 1:
+        raise RuntimeError(
+            f"Expected exactly one {DIST_INFO_GLOB} next to {package_dir}, "
+            f"found {len(dist_infos)}"
+        )
+    record = dist_infos[0] / "RECORD"
+    if not record.is_file():
+        raise RuntimeError(f"Installed wheel RECORD is missing: {record}")
+    return record
+
+
+def _refresh_record(package_dir: Path) -> Path:
+    record = _find_record(package_dir)
+    site_root = package_dir.parent.resolve()
+    opp_root = package_dir / "opp"
+    opp_prefix = f"{package_dir.name}/opp/"
+
+    with record.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.reader(handle))
+
+    rows = [row for row in rows if row and not row[0].startswith(opp_prefix)]
+    for path in sorted(opp_root.rglob("*")):
+        if not (path.is_file() or path.is_symlink()):
+            continue
+        relative = path.relative_to(site_root).as_posix()
+        digest, size = _record_digest(path)
+        rows.append([relative, digest, size])
+
+    record_mode = stat.S_IMODE(record.stat().st_mode)
+    temp_name = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            newline="",
+            dir=record.parent,
+            prefix=".RECORD.",
+            delete=False,
+        ) as handle:
+            temp_name = handle.name
+            writer = csv.writer(handle, lineterminator="\n")
+            writer.writerows(rows)
+        os.chmod(temp_name, record_mode)
+        os.replace(temp_name, record)
+    finally:
+        if temp_name:
+            try:
+                Path(temp_name).unlink()
+            except FileNotFoundError:
+                pass
+    return record
+
+
+def finalize_wheel_opp(package_dir: Path, vendor_name: str = DEFAULT_VENDOR_DIR) -> Path:
+    package_dir = package_dir.expanduser().resolve()
+    vendor_dir = package_dir / "opp" / "vendors" / vendor_name
+    custom_opapi = vendor_dir / "op_api" / "lib" / "libcust_opapi.so"
+    if not custom_opapi.is_file():
+        raise RuntimeError(f"Wheel OPP is missing custom op_api library: {custom_opapi}")
+
+    conflicting_alias = custom_opapi.with_name("libopapi.so")
+    if conflicting_alias.exists() or conflicting_alias.is_symlink():
+        conflicting_alias.unlink()
+
+    _write_set_env(vendor_dir)
+    return _refresh_record(package_dir)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--package-dir", required=True, type=Path)
+    parser.add_argument("--vendor-name", default=DEFAULT_VENDOR_DIR)
+    args = parser.parse_args()
+
+    record = finalize_wheel_opp(args.package_dir, args.vendor_name)
+    print(f"Finalized wheel OPP and refreshed {record.name}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/package/ops_transformer/scripts/help.info
+++ b/scripts/package/ops_transformer/scripts/help.info
@@ -1,7 +1,7 @@
-  --full                            Install full mode
-    --install-path=<path>           Install product to specific dir path
-    --install-for-all               Install for all user
-    --quiet                         Quiet install mode, skip human-computer interactions
+  --install                         Merge this run package into the active Python flash-linear-attention-npu wheel OPP
+  --full                            Same as --install
+    The installer lists package operators, support status, and scoped aclnn ABI changes
+    --quiet                         Quiet install mode
   --uninstall                       Uninstall product with compatible run package which is installed before
     --install-path=<path>           Uninstall specific ops_transformer dir path
   --upgrade                         Upgrade product immediately

--- a/scripts/package/ops_transformer/scripts/install.sh
+++ b/scripts/package/ops_transformer/scripts/install.sh
@@ -328,7 +328,7 @@ get_opts() {
   while true; do
     # skip 2 parameters avoid run pkg and directory as input parameter
     case "$1" in
-      --full)
+      --full|--install)
         IN_INSTALL_TYPE=$(echo ${1} | awk -F"--" '{print $2}')
         IS_INSTALL="y"
         CONFLICT_CMD_NUMS=$(expr $CONFLICT_CMD_NUMS + 1)
@@ -377,11 +377,406 @@ get_opts() {
 check_opts() {
   if [ "${CONFLICT_CMD_NUMS}" != 1 ]; then
     echo "[OpsTransformer] [ERROR]: ERR_NO:${PARAM_INVALID};ERR_DES:\
- only support one type: full/run/devel/upgrade/uninstall/check, operation execute failed!\
+ only support one type: install/full/upgrade/uninstall, operation execute failed!\
  Please use [--help] to see the usage."
     exitlog
     exit 1
   fi
+}
+
+get_python_bin() {
+  local candidate
+  for candidate in python python3; do
+    if command -v "${candidate}" >/dev/null 2>&1 && "${candidate}" -c 'import sys; raise SystemExit(0 if sys.version_info[0] >= 3 else 1)' >/dev/null 2>&1; then
+      command -v "${candidate}"
+      return
+    fi
+  done
+  echo ""
+}
+
+get_wheel_opp_root() {
+  local python_bin
+  python_bin=$(get_python_bin)
+  if [ -z "${python_bin}" ]; then
+    logandprint "[ERROR]: python is required to locate the installed fla_npu wheel OPP."
+    exitlog
+    exit 1
+  fi
+
+  "${python_bin}" - <<'PY'
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.find_spec("fla_npu")
+if spec is None or spec.origin is None:
+    raise SystemExit("fla_npu is not importable. Install flash-linear-attention-npu wheel first.")
+
+package_dir = Path(spec.origin).resolve().parent
+print(package_dir / "opp")
+PY
+}
+
+to_snake_name() {
+  echo "$1" | sed -E 's/([A-Z]+)([A-Z][a-z])/\1_\2/g; s/([a-z0-9])([A-Z])/\1_\2/g' | tr '[:upper:]' '[:lower:]'
+}
+
+support_status_tag() {
+  local status="$1"
+
+  case "${status}" in
+    warning)
+      printf 'WARNING'
+      ;;
+    notice)
+      printf 'NOTICE'
+      ;;
+    ok)
+      printf 'OK'
+      ;;
+    *)
+      printf 'INFO'
+      ;;
+  esac
+}
+
+collect_vendor_op_names() {
+  local vendor_dir="$1"
+  local abi_dir="${vendor_dir}/op_api/include/aclnnop"
+  local kernel_root="${vendor_dir}/op_impl/ai_core/tbe/kernel"
+
+  (
+    if [ -d "${abi_dir}" ]; then
+      while IFS= read -r header_file; do
+        local file_name
+        file_name=$(basename "${header_file}")
+        case "${file_name}" in
+          aclnn_ops_transformer*.h)
+            continue
+            ;;
+          aclnn_*.h)
+            echo "${file_name}" | sed -E 's/^aclnn_(.*)\.h$/\1/'
+            ;;
+        esac
+      done < <(find "${abi_dir}" -type f -name 'aclnn_*.h' | sort)
+    fi
+
+    if [ -d "${kernel_root}" ]; then
+      while IFS= read -r src_op_dir; do
+        local rel_dir="${src_op_dir#${kernel_root}/}"
+        case "${rel_dir}" in
+          config/*)
+            continue
+            ;;
+        esac
+        to_snake_name "$(basename "${src_op_dir}")"
+      done < <(find "${kernel_root}" -mindepth 2 -maxdepth 2 -type d | sort)
+    fi
+  ) | sort -u
+}
+
+collect_op_aclnn_abi_changes() {
+  local src_vendor="$1"
+  local dst_vendor="$2"
+  local op_name="$3"
+  local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
+  local dst_abi_dir="${dst_vendor}/op_api/include/aclnnop"
+  local rel_file
+
+  for rel_file in "aclnn_${op_name}.h" "level2/aclnn_${op_name}.h"; do
+    if [ -f "${src_abi_dir}/${rel_file}" ] && [ ! -f "${dst_abi_dir}/${rel_file}" ]; then
+      echo "ADDED ${rel_file}"
+    elif [ -f "${src_abi_dir}/${rel_file}" ] && [ -f "${dst_abi_dir}/${rel_file}" ] && ! cmp -s "${src_abi_dir}/${rel_file}" "${dst_abi_dir}/${rel_file}"; then
+      echo "MODIFIED ${rel_file}"
+    elif [ ! -f "${src_abi_dir}/${rel_file}" ] && [ -f "${dst_abi_dir}/${rel_file}" ]; then
+      echo "DELETED ${rel_file}"
+    fi
+  done
+}
+
+op_has_source_aclnn_header() {
+  local src_vendor="$1"
+  local op_name="$2"
+  local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
+
+  [ -f "${src_abi_dir}/aclnn_${op_name}.h" ] || [ -f "${src_abi_dir}/level2/aclnn_${op_name}.h" ]
+}
+
+format_change_summary() {
+  local change_file="$1"
+  local summary=""
+  local line
+
+  while IFS= read -r line; do
+    if [ -z "${summary}" ]; then
+      summary="${line}"
+    else
+      summary="${summary}; ${line}"
+    fi
+  done <"${change_file}"
+  echo "${summary}"
+}
+
+log_op_status() {
+  local level="$1"
+  local status="$2"
+  local op_name="$3"
+  local reason="$4"
+  local tag
+
+  tag=$(support_status_tag "${status}")
+  logandprint "[${level}]:   $(printf '%-7s %-36s - %s' "${tag}" "${op_name}" "${reason}")"
+}
+
+log_op_scope_file() {
+  local title="$1"
+  local op_file="$2"
+  local level="$3"
+  local op_name
+
+  logandprint "[${level}]: ${title}"
+  if [ ! -s "${op_file}" ]; then
+    logandprint "[${level}]:   (none detected)"
+    return
+  fi
+
+  while IFS= read -r op_name; do
+    logandprint "[${level}]:   ${op_name}"
+  done <"${op_file}"
+}
+
+log_included_op_status() {
+  local src_vendor="$1"
+  local dst_vendor="$2"
+  local op_name="$3"
+  local changes_file
+  local summary
+
+  changes_file=$(mktemp)
+  collect_op_aclnn_abi_changes "${src_vendor}" "${dst_vendor}" "${op_name}" >"${changes_file}"
+  summary=$(format_change_summary "${changes_file}")
+
+  if grep -qE '^(MODIFIED|DELETED) ' "${changes_file}"; then
+    log_op_status "WARNING" "warning" "${op_name}" "unsupported after install because aclnn ABI changed: ${summary}"
+  elif grep -q '^ADDED ' "${changes_file}"; then
+    log_op_status "WARNING" "notice" "${op_name}" "included in run package, but aclnn ABI is new in the installed wheel: ${summary}"
+  elif ! op_has_source_aclnn_header "${src_vendor}" "${op_name}"; then
+    log_op_status "WARNING" "notice" "${op_name}" "included in run package, but no aclnn ABI header was found to compare"
+  else
+    log_op_status "INFO" "ok" "${op_name}" "included in run package and aclnn ABI is unchanged"
+  fi
+
+  rm -f "${changes_file}"
+}
+
+confirm_partial_shared_lib_impact() {
+  local src_vendor="$1"
+  local dst_vendor="$2"
+  local src_ops_file
+  local dst_ops_file
+  local unavailable_ops_file
+  local op_name
+
+  src_ops_file=$(mktemp)
+  dst_ops_file=$(mktemp)
+  unavailable_ops_file=$(mktemp)
+
+  collect_vendor_op_names "${src_vendor}" >"${src_ops_file}"
+  collect_vendor_op_names "${dst_vendor}" >"${dst_ops_file}"
+  comm -23 "${dst_ops_file}" "${src_ops_file}" >"${unavailable_ops_file}"
+
+  log_op_scope_file "This run package contains operators:" "${src_ops_file}" "INFO"
+
+  logandprint "[INFO]: Operator support status after installing this run package:"
+  logandprint "[INFO]:   $(printf '%-7s %s' "$(support_status_tag "warning")" "unsupported after install")"
+  logandprint "[INFO]:   $(printf '%-7s %s' "$(support_status_tag "notice")" "requires manual attention")"
+  logandprint "[INFO]:   $(printf '%-7s %s' "$(support_status_tag "ok")" "supported after install")"
+
+  while IFS= read -r op_name; do
+    log_included_op_status "${src_vendor}" "${dst_vendor}" "${op_name}"
+  done <"${src_ops_file}"
+
+  if [ ! -s "${unavailable_ops_file}" ]; then
+    rm -f "${src_ops_file}" "${dst_ops_file}" "${unavailable_ops_file}"
+    return
+  fi
+
+  logandprint "[WARNING]: Installing this run package replaces shared opapi/tiling/proto libraries in the wheel with the scoped build from this package."
+  logandprint "[WARNING]: The following installed operators are not included in this run package and will not be usable after replacement:"
+  while IFS= read -r op_name; do
+    log_op_status "WARNING" "warning" "${op_name}" "not included in this run package; shared opapi/tiling/proto libraries will be replaced"
+  done <"${unavailable_ops_file}"
+  rm -f "${src_ops_file}" "${dst_ops_file}" "${unavailable_ops_file}"
+
+  if [ "${IS_QUIET}" = "y" ]; then
+    logandprint "[WARNING]: --quiet is set, treating partial shared-library replacement impact as confirmed."
+    return
+  fi
+
+  logandprint "[INFO]: Continue to replace the installed wheel shared libraries with this scoped run package? [y/n]"
+  while true; do
+    read yn
+    if [ "${yn}" = "y" ]; then
+      return
+    elif [ "${yn}" = "n" ]; then
+      logandprint "[INFO]: Exit without installing run package."
+      exitlog
+      exit 0
+    else
+      echo "[WARNING]: Input error, please input y or n to choose!"
+    fi
+  done
+}
+
+remove_deleted_aclnn_headers() {
+  local src_vendor="$1"
+  local dst_vendor="$2"
+  local src_abi_dir="${src_vendor}/op_api/include/aclnnop"
+  local dst_abi_dir="${dst_vendor}/op_api/include/aclnnop"
+  local op_name
+  local rel_file
+
+  if [ ! -d "${src_abi_dir}" ] || [ ! -d "${dst_abi_dir}" ]; then
+    return
+  fi
+
+  # Only delete aclnn headers for operators carried by this run package. A
+  # partial run package intentionally omits unrelated operators, so treating all
+  # target-only headers as deleted would break incremental replacement.
+  while IFS= read -r op_name; do
+    for rel_file in "aclnn_${op_name}.h" "level2/aclnn_${op_name}.h"; do
+      if [ -f "${dst_abi_dir}/${rel_file}" ] && [ ! -f "${src_abi_dir}/${rel_file}" ]; then
+        rm -f "${dst_abi_dir}/${rel_file}"
+      fi
+    done
+  done < <(collect_vendor_op_names "${src_vendor}")
+}
+
+merge_vendor_to_wheel_opp() {
+  local src_vendor="$1"
+  local dst_vendor="$2"
+
+  if [ ! -d "${src_vendor}" ]; then
+    logandprint "[ERROR]: Source vendor directory not found: ${src_vendor}"
+    exitlog
+    exit 1
+  fi
+
+  mkdir -p "${dst_vendor}"
+
+  # A partial run package is expected to replace only the operators it carries.
+  # Remove matching per-operator kernel directories first so stale .o files from
+  # an older build cannot survive when a kernel filename changes.
+  local src_kernel_root="${src_vendor}/op_impl/ai_core/tbe/kernel"
+  local dst_kernel_root="${dst_vendor}/op_impl/ai_core/tbe/kernel"
+  if [ -d "${src_kernel_root}" ]; then
+    while IFS= read -r src_op_dir; do
+      local rel_dir="${src_op_dir#${src_kernel_root}/}"
+      case "${rel_dir}" in
+        config/*)
+          continue
+          ;;
+      esac
+      local dst_op_dir="${dst_kernel_root}/${rel_dir}"
+      if [ -d "${dst_op_dir}" ]; then
+        rm -rf "${dst_op_dir}"
+      fi
+    done < <(find "${src_kernel_root}" -mindepth 2 -maxdepth 2 -type d)
+  fi
+
+  remove_deleted_aclnn_headers "${src_vendor}" "${dst_vendor}"
+
+  if command -v rsync >/dev/null 2>&1; then
+    rsync -a --checksum "${src_vendor}/" "${dst_vendor}/"
+  else
+    cp -a "${src_vendor}/." "${dst_vendor}/"
+  fi
+
+}
+
+finalize_wheel_opp() {
+  local wheel_opp_root="$1"
+  local python_bin
+  python_bin=$(get_python_bin)
+  if [ -z "${python_bin}" ]; then
+    logandprint "[ERROR]: python is required to finalize the installed wheel OPP."
+    exitlog
+    exit 1
+  fi
+
+  if ! "${python_bin}" "${CURR_PATH}/finalize_wheel_opp.py" \
+      --package-dir "$(dirname "${wheel_opp_root}")" \
+      --vendor-name "fla_npu_transformer"; then
+    logandprint "[ERROR]: Failed to finalize the installed wheel OPP and refresh wheel RECORD."
+    exitlog
+    exit 1
+  fi
+}
+
+update_wheel_vendors_config() {
+  local vendors_root="$1"
+  local vendor_name="$2"
+  local config_file="${vendors_root}/config.ini"
+  mkdir -p "${vendors_root}"
+
+  local existing=""
+  if [ -f "${config_file}" ]; then
+    existing=$(grep -w "load_priority" "${config_file}" | tail -n 1 | cut --only-delimited -d"=" -f2-)
+  fi
+
+  local merged="${vendor_name}"
+  local item
+  IFS=',' read -ra vendor_items <<< "${existing}"
+  for item in "${vendor_items[@]}"; do
+    item=$(echo "${item}" | xargs)
+    if [ -n "${item}" ] && [ "${item}" != "${vendor_name}" ]; then
+      merged="${merged},${item}"
+    fi
+  done
+  echo "load_priority=${merged}" >"${config_file}"
+}
+
+install_wheel_opp_package() {
+  if [ "${IS_INSTALL}" = "n" ]; then
+    return
+  fi
+
+  local src_vendors_root="${CURR_PATH}/../../../../ops_transformer/packages/vendors"
+  local src_vendor="${src_vendors_root}/fla_npu_transformer"
+  if [ ! -d "${src_vendor}" ]; then
+    logandprint "[ERROR]: The run package does not contain ${src_vendor}."
+    exitlog
+    exit 1
+  fi
+
+  local wheel_opp_root
+  wheel_opp_root=$(get_wheel_opp_root)
+  wheel_opp_root="${wheel_opp_root%/}"
+  if [ -z "${wheel_opp_root}" ]; then
+    logandprint "[ERROR]: Unable to locate wheel OPP root."
+    exitlog
+    exit 1
+  fi
+
+  local dst_vendor="${wheel_opp_root}/vendors/fla_npu_transformer"
+  if [ ! -d "${dst_vendor}" ]; then
+    logandprint "[ERROR]: Target wheel OPP vendor not found: ${dst_vendor}. Install the full flash-linear-attention-npu wheel first."
+    exitlog
+    exit 1
+  fi
+
+  logandprint "[INFO]: Merge FLA NPU run package into installed wheel OPP root: ${wheel_opp_root}"
+  logandprint "[INFO]: Source vendor ${src_vendor}"
+  logandprint "[INFO]: Target vendor ${dst_vendor}"
+
+  confirm_partial_shared_lib_impact "${src_vendor}" "${dst_vendor}"
+  merge_vendor_to_wheel_opp "${src_vendor}" "${dst_vendor}"
+  update_wheel_vendors_config "${wheel_opp_root}/vendors" "fla_npu_transformer"
+  finalize_wheel_opp "${wheel_opp_root}"
+
+  logandprint "[INFO]: FLA NPU wheel OPP update completed. Restart Python processes to load the new libcust_opapi.so and kernels."
+  exitlog
+  exit 0
 }
 
 # init target_dir and log for install
@@ -599,6 +994,8 @@ main() {
   get_opts "$@"
 
   check_opts
+
+  install_wheel_opp_package
 
   init_env
 

--- a/tests/test_wheel_environment.py
+++ b/tests/test_wheel_environment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import csv
 import importlib
 import runpy
 import subprocess
@@ -48,6 +49,19 @@ def _load_setup() -> tuple[dict[str, object], dict[str, object]]:
     with mock.patch.object(setuptools, "setup", side_effect=capture_setup):
         setup_globals = runpy.run_path(str(REPO_ROOT / "setup.py"))
     return setup_globals, setup_kwargs
+
+
+def _load_run_package_finalizer() -> dict[str, object]:
+    return runpy.run_path(
+        str(
+            REPO_ROOT
+            / "scripts"
+            / "package"
+            / "ops_transformer"
+            / "scripts"
+            / "finalize_wheel_opp.py"
+        )
+    )
 
 
 def _create_minimal_vendor(vendor_dir: Path, *, include_alias: bool = False) -> None:
@@ -174,6 +188,83 @@ source {set_env!s}
             self.assertFalse(
                 (installed_vendor / "op_api" / "lib" / "libopapi.so").exists()
             )
+
+    def test_run_package_overlay_finalization_is_idempotent(self) -> None:
+        finalize_wheel_opp = _load_run_package_finalizer()["finalize_wheel_opp"]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            site_root = Path(temp_dir) / "site-packages"
+            package_dir = site_root / "fla_npu"
+            vendor_dir = (
+                package_dir / "opp" / "vendors" / "fla_npu_transformer"
+            )
+            _create_minimal_vendor(vendor_dir, include_alias=True)
+            config = package_dir / "opp" / "vendors" / "config.ini"
+            config.write_text("load_priority=fla_npu_transformer\n", encoding="utf-8")
+
+            dist_info = site_root / "flash_linear_attention_npu-1.0.dist-info"
+            dist_info.mkdir(parents=True)
+            record = dist_info / "RECORD"
+            with record.open("w", encoding="utf-8", newline="") as handle:
+                csv.writer(handle, lineterminator="\n").writerows(
+                    [
+                        ["fla_npu/__init__.py", "", ""],
+                        ["fla_npu/opp/stale-from-older-overlay.json", "", ""],
+                        [f"{dist_info.name}/RECORD", "", ""],
+                    ]
+                )
+
+            finalize_wheel_opp(package_dir)
+            first_record = record.read_bytes()
+            first_set_env = (vendor_dir / "bin" / "set_env.bash").read_bytes()
+            finalize_wheel_opp(package_dir)
+
+            self.assertEqual(record.read_bytes(), first_record)
+            self.assertEqual(
+                (vendor_dir / "bin" / "set_env.bash").read_bytes(),
+                first_set_env,
+            )
+            self.assertFalse(
+                (vendor_dir / "op_api" / "lib" / "libopapi.so").exists()
+            )
+
+            with record.open("r", encoding="utf-8", newline="") as handle:
+                recorded_paths = {row[0] for row in csv.reader(handle) if row}
+            current_opp_paths = {
+                path.relative_to(site_root).as_posix()
+                for path in (package_dir / "opp").rglob("*")
+                if path.is_file() or path.is_symlink()
+            }
+            self.assertTrue(current_opp_paths.issubset(recorded_paths))
+            self.assertNotIn(
+                "fla_npu/opp/stale-from-older-overlay.json",
+                recorded_paths,
+            )
+
+    def test_run_package_installers_target_wheel_opp(self) -> None:
+        custom_installer = (
+            REPO_ROOT / "cmake" / "scripts" / "custom" / "install.sh"
+        ).read_text(encoding="utf-8")
+        transformer_installer = (
+            REPO_ROOT
+            / "scripts"
+            / "package"
+            / "ops_transformer"
+            / "scripts"
+            / "install.sh"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('WHEEL_INSTALL="y"', custom_installer)
+        self.assertIn("--cann)", custom_installer)
+        self.assertIn('finalize_wheel_opp "${wheel_opp_root}"', custom_installer)
+        self.assertIn(
+            'finalize_wheel_opp "${wheel_opp_root}"', transformer_installer
+        )
+
+        custom_build = (REPO_ROOT / "cmake" / "custom_build.cmake").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("finalize_wheel_opp.py", custom_build)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` release family 的配套 `torch_npu` wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 release family 的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: Fixes #304
- 背景与目标: `v26.6.0` 完整 wheel 已内嵌 OPP，但同版本 run 包仍默认安装到外部 CANN OPP。后续只编译并安装单算子 run 包时，当前 Python 环境中的 wheel OPP 不会更新，新 shell 还需要额外设置 FLA OPP 环境变量。
- 本 PR 解决的问题: 回补主干已验证的 wheel OPP overlay 能力，使首次安装完整 wheel 后可以用单算子 run 包更新当前 Python 环境中的内嵌 OPP。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [x] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: 不修改算子实现；安装链路验证使用 `chunk_fwd_o`
- 涉及目录 / 文件: run 包安装脚本、custom run 打包逻辑、wheel OPP finalizer、README、wheel 环境测试
- 责任人 / 提交人: @chen-linxin
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不变
- 明确不包含的范围: 不修改算子 Kernel、Tiling、InferShape、aclnn 或 torch 接口
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [x] 是，请说明影响面、兼容策略和回归范围: 影响 run 包公共安装行为；`--install` / `--full` / 无参数运行更新当前 wheel OPP，`--cann` / `--install-path` 保留外部 OPP 安装路径
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无新增 ABI 变化；安装器会检测 scoped run 与已安装 wheel 的 aclnn ABI 差异并给出状态提示

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0 beta | `bash build.sh --pkg --soc=ascend910b --ops=chunk_fwd_o --vendor_name=fla_npu` | 通过 | 生成 A2 run 包 |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_fwd_o --vendor_name=fla_npu` | 未执行 | 本地仅具备 A2 环境，待 NPU CI 补齐 |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0 beta | `bash build.sh --pkg --soc=ascend910b --ops=chunk_fwd_o --vendor_name=fla_npu` | 通过 | 生成 A2 run 包并完成 wheel OPP overlay |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_fwd_o --vendor_name=fla_npu` | 未执行 | 本地仅具备 A2 环境，待 NPU CI 补齐 |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=chunk_fwd_o --vendor_name=fla_npu` | 未执行 | 本地仅具备 A2 环境，待 NPU CI 补齐 |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `bash torch_custom/fla_npu/test/run_gdn_fwd_o.sh` | 未通过（基线同现） | 算子完成计算并写出结果，进程退出阶段触发 allocator abort；未安装 scoped run 的同提交完整 wheel 结果相同 |
| A3 | `ascend910_93` |  | 未执行 | 本地仅具备 A2 环境，待 NPU CI 补齐 |
| A5 | `ascend950` |  | 未执行 | 本地仅具备 A2 环境，待 NPU CI 补齐 |

- 精度对比: `chunk_fwd_o` 现有用例未通过；同提交完整 wheel 基线结果与 scoped run 结果一致，确认不是本 PR 的安装改动引入
- 性能对比: 不涉及性能改动
- 边界 / 异常场景: 覆盖官方 `v26.6.0` wheel overlay、同提交完整 wheel overlay、重复 finalizer、wheel `RECORD` 刷新和独立新 shell 无 FLA 环境变量导入
- 未覆盖风险: A3 / A5 构建与整体 Example ST 待 NPU CI 补齐

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 本 PR 不修改算子实现，已执行目标算子安装后调用验证 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐 |

- 端到端场景说明: 未执行整体 GDN ST；已验证完整 wheel -> 单算子 run -> 独立新 shell 无 FLA 专用环境变量加载
- 与本 PR 修改算子的关联: 本 PR 只修改安装链路，不修改算子实现
- 未覆盖原因及补充计划: 创建 PR 后请求 NPU CI 补齐 A3 / A5 与整体 Example ST

</details>

## 兼容性、风险与回退

- 兼容性说明: 保留 `--cann` 和 `--install-path` 外部 OPP 安装；首次完整 wheel 的构建与安装行为不变
- 风险点: scoped run 会整体替换共享 opapi/tiling/proto 产物，未包含在 run 包中的算子可能暂时不可用；安装器会在覆盖前逐项提示
- 回退方案: 重新安装完整 wheel 可恢复完整 OPP；代码层面可回退本 PR
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

本次为主干 wheel OPP overlay 安装能力向 `v26.6.0` 维护分支的回补。推荐 wheel 与后续 run 包来自相同代码版本；如果安装器提示 aclnn ABI 已修改或删除，应先重新构建并安装完整 wheel。

安装链路回归：`python3 -m unittest tests.test_wheel_environment`，5 项通过。A2 `chunk_fwd_o` 用例的退出阶段 allocator abort 与精度失败在未安装 scoped run 的同提交完整 wheel 基线上同样复现，不作为本 PR 引入的回归，但已在测试矩阵中保留记录。
