### PR TITLE
fix: align bwd dhu state shapes with FLA semantics

### DIFF
--- a/chunk_gated_delta_rule_bwd_dhu_design.md
+++ b/chunk_gated_delta_rule_bwd_dhu_design.md
@@ -24,7 +24,7 @@ varlen:        seqNum * ceil_div(HV, 4)
 1. stage0 已调通，固定/变长使用同一套 kernel 主流程。
 2. 当前三阶段首版已经接入 Vector/Cube 跨核 ready 边界、workspace 段布局、Cube 侧 `dvState/termQ/termW` 三个 GEMM，以及 Vector 侧 `dv2` 写回和 `dhState` 倒序更新。
 3. Cube 侧直接对齐 `prepare_wy_repr_bwd` 的 tile 级 resident/双缓冲写法：使用 `GM->L1->L0A/L0B->TileMmadTla->L0C->Dst`，其中 Dst 按路径选择 GM 或 AIV UB。
-4. 后续仍需继续对齐 `dht/h0/dh0` 初始/输出语义、`state_v_first` 布局，以及必要的 AIC/AIV UB 直连性能优化。
+4. `dht/h0/dh0` 初始/输出语义已对齐；后续仍需支持 `state_v_first` 布局，以及必要的 AIC/AIV UB 直连性能优化。
 
 说明：完整递推版本的 `dH` 在相邻 chunk 间存在倒序依赖。当前代码已经让每个 `(seq,hv)` 的 `dhState` 由负责该 head 的 Vector subblock 以 row tile 形式在 workspace state 段和 UB 间跨 chunk 倒序流转，chunk 主循环按 seq 内倒序执行；定长和变长差异仍只在 chunk offset helper 内处理，不在 kernel 主流程拆两套分支。
 
@@ -73,10 +73,8 @@ g 或 gK 使用低精度类型时必须与 q/k 同为 fp16 或同为 bf16；也�
 | 名称 | Shape | dtype | 说明 |
 |---|---|---|---|
 | `dh` | fixed: `[B, HV, chunkNumPerB, K, V]`; varlen: `[1, HV, totalChunkNum, K, V]` | fp16/bf16 | 每个 chunk 开始处的 `dH` |
-| `dh0` | `[N, HV, K, V]` | fp32 | 如果 `h0` 非空则输出最终递推到序列开头的 `dH`；否则返回空 tensor |
+| `dh0` | `[N, HV, K, V]` | fp16/bf16 | 如果 `h0` 非空则输出最终递推到序列开头的 `dH`；否则返回空 tensor |
 | `dv2` | `[B, HV, T, V]` | fp16/bf16 | `dv + K @ dH` 加 gate 后的结果 |
-
-注意：当前 fast-kernel launch 占位 meta 如果把 `dh0` 做成 `[B, HV, chunkNum, K, V]` 且 dtype 跟随 `q`，建议实现时修正为上表语义，和上游功能保持一致。
 
 ## 3. 数学语义
 
@@ -253,7 +251,7 @@ chunkLen = tokenEnd - tokenStart
 
 当前三阶段首版让同一 `(seq,hv)` 的 chunk 在同一个 task 内倒序串行。每个 head 的 `dhState` carry 固定为 fp32，按 row tile 在 GM workspace 的 fp32 state 段和 Vector 专用 `stateFp32` ping/pong UB 之间搬运；每个 chunk 的 `stage_0` 将当前 `dhState=dH_old` 保存为公开输出 `dh`，Cube 的 `dvState=K@dh[chunk]` 因而读取的是更新前状态；Vector 随后按 `g/gK` 分支对 fp32 state row tile 做 decay，`stage_1/stage_2` 再用 `termQ/termW` 更新 fp32 state，作为下一个倒序 chunk 的输入。
 
-当前递推调度已经满足 `chunk i` 依赖 `chunk i+1` 的串行顺序；仍未完整对齐的是 `dht` 初始化和 `dh0` fp32 输出语义。定长/变长差异必须继续收敛在统一 offset helper 中，不允许在 kernel 主流程拆两套分支。
+当前递推调度已经满足 `chunk i` 依赖 `chunk i+1` 的串行顺序；`dht` 已作为反向递推初值加载，`dh0` 按 `[N,HV,K,V]` 且 dtype 与 `q` 一致输出。定长/变长差异必须继续收敛在统一 offset helper 中，不允许在 kernel 主流程拆两套分支。
 
 ### 4.4 4-head round 内部顺序
 
@@ -304,19 +302,19 @@ for headOffset = 0; headOffset < headCnt; ++headOffset:
 | 代码位置 | 当前已实现 | 还未实现 |
 |---|---|---|
 | `GetSeqInfo` / `GetChunkInfoBySeqChunk` | 参考 `prepare_wy_repr_bwd`，用 helper 同时处理定长和变长 offset；定长由 `seqIdx/localChunkIdx` 计算 batch 内 token 区间，变长由 `cu_seqlens` 得到 packed token 区间，并在 task 粒度计算 canonical flattened chunk 前缀，chunk 内 O(1) 校验 `chunk_indices`，非 canonical 输入才 fallback 线性反查 | 后续仍可继续减少 `cu_seqlens` 前缀计算的重复读取，但不能把主流程拆成定长/变长两套分支 |
-| Kernel 主循环 | Cube/Vector 都按相同 `taskIdx -> seqIdx/headWindowIdx/hvBase/headCnt` 映射处理；若 `hasDh0`，Vector 在进入 task 循环前用 CANN `AscendC::Fill` 对完整 `dh0` GM 做一次性清零，并用 `SyncAll<true>()` 做全 Vector 同步，不需要 Cube 参与；一个 task 最多覆盖四个 value head；task 内负责当前 head 的 AIV 初始化该 head 的完整 fp32 workspace state，再按 seq 内 chunk 倒序串行执行 stage0/stage1/stage2 | 当前 `dhState` 入口仍固定清零，尚未从 `dht` 初始化；`dh0` 仍未按上游 fp32 shape/dtype 完整输出 |
+| Kernel 主循环 | Cube/Vector 都按相同 `taskIdx -> seqIdx/headWindowIdx/hvBase/headCnt` 映射处理；若 `hasDh0`，Vector 在进入 task 循环前用 CANN `AscendC::Fill` 对完整 `dh0` GM 做一次性清零，并用 `SyncAll<true>()` 做全 Vector 同步，不需要 Cube 参与；一个 task 最多覆盖四个 value head；task 内负责当前 head 的 AIV 从 `dht` 初始化完整 fp32 workspace state（`dht` 为空时清零），再按 seq 内 chunk 倒序串行执行 stage0/stage1/stage2 | `dh0` 按 `[N,HV,K,V]` 输出，dtype 与 `q` 一致 |
 | `ChunkGatedDeltaRuleBwdDhuVector` 调度 | A2/A5 中对每个 `headOffset`，`headOffset % subBlockNum` 选中的 subblock 执行当前 head 的完整 stage0/stage1/stage2 计算；另一个 subblock 不读写该 head 的 workspace/output，只参与同一 raw flag 的 set/wait 配平。一个 4-head window 内 subblock0 处理 `headOffset=0/2`，subblock1 处理 `headOffset=1/3` | 后续可继续优化四个 head 的跨阶段 overlap |
