### PR TITLE
fix(v26.6.0): 隔离 FLA 与 CANN opapi 动态符号

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ FLA_NPU_SOC=ascend910b FLA_NPU_INCREMENTAL_BUILD=1 python -m pip wheel --no-buil
 | `FLA_NPU_INCREMENTAL_BUILD` | `TRUE` / `FALSE` | 复用 `build/` 做完整 wheel 的真增量构建；本地反复调试可设 `TRUE`，release wheel 或干净验证建议保持 `FALSE` | `FALSE` |
 | `FLA_NPU_OPS` | 逗号分隔的算子名，如 `chunk_fwd_o,recompute_wu_fwd` | 仅构建指定算子；用于单算子定位，不要用于 release wheel | 空 |
 | `FLA_NPU_SKIP_RUN_BUILD` | `TRUE` / `FALSE` | 跳过 run 包编译；仅在已准备好匹配的 `build_out/fla-npu-*.run` 且只重打 wheel 时可设 `TRUE`，常规构建建议保持 `FALSE` | `FALSE` |
-| `FLA_NPU_SKIP_RUN_INSTALL` | `TRUE` / `FALSE` | 跳过将 run 包安装产物内嵌到 wheel；会得到不含内嵌 OPP 的 wheel，除非使用外部 OPP 调试，否则建议保持 `FALSE` | `FALSE` |
+| `FLA_NPU_SKIP_RUN_INSTALL` | `TRUE` / `FALSE` | 跳过将 run 包安装产物内嵌到 wheel；会得到不能直接导入运行的源码骨架 wheel，仅用于打包流程调试，发布和运行验证必须保持 `FALSE` | `FALSE` |
 | `FLA_NPU_DISABLE_LOCAL_VERSION` | `TRUE` / `FALSE` | wheel 版本号不追加 SOC/torch/ABI 本地版本；内部统一发版需要固定版本号时可设 `TRUE`，日常构建建议保持 `FALSE` 以区分产物兼容范围 | `FALSE` |
 
 布尔变量设为 `TRUE` 时也接受 `1`、`YES`、`ON`；未设置或其他值按 `FALSE` 处理。
@@ -138,12 +138,15 @@ python -m pip install --force-reinstall --no-deps dist/flash_linear_attention_np
 方式 A wheel 不安装或执行 shell 环境钩子。无论使用系统 Python、Conda、venv
 还是 Docker，每次进入新的 shell 后都需要先按 Step 1 手工 source CANN 的
 `set_env.sh`。`import fla_npu` 会在当前 Python 进程内定位并加载 wheel 内嵌 OPP；
-wheel 通过绝对路径加载 `libcust_opapi.so`，不会再生成或加载可能覆盖 CANN
-运行库的自定义 `libopapi.so`。
+wheel 通过当前 `fla_npu.__file__` 推导出的包内绝对路径加载
+`libcust_opapi.so`，不会从外部 OPP 环境回退，也不会生成或加载可能覆盖
+CANN 运行库的自定义 `libopapi.so`。CANN 与 FLA opapi 均以局部符号作用域加载。
 
-#### 方式 B 产物安装
+#### 方式 B 独立产物安装（仅用于 OPP/extension 开发）
 
-先安装 run 包，再安装 torch_custom wheel。运行 Python 前需要 source custom OPP 的 `set_env.bash`，或设置 `FLA_NPU_OPP_PATH` 指向 OPP root / vendor 目录。
+独立 run 包仍可用于 CANN OPP 开发和调试；但 `fla_npu` Python runtime 不再从
+外部 OPP 路径选择 `libcust_opapi.so`。需要运行 Python API 时，请使用方式 A 生成的
+完整一键 wheel，确保 Python、legacy extension 和包内 OPP 来自同一次构建。
 
 ```sh
 export FLA_NPU_OPP_INSTALL_PATH=/path/to/fla_npu_opp
@@ -152,7 +155,9 @@ source ${FLA_NPU_OPP_INSTALL_PATH}/vendors/fla_npu_transformer/bin/set_env.bash
 python -m pip install --force-reinstall --no-deps torch_custom/fla_npu/dist/fla_npu-*.whl
 ```
 
-`import fla_npu` 会优先使用 wheel 内嵌 OPP，找不到时会继续从 `FLA_NPU_OPP_PATH`、`ASCEND_CUSTOM_OPP_PATH` 和 `ASCEND_OPP_PATH` 查找已安装 OPP。外部 OPP 的 `op_api/lib` 目录同样不得包含自定义 `libopapi.so`；如果残留该文件并可能遮蔽 CANN 运行库，导入会明确报错并要求清理旧别名。
+`import fla_npu` 只使用完整 wheel 内嵌的
+`fla_npu/opp/vendors/fla_npu_transformer`。`ASCEND_CUSTOM_OPP_PATH` 仍用于
+CANN 发现 host、tiling 和 kernel，但不参与 FLA Python runtime 动态库选取。
 
 ### Step 4. 测试安装成功
 