-| `ChunkGatedDeltaRuleBwdDhuVector::ProcessChunkStage0` | 负责当前 head 的 AIV 从 fp32 workspace state 段按 row tile 读取 `stateFp32`，写公开 `dh` 对应行，Cube stage1 直接从 `dh` 读取 state；stage 内直接按 token 生成 `qgDt`；`g` 分支整段搬入 `g[M]` 到当前 head 的 `gRaw`，用向量 `Exp` 生成 `gateFactor=exp(g_t)` 和 `dvGateFactor=exp(g_last-g_t)` 并驻留，复用当前 chunk 最后 token 的向量 gate 结果做统一 decay；`gK` 分支生成 `qgDt=q`，读取 `gK_last[K]` 并用向量 `Muls/Exp` 生成 K 行 `gkLastFactor=exp2(gK_last)`；A5 将 `qgDt` 从 output UB 通过 MTE3 直接写入 L1A，`g` 按当前 `headOffset` 映射，`gK` 按当前 window 内共享 `hk` 的组首 head 映射，省去 UB->GM workspace 和 Cube GM->L1 两段搬运，A2 保持 qg workspace 路径；decay 后的 fp32 state 写回 workspace | 还没有从 `dht` 初始化真实 `dhState`，当前入口仍从 0 初始化 |
+| `ChunkGatedDeltaRuleBwdDhuVector::ProcessChunkStage0` | 负责当前 head 的 AIV 从 fp32 workspace state 段按 row tile 读取 `stateFp32`，写公开 `dh` 对应行，Cube stage1 直接从 `dh` 读取 state；stage 内直接按 token 生成 `qgDt`；`g` 分支整段搬入 `g[M]` 到当前 head 的 `gRaw`，用向量 `Exp` 生成 `gateFactor=exp(g_t)` 和 `dvGateFactor=exp(g_last-g_t)` 并驻留，复用当前 chunk 最后 token 的向量 gate 结果做统一 decay；`gK` 分支生成 `qgDt=q`，读取 `gK_last[K]` 并用向量 `Muls/Exp` 生成 K 行 `gkLastFactor=exp2(gK_last)`；A5 将 `qgDt` 从 output UB 通过 MTE3 直接写入 L1A，`g` 按当前 `headOffset` 映射，`gK` 按当前 window 内共享 `hk` 的组首 head 映射，省去 UB->GM workspace 和 Cube GM->L1 两段搬运，A2 保持 qg workspace 路径；decay 后的 fp32 state 写回 workspace | state 在 task 入口从 `dht` 初始化，`dht` 为空时清零 |
 | `ChunkGatedDeltaRuleBwdDhuVector` copy helpers | 对齐 `prepare_wy_repr_bwd`：q 行输入、gate 输入、dv 行输入和输出写回拆成 `CopyIn/Cast/CopyOut` helper。q 输入、gate 输入和输出各自使用独立 ping-pong 事件组 | 当前调用顺序较直，但事件设计不要求 q/gate 固定串行 |
 | stage0 的 `USE_GK=0` 分支 | stage 内读取 `q/g`，`gRaw/gateFactor/dvGateFactor` 按当前 headOffset 在 UB 中驻留；用向量 `Exp` 生成自然指数系数，再用 `Brcb+Mul` 写出 `qgDt = q * exp(g_t)`；随后按当前 chunk 最后 token 做 `dhState *= exp(g_last)`；stage1 直接复用 `dvGateFactor=exp(g_last-g_t)` | `g` 分支代码和 golden 都使用自然指数；不通过 scalar 读 gate 系数生成向量 |
 | stage0 的 `USE_GK=1` 分支 | 每个 head 仍独立读取 `gK_last[K]`，生成 `exp2(gK_last[K])` 并完成 state decay；A5 当前 window 内同一 `hk` 只由首个 V head 读取和转换 q、写一次共享 qg L1A slot，后续 V heads 不重复 q 的 GM->UB、cast 和 UB->L1；`gK` 不参与 token gate 或 `qgDt` | 已对齐上游 gate 指数语义；继续保持 `gK` dtype/shape 与上游一致 |
 | `ChunkGatedDeltaRuleBwdDhuCube` | 先搬 `K/dO`，等待当前 `headOffset` 的 `vecToCube` flag；A5 `g` 分支按 headOffset 消费独立 qg slot，`gK` 分支按当前 window 内 `hk` 首 head 映射消费共享 qg slot，A2 从 qg workspace 搬入；用 tile 级 resident/双缓冲计算 `dvState = K @ dh[chunk]` 和 `termQ = qgDt.T @ d_o`；bf16 路径将 `dvState` 按 `vecRow` row tile 通过 CV 发给负责当前 head 的 Vector subblock；fp16/fp32 路径写 GM workspace；随后发布 `cubeToVec`；`K` 使用 L1 resident ping/pong 并在同 chunk shared-key heads 间复用；A5 BF16 `V=128` 进一步让同组 K 驻留 L0A slot0，`termQ` 使用 slot1 | 其它 dtype/V 档位保持 L1 resident 到 L0 ping/pong 路径 |
 | CrossCore 同步 | 当前使用 `prepare_wy_repr_bwd` 风格的两套 raw flag：`vecToCube=2`、`cubeToVec=4`。每个 head 的每个同步点两个 Vector subblock 都参与一次 `CrossCoreSetFlag<0x2, PIPE_MTE3>` 或 `CrossCoreWaitFlag`，Cube 侧按 head 串行等待/发布；A2/A5 head 交替分摊只改变实际 producer，不改变 raw flag 次数 | 后续可继续优化四个 head 的跨阶段 overlap |
-| `ChunkGatedDeltaRuleBwdDhuVector::ProcessChunkStage1` | 负责当前 head 的 subblock 消费 `dvState` 和输入 `dv`。A5 bf16 路径先发起 `dv` 的 GM->UB 搬运，再等待矩阵 CV ready、cast `dvState` 并立即归还 free；fp16/fp32 路径从 GM workspace 读回 `dvState`；`g` 分支复用 stage0 的 `dvGateFactor` UB resident，`gK` 分支直接相加；按 token row tile 只写公开 `dv2` | 后续精度对齐仍需确认 dht/h0 语义 |
+| `ChunkGatedDeltaRuleBwdDhuVector::ProcessChunkStage1` | 负责当前 head 的 subblock 消费 `dvState` 和输入 `dv`。A5 bf16 路径先发起 `dv` 的 GM->UB 搬运，再等待矩阵 CV ready、cast `dvState` 并立即归还 free；fp16/fp32 路径从 GM workspace 读回 `dvState`；`g` 分支复用 stage0 的 `dvGateFactor` UB resident，`gK` 分支直接相加；按 token row tile 只写公开 `dv2` | 后续继续扩展大 shape 精度覆盖 |
 | `ChunkGatedDeltaRuleBwdDhuCube::ProcessChunkStage2` | 等待 Vector 的 `dv2` ready 后，用 tile 级 W resident/双缓冲计算 `termW = w.T @ dv2`；A5 bf16 在首个矩阵 CV tile 前发布 `cubeToVec`，逐 tile 使用 ready/free；fp16/fp32 写 GM workspace 后发布 `cubeToVec` | `W` 当前按 head resident，不做跨 chunk 复用 |
-| `ChunkGatedDeltaRuleBwdDhuVector::ProcessChunkStage2` | 等待 stage2 可启动后，按 K 行读取 workspace `termQ` 和 fp32 state；A5 bf16 从矩阵 CV 读取 `termW`，fp16/fp32 从 workspace 读取；计算 `dhState = dhState + termQ * scale - termW`，再以 fp32 写回 workspace 供下一个倒序 chunk 使用 | 还没有支持从 `dht` 初始化和 `dh0` fp32 输出语义 |
+| `ChunkGatedDeltaRuleBwdDhuVector::ProcessChunkStage2` | 等待 stage2 可启动后，按 K 行读取 workspace `termQ` 和 fp32 state；A5 bf16 从矩阵 CV 读取 `termW`，fp16/fp32 从 workspace 读取；计算 `dhState = dhState + termQ * scale - termW`，再以 fp32 写回 workspace 供下一个倒序 chunk 使用 | 入口 state 来自 `dht`（为空时清零），最终 state 转为 `q` dtype 写入 `dh0` |
 
-因此，当前代码已经完成的是 `g/gK` 二选一、shape/tilingKey 分支、固定/变长统一 seq-head task 调度、seq 内 chunk 倒序串行、Vector fp32 `dhState` workspace carry 和专用 `stateFp32` ping/pong UB、`g` 自然指数与 `gK` exp2 的分支语义、stage0 的 `qgDt/dh`、stage1 的 `dvState/termQ/dv2`、stage2 的 `termW` 和 state update，以及 A5 bf16 `dvState/termW` 共用矩阵 CV 双缓冲传递。继续缺口主要是 `dht/h0/dh0` 完整语义、`state_v_first` 布局和进一步性能流水。
+因此，当前代码已经完成的是 `g/gK` 二选一、shape/tilingKey 分支、固定/变长统一 seq-head task 调度、seq 内 chunk 倒序串行、Vector fp32 `dhState` workspace carry 和专用 `stateFp32` ping/pong UB、`g` 自然指数与 `gK` exp2 的分支语义、stage0 的 `qgDt/dh`、stage1 的 `dvState/termQ/dv2`、stage2 的 `termW` 和 state update、`dht` 初始化与 4D `dh0` 输出，以及 A5 bf16 `dvState/termW` 共用矩阵 CV 双缓冲传递。继续缺口主要是 `state_v_first` 布局和进一步性能流水。
 
 ### 5.2 当前代码与完整方案不一致项
 
@@ -325,14 +323,14 @@ for headOffset = 0; headOffset < headCnt; ++headOffset:
 | gate 指数函数 | `g` 分支直接用 `AscendC::Exp`，golden 用 `torch.exp`；`gK` 分支用 `x * ln2` 后调用 `AscendC::Exp`，golden 用 `torch.exp(x * ln2)` | 两个模板分支分别保持对应指数语义 |
 | chunk 调度 | 当前已经按 `seqIdx/headWindowIdx` 作为 task，task 内按 `headOffset % subBlockNum` 选中的 AIV 初始化该 head 的 fp32 workspace state，再按 seq 内 chunk 倒序串行；定长/变长都通过统一 helper 拿 offset | 后续如果引入 V tile 并行、head 间 overlap 或 chunk 级流水，必须保持每个 `(seq,hv,vTile)` 的 chunk 倒序依赖，不允许退回 chunk 并行 |
 | workspace slot | 当前对齐 prepare 的 8-slot 方式：每个 AIC core 保留 8 个 per-head slot，大小为 `blockDim * 8 * workspaceElemsPerSubBlock * sizeof(DT)`，slot 地址为 `coreIdx * 8 + windowStartSlot + headOffset`，布局保留 `qgDt/dhState/dvState/termQ/termW` 五段；A5 的 `qgDt` 及 bf16 `dvState/termW` 段仅预留，运行时有效 workspace 数据为 `dhState/termQ`；`dhState` 按 fp32 字节数预留，`stateDt/dv2Dt` 不占 workspace | 后续如果其它段也改 fp32，应继续按 byte 对齐折算到对应 dtype 指针 |
-| `dhState` | 当前使用 fp32 workspace carry 和单独 `stateFp32` ping/pong UB；负责当前 head 的 AIV 按 `vecRow` 连续 row tile 搬入、更新和写回完整 `[K,V]`，入口仍固定清零 | 后续要从 `dht` 或 0 初始化 fp32 `dhState[K,V]`，最后按需输出真实 `dh0` |
+| `dhState` | 当前使用 fp32 workspace carry 和单独 `stateFp32` ping/pong UB；负责当前 head 的 AIV 按 `vecRow` 连续 row tile 搬入、更新和写回完整 `[K,V]`，入口从 `dht` 初始化（未提供时清零），最后按需输出 `dh0` | 后续继续优化状态搬运流水 |
 | `gK` 分支 | 当前整行读取当前 chunk 最后有效 token的 `gK_last[K]` 到 UB，用向量指令生成 K 个 `exp2` decay 系数，并保持 `qgDt=q`、`dv2` 不加 token gate | 需要继续保持上游 dtype/shape 行为 |
-| `dv2` | 当前 stage1 按 `dvState(+gate)+dv` 路径只写公开 `dv2`；`g` 分支加自然指数 token gate，`gK` 分支不加 | 需要和 `dht/h0` 完整语义一起继续做全量精度闭环 |
+| `dv2` | 当前 stage1 按 `dvState(+gate)+dv` 路径只写公开 `dv2`；`g` 分支加自然指数 token gate，`gK` 分支不加 | 状态语义已对齐，后续继续扩展全量精度覆盖 |
 | Cube 路径 | 当前 Cube 使用 tile 级接口写 `K @ dh[chunk]`、`qgDt.T @ d_o` 和 `w.T @ dv2`；`K/W` 有独立 L1 resident，scratch/L0A/L0B/L0C 按 prepare 风格管理事件；A5 BF16 `V=128` 在共享 `hk` 的 V heads 间复用 K 的 L0A slot0，`termQ` 固定使用 slot1 | 其它模板分支继续使用现有 L0 ping/pong，后续优化保持相同事件闭环 |
 | 跨 AIC/AIV 同步 | 当前已经按 `prepare_wy_repr_bwd` 形态接入 stage1/stage2 的 `vecToCube/cubeToVec`。四个 head 串行复用同一对 raw flag；同一 head 内两个 Vector subblock 必须都参与同一个 `<0x2>` 同步点，其中负责该 head 的 subblock 生产数据，另一个 subblock 只做同步配平 | 后续若做 head 间并行，需要先证明 raw flag 顺序协议或设计 ready/free 复用协议 |
-| `dh0` | 当前 `hasDh0` 时入口通过 tiling 给出的 `dh0ClearCoreNum/dh0ClearElemsPerCore/dh0ClearTailElems` 切分，使用 `AscendC::Fill` 一次性清零完整当前 5D `dh0` 输出；非最后参与 Vector 核的清零字节数保持 512B 对齐，最后参与核处理尾部。最终每个 seq/head 在出口只写对应首 chunk 的递推 state | 后续应输出 `[N,HV,K,V] fp32`，并在 wrapper/meta/kernel 地址计算中统一 |
+| `dh0` | 当前 `hasDh0` 时入口通过 tiling 给出的 `dh0ClearCoreNum/dh0ClearElemsPerCore/dh0ClearTailElems` 切分，使用 `AscendC::Fill` 一次性清零完整 `[N,HV,K,V]` 输出；非最后参与 Vector 核的清零字节数保持 512B 对齐，最后参与核处理尾部。最终每个 seq/head 在出口写回对应的递推 state | dtype 与 `q` 一致 |
 
-当前代码主流程已经按下面的倒序递推框架执行；尚未完整对齐的是 `InitDHTile` 从 `dht` 初始化和 `StoreDh0` 的上游 shape/dtype 语义。单个 head 的每个 V tile 按以下顺序执行：
+当前代码主流程已经按下面的倒序递推框架执行，`InitDHTile` 从 `dht` 初始化，`StoreDh0` 按上游 4D shape 和输入 dtype 写回。单个 head 的每个 V tile 按以下顺序执行：
 
 ```text
 InitDHTile
@@ -887,11 +885,9 @@ Vector 内部同步遵循：
 5. 保持 fixed/varlen 在同一个 `GetChunkInfo` helper 内处理，kernel 主流程不拆两套分支。
 6. DHU Cube 禁止 `BlockMmadTla`、`DeviceGemm` 等 block 级接口；所有 GEMM 只允许 `CopyGmToL1A/B`、`CopyL1ToL0A/B`、`TileMmadTla`、`CopyL0CToGm` 这套 tile 级路径。
 
-下一阶段：补齐完整语义
+下一阶段
 
-1. 支持 `dht` 作为初始 final state gradient；按 AIV row tile 分片后的 `dhState` 已经在 Vector UB 中跨 chunk 倒序常驻，后续只补真实初始化来源。
-2. 写真实 `dh/dh0`；如果 `h0` 非空，输出 `dh0[N,HV,K,V]` fp32，并修正 fast-kernel launch meta 中 `dh0` 的 shape/dtype。
-3. 支持 `state_v_first=true` 时，需要输出和 state 地址模板化。
+1. 支持 `state_v_first=true` 时，需要输出和 state 地址模板化。
 
 后续性能优化
 
@@ -965,4 +961,4 @@ CPU golden 较慢的机器可使用分段验证：目标 NPU 机器逐 case 运�
 8. `g` 和 `gK` 是互斥关系，二者都传或都不传必须在 wrapper/aclnn/tiling 层拒绝。
 9. 尾 chunk 的无效 token 不参与 GEMM、gate、写回。
 10. varlen 的 `dh` 使用 flattened `chunkFlatIdx`，不是 local chunkIdx。
-11. `dh0` 如果输出，shape 应为 `[N,HV,K,V]`，dtype 应为 fp32。
+11. `dh0` 如果输出，shape 应为 `[N,HV,K,V]`，dtype 与 `q` 一致。

--- a/examples/fast_kernel_launch_example/csrc/chunk_gated_delta_rule_bwd_dhu/ascend910b/chunk_gated_delta_rule_bwd_dhu.cpp
+++ b/examples/fast_kernel_launch_example/csrc/chunk_gated_delta_rule_bwd_dhu/ascend910b/chunk_gated_delta_rule_bwd_dhu.cpp
@@ -54,16 +54,20 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_bwd_dhu_me
     int64_t K = q.size(3);
     int64_t Hv = dv.size(1);
     int64_t V = dv.size(3);
+    int64_t sequenceNum = B;
     int64_t chunkNum = (T + chunk_size - 1) / chunk_size;
     if (chunk_indices.has_value()) {
         chunkNum = static_cast<int64_t>(chunk_indices.value().size()) / 2;
+    }
+    if (cu_seqlens.has_value()) {
+        sequenceNum = static_cast<int64_t>(cu_seqlens.value().size()) - 1;
     }
 
     at::Tensor dh = at::empty({B, Hv, chunkNum, K, V}, q.options());
     at::Tensor dv2 = at::empty_like(dv);
     at::Tensor dh0;
     if (h0.has_value()) {
-        dh0 = at::empty({B, Hv, chunkNum, K, V}, q.options());
+        dh0 = at::empty({sequenceNum, Hv, K, V}, q.options());
     } else {
         dh0 = at::empty({0}, q.options());
     }
@@ -251,7 +255,7 @@ __global__ __aicore__ void chunk_gated_delta_rule_bwd_dhu_kernel(
         KERNEL_TASK_TYPE(1, KERNEL_TYPE_MIX_AIC_1_2);
     }
     GDN::ChunkGatedDeltaRuleBwdDhuKernelImpl<DT, GT>(
-        q, k, w, d_o, dv, g, cu_seqlens, chunk_indices, dh, dh0, dv2, userWS, &tilingData);
+        q, k, w, d_o, dv, g, nullptr, cu_seqlens, chunk_indices, dh, dh0, dv2, userWS, &tilingData);
 }
 
 template <typename DT, typename GT>

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/README.md
@@ -62,8 +62,8 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhu(
 | `dv` | 输入 | 必选 | Value 的上游梯度张量 | 将与来自 `dh` 的贡献叠加后输出为 `dv2` | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, V]` | 支持 |
 | `gOptional` | 输入 | 可选 | Gate 张量 | 对隐藏状态递推施加指数门控 `exp(g)` | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, HV, T]` | 支持 |
 | `gkOptional` | 输入 | 可选 | Key-wise Gate 张量 | 对每个 Key 维度施加额外门控 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, K]` | 支持 |
-| `h0Optional` | 输入 | 可选 | 初始隐藏状态张量 | 提供时参与递推初始化 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, K, V]` | 支持 |
-| `dhtOptional` | 输入 | 可选 | 末尾隐藏状态的梯度张量 | 反向递推的起始梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, K, V]` | 支持 |
+| `h0Optional` | 输入 | 可选 | 初始隐藏状态张量 | 用于标识是否需要输出 `dh0Out`，数值不参与本算子计算 | `FLOAT16`、`BFLOAT16` | `ND` | `[N, HV, K, V]` | 支持 |
+| `dhtOptional` | 输入 | 可选 | 末尾隐藏状态的梯度张量 | 作为每条序列反向递推的起始梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[N, HV, K, V]` | 支持 |
 | `cuSeqlensOptional` | 输入 | 可选 | 变长序列的累计长度信息 | 变长模式输入，形状为 `[N+1]` | `INT64` | `ND` | 1 维 | - |
 | `chunkIndicesOptional` | 输入 | 可选 | 分块索引信息 | 变长模式输入，扁平化存储 `[seqIdx0, chunkIdx0, ...]`，长度为 `2 * numChunks` | `INT64` | `ND` | 1 维 | - |
 
@@ -80,12 +80,12 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhu(
 | 参数名 | 输入/输出 | 描述 | 数据类型 | 数据格式 | 维度（Shape） | 非连续 Tensor |
 |---|---|---|---|---|---|---|
 | `dhOut` | 输出 | 各 chunk 起始时刻的隐藏状态梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, NT, K, V]` | 支持 |