--- a/cmake/custom_build.cmake
+++ b/cmake/custom_build.cmake
@@ -95,6 +95,7 @@ if (BUILD_OPEN_PROJECT)
     )
     set_target_properties(cust_opapi PROPERTIES OUTPUT_NAME
             cust_opapi
+            NO_SONAME ON
     )
     if (NOT ENABLE_BUILT_IN)
         install(TARGETS cust_opapi

--- a/cmake/symbol.cmake
+++ b/cmake/symbol.cmake
@@ -178,7 +178,10 @@ endfunction()
 
 function(gen_cust_opapi_symbol)
   #op_api
-  set_target_properties(${OPAPI_NAME} PROPERTIES OUTPUT_NAME "cust_opapi")
+  set_target_properties(${OPAPI_NAME} PROPERTIES
+    OUTPUT_NAME "cust_opapi"
+    NO_SONAME ON
+  )
 
   install(TARGETS ${OPAPI_NAME}
     LIBRARY DESTINATION ${ACLNN_LIB_INSTALL_DIR}

--- a/common/include/fallback/fallback.h
+++ b/common/include/fallback/fallback.h
@@ -99,7 +99,11 @@ inline void* GetOpApiLibHandler(const char* libName) {
   if (std::string(libName) == GetCustOpApiLibName()) {
     const char* embeddedOpApiLib = std::getenv("FLA_NPU_OP_API_LIB");
     if (embeddedOpApiLib != nullptr && embeddedOpApiLib[0] != '\0') {
-      auto handler = dlopen(embeddedOpApiLib, RTLD_LAZY | RTLD_GLOBAL);
+      int mode = RTLD_LOCAL | RTLD_NOW;
+#ifdef RTLD_NODELETE
+      mode |= RTLD_NODELETE;
+#endif
+      auto handler = dlopen(embeddedOpApiLib, mode);
       if (handler != nullptr) {
         return handler;
       }

--- a/scripts/check_packaged_wheel_api.py
+++ b/scripts/check_packaged_wheel_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import subprocess
 from pathlib import Path
 
 
@@ -97,6 +98,38 @@ def _require_safe_packaged_opapi(fla_npu_module) -> None:
         raise AssertionError(
             "FLA_NPU_OP_API_LIB must point to the packaged libcust_opapi.so"
         )
+
+    packaged_library = next(path for path in custom_libraries if path.is_file())
+    dynamic = subprocess.check_output(
+        ["readelf", "-d", str(packaged_library)],
+        encoding="utf-8",
+        errors="replace",
+    )
+    if "(SONAME)" in dynamic:
+        raise AssertionError(
+            "packaged libcust_opapi.so must not define a SONAME: "
+            f"{packaged_library}"
+        )
+
+    opapi_dirs = {str(path.parent.resolve()) for path in custom_libraries}
+    ld_library_dirs = {
+        str(Path(path).resolve())
+        for path in os.environ.get("LD_LIBRARY_PATH", "").split(os.pathsep)
+        if path
+    }
+    if opapi_dirs & ld_library_dirs:
+        raise AssertionError("packaged FLA op_api directory leaked into LD_LIBRARY_PATH")
+
+    extensions = list(package_root.glob("custom_aclnn_extension_lib*.so"))
+    if not extensions:
+        raise AssertionError("packaged legacy custom_aclnn_extension_lib is missing")
+    extension_dynamic = subprocess.check_output(
+        ["readelf", "-d", str(extensions[0])],
+        encoding="utf-8",
+        errors="replace",
+    )
+    if "/op_api/lib" in extension_dynamic:
+        raise AssertionError("legacy extension still contains the FLA op_api RUNPATH")
 
 
 def main() -> int:

--- a/setup.py
+++ b/setup.py
@@ -433,7 +433,6 @@ def _rewrite_set_env(vendor_dir):
                 "}",
                 '_fla_npu_prepend_path ASCEND_CUSTOM_OPP_PATH "${_FLA_NPU_VENDOR_DIR}"',
                 '_fla_npu_prepend_path ASCEND_CUSTOM_OPP_PATH "${_FLA_NPU_OPP_ROOT}"',
-                '_fla_npu_prepend_path LD_LIBRARY_PATH "${_FLA_NPU_VENDOR_DIR}/op_api/lib"',
                 'export FLA_NPU_OPP_PATH="${_FLA_NPU_OPP_ROOT}"',
                 'export FLA_NPU_OP_API_LIB="${_FLA_NPU_VENDOR_DIR}/op_api/lib/libcust_opapi.so"',
                 "unset -f _fla_npu_prepend_path",

--- a/tests/test_wheel_environment.py
+++ b/tests/test_wheel_environment.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import importlib
+import os
 import runpy
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -37,6 +39,13 @@ if not hasattr(importlib, "metadata"):
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_SOURCE = (
+    REPO_ROOT
+    / "torch_custom"
+    / "fla_npu"
+    / "fla_npu"
+    / "__init__.py"
+)
 
 
 def _load_setup() -> tuple[dict[str, object], dict[str, object]]:
@@ -87,6 +96,32 @@ def _create_minimal_vendor(vendor_dir: Path, *, include_alias: bool = False) -> 
         (vendor_dir / "op_api" / "lib" / "libopapi.so").write_bytes(b"unsafe")
 
 
+def _create_runtime_package(site_root: Path) -> tuple[Path, Path, Path]:
+    package_dir = site_root / "fla_npu"
+    package_dir.mkdir(parents=True)
+    runtime_path = package_dir / "__init__.py"
+    shutil.copy2(RUNTIME_SOURCE, runtime_path)
+    vendor_dir = package_dir / "opp" / "vendors" / "fla_npu_transformer"
+    packaged_opapi = vendor_dir / "op_api" / "lib" / "libcust_opapi.so"
+    packaged_opapi.parent.mkdir(parents=True)
+    packaged_opapi.write_bytes(b"packaged-test")
+    return runtime_path, vendor_dir, packaged_opapi
+
+
+def _load_runtime_without_legacy_extension(runtime_path: Path) -> dict[str, object]:
+    source = runtime_path.read_text(encoding="utf-8")
+    marker = "\n_load_opextension_so()\n"
+    if marker not in source:
+        raise AssertionError("Unable to isolate fla_npu runtime initialization")
+    source = source.rsplit(marker, 1)[0]
+    namespace = {
+        "__file__": str(runtime_path),
+        "__name__": "fla_npu_runtime_test",
+    }
+    exec(compile(source, str(runtime_path), "exec"), namespace)
+    return namespace
+
+
 class WheelEnvironmentTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -117,6 +152,15 @@ class WheelEnvironmentTest(unittest.TestCase):
             self.assertTrue((lib_dir / "libcust_opapi.so").is_file())
             self.assertFalse((lib_dir / "libopapi.so").exists())
 
+            custom_build = (REPO_ROOT / "cmake" / "custom_build.cmake").read_text(
+                encoding="utf-8"
+            )
+            symbol_build = (REPO_ROOT / "cmake" / "symbol.cmake").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("NO_SONAME ON", custom_build)
+            self.assertIn("NO_SONAME ON", symbol_build)
+
     def test_generated_set_env_is_idempotent(self) -> None:
         rewrite_set_env = self.setup_globals["_rewrite_set_env"]
 
@@ -132,7 +176,7 @@ unset ASCEND_CUSTOM_OPP_PATH LD_LIBRARY_PATH FLA_NPU_OPP_PATH FLA_NPU_OP_API_LIB
 source {set_env!s}
 source {set_env!s}
 [[ "${{ASCEND_CUSTOM_OPP_PATH}}" == "{vendor_dir.parent.parent}:{vendor_dir}" ]]
-[[ "${{LD_LIBRARY_PATH}}" == "{vendor_dir}/op_api/lib" ]]
+[[ -z "${{LD_LIBRARY_PATH-}}" ]]
 [[ "${{FLA_NPU_OPP_PATH}}" == "{vendor_dir.parent.parent}" ]]
 [[ "${{FLA_NPU_OP_API_LIB}}" == "{vendor_dir}/op_api/lib/libcust_opapi.so" ]]
 """
@@ -174,6 +218,132 @@ source {set_env!s}
             self.assertFalse(
                 (installed_vendor / "op_api" / "lib" / "libopapi.so").exists()
             )
+
+            set_env = installed_vendor / "bin" / "set_env.bash"
+            script = f"""
+set -euo pipefail
+unset ASCEND_CUSTOM_OPP_PATH LD_LIBRARY_PATH FLA_NPU_OPP_PATH FLA_NPU_OP_API_LIB
+source {set_env!s}
+[[ -z "${{LD_LIBRARY_PATH-}}" ]]
+"""
+            subprocess.run(["bash", "-c", script], check=True)
+
+    def test_legacy_extension_does_not_publish_packaged_opapi(self) -> None:
+        extension_source = (
+            REPO_ROOT
+            / "torch_custom"
+            / "fla_npu"
+            / "op_plugin"
+            / "ops"
+            / "opapi"
+            / "FLANpuOpApi.cpp"
+        ).read_text(encoding="utf-8")
+        fallback_source = (
+            REPO_ROOT / "common" / "include" / "fallback" / "fallback.h"
+        ).read_text(encoding="utf-8")
+        extension_setup = (
+            REPO_ROOT / "torch_custom" / "fla_npu" / "setup.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("RTLD_LOCAL | RTLD_NOW", extension_source)
+        self.assertNotIn("RTLD_LAZY | RTLD_GLOBAL", extension_source)
+        self.assertIn("RTLD_LOCAL | RTLD_NOW", fallback_source)
+        self.assertNotIn("dlopen(embeddedOpApiLib, RTLD_LAZY | RTLD_GLOBAL)", fallback_source)
+        self.assertNotIn("/opp/vendors/{vendor_dir}/op_api/lib", extension_setup)
+        self.assertIn("$ORIGIN/../torch/lib", extension_setup)
+        self.assertIn("$ORIGIN/../torch_npu/lib", extension_setup)
+
+    def test_runtime_loads_cann_then_packaged_opapi_locally(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_path, vendor_dir, packaged_opapi = _create_runtime_package(
+                Path(temp_dir) / "site-packages"
+            )
+            external_vendor = Path(temp_dir) / "external" / "vendors" / "other"
+            _create_minimal_vendor(external_vendor)
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "ASCEND_HOME_PATH": "/fake/cann",
+                    "FLA_NPU_OPP_PATH": str(external_vendor),
+                    "ASCEND_CUSTOM_OPP_PATH": str(external_vendor),
+                    "ASCEND_OPP_PATH": str(external_vendor.parent.parent),
+                },
+                clear=True,
+            ):
+                def fake_cdll(path, *, mode):
+                    if str(path) == "libopapi.so":
+                        return mock.sentinel.cann_opapi
+                    return mock.sentinel.custom_opapi
+
+                with mock.patch("ctypes.CDLL", side_effect=fake_cdll) as cdll:
+                    runtime_globals = _load_runtime_without_legacy_extension(runtime_path)
+                    first = runtime_globals["load_ascendc_opapi_libraries"]()
+                    second = runtime_globals["load_ascendc_opapi_libraries"]()
+
+                self.assertIs(first, second)
+                self.assertEqual(
+                    first,
+                    [mock.sentinel.custom_opapi, mock.sentinel.cann_opapi],
+                )
+                self.assertEqual(len(cdll.call_args_list), 2)
+                self.assertEqual(cdll.call_args_list[0].args, ("libopapi.so",))
+                self.assertEqual(
+                    Path(cdll.call_args_list[1].args[0]).resolve(),
+                    packaged_opapi.resolve(),
+                )
+                expected_mode = (
+                    getattr(os, "RTLD_LOCAL", 0)
+                    | getattr(os, "RTLD_NOW", 0)
+                    | getattr(os, "RTLD_NODELETE", 0)
+                )
+                self.assertEqual(cdll.call_args_list[0].kwargs["mode"], expected_mode)
+                self.assertEqual(cdll.call_args_list[1].kwargs["mode"], expected_mode)
+                self.assertEqual(
+                    expected_mode & getattr(os, "RTLD_GLOBAL", 0),
+                    0,
+                )
+                self.assertNotIn("LD_LIBRARY_PATH", os.environ)
+                self.assertEqual(
+                    os.environ["FLA_NPU_OP_API_LIB"],
+                    str(packaged_opapi.resolve()),
+                )
+                self.assertEqual(
+                    os.environ["ASCEND_CUSTOM_OPP_PATH"],
+                    os.pathsep.join(
+                        [
+                            str(vendor_dir.parent.parent),
+                            str(vendor_dir),
+                            str(external_vendor),
+                        ]
+                    ),
+                )
+
+    def test_runtime_does_not_fallback_to_external_custom_opp(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_path, _, packaged_opapi = _create_runtime_package(
+                Path(temp_dir) / "site-packages"
+            )
+            packaged_opapi.unlink()
+            external_vendor = Path(temp_dir) / "external" / "vendors" / "other"
+            _create_minimal_vendor(external_vendor)
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "ASCEND_HOME_PATH": "/fake/cann",
+                    "FLA_NPU_OPP_PATH": str(external_vendor),
+                    "ASCEND_CUSTOM_OPP_PATH": str(external_vendor),
+                    "ASCEND_OPP_PATH": str(external_vendor.parent.parent),
+                },
+                clear=True,
+            ):
+                runtime_globals = _load_runtime_without_legacy_extension(runtime_path)
+                with self.assertRaisesRegex(
+                    FileNotFoundError,
+                    r"packaged FLA NPU op_api library",
+                ):
+                    runtime_globals["load_ascendc_opapi_libraries"]()
 
 if __name__ == "__main__":
     unittest.main()

--- a/torch_custom/fla_npu/README.md
+++ b/torch_custom/fla_npu/README.md
@@ -55,7 +55,7 @@ fla_npu/
 └── ...
 ```
 
-使用方式：`pip install fla_npu*.whl` 安装后，先 source 已安装 custom OPP 的 `set_env.bash`，或设置 `FLA_NPU_OPP_PATH` 指向 OPP root / vendor 目录，即可在 Python 中调用本样例接入的自定义算子（如 `torch.ops.npu.npu_fast_gelu_custom`、`torch_npu.ops.fast_gelu_custom` 或 `from fla_npu.ops.ascendc import fast_gelu_custom`）。FLA 自定义 op_api 使用 `libcust_opapi.so`，不要在 custom OPP 的 `op_api/lib` 目录创建会遮蔽 CANN 运行库的 `libopapi.so` 别名。
+正式 Python 运行请安装仓库根目录一键构建的完整 wheel。`import fla_npu` 只从当前 Python 包内嵌的 `opp/vendors/fla_npu_transformer` 加载 `libcust_opapi.so`，不会从 `FLA_NPU_OPP_PATH`、`ASCEND_CUSTOM_OPP_PATH` 或 `ASCEND_OPP_PATH` 选择外部同名动态库。外部 OPP 仍可供 CANN 发现 host、tiling 和 kernel；不要在其 `op_api/lib` 目录创建会遮蔽 CANN 运行库的 `libopapi.so` 别名。
 
 
 ## 一键运行样例

--- a/torch_custom/fla_npu/build.sh
+++ b/torch_custom/fla_npu/build.sh
@@ -4,3 +4,28 @@ cd "$(dirname "$0")"
 bash gen.sh npu_custom.yaml
 python3 setup.py bdist_wheel
 pip3 install ./dist/fla_npu-1.0.0-*.whl --force-reinstall --no-deps
+
+# The fla_npu runtime loads libcust_opapi.so only from the OPP tree embedded in
+# the installed package (fla_npu/opp/vendors/fla_npu_transformer). The standalone
+# wheel built here ships only the OPP skeleton, so importing fla_npu fails with
+# FileNotFoundError once the external-vendor runtime fallback was removed (PR #322).
+# Overlay the compiled custom OPP from the just-built fla-npu-*.run package into
+# the installed package before any consumer imports fla_npu. Unlike main, the
+# v26.6.0 run installer has no --install wheel-merge, so we install the OPP
+# directly into the package-local opp/ tree.
+run_pkg=""
+shopt -s nullglob
+for cand in ../../build_out/fla-npu-*.run ../../build/fla-npu-*.run; do
+    if [ -n "$cand" ] && [ -s "$cand" ]; then
+        run_pkg="$cand"
+        break
+    fi
+done
+shopt -u nullglob
+if [ -z "$run_pkg" ]; then
+    echo "[ERROR] No fla-npu-*.run package found to overlay the embedded OPP into the installed wheel." >&2
+    exit 1
+fi
+chmod +x "$run_pkg"
+opp_root="$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/fla_npu/opp"
+"$run_pkg" --quiet --install-path="$opp_root"

--- a/torch_custom/fla_npu/build.sh
+++ b/torch_custom/fla_npu/build.sh
@@ -10,9 +10,10 @@ pip3 install ./dist/fla_npu-1.0.0-*.whl --force-reinstall --no-deps
 # wheel built here ships only the OPP skeleton, so importing fla_npu fails with
 # FileNotFoundError once the external-vendor runtime fallback was removed (PR #322).
 # Overlay the compiled custom OPP from the just-built fla-npu-*.run package into
-# the installed package before any consumer imports fla_npu. Unlike main, the
-# v26.6.0 run installer has no --install wheel-merge, so we install the OPP
-# directly into the package-local opp/ tree.
+# the installed package, then refresh the installed wheel RECORD so pip uninstall
+# also removes the embedded OPP. Unlike main, the v26.6.0 run installer has no
+# --install wheel-merge, so we install the OPP directly into the package-local
+# opp/ tree and finalize the RECORD ourselves.
 run_pkg=""
 shopt -s nullglob
 for cand in ../../build_out/fla-npu-*.run ../../build/fla-npu-*.run; do
@@ -27,5 +28,6 @@ if [ -z "$run_pkg" ]; then
     exit 1
 fi
 chmod +x "$run_pkg"
-opp_root="$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/fla_npu/opp"
-"$run_pkg" --quiet --install-path="$opp_root"
+pkg_dir="$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/fla_npu"
+"$run_pkg" --quiet --install-path="$pkg_dir/opp"
+python3 "$(dirname "$0")/finalize_wheel_opp.py" --package-dir "$pkg_dir"

--- a/torch_custom/fla_npu/finalize_wheel_opp.py
+++ b/torch_custom/fla_npu/finalize_wheel_opp.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tianjin University, Ltd.
+# Canonical CANN Open Software License reference; see LICENSE in repo root for details.
+# ---------------------------------------------------------------------------
+
+"""Finalize an OPP overlay inside an installed fla_npu wheel (v26.6.0 standalone wheel)."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import hashlib
+import os
+import stat
+import tempfile
+from pathlib import Path
+
+
+DIST_INFO_GLOB = "fla_npu-*.dist-info"
+DEFAULT_VENDOR_DIR = "fla_npu_transformer"
+
+
+def _write_set_env(vendor_dir: Path) -> None:
+    bin_dir = vendor_dir / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    set_env = bin_dir / "set_env.bash"
+    set_env.write_text(
+        "\n".join(
+            [
+                "#!/bin/bash",
+                '_FLA_NPU_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"',
+                '_FLA_NPU_VENDOR_DIR="$(cd "${_FLA_NPU_SCRIPT_DIR}/.." && pwd)"',
+                '_FLA_NPU_OPP_ROOT="$(cd "${_FLA_NPU_VENDOR_DIR}/../.." && pwd)"',
+                "_fla_npu_prepend_path() {",
+                '    local name="$1"',
+                '    local value="$2"',
+                '    local current=""',
+                '    if [[ -v "${name}" ]]; then',
+                '        current="${!name}"',
+                "    fi",
+                '    case ":${current}:" in',
+                '        *":${value}:"*) return 0 ;;',
+                "    esac",
+                '    printf -v "${name}" "%s" "${value}${current:+:${current}}"',
+                '    export "${name}"',
+                "}",
+                '_fla_npu_prepend_path ASCEND_CUSTOM_OPP_PATH "${_FLA_NPU_VENDOR_DIR}"',
+                '_fla_npu_prepend_path ASCEND_CUSTOM_OPP_PATH "${_FLA_NPU_OPP_ROOT}"',
+                'export FLA_NPU_OPP_PATH="${_FLA_NPU_OPP_ROOT}"',
+                'export FLA_NPU_OP_API_LIB="${_FLA_NPU_VENDOR_DIR}/op_api/lib/libcust_opapi.so"',
+                "unset -f _fla_npu_prepend_path",
+                "unset _FLA_NPU_SCRIPT_DIR _FLA_NPU_VENDOR_DIR _FLA_NPU_OPP_ROOT",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    set_env.chmod(0o755)
+
+
+def _record_digest(path: Path) -> tuple[str, str]:
+    content = path.read_bytes()
+    digest = base64.urlsafe_b64encode(hashlib.sha256(content).digest()).rstrip(b"=").decode("ascii")
+    return f"sha256={digest}", str(len(content))
+
+
+def _find_record(package_dir: Path) -> Path:
+    dist_infos = sorted(package_dir.parent.glob(DIST_INFO_GLOB))
+    if len(dist_infos) != 1:
+        raise RuntimeError(
+            f"Expected exactly one {DIST_INFO_GLOB} next to {package_dir}, ",
+            f"found {len(dist_infos)}"
+        )
+    record = dist_infos[0] / "RECORD"
+    if not record.is_file():
+        raise RuntimeError(f"Installed wheel RECORD is missing: {record}")
+    return record
+
+
+def _refresh_record(package_dir: Path) -> Path:
+    record = _find_record(package_dir)
+    site_root = package_dir.parent.resolve()
+    package_roots = (package_dir / "opp",)
+    package_prefixes = (f"{package_dir.name}/opp/",)
+
+    with record.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.reader(handle))
+
+    rows = [
+        row
+        for row in rows
+        if row and not row[0].startswith(package_prefixes)
+    ]
+    for package_root in package_roots:
+        for path in sorted(package_root.rglob("*")):
+            if not (path.is_file() or path.is_symlink()):
+                continue
+            relative = path.relative_to(site_root).as_posix()
+            digest, size = _record_digest(path)
+            rows.append([relative, digest, size])
+
+    record_mode = stat.S_IMODE(record.stat().st_mode)
+    temp_name = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            newline="",
+            dir=record.parent,
+            prefix=".RECORD.",
+            delete=False,
+        ) as handle:
+            temp_name = handle.name
+            writer = csv.writer(handle, lineterminator="\n")
+            writer.writerows(rows)
+        os.chmod(temp_name, record_mode)
+        os.replace(temp_name, record)
+    finally:
+        if temp_name:
+            try:
+                Path(temp_name).unlink()
+            except FileNotFoundError:
+                pass
+    return record
+
+
+def finalize_wheel_opp(package_dir: Path, vendor_name: str = DEFAULT_VENDOR_DIR) -> Path:
+    package_dir = package_dir.expanduser().resolve()
+    vendor_dir = package_dir / "opp" / "vendors" / vendor_name
+    custom_opapi = vendor_dir / "op_api" / "lib" / "libcust_opapi.so"
+    if not custom_opapi.is_file():
+        raise RuntimeError(f"Wheel is missing packaged custom op_api: {custom_opapi}")
+
+    conflicting_alias = custom_opapi.with_name("libopapi.so")
+    if conflicting_alias.exists() or conflicting_alias.is_symlink():
+        conflicting_alias.unlink()
+
+    _write_set_env(vendor_dir)
+    return _refresh_record(package_dir)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--package-dir", required=True, type=Path)
+    parser.add_argument("--vendor-name", default=DEFAULT_VENDOR_DIR)
+    args = parser.parse_args()
+
+    record = finalize_wheel_opp(args.package_dir, args.vendor_name)
+    print(f"Finalized wheel OPP and refreshed {record.name}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/torch_custom/fla_npu/fla_npu/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/__init__.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import ctypes
 import os
 import pathlib
+from typing import Optional
 
 
 _PACKAGE_DIR = pathlib.Path(__file__).resolve().parent
 _DEFAULT_VENDOR_DIR = "fla_npu_transformer"
+_ASCENDC_OPAPI_LIBRARIES: Optional[list[ctypes.CDLL]] = None
 
 
 def _prepend_env_path(name: str, value: pathlib.Path) -> None:
@@ -16,48 +18,40 @@ def _prepend_env_path(name: str, value: pathlib.Path) -> None:
         os.environ[name] = os.pathsep.join([value_str, *parts])
 
 
-def _candidate_vendor_names() -> list[str]:
-    return [_DEFAULT_VENDOR_DIR]
-
-
-def _candidate_opp_roots() -> list[pathlib.Path]:
-    roots: list[pathlib.Path] = []
-    override = os.environ.get("FLA_NPU_OPP_PATH", "").strip()
-    if override:
-        roots.append(pathlib.Path(override).expanduser())
-
-    roots.append(_PACKAGE_DIR / "opp")
-
-    for env_name in ("ASCEND_CUSTOM_OPP_PATH", "ASCEND_OPP_PATH"):
-        for part in os.environ.get(env_name, "").split(os.pathsep):
-            if part:
-                roots.append(pathlib.Path(part).expanduser())
-
-    return list(dict.fromkeys(roots))
-
-
 def _resolve_vendor_dir() -> pathlib.Path:
-    for root in _candidate_opp_roots():
-        if (root / "op_api" / "lib" / "libcust_opapi.so").exists():
-            return root.resolve()
-
-        vendors_root = root / "vendors"
-        for name in _candidate_vendor_names():
-            vendor_dir = vendors_root / name
-            if vendor_dir.exists():
-                return vendor_dir.resolve()
-
-        if vendors_root.exists():
-            vendor_dirs = [path for path in vendors_root.iterdir() if path.is_dir()]
-            if len(vendor_dirs) == 1:
-                return vendor_dirs[0].resolve()
+    package_dir = _PACKAGE_DIR.resolve()
+    vendor_dir = package_dir / "opp" / "vendors" / _DEFAULT_VENDOR_DIR
+    if vendor_dir.is_dir():
+        resolved_vendor_dir = vendor_dir.resolve()
+        try:
+            resolved_vendor_dir.relative_to(package_dir)
+        except ValueError:
+            pass
+        else:
+            return resolved_vendor_dir
 
     raise FileNotFoundError(
-        "Unable to find FLA NPU custom OPP. Expected "
-        f"{_PACKAGE_DIR / 'opp' / 'vendors' / _DEFAULT_VENDOR_DIR}. "
-        "If you installed it separately, source the custom OPP set_env.bash, "
-        "or set FLA_NPU_OPP_PATH to either the OPP root containing vendors/ "
-        "or the vendor directory itself."
+        "Unable to find the FLA NPU custom OPP embedded in this Python package. "
+        f"Expected a regular package-local OPP at {vendor_dir}. Reinstall the "
+        "complete wheel. External CANN vendor directories are not used as a "
+        "runtime library fallback."
+    )
+
+
+def _resolve_packaged_opapi(vendor_dir: pathlib.Path) -> pathlib.Path:
+    package_dir = _PACKAGE_DIR.resolve()
+    op_api_lib = (vendor_dir / "op_api" / "lib" / "libcust_opapi.so").resolve()
+    try:
+        op_api_lib.relative_to(package_dir)
+    except ValueError:
+        pass
+    else:
+        if op_api_lib.is_file():
+            return op_api_lib
+    raise FileNotFoundError(
+        "Unable to find the packaged FLA NPU op_api library. Expected "
+        f"{vendor_dir / 'op_api' / 'lib' / 'libcust_opapi.so'}. Reinstall the "
+        "complete wheel."
     )
 
 
@@ -69,10 +63,7 @@ def _prepare_embedded_opp() -> pathlib.Path:
         )
 
     vendor_dir = _resolve_vendor_dir()
-    opp_root = vendor_dir.parent.parent if vendor_dir.parent.name == "vendors" else vendor_dir
-    op_api_lib = vendor_dir / "op_api" / "lib" / "libcust_opapi.so"
-    if not op_api_lib.exists():
-        raise FileNotFoundError(f"Embedded custom op_api library not found: {op_api_lib}")
+    op_api_lib = _resolve_packaged_opapi(vendor_dir)
     op_api_alias = op_api_lib.with_name("libopapi.so")
     if op_api_alias.exists() or op_api_alias.is_symlink():
         raise RuntimeError(
@@ -82,13 +73,51 @@ def _prepare_embedded_opp() -> pathlib.Path:
         )
 
     _prepend_env_path("ASCEND_CUSTOM_OPP_PATH", vendor_dir)
-    _prepend_env_path("ASCEND_CUSTOM_OPP_PATH", opp_root)
-    _prepend_env_path("LD_LIBRARY_PATH", op_api_lib.parent)
+    _prepend_env_path("ASCEND_CUSTOM_OPP_PATH", vendor_dir.parent.parent)
     os.environ["FLA_NPU_OP_API_LIB"] = str(op_api_lib)
-
-    mode = getattr(os, "RTLD_GLOBAL", 0) | getattr(os, "RTLD_NOW", 0)
-    ctypes.CDLL(str(op_api_lib), mode=mode)
     return vendor_dir
+
+
+def _load_shared_library_required(path_or_name) -> ctypes.CDLL:
+    mode = (
+        getattr(os, "RTLD_LOCAL", 0)
+        | getattr(os, "RTLD_NOW", 0)
+        | getattr(os, "RTLD_NODELETE", 0)
+    )
+    return ctypes.CDLL(str(path_or_name), mode=mode)
+
+
+def load_ascendc_opapi_libraries() -> list[ctypes.CDLL]:
+    """Load CANN and packaged FLA opapi without publishing global symbols."""
+
+    global _ASCENDC_OPAPI_LIBRARIES
+    if _ASCENDC_OPAPI_LIBRARIES is not None:
+        return _ASCENDC_OPAPI_LIBRARIES
+
+    vendor_dir = _prepare_embedded_opp()
+    custom_opapi = _resolve_packaged_opapi(vendor_dir)
+
+    try:
+        cann_library = _load_shared_library_required("libopapi.so")
+    except OSError as exc:
+        raise RuntimeError(
+            "Unable to load the CANN op_api library libopapi.so. Please source "
+            "the matching CANN set_env.sh before importing fla_npu. "
+            f"Dynamic loader error: {exc}"
+        ) from exc
+
+    try:
+        custom_library = _load_shared_library_required(custom_opapi)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Unable to load packaged FLA NPU custom op_api library: {custom_opapi}. "
+            f"Dynamic loader error: {exc}"
+        ) from exc
+
+    # CANN is loaded first, while the explicit custom handle remains available
+    # to the legacy C++ extension through FLA_NPU_OP_API_LIB.
+    _ASCENDC_OPAPI_LIBRARIES = [custom_library, cann_library]
+    return _ASCENDC_OPAPI_LIBRARIES
 
 
 def _preload_library(path: pathlib.Path) -> None:
@@ -115,7 +144,7 @@ def _preload_torch_npu_dependencies(torch_module, torch_npu_module) -> None:
 
 # Load the custom operator library
 def _load_opextension_so():
-    _prepare_embedded_opp()
+    load_ascendc_opapi_libraries()
 
     import torch
     import torch_npu

--- a/torch_custom/fla_npu/fla_npu/install_opp.py
+++ b/torch_custom/fla_npu/fla_npu/install_opp.py
@@ -34,7 +34,6 @@ def _write_set_env(vendor_dir: Path) -> None:
                 "}",
                 '_fla_npu_prepend_path ASCEND_CUSTOM_OPP_PATH "${_FLA_NPU_VENDOR_DIR}"',
                 '_fla_npu_prepend_path ASCEND_CUSTOM_OPP_PATH "${_FLA_NPU_OPP_ROOT}"',
-                '_fla_npu_prepend_path LD_LIBRARY_PATH "${_FLA_NPU_VENDOR_DIR}/op_api/lib"',
                 'export FLA_NPU_OPP_PATH="${_FLA_NPU_OPP_ROOT}"',
                 'export FLA_NPU_OP_API_LIB="${_FLA_NPU_VENDOR_DIR}/op_api/lib/libcust_opapi.so"',
                 "unset -f _fla_npu_prepend_path",
@@ -75,6 +74,9 @@ def install_opp(install_path: Path, force: bool = False) -> None:
                 raise FileExistsError(f"{vendor_dst} already exists. Use --force to replace it.")
             shutil.rmtree(vendor_dst)
         shutil.copytree(vendor_src, vendor_dst)
+        custom_opapi = vendor_dst / "op_api" / "lib" / "libcust_opapi.so"
+        if not custom_opapi.is_file():
+            raise FileNotFoundError(f"Custom op_api library not found: {custom_opapi}")
         op_api_alias = vendor_dst / "op_api" / "lib" / "libopapi.so"
         if op_api_alias.exists() or op_api_alias.is_symlink():
             op_api_alias.unlink()
@@ -87,7 +89,11 @@ def install_opp(install_path: Path, force: bool = False) -> None:
 
     for vendor_dir in copied:
         print(f"Installed OPP vendor: {vendor_dir}")
-    print(f"To use this external OPP location, set FLA_NPU_OPP_PATH={install_path}")
+    print(
+        "The external OPP is available to CANN/ACLNN after sourcing its "
+        "set_env.bash. The fla_npu Python runtime always loads libcust_opapi.so "
+        "from the vendor tree embedded in its installed package."
+    )
 
 
 def main() -> int:

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -29,13 +29,22 @@ using namespace op_plugin::utils;
 using namespace op_infer;
 
 namespace {
+int GetLocalOpApiDlopenMode()
+{
+    int mode = RTLD_LOCAL | RTLD_NOW;
+#ifdef RTLD_NODELETE
+    mode |= RTLD_NODELETE;
+#endif
+    return mode;
+}
+
 void* GetEmbeddedOpApiHandler()
 {
     const char* opApiLib = std::getenv("FLA_NPU_OP_API_LIB");
     if (opApiLib == nullptr || opApiLib[0] == '\0') {
         return nullptr;
     }
-    return dlopen(opApiLib, RTLD_LAZY | RTLD_GLOBAL);
+    return dlopen(opApiLib, GetLocalOpApiDlopenMode());
 }
 
 void* GetEmbeddedOpApiFuncAddr(const char* apiName)

--- a/torch_custom/fla_npu/setup.py
+++ b/torch_custom/fla_npu/setup.py
@@ -122,12 +122,10 @@ def get_link_args():
         link_args.append(f"-L{lib_dir}")
 
     if sys.platform == "linux":
-        vendor_dir = get_vendor_dir_name()
         link_args.extend([
             "-Wl,--enable-new-dtags",
             "-Wl,-rpath,$ORIGIN/../torch/lib",
             "-Wl,-rpath,$ORIGIN/../torch_npu/lib",
-            f"-Wl,-rpath,$ORIGIN/opp/vendors/{vendor_dir}/op_api/lib",
         ])
     return link_args
 


### PR DESCRIPTION
## 关联 Issue / 背景

- 关联 Issue：Refs #310
- 主线修复：#311
- Backport 目标：将 opapi 动态库隔离方案回移到 `v26.6.0` 的 legacy `custom_aclnn_extension_lib` 调用链。

`v26.6.0` 默认导入链仍依赖 legacy C++ extension。原实现通过 `RTLD_GLOBAL` 加载 FLA `libcust_opapi.so`，并把其目录加入 `LD_LIBRARY_PATH` / extension RUNPATH，可能将 FLA 内部符号发布到进程全局域，导致后加载的 CANN `libopapi.so` 错误绑定，最终在进程退出阶段触发 Issue #310 中的 double free。

## 修改内容

- Python 先局部加载 CANN `libopapi.so`，再通过包内绝对路径局部加载 FLA `libcust_opapi.so`，并保存 `CDLL` 句柄。
- legacy C++ extension 和公共 fallback 均改用 `RTLD_LOCAL | RTLD_NOW | RTLD_NODELETE`。
- 保留 v26.6.0 的显式符号查找逻辑：优先在 FLA 私有句柄中 `dlsym`，找不到时回退 CANN `GetOpApiFuncAddr`。
- FLA custom opapi 只从当前 `fla_npu.__file__` 对应的完整 wheel 中定位，不再从外部 OPP 环境选择同名库。
- 不再把 FLA `op_api/lib` 加入 `LD_LIBRARY_PATH`，并从 legacy extension 中移除该目录的 RUNPATH。
- 为 `libcust_opapi.so` 设置 `NO_SONAME`，避免多个同名 custom 库被动态加载器复用为同一逻辑库。
- 增加 wheel 打包、ELF 属性和动态加载边界测试，并更新相关文档。

## 兼容性与影响范围

- 不修改算子 kernel、tiling、公开 Python API 或 aclnn C ABI。
- 保留 v26.6.0 的 legacy `custom_aclnn_extension_lib` 调用链。
- 正式 Python 运行要求使用仓库根目录构建的完整一键 wheel；外部 OPP 仍可供 CANN 发现 host、tiling 和 kernel，但不再作为 Python runtime 的 `libcust_opapi.so` 回退来源。

## A5 验证结果

验证环境：A5 `ascend950`，CANN 9.1.0，Python 3.10.20，torch 2.7.1，torch_npu 2.7.1.post5；使用物理 1 卡。

- `tests/test_wheel_environment.py`：6 项全部通过。
- 完整 wheel 构建、强制安装及 `scripts/check_packaged_wheel_api.py`：通过。
- Issue #310 加载顺序在 10 个独立 Python 进程中连续通过。
- `/proc/self/maps` 同时存在 CANN `libopapi.so` 与 wheel 内 `libcust_opapi.so` 两个独立映射。
- FLA 自定义符号可通过私有句柄解析，`RTLD_DEFAULT` 全局域不可见，确认无符号泄漏。
- legacy `torch.ops.npu.npu_fast_gelu_custom` 实算通过，与 CANN 参考算子最大绝对误差为 `0.0`。
- `libcust_opapi.so` 无 `DT_SONAME`；legacy extension RUNPATH 仅保留 Torch/Torch-NPU 路径，不含 FLA `op_api/lib`。

构建产物：

```text
flash_linear_attention_npu-26.6.0-1fix.v26.6.0.opapi.symbol.isolation.950.x86_64-py3-none-any.whl
SHA256: b8ecb141b78c273679d33be1a825cbeb32c5d54cdb00f395aa83cca60860444e
```

## Checklist

- [x] 已关联 Issue 和主线修复 PR
- [x] 已明确 backport 范围与 legacy 调用链差异
- [x] 已完成 A5 完整 wheel 构建、安装和真实算子调用验证
- [x] 未引入 kernel、tiling 或公开接口变化
- [x] 已补充测试和文档
- [ ] 待仓库维护者按需触发 NPU CI，并补齐其他产品验证