-| `dh0Out` | 输出 | 初始隐藏状态 `h0` 的梯度（仅当 `h0Optional` 非空时有意义）| `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, K, V]` | 支持 |
+| `dh0Out` | 输出 | 初始隐藏状态 `h0` 的梯度（仅当 `h0Optional` 非空时有意义）| `FLOAT16`、`BFLOAT16` | `ND` | `[N, HV, K, V]` | 支持 |
 | `dv2Out` | 输出 | 融合了隐藏状态贡献后的 Value 梯度 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, HV, T, V]` | 支持 |
 | `workspaceSize` | 输出 | Device 侧所需 workspace 大小 | `uint64_t` | - | 标量 | - |
 | `executor` | 输出 | 算子执行器，封装了计算流程 | `aclOpExecutor*` | - | - | - |
 
-> **注**：`NT` 为 chunk 总数，定长模式下 `NT = ceil(T / chunkSize)`；变长模式下 `NT` 由 `chunkIndices` 推导。
+> **注**：`NT` 为 chunk 总数，定长模式下 `NT = ceil(T / chunkSize)`；变长模式下 `NT` 由 `chunkIndices` 推导。`N` 为实际序列数，定长模式下 `N = B`，变长模式下 `N = len(cuSeqlensOptional) - 1`。
 
 ### 3.4 形状与约束
 
@@ -95,7 +95,7 @@ aclnnStatus aclnnChunkGatedDeltaRuleBwdDhu(
 - `q` 与 `dO`/`dv` 的 `B`、`T` 必须一致，head 数允许不同（GVA）。
 - `gOptional` 的形状必须为 `[B, HV, T]`（若提供）。
 - `gkOptional` 的形状必须为 `[B, HV, T, K]`（若提供）。
-- `h0Optional`、`dhtOptional` 的形状必须为 `[B, HV, K, V]`（若提供）。
+- `h0Optional`、`dhtOptional` 的形状必须为 `[N, HV, K, V]`（若提供）；定长模式下 `N = B`，变长模式下 `N = len(cuSeqlensOptional) - 1`。
 - `dhOut` 的形状必须为 `[B, HV, NT, K, V]`。
 - **GVA 约束**：`HV % HK == 0`；读 `q`/`k` 时使用 `hq = hv / (HV / HK)`，读/写 `w`/`dO`/`dv`/`g`/`dh`/`dv2` 使用 value head 索引 `hv`。
 - 当前实现仅支持 `K = 128`；其他 `K` 尺寸会在 tiling 阶段被拒绝。

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/examples/test_aclnn_chunk_gated_delta_rule_bwd_dhu.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/examples/test_aclnn_chunk_gated_delta_rule_bwd_dhu.cpp
@@ -173,7 +173,7 @@ int main() {
 
   std::vector<int64_t> dv2Shape = {B, H, T, V};
   std::vector<int64_t> dhShape = {B, H, chunk_num, K, V};
-  std::vector<int64_t> dh0Shape = {B, H, chunk_num, K, V};
+  std::vector<int64_t> dh0Shape = {B, H, K, V};
 
   void* qDeviceAddr = nullptr;
   void* kDeviceAddr = nullptr;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_api/aclnn_chunk_gated_delta_rule_bwd_dhu.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_api/aclnn_chunk_gated_delta_rule_bwd_dhu.cpp
@@ -62,6 +62,8 @@ static aclnnStatus CheckNotNull(ChunkGatedDeltaRuleBwdDhuParams params)
     CHECK_COND(params.gkOptional == nullptr || params.useExp2, ACLNN_ERR_PARAM_INVALID,
                "use_exp2 must be true when gk is provided.");
     CHECK_COND(params.dhOut != nullptr, ACLNN_ERR_PARAM_NULLPTR, "dhOut must not be nullptr.");
+    CHECK_COND(params.h0Optional == nullptr || params.dh0Out != nullptr, ACLNN_ERR_PARAM_NULLPTR,
+               "dh0Out must not be nullptr when h0 is provided.");
     CHECK_COND(params.dv2Out != nullptr, ACLNN_ERR_PARAM_NULLPTR, "dv2Out must not be nullptr.");
     return ACLNN_SUCCESS;
 }
@@ -74,13 +76,50 @@ static aclnnStatus CheckFormat(ChunkGatedDeltaRuleBwdDhuParams params)
 
 static aclnnStatus CheckShape(ChunkGatedDeltaRuleBwdDhuParams params)
 {
-    (void)params;
+    const auto qShape = params.q->GetViewShape();
+    const auto dvShape = params.dv->GetViewShape();
+    CHECK_COND(qShape.GetDimNum() == 4 && dvShape.GetDimNum() == 4, ACLNN_ERR_PARAM_INVALID,
+               "q and dv must be rank-4 tensors.");
+    if (params.cuSeqlensOptional != nullptr) {
+        CHECK_COND(params.cuSeqlensOptional->Size() >= 2, ACLNN_ERR_PARAM_INVALID,
+                   "cuSeqlensOptional must contain at least two offsets.");
+    }
+
+    const int64_t sequenceNum = params.cuSeqlensOptional == nullptr
+                                    ? qShape.GetDim(0)
+                                    : static_cast<int64_t>(params.cuSeqlensOptional->Size()) - 1;
+    const int64_t hv = dvShape.GetDim(1);
+    const int64_t kDim = qShape.GetDim(3);
+    const int64_t vDim = dvShape.GetDim(3);
+    const aclTensor *states[] = {
+        params.h0Optional, params.dhtOptional, params.h0Optional == nullptr ? nullptr : params.dh0Out};
+    const char *stateNames[] = {"h0Optional", "dhtOptional", "dh0Out"};
+    for (size_t idx = 0; idx < 3; ++idx) {
+        if (states[idx] == nullptr) {
+            continue;
+        }
+        const auto stateShape = states[idx]->GetViewShape();
+        CHECK_COND(stateShape.GetDimNum() == 4 && stateShape.GetDim(0) == sequenceNum &&
+                       stateShape.GetDim(1) == hv && stateShape.GetDim(2) == kDim &&
+                       stateShape.GetDim(3) == vDim,
+                   ACLNN_ERR_PARAM_INVALID, "%s must have shape [N, HV, K, V].", stateNames[idx]);
+    }
     return ACLNN_SUCCESS;
 }
 
 static aclnnStatus CheckDtype(ChunkGatedDeltaRuleBwdDhuParams params)
 {
-    (void)params;
+    const auto qDtype = params.q->GetDataType();
+    const aclTensor *states[] = {
+        params.h0Optional, params.dhtOptional, params.h0Optional == nullptr ? nullptr : params.dh0Out};
+    const char *stateNames[] = {"h0Optional", "dhtOptional", "dh0Out"};
+    for (size_t idx = 0; idx < 3; ++idx) {
+        if (states[idx] == nullptr) {
+            continue;
+        }
+        CHECK_COND(states[idx]->GetDataType() == qDtype, ACLNN_ERR_PARAM_INVALID,
+                   "%s dtype must match q.", stateNames[idx]);
+    }
     return ACLNN_SUCCESS;
 }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_host/op_tiling/chunk_gated_delta_rule_bwd_dhu_tiling_processor.h
@@ -462,8 +462,8 @@ private:
         tiling_.dh0ClearTailElems = 0;
         if (ctx_.hasDh0) {
             const uint64_t dh0Elems =
-                static_cast<uint64_t>(tiling_.B) * static_cast<uint64_t>(tiling_.HV) *
-                static_cast<uint64_t>(tiling_.totalChunkNum) * static_cast<uint64_t>(tiling_.K) *
+                static_cast<uint64_t>(tiling_.seqNum) * static_cast<uint64_t>(tiling_.HV) *
+                static_cast<uint64_t>(tiling_.K) *
                 static_cast<uint64_t>(tiling_.V);
             const uint64_t dh0Bytes = dh0Elems * qSize;
             if (dh0Bytes > 0) {

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/arch35/chunk_gated_delta_rule_bwd_dhu_vector.h
@@ -186,14 +186,18 @@ class ChunkGatedDeltaRuleBwdDhuVector {
 public:
     __aicore__ inline ChunkGatedDeltaRuleBwdDhuVector() = default;
 
-    __aicore__ inline void Init(GM_ADDR q, GM_ADDR gate, GM_ADDR dv, GM_ADDR cuSeqlens, GM_ADDR chunkIndices, GM_ADDR dh,
-                                GM_ADDR dh0, GM_ADDR dv2, GM_ADDR workspace,
+    __aicore__ inline void Init(GM_ADDR q, GM_ADDR gate, GM_ADDR dv, GM_ADDR dht, GM_ADDR cuSeqlens,
+                                GM_ADDR chunkIndices, GM_ADDR dh, GM_ADDR dh0, GM_ADDR dv2, GM_ADDR workspace,
                                 const ChunkGatedDeltaRuleBwdDhuTilingData *__restrict tilingData,
                                 AscendC::TPipe *pipe)
     {
         qGm_.SetGlobalBuffer(reinterpret_cast<__gm__ DT *>(q));
         gateGm_.SetGlobalBuffer(reinterpret_cast<__gm__ GT *>(gate));
         dvGm_.SetGlobalBuffer(reinterpret_cast<__gm__ DT *>(dv));
+        if (dht != nullptr) {
+            dhtGm_.SetGlobalBuffer(reinterpret_cast<__gm__ DT *>(dht));
+            hasDht_ = true;
+        }
         cuSeqlens_ = cuSeqlens;
         chunkIndices_ = chunkIndices;
         dhGm_.SetGlobalBuffer(reinterpret_cast<__gm__ DT *>(dh));
@@ -352,8 +356,15 @@ public:
                     AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(stateVToMte2Event_[stateIdx]);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(stateMte3ToMte2Event_[stateIdx]);
                     AscendC::LocalTensor<float> stateFp32 = stateBuf_[stateIdx];
-                    FillFloatRegbase((__ubuf__ float *)reinterpret_cast<uint64_t>(stateFp32.GetPhyAddr()), 0.0f,
-                                     static_cast<uint16_t>(elems));
+                    if (hasDht_) {
+                        const uint32_t dhtIdx = CopyInRows(
+                            dhtGm_, qInputBuf_[curQInputPingPong_], StateOffset(seqIdx, hvBase + headOffset, rowOffset),
+                            elems);
+                        CastInputRows(stateFp32, qInputBuf_[dhtIdx], elems, dhtIdx);
+                    } else {
+                        FillFloatRegbase((__ubuf__ float *)reinterpret_cast<uint64_t>(stateFp32.GetPhyAddr()), 0.0f,
+                                         static_cast<uint16_t>(elems));
+                    }
                     AscendC::PipeBarrier<PIPE_V>();
                     CopyOutStateRows(stateIdx, stateFp32, stateBase + rowOffset * V_, elems);
                     curStatePingPong_ ^= 1U;
@@ -640,20 +651,7 @@ public:
                     const int64_t workspaceSlot = windowStartSlot + headOffset;
                     const int64_t workspaceBase = WorkspaceBase(coreIdx, workspaceSlot);
                     const int64_t hv = hvBase + headOffset;
-                    const int64_t b = isVariable_ != 0 ? 0 : seqIdx;
-                    int64_t outputChunkIdx = 0;
-                    if (isVariable_ != 0) {
-                        outputChunkIdx = seqInfo.outputChunkBase;
-                        if (outputChunkIdx >= totalChunkNum_ ||
-                            !ChunkIndexMatches(chunkIndices_, outputChunkIdx, seqIdx, 0)) {
-                            outputChunkIdx = FindVarlenChunkOutputIdx(chunkIndices_, *tiling_, seqIdx, 0);
-                        }
-                        if (outputChunkIdx < 0) {
-                            continue;
-                        }
-                    }
-
-                    const int64_t dh0Base = DhOffset(b, hv, outputChunkIdx);
+                    const int64_t dh0Base = StateOffset(seqIdx, hv, 0);
                     const int64_t stateBase = StateWorkspaceFloatOffset(workspaceBase, 0);
                     for (int64_t rowOffset = 0; rowOffset < K_; rowOffset += vecRow_) {
                         const int64_t curRows = Min(vecRow_, K_ - rowOffset);
@@ -814,6 +812,11 @@ private:
         return ((b * HV_ + hv) * totalChunkNum_ + chunkIdx) * K_ * V_;
     }
 
+    __aicore__ inline int64_t StateOffset(int64_t seqIdx, int64_t hv, int64_t row) const
+    {
+        return ((seqIdx * HV_ + hv) * K_ + row) * V_;
+    }
+
     __aicore__ inline int64_t WorkspaceBase(int64_t coreIdx, int64_t workspaceSlot) const
     {
         return (coreIdx * WORKSPACE_BUFFER_COUNT + workspaceSlot) * workspaceElemsPerSubBlock_;
@@ -829,6 +832,7 @@ private:
     AscendC::GlobalTensor<DT> qGm_;
     AscendC::GlobalTensor<GT> gateGm_;
     AscendC::GlobalTensor<DT> dvGm_;
+    AscendC::GlobalTensor<DT> dhtGm_;
     AscendC::GlobalTensor<DT> dhGm_;
     AscendC::GlobalTensor<DT> dh0Gm_;
     AscendC::GlobalTensor<DT> dv2Gm_;
@@ -898,6 +902,7 @@ private:
     int64_t isVariable_ = 0;
     float scale_ = 1.0f;
     bool hasDh0_ = false;
+    bool hasDht_ = false;
     int64_t dh0ClearCoreNum_ = 0;
     int64_t dh0ClearElemsPerCore_ = 0;
     int64_t dh0ClearTailElems_ = 0;

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu.cpp
@@ -31,7 +31,7 @@ namespace GDN {
 
 template <typename DT, typename GT, int V_DIM, int USE_GK>
 __aicore__ inline void ChunkGatedDeltaRuleBwdDhuKernelImpl(
-    GM_ADDR q, GM_ADDR k, GM_ADDR w, GM_ADDR d_o, GM_ADDR dv, GM_ADDR gate,
+    GM_ADDR q, GM_ADDR k, GM_ADDR w, GM_ADDR d_o, GM_ADDR dv, GM_ADDR gate, GM_ADDR dht,
     GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR dh, GM_ADDR dh0, GM_ADDR dv2,
     GM_ADDR workspace, const ChunkGatedDeltaRuleBwdDhuTilingData *tilingData)
 {
@@ -43,7 +43,7 @@ __aicore__ inline void ChunkGatedDeltaRuleBwdDhuKernelImpl(
     if ASCEND_IS_AIV {
         AscendC::TPipe pipe;
         ChunkGatedDeltaRuleBwdDhuVector<DT, GT, USE_GK> vec;
-        vec.Init(q, gate, dv, cu_seqlens, chunk_indices, dh, dh0, dv2, workspace, tilingData, &pipe);
+        vec.Init(q, gate, dv, dht, cu_seqlens, chunk_indices, dh, dh0, dv2, workspace, tilingData, &pipe);
         vec.Process();
     }
 }
@@ -76,7 +76,6 @@ __global__ __aicore__ void chunk_gated_delta_rule_bwd_dhu(
     GM_ADDR dh, GM_ADDR dh0, GM_ADDR dv2, GM_ADDR workspace, GM_ADDR tiling)
 {
     (void)h0;
-    (void)dht;
 
     AscendC::AscendCUtils::SetOverflow(1);
 
@@ -93,6 +92,6 @@ __global__ __aicore__ void chunk_gated_delta_rule_bwd_dhu(
     using GType = typename GDN::ChunkGatedDeltaRuleBwdDhuDTypeTraits<D_T_G>::type;
     GM_ADDR gate = (USE_GK == 0) ? g : gk;
     GDN::ChunkGatedDeltaRuleBwdDhuKernelImpl<QType, GType, V, USE_GK>(
-        q, k, w, d_o, dv, gate, cu_seqlens, chunk_indices, dh, dh0, dv2, userWS, &tilingData);
+        q, k, w, d_o, dv, gate, dht, cu_seqlens, chunk_indices, dh, dh0, dv2, userWS, &tilingData);
 }
 #endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_gated_delta_rule_bwd_dhu/op_kernel/chunk_gated_delta_rule_bwd_dhu_vector.h
@@ -30,14 +30,18 @@ class ChunkGatedDeltaRuleBwdDhuVector {
 public:
     __aicore__ inline ChunkGatedDeltaRuleBwdDhuVector() = default;
 
-    __aicore__ inline void Init(GM_ADDR q, GM_ADDR gate, GM_ADDR dv, GM_ADDR cuSeqlens, GM_ADDR chunkIndices, GM_ADDR dh,
-                                GM_ADDR dh0, GM_ADDR dv2, GM_ADDR workspace,
+    __aicore__ inline void Init(GM_ADDR q, GM_ADDR gate, GM_ADDR dv, GM_ADDR dht, GM_ADDR cuSeqlens,
+                                GM_ADDR chunkIndices, GM_ADDR dh, GM_ADDR dh0, GM_ADDR dv2, GM_ADDR workspace,
                                 const ChunkGatedDeltaRuleBwdDhuTilingData *__restrict tilingData,
                                 AscendC::TPipe *pipe)
     {
         qGm_.SetGlobalBuffer(reinterpret_cast<__gm__ DT *>(q));
         gateGm_.SetGlobalBuffer(reinterpret_cast<__gm__ GT *>(gate));
         dvGm_.SetGlobalBuffer(reinterpret_cast<__gm__ DT *>(dv));
+        if (dht != nullptr) {
+            dhtGm_.SetGlobalBuffer(reinterpret_cast<__gm__ DT *>(dht));
+            hasDht_ = true;
+        }
         cuSeqlens_ = cuSeqlens;
         chunkIndices_ = chunkIndices;
         dhGm_.SetGlobalBuffer(reinterpret_cast<__gm__ DT *>(dh));
@@ -180,7 +184,14 @@ public:
                     AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(stateVToMte2Event_[stateIdx]);
                     AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(stateMte3ToMte2Event_[stateIdx]);
                     AscendC::LocalTensor<float> stateFp32 = stateBuf_[stateIdx];
-                    AscendC::Duplicate(stateFp32, 0.0f, elems);
+                    if (hasDht_) {
+                        const uint32_t dhtIdx = CopyInRows(
+                            dhtGm_, qInputBuf_[curQInputPingPong_], StateOffset(seqIdx, hvBase + headOffset, rowOffset),
+                            elems);
+                        CastInputRows(stateFp32, qInputBuf_[dhtIdx], elems, dhtIdx);
+                    } else {
+                        AscendC::Duplicate(stateFp32, 0.0f, elems);
+                    }
                     AscendC::PipeBarrier<PIPE_V>();
                     CopyOutStateRows(stateIdx, stateFp32, StateWorkspaceFloatOffset(workspaceBase, rowOffset), elems);
                     curStatePingPong_ ^= 1U;
@@ -442,20 +453,7 @@ public:
                     const int64_t workspaceSlot = windowStartSlot + headOffset;
                     const int64_t workspaceBase = WorkspaceBase(coreIdx, workspaceSlot);
                     const int64_t hv = hvBase + headOffset;
-                    const int64_t b = isVariable_ != 0 ? 0 : seqIdx;
-                    int64_t outputChunkIdx = 0;
-                    if (isVariable_ != 0) {
-                        outputChunkIdx = seqInfo.outputChunkBase;
-                        if (outputChunkIdx >= totalChunkNum_ ||
-                            !ChunkIndexMatches(chunkIndices_, outputChunkIdx, seqIdx, 0)) {
-                            outputChunkIdx = FindVarlenChunkOutputIdx(chunkIndices_, *tiling_, seqIdx, 0);
-                        }
-                        if (outputChunkIdx < 0) {
-                            continue;
-                        }
-                    }
-
-                    const int64_t dh0Base = DhOffset(b, hv, outputChunkIdx);
+                    const int64_t dh0Base = StateOffset(seqIdx, hv, 0);
                     for (int64_t rowOffset = 0; rowOffset < K_; rowOffset += vecRow_) {
                         const int64_t curRows = Min(vecRow_, K_ - rowOffset);
                         const uint32_t elems = static_cast<uint32_t>(curRows * V_);
@@ -626,6 +624,11 @@ private:
         return ((b * HV_ + hv) * totalChunkNum_ + chunkIdx) * K_ * V_;
     }
 
+    __aicore__ inline int64_t StateOffset(int64_t seqIdx, int64_t hv, int64_t row) const
+    {
+        return ((seqIdx * HV_ + hv) * K_ + row) * V_;
+    }
+
     __aicore__ inline int64_t WorkspaceBase(int64_t coreIdx, int64_t workspaceSlot) const
     {
         return (coreIdx * WORKSPACE_BUFFER_COUNT + workspaceSlot) * workspaceElemsPerSubBlock_;
@@ -641,6 +644,7 @@ private:
     AscendC::GlobalTensor<DT> qGm_;
     AscendC::GlobalTensor<GT> gateGm_;
     AscendC::GlobalTensor<DT> dvGm_;
+    AscendC::GlobalTensor<DT> dhtGm_;
     AscendC::GlobalTensor<DT> dhGm_;
     AscendC::GlobalTensor<DT> dh0Gm_;
     AscendC::GlobalTensor<DT> dv2Gm_;
@@ -708,6 +712,7 @@ private:
     int64_t isVariable_ = 0;
     float scale_ = 1.0f;
     bool hasDh0_ = false;
+    bool hasDht_ = false;
     int64_t dh0ClearCoreNum_ = 0;
     int64_t dh0ClearElemsPerCore_ = 0;
     int64_t dh0ClearTailElems_ = 0;

--- a/tests/atk/chunk_gated_delta_rule_bwd_dhu/README.md
+++ b/tests/atk/chunk_gated_delta_rule_bwd_dhu/README.md
@@ -7,7 +7,7 @@
 - `q/k` 必须为 `[B,HK,T,K]`，且二者形状完全一致。
 - `w` 必须为 `[B,HV,T,K]`；`dO/dv/dv2` 必须为 `[B,HV,T,V]`，且 `dO` 与 `dv` 形状完全一致。
 - `g` 与 `gk` 必须二选一：`g=[B,HV,T]`，`gk=[B,HV,T,K]`；门控 dtype 需要为 `FLOAT` 或与 `q/k` 一致。
-- `h0/dht` 如提供，形状为 `[B,HV,K,V]`；`dh` 输出为 `[B,HV,NT,K,V]`。
+- `h0/dht` 如提供，形状为 `[N,HV,K,V]`；定长模式下 `N=B`，变长模式下 `N=len(cu_seqlens)-1`。`dh0` 与状态同形，`dh` 输出为 `[B,HV,NT,K,V]`。
 - `q/k` 与 `w/dO/dv/g` 的 `B`、`T` 必须一致；`HV % HK == 0`。
 - tiling 要求 `K=128`，`V` 支持 `128/256`，`chunk_size` 仅支持 `64/128`。
 - 变长模式下 `cu_seqlens` 与 `chunk_indices` 必须同时提供，`chunk_indices` 长度为正偶数，且 `B=1`。

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
@@ -374,9 +374,20 @@ def npu_chunk_gated_delta_rule_bwd_dhu(
         raise ValueError(f"g must have shape {(B, Hv, T)}, got {_shape(g)}.")
     if gK is not None and _shape(gK) != (B, Hv, T, K):
         raise ValueError(f"gK must have shape {(B, Hv, T, K)}, got {_shape(gK)}.")
+    if cu_seqlens is not None and len(cu_seqlens) < 2:
+        raise ValueError("cu_seqlens must contain at least the start and end offsets.")
+    N = B if cu_seqlens is None else len(cu_seqlens) - 1
+    state_shape = (N, Hv, K, V)
+    for name, state in (("h0", h0), ("dht", dht)):
+        if state is None:
+            continue
+        if _shape(state) != state_shape:
+            raise ValueError(f"{name} must have shape {state_shape}, got {_shape(state)}.")
+        if state.dtype != q.dtype:
+            raise ValueError(f"{name} must have the same dtype as q.")
     NT = _chunk_num(T, int(chunk_size), chunk_indices)
     dh = _empty((B, Hv, NT, K, V), q)
-    dh0 = _empty((B, Hv, NT, K, V), q) if h0 is not None else None
+    dh0 = _empty(state_shape, q) if h0 is not None else None
     dv2 = _empty_like(dv)
     outputs = (dh, dh0, dv2)
 

--- a/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
+++ b/torch_custom/fla_npu/op_plugin/ops/opapi/FLANpuOpApi.cpp
@@ -241,6 +241,7 @@ bool ResolveChunkLocalCumsumOutputDtype(
     int64_t Hv = dv_size[1];
     int64_t V = dv_size[3];
     int64_t chunk_num = (T + chunk_size -1) / chunk_size;
+    int64_t sequence_num = B;
 
     TORCH_CHECK(
         k_size[0] == B && k_size[1] == Hk && k_size[2] == T && k_size[3] == K,
@@ -265,13 +266,19 @@ bool ResolveChunkLocalCumsumOutputDtype(
         auto chunk_indices_ref = chunk_indices.value();
         chunk_num = chunk_indices_ref.size() / 2;
     }
+    if (cu_seqlens.has_value()) {
+        TORCH_CHECK(
+            cu_seqlens.value().size() >= 2,
+            "npu_chunk_gated_delta_rule_bwd_dhu: cu_seqlens must contain at least two offsets");
+        sequence_num = static_cast<int64_t>(cu_seqlens.value().size()) - 1;
+    }
 
-    // 创建输出 tensor：dh/dh0 与 value 头维 Hv 对齐（device 输出 [B,Hv,chunk_num,K,V]）
+    // dh 按 chunk 展开，dh0 与输入状态保持 [N,Hv,K,V]。
     at::Tensor dv2 = at::empty_like(dv);
     at::Tensor dh = at::empty({B, Hv, chunk_num, K, V}, q.options());
     at::Tensor dh0;
     if (h0.has_value()) {
-        dh0 = at::empty({B, Hv, chunk_num, K, V}, q.options());
+        dh0 = at::empty({sequence_num, Hv, K, V}, q.options());
     } else {
         dh0 = at::Tensor();
     }
@@ -289,24 +296,33 @@ bool ResolveChunkLocalCumsumOutputDtype(
     }
     if (h0_.defined()) {
         TORCH_CHECK(
-            h0_.dim() == 5 && h0_.size(0) == B && h0_.size(1) == Hv && h0_.size(2) == chunk_num,
-            "npu_chunk_gated_delta_rule_bwd_dhu: h0 must be [B,Hv,chunk_num,K,V]; h0=", h0_.sizes(),
-            " chunk_num=", chunk_num);
+            h0_.dim() == 4 && h0_.size(0) == sequence_num && h0_.size(1) == Hv &&
+                h0_.size(2) == K && h0_.size(3) == V,
+            "npu_chunk_gated_delta_rule_bwd_dhu: h0 must be [N,Hv,K,V]; h0=", h0_.sizes(),
+            " N=", sequence_num);
+        TORCH_CHECK(
+            h0_.scalar_type() == q.scalar_type(),
+            "npu_chunk_gated_delta_rule_bwd_dhu: h0 must have the same dtype as q");
     }
     if (dht_.defined()) {
         TORCH_CHECK(
-            dht_.dim() == 5 && dht_.size(0) == B && dht_.size(1) == Hv && dht_.size(2) == chunk_num,
-            "npu_chunk_gated_delta_rule_bwd_dhu: dht must be [B,Hv,chunk_num,K,V]; dht=", dht_.sizes(),
-            " chunk_num=", chunk_num);
+            dht_.dim() == 4 && dht_.size(0) == sequence_num && dht_.size(1) == Hv &&
+                dht_.size(2) == K && dht_.size(3) == V,
+            "npu_chunk_gated_delta_rule_bwd_dhu: dht must be [N,Hv,K,V]; dht=", dht_.sizes(),
+            " N=", sequence_num);
+        TORCH_CHECK(
+            dht_.scalar_type() == q.scalar_type(),
+            "npu_chunk_gated_delta_rule_bwd_dhu: dht must have the same dtype as q");
     }
 
     // 调用ACLNN算子
+    bool use_exp2_value = use_exp2.value_or(gK_.defined());
     EXEC_NPU_CMD_EXT(
         aclnnChunkGatedDeltaRuleBwdDhu,
         q, k, w, d_o, dv,
         g_, gK_, h0_, dht_,
         cu_seqlens, chunk_indices,
-        scale, chunk_size, static_cast<bool>(use_exp2.value_or(gK_.defined())),
+        scale, chunk_size, use_exp2_value,
         dh, dh0, dv2
     );
     return std::make_tuple(dh, dh0, dv2);

--- a/torch_custom/fla_npu/test/test_aclnn_ctypes_abi.py
+++ b/torch_custom/fla_npu/test/test_aclnn_ctypes_abi.py
@@ -138,6 +138,78 @@ class AclnnCtypesAbiTest(unittest.TestCase):
         self.assertEqual([type(arg) for arg in captured["args"]], operator_argtypes)
         self.assertFalse(captured["args"][13].value)
 
+    def test_chunk_gated_delta_rule_bwd_dhu_uses_sequence_state_shape(self):
+        import torch
+
+        captured = {}
+
+        def fake_empty(shape, like, **kwargs):
+            return FakeTensor(shape, kwargs.get("dtype", like.dtype))
+
+        def fake_empty_like(tensor, **kwargs):
+            return FakeTensor(tensor.shape, kwargs.get("dtype", tensor.dtype))
+
+        def fake_call_aclnn(name, build_args, outputs):
+            context = FakeCallContext()
+            build_args(context)
+            captured["name"] = name
+            return outputs
+
+        dtype = torch.float16
+        q = FakeTensor((1, 2, 128, 128), dtype)
+        value = FakeTensor((1, 4, 128, 128), dtype)
+        gate = FakeTensor((1, 4, 128), torch.float32)
+        h0 = FakeTensor((2, 4, 128, 128), dtype)
+        dht = FakeTensor((2, 4, 128, 128), dtype)
+
+        with mock.patch.object(ACLNN_CTYPES, "_empty", side_effect=fake_empty):
+            with mock.patch.object(ACLNN_CTYPES, "_empty_like", side_effect=fake_empty_like):
+                with mock.patch.object(ACLNN_CTYPES, "_call_aclnn", side_effect=fake_call_aclnn):
+                    dh, dh0, dv2 = ACLNN_CTYPES.npu_chunk_gated_delta_rule_bwd_dhu(
+                        q,
+                        q,
+                        FakeTensor((1, 4, 128, 128), dtype),
+                        value,
+                        value,
+                        scale=0.125,
+                        chunk_size=64,
+                        g=gate,
+                        h0=h0,
+                        dht=dht,
+                        cu_seqlens=[0, 64, 128],
+                        chunk_indices=[0, 0, 1, 0],
+                    )
+
+        self.assertEqual(captured["name"], "aclnnChunkGatedDeltaRuleBwdDhu")
+        self.assertEqual(dh.shape, (1, 4, 2, 128, 128))
+        self.assertEqual(dh0.shape, (2, 4, 128, 128))
+        self.assertEqual(dv2.shape, value.shape)
+
+    def test_chunk_gated_delta_rule_bwd_dhu_rejects_chunk_expanded_state(self):
+        import torch
+
+        dtype = torch.float16
+        q = FakeTensor((1, 2, 128, 128), dtype)
+        value = FakeTensor((1, 4, 128, 128), dtype)
+        gate = FakeTensor((1, 4, 128), torch.float32)
+        chunk_expanded_h0 = FakeTensor((1, 4, 2, 128, 128), dtype)
+
+        with mock.patch.object(ACLNN_CTYPES, "_call_aclnn") as call_aclnn:
+            with self.assertRaisesRegex(ValueError, r"h0 must have shape \(1, 4, 128, 128\)"):
+                ACLNN_CTYPES.npu_chunk_gated_delta_rule_bwd_dhu(
+                    q,
+                    q,
+                    FakeTensor((1, 4, 128, 128), dtype),
+                    value,
+                    value,
+                    scale=0.125,
+                    chunk_size=64,
+                    g=gate,
+                    h0=chunk_expanded_h0,
+                )
+
+        call_aclnn.assert_not_called()
+
     def test_recurrent_gated_delta_rule_requires_at_least_one_gate_before_launch(self):
         with mock.patch.object(ACLNN_CTYPES, "_call_aclnn") as call_aclnn:
             with self.assertRaisesRegex(

--- a/torch_custom/fla_npu/test/test_bwd_dhu.py
+++ b/torch_custom/fla_npu/test/test_bwd_dhu.py
@@ -76,7 +76,6 @@ def chunk_gated_delta_rule_bwd_dhu_cpu(
     use_exp2: bool = False,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
     """GVA 形状 CPU 标杆。golden_mode: fp64 / npu / fp32。"""
-    del dht
     dtype_ = q.dtype
     if golden_mode == "fp64":
         compute_dtype = torch.float64
@@ -122,6 +121,8 @@ def chunk_gated_delta_rule_bwd_dhu_cpu(
             g = g.float()
         if gK is not None:
             gK = gK.float()
+        if dht is not None:
+            dht = dht.to(dtype_).to(compute_dtype)
     else:
         q = q.to(compute_dtype)
         k = k.to(compute_dtype)
@@ -132,6 +133,8 @@ def chunk_gated_delta_rule_bwd_dhu_cpu(
             g = g.to(compute_dtype)
         if gK is not None:
             gK = gK.to(compute_dtype)
+        if dht is not None:
+            dht = dht.to(compute_dtype)
 
     def _mm(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         if elem_dtype is None:
@@ -175,13 +178,21 @@ def chunk_gated_delta_rule_bwd_dhu_cpu(
             "global_end_t": global_end_t,
         })
 
+    sequence_num = B if cu_seqlens is None else len(cu_seqlens) - 1
+    state_shape = (sequence_num, Hv, K, V)
+    if h0 is not None and tuple(h0.shape) != state_shape:
+        raise ValueError(f"h0 must have shape {state_shape}, got {tuple(h0.shape)}")
+    if dht is not None and tuple(dht.shape) != state_shape:
+        raise ValueError(f"dht must have shape {state_shape}, got {tuple(dht.shape)}")
+
     dh = torch.zeros(B, Hv, NT, K, V, device=device, dtype=compute_dtype)
-    dh0 = torch.zeros_like(dh) if h0 is not None else None
+    dh0 = torch.zeros(state_shape, device=device, dtype=compute_dtype) if h0 is not None else None
     dv2 = dv.clone() if cu_seqlens is not None else torch.zeros(B, Hv, T, V, device=device, dtype=dtype_)
 
     if cu_seqlens is None:
         hq = torch.arange(Hv, device=device, dtype=torch.long) // hv_per_hk
-        b_dh = torch.zeros(B, Hv, K, V, device=device, dtype=compute_dtype)
+        b_dh = (torch.zeros(B, Hv, K, V, device=device, dtype=compute_dtype)
+                if dht is None else dht.clone())
         for i_t in range(NT - 1, -1, -1):
             info = chunk_info[i_t]
             gs, ge = info["global_start_t"], info["global_end_t"]
@@ -229,17 +240,18 @@ def chunk_gated_delta_rule_bwd_dhu_cpu(
             b_dh = _store(b_dh_for_update + term1 - term2)
 
         if dh0 is not None:
-            dh0[:, :, 0, :, :] = b_dh
+            dh0.copy_(b_dh)
     else:
         hq = torch.arange(Hv, device=device, dtype=torch.long) // hv_per_hk
         num_tokens = len(cu_seqlens) - 1
-        b_dh_buffers = torch.zeros(B, Hv, num_tokens, K, V, device=device, dtype=compute_dtype)
+        b_dh_buffers = (torch.zeros(num_tokens, Hv, K, V, device=device, dtype=compute_dtype)
+                        if dht is None else dht.clone())
         for i_t in range(NT - 1, -1, -1):
             info = chunk_info[i_t]
             i_n = info["i_n"]
             gs, ge = info["global_start_t"], info["global_end_t"]
             block_size_t = info["block_size_t"]
-            b_dh = b_dh_buffers[:, :, i_n, :, :]
+            b_dh = b_dh_buffers[i_n].unsqueeze(0)
             dh[:, :, i_t, :, :] = b_dh
 
             last_idx = min((info["block_idx_in_token"] + 1) * BT, info["token_length"]) - 1
@@ -280,11 +292,9 @@ def chunk_gated_delta_rule_bwd_dhu_cpu(
 
             term1 = _store(_mm(b_q_gated, b_do)) * scale_f
             term2 = _store(_mm(b_w_t, b_dv))
-            b_dh_buffers[:, :, i_n, :, :] = _store(b_dh_for_update + term1 - term2)
+            b_dh_buffers[i_n] = _store(b_dh_for_update + term1 - term2).squeeze(0)
 
         if dh0 is not None:
-            for info in chunk_info:
-                if info["block_idx_in_token"] == 0:
-                    dh0[:, :, info["i_t"], :, :] = b_dh_buffers[:, :, info["i_n"], :, :]
+            dh0.copy_(b_dh_buffers)
 
     return dh, dh0, dv2

--- a/torch_custom/fla_npu/test/test_npu_bwd_dhu_gva.py
+++ b/torch_custom/fla_npu/test/test_npu_bwd_dhu_gva.py
@@ -54,6 +54,7 @@ class BwdDhuCase:
     varlen: bool = True
     cu_seqlens_len: Optional[int] = None
     dtype: str = "bf16"
+    with_state: bool = False
     supported: bool = True
     skip_reason: str = ""
 
@@ -66,6 +67,10 @@ class BwdDhuCase:
 
 # 覆盖泛化表中的 fixed/varlen、V=128/256、chunk=64/128 和 MHA/GVA 组合。
 CASES = [
+    BwdDhuCase("smoke_fixed_state_t128_v128", 1, 2, 4, 128, v_dim=128, chunk_size=64,
+               varlen=False, with_state=True),
+    BwdDhuCase("smoke_varlen_state_t128_v128", 1, 2, 4, 128, v_dim=128, chunk_size=64,
+               cu_seqlens_len=3, with_state=True),
     BwdDhuCase("smoke_varlen_t256_v256", 1, 16, 32, 256, chunk_size=64, cu_seqlens_len=5),
     BwdDhuCase("smoke_fixed_mha_t257_v128", 1, 4, 4, 257, v_dim=128, chunk_size=128,
                varlen=False),
@@ -122,8 +127,14 @@ def _build_inputs(case: BwdDhuCase, seed: int = 0):
         segment_max = max(128, math.ceil(case.tokens / sequence_count))
         cu_seqlens = generate_cu_seqlens(case.cu_seqlens_len, case.tokens, seg_min=1, seg_max=segment_max)
         chunk_indices = prepare_chunk_indices(cu_seqlens, case.chunk_size)
+    sequence_num = case.batch if cu_seqlens is None else len(cu_seqlens) - 1
+    h0 = dht = None
+    if case.with_state:
+        state_shape = (sequence_num, case.v_h, case.k_dim, case.v_dim)
+        h0 = torch.zeros(state_shape, dtype=ktype)
+        dht = (torch.rand(state_shape, dtype=torch.float32) * 2e-2 - 1e-2).to(ktype)
     scale = scale_for_compute_dtype(effective_scale(1.0 / math.sqrt(case.k_dim), case.k_dim), ktype)
-    return q, k, w, do, dv, g, cu_seqlens, chunk_indices, scale
+    return q, k, w, do, dv, g, h0, dht, cu_seqlens, chunk_indices, scale
 
 
 def run_case(case: BwdDhuCase, device: int, out_root: str, seed: int = 0) -> tuple[str, str]:
@@ -137,31 +148,38 @@ def run_case(case: BwdDhuCase, device: int, out_root: str, seed: int = 0) -> tup
         flush=True,
     )
 
-    q, k, w, do, dv, g, cu_seqlens, chunk_indices, scale = _build_inputs(case, seed=seed)
+    q, k, w, do, dv, g, h0, dht, cu_seqlens, chunk_indices, scale = _build_inputs(case, seed=seed)
 
-    dh_fp64, _, dv2_fp64 = chunk_gated_delta_rule_bwd_dhu_cpu(
-        q, k, w, do, dv, cu_seqlens, chunk_indices, g=g, scale=scale,
+    dh_fp64, dh0_fp64, dv2_fp64 = chunk_gated_delta_rule_bwd_dhu_cpu(
+        q, k, w, do, dv, cu_seqlens, chunk_indices, g=g, h0=h0, dht=dht, scale=scale,
         chunk_size=case.chunk_size, golden_mode="fp64",
     )
-    dh_npu_bench, _, dv2_npu_bench = chunk_gated_delta_rule_bwd_dhu_cpu(
-        q, k, w, do, dv, cu_seqlens, chunk_indices, g=g, scale=scale,
+    dh_npu_bench, dh0_npu_bench, dv2_npu_bench = chunk_gated_delta_rule_bwd_dhu_cpu(
+        q, k, w, do, dv, cu_seqlens, chunk_indices, g=g, h0=h0, dht=dht, scale=scale,
         chunk_size=case.chunk_size, golden_mode="npu",
     )
 
-    dh_npu, _, dv2_npu = ascendc_ops.npu_chunk_gated_delta_rule_bwd_dhu(
+    dh_npu, dh0_npu, dv2_npu = ascendc_ops.npu_chunk_gated_delta_rule_bwd_dhu(
         q.npu(), k.npu(), w.npu(), do.npu(), dv.npu(),
         scale=scale,
         chunk_size=case.chunk_size,
         g=g.npu(),
         gK=None,
-        h0=None,
-        dht=None,
+        h0=None if h0 is None else h0.npu(),
+        dht=None if dht is None else dht.npu(),
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
     )
 
     dh_ok, _, _ = _dual_check("dh", dh_npu, dh_fp64, dh_npu_bench)
     dv2_ok, _, _ = _dual_check("dv2", dv2_npu, dv2_fp64, dv2_npu_bench)
+    dh0_ok = True
+    if dh0_npu is not None:
+        if tuple(dh0_npu.shape) != tuple(h0.shape):
+            dh0_ok = False
+            print(f"[dh0] shape FAIL: got={tuple(dh0_npu.shape)} expected={tuple(h0.shape)}", flush=True)
+        else:
+            dh0_ok, _, _ = _dual_check("dh0", dh0_npu, dh0_fp64, dh0_npu_bench)
 
     case_dir = os.path.join(out_root, case.name)
     if os.environ.get("BWD_HU_SAVE_OUT", "1") == "1":
@@ -169,16 +187,19 @@ def run_case(case: BwdDhuCase, device: int, out_root: str, seed: int = 0) -> tup
         torch.save({
             "case": case.name,
             "dh_npu": dh_npu.cpu(),
+            "dh0_npu": None if dh0_npu is None else dh0_npu.cpu(),
             "dv2_npu": dv2_npu.cpu(),
             "dh_fp64": dh_fp64.cpu(),
+            "dh0_fp64": None if dh0_fp64 is None else dh0_fp64.cpu(),
             "dh_npu_bench": dh_npu_bench.cpu(),
             "dv2_fp64": dv2_fp64.cpu(),
             "dv2_npu_bench": dv2_npu_bench.cpu(),
         }, os.path.join(case_dir, "outputs.pt"))
 
-    if dh_ok and dv2_ok:
-        return "PASS", f"dh=PASS dv2=PASS | out={case_dir}"
-    return "FAIL", f"dh={'PASS' if dh_ok else 'FAIL'} dv2={'PASS' if dv2_ok else 'FAIL'}"
+    if dh_ok and dh0_ok and dv2_ok:
+        return "PASS", f"dh=PASS dh0=PASS dv2=PASS | out={case_dir}"
+    return "FAIL", (f"dh={'PASS' if dh_ok else 'FAIL'} dh0={'PASS' if dh0_ok else 'FAIL'} "
+                    f"dv2={'PASS' if dv2_ok else 'FAIL'}")
 
 
 def main():


### PR DESCRIPTION
## 关联 Issue / 背景

- Closes #312
- `ChunkGatedDeltaRuleBwdDhu` 的状态语义应为 `[N, HV, K, V]`，但部分 Runtime 仍要求并分配带 chunk 维度的 5D Tensor。
- 同时 Kernel 未使用 `dht` 初始化反向递推，`dh0` 仍按旧的 chunk-expanded 地址写回。

## 修改内容

- 统一 ctypes、legacy wrapper、aclnn 校验及示例中的 `h0/dht/dh0` 形状为 `[N, HV, K, V]`
- 定长模式使用 `N=B`，变长模式使用 `N=len(cu_seqlens)-1`
- 增加状态 shape、dtype 和 `cu_seqlens` 长度的前置校验
- 在 A2/A5 Kernel 中使用 `dht` 初始化反向递推状态
- 将 `dh0` 的清零范围和写回地址改为 4D 状态布局
- 更新 CPU golden、ABI 测试、NPU 定长/变长状态测试及相关文档

公共函数原型、参数数量和返回值数量均未变化。本次修正的是可选状态 Tensor 的 shape 语义。

## 支持范围

- `K=128`
- `V=128/256`
- `chunk_size=64/128`
- Issue 复现中的 `V=20` 仍属于不支持的 shape

## 验证

- A2 单算子 wheel 构建：通过
- ctypes ABI 单测：8 项通过
- A2 定长带状态：`dh/dh0/dv2` 全部通过
- A2 变长带状态：`dh/dh0/dv2` 全部通过
- A2 原有无状态 MHA 回归：通过
- A3/A5：未执行，待 CI 补充
- fast-kernel 和全量 legacy 扩展构建受主干既有编译问题阻断，未作为本次通过项

## 风险

状态 Tensor 的旧 5D 非标准调用将被明确拒绝。符合 FLA 语义的 4D 调用现在可正常执行。