### PR TITLE
docs: add FwdH A5 stage pseudocode blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ NPU CI 的 Example/ST 用例由 [`ci/example_st_cases.json`](ci/example_st_cases
 │       │   ├── common                 # 公共模块（GroupedMatMul 等）
 │       │   └── gdn                    # GDN 算子
 │       │       ├── chunk_gdn_fwd      # 前向传播算子
+│       │       │   ├── chunk_fwd_h
 │       │       │   ├── chunk_fwd_o
 │       │       │   ├── chunk_gated_delta_rule_fwd_h
 │       │       │   └── recompute_w_u_fwd

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/CMakeLists.txt
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/CMakeLists.txt
@@ -1,0 +1,19 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# Adapted for flash-linear-attention-npu by Tianjin University.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# -----------------------------------------------------------------------------------------------------------
+
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+if(NOT ENABLE_TEST AND NOT BENCHMARK)
+    list(REMOVE_ITEM CURRENT_DIRS tests)
+endif()
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/README.md
@@ -79,6 +79,10 @@ Stage0 和 Stage2 均使用 BF16 矩阵乘输入、FP32 累加。Stage0 在写�
 
 当前仅支持 `K=V=128`、`chunk_size=64`、`save_new_value=true`，支持 A2、A3 和 A5。
 
+所有 aclnn tensor descriptor 必须使用非私有 ND storage/view format；输入可以是 ND view，
+host 会在需要时连续化，`h/v_new/final_state` 输出必须是连续 ND。Python 入口只接受标准物理
+布局并创建连续 ND 输出，不支持将私有 NPU format 伪装成 ND。
+
 ## 变长序列
 
 变长模式使用 BNSD 容器且要求 `B=1`。`cu_seqlens` 必须从 0 开始、以 `T` 结束并严格递增。`chunk_indices` 若提供，必须严格等于由 `cu_seqlens` 和 `chunk_size=64` 推导出的 sequence-major `(seq_id, chunk_id)` 序列。
@@ -90,7 +94,9 @@ Stage0 和 Stage2 均使用 BF16 矩阵乘输入、FP32 累加。Stage0 在写�
 - A2/A3 的 P/D 从 L0C 经 Fixpipe 写 GM scratch，AIV 再从 GM 搬入 UB；A5 的 P/D 从 L0C 直接写配对 AIV UB。
 - Stage1 的 ND 右操作数统一经 UB MTE3 到 GM，再由 AIC MTE2 搬入 L1 NZ，不使用 UB 到 L1 的直搬通路。
 - tail chunk 的 W、kg/k_raw 和 right 在有效 ND 数据覆盖前先由 MTE2 清零对应 L1 NZ 槽，Cube 的 M/K 按 16 对齐，未覆盖位置不会参与有效累加。
-- 每个 ping/pong slot 使用独立 ready/free 事件。某 slot 的 MTE2、Cube/Fixpipe 或 VEC/MTE3 完成后立即发布该 slot，不等待另一个 slot。
+- A5 每个 ping/pong slot 使用独立 ready/free 事件。A2/A3 的 mode2 按一组
+  `AIC + 2*AIV` 做 pair 集合同步，尾 pair 缺少 head 的 AIV 也参与 dummy wait/set。
+  某 slot/pair 的 MTE2、Cube/Fixpipe 或 VEC/MTE3 完成后立即发布，不等待下一组。
 - 下一 head round 的 kg/H/W 预取必须等待上一 round 的 P/D、L1 right 和所有 AIV MTE3 完成。
 
 ## aclnn 接口

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/README.md
@@ -1,0 +1,118 @@
+# ChunkFwdH
+
+[设计文档](docs/design.md) | [API 文档](docs/api.md)
+
+## 功能
+
+`ChunkFwdH` 计算 GDN/KDA 的 chunk 间状态和 `v_new`。稳定 Python 入口为：
+
+```python
+from fla_npu.ops.ascendc import chunk_fwd_h
+
+h, v_new, final_state = chunk_fwd_h(
+    k,
+    w,
+    u,
+    g=None,
+    gk=None,
+    initial_state=None,
+    output_final_state=False,
+    chunk_size=64,
+    save_new_value=True,
+    cu_seqlens=None,
+    chunk_indices=None,
+    use_exp2=False,
+    state_v_first=False,
+)
+```
+
+`g` 与 `gk` 必须且只能提供一个：
+
+- g-only：`k` 是 raw key，shape 为 `[B, HK, T, 128]`，要求 `HV % HK == 0`。
+- gk-only：`k` 是 Prepare 阶段已经生成的 `kg`，shape 为 `[B, HV, T, 128]`；本算子不会再次把 `gk` 乘到 `k` 上。
+
+## 计算语义
+
+记 `E(x)=exp(x)`；`use_exp2=true` 时改为 `E(x)=exp2(x)`。对 value head `h` 的每个 chunk `c`：
+
+```text
+H_c = cast_BF16(R_c)
+Pacc_c = W_c @ H_c
+P_c = cast_PType(Pacc_c)  # StateT=BF16 时 PType=BF16，否则为 FP32
+V_new_fp32_c = fp32(U_c) - fp32(P_c)
+V_new_c = cast_BF16(V_new_fp32_c)
+
+g-only:
+    V_new_g_c[i,:] = cast_BF16(E(g_last - g_i) * V_new_fp32_c[i,:])
+    D_c = k_raw_c^T @ V_new_g_c
+    R_{c+1} = E(g_last) * R_c + D_c
+
+gk-only:
+    D_c = kg_c^T @ V_new_c
+    R_{c+1}[k,v] = E(gk_last[k]) * R_c[k,v] + D_c[k,v]
+```
+
+Stage0 和 Stage2 均使用 BF16 矩阵乘输入、FP32 累加。Stage0 在写出时按 `PType` 转换，
+`D_c` 保持 FP32 进入 Stage3。`StateT` 按以下优先级确定：
+
+1. 存在 `initial_state` 时，取 `initial_state.dtype`。
+2. 否则输出 `final_state` 时，取 `final_state.dtype`。
+3. 否则使用 FP32 rolling state。
+
+最终 chunk 若不输出 `final_state`，只执行 Stage0/Stage1，跳过 Stage2/Stage3，也不生成 Stage2 的 L1 右操作数。
+
+## 输入输出
+
+| 名称 | dtype | Shape/约束 |
+| --- | --- | --- |
+| `k` | BF16 | g-only `[B,HK,T,128]`；gk-only `[B,HV,T,128]` |
+| `w` | BF16 | `[B,HV,T,128]` |
+| `u` | BF16 | `[B,HV,T,128]` |
+| `g` | BF16/FP32 | g-only 必传，`[B,HV,T]` |
+| `gk` | BF16/FP32 | gk-only 必传，`[B,HV,T,128]` |
+| `initial_state` | BF16/FP32 | 可空；`[N,HV,K,V]` 或 `[N,HV,V,K]` |
+| `h` | BF16 | `[B,HV,C,K,V]` 或 `[B,HV,C,V,K]` |
+| `v_new` | BF16 | `[B,HV,T,128]` |
+| `final_state` | BF16/FP32 | 可空；shape/layout 与 `initial_state` 相同 |
+
+`state_v_first=false` 时 state 末两维为 `[K,V]`，为 `true` 时为 `[V,K]`。两种布局均由 kernel 原生处理，不依赖外部转置。
+
+当前仅支持 `K=V=128`、`chunk_size=64`、`save_new_value=true`，支持 A2、A3 和 A5。
+
+## 变长序列
+
+变长模式使用 BNSD 容器且要求 `B=1`。`cu_seqlens` 必须从 0 开始、以 `T` 结束并严格递增。`chunk_indices` 若提供，必须严格等于由 `cu_seqlens` 和 `chunk_size=64` 推导出的 sequence-major `(seq_id, chunk_id)` 序列。
+
+## 内核分工
+
+- AIC 每个 head round 固定四个 round-head 槽；AIV0 处理 round head 0/2，AIV1 处理 1/3，每个 AIV 使用两个 local slot。
+- round 进入 chunk 循环前确定 `head -> kh -> kg slot` 映射。Stage2 只加载本 round 实际需要的 `k_raw/kg`，最多四份；不跨 round 保留，跨 round 复用同一 key head 时重新读取。
+- A2/A3 的 P/D 从 L0C 经 Fixpipe 写 GM scratch，AIV 再从 GM 搬入 UB；A5 的 P/D 从 L0C 直接写配对 AIV UB。
+- Stage1 的 ND 右操作数统一经 UB MTE3 到 GM，再由 AIC MTE2 搬入 L1 NZ，不使用 UB 到 L1 的直搬通路。
+- tail chunk 的 W、kg/k_raw 和 right 在有效 ND 数据覆盖前先由 MTE2 清零对应 L1 NZ 槽，Cube 的 M/K 按 16 对齐，未覆盖位置不会参与有效累加。
+- 每个 ping/pong slot 使用独立 ready/free 事件。某 slot 的 MTE2、Cube/Fixpipe 或 VEC/MTE3 完成后立即发布该 slot，不等待另一个 slot。
+- 下一 head round 的 kg/H/W 预取必须等待上一 round 的 P/D、L1 right 和所有 AIV MTE3 完成。
+
+## aclnn 接口
+
+```cpp
+aclnnStatus aclnnChunkFwdHGetWorkspaceSize(
+    const aclTensor *k,
+    const aclTensor *w,
+    const aclTensor *u,
+    const aclTensor *gOptional,
+    const aclTensor *gkOptional,
+    const aclTensor *initialStateOptional,
+    bool outputFinalState,
+    int64_t chunkSize,
+    bool saveNewValue,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    bool useExp2,
+    bool stateVFirst,
+    const aclTensor *hOut,
+    const aclTensor *vNewOut,
+    const aclTensor *finalStateOut,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor);
+```

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/docs/api.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/docs/api.md
@@ -74,6 +74,10 @@ HV，本算子不会再次把 gk 应用到 prepared kg。
 `B/HK/HV/T` 必须为正；固定 `K=V=128`、`chunk_size=64`、`save_new_value=true`。
 变长模式要求输入容器 `B=1`。
 
+所有 aclnn tensor descriptor 的 storage/view format 必须是非私有 ND。输入 ND view 会由 host
+连续化；三个输出必须是连续 ND，因为 kernel 直接写入输出地址。Python 入口会为输出创建新的
+连续 tensor，并拒绝私有 NPU format。
+
 ## 输出
 
 | 输出 | dtype | Shape |
@@ -86,6 +90,13 @@ HV，本算子不会再次把 gk 应用到 prepared kg。
 存在 initial_state 时 StateT 等于其 dtype；Python 在没有 initial_state 但请求 final_state 时使用
 FP32。aclnn 调用者可通过 final_state 输出 dtype 选择 BF16 或 FP32。
 
-`output_final_state` 必须与 `finalStateOut` 的物理存在性一致。参数空指针返回
-`ACLNN_ERR_PARAM_NULLPTR`；dtype、shape、layout、属性、gate 组合和变长元数据不合法返回
-`ACLNN_ERR_PARAM_INVALID`。
+`output_final_state` 必须与 `finalStateOut` 的物理存在性一致。
+
+| 返回码 | 触发条件 |
+| --- | --- |
+| `ACLNN_SUCCESS` | workspace 查询或执行成功 |
+| `ACLNN_ERR_PARAM_NULLPTR` | 必传输入/输出、`workspaceSize` 或 `executor` 为空 |
+| `ACLNN_ERR_PARAM_INVALID` | dtype、shape、format、连续性、属性、gate 组合或变长元数据不合法 |
+| `ACLNN_ERR_INNER_CREATE_EXECUTOR` | executor 创建失败 |
+| `ACLNN_ERR_INNER_NULLPTR` | 元数据转换、内部占位输出分配、Contiguous 或 ViewCopy 未返回有效 tensor |
+| `ACLNN_ERR_INNER` | kernel executor 执行失败 |

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/docs/api.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/docs/api.md
@@ -1,0 +1,91 @@
+# ChunkFwdH API
+
+## Python
+
+```python
+from fla_npu.ops.ascendc import chunk_fwd_h
+
+h, v_new, final_state = chunk_fwd_h(
+    k,
+    w,
+    u,
+    *,
+    g=None,
+    gk=None,
+    initial_state=None,
+    output_final_state=False,
+    chunk_size=64,
+    save_new_value=True,
+    cu_seqlens=None,
+    chunk_indices=None,
+    use_exp2=False,
+    state_v_first=False,
+)
+```
+
+这是 ctypes 直调 `aclnnChunkFwdH` 的稳定入口，不注册 legacy `torch.ops.npu` 接口。
+
+## aclnn
+
+```cpp
+aclnnStatus aclnnChunkFwdHGetWorkspaceSize(
+    const aclTensor *k,
+    const aclTensor *w,
+    const aclTensor *u,
+    const aclTensor *gOptional,
+    const aclTensor *gkOptional,
+    const aclTensor *initialStateOptional,
+    bool outputFinalState,
+    int64_t chunkSize,
+    bool saveNewValue,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    bool useExp2,
+    bool stateVFirst,
+    const aclTensor *hOut,
+    const aclTensor *vNewOut,
+    const aclTensor *finalStateOut,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor);
+
+aclnnStatus aclnnChunkFwdH(
+    void *workspace,
+    uint64_t workspaceSize,
+    aclOpExecutor *executor,
+    aclrtStream stream);
+```
+
+## 参数
+
+| 参数 | dtype | 约束 |
+| --- | --- | --- |
+| `k` | BF16 | g-only `[B,HK,T,128]` raw K；gk-only `[B,HV,T,128]` prepared kg |
+| `w` | BF16 | `[B,HV,T,128]` |
+| `u` | BF16 | `[B,HV,T,128]` |
+| `g` | BF16/FP32 | g-only `[B,HV,T]` |
+| `gk` | BF16/FP32 | gk-only `[B,HV,T,128]` |
+| `initial_state` | BF16/FP32 | 可空；`[N,HV,128,128]`，末两维物理顺序由 `state_v_first` 决定 |
+| `cu_seqlens` | host int array | 可空；变长时从 0 开始、以 T 结束且严格递增 |
+| `chunk_indices` | host int array | 可空；必须为 canonical sequence-major pair 序列 |
+
+`g` 与 `gk` 必须且只能提供一个。g-only 要求 `HV%HK==0`；gk-only 要求 `k` 的 head 数等于
+HV，本算子不会再次把 gk 应用到 prepared kg。
+
+`B/HK/HV/T` 必须为正；固定 `K=V=128`、`chunk_size=64`、`save_new_value=true`。
+变长模式要求输入容器 `B=1`。
+
+## 输出
+
+| 输出 | dtype | Shape |
+| --- | --- | --- |
+| `h` | BF16 | dense `[B,HV,C,128,128]`；varlen `[1,HV,total_chunks,128,128]` |
+| `v_new` | BF16 | `[B,HV,T,128]` |
+| `final_state` | StateT | `[N,HV,128,128]`，仅 `output_final_state=true` 时存在 |
+
+`state_v_first=false` 时 state/H 的末两维语义为 `[K,V]`；为 true 时物理布局为 `[V,K]`。
+存在 initial_state 时 StateT 等于其 dtype；Python 在没有 initial_state 但请求 final_state 时使用
+FP32。aclnn 调用者可通过 final_state 输出 dtype 选择 BF16 或 FP32。
+
+`output_final_state` 必须与 `finalStateOut` 的物理存在性一致。参数空指针返回
+`ACLNN_ERR_PARAM_NULLPTR`；dtype、shape、layout、属性、gate 组合和变长元数据不合法返回
+`ACLNN_ERR_PARAM_INVALID`。

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/docs/design.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/docs/design.md
@@ -1,0 +1,161 @@
+# ChunkFwdH 设计
+
+## 1. 目标与边界
+
+`ChunkFwdH` 是独立的 Ascend C 算子，符号为 `ChunkFwdH`、`aclnnChunkFwdH` 和
+`fla_npu.ops.ascendc.chunk_fwd_h`。它不复用、不修改 `ChunkGatedDeltaRuleFwdH`，也不提供
+legacy `torch.ops.npu` 兼容入口。
+
+当前支持 A2、A3、A5，固定 `K=V=128`、`chunk_size=64`，`k/w/u` 为 BF16。gate 和
+state 分别支持 BF16/FP32，`state_v_first=true/false` 均由 kernel 原生处理。
+
+## 2. 计算语义
+
+记 `E(x)=exp(x)`，`use_exp2=true` 时为 `exp2(x)`。每个 value head、每个 chunk 执行：
+
+```text
+H_c = cast_BF16(R_c)
+Pacc_c = W_c @ H_c
+P_c = cast_PType(Pacc_c)  # StateT=BF16 时 PType=BF16，否则为 FP32
+V_new_fp32_c = fp32(U_c) - fp32(P_c)
+V_new_c = cast_BF16(V_new_fp32_c)
+
+g-only:
+  V_new_g_c[i,:] = cast_BF16(E(g_last-g_i) * V_new_fp32_c[i,:])
+  D_c = k_raw_c^T @ V_new_g_c
+  R_next = E(g_last) * R_c + D_c
+
+gk-only:
+  D_c = kg_c^T @ V_new_c
+  R_next[k,v] = E(gk_last[k]) * R_c[k,v] + D_c[k,v]
+```
+
+最终 chunk 不请求 `final_state` 时，只生成当前 `H` 和 `V_new`，跳过 Stage2/Stage3。
+
+## 3. head round 规划
+
+规划在 chunk 循环前完成。每个 AIC round 最多四个 head：AIV0 处理 round head 0/2，
+AIV1 处理 1/3；两个 AIV 各有 local slot 0/1。
+
+g-only 先按 `group_size=HV/HK` 划分共享 raw K 的 value-head 组：
+
+- `HK:HV=1:3`：每轮三个 value head，一个 kg slot，只读一次 raw K。
+- `HK:HV=1:2`：每轮四个 value head，两个 kg slot，各 raw K 只读一次。
+- `HK:HV=1:6`：拆为 4+2 两轮；第二轮重新读取同一个 raw K，不跨 round 保留。
+
+gk-only 每个 value head 对应自己的 prepared kg；本轮按 active head 数读取 1..4 份。
+`FwdHHeadRoundPlan` 显式记录 `head -> hv -> kh -> kgSlot -> aiv -> localSlot`，Stage2 只遍历
+`requiredKhCount`，不预留或加载 16 份 kg。
+
+## 4. 分阶段实现
+
+### S-1：FP32 初态转换
+
+仅 `initial_state` 为 FP32 时执行 `H0=cast_BF16(initial_state)`。A2/A3 逐 tile 处理；A5
+每个 head 使用一次完整 RegBase VF，并为两个 local head 分配独立 FP32 input/BF16 output
+bank，以“预取当前 head、计算前一 head”的循环实现 ping-pong。全部 active H MTE3 drain
+后统一发布本 phase 的 `H_READY`。
+
+### Stage0：入口状态与第一次矩阵乘
+
+AIC 将当前 `W[M,K]` 与 `H[K,V]` 从 GM 搬到四个 round-head L1 槽，随后执行
+`P=W@H`。Stage0 不读取 kg/k_raw。tail chunk 先用 MTE2 `InitConstValue` 清零当前 W 槽，
+再覆盖有效 ND 行；Cube M 取 `AlignUp(valid_tokens,16)`，最终只写真实 token 行。
+
+- A2/A3：L0C 经 Fixpipe 写 P GM scratch，AIV 再以 MTE2 读取。
+- A5：L0C 经 Fixpipe 直接写配对 AIV 的 local UB slot。
+
+### Stage1：向量修正
+
+AIV 读取 `U` 和 P，计算 `V_new`；g-only 同时生成带相对 gate 的 BF16 right，gk-only
+直接以 BF16 `V_new` 作为 right。`V_new` 写 GM。right 必须经 MTE3 写 GM workspace，禁止
+UB 直搬 L1。
+
+A5 从 MTE2 后开始的全部向量计算由每个 head 一次 RegBase VF 完成。VF 只使用
+`if constexpr` 模板分支和明确类型的 `for` 循环，并以两组 FP32 寄存器覆盖 128 列。
+
+### Stage2：第二次矩阵乘
+
+AIC 此时才读取本 round 实际需要的 kg/k_raw，并等待每个 head 独立的 `RIGHT_READY`，把
+GM ND right 搬为 L1 Cube 输入。计算 `D=k^T@right`；`state_v_first=true` 时使用等价转置式
+`D_physical=right^T@k`，直接生成物理 `[V,K]`。tail chunk 对当前实际 kg/k_raw 槽和各 head
+right 槽分别清零后再覆盖有效数据，Cube K 取 `AlignUp(valid_tokens,16)`。
+
+- A2/A3：L0C 经 Fixpipe 写 D GM scratch，AIV MTE2 读取。
+- A5：L0C 经 Fixpipe 直接写配对 AIV UB。
+
+### Stage3：递推状态更新
+
+AIV 用 FP32 算术执行 `R_next=decay*R+D`，按 StateT 保存 BF16 或 FP32 rolling state，并按需
+写下一 chunk 的 H 或 final_state。A5 使用独立 RegBase VF，不调用 A2/A3 向量实现。
+
+## 5. 存储布局
+
+AIC L1 固定分区：W `[0,64) KiB`，保留空洞 `[64,128) KiB`，H/right `[128,256) KiB`，
+kg `[256,320) KiB`。kg 区最多四个 16 KiB slot；每个 round 只占用 `requiredKhCount` 个。
+
+A5 每个 AIV 有两个 64 KiB local slot，Stage0 的 P 与 Stage2 的 D 按生命周期复用；BF16
+state、FP32 state、BF16 work 和 gate 区保持固定地址。A2/A3 使用两个 32 KiB tile local slot
+和两个 32 KiB BF16 state slot，P/D 使用每核每 round-head 独立的 GM scratch。
+
+## 6. 同步协议
+
+每个 local slot 分别维护 `P_READY/P_FREE`、`D_READY/D_FREE`、
+`RIGHT_READY/RIGHT_FREE`、`H_READY`。ready 由真实生产 pipe 发布，free 由最后消费者发布；
+同一 slot 的事件复用前必须完成上一代 wait。
+
+Stage 内按核内 head id 统一写一套流程，`headId&1` 选择 ping/pong L0 slot。当前 slot 的
+MTE2 完成即可启动该 slot 的 VEC/Cube，不等待另一 slot；Cube->Fixpipe 和 VEC->MTE3 同理。
+
+A2/A3 在无初态、多 chunk 场景为第二个 chunk 的 P scratch 预置一次 free credit，因为首
+chunk 没有 Stage0/P；后续 credit 由前一 chunk Stage1 产生。round 结束时 P 与 D 两条独立
+scratch 链分别回收，不能用互斥分支漏掉其中一条。
+
+跨 head round 使用双向收口：两个 AIV 等本轮 MTE3 全部完成后发布 `ROUND_DONE`；AIC 收到
+两份完成信号并回收 P/D/right 后才回 ACK。下一 round 的 kg/H/W MTE2 必须等待 ACK，因而
+不会与上一 round 的未完成写回交叠。
+调度上将同一 sequence 的全部 head-round 绑定到同一核并顺序执行；不同 sequence 才允许在不同核并行，
+因此上述 ACK 是实际的 round 边界，而不是依赖 block 启动顺序推断。
+
+## 7. 变长序列
+
+变长模式要求 BNSD 容器 `B=1`。`cu_seqlens` 从 0 开始、以 T 结束且严格递增；
+`chunk_indices` 若存在，必须是 sequence-major canonical `(seq_id, chunk_id)`。不同 sequence
+分配为独立 work unit，state/final_state 的首维是 sequence 数，H 的 chunk 维使用全局 chunk
+前缀，GM 输出区间互不重叠。
+
+## 8. TilingData
+
+`ChunkFwdHTilingData` 只保存 host 已校验并由 kernel 直接消费的数据，不在 tiling 中保存每个
+head round 的展开数组。kernel 在进入 chunk 循环前，按 `kNumHead/vNumHead` 生成
+`FwdHHeadRoundPlan`，因此每个 round 的 active head 数、实际 Hk 数和 head-to-kg-slot 映射
+不会随 chunk 改变。
+
+| 字段 | 语义 |
+| --- | --- |
+| `batch` | dense 时为逻辑 batch 数，varlen 时为 sequence 数 |
+| `seqlen` | k/w/u 容器的 token 维长度 |
+| `kNumHead` / `vNumHead` | Hk/Hv 数；g-only 要求 `vNumHead % kNumHead == 0` |
+| `kHeadDim` / `vHeadDim` | 当前均固定为 128 |
+| `chunkSize` | 当前固定为 64 |
+| `useInitialState` | 是否读取 initial_state |
+| `storeFinalState` | 是否生成并写 final_state |
+| `dataType` | k/w/u dtype 枚举，当前为 BF16 |
+| `gDataType` | g 或 gk 的 dtype 枚举 |
+| `stateDataType` | rolling/final state dtype 枚举；无初态且无 final_state 时为 FP32 |
+| `isVariedLen` | 是否启用 varlen 调度 |
+| `shapeBatch` | dense 的物理 batch；varlen 固定为 1 |
+| `tokenBatch` | varlen 的 sequence 数；dense 固定为 1 |
+| `useG` / `useGk` | gate 模式，二者严格一真一假 |
+| `useExp2` | gate 指数函数是否使用 exp2 |
+| `stateVFirst` | state 物理布局为 `[V,K]` 还是 `[K,V]` |
+| `vWorkspaceOffset` | A2/A3 P 的 FP32 GM scratch，形状为 `[AIC,4,64,128]` |
+| `vUpdateWorkspaceOffset` | Stage1 BF16 right 的 GM workspace，形状为 `[AIC,4,64,128]` |
+| `kDecayWorkspaceOffset` | FP32 rolling state 的 GM workspace，形状为 `[AIC,4,128,128]` |
+| `hWorkspaceOffset` | A2/A3 D 的 FP32 GM scratch，形状为 `[AIC,4,128,128]` |
+| `numSeqWorkspaceOffset` | varlen sequence 前缀辅助区，长度为 `tokenBatch+1` |
+| `numChunksWorkspaceOffset` | varlen chunk 前缀辅助区，长度为 `tokenBatch+1` |
+
+workspace 的各段按 512 Byte 对齐，并在 CANN lib-api workspace 之后额外保留运行时安全区。
+A5 的 P/D 走 L0C->AIV UB，不消费对应的 P/D GM scratch；为保持跨架构统一 tiling，offset
+仍由 host 生成，但 A5 kernel 不访问这些地址。

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/docs/design.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/docs/design.md
@@ -7,7 +7,8 @@
 legacy `torch.ops.npu` 兼容入口。
 
 当前支持 A2、A3、A5，固定 `K=V=128`、`chunk_size=64`，`k/w/u` 为 BF16。gate 和
-state 分别支持 BF16/FP32，`state_v_first=true/false` 均由 kernel 原生处理。
+state 分别支持 BF16/FP32，`state_v_first=true/false` 均由 kernel 原生处理。公开 tensor
+descriptor 使用非私有 ND；输入可由 host 连续化，直接写入的输出必须连续。
 
 ## 2. 计算语义
 
@@ -60,10 +61,11 @@ bank，以“预取当前 head、计算前一 head”的循环实现 ping-pong�
 
 AIC 将当前 `W[M,K]` 与 `H[K,V]` 从 GM 搬到四个 round-head L1 槽，随后执行
 `P=W@H`。Stage0 不读取 kg/k_raw。tail chunk 先用 MTE2 `InitConstValue` 清零当前 W 槽，
-再覆盖有效 ND 行；Cube M 取 `AlignUp(valid_tokens,16)`，最终只写真实 token 行。
+再覆盖有效 ND 行；Cube M 取 `AlignUp(valid_tokens,16)`。
 
-- A2/A3：L0C 经 Fixpipe 写 P GM scratch，AIV 再以 MTE2 读取。
-- A5：L0C 经 Fixpipe 直接写配对 AIV 的 local UB slot。
+- A2/A3：L0C 经 Fixpipe 将对齐后的 M 行写入 P GM scratch，补齐行恒为零；AIV 再以
+  MTE2 只读取 `valid_tokens` 个有效行。
+- A5：L0C 经 Fixpipe 直接将有效行写入配对 AIV 的 local UB slot。
 
 ### Stage1：向量修正
 
@@ -100,9 +102,11 @@ state、FP32 state、BF16 work 和 gate 区保持固定地址。A2/A3 使用两�
 
 ## 6. 同步协议
 
-每个 local slot 分别维护 `P_READY/P_FREE`、`D_READY/D_FREE`、
-`RIGHT_READY/RIGHT_FREE`、`H_READY`。ready 由真实生产 pipe 发布，free 由最后消费者发布；
-同一 slot 的事件复用前必须完成上一代 wait。
+A5 每个 local slot 分别维护 `P_READY/P_FREE`、`D_READY/D_FREE`、
+`RIGHT_READY/RIGHT_FREE`、`H_READY`。A2/A3 mode2 是 `AIC + 2*AIV` 集合同步：每个
+pair 由 AIC set/wait 一次，两个 AIV 对同一 ID 各 wait/set 一次；尾 pair 缺 head 的 AIV
+执行 dummy 同步但不访问数据。ready 由真实生产 pipe 发布，free 由最后消费者发布；同一
+slot/pair 的事件复用前必须完成上一代 wait。
 
 Stage 内按核内 head id 统一写一套流程，`headId&1` 选择 ping/pong L0 slot。当前 slot 的
 MTE2 完成即可启动该 slot 的 VEC/Cube，不等待另一 slot；Cube->Fixpipe 和 VEC->MTE3 同理。
@@ -112,8 +116,9 @@ chunk 没有 Stage0/P；后续 credit 由前一 chunk Stage1 产生。round 结�
 scratch 链分别回收，不能用互斥分支漏掉其中一条。
 
 跨 head round 使用双向收口：两个 AIV 等本轮 MTE3 全部完成后发布 `ROUND_DONE`；AIC 收到
-两份完成信号并回收 P/D/right 后才回 ACK。下一 round 的 kg/H/W MTE2 必须等待 ACK，因而
-不会与上一 round 的未完成写回交叠。
+完成信号并回收 P/D/right 后才回 ACK。A5 的 DONE 由 `PIPE_MTE3` 发布，DONE wait 和 ACK
+使用 `PIPE_S` 作为 scalar/control gate；下一 round 的 kg/H/W MTE2 因而不能越过 ACK，
+不会与上一 round 的未完成写回交叠。A2/A3 用 mode2 collective 完成同等的 pair 收口。
 调度上将同一 sequence 的全部 head-round 绑定到同一核并顺序执行；不同 sequence 才允许在不同核并行，
 因此上述 ACK 是实际的 round 边界，而不是依赖 block 启动顺序推断。
 
@@ -149,12 +154,10 @@ head round 的展开数组。kernel 在进入 chunk 循环前，按 `kNumHead/vN
 | `useG` / `useGk` | gate 模式，二者严格一真一假 |
 | `useExp2` | gate 指数函数是否使用 exp2 |
 | `stateVFirst` | state 物理布局为 `[V,K]` 还是 `[K,V]` |
-| `vWorkspaceOffset` | A2/A3 P 的 FP32 GM scratch，形状为 `[AIC,4,64,128]` |
+| `vWorkspaceOffset` | A2/A3 P 的 GM scratch，按 FP32 slot stride 预留 `[AIC,4,64,128]`；实际元素为 PType |
 | `vUpdateWorkspaceOffset` | Stage1 BF16 right 的 GM workspace，形状为 `[AIC,4,64,128]` |
 | `kDecayWorkspaceOffset` | FP32 rolling state 的 GM workspace，形状为 `[AIC,4,128,128]` |
 | `hWorkspaceOffset` | A2/A3 D 的 FP32 GM scratch，形状为 `[AIC,4,128,128]` |
-| `numSeqWorkspaceOffset` | varlen sequence 前缀辅助区，长度为 `tokenBatch+1` |
-| `numChunksWorkspaceOffset` | varlen chunk 前缀辅助区，长度为 `tokenBatch+1` |
 
 workspace 的各段按 512 Byte 对齐，并在 CANN lib-api workspace 之后额外保留运行时安全区。
 A5 的 P/D 走 L0C->AIV UB，不消费对应的 P/D GM scratch；为保持跨架构统一 tiling，offset

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/CMakeLists.txt
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/CMakeLists.txt
@@ -1,0 +1,22 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# -----------------------------------------------------------------------------------------------------------
+add_op_to_compiled_list()
+
+if (BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnnExc PRIVATE
+        chunk_fwd_h_def.cpp
+    )
+endif()
+
+add_modules_sources(OPTYPE chunk_fwd_h ACLNNTYPE aclnn_exclude)
+add_ops_compile_options(
+    OP_NAME ChunkFwdH
+    OPTIONS --cce-auto-sync=off
+            -Wno-deprecated-declarations
+)

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/chunk_fwd_h_def.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/chunk_fwd_h_def.cpp
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_fwd_h_def.cpp
+ * \brief
+ */
+
+#include "register/op_def_registry.h"
+
+namespace ops {
+
+class ChunkFwdH : public OpDef {
+public:
+    explicit ChunkFwdH(const char *name) : OpDef(name)
+    {
+        const std::initializer_list<ge::DataType> dataTypes = {ge::DT_BF16, ge::DT_BF16,
+                                                               ge::DT_BF16, ge::DT_BF16};
+        const std::initializer_list<ge::DataType> gateTypes = {ge::DT_BF16, ge::DT_BF16,
+                                                               ge::DT_FLOAT, ge::DT_FLOAT};
+        const std::initializer_list<ge::DataType> stateTypes = {ge::DT_BF16, ge::DT_FLOAT,
+                                                                ge::DT_BF16, ge::DT_FLOAT};
+        const std::initializer_list<ge::DataType> indexTypes = {ge::DT_INT64, ge::DT_INT64,
+                                                                ge::DT_INT64, ge::DT_INT64};
+        const std::initializer_list<ge::Format> formats = {ge::FORMAT_ND, ge::FORMAT_ND,
+                                                           ge::FORMAT_ND, ge::FORMAT_ND};
+
+        this->Input("k")
+            .ParamType(REQUIRED)
+            .DataType(dataTypes).Format(formats).UnknownShapeFormat(formats)
+            .AutoContiguous();
+
+        this->Input("w")
+            .ParamType(REQUIRED)
+            .DataType(dataTypes).Format(formats).UnknownShapeFormat(formats)
+            .AutoContiguous();
+
+        this->Input("u")
+            .ParamType(REQUIRED)
+            .DataType(dataTypes).Format(formats).UnknownShapeFormat(formats)
+            .AutoContiguous();
+
+        this->Input("g")
+            .ParamType(OPTIONAL)
+            .DataType(gateTypes).Format(formats).UnknownShapeFormat(formats)
+            .AutoContiguous();
+
+        this->Input("gk")
+            .ParamType(OPTIONAL)
+            .DataType(gateTypes).Format(formats).UnknownShapeFormat(formats)
+            .AutoContiguous();
+
+        this->Input("initial_state")
+            .ParamType(OPTIONAL)
+            .DataType(stateTypes).Format(formats).UnknownShapeFormat(formats)
+            .AutoContiguous();
+
+        this->Input("cu_seqlens")
+            .ParamType(OPTIONAL)
+            .ValueDepend(OPTIONAL)
+            .DataType(indexTypes).Format(formats).UnknownShapeFormat(formats)
+            .AutoContiguous();
+
+        this->Input("chunk_indices")
+            .ParamType(OPTIONAL)
+            .ValueDepend(OPTIONAL)
+            .DataType(indexTypes).Format(formats).UnknownShapeFormat(formats)
+            .AutoContiguous();
+
+        this->Output("h")
+            .ParamType(REQUIRED)
+            .DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+
+        this->Output("v_new")
+            .ParamType(REQUIRED)
+            .DataType(dataTypes).Format(formats).UnknownShapeFormat(formats);
+
+        this->Output("final_state")
+            .ParamType(OPTIONAL)
+            .DataType(stateTypes).Format(formats).UnknownShapeFormat(formats);
+
+        this->Attr("output_final_state").AttrType(REQUIRED).Bool(false);
+        this->Attr("chunk_size").AttrType(REQUIRED).Int(64);
+        this->Attr("save_new_value").AttrType(REQUIRED).Bool(true);
+        this->Attr("use_exp2").AttrType(REQUIRED).Bool(false);
+        this->Attr("state_v_first").AttrType(REQUIRED).Bool(false);
+        this->Attr("logical_batch").AttrType(REQUIRED).Int(1);
+        this->Attr("logical_seqlen").AttrType(REQUIRED).Int(1);
+        this->Attr("logical_k_heads").AttrType(REQUIRED).Int(1);
+        this->Attr("logical_v_heads").AttrType(REQUIRED).Int(1);
+        this->Attr("logical_k_dim").AttrType(REQUIRED).Int(1);
+        this->Attr("logical_v_dim").AttrType(REQUIRED).Int(1);
+
+        OpAICoreConfig aicore_config;
+        aicore_config.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .PrecisionReduceFlag(true)
+            .ExtendCfgInfo("prebuildPattern.value", "Opaque")
+            .ExtendCfgInfo("coreType.value", "AiCore")
+            .ExtendCfgInfo("jitCompile.flag", "static_false,dynamic_false");
+
+        this->AICore().AddConfig("ascend910b", aicore_config);
+        this->AICore().AddConfig("ascend910_93", aicore_config);
+        this->AICore().AddConfig("ascend950", aicore_config);
+
+    }
+};
+
+OP_ADD(ChunkFwdH);
+
+} // namespace ops

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/chunk_fwd_h_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/chunk_fwd_h_tiling.cpp
@@ -203,9 +203,6 @@ ge::graphStatus Tiling4ChunkFwdH(gert::TilingContext *context)
     tiling.set_vUpdateWorkspaceOffset(plainTiling.vUpdateWorkspaceOffset);
     tiling.set_kDecayWorkspaceOffset(plainTiling.kDecayWorkspaceOffset);
     tiling.set_hWorkspaceOffset(plainTiling.hWorkspaceOffset);
-    tiling.set_numSeqWorkspaceOffset(plainTiling.numSeqWorkspaceOffset);
-    tiling.set_numChunksWorkspaceOffset(plainTiling.numChunksWorkspaceOffset);
-
     tiling.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
     context->GetRawTilingData()->SetDataSize(tiling.GetDataSize());
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/chunk_fwd_h_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/chunk_fwd_h_tiling.cpp
@@ -1,0 +1,227 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_fwd_h_tiling.cpp
+ * \brief
+ */
+
+#include "chunk_fwd_h_tiling.h"
+#include <register/op_impl_registry.h>
+#include "tiling_base/data_copy_transpose_tiling.h"
+#include "tiling_base/tiling_templates_registry.h"
+#include "chunk_fwd_h_tiling_processor.h"
+
+namespace optiling {
+
+// Maps a ge::DataType to the {fp16:0, bf16:1, fp32:2} convention shared with the kernel.
+static int64_t ChunkFwdHDtypeToEnum(ge::DataType dtype)
+{
+    if (dtype == ge::DT_BF16) {
+        return CHUNK_FWD_H_DTYPE_BF16;
+    }
+    if (dtype == ge::DT_FLOAT16) {
+        return CHUNK_FWD_H_DTYPE_FP16;
+    }
+    return CHUNK_FWD_H_DTYPE_FP32;
+}
+static constexpr size_t INPUT_K_IDX = 0;
+static constexpr size_t INPUT_W_IDX = 1;
+static constexpr size_t INPUT_U_IDX = 2;
+static constexpr size_t INPUT_G_IDX = 3;
+static constexpr size_t INPUT_GK_IDX = 4;
+static constexpr size_t INPUT_INITIAL_STATE_IDX = 5;
+static constexpr size_t INPUT_SEQLENS_IDX = 6;
+static constexpr size_t INPUT_CHUNK_INDICES_IDX = 7;
+static constexpr size_t OUTPUT_FINAL_STATE_IDX = 2;
+
+static constexpr size_t ATTR_STORE_FINAL_STATE_IDX = 0;
+static constexpr size_t ATTR_CHUNK_SIZE_IDX = 1;
+static constexpr size_t ATTR_SAVE_NEW_VALUE_IDX = 2;
+static constexpr size_t ATTR_USE_EXP2_IDX = 3;
+static constexpr size_t ATTR_STATE_V_FIRST_IDX = 4;
+static constexpr size_t ATTR_LOGICAL_BATCH_IDX = 5;
+static constexpr size_t ATTR_LOGICAL_SEQLEN_IDX = 6;
+static constexpr size_t ATTR_LOGICAL_K_HEADS_IDX = 7;
+static constexpr size_t ATTR_LOGICAL_V_HEADS_IDX = 8;
+static constexpr size_t ATTR_LOGICAL_K_DIM_IDX = 9;
+static constexpr size_t ATTR_LOGICAL_V_DIM_IDX = 10;
+
+static constexpr uint32_t TILING_KEY_V128 = 1;
+static constexpr int64_t V_DIM_128 = 128;
+static constexpr int64_t K_DIM_128 = 128;
+static constexpr int64_t CHUNK_SIZE_64 = 64;
+
+static void ChunkFwdHTilingDataPrint(gert::TilingContext *context, ChunkFwdHTilingData &tiling)
+{
+    auto nodeName = context->GetNodeName();
+    OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Start to print ChunkFwdH tiling data <<<<<<<<<<<<<<<<");
+    OP_LOGD(nodeName, "=== batch: %ld", tiling.get_batch());
+    OP_LOGD(nodeName, "=== seqlen: %ld", tiling.get_seqlen());
+    OP_LOGD(nodeName, "=== kNumHead: %ld", tiling.get_kNumHead());
+    OP_LOGD(nodeName, "=== vNumHead: %ld", tiling.get_vNumHead());
+    OP_LOGD(nodeName, "=== kHeadDim: %ld", tiling.get_kHeadDim());
+    OP_LOGD(nodeName, "=== vHeadDim: %ld", tiling.get_vHeadDim());
+    OP_LOGD(nodeName, "=== chunkSize: %ld", tiling.get_chunkSize());
+    OP_LOGD(nodeName, "=== useInitialState: %ld", tiling.get_useInitialState());
+    OP_LOGD(nodeName, "=== storeFinalState: %ld", tiling.get_storeFinalState());
+    OP_LOGD(nodeName, "=== useG: %d", tiling.get_useG());
+    OP_LOGD(nodeName, "=== useGk: %d", tiling.get_useGk());
+    OP_LOGD(nodeName, "=== useExp2: %d", tiling.get_useExp2());
+    OP_LOGD(nodeName, "=== stateVFirst: %d", tiling.get_stateVFirst());
+    OP_LOGD(nodeName, "=== dataType: %ld", tiling.get_dataType());
+    OP_LOGD(nodeName, "=== isVariedLen: %ld", tiling.get_isVariedLen());
+    OP_LOGD(nodeName, "=== shapeBatch: %ld", tiling.get_shapeBatch());
+    OP_LOGD(nodeName, "=== tokenBatch: %ld", tiling.get_tokenBatch());
+    OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Print ChunkFwdH tiling data end <<<<<<<<<<<<<<<<");
+}
+
+ge::graphStatus Tiling4ChunkFwdH(gert::TilingContext *context)
+{
+    OP_LOGD(context->GetNodeName(), "Tiling4ChunkFwdH start.");
+    ChunkFwdHTilingData tiling;
+
+    auto cuSeqlensTensor = context->GetOptionalInputTensor(INPUT_SEQLENS_IDX);
+    auto initialStateTensor = context->GetOptionalInputTensor(INPUT_INITIAL_STATE_IDX);
+    bool useInitialState = initialStateTensor != nullptr;
+    auto gTensor = context->GetOptionalInputTensor(INPUT_G_IDX);
+    auto gkTensor = context->GetOptionalInputTensor(INPUT_GK_IDX);
+    bool useG = gTensor != nullptr;
+    bool useGk = gkTensor != nullptr;
+    OP_CHECK_IF(useG == useGk,
+                OP_LOGE(context->GetNodeName(), "Exactly one of g and gk must be provided."),
+                return ge::GRAPH_FAILED);
+    auto gateTensor = useGk ? gkTensor : gTensor;
+
+    auto attrPtr = context->GetAttrs();
+    bool storeFinalState = *(attrPtr->GetAttrPointer<bool>(ATTR_STORE_FINAL_STATE_IDX));
+    int64_t chunkSize = *(attrPtr->GetAttrPointer<int64_t>(ATTR_CHUNK_SIZE_IDX));
+    bool saveNewValue = *(attrPtr->GetAttrPointer<bool>(ATTR_SAVE_NEW_VALUE_IDX));
+    bool useExp2 = *(attrPtr->GetAttrPointer<bool>(ATTR_USE_EXP2_IDX));
+    bool stateVFirst = *(attrPtr->GetAttrPointer<bool>(ATTR_STATE_V_FIRST_IDX));
+    int64_t logicalBatch = *(attrPtr->GetAttrPointer<int64_t>(ATTR_LOGICAL_BATCH_IDX));
+    int64_t logicalSeqlen = *(attrPtr->GetAttrPointer<int64_t>(ATTR_LOGICAL_SEQLEN_IDX));
+    int64_t logicalKHeads = *(attrPtr->GetAttrPointer<int64_t>(ATTR_LOGICAL_K_HEADS_IDX));
+    int64_t logicalVHeads = *(attrPtr->GetAttrPointer<int64_t>(ATTR_LOGICAL_V_HEADS_IDX));
+    int64_t logicalKDim = *(attrPtr->GetAttrPointer<int64_t>(ATTR_LOGICAL_K_DIM_IDX));
+    int64_t logicalVDim = *(attrPtr->GetAttrPointer<int64_t>(ATTR_LOGICAL_V_DIM_IDX));
+
+    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
+
+    ChunkFwdHTilingContext tilingCtx{};
+    tilingCtx.seqlen = logicalSeqlen;
+    tilingCtx.kNumHead = logicalKHeads;
+    tilingCtx.kHeadDim = logicalKDim;
+    tilingCtx.vNumHead = logicalVHeads;
+    tilingCtx.vHeadDim = logicalVDim;
+    tilingCtx.shapeBatchDim = logicalBatch;
+    tilingCtx.hasCuSeqlens = cuSeqlensTensor != nullptr;
+    tilingCtx.cuSeqlensDim0 =
+        cuSeqlensTensor != nullptr ? cuSeqlensTensor->GetStorageShape().GetDim(0) : 0;
+    tilingCtx.dataType = ChunkFwdHDtypeToEnum(context->GetInputTensor(0)->GetDataType());
+    tilingCtx.gDataType = ChunkFwdHDtypeToEnum(gateTensor->GetDataType());
+    tilingCtx.useInitialState = useInitialState;
+    tilingCtx.stateDataType = useInitialState
+                                  ? ChunkFwdHDtypeToEnum(initialStateTensor->GetDataType())
+                                  : (storeFinalState
+                                         ? ChunkFwdHDtypeToEnum(
+                                               context->GetOutputDesc(OUTPUT_FINAL_STATE_IDX)->GetDataType())
+                                         : CHUNK_FWD_H_DTYPE_FP32);
+    tilingCtx.useG = useG;
+    tilingCtx.useGk = useGk;
+    tilingCtx.useExp2 = useExp2;
+    tilingCtx.stateVFirst = stateVFirst;
+    tilingCtx.storeFinalState = storeFinalState;
+    tilingCtx.chunkSize = chunkSize;
+    tilingCtx.aicCoreNum = ascendcPlatform.GetCoreNumAic();
+    tilingCtx.libApiWorkSpaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
+
+    if (logicalBatch <= 0 || logicalSeqlen <= 0 || logicalKHeads <= 0 || logicalVHeads <= 0) {
+        OP_LOGE(context->GetNodeName(),
+                "Logical batch, sequence length and head counts must be positive, but got "
+                "batch=%ld, seqlen=%ld, HK=%ld, HV=%ld.",
+                logicalBatch, logicalSeqlen, logicalKHeads, logicalVHeads);
+        return ge::GRAPH_FAILED;
+    }
+    if (logicalKDim != K_DIM_128 || logicalVDim != V_DIM_128 || chunkSize != CHUNK_SIZE_64) {
+        OP_LOGE(context->GetNodeName(),
+                "FwdH requires K=128, V=128 and chunk_size=64, but got K=%ld, V=%ld, chunk_size=%ld.",
+                logicalKDim, logicalVDim, chunkSize);
+        return ge::GRAPH_FAILED;
+    }
+    if (!saveNewValue) {
+        OP_LOGE(context->GetNodeName(), "save_new_value must be true.");
+        return ge::GRAPH_FAILED;
+    }
+    if ((useG && logicalVHeads % logicalKHeads != 0) || (useGk && logicalKHeads != logicalVHeads)) {
+        OP_LOGE(context->GetNodeName(),
+                "g-only requires HV %% HK == 0; gk-only requires k/ kg head count equal HV. "
+                "Current mode useG=%d, useGk=%d, HK=%ld, HV=%ld.",
+                useG, useGk, logicalKHeads, logicalVHeads);
+        return ge::GRAPH_FAILED;
+    }
+
+    ::ChunkFwdHPlainTilingData plainTiling{};
+    uint32_t blockDim = 0;
+    size_t workspaceSize = 0;
+    ChunkFwdHTilingProcessor processor(tilingCtx);
+    processor.Process(plainTiling, blockDim, workspaceSize);
+
+    context->SetTilingKey(TILING_KEY_V128);
+    OP_LOGD(context->GetNodeName(), "tilingKey: %u", TILING_KEY_V128);
+
+    context->SetBlockDim(blockDim);
+    size_t *currentWorkspace = context->GetWorkspaceSizes(1);
+    currentWorkspace[0] = workspaceSize;
+
+    tiling.set_batch(plainTiling.batch);
+    tiling.set_seqlen(plainTiling.seqlen);
+    tiling.set_kNumHead(plainTiling.kNumHead);
+    tiling.set_vNumHead(plainTiling.vNumHead);
+    tiling.set_kHeadDim(plainTiling.kHeadDim);
+    tiling.set_vHeadDim(plainTiling.vHeadDim);
+    tiling.set_chunkSize(plainTiling.chunkSize);
+    tiling.set_useInitialState(plainTiling.useInitialState);
+    tiling.set_storeFinalState(plainTiling.storeFinalState);
+    tiling.set_dataType(plainTiling.dataType);
+    tiling.set_stateDataType(plainTiling.stateDataType);
+    tiling.set_gDataType(plainTiling.gDataType);
+    tiling.set_isVariedLen(plainTiling.isVariedLen);
+    tiling.set_shapeBatch(plainTiling.shapeBatch);
+    tiling.set_tokenBatch(plainTiling.tokenBatch);
+    tiling.set_useG(plainTiling.useG);
+    tiling.set_useGk(plainTiling.useGk);
+    tiling.set_useExp2(plainTiling.useExp2);
+    tiling.set_stateVFirst(plainTiling.stateVFirst);
+    tiling.set_vWorkspaceOffset(plainTiling.vWorkspaceOffset);
+    tiling.set_vUpdateWorkspaceOffset(plainTiling.vUpdateWorkspaceOffset);
+    tiling.set_kDecayWorkspaceOffset(plainTiling.kDecayWorkspaceOffset);
+    tiling.set_hWorkspaceOffset(plainTiling.hWorkspaceOffset);
+    tiling.set_numSeqWorkspaceOffset(plainTiling.numSeqWorkspaceOffset);
+    tiling.set_numChunksWorkspaceOffset(plainTiling.numChunksWorkspaceOffset);
+
+    tiling.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
+    context->GetRawTilingData()->SetDataSize(tiling.GetDataSize());
+
+    ChunkFwdHTilingDataPrint(context, tiling);
+    OP_LOGD(context->GetNodeName(), "Tiling4ChunkFwdH end.");
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus TilingPrepareForChunkFwdH(gert::TilingParseContext *context)
+{
+    (void)context;
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(ChunkFwdH)
+    .Tiling(Tiling4ChunkFwdH)
+    .TilingParse<ChunkFwdHCompileInfo>(TilingPrepareForChunkFwdH);
+
+} // namespace optiling

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/chunk_fwd_h_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/chunk_fwd_h_tiling.h
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_fwd_h_tiling.h
+ * \brief
+ */
+
+#ifndef CHUNK_FWD_H_TILING_H
+#define CHUNK_FWD_H_TILING_H
+
+#include <cstdint>
+#include <register/tilingdata_base.h>
+#include <tiling/tiling_api.h>
+
+namespace optiling {
+
+BEGIN_TILING_DATA_DEF(ChunkFwdHTilingData)
+TILING_DATA_FIELD_DEF(int64_t, batch);
+TILING_DATA_FIELD_DEF(int64_t, seqlen);
+TILING_DATA_FIELD_DEF(int64_t, kNumHead);
+TILING_DATA_FIELD_DEF(int64_t, vNumHead);
+TILING_DATA_FIELD_DEF(int64_t, kHeadDim);
+TILING_DATA_FIELD_DEF(int64_t, vHeadDim);
+TILING_DATA_FIELD_DEF(int64_t, chunkSize);
+TILING_DATA_FIELD_DEF(bool, useInitialState);
+TILING_DATA_FIELD_DEF(bool, storeFinalState);
+TILING_DATA_FIELD_DEF(int64_t, dataType);
+TILING_DATA_FIELD_DEF(int64_t, gDataType);
+TILING_DATA_FIELD_DEF(int64_t, stateDataType);
+TILING_DATA_FIELD_DEF(int64_t, isVariedLen);
+TILING_DATA_FIELD_DEF(int64_t, shapeBatch);
+TILING_DATA_FIELD_DEF(int64_t, tokenBatch);
+TILING_DATA_FIELD_DEF(bool, useG);
+TILING_DATA_FIELD_DEF(bool, useGk);
+TILING_DATA_FIELD_DEF(bool, useExp2);
+TILING_DATA_FIELD_DEF(bool, stateVFirst);
+TILING_DATA_FIELD_DEF(int64_t, vWorkspaceOffset);
+TILING_DATA_FIELD_DEF(int64_t, vUpdateWorkspaceOffset);
+TILING_DATA_FIELD_DEF(int64_t, kDecayWorkspaceOffset);
+TILING_DATA_FIELD_DEF(int64_t, hWorkspaceOffset);
+TILING_DATA_FIELD_DEF(int64_t, numSeqWorkspaceOffset);
+TILING_DATA_FIELD_DEF(int64_t, numChunksWorkspaceOffset);
+END_TILING_DATA_DEF;
+
+REGISTER_TILING_DATA_CLASS(ChunkFwdH, ChunkFwdHTilingData)
+
+struct ChunkFwdHCompileInfo {};
+} // namespace optiling
+
+#endif // CHUNK_FWD_H_TILING_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/chunk_fwd_h_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/chunk_fwd_h_tiling.h
@@ -45,8 +45,6 @@ TILING_DATA_FIELD_DEF(int64_t, vWorkspaceOffset);
 TILING_DATA_FIELD_DEF(int64_t, vUpdateWorkspaceOffset);
 TILING_DATA_FIELD_DEF(int64_t, kDecayWorkspaceOffset);
 TILING_DATA_FIELD_DEF(int64_t, hWorkspaceOffset);
-TILING_DATA_FIELD_DEF(int64_t, numSeqWorkspaceOffset);
-TILING_DATA_FIELD_DEF(int64_t, numChunksWorkspaceOffset);
 END_TILING_DATA_DEF;
 
 REGISTER_TILING_DATA_CLASS(ChunkFwdH, ChunkFwdHTilingData)

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/chunk_fwd_h_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/chunk_fwd_h_tiling_processor.h
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_fwd_h_tiling_processor.h
+ * \brief Tiling computation decoupled from gert::TilingContext.
+ *
+ * The caller is responsible for resolving framework-specific information (shapes, dtypes,
+ * platform core number, lib-api workspace size) into the plain context struct below. The
+ * processor then fills ChunkFwdHPlainTilingData together with the block
+ * dim and the total workspace size, mirroring exactly the original Tiling4ChunkFwdH.
+ */
+
+#ifndef CHUNK_FWD_H_TILING_PROCESSOR_H
+#define CHUNK_FWD_H_TILING_PROCESSOR_H
+
+#include <cstddef>
+#include <cstdint>
+
+#include "../op_kernel/chunk_fwd_h_struct.h"
+
+namespace optiling {
+
+// dtype enum convention shared with the kernel: 0 - fp16, 1 - bf16, 2 - fp32
+static constexpr int64_t CHUNK_FWD_H_DTYPE_FP16 = 0;
+static constexpr int64_t CHUNK_FWD_H_DTYPE_BF16 = 1;
+static constexpr int64_t CHUNK_FWD_H_DTYPE_FP32 = 2;
+
+static constexpr size_t CHUNK_FWD_H_WORKSPACE_RSV_BYTE = 16 * 1024 * 1024;
+static constexpr size_t CHUNK_FWD_H_GM_ALIGN = 512;
+static constexpr int64_t CHUNK_FWD_H_ROUND_HEAD_SLOTS = 4;
+static constexpr int64_t CHUNK_FWD_H_CHUNK_SIZE = 64;
+static constexpr int64_t CHUNK_FWD_H_K_DIM = 128;
+static constexpr int64_t CHUNK_FWD_H_V_DIM = 128;
+
+// Plain, framework-agnostic inputs needed to compute the tiling.
+struct ChunkFwdHTilingContext {
+    // shapes
+    int64_t seqlen;        // k.dim(2)
+    int64_t kNumHead;      // k.dim(1)
+    int64_t kHeadDim;      // k.dim(3)
+    int64_t vNumHead;      // u.dim(1)
+    int64_t vHeadDim;      // u.dim(3)
+    int64_t shapeBatchDim; // k.dim(0)
+    // variable length
+    bool hasCuSeqlens;
+    int64_t cuSeqlensDim0; // length of cu_seqlens (only used when hasCuSeqlens)
+    // dtypes (use CHUNK_FWD_H_DTYPE_*)
+    int64_t dataType;      // input (k/w/u) dtype: fp16 or bf16
+    int64_t gDataType;     // g dtype
+    bool useInitialState;
+    int64_t stateDataType; // initial/final state dtype
+    bool useG;
+    bool useGk;
+    bool useExp2;
+    bool stateVFirst;
+    // attrs
+    bool storeFinalState;
+    int64_t chunkSize;
+    // platform
+    uint32_t aicCoreNum;
+    size_t libApiWorkSpaceSize;
+};
+
+class ChunkFwdHTilingProcessor {
+public:
+    explicit ChunkFwdHTilingProcessor(const ChunkFwdHTilingContext &ctx) : ctx_(ctx) {}
+
+    // Fills the plain tiling struct, the block dim and the total workspace size.
+    void Process(::ChunkFwdHPlainTilingData &tiling,
+                 uint32_t &blockDim, size_t &workspaceSize) const
+    {
+        int64_t isVariedLen;
+        int64_t shapeBatch;
+        int64_t tokenBatch;
+        int64_t batch;
+
+        if (!ctx_.hasCuSeqlens) {
+            isVariedLen = 0;
+            shapeBatch = ctx_.shapeBatchDim;
+            tokenBatch = 1;
+            batch = shapeBatch;
+        } else {
+            isVariedLen = 1;
+            shapeBatch = 1;
+            tokenBatch = ctx_.cuSeqlensDim0 - 1;
+            batch = tokenBatch;
+        }
+
+        blockDim = ctx_.aicCoreNum;
+        const int64_t aicCoreNum = static_cast<int64_t>(ctx_.aicCoreNum);
+        constexpr int64_t chunkSize = CHUNK_FWD_H_CHUNK_SIZE;
+        constexpr int64_t kHeadDim = CHUNK_FWD_H_K_DIM;
+        constexpr int64_t vHeadDim = CHUNK_FWD_H_V_DIM;
+
+        size_t workspaceOffset = ctx_.libApiWorkSpaceSize;
+        workspaceOffset += CHUNK_FWD_H_WORKSPACE_RSV_BYTE;
+
+        tiling.vWorkspaceOffset = static_cast<int64_t>(workspaceOffset);
+        workspaceOffset += AlignUp(static_cast<size_t>(aicCoreNum * CHUNK_FWD_H_ROUND_HEAD_SLOTS *
+                                                        chunkSize * vHeadDim * sizeof(float)));
+
+        tiling.vUpdateWorkspaceOffset = static_cast<int64_t>(workspaceOffset);
+        workspaceOffset += AlignUp(static_cast<size_t>(aicCoreNum * CHUNK_FWD_H_ROUND_HEAD_SLOTS *
+                                                        chunkSize * vHeadDim * sizeof(uint16_t)));
+
+        tiling.kDecayWorkspaceOffset = static_cast<int64_t>(workspaceOffset);
+        workspaceOffset += AlignUp(static_cast<size_t>(aicCoreNum * CHUNK_FWD_H_ROUND_HEAD_SLOTS *
+                                                        kHeadDim * vHeadDim * sizeof(float)));
+
+        tiling.hWorkspaceOffset = static_cast<int64_t>(workspaceOffset);
+        workspaceOffset += AlignUp(static_cast<size_t>(aicCoreNum * CHUNK_FWD_H_ROUND_HEAD_SLOTS *
+                                                        kHeadDim * vHeadDim * sizeof(float)));
+
+        tiling.numSeqWorkspaceOffset = static_cast<int64_t>(workspaceOffset);
+        workspaceOffset += AlignUp(static_cast<size_t>((tokenBatch + 1) * static_cast<int64_t>(sizeof(int64_t))));
+
+        tiling.numChunksWorkspaceOffset = static_cast<int64_t>(workspaceOffset);
+        workspaceOffset += AlignUp(static_cast<size_t>((tokenBatch + 1) * static_cast<int64_t>(sizeof(int64_t))));
+
+        workspaceOffset += CHUNK_FWD_H_WORKSPACE_RSV_BYTE;
+        workspaceSize = workspaceOffset;
+
+        tiling.batch = batch;
+        tiling.seqlen = ctx_.seqlen;
+        tiling.kNumHead = ctx_.kNumHead;
+        tiling.vNumHead = ctx_.vNumHead;
+        tiling.kHeadDim = ctx_.kHeadDim;
+        tiling.vHeadDim = ctx_.vHeadDim;
+        tiling.chunkSize = chunkSize;
+        tiling.useInitialState = ctx_.useInitialState;
+        tiling.storeFinalState = ctx_.storeFinalState;
+        tiling.dataType = ctx_.dataType;
+        tiling.gDataType = ctx_.gDataType;
+        tiling.stateDataType = ctx_.stateDataType;
+        tiling.isVariedLen = isVariedLen;
+        tiling.shapeBatch = shapeBatch;
+        tiling.tokenBatch = tokenBatch;
+        tiling.useG = ctx_.useG;
+        tiling.useGk = ctx_.useGk;
+        tiling.useExp2 = ctx_.useExp2;
+        tiling.stateVFirst = ctx_.stateVFirst;
+    }
+
+private:
+    // Mirrors the original "(x + GM_ALIGN) / GM_ALIGN * GM_ALIGN" alignment.
+    static size_t AlignUp(size_t x)
+    {
+        return (x + CHUNK_FWD_H_GM_ALIGN - 1) / CHUNK_FWD_H_GM_ALIGN * CHUNK_FWD_H_GM_ALIGN;
+    }
+
+    const ChunkFwdHTilingContext &ctx_;
+};
+
+} // namespace optiling
+
+#endif // CHUNK_FWD_H_TILING_PROCESSOR_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/chunk_fwd_h_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/chunk_fwd_h_tiling_processor.h
@@ -118,12 +118,6 @@ public:
         workspaceOffset += AlignUp(static_cast<size_t>(aicCoreNum * CHUNK_FWD_H_ROUND_HEAD_SLOTS *
                                                         kHeadDim * vHeadDim * sizeof(float)));
 
-        tiling.numSeqWorkspaceOffset = static_cast<int64_t>(workspaceOffset);
-        workspaceOffset += AlignUp(static_cast<size_t>((tokenBatch + 1) * static_cast<int64_t>(sizeof(int64_t))));
-
-        tiling.numChunksWorkspaceOffset = static_cast<int64_t>(workspaceOffset);
-        workspaceOffset += AlignUp(static_cast<size_t>((tokenBatch + 1) * static_cast<int64_t>(sizeof(int64_t))));
-
         workspaceOffset += CHUNK_FWD_H_WORKSPACE_RSV_BYTE;
         workspaceSize = workspaceOffset;
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/op_api/aclnn_chunk_fwd_h.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/op_api/aclnn_chunk_fwd_h.cpp
@@ -68,7 +68,51 @@ static aclnnStatus CheckNotNull(ChunkFwdHParams params)
 
 static aclnnStatus CheckFormat(ChunkFwdHParams params)
 {
-    (void)params;
+    const aclTensor *tensors[] = {
+        params.k,
+        params.w,
+        params.u,
+        params.gOptional,
+        params.gkOptional,
+        params.initialStateOptional,
+        params.hOut,
+        params.vNewOut,
+        params.finalStateOut,
+    };
+    const char *tensorNames[] = {
+        "k",
+        "w",
+        "u",
+        "gOptional",
+        "gkOptional",
+        "initialStateOptional",
+        "hOut",
+        "vNewOut",
+        "finalStateOut",
+    };
+    for (size_t idx = 0; idx < sizeof(tensors) / sizeof(tensors[0]); ++idx) {
+        if (tensors[idx] == nullptr) {
+            continue;
+        }
+        const auto storageFormat = tensors[idx]->GetStorageFormat();
+        const auto viewFormat = tensors[idx]->GetViewFormat();
+        CHECK_COND(storageFormat == Format::FORMAT_ND && viewFormat == Format::FORMAT_ND &&
+                       !IsPrivateFormat(storageFormat),
+                   ACLNN_ERR_PARAM_INVALID,
+                   "%s must use non-private ND storage/view format, but got storage=%d and view=%d.",
+                   tensorNames[idx], static_cast<int>(storageFormat),
+                   static_cast<int>(viewFormat));
+    }
+    const aclTensor *outputs[] = {params.hOut, params.vNewOut, params.finalStateOut};
+    const char *outputNames[] = {"hOut", "vNewOut", "finalStateOut"};
+    for (size_t idx = 0; idx < sizeof(outputs) / sizeof(outputs[0]); ++idx) {
+        if (outputs[idx] == nullptr) {
+            continue;
+        }
+        CHECK_COND(IsContiguous(outputs[idx]), ACLNN_ERR_PARAM_INVALID,
+                   "%s must be contiguous because ChunkFwdH writes it directly.",
+                   outputNames[idx]);
+    }
     return ACLNN_SUCCESS;
 }
 
@@ -249,23 +293,35 @@ static aclnnStatus DataContiguous(const aclTensor *&tensor, aclOpExecutor *execu
 
 static aclnnStatus ParamsDataContiguous(ChunkFwdHParams &params, aclOpExecutor *executorPtr)
 {
-    CHECK_COND(DataContiguous(params.k, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
-               "Contiguous k failed.");
-    CHECK_COND(DataContiguous(params.w, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
-               "Contiguous w failed.");
-    CHECK_COND(DataContiguous(params.u, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
-               "Contiguous u failed.");
+    auto status = DataContiguous(params.k, executorPtr);
+    if (status != ACLNN_SUCCESS) {
+        return status;
+    }
+    status = DataContiguous(params.w, executorPtr);
+    if (status != ACLNN_SUCCESS) {
+        return status;
+    }
+    status = DataContiguous(params.u, executorPtr);
+    if (status != ACLNN_SUCCESS) {
+        return status;
+    }
     if (params.gOptional != nullptr) {
-        CHECK_COND(DataContiguous(params.gOptional, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
-                   "Contiguous gOptional failed.");
+        status = DataContiguous(params.gOptional, executorPtr);
+        if (status != ACLNN_SUCCESS) {
+            return status;
+        }
     }
     if (params.gkOptional != nullptr) {
-        CHECK_COND(DataContiguous(params.gkOptional, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
-                   "Contiguous gkOptional failed.");
+        status = DataContiguous(params.gkOptional, executorPtr);
+        if (status != ACLNN_SUCCESS) {
+            return status;
+        }
     }
     if (params.initialStateOptional != nullptr) {
-        CHECK_COND(DataContiguous(params.initialStateOptional, executorPtr) == ACLNN_SUCCESS,
-                   ACLNN_ERR_PARAM_INVALID, "Contiguous initialStateOptional failed.");
+        status = DataContiguous(params.initialStateOptional, executorPtr);
+        if (status != ACLNN_SUCCESS) {
+            return status;
+        }
     }
 
     return ACLNN_SUCCESS;
@@ -381,14 +437,18 @@ aclnnStatus aclnnChunkFwdHGetWorkspaceSize(
     if (ret != ACLNN_SUCCESS) {
         return ret;
     }
-    CHECK_COND(ParamsDataContiguous(params, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
-               "ParamsDataContiguous failed.");
+    ret = ParamsDataContiguous(params, executorPtr);
+    if (ret != ACLNN_SUCCESS) {
+        return ret;
+    }
     auto result = l0op::ChunkFwdH(
         params.k, params.w, params.u, params.gOptional, params.gkOptional, params.initialStateOptional,
         params.cuSeqlensOptional, params.chunkIndicesOptional, params.outputFinalState, params.chunkSize,
         params.saveNewValue, params.useExp2, params.stateVFirst,
         params.hOut, params.vNewOut, params.finalStateOut, executorPtr);
-    CHECK_RET(result[0] != nullptr, ACLNN_ERR_PARAM_NULLPTR);
+    CHECK_RET(result[0] != nullptr && result[1] != nullptr &&
+                  (!outputFinalState || result[2] != nullptr),
+              ACLNN_ERR_INNER_NULLPTR);
 
     auto viewCopyResult0 = l0op::ViewCopy(result[0], params.hOut, executorPtr);
     CHECK_RET(viewCopyResult0 != nullptr, ACLNN_ERR_INNER_NULLPTR);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/op_api/aclnn_chunk_fwd_h.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/op_api/aclnn_chunk_fwd_h.cpp
@@ -1,0 +1,420 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+#include "aclnn_chunk_fwd_h.h"
+#include "chunk_fwd_h.h"
+#include <dlfcn.h>
+#include <new>
+
+#include "aclnn_kernels/contiguous.h"
+#include "acl/acl.h"
+#include "aclnn/aclnn_base.h"
+#include "aclnn_kernels/common/op_error_check.h"
+#include "opdev/common_types.h"
+#include "opdev/data_type_utils.h"
+#include "opdev/format_utils.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_executor.h"
+#include "opdev/op_log.h"
+#include "opdev/platform.h"
+#include "opdev/shape_utils.h"
+#include "opdev/tensor_view_utils.h"
+#include "opdev/make_op_executor.h"
+
+
+using namespace op;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ChunkFwdHParams {
+    const aclTensor *k = nullptr;
+    const aclTensor *w = nullptr;
+    const aclTensor *u = nullptr;
+    const aclTensor *gOptional = nullptr;
+    const aclTensor *gkOptional = nullptr;
+    const aclTensor *initialStateOptional = nullptr;
+    bool outputFinalState = false;
+    int64_t chunkSize = 64;
+    bool saveNewValue = true;
+    const aclIntArray *cuSeqlensOptional = nullptr;
+    const aclIntArray *chunkIndicesOptional = nullptr;
+    bool useExp2 = false;
+    bool stateVFirst = false;
+    const aclTensor *hOut = nullptr;
+    const aclTensor *vNewOut = nullptr;
+    const aclTensor *finalStateOut = nullptr;
+};
+
+static aclnnStatus CheckNotNull(ChunkFwdHParams params)
+{
+    CHECK_COND(params.k != nullptr, ACLNN_ERR_PARAM_NULLPTR, "k must not be nullptr.");
+    CHECK_COND(params.w != nullptr, ACLNN_ERR_PARAM_NULLPTR, "w must not be nullptr.");
+    CHECK_COND(params.u != nullptr, ACLNN_ERR_PARAM_NULLPTR, "u must not be nullptr.");
+
+    CHECK_COND(params.hOut != nullptr, ACLNN_ERR_PARAM_NULLPTR, "hOut must not be nullptr.");
+    CHECK_COND(params.vNewOut != nullptr, ACLNN_ERR_PARAM_NULLPTR, "vNewOut must not be nullptr.");
+    CHECK_COND(params.outputFinalState == (params.finalStateOut != nullptr), ACLNN_ERR_PARAM_INVALID,
+               "outputFinalState must equal the physical presence of finalStateOut.");
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckFormat(ChunkFwdHParams params)
+{
+    (void)params;
+    return ACLNN_SUCCESS;
+}
+
+static int64_t CountChunks(const aclIntArray *cuSeqlens, int64_t seqlen, int64_t chunkSize)
+{
+    if (cuSeqlens == nullptr) {
+        return (seqlen + chunkSize - 1) / chunkSize;
+    }
+    int64_t totalChunks = 0;
+    for (size_t seq = 0; seq + 1 < cuSeqlens->Size(); ++seq) {
+        const int64_t length = (*cuSeqlens)[seq + 1] - (*cuSeqlens)[seq];
+        totalChunks += (length + chunkSize - 1) / chunkSize;
+    }
+    return totalChunks;
+}
+
+static aclnnStatus CheckVariableLengthInputs(const ChunkFwdHParams &params)
+{
+    const auto kShape = params.k->GetViewShape();
+    CHECK_COND(kShape.GetDimNum() == 4, ACLNN_ERR_PARAM_INVALID,
+               "k must be rank 4 before validating variable-length metadata.");
+    if (params.cuSeqlensOptional == nullptr) {
+        CHECK_COND(params.chunkIndicesOptional == nullptr, ACLNN_ERR_PARAM_INVALID,
+                   "chunkIndicesOptional requires cuSeqlensOptional.");
+        return ACLNN_SUCCESS;
+    }
+
+    CHECK_COND(kShape.GetDim(0) == 1, ACLNN_ERR_PARAM_INVALID,
+               "Variable-length BNSD input requires B=1, but got B=%ld.", kShape.GetDim(0));
+    CHECK_COND(params.cuSeqlensOptional->Size() >= 2, ACLNN_ERR_PARAM_INVALID,
+               "cuSeqlensOptional must contain at least [0, total_tokens].");
+    CHECK_COND((*params.cuSeqlensOptional)[0] == 0, ACLNN_ERR_PARAM_INVALID,
+               "cuSeqlensOptional[0] must be 0.");
+    CHECK_COND((*params.cuSeqlensOptional)[params.cuSeqlensOptional->Size() - 1] == kShape.GetDim(2),
+               ACLNN_ERR_PARAM_INVALID,
+               "cuSeqlensOptional last element must equal T=%ld.", kShape.GetDim(2));
+    for (size_t seq = 0; seq + 1 < params.cuSeqlensOptional->Size(); ++seq) {
+        CHECK_COND((*params.cuSeqlensOptional)[seq] < (*params.cuSeqlensOptional)[seq + 1],
+                   ACLNN_ERR_PARAM_INVALID,
+                   "cuSeqlensOptional must be strictly increasing; empty sequences are not supported.");
+    }
+
+    if (params.chunkIndicesOptional == nullptr) {
+        return ACLNN_SUCCESS;
+    }
+    const int64_t totalChunks = CountChunks(params.cuSeqlensOptional, kShape.GetDim(2), params.chunkSize);
+    CHECK_COND(params.chunkIndicesOptional->Size() == static_cast<size_t>(totalChunks) * 2,
+               ACLNN_ERR_PARAM_INVALID,
+               "chunkIndicesOptional must contain exactly one (seq_id, chunk_id) pair per chunk.");
+    size_t offset = 0;
+    for (size_t seq = 0; seq + 1 < params.cuSeqlensOptional->Size(); ++seq) {
+        const int64_t length = (*params.cuSeqlensOptional)[seq + 1] - (*params.cuSeqlensOptional)[seq];
+        const int64_t chunks = (length + params.chunkSize - 1) / params.chunkSize;
+        for (int64_t chunk = 0; chunk < chunks; ++chunk) {
+            CHECK_COND((*params.chunkIndicesOptional)[offset] == static_cast<int64_t>(seq) &&
+                           (*params.chunkIndicesOptional)[offset + 1] == chunk,
+                       ACLNN_ERR_PARAM_INVALID,
+                       "chunkIndicesOptional must use canonical sequence-major chunk order.");
+            offset += 2;
+        }
+    }
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckShape(ChunkFwdHParams params)
+{
+    auto kShape = params.k->GetViewShape();
+    auto wShape = params.w->GetViewShape();
+    auto uShape = params.u->GetViewShape();
+    CHECK_COND(kShape.GetDimNum() == 4 && wShape.GetDimNum() == 4 && uShape.GetDimNum() == 4,
+               ACLNN_ERR_PARAM_INVALID, "k, w and u must be rank-4 BNSD tensors.");
+    CHECK_COND(kShape.GetDim(0) > 0 && kShape.GetDim(1) > 0 && kShape.GetDim(2) > 0 &&
+                   uShape.GetDim(1) > 0,
+               ACLNN_ERR_PARAM_INVALID,
+               "B, HK, T and HV must all be positive, but got B=%ld, HK=%ld, T=%ld, HV=%ld.",
+               kShape.GetDim(0), kShape.GetDim(1), kShape.GetDim(2), uShape.GetDim(1));
+    CHECK_COND(kShape.GetDim(0) == wShape.GetDim(0) && kShape.GetDim(0) == uShape.GetDim(0) &&
+                   wShape.GetDim(1) == uShape.GetDim(1) && kShape.GetDim(2) == wShape.GetDim(2) &&
+                   kShape.GetDim(2) == uShape.GetDim(2) && kShape.GetDim(3) == wShape.GetDim(3),
+               ACLNN_ERR_PARAM_INVALID,
+               "k, w and u must match in B/T, w and u must match in HV, and k and w must match in K.");
+    CHECK_COND(kShape.GetDim(3) == 128 && uShape.GetDim(3) == 128, ACLNN_ERR_PARAM_INVALID,
+               "FwdH requires K=128 and V=128, but got K=%ld and V=%ld.",
+               kShape.GetDim(3), uShape.GetDim(3));
+    if (params.gOptional != nullptr) {
+        CHECK_COND(uShape.GetDim(1) >= kShape.GetDim(1) && uShape.GetDim(1) % kShape.GetDim(1) == 0,
+                   ACLNN_ERR_PARAM_INVALID,
+                   "g-only requires HV >= HK and HV divisible by HK, but got HK=%ld and HV=%ld.",
+                   kShape.GetDim(1), uShape.GetDim(1));
+    } else {
+        CHECK_COND(kShape.GetDim(1) == uShape.GetDim(1), ACLNN_ERR_PARAM_INVALID,
+                   "gk-only requires the prepared kg head count to equal HV, but got kg heads=%ld and HV=%ld.",
+                   kShape.GetDim(1), uShape.GetDim(1));
+    }
+    if (params.gOptional != nullptr) {
+        auto gShape = params.gOptional->GetViewShape();
+        CHECK_COND(gShape.GetDimNum() == 3 && gShape.GetDim(0) == uShape.GetDim(0) &&
+                       gShape.GetDim(1) == uShape.GetDim(1) && gShape.GetDim(2) == uShape.GetDim(2),
+                   ACLNN_ERR_PARAM_INVALID, "g must have shape [B, HV, T].");
+    }
+    const int64_t batch = kShape.GetDim(0);
+    const int64_t hv = uShape.GetDim(1);
+    const int64_t kDim = kShape.GetDim(3);
+    const int64_t vDim = uShape.GetDim(3);
+    const int64_t seqNum = params.cuSeqlensOptional == nullptr
+                               ? batch
+                               : static_cast<int64_t>(params.cuSeqlensOptional->Size()) - 1;
+    const int64_t totalChunks = CountChunks(params.cuSeqlensOptional, kShape.GetDim(2), params.chunkSize);
+    auto hShape = params.hOut->GetViewShape();
+    CHECK_COND(hShape.GetDimNum() == 5 && hShape.GetDim(0) == batch && hShape.GetDim(1) == hv &&
+                   hShape.GetDim(2) == totalChunks,
+               ACLNN_ERR_PARAM_INVALID,
+               "hOut must be [B, HV, num_chunks, K, V] (or [B, HV, num_chunks, V, K]), "
+               "where num_chunks=%ld.", totalChunks);
+    const int64_t hK = params.stateVFirst ? hShape.GetDim(4) : hShape.GetDim(3);
+    const int64_t hV = params.stateVFirst ? hShape.GetDim(3) : hShape.GetDim(4);
+    CHECK_COND(hK == kDim && hV == vDim, ACLNN_ERR_PARAM_INVALID,
+               "hOut state dimensions must be [K, V] when stateVFirst=false and [V, K] otherwise.");
+    auto vNewShape = params.vNewOut->GetViewShape();
+    CHECK_COND(vNewShape.GetDimNum() == 4 && vNewShape.GetDim(0) == batch &&
+                   vNewShape.GetDim(1) == hv && vNewShape.GetDim(2) == kShape.GetDim(2) &&
+                   vNewShape.GetDim(3) == vDim,
+               ACLNN_ERR_PARAM_INVALID, "vNewOut must have shape [B, HV, T, V].");
+    const aclTensor *states[] = {params.initialStateOptional, params.finalStateOut};
+    const char *stateNames[] = {"initialStateOptional", "finalStateOut"};
+    for (size_t idx = 0; idx < 2; ++idx) {
+        if (states[idx] == nullptr) {
+            continue;
+        }
+        auto stateShape = states[idx]->GetViewShape();
+        CHECK_COND(stateShape.GetDimNum() == 4, ACLNN_ERR_PARAM_INVALID,
+                   "%s must be rank 4.", stateNames[idx]);
+        const int64_t stateK = params.stateVFirst ? stateShape.GetDim(3) : stateShape.GetDim(2);
+        const int64_t stateV = params.stateVFirst ? stateShape.GetDim(2) : stateShape.GetDim(3);
+        CHECK_COND(stateShape.GetDim(0) == seqNum &&
+                       stateShape.GetDim(1) == hv && stateK == kDim && stateV == vDim,
+                   ACLNN_ERR_PARAM_INVALID,
+                   "%s must be [N, HV, K, V] when stateVFirst=false and [N, HV, V, K] otherwise.",
+                   stateNames[idx]);
+    }
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckDtype(ChunkFwdHParams params)
+{
+    auto inputDtype = params.k->GetDataType();
+    CHECK_COND(inputDtype == DataType::DT_BF16, ACLNN_ERR_PARAM_INVALID,
+               "k, w and u only support bfloat16.");
+    CHECK_COND(params.w->GetDataType() == inputDtype && params.u->GetDataType() == inputDtype,
+               ACLNN_ERR_PARAM_INVALID, "k, w and u must have the same dtype.");
+    CHECK_COND(params.hOut->GetDataType() == inputDtype && params.vNewOut->GetDataType() == inputDtype,
+               ACLNN_ERR_PARAM_INVALID, "hOut and vNewOut dtype must match k, w and u.");
+    auto gateDtype = params.gOptional != nullptr ? params.gOptional->GetDataType() : params.gkOptional->GetDataType();
+    CHECK_COND(gateDtype == DataType::DT_FLOAT || gateDtype == DataType::DT_BF16,
+               ACLNN_ERR_PARAM_INVALID, "g/gk dtype must be bfloat16 or float32.");
+    if (params.initialStateOptional != nullptr) {
+        auto stateDtype = params.initialStateOptional->GetDataType();
+        CHECK_COND(stateDtype == DataType::DT_BF16 || stateDtype == DataType::DT_FLOAT,
+                   ACLNN_ERR_PARAM_INVALID, "initialStateOptional dtype must be bfloat16 or float32.");
+        if (params.finalStateOut != nullptr) {
+            CHECK_COND(params.finalStateOut->GetDataType() == stateDtype, ACLNN_ERR_PARAM_INVALID,
+                       "finalStateOut dtype must match initialStateOptional dtype.");
+        }
+    } else if (params.finalStateOut != nullptr) {
+        auto stateDtype = params.finalStateOut->GetDataType();
+        CHECK_COND(stateDtype == DataType::DT_BF16 || stateDtype == DataType::DT_FLOAT,
+                   ACLNN_ERR_PARAM_INVALID, "finalStateOut dtype must be bfloat16 or float32.");
+    }
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus DataContiguous(const aclTensor *&tensor, aclOpExecutor *executor)
+{
+    tensor = l0op::Contiguous(tensor, executor);
+    CHECK_RET(tensor != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus ParamsDataContiguous(ChunkFwdHParams &params, aclOpExecutor *executorPtr)
+{
+    CHECK_COND(DataContiguous(params.k, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous k failed.");
+    CHECK_COND(DataContiguous(params.w, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous w failed.");
+    CHECK_COND(DataContiguous(params.u, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous u failed.");
+    if (params.gOptional != nullptr) {
+        CHECK_COND(DataContiguous(params.gOptional, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+                   "Contiguous gOptional failed.");
+    }
+    if (params.gkOptional != nullptr) {
+        CHECK_COND(DataContiguous(params.gkOptional, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+                   "Contiguous gkOptional failed.");
+    }
+    if (params.initialStateOptional != nullptr) {
+        CHECK_COND(DataContiguous(params.initialStateOptional, executorPtr) == ACLNN_SUCCESS,
+                   ACLNN_ERR_PARAM_INVALID, "Contiguous initialStateOptional failed.");
+    }
+
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckGateOptionalNonNull(const ChunkFwdHParams &params)
+{
+    CHECK_COND((params.gOptional != nullptr) != (params.gkOptional != nullptr), ACLNN_ERR_PARAM_INVALID,
+               "Exactly one of g and gk must be provided.");
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckGkParams(const ChunkFwdHParams &params)
+{
+    if (params.gkOptional != nullptr) {
+        auto gkShape = params.gkOptional->GetViewShape();
+        CHECK_COND(gkShape.GetDimNum() == 4, ACLNN_ERR_PARAM_INVALID,
+                   "gk must have rank 4 when provided, got rank %ld.", gkShape.GetDimNum());
+        CHECK_COND(gkShape.GetDim(3) == params.k->GetViewShape().GetDim(3), ACLNN_ERR_PARAM_INVALID,
+                   "gk.shape[3] (K) must match k.shape[3] (K).");
+        CHECK_COND(gkShape.GetDim(2) == params.k->GetViewShape().GetDim(2), ACLNN_ERR_PARAM_INVALID,
+                   "gk.shape[2] (T) must match k.shape[2] (T).");
+        CHECK_COND(gkShape.GetDim(1) == params.u->GetViewShape().GetDim(1), ACLNN_ERR_PARAM_INVALID,
+                   "gk.shape[1] (HV) must match u.shape[1] (HV).");
+        CHECK_COND(gkShape.GetDim(0) == params.k->GetViewShape().GetDim(0), ACLNN_ERR_PARAM_INVALID,
+                   "gk.shape[0] (B) must match k.shape[0] (B).");
+    }
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckParams(ChunkFwdHParams params)
+{
+    auto status = CheckNotNull(params);
+    if (status != ACLNN_SUCCESS) {
+        return status;
+    }
+    status = CheckGateOptionalNonNull(params);
+    if (status != ACLNN_SUCCESS) {
+        return status;
+    }
+    CHECK_COND(params.chunkSize == 64, ACLNN_ERR_PARAM_INVALID,
+               "chunkSize must be 64, but got %ld.", params.chunkSize);
+    CHECK_COND(params.saveNewValue, ACLNN_ERR_PARAM_INVALID, "saveNewValue must be true.");
+    status = CheckVariableLengthInputs(params);
+    if (status != ACLNN_SUCCESS) {
+        return status;
+    }
+    status = CheckFormat(params);
+    if (status != ACLNN_SUCCESS) {
+        return status;
+    }
+    status = CheckShape(params);
+    if (status != ACLNN_SUCCESS) {
+        return status;
+    }
+    status = CheckGkParams(params);
+    if (status != ACLNN_SUCCESS) {
+        return status;
+    }
+    return CheckDtype(params);
+}
+
+aclnnStatus aclnnChunkFwdHGetWorkspaceSize(
+    const aclTensor *k,
+    const aclTensor *w,
+    const aclTensor *u,
+    const aclTensor *gOptional,
+    const aclTensor *gkOptional,
+    const aclTensor *initialStateOptional,
+    bool outputFinalState,
+    int64_t chunkSize,
+    bool saveNewValue,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    bool useExp2,
+    bool stateVFirst,
+    const aclTensor *hOut,
+    const aclTensor *vNewOut,
+    const aclTensor *finalStateOut,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor)
+{
+    CHECK_COND(workspaceSize != nullptr, ACLNN_ERR_PARAM_NULLPTR,
+               "workspaceSize must not be nullptr.");
+    CHECK_COND(executor != nullptr, ACLNN_ERR_PARAM_NULLPTR,
+               "executor must not be nullptr.");
+    ChunkFwdHParams params{k,
+                                         w,
+                                         u,
+                                         gOptional,
+                                         gkOptional,
+                                         initialStateOptional,
+                                         outputFinalState,
+                                         chunkSize,
+                                         saveNewValue,
+                                         cuSeqlensOptional,
+                                         chunkIndicesOptional,
+                                         useExp2,
+                                         stateVFirst,
+                                         hOut,
+                                         vNewOut,
+                                         finalStateOut};
+    // Standard syntax, Check parameters.
+    L2_DFX_PHASE_1(aclnnChunkFwdH,
+                   DFX_IN(k, w, u, gOptional, gkOptional, initialStateOptional, cuSeqlensOptional,
+                          chunkIndicesOptional, outputFinalState, chunkSize, saveNewValue, useExp2,
+                          stateVFirst),
+                   DFX_OUT(hOut, vNewOut, finalStateOut));
+    auto uniqueExecutor = CREATE_EXECUTOR();
+    CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);
+    auto executorPtr = uniqueExecutor.get();
+    auto ret = CheckParams(params);
+    if (ret != ACLNN_SUCCESS) {
+        return ret;
+    }
+    CHECK_COND(ParamsDataContiguous(params, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "ParamsDataContiguous failed.");
+    auto result = l0op::ChunkFwdH(
+        params.k, params.w, params.u, params.gOptional, params.gkOptional, params.initialStateOptional,
+        params.cuSeqlensOptional, params.chunkIndicesOptional, params.outputFinalState, params.chunkSize,
+        params.saveNewValue, params.useExp2, params.stateVFirst,
+        params.hOut, params.vNewOut, params.finalStateOut, executorPtr);
+    CHECK_RET(result[0] != nullptr, ACLNN_ERR_PARAM_NULLPTR);
+
+    auto viewCopyResult0 = l0op::ViewCopy(result[0], params.hOut, executorPtr);
+    CHECK_RET(viewCopyResult0 != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    auto viewCopyResult1 = l0op::ViewCopy(result[1], params.vNewOut, executorPtr);
+    CHECK_RET(viewCopyResult1 != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    if (outputFinalState && params.finalStateOut != nullptr) {
+        auto viewCopyResult2 = l0op::ViewCopy(result[2], params.finalStateOut, executorPtr);
+        CHECK_RET(viewCopyResult2 != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    }
+
+    // Standard syntax, get the size of workspace needed during computation.
+    *workspaceSize = uniqueExecutor->GetWorkspaceSize();
+    uniqueExecutor.ReleaseTo(executor);
+    return ACLNN_SUCCESS;
+}
+
+
+aclnnStatus aclnnChunkFwdH(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor, aclrtStream stream)
+{
+    L2_DFX_PHASE_2(aclnnChunkFwdH);
+    CHECK_COND(CommonOpExecutorRun(workspace, workspaceSize, executor, stream) == ACLNN_SUCCESS, ACLNN_ERR_INNER,
+               "This is an error in ChunkFwdH launch aicore.");
+    return ACLNN_SUCCESS;
+}
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/op_api/aclnn_chunk_fwd_h.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/op_api/aclnn_chunk_fwd_h.h
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+#ifndef OP_API_INC_ACLNN_CHUNK_FWD_H_H
+#define OP_API_INC_ACLNN_CHUNK_FWD_H_H
+#include "aclnn/aclnn_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* function: aclnnChunkFwdHGetWorkspaceSize
+ * parameters (order aligned with chunk_fwd_h Python API):
+ * k : required
+ * w : required
+ * u : required
+ * gOptional : optional, scalar gate tensor; either gOptional or gkOptional must be non-null
+ * gkOptional : optional, key-wise gate tensor; either gOptional or gkOptional must be non-null
+ * initialStateOptional : optional
+ * outputFinalState : required
+ * chunkSize : required
+ * saveNewValue : reserved, must be true
+ * cuSeqlensOptional : optional
+ * chunkIndicesOptional : optional
+ * useExp2 : false selects exp, true selects exp2
+ * stateVFirst : whether initial/final state and h use [..., V, K] instead of [..., K, V]
+ * hOut : required
+ * vNewOut : required
+ * finalStateOut : optional
+ * workspaceSize : size of workspace(output).
+ * executor : executor context(output).
+ */
+__attribute__((visibility("default")))
+aclnnStatus aclnnChunkFwdHGetWorkspaceSize(
+    const aclTensor *k,
+    const aclTensor *w,
+    const aclTensor *u,
+    const aclTensor *gOptional,
+    const aclTensor *gkOptional,
+    const aclTensor *initialStateOptional,
+    bool outputFinalState,
+    int64_t chunkSize,
+    bool saveNewValue,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    bool useExp2,
+    bool stateVFirst,
+    const aclTensor *hOut,
+    const aclTensor *vNewOut,
+    const aclTensor *finalStateOut,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor);
+
+/* function: aclnnChunkFwdH
+ * parameters :
+ * workspace : workspace memory addr(input).
+ * workspaceSize : size of workspace(input).
+ * executor : executor context(input).
+ * stream : acl stream.
+ */
+__attribute__((visibility("default")))
+aclnnStatus aclnnChunkFwdH(
+    void *workspace,
+    uint64_t workspaceSize,
+    aclOpExecutor *executor,
+    aclrtStream stream);
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/op_api/chunk_fwd_h.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/op_api/chunk_fwd_h.cpp
@@ -13,10 +13,25 @@
 #include "opdev/make_op_executor.h"
 #include "chunk_fwd_h.h"
 
+#include <initializer_list>
+
 using namespace op;
 
 namespace l0op {
 OP_TYPE_REGISTER(ChunkFwdH);
+
+namespace {
+
+op::Shape MakeShape(std::initializer_list<int64_t> dims)
+{
+    op::Shape shape;
+    for (int64_t dim : dims) {
+        shape.AppendDim(dim);
+    }
+    return shape;
+}
+
+} // namespace
 
 const std::array<const aclTensor *, 3> ChunkFwdH(
     const aclTensor *k,
@@ -44,6 +59,10 @@ const std::array<const aclTensor *, 3> ChunkFwdH(
     const aclTensor *actualCuSeqlens = nullptr;
     if (cuSeqlensOptional) {
         actualCuSeqlens = executor->ConvertToTensor(cuSeqlensOptional, DataType::DT_INT64);
+        if (actualCuSeqlens == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "Convert cuSeqlens to tensor failed.");
+            return {nullptr, nullptr, nullptr};
+        }
         const_cast<aclTensor *>(actualCuSeqlens)->SetStorageFormat(Format::FORMAT_ND);
         const_cast<aclTensor *>(actualCuSeqlens)->SetViewFormat(Format::FORMAT_ND);
         const_cast<aclTensor *>(actualCuSeqlens)->SetOriginalFormat(Format::FORMAT_ND);
@@ -54,6 +73,10 @@ const std::array<const aclTensor *, 3> ChunkFwdH(
     const aclTensor *actualChunkIndices = nullptr;
     if (chunkIndicesOptional) {
         actualChunkIndices = executor->ConvertToTensor(chunkIndicesOptional, DataType::DT_INT64);
+        if (actualChunkIndices == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "Convert chunkIndices to tensor failed.");
+            return {nullptr, nullptr, nullptr};
+        }
         const_cast<aclTensor *>(actualChunkIndices)->SetStorageFormat(Format::FORMAT_ND);
         const_cast<aclTensor *>(actualChunkIndices)->SetViewFormat(Format::FORMAT_ND);
         const_cast<aclTensor *>(actualChunkIndices)->SetOriginalFormat(Format::FORMAT_ND);
@@ -69,9 +92,20 @@ const std::array<const aclTensor *, 3> ChunkFwdH(
     const int64_t logicalKDim = kShape.GetDim(3);
     const int64_t logicalVHeads = uShape.GetDim(1);
     const int64_t logicalVDim = uShape.GetDim(3);
+    const aclTensor *finalStateOutKernel = finalStateOut;
+    if (finalStateOutKernel == nullptr) {
+        const DataType stateType = initialStateOptional == nullptr
+                                       ? DataType::DT_FLOAT
+                                       : initialStateOptional->GetDataType();
+        finalStateOutKernel = executor->AllocTensor(MakeShape({0}), stateType, Format::FORMAT_ND);
+        if (finalStateOutKernel == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "Alloc finalStateOut placeholder failed.");
+            return {nullptr, nullptr, nullptr};
+        }
+    }
     auto ret = ADD_TO_LAUNCHER_LIST_AICORE(ChunkFwdH,
         OP_INPUT(k, w, u, g, gkOptional, initialStateOptional, actualCuSeqlens, actualChunkIndices),
-        OP_OUTPUT(hOut, vNewOut, finalStateOut),
+        OP_OUTPUT(hOut, vNewOut, finalStateOutKernel),
         OP_ATTR(outputFinalState, chunkSize, saveNewValue, useExp2, stateVFirst,
                 logicalBatch, logicalSeqlen,
                 logicalKHeads, logicalVHeads, logicalKDim, logicalVDim));

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/op_api/chunk_fwd_h.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/op_api/chunk_fwd_h.cpp
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#include "opdev/op_log.h"
+#include "opdev/op_dfx.h"
+#include "opdev/make_op_executor.h"
+#include "chunk_fwd_h.h"
+
+using namespace op;
+
+namespace l0op {
+OP_TYPE_REGISTER(ChunkFwdH);
+
+const std::array<const aclTensor *, 3> ChunkFwdH(
+    const aclTensor *k,
+    const aclTensor *w,
+    const aclTensor *u,
+    const aclTensor *g,
+    const aclTensor *gkOptional,
+    const aclTensor *initialStateOptional,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    bool outputFinalState,
+    int64_t chunkSize,
+    bool saveNewValue,
+    bool useExp2,
+    bool stateVFirst,
+    const aclTensor *hOut,
+    const aclTensor *vNewOut,
+    const aclTensor *finalStateOut,
+    aclOpExecutor *executor)
+{
+    L0_DFX(ChunkFwdH, k, w, u, g, gkOptional, initialStateOptional, cuSeqlensOptional,
+           chunkIndicesOptional, outputFinalState, chunkSize, saveNewValue, useExp2, stateVFirst,
+           hOut, vNewOut, finalStateOut);
+
+    const aclTensor *actualCuSeqlens = nullptr;
+    if (cuSeqlensOptional) {
+        actualCuSeqlens = executor->ConvertToTensor(cuSeqlensOptional, DataType::DT_INT64);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetStorageFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetViewFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetOriginalFormat(Format::FORMAT_ND);
+    } else {
+        actualCuSeqlens = nullptr;
+    }
+
+    const aclTensor *actualChunkIndices = nullptr;
+    if (chunkIndicesOptional) {
+        actualChunkIndices = executor->ConvertToTensor(chunkIndicesOptional, DataType::DT_INT64);
+        const_cast<aclTensor *>(actualChunkIndices)->SetStorageFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualChunkIndices)->SetViewFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualChunkIndices)->SetOriginalFormat(Format::FORMAT_ND);
+    } else {
+        actualChunkIndices = nullptr;
+    }
+
+    const auto &kShape = k->GetViewShape();
+    const auto &uShape = u->GetViewShape();
+    const int64_t logicalBatch = kShape.GetDim(0);
+    const int64_t logicalKHeads = kShape.GetDim(1);
+    const int64_t logicalSeqlen = kShape.GetDim(2);
+    const int64_t logicalKDim = kShape.GetDim(3);
+    const int64_t logicalVHeads = uShape.GetDim(1);
+    const int64_t logicalVDim = uShape.GetDim(3);
+    auto ret = ADD_TO_LAUNCHER_LIST_AICORE(ChunkFwdH,
+        OP_INPUT(k, w, u, g, gkOptional, initialStateOptional, actualCuSeqlens, actualChunkIndices),
+        OP_OUTPUT(hOut, vNewOut, finalStateOut),
+        OP_ATTR(outputFinalState, chunkSize, saveNewValue, useExp2, stateVFirst,
+                logicalBatch, logicalSeqlen,
+                logicalKHeads, logicalVHeads, logicalKDim, logicalVDim));
+    if (ret != ACLNN_SUCCESS) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "ADD_TO_LAUNCHER_LIST_AICORE failed.");
+        return {nullptr, nullptr, nullptr};
+    }
+    return {hOut, vNewOut, finalStateOut};
+}
+
+} // namespace l0op

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/op_api/chunk_fwd_h.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/op_api/chunk_fwd_h.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+#ifndef OP_API_INC_LEVEL0_OP_CHUNK_FWD_H_H
+#define OP_API_INC_LEVEL0_OP_CHUNK_FWD_H_H
+
+#include "opdev/op_executor.h"
+
+namespace l0op {
+const std::array<const aclTensor *, 3> ChunkFwdH(
+    const aclTensor *k,
+    const aclTensor *w,
+    const aclTensor *u,
+    const aclTensor *g,
+    const aclTensor *gkOptional,
+    const aclTensor *initialStateOptional,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    bool outputFinalState,
+    int64_t chunkSize,
+    bool saveNewValue,
+    bool useExp2,
+    bool stateVFirst,
+    const aclTensor *hOut,
+    const aclTensor *vNewOut,
+    const aclTensor *finalStateOut,
+    aclOpExecutor *executor);
+}
+
+#endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch22/chunk_fwd_h_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch22/chunk_fwd_h_cube.h
@@ -1,0 +1,602 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ */
+
+#ifndef ARCH22_CHUNK_FWD_H_CUBE_H
+#define ARCH22_CHUNK_FWD_H_CUBE_H
+
+#ifndef CATLASS_ARCH
+#define CATLASS_ARCH 2201
+#endif
+
+#include <type_traits>
+
+#include "../chunk_fwd_h_policy.h"
+#include "../chunk_fwd_h_utils.h"
+#include "catlass/arch/arch.hpp"
+#include "catlass/arch/resource.hpp"
+#include "catlass/gemm/tile/tile_copy.hpp"
+#include "catlass/gemm/tile/tile_mmad.hpp"
+#include "catlass/layout/layout.hpp"
+#include "tla/layout.hpp"
+#include "tla/tensor.hpp"
+
+namespace GDN {
+
+template <typename CompilePolicy, bool STATE_V_FIRST>
+class ChunkFwdHCubeArch22 {
+public:
+    __aicore__ inline void Init(const FwdHKernelArgs &args)
+    {
+        args_ = args;
+        coreIdx_ = AscendC::GetBlockIdx();
+        coreNum_ = AscendC::GetBlockNum();
+        hasCubeWork_ = args_.tiling.useInitialState || args_.tiling.storeFinalState ||
+            args_.tiling.seqlen > static_cast<int64_t>(FWD_H_CHUNK);
+        if (!hasCubeWork_) {
+            return;
+        }
+        InitBuffers();
+        InitEvents();
+    }
+
+    __aicore__ inline void Process()
+    {
+        const uint32_t sequenceCount = args_.tiling.isVariedLen != 0
+                                           ? static_cast<uint32_t>(args_.tiling.tokenBatch)
+                                           : static_cast<uint32_t>(args_.tiling.shapeBatch);
+        const uint32_t rounds = FwdHHeadRoundsPerSequence<CompilePolicy::GATE_MODE>(args_.tiling);
+        // 同一 sequence 的所有 head-round 绑定到同一核，round 内串行收口；
+        // ProcessWorkUnit 返回时已完成本轮 ROUND_DONE/ACK，下一轮才允许预取。
+        for (uint32_t sequence = coreIdx_; sequence < sequenceCount; sequence += coreNum_) {
+            const FwdHSequenceSpan sequenceSpan = FwdHResolveSequence(args_, sequence);
+            for (uint32_t round = 0; round < rounds; ++round) {
+                const FwdHWorkUnit unit{sequenceSpan,
+                                        FwdHBuildHeadRound<CompilePolicy::GATE_MODE>(args_.tiling,
+                                                                                      round)};
+                if (unit.sequence.chunkCount != 0 && unit.headRound.activeHeadCount != 0) {
+                    ProcessWorkUnit(unit);
+                }
+            }
+        }
+        if (hasCubeWork_) {
+            DrainEvents();
+        }
+    }
+
+private:
+    using ArchTag = Catlass::Arch::AtlasA2;
+    using PType = std::conditional_t<CompilePolicy::STATE_FP32, float, bfloat16_t>;
+    using LayoutW = Catlass::layout::RowMajor;
+    using LayoutH = std::conditional_t<STATE_V_FIRST, Catlass::layout::ColumnMajor,
+                                       Catlass::layout::RowMajor>;
+    using LayoutLeftS2 = Catlass::layout::ColumnMajor;
+    using LayoutRightS2 = Catlass::layout::RowMajor;
+    using LayoutOutput = Catlass::layout::RowMajor;
+    using TileS0 = Catlass::Gemm::Tile::PackedTileCopyTla<
+        ArchTag, bfloat16_t, LayoutW, bfloat16_t, LayoutH, PType, LayoutOutput>;
+    using TileS2 = Catlass::Gemm::Tile::PackedTileCopyTla<
+        ArchTag, bfloat16_t, LayoutLeftS2, bfloat16_t, LayoutRightS2, float, LayoutOutput>;
+    using ElementAccumulator = typename TileS2::ElementAccumulator;
+    using CopyL1ToL0AS0 = typename TileS0::CopyL1ToL0A;
+    using CopyL1ToL0BS0 = typename TileS0::CopyL1ToL0B;
+    using CopyL1ToL0AS2 = typename TileS2::CopyL1ToL0A;
+    using CopyL1ToL0BS2 = typename TileS2::CopyL1ToL0B;
+    using TileMmadS0 = Catlass::Gemm::Tile::TileMmadTla<ArchTag, bfloat16_t,
+                                                        typename TileS0::LayoutTagL1A>;
+    using TileMmadS2 = Catlass::Gemm::Tile::TileMmadTla<ArchTag, bfloat16_t,
+                                                        typename TileS2::LayoutTagL1A>;
+    template <typename Tensor>
+    using CopyGmToL1AS0 = typename TileS0::template CopyGmToL1A<Tensor>;
+    template <typename Tensor>
+    using CopyGmToL1BS0 = typename TileS0::template CopyGmToL1B<Tensor>;
+    template <typename Tensor>
+    using CopyGmToL1AS2 = typename TileS2::template CopyGmToL1A<Tensor>;
+    template <typename Tensor>
+    using CopyGmToL1BS2 = typename TileS2::template CopyGmToL1B<Tensor>;
+    template <typename Tensor>
+    using CopyL0CToGmS0 = typename TileS0::template CopyL0CToGm<Tensor>;
+    template <typename Tensor>
+    using CopyL0CToGmS2 = typename TileS2::template CopyL0CToGm<Tensor>;
+
+    static constexpr auto L1_W_LAYOUT = tla::MakeLayout<bfloat16_t, typename TileS0::LayoutTagL1A>(
+        tla::Int<FWD_H_CHUNK>{}, tla::Int<FWD_H_K>{});
+    static constexpr auto L1_H_LAYOUT = tla::MakeLayout<bfloat16_t, typename TileS0::LayoutTagL1B>(
+        tla::Int<FWD_H_K>{}, tla::Int<FWD_H_V>{});
+    static constexpr auto L1_LEFT_S2_LAYOUT =
+        tla::MakeLayout<bfloat16_t, typename TileS2::LayoutTagL1A>(
+            tla::Int<FWD_H_K>{}, tla::Int<FWD_H_CHUNK>{});
+    static constexpr auto L1_RIGHT_S2_LAYOUT =
+        tla::MakeLayout<bfloat16_t, typename TileS2::LayoutTagL1B>(
+            tla::Int<FWD_H_CHUNK>{}, tla::Int<FWD_H_V>{});
+    static constexpr uint32_t L0_SLOTS = 2;
+    static constexpr uint32_t L0A_SLOT_BYTES = FWD_H_CHUNK * FWD_H_K * sizeof(bfloat16_t);
+    static constexpr uint32_t L0B_SLOT_BYTES = FWD_H_K * FWD_H_V * sizeof(bfloat16_t);
+    static constexpr uint32_t L0C_SLOT_BYTES = FWD_H_K * FWD_H_V * sizeof(ElementAccumulator);
+
+    __aicore__ inline AscendC::TEventID WReadyEvent(uint32_t slot) const
+    {
+        return wReadyEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID WDoneEvent(uint32_t slot) const
+    {
+        return wDoneEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID HRightReadyEvent(uint32_t slot) const
+    {
+        return hRightReadyEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID HRightDoneEvent(uint32_t slot) const
+    {
+        return hRightDoneEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID L0AFreeEvent(uint32_t slot) const
+    {
+        return l0AFreeEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID L0AReadyEvent(uint32_t slot) const
+    {
+        return l0AReadyEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID L0BFreeEvent(uint32_t slot) const
+    {
+        return l0BFreeEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID L0BReadyEvent(uint32_t slot) const
+    {
+        return l0BReadyEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID FixFreeEvent(uint32_t slot) const
+    {
+        return fixFreeEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID FixDoneEvent(uint32_t slot) const
+    {
+        return fixDoneEvent_[slot];
+    }
+
+    __aicore__ inline uint64_t ScratchByteOffset(int64_t base, uint32_t slot,
+                                                  uint32_t slotBytes) const
+    {
+        return static_cast<uint64_t>(base) +
+            (static_cast<uint64_t>(coreIdx_) * FWD_H_AIC_HEAD_SLOTS + slot) * slotBytes;
+    }
+
+    __aicore__ inline void ClearL1(AscendC::LocalTensor<bfloat16_t> tensor,
+                                   uint32_t bytes) const
+    {
+        AscendC::InitConstValueParams<bfloat16_t> params(
+            1, static_cast<uint16_t>(bytes / 32U), 0, static_cast<bfloat16_t>(0));
+        AscendC::InitConstValue(tensor, params);
+    }
+
+    __aicore__ inline void InitBuffers()
+    {
+        GetTPipePtr()->InitBuffer(l1Buf_, ArchTag::L1_SIZE);
+        GetTPipePtr()->InitBuffer(l0ABuf_, ArchTag::L0A_SIZE);
+        GetTPipePtr()->InitBuffer(l0BBuf_, ArchTag::L0B_SIZE);
+        GetTPipePtr()->InitBuffer(l0CBuf_, ArchTag::L0C_SIZE);
+        GetTPipePtr()->InitBuffer(fixBuf_, ArchTag::FIXBUF_SIZE);
+        for (uint32_t slot = 0; slot < FWD_H_AIC_HEAD_SLOTS; ++slot) {
+            l1W_[slot] = l1Buf_.Get<uint8_t>()[FWD_H_L1_W_BASE + slot * FWD_H_L1_W_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
+            l1HRight_[slot] = l1Buf_.Get<uint8_t>()[FWD_H_L1_H_RIGHT_BASE + slot * FWD_H_L1_H_RIGHT_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
+            l1Kg_[slot] = l1Buf_.Get<uint8_t>()[FWD_H_L1_KG_BASE + slot * FWD_H_L1_KG_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
+        }
+        for (uint32_t slot = 0; slot < L0_SLOTS; ++slot) {
+            l0A_[slot] = l0ABuf_.Get<uint8_t>()[slot * L0A_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
+            l0B_[slot] = l0BBuf_.Get<uint8_t>()[slot * L0B_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
+            l0C_[slot] = l0CBuf_.Get<uint8_t>()[slot * L0C_SLOT_BYTES].template ReinterpretCast<ElementAccumulator>();
+        }
+    }
+
+    __aicore__ inline void InitEvents()
+    {
+        for (uint32_t slot = 0; slot < FWD_H_AIC_HEAD_SLOTS; ++slot) {
+            wReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE1_MTE2);
+            wDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_MTE1);
+            hRightReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE1_MTE2);
+            hRightDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_MTE1);
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(slot));
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(slot));
+        }
+        for (uint32_t slot = 0; slot < L0_SLOTS; ++slot) {
+            l0AFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::M_MTE1);
+            l0AReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE1_M);
+            l0BFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::M_MTE1);
+            l0BReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE1_M);
+            fixFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::FIX_M);
+            fixDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::M_FIX);
+            AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(slot));
+            AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(slot));
+            AscendC::SetFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(slot));
+        }
+    }
+
+    __aicore__ inline void DrainEvents()
+    {
+        for (uint32_t slot = 0; slot < FWD_H_AIC_HEAD_SLOTS; ++slot) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(slot));
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(slot));
+        }
+        for (uint32_t slot = 0; slot < L0_SLOTS; ++slot) {
+            AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(slot));
+            AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(slot));
+            AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(slot));
+        }
+    }
+
+    __aicore__ inline uint64_t WOffset(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                       const FwdHHeadBinding &head) const
+    {
+        return FwdHInputOffset(args_.tiling, unit.sequence.physicalBatch, head.hv,
+                               chunk.tokenBegin, FWD_H_K);
+    }
+
+    __aicore__ inline uint64_t HOffset(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                       const FwdHHeadBinding &head) const
+    {
+        return FwdHHOffset(args_.tiling, unit.sequence, head.hv, chunk.globalChunk);
+    }
+
+    __aicore__ inline void LoadStage0Head(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                          const FwdHHeadBinding &head)
+    {
+        // Stage0 搬运：W_c,h[M,K] 与 H_c,h[K,V] 分别进入四个 roundHead L1 resident 槽。
+        const uint32_t slot = head.roundHead;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(slot));
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(slot));
+        AscendC::GlobalTensor<bfloat16_t> gmW;
+        gmW.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.w) + WOffset(unit, chunk, head));
+        if (chunk.validTokens < FWD_H_CHUNK) {
+            ClearL1(l1W_[slot], FWD_H_L1_W_SLOT_BYTES);
+        }
+        auto gmWLayout = tla::MakeLayout<bfloat16_t, LayoutW>(chunk.validTokens, FWD_H_K);
+        auto tensorW = tla::MakeTensor(gmW, gmWLayout, Catlass::Arch::PositionGM{});
+        auto blockW = tla::GetTile(tensorW, tla::MakeCoord(0, 0),
+                                   tla::MakeShape(chunk.validTokens, FWD_H_K));
+        auto tensorL1W = tla::MakeTensor(l1W_[slot], L1_W_LAYOUT, Catlass::Arch::PositionL1{});
+        CopyGmToL1AS0<decltype(blockW)> copyW;
+        copyW(tensorL1W, blockW);
+
+        AscendC::GlobalTensor<bfloat16_t> gmH;
+        if (chunk.first && args_.tiling.useInitialState != 0 && !CompilePolicy::STATE_FP32) {
+            const uint64_t stateOffset = FwdHStateOffset(args_.tiling, unit.sequence.sequence,
+                                                         head.hv, 0, 0);
+            gmH.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.initialState) + stateOffset);
+        } else {
+            AscendC::CrossCoreWaitFlag<0x2, PIPE_MTE2>(
+                FwdHAicPeerFlag(FWD_H_H_READY_FLAG, head.localSlot, head.aiv));
+            gmH.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.h) + HOffset(unit, chunk, head));
+        }
+        auto gmHLayout = tla::MakeLayout<bfloat16_t, LayoutH>(FWD_H_K, FWD_H_V);
+        auto tensorH = tla::MakeTensor(gmH, gmHLayout, Catlass::Arch::PositionGM{});
+        auto blockH = tla::GetTile(tensorH, tla::MakeCoord(0, 0), tla::MakeShape(FWD_H_K, FWD_H_V));
+        auto tensorL1H = tla::MakeTensor(l1HRight_[slot], L1_H_LAYOUT, Catlass::Arch::PositionL1{});
+        CopyGmToL1BS0<decltype(blockH)> copyH;
+        copyH(tensorL1H, blockH);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(WDoneEvent(slot));
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(HRightDoneEvent(slot));
+    }
+
+    __aicore__ inline void ComputeStage0Head(const FwdHChunkSpan &chunk,
+                                             const FwdHHeadBinding &head, uint32_t pipelineSlot)
+    {
+        // Stage0 计算：Pacc=W@H；A2/A3 不支持 L0C->UB，PType 结果由 Fixpipe 写 P GM scratch。
+        const uint32_t slot = head.roundHead;
+        const uint32_t m = FwdHAlignCube(chunk.validTokens);
+        auto tensorL1W = tla::MakeTensor(l1W_[slot], L1_W_LAYOUT, Catlass::Arch::PositionL1{});
+        auto tensorL1H = tla::MakeTensor(l1HRight_[slot], L1_H_LAYOUT, Catlass::Arch::PositionL1{});
+        auto tensorL0A = tla::MakeTensor(l0A_[pipelineSlot],
+            tla::MakeLayout<bfloat16_t, typename TileS0::LayoutTagL0A>(m, FWD_H_K),
+            Catlass::Arch::PositionL0A{});
+        auto tensorL0B = tla::MakeTensor(l0B_[pipelineSlot],
+            tla::MakeLayout<bfloat16_t, typename TileS0::LayoutTagL0B>(FWD_H_K, FWD_H_V),
+            Catlass::Arch::PositionL0B{});
+        auto tensorL0C = tla::MakeTensor(l0C_[pipelineSlot], tla::MakeLayoutL0C(m, FWD_H_V),
+                                         Catlass::Arch::PositionL0C{});
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(WDoneEvent(slot));
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(HRightDoneEvent(slot));
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(pipelineSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(pipelineSlot));
+        CopyL1ToL0AS0 copyA;
+        CopyL1ToL0BS0 copyB;
+        copyA(tensorL0A, tla::GetTile(tensorL1W, tla::MakeCoord(0, 0), tla::MakeShape(m, FWD_H_K)));
+        copyB(tensorL0B, tla::GetTile(tensorL1H, tla::MakeCoord(0, 0),
+                                     tla::MakeShape(FWD_H_K, FWD_H_V)));
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(slot));
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(slot));
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0AReadyEvent(pipelineSlot));
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0BReadyEvent(pipelineSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0AReadyEvent(pipelineSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0BReadyEvent(pipelineSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(pipelineSlot));
+        TileMmadS0 mmad;
+        mmad(tensorL0C, tensorL0A, tensorL0B, true, 0b11);
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(pipelineSlot));
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(pipelineSlot));
+        AscendC::SetFlag<AscendC::HardEvent::M_FIX>(FixDoneEvent(pipelineSlot));
+        if (!chunk.first) {
+            AscendC::CrossCoreWaitFlag<0x2, PIPE_FIX>(
+                FwdHAicPeerFlag(FWD_H_P_FREE_FLAG, head.localSlot, head.aiv));
+        }
+        AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(FixDoneEvent(pipelineSlot));
+        const uint64_t pByteOffset = ScratchByteOffset(args_.tiling.vWorkspaceOffset,
+                                                       head.roundHead,
+                                                       FWD_H_TOKEN_MATRIX_FP32_BYTES);
+        AscendC::GlobalTensor<PType> gmP;
+        gmP.SetGlobalBuffer(reinterpret_cast<__gm__ PType *>(args_.workspace + pByteOffset));
+        auto tensorP = tla::MakeTensor(gmP, tla::MakeLayout<PType, LayoutOutput>(m, FWD_H_V),
+                                       Catlass::Arch::PositionGM{});
+        auto blockP = tla::GetTile(tensorP, tla::MakeCoord(0, 0),
+                                   tla::MakeShape(chunk.validTokens, FWD_H_V));
+        CopyL0CToGmS0<decltype(blockP)> copyP;
+        copyP(blockP, tensorL0C, 0b11);
+        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(
+            FwdHAicPeerFlag(FWD_H_P_READY_FLAG, head.localSlot, head.aiv));
+        AscendC::SetFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(pipelineSlot));
+    }
+
+    __aicore__ inline void RunStage0(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk)
+    {
+        // Stage0：H_c=cast_BF16(R_c)，P_c=W_c@H_c；Cube 使用 BF16 输入、FP32 累加。
+        if (chunk.first && args_.tiling.useInitialState == 0) {
+            return;
+        }
+        for (uint32_t headId = 0; headId < unit.headRound.activeHeadCount; ++headId) {
+            LoadStage0Head(unit, chunk, unit.headRound.heads[headId]);
+            if (headId > 0) {
+                ComputeStage0Head(chunk, unit.headRound.heads[headId - 1], (headId - 1) & 1U);
+            }
+        }
+        if (unit.headRound.activeHeadCount > 0) {
+            const uint32_t last = unit.headRound.activeHeadCount - 1;
+            ComputeStage0Head(chunk, unit.headRound.heads[last], last & 1U);
+        }
+    }
+
+    __aicore__ inline void LoadKg(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                  const FwdHKgBinding &binding)
+    {
+        // Stage2 搬运：按 requiredKhCount 加载当前 chunk/round 的实际 k_raw/kg，不跨 round 缓存。
+        const uint32_t slot = binding.slot;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(slot));
+        if (chunk.validTokens < FWD_H_CHUNK) {
+            ClearL1(l1Kg_[slot], FWD_H_L1_KG_SLOT_BYTES);
+        }
+        AscendC::GlobalTensor<bfloat16_t> gmKg;
+        gmKg.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.k) +
+            FwdHKOffset(args_.tiling, unit.sequence.physicalBatch, binding.kh, chunk.tokenBegin));
+        if constexpr (!STATE_V_FIRST) {
+            auto tensorGm = tla::MakeTensor(gmKg,
+                tla::MakeLayout<bfloat16_t, LayoutLeftS2>(FWD_H_K, chunk.validTokens),
+                Catlass::Arch::PositionGM{});
+            auto blockGm = tla::GetTile(tensorGm, tla::MakeCoord(0, 0),
+                                        tla::MakeShape(FWD_H_K, chunk.validTokens));
+            auto tensorL1 = tla::MakeTensor(l1Kg_[slot], L1_LEFT_S2_LAYOUT,
+                                            Catlass::Arch::PositionL1{});
+            CopyGmToL1AS2<decltype(blockGm)> copy;
+            copy(tensorL1, blockGm);
+        } else {
+            auto tensorGm = tla::MakeTensor(gmKg,
+                tla::MakeLayout<bfloat16_t, LayoutRightS2>(chunk.validTokens, FWD_H_K),
+                Catlass::Arch::PositionGM{});
+            auto blockGm = tla::GetTile(tensorGm, tla::MakeCoord(0, 0),
+                                        tla::MakeShape(chunk.validTokens, FWD_H_K));
+            auto tensorL1 = tla::MakeTensor(l1Kg_[slot], L1_RIGHT_S2_LAYOUT,
+                                            Catlass::Arch::PositionL1{});
+            CopyGmToL1BS2<decltype(blockGm)> copy;
+            copy(tensorL1, blockGm);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(WDoneEvent(slot));
+    }
+
+    __aicore__ inline void LoadRight(const FwdHChunkSpan &chunk, const FwdHHeadBinding &head)
+    {
+        const uint32_t slot = head.roundHead;
+        AscendC::CrossCoreWaitFlag<0x2, PIPE_MTE2>(
+            FwdHAicPeerFlag(FWD_H_RIGHT_READY_FLAG, head.localSlot, head.aiv));
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(slot));
+        if (chunk.validTokens < FWD_H_CHUNK) {
+            ClearL1(l1HRight_[slot], FWD_H_L1_KG_SLOT_BYTES);
+        }
+        const uint64_t rightOffset = args_.tiling.vUpdateWorkspaceOffset / sizeof(bfloat16_t) +
+            FwdHCoreSlotOffset(coreIdx_, head.roundHead, FWD_H_CHUNK * FWD_H_V);
+        AscendC::GlobalTensor<bfloat16_t> gmRight;
+        gmRight.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.workspace) + rightOffset);
+        if constexpr (!STATE_V_FIRST) {
+            auto tensorGm = tla::MakeTensor(gmRight,
+                tla::MakeLayout<bfloat16_t, LayoutRightS2>(chunk.validTokens, FWD_H_V),
+                Catlass::Arch::PositionGM{});
+            auto blockGm = tla::GetTile(tensorGm, tla::MakeCoord(0, 0),
+                                        tla::MakeShape(chunk.validTokens, FWD_H_V));
+            auto tensorL1 = tla::MakeTensor(l1HRight_[slot], L1_RIGHT_S2_LAYOUT,
+                                            Catlass::Arch::PositionL1{});
+            CopyGmToL1BS2<decltype(blockGm)> copy;
+            copy(tensorL1, blockGm);
+        } else {
+            auto tensorGm = tla::MakeTensor(gmRight,
+                tla::MakeLayout<bfloat16_t, LayoutLeftS2>(FWD_H_V, chunk.validTokens),
+                Catlass::Arch::PositionGM{});
+            auto blockGm = tla::GetTile(tensorGm, tla::MakeCoord(0, 0),
+                                        tla::MakeShape(FWD_H_V, chunk.validTokens));
+            auto tensorL1 = tla::MakeTensor(l1HRight_[slot], L1_LEFT_S2_LAYOUT,
+                                            Catlass::Arch::PositionL1{});
+            CopyGmToL1AS2<decltype(blockGm)> copy;
+            copy(tensorL1, blockGm);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(HRightDoneEvent(slot));
+    }
+
+    __aicore__ inline void ComputeStage2Head(const FwdHWorkUnit &unit,
+                                             const FwdHChunkSpan &chunk,
+                                             const FwdHHeadBinding &head,
+                                             uint32_t pipelineSlot)
+    {
+        // Stage2 计算：state_v_first=false 时 D=kg^T@right，输出 [K,V]；
+        // state_v_first=true 时交换两个输入，计算 right^T@kg，输出物理 [V,K]；
+        // A2/A3 的 FP32 D 经 Fixpipe 写 GM scratch。
+        const FwdHKgBinding &binding = unit.headRound.kg[head.kgSlot];
+        const uint32_t m = FWD_H_K;
+        const uint32_t k = FwdHAlignCube(chunk.validTokens);
+        auto tensorL0A = tla::MakeTensor(l0A_[pipelineSlot],
+            tla::MakeLayout<bfloat16_t, typename TileS2::LayoutTagL0A>(m, k),
+            Catlass::Arch::PositionL0A{});
+        auto tensorL0B = tla::MakeTensor(l0B_[pipelineSlot],
+            tla::MakeLayout<bfloat16_t, typename TileS2::LayoutTagL0B>(k, FWD_H_V),
+            Catlass::Arch::PositionL0B{});
+        auto tensorL0C = tla::MakeTensor(l0C_[pipelineSlot], tla::MakeLayoutL0C(m, FWD_H_V),
+                                         Catlass::Arch::PositionL0C{});
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(pipelineSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(pipelineSlot));
+        if (head.roundHead == binding.firstConsumer) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(WDoneEvent(binding.slot));
+        }
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(HRightDoneEvent(head.roundHead));
+        CopyL1ToL0AS2 copyA;
+        CopyL1ToL0BS2 copyB;
+        if constexpr (STATE_V_FIRST) {
+            // LoadRight 已将 GM ND right[M,V] 按 ColumnMajor 映射为 L1[V,M]，
+            // kg 保持 GM ND[M,K]，Cube 直接执行 [V,M]@[M,K] -> [V,K]。
+            auto tensorRight = tla::MakeTensor(l1HRight_[head.roundHead], L1_LEFT_S2_LAYOUT,
+                                               Catlass::Arch::PositionL1{});
+            auto tensorKg = tla::MakeTensor(l1Kg_[binding.slot], L1_RIGHT_S2_LAYOUT,
+                                            Catlass::Arch::PositionL1{});
+            copyA(tensorL0A, tla::GetTile(tensorRight, tla::MakeCoord(0, 0),
+                                          tla::MakeShape(m, k)));
+            copyB(tensorL0B, tla::GetTile(tensorKg, tla::MakeCoord(0, 0),
+                                          tla::MakeShape(k, FWD_H_V)));
+        } else {
+            auto tensorKg = tla::MakeTensor(l1Kg_[binding.slot], L1_LEFT_S2_LAYOUT,
+                                            Catlass::Arch::PositionL1{});
+            auto tensorRight = tla::MakeTensor(l1HRight_[head.roundHead], L1_RIGHT_S2_LAYOUT,
+                                               Catlass::Arch::PositionL1{});
+            copyA(tensorL0A, tla::GetTile(tensorKg, tla::MakeCoord(0, 0),
+                                          tla::MakeShape(m, k)));
+            copyB(tensorL0B, tla::GetTile(tensorRight, tla::MakeCoord(0, 0),
+                                          tla::MakeShape(k, FWD_H_V)));
+        }
+        if (head.roundHead == binding.lastConsumer) {
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(binding.slot));
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(head.roundHead));
+        AscendC::CrossCoreSetFlag<0x2, PIPE_MTE1>(
+            FwdHAicPeerFlag(FWD_H_RIGHT_FREE_FLAG, head.localSlot, head.aiv));
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0AReadyEvent(pipelineSlot));
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0BReadyEvent(pipelineSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0AReadyEvent(pipelineSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0BReadyEvent(pipelineSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(pipelineSlot));
+        TileMmadS2 mmad;
+        mmad(tensorL0C, tensorL0A, tensorL0B, true, 0b11);
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(pipelineSlot));
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(pipelineSlot));
+        AscendC::SetFlag<AscendC::HardEvent::M_FIX>(FixDoneEvent(pipelineSlot));
+        if (!chunk.first) {
+            AscendC::CrossCoreWaitFlag<0x2, PIPE_FIX>(
+                FwdHAicPeerFlag(FWD_H_D_FREE_FLAG, head.localSlot, head.aiv));
+        }
+        AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(FixDoneEvent(pipelineSlot));
+        const uint64_t dByteOffset = ScratchByteOffset(args_.tiling.hWorkspaceOffset,
+                                                       head.roundHead,
+                                                       FWD_H_STATE_FP32_BYTES);
+        AscendC::GlobalTensor<float> gmD;
+        gmD.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.workspace + dByteOffset));
+        auto tensorD = tla::MakeTensor(gmD,
+            tla::MakeLayout<float, LayoutOutput>(FWD_H_K, FWD_H_V), Catlass::Arch::PositionGM{});
+        CopyL0CToGmS2<decltype(tensorD)> copyD;
+        copyD(tensorD, tensorL0C, 0b11);
+        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(
+            FwdHAicPeerFlag(FWD_H_D_READY_FLAG, head.localSlot, head.aiv));
+        AscendC::SetFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(pipelineSlot));
+    }
+
+    __aicore__ inline void RunStage2(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk)
+    {
+        // Stage2：g-only 计算 D_c=k_raw_c^T@V_new_g；gk-only 计算 D_c=kg_c^T@V_new。
+        for (uint32_t kgSlot = 0; kgSlot < unit.headRound.requiredKhCount; ++kgSlot) {
+            LoadKg(unit, chunk, unit.headRound.kg[kgSlot]);
+        }
+        for (uint32_t headId = 0; headId < unit.headRound.activeHeadCount; ++headId) {
+            LoadRight(chunk, unit.headRound.heads[headId]);
+            if (headId > 0) {
+                ComputeStage2Head(unit, chunk, unit.headRound.heads[headId - 1], (headId - 1) & 1U);
+            }
+        }
+        if (unit.headRound.activeHeadCount > 0) {
+            const uint32_t last = unit.headRound.activeHeadCount - 1;
+            ComputeStage2Head(unit, chunk, unit.headRound.heads[last], last & 1U);
+        }
+    }
+
+    __aicore__ inline void ProcessWorkUnit(const FwdHWorkUnit &unit)
+    {
+        if (!hasCubeWork_) {
+            return;
+        }
+        for (uint32_t chunkId = 0; chunkId < unit.sequence.chunkCount; ++chunkId) {
+            const FwdHChunkSpan chunk = FwdHBuildChunk(unit.sequence, chunkId);
+            RunStage0(unit, chunk);
+            if (args_.tiling.storeFinalState != 0 || !chunk.last) {
+                RunStage2(unit, chunk);
+            }
+        }
+        const bool terminalStage2 = args_.tiling.storeFinalState != 0;
+        const bool terminalStage0 = args_.tiling.useInitialState != 0 || unit.sequence.chunkCount > 1;
+        for (uint32_t headId = 0; headId < unit.headRound.activeHeadCount; ++headId) {
+            const FwdHHeadBinding &head = unit.headRound.heads[headId];
+            if (terminalStage2) {
+                AscendC::CrossCoreWaitFlag<0x2, PIPE_FIX>(
+                    FwdHAicPeerFlag(FWD_H_D_FREE_FLAG, head.localSlot, head.aiv));
+            }
+            if (terminalStage0) {
+                AscendC::CrossCoreWaitFlag<0x2, PIPE_FIX>(
+                    FwdHAicPeerFlag(FWD_H_P_FREE_FLAG, head.localSlot, head.aiv));
+            }
+        }
+        AscendC::CrossCoreWaitFlag<0x2, PIPE_FIX>(FwdHAicPeerFlag(FWD_H_ROUND_DONE_FLAG, 0, 0));
+        AscendC::CrossCoreWaitFlag<0x2, PIPE_FIX>(FwdHAicPeerFlag(FWD_H_ROUND_DONE_FLAG, 0, 1));
+        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(FwdHAicPeerFlag(FWD_H_H_READY_FLAG, 0, 0));
+        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(FwdHAicPeerFlag(FWD_H_H_READY_FLAG, 0, 1));
+    }
+
+    FwdHKernelArgs args_{};
+    uint32_t coreIdx_ = 0;
+    uint32_t coreNum_ = 1;
+    bool hasCubeWork_ = false;
+    AscendC::TBuf<AscendC::TPosition::A1> l1Buf_{};
+    AscendC::TBuf<AscendC::TPosition::A2> l0ABuf_{};
+    AscendC::TBuf<AscendC::TPosition::B2> l0BBuf_{};
+    AscendC::TBuf<AscendC::TPosition::CO1> l0CBuf_{};
+    AscendC::TBuf<AscendC::TPosition::C2PIPE2GM> fixBuf_{};
+    AscendC::TEventID wReadyEvent_[FWD_H_AIC_HEAD_SLOTS]{};
+    AscendC::TEventID wDoneEvent_[FWD_H_AIC_HEAD_SLOTS]{};
+    AscendC::TEventID hRightReadyEvent_[FWD_H_AIC_HEAD_SLOTS]{};
+    AscendC::TEventID hRightDoneEvent_[FWD_H_AIC_HEAD_SLOTS]{};
+    AscendC::TEventID l0AFreeEvent_[L0_SLOTS]{};
+    AscendC::TEventID l0AReadyEvent_[L0_SLOTS]{};
+    AscendC::TEventID l0BFreeEvent_[L0_SLOTS]{};
+    AscendC::TEventID l0BReadyEvent_[L0_SLOTS]{};
+    AscendC::TEventID fixFreeEvent_[L0_SLOTS]{};
+    AscendC::TEventID fixDoneEvent_[L0_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> l1W_[FWD_H_AIC_HEAD_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> l1HRight_[FWD_H_AIC_HEAD_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> l1Kg_[FWD_H_AIC_HEAD_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> l0A_[L0_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> l0B_[L0_SLOTS]{};
+    AscendC::LocalTensor<ElementAccumulator> l0C_[L0_SLOTS]{};
+};
+
+} // namespace GDN
+
+#endif // ARCH22_CHUNK_FWD_H_CUBE_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch22/chunk_fwd_h_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch22/chunk_fwd_h_cube.h
@@ -49,7 +49,7 @@ public:
                                            : static_cast<uint32_t>(args_.tiling.shapeBatch);
         const uint32_t rounds = FwdHHeadRoundsPerSequence<CompilePolicy::GATE_MODE>(args_.tiling);
         // 同一 sequence 的所有 head-round 绑定到同一核，round 内串行收口；
-        // ProcessWorkUnit 返回时已完成本轮 ROUND_DONE/ACK，下一轮才允许预取。
+        // 只有存在下一轮消费者时才等待 ROUND_DONE，保证下一轮预取不越过本轮消费。
         for (uint32_t sequence = coreIdx_; sequence < sequenceCount; sequence += coreNum_) {
             const FwdHSequenceSpan sequenceSpan = FwdHResolveSequence(args_, sequence);
             for (uint32_t round = 0; round < rounds; ++round) {
@@ -57,7 +57,7 @@ public:
                                         FwdHBuildHeadRound<CompilePolicy::GATE_MODE>(args_.tiling,
                                                                                       round)};
                 if (unit.sequence.chunkCount != 0 && unit.headRound.activeHeadCount != 0) {
-                    ProcessWorkUnit(unit);
+                    ProcessWorkUnit(unit, round + 1 < rounds);
                 }
             }
         }
@@ -203,20 +203,20 @@ private:
     __aicore__ inline void InitEvents()
     {
         for (uint32_t slot = 0; slot < FWD_H_AIC_HEAD_SLOTS; ++slot) {
-            wReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE1_MTE2);
-            wDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_MTE1);
-            hRightReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE1_MTE2);
-            hRightDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_MTE1);
+            wReadyEvent_[slot] = GetTPipePtr()->AllocEventID<AscendC::HardEvent::MTE1_MTE2>();
+            wDoneEvent_[slot] = GetTPipePtr()->AllocEventID<AscendC::HardEvent::MTE2_MTE1>();
+            hRightReadyEvent_[slot] = GetTPipePtr()->AllocEventID<AscendC::HardEvent::MTE1_MTE2>();
+            hRightDoneEvent_[slot] = GetTPipePtr()->AllocEventID<AscendC::HardEvent::MTE2_MTE1>();
             AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(slot));
             AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(slot));
         }
         for (uint32_t slot = 0; slot < L0_SLOTS; ++slot) {
-            l0AFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::M_MTE1);
-            l0AReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE1_M);
-            l0BFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::M_MTE1);
-            l0BReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE1_M);
-            fixFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::FIX_M);
-            fixDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::M_FIX);
+            l0AFreeEvent_[slot] = GetTPipePtr()->AllocEventID<AscendC::HardEvent::M_MTE1>();
+            l0AReadyEvent_[slot] = GetTPipePtr()->AllocEventID<AscendC::HardEvent::MTE1_M>();
+            l0BFreeEvent_[slot] = GetTPipePtr()->AllocEventID<AscendC::HardEvent::M_MTE1>();
+            l0BReadyEvent_[slot] = GetTPipePtr()->AllocEventID<AscendC::HardEvent::MTE1_M>();
+            fixFreeEvent_[slot] = GetTPipePtr()->AllocEventID<AscendC::HardEvent::FIX_M>();
+            fixDoneEvent_[slot] = GetTPipePtr()->AllocEventID<AscendC::HardEvent::M_FIX>();
             AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(slot));
             AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(slot));
             AscendC::SetFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(slot));
@@ -233,6 +233,20 @@ private:
             AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(slot));
             AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(slot));
             AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(slot));
+        }
+        for (uint32_t slot = 0; slot < FWD_H_AIC_HEAD_SLOTS; ++slot) {
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(slot));
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::MTE2_MTE1>(WDoneEvent(slot));
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(slot));
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::MTE2_MTE1>(HRightDoneEvent(slot));
+        }
+        for (uint32_t slot = 0; slot < L0_SLOTS; ++slot) {
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(slot));
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::MTE1_M>(L0AReadyEvent(slot));
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(slot));
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::MTE1_M>(L0BReadyEvent(slot));
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::FIX_M>(FixFreeEvent(slot));
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::M_FIX>(FixDoneEvent(slot));
         }
     }
 
@@ -275,8 +289,6 @@ private:
                                                          head.hv, 0, 0);
             gmH.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.initialState) + stateOffset);
         } else {
-            AscendC::CrossCoreWaitFlag<0x2, PIPE_MTE2>(
-                FwdHAicPeerFlag(FWD_H_H_READY_FLAG, head.localSlot, head.aiv));
             gmH.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.h) + HOffset(unit, chunk, head));
         }
         auto gmHLayout = tla::MakeLayout<bfloat16_t, LayoutH>(FWD_H_K, FWD_H_V);
@@ -322,14 +334,10 @@ private:
         AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0BReadyEvent(pipelineSlot));
         AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(pipelineSlot));
         TileMmadS0 mmad;
-        mmad(tensorL0C, tensorL0A, tensorL0B, true, 0b11);
+        mmad(tensorL0C, tensorL0A, tensorL0B, true, 0);
         AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(pipelineSlot));
         AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(pipelineSlot));
         AscendC::SetFlag<AscendC::HardEvent::M_FIX>(FixDoneEvent(pipelineSlot));
-        if (!chunk.first) {
-            AscendC::CrossCoreWaitFlag<0x2, PIPE_FIX>(
-                FwdHAicPeerFlag(FWD_H_P_FREE_FLAG, head.localSlot, head.aiv));
-        }
         AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(FixDoneEvent(pipelineSlot));
         const uint64_t pByteOffset = ScratchByteOffset(args_.tiling.vWorkspaceOffset,
                                                        head.roundHead,
@@ -338,12 +346,10 @@ private:
         gmP.SetGlobalBuffer(reinterpret_cast<__gm__ PType *>(args_.workspace + pByteOffset));
         auto tensorP = tla::MakeTensor(gmP, tla::MakeLayout<PType, LayoutOutput>(m, FWD_H_V),
                                        Catlass::Arch::PositionGM{});
-        auto blockP = tla::GetTile(tensorP, tla::MakeCoord(0, 0),
-                                   tla::MakeShape(chunk.validTokens, FWD_H_V));
-        CopyL0CToGmS0<decltype(blockP)> copyP;
-        copyP(blockP, tensorL0C, 0b11);
-        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(
-            FwdHAicPeerFlag(FWD_H_P_READY_FLAG, head.localSlot, head.aiv));
+        // A2/A3 的 FP32 Fixpipe 按 16 行块写出。尾 chunk 的 W 已在 L1 补零，
+        // 因此写满对齐后的 m 行，并由 AIV 只读取 validTokens 行。
+        CopyL0CToGmS0<decltype(tensorP)> copyP;
+        copyP(tensorP, tensorL0C, 0);
         AscendC::SetFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(pipelineSlot));
     }
 
@@ -353,15 +359,33 @@ private:
         if (chunk.first && args_.tiling.useInitialState == 0) {
             return;
         }
-        for (uint32_t headId = 0; headId < unit.headRound.activeHeadCount; ++headId) {
-            LoadStage0Head(unit, chunk, unit.headRound.heads[headId]);
-            if (headId > 0) {
-                ComputeStage0Head(chunk, unit.headRound.heads[headId - 1], (headId - 1) & 1U);
+        const uint32_t pairCount = FwdHMode2PairCount(unit.headRound.activeHeadCount);
+        const bool waitHReady = !(chunk.first && args_.tiling.useInitialState != 0 &&
+                                  !CompilePolicy::STATE_FP32);
+        for (uint32_t pairSlot = 0; pairSlot < pairCount; ++pairSlot) {
+            if (waitHReady) {
+                AscendC::CrossCoreWaitFlag<0x2, PIPE_MTE2>(
+                    FwdHAicPeerFlag(FWD_H_H_READY_FLAG, pairSlot, 0));
             }
-        }
-        if (unit.headRound.activeHeadCount > 0) {
-            const uint32_t last = unit.headRound.activeHeadCount - 1;
+            if (!chunk.first) {
+                AscendC::CrossCoreWaitFlag<0x2, PIPE_FIX>(
+                    FwdHAicPeerFlag(FWD_H_P_FREE_FLAG, pairSlot, 0));
+            }
+            const uint32_t firstHead = pairSlot * 2U;
+            const uint32_t pairHeads =
+                unit.headRound.activeHeadCount - firstHead > 1U ? 2U : 1U;
+            for (uint32_t pairHead = 0; pairHead < pairHeads; ++pairHead) {
+                const uint32_t headId = firstHead + pairHead;
+                LoadStage0Head(unit, chunk, unit.headRound.heads[headId]);
+                if (pairHead > 0) {
+                    const uint32_t previous = headId - 1U;
+                    ComputeStage0Head(chunk, unit.headRound.heads[previous], previous & 1U);
+                }
+            }
+            const uint32_t last = firstHead + pairHeads - 1U;
             ComputeStage0Head(chunk, unit.headRound.heads[last], last & 1U);
+            AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(
+                FwdHAicPeerFlag(FWD_H_P_READY_FLAG, pairSlot, 0));
         }
     }
 
@@ -404,8 +428,6 @@ private:
     __aicore__ inline void LoadRight(const FwdHChunkSpan &chunk, const FwdHHeadBinding &head)
     {
         const uint32_t slot = head.roundHead;
-        AscendC::CrossCoreWaitFlag<0x2, PIPE_MTE2>(
-            FwdHAicPeerFlag(FWD_H_RIGHT_READY_FLAG, head.localSlot, head.aiv));
         AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(slot));
         if (chunk.validTokens < FWD_H_CHUNK) {
             ClearL1(l1HRight_[slot], FWD_H_L1_KG_SLOT_BYTES);
@@ -446,7 +468,7 @@ private:
         // Stage2 计算：state_v_first=false 时 D=kg^T@right，输出 [K,V]；
         // state_v_first=true 时交换两个输入，计算 right^T@kg，输出物理 [V,K]；
         // A2/A3 的 FP32 D 经 Fixpipe 写 GM scratch。
-        const FwdHKgBinding &binding = unit.headRound.kg[head.kgSlot];
+        const FwdHKgBinding binding = FwdHBuildKgBinding(unit.headRound, head.kgSlot);
         const uint32_t m = FWD_H_K;
         const uint32_t k = FwdHAlignCube(chunk.validTokens);
         auto tensorL0A = tla::MakeTensor(l0A_[pipelineSlot],
@@ -490,22 +512,16 @@ private:
             AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(binding.slot));
         }
         AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(head.roundHead));
-        AscendC::CrossCoreSetFlag<0x2, PIPE_MTE1>(
-            FwdHAicPeerFlag(FWD_H_RIGHT_FREE_FLAG, head.localSlot, head.aiv));
         AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0AReadyEvent(pipelineSlot));
         AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0BReadyEvent(pipelineSlot));
         AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0AReadyEvent(pipelineSlot));
         AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0BReadyEvent(pipelineSlot));
         AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(pipelineSlot));
         TileMmadS2 mmad;
-        mmad(tensorL0C, tensorL0A, tensorL0B, true, 0b11);
+        mmad(tensorL0C, tensorL0A, tensorL0B, true, 0);
         AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(pipelineSlot));
         AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(pipelineSlot));
         AscendC::SetFlag<AscendC::HardEvent::M_FIX>(FixDoneEvent(pipelineSlot));
-        if (!chunk.first) {
-            AscendC::CrossCoreWaitFlag<0x2, PIPE_FIX>(
-                FwdHAicPeerFlag(FWD_H_D_FREE_FLAG, head.localSlot, head.aiv));
-        }
         AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(FixDoneEvent(pipelineSlot));
         const uint64_t dByteOffset = ScratchByteOffset(args_.tiling.hWorkspaceOffset,
                                                        head.roundHead,
@@ -515,9 +531,7 @@ private:
         auto tensorD = tla::MakeTensor(gmD,
             tla::MakeLayout<float, LayoutOutput>(FWD_H_K, FWD_H_V), Catlass::Arch::PositionGM{});
         CopyL0CToGmS2<decltype(tensorD)> copyD;
-        copyD(tensorD, tensorL0C, 0b11);
-        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(
-            FwdHAicPeerFlag(FWD_H_D_READY_FLAG, head.localSlot, head.aiv));
+        copyD(tensorD, tensorL0C, 0);
         AscendC::SetFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(pipelineSlot));
     }
 
@@ -525,21 +539,37 @@ private:
     {
         // Stage2：g-only 计算 D_c=k_raw_c^T@V_new_g；gk-only 计算 D_c=kg_c^T@V_new。
         for (uint32_t kgSlot = 0; kgSlot < unit.headRound.requiredKhCount; ++kgSlot) {
-            LoadKg(unit, chunk, unit.headRound.kg[kgSlot]);
+            LoadKg(unit, chunk, FwdHBuildKgBinding(unit.headRound, kgSlot));
         }
-        for (uint32_t headId = 0; headId < unit.headRound.activeHeadCount; ++headId) {
-            LoadRight(chunk, unit.headRound.heads[headId]);
-            if (headId > 0) {
-                ComputeStage2Head(unit, chunk, unit.headRound.heads[headId - 1], (headId - 1) & 1U);
+        const uint32_t pairCount = FwdHMode2PairCount(unit.headRound.activeHeadCount);
+        for (uint32_t pairSlot = 0; pairSlot < pairCount; ++pairSlot) {
+            AscendC::CrossCoreWaitFlag<0x2, PIPE_MTE2>(
+                FwdHAicPeerFlag(FWD_H_RIGHT_READY_FLAG, pairSlot, 0));
+            if (!chunk.first) {
+                AscendC::CrossCoreWaitFlag<0x2, PIPE_FIX>(
+                    FwdHAicPeerFlag(FWD_H_D_FREE_FLAG, pairSlot, 0));
             }
-        }
-        if (unit.headRound.activeHeadCount > 0) {
-            const uint32_t last = unit.headRound.activeHeadCount - 1;
+            const uint32_t firstHead = pairSlot * 2U;
+            const uint32_t pairHeads =
+                unit.headRound.activeHeadCount - firstHead > 1U ? 2U : 1U;
+            for (uint32_t pairHead = 0; pairHead < pairHeads; ++pairHead) {
+                const uint32_t headId = firstHead + pairHead;
+                LoadRight(chunk, unit.headRound.heads[headId]);
+                if (pairHead > 0) {
+                    const uint32_t previous = headId - 1U;
+                    ComputeStage2Head(unit, chunk, unit.headRound.heads[previous], previous & 1U);
+                }
+            }
+            const uint32_t last = firstHead + pairHeads - 1U;
             ComputeStage2Head(unit, chunk, unit.headRound.heads[last], last & 1U);
+            AscendC::CrossCoreSetFlag<0x2, PIPE_MTE1>(
+                FwdHAicPeerFlag(FWD_H_RIGHT_FREE_FLAG, pairSlot, 0));
+            AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(
+                FwdHAicPeerFlag(FWD_H_D_READY_FLAG, pairSlot, 0));
         }
     }
 
-    __aicore__ inline void ProcessWorkUnit(const FwdHWorkUnit &unit)
+    __aicore__ inline void ProcessWorkUnit(const FwdHWorkUnit &unit, bool hasNextRound)
     {
         if (!hasCubeWork_) {
             return;
@@ -551,23 +581,27 @@ private:
                 RunStage2(unit, chunk);
             }
         }
-        const bool terminalStage2 = args_.tiling.storeFinalState != 0;
+        const bool terminalStage2 = args_.tiling.storeFinalState != 0 ||
+            unit.sequence.chunkCount > 1;
         const bool terminalStage0 = args_.tiling.useInitialState != 0 || unit.sequence.chunkCount > 1;
-        for (uint32_t headId = 0; headId < unit.headRound.activeHeadCount; ++headId) {
-            const FwdHHeadBinding &head = unit.headRound.heads[headId];
+        const uint32_t pairCount = FwdHMode2PairCount(unit.headRound.activeHeadCount);
+        for (uint32_t pairSlot = 0; pairSlot < pairCount; ++pairSlot) {
             if (terminalStage2) {
                 AscendC::CrossCoreWaitFlag<0x2, PIPE_FIX>(
-                    FwdHAicPeerFlag(FWD_H_D_FREE_FLAG, head.localSlot, head.aiv));
+                    FwdHAicPeerFlag(FWD_H_D_FREE_FLAG, pairSlot, 0));
             }
             if (terminalStage0) {
                 AscendC::CrossCoreWaitFlag<0x2, PIPE_FIX>(
-                    FwdHAicPeerFlag(FWD_H_P_FREE_FLAG, head.localSlot, head.aiv));
+                    FwdHAicPeerFlag(FWD_H_P_FREE_FLAG, pairSlot, 0));
             }
         }
-        AscendC::CrossCoreWaitFlag<0x2, PIPE_FIX>(FwdHAicPeerFlag(FWD_H_ROUND_DONE_FLAG, 0, 0));
-        AscendC::CrossCoreWaitFlag<0x2, PIPE_FIX>(FwdHAicPeerFlag(FWD_H_ROUND_DONE_FLAG, 0, 1));
-        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(FwdHAicPeerFlag(FWD_H_H_READY_FLAG, 0, 0));
-        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(FwdHAicPeerFlag(FWD_H_H_READY_FLAG, 0, 1));
+        if (hasNextRound) {
+            AscendC::CrossCoreWaitFlag<0x2, PIPE_FIX>(
+                FwdHAicPeerFlag(FWD_H_ROUND_DONE_FLAG, 0, 0));
+            // ACK 表示 AIC 已完成本轮消费；AIV 收到后才可复用下一轮的本地槽。
+            AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(
+                FwdHAicPeerFlag(FWD_H_ROUND_ACK_FLAG, 0, 0));
+        }
     }
 
     FwdHKernelArgs args_{};

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch22/chunk_fwd_h_vec.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch22/chunk_fwd_h_vec.h
@@ -1,0 +1,728 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ */
+
+#ifndef ARCH22_CHUNK_FWD_H_VEC_H
+#define ARCH22_CHUNK_FWD_H_VEC_H
+
+#include <type_traits>
+
+#include "../chunk_fwd_h_policy.h"
+#include "../chunk_fwd_h_utils.h"
+
+namespace GDN {
+
+constexpr float FWD_H_ARCH22_LN2 = 0.69314718055994530942f;
+
+template <typename GateT, typename CompilePolicy, bool STATE_V_FIRST>
+class ChunkFwdHVecArch22 {
+public:
+    __aicore__ inline void Init(const FwdHKernelArgs &args)
+    {
+        args_ = args;
+        coreIdx_ = AscendC::GetBlockIdx() / AscendC::GetSubBlockNum();
+        coreNum_ = AscendC::GetBlockNum();
+        aiv_ = AscendC::GetSubBlockIdx();
+        InitBuffers();
+        InitEvents();
+    }
+
+    __aicore__ inline void InitEvents()
+    {
+        for (uint32_t slot = 0; slot < FWD_H_AIV_HEAD_SLOTS; ++slot) {
+            ioFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE3_MTE2);
+            ioReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_V);
+            ioDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::V_MTE3);
+            scalarReadEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::V_S);
+            scalarWriteEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::S_V);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        }
+    }
+
+    __aicore__ inline AscendC::TEventID IoFreeEvent(uint32_t slot) const
+    {
+        return ioFreeEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID IoReadyEvent(uint32_t slot) const
+    {
+        return ioReadyEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID IoDoneEvent(uint32_t slot) const
+    {
+        return ioDoneEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID ScalarReadEvent(uint32_t slot) const
+    {
+        return scalarReadEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID ScalarWriteEvent(uint32_t slot) const
+    {
+        return scalarWriteEvent_[slot];
+    }
+
+    __aicore__ inline void Process()
+    {
+        const uint32_t sequenceCount = args_.tiling.isVariedLen != 0
+                                           ? static_cast<uint32_t>(args_.tiling.tokenBatch)
+                                           : static_cast<uint32_t>(args_.tiling.shapeBatch);
+        const uint32_t rounds = FwdHHeadRoundsPerSequence<CompilePolicy::GATE_MODE>(args_.tiling);
+        // 同一 sequence 的所有 head-round 绑定到同一核，round 内串行收口；
+        // ProcessWorkUnit 返回时已完成本轮 ROUND_DONE/ACK，下一轮才允许预取。
+        for (uint32_t sequence = coreIdx_; sequence < sequenceCount; sequence += coreNum_) {
+            const FwdHSequenceSpan sequenceSpan = FwdHResolveSequence(args_, sequence);
+            for (uint32_t round = 0; round < rounds; ++round) {
+                const FwdHWorkUnit unit{sequenceSpan,
+                                        FwdHBuildHeadRound<CompilePolicy::GATE_MODE>(args_.tiling,
+                                                                                      round)};
+                if (unit.sequence.chunkCount != 0 && unit.headRound.activeHeadCount != 0) {
+                    ProcessWorkUnit(unit);
+                }
+            }
+        }
+        for (uint32_t slot = 0; slot < FWD_H_AIV_HEAD_SLOTS; ++slot) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        }
+    }
+
+private:
+    using PType = std::conditional_t<CompilePolicy::STATE_FP32, float, bfloat16_t>;
+    static constexpr uint32_t TILE_ROWS = 8;
+    static constexpr uint32_t TILE_ELEMENTS = TILE_ROWS * FWD_H_V;
+    static constexpr uint32_t LOCAL_SLOT_BYTES = 32 * 1024;
+    static constexpr uint32_t LOCAL0_BASE = 0;
+    static constexpr uint32_t LOCAL1_BASE = LOCAL_SLOT_BYTES;
+    static constexpr uint32_t STATE0_BASE = 64 * 1024;
+    static constexpr uint32_t STATE1_BASE = 96 * 1024;
+    static constexpr uint32_t RAW_BASE = 0;
+    static constexpr uint32_t CAST_BASE = 4 * 1024;
+    static constexpr uint32_t CALC_BASE = 8 * 1024;
+    static constexpr uint32_t IO_BASE = 12 * 1024;
+    static constexpr uint32_t RIGHT_BASE = 14 * 1024;
+    static constexpr uint32_t GATE_RAW_BASE = 16 * 1024;
+    static constexpr uint32_t GATE_FP32_BASE = 17 * 1024;
+    static constexpr uint32_t ALPHA_BASE = 18 * 1024;
+    static constexpr uint32_t SHARE_BASE = 19 * 1024;
+
+    __aicore__ inline uint32_t LocalBase(uint32_t slot) const
+    {
+        return slot == 0 ? LOCAL0_BASE : LOCAL1_BASE;
+    }
+
+    __aicore__ inline uint32_t TileRows(uint32_t rows) const
+    {
+        return rows < TILE_ROWS ? rows : TILE_ROWS;
+    }
+
+    __aicore__ inline void InitBuffers()
+    {
+        GetTPipePtr()->InitBuffer(ubBuf_, 192 * 1024);
+        AscendC::LocalTensor<uint8_t> ub = ubBuf_.Get<uint8_t>();
+        for (uint32_t slot = 0; slot < FWD_H_AIV_HEAD_SLOTS; ++slot) {
+            const uint32_t base = LocalBase(slot);
+            raw_[slot] = ub[base + RAW_BASE].template ReinterpretCast<uint8_t>();
+            cast_[slot] = ub[base + CAST_BASE].template ReinterpretCast<float>();
+            calc_[slot] = ub[base + CALC_BASE].template ReinterpretCast<float>();
+            io_[slot] = ub[base + IO_BASE].template ReinterpretCast<bfloat16_t>();
+            right_[slot] = ub[base + RIGHT_BASE].template ReinterpretCast<bfloat16_t>();
+            gateRaw_[slot] = ub[base + GATE_RAW_BASE].template ReinterpretCast<GateT>();
+            gateFp32_[slot] = ub[base + GATE_FP32_BASE].template ReinterpretCast<float>();
+            alpha_[slot] = ub[base + ALPHA_BASE].template ReinterpretCast<float>();
+            share_[slot] = ub[base + SHARE_BASE].template ReinterpretCast<uint8_t>();
+        }
+        stateBf16_[0] = ub[STATE0_BASE].template ReinterpretCast<bfloat16_t>();
+        stateBf16_[1] = ub[STATE1_BASE].template ReinterpretCast<bfloat16_t>();
+    }
+
+    __aicore__ inline uint64_t UOffset(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                       const FwdHHeadBinding &head, uint32_t row) const
+    {
+        return FwdHInputOffset(args_.tiling, unit.sequence.physicalBatch, head.hv,
+                               chunk.tokenBegin + row, FWD_H_V);
+    }
+
+    __aicore__ inline uint64_t GateOffset(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                          const FwdHHeadBinding &head) const
+    {
+        const uint32_t dim = CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G ? 1 : FWD_H_K;
+        return FwdHInputOffset(args_.tiling, unit.sequence.physicalBatch, head.hv,
+                               chunk.tokenBegin, dim);
+    }
+
+    __aicore__ inline uint64_t HOffset(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                       const FwdHHeadBinding &head) const
+    {
+        return FwdHHOffset(args_.tiling, unit.sequence, head.hv, chunk.globalChunk);
+    }
+
+    __aicore__ inline uint64_t ScratchByteOffset(int64_t base, uint32_t slot,
+                                                  uint32_t slotBytes) const
+    {
+        return static_cast<uint64_t>(base) +
+            (static_cast<uint64_t>(coreIdx_) * FWD_H_AIC_HEAD_SLOTS + slot) * slotBytes;
+    }
+
+    __aicore__ inline float ReadScalar(const AscendC::LocalTensor<float> &tensor,
+                                       uint32_t index, uint32_t slot) const
+    {
+        AscendC::SetFlag<AscendC::HardEvent::V_S>(ScalarReadEvent(slot));
+        AscendC::WaitFlag<AscendC::HardEvent::V_S>(ScalarReadEvent(slot));
+        const float value = tensor.GetValue(index);
+        AscendC::SetFlag<AscendC::HardEvent::S_V>(ScalarWriteEvent(slot));
+        AscendC::WaitFlag<AscendC::HardEvent::S_V>(ScalarWriteEvent(slot));
+        return value;
+    }
+
+    __aicore__ inline void PrepareScalarGate(uint32_t slot, uint32_t validTokens)
+    {
+        if constexpr (std::is_same<GateT, float>::value) {
+            AscendC::Adds(gateFp32_[slot], gateRaw_[slot], 0.0f, validTokens);
+        } else {
+            AscendC::Cast(gateFp32_[slot], gateRaw_[slot], AscendC::RoundMode::CAST_NONE,
+                          validTokens);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        const float last = ReadScalar(gateFp32_[slot], validTokens - 1, slot);
+        AscendC::Duplicate(cast_[slot], last, validTokens);
+        AscendC::Sub(gateFp32_[slot], cast_[slot], gateFp32_[slot], validTokens);
+        AscendC::Duplicate(alpha_[slot], last, 1);
+        if constexpr (CompilePolicy::USE_EXP2) {
+            AscendC::Muls(gateFp32_[slot], gateFp32_[slot], FWD_H_ARCH22_LN2, validTokens);
+            AscendC::Muls(alpha_[slot], alpha_[slot], FWD_H_ARCH22_LN2, 1);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Exp(gateFp32_[slot], gateFp32_[slot], validTokens);
+        AscendC::Exp(alpha_[slot], alpha_[slot], 1);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void PrepareKeyGate(uint32_t slot)
+    {
+        if constexpr (std::is_same<GateT, float>::value) {
+            AscendC::Adds(gateFp32_[slot], gateRaw_[slot], 0.0f, FWD_H_K);
+        } else {
+            AscendC::Cast(gateFp32_[slot], gateRaw_[slot], AscendC::RoundMode::CAST_NONE,
+                          FWD_H_K);
+        }
+        if constexpr (CompilePolicy::USE_EXP2) {
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Muls(gateFp32_[slot], gateFp32_[slot], FWD_H_ARCH22_LN2, FWD_H_K);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Exp(gateFp32_[slot], gateFp32_[slot], FWD_H_K);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void RunSMinusOne(const FwdHWorkUnit &unit)
+    {
+        // S-1：StateT=FP32 且存在 initial_state 时，逐 tile 执行 H0=cast_BF16(R0)，
+        // GM 物理顺序原生遵循 state_v_first，不依赖外部转置。
+        if constexpr (!CompilePolicy::STATE_FP32) {
+            return;
+        }
+        if (args_.tiling.useInitialState == 0) {
+            return;
+        }
+        AscendC::GlobalTensor<float> initial;
+        AscendC::GlobalTensor<bfloat16_t> h;
+        initial.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.initialState));
+        h.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.h));
+        const uint32_t localHeads = FwdHAivHeadCount(unit.headRound.activeHeadCount, aiv_);
+        for (uint32_t coreHeadId = 0; coreHeadId < localHeads; ++coreHeadId) {
+            const FwdHHeadBinding &head = unit.headRound.heads[aiv_ + 2 * coreHeadId];
+            const uint32_t slot = head.localSlot;
+            const uint64_t stateBase = FwdHStateOffset(args_.tiling, unit.sequence.sequence,
+                                                       head.hv, 0, 0);
+            const FwdHChunkSpan first = FwdHBuildChunk(unit.sequence, 0);
+            for (uint32_t row = 0; row < FWD_H_K; row += TILE_ROWS) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+                AscendC::DataCopy(calc_[slot], initial[stateBase + row * FWD_H_V], TILE_ELEMENTS);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+                AscendC::Cast(io_[slot], calc_[slot], AscendC::RoundMode::CAST_RINT, TILE_ELEMENTS);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+                AscendC::DataCopy(h[HOffset(unit, first, head) + row * FWD_H_V],
+                                  io_[slot], TILE_ELEMENTS);
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+            }
+            AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(
+                FwdHAivLocalFlag(FWD_H_H_READY_FLAG, slot));
+        }
+    }
+
+    template <bool HAS_P>
+    __aicore__ inline void PrefetchStage1Head(const FwdHWorkUnit &unit,
+                                              const FwdHChunkSpan &chunk,
+                                              const FwdHHeadBinding &head)
+    {
+        const uint32_t slot = head.localSlot;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        AscendC::GlobalTensor<bfloat16_t> u;
+        u.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.u));
+        const uint32_t firstRows = TileRows(chunk.validTokens);
+        AscendC::DataCopy(io_[slot], u[UOffset(unit, chunk, head, 0)], firstRows * FWD_H_V);
+        if constexpr (HAS_P) {
+            AscendC::CrossCoreWaitFlag<0x2, PIPE_MTE2>(
+                FwdHAivLocalFlag(FWD_H_P_READY_FLAG, slot));
+            const uint64_t pByteOffset = ScratchByteOffset(args_.tiling.vWorkspaceOffset,
+                                                           head.roundHead,
+                                                           FWD_H_TOKEN_MATRIX_FP32_BYTES);
+            AscendC::GlobalTensor<PType> p;
+            p.SetGlobalBuffer(reinterpret_cast<__gm__ PType *>(args_.workspace + pByteOffset));
+            AscendC::LocalTensor<PType> rawP = raw_[slot].template ReinterpretCast<PType>();
+            AscendC::DataCopy(rawP, p, firstRows * FWD_H_V);
+        }
+        if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G) {
+            if (args_.tiling.storeFinalState != 0 || !chunk.last) {
+                AscendC::GlobalTensor<GateT> gate;
+                gate.SetGlobalBuffer(reinterpret_cast<__gm__ GateT *>(args_.g));
+                AscendC::DataCopy(gateRaw_[slot], gate[GateOffset(unit, chunk, head)], chunk.validTokens);
+            }
+        }
+        if (chunk.first && !CompilePolicy::STATE_FP32 && args_.tiling.useInitialState != 0) {
+            AscendC::GlobalTensor<bfloat16_t> initial;
+            initial.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.initialState));
+            const uint64_t offset = FwdHStateOffset(args_.tiling, unit.sequence.sequence,
+                                                    head.hv, 0, 0);
+            AscendC::DataCopy(stateBf16_[slot], initial[offset], FWD_H_K * FWD_H_V);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+    }
+
+    template <bool HAS_P>
+    __aicore__ inline void LoadStage1Tile(const FwdHWorkUnit &unit,
+                                          const FwdHChunkSpan &chunk,
+                                          const FwdHHeadBinding &head,
+                                          uint32_t row)
+    {
+        const uint32_t slot = head.localSlot;
+        const uint32_t rows = TileRows(chunk.validTokens - row);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        AscendC::GlobalTensor<bfloat16_t> u;
+        u.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.u));
+        AscendC::DataCopy(io_[slot], u[UOffset(unit, chunk, head, row)], rows * FWD_H_V);
+        if constexpr (HAS_P) {
+            const uint64_t pByteOffset = ScratchByteOffset(args_.tiling.vWorkspaceOffset,
+                                                           head.roundHead,
+                                                           FWD_H_TOKEN_MATRIX_FP32_BYTES);
+            AscendC::GlobalTensor<PType> p;
+            p.SetGlobalBuffer(reinterpret_cast<__gm__ PType *>(args_.workspace + pByteOffset));
+            AscendC::LocalTensor<PType> rawP = raw_[slot].template ReinterpretCast<PType>();
+            AscendC::DataCopy(rawP, p[row * FWD_H_V], rows * FWD_H_V);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+    }
+
+    template <bool HAS_P, bool WRITE_RIGHT>
+    __aicore__ inline void ComputeStage1Tile(const FwdHWorkUnit &unit,
+                                             const FwdHChunkSpan &chunk,
+                                             const FwdHHeadBinding &head,
+                                             uint32_t row)
+    {
+        const uint32_t slot = head.localSlot;
+        const uint32_t rows = TileRows(chunk.validTokens - row);
+        const uint32_t elements = rows * FWD_H_V;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+        AscendC::Cast(calc_[slot], io_[slot], AscendC::RoundMode::CAST_NONE, elements);
+        if constexpr (HAS_P) {
+            if constexpr (std::is_same<PType, float>::value) {
+                AscendC::Sub(calc_[slot], calc_[slot], raw_[slot].template ReinterpretCast<float>(), elements);
+            } else {
+                AscendC::Cast(cast_[slot], raw_[slot].template ReinterpretCast<bfloat16_t>(),
+                              AscendC::RoundMode::CAST_NONE, elements);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Sub(calc_[slot], calc_[slot], cast_[slot], elements);
+            }
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Cast(io_[slot], calc_[slot], AscendC::RoundMode::CAST_RINT, elements);
+        if constexpr (WRITE_RIGHT) {
+            if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G) {
+                uint32_t dstShape[2] = {rows, FWD_H_V};
+                uint32_t srcShape[2] = {rows, 1};
+                AscendC::Broadcast<float, 2, 1>(
+                    raw_[slot].template ReinterpretCast<float>(), gateFp32_[slot][row],
+                    dstShape, srcShape, share_[slot]);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Mul(calc_[slot], calc_[slot],
+                             raw_[slot].template ReinterpretCast<float>(), elements);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Cast(right_[slot], calc_[slot], AscendC::RoundMode::CAST_RINT, elements);
+            }
+        }
+
+        AscendC::GlobalTensor<bfloat16_t> vNew;
+        vNew.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.vNew));
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+        AscendC::DataCopy(vNew[UOffset(unit, chunk, head, row)], io_[slot], elements);
+        if constexpr (WRITE_RIGHT) {
+            const uint64_t rightOffset = args_.tiling.vUpdateWorkspaceOffset / sizeof(bfloat16_t) +
+                FwdHCoreSlotOffset(coreIdx_, head.roundHead, FWD_H_CHUNK * FWD_H_V) +
+                row * FWD_H_V;
+            AscendC::GlobalTensor<bfloat16_t> rightGm;
+            rightGm.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.workspace));
+            if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G) {
+                AscendC::DataCopy(rightGm[rightOffset], right_[slot], elements);
+            } else {
+                AscendC::DataCopy(rightGm[rightOffset], io_[slot], elements);
+            }
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+    }
+
+    template <bool HAS_P, bool WRITE_RIGHT>
+    __aicore__ inline void ConsumeStage1Head(const FwdHWorkUnit &unit,
+                                             const FwdHChunkSpan &chunk,
+                                             const FwdHHeadBinding &head)
+    {
+        // Stage1：V_new=cast_BF16(fp32(U)-fp32(P))；g-only 同时生成
+        // V_new_g=cast_BF16(E(g_last-g_i)*V_new_fp32)，gk-only 的 right 即 V_new。
+        const uint32_t slot = head.localSlot;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+        if constexpr (WRITE_RIGHT && CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G) {
+            PrepareScalarGate(slot, chunk.validTokens);
+        }
+        if (chunk.first && args_.tiling.useInitialState == 0) {
+            AscendC::Duplicate(stateBf16_[slot], static_cast<bfloat16_t>(0), FWD_H_K * FWD_H_V);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+        ComputeStage1Tile<HAS_P, WRITE_RIGHT>(unit, chunk, head, 0);
+        for (uint32_t row = TILE_ROWS; row < chunk.validTokens; row += TILE_ROWS) {
+            LoadStage1Tile<HAS_P>(unit, chunk, head, row);
+            ComputeStage1Tile<HAS_P, WRITE_RIGHT>(unit, chunk, head, row);
+        }
+        if constexpr (HAS_P) {
+            AscendC::CrossCoreSetFlag<0x2, PIPE_V>(FwdHAivLocalFlag(FWD_H_P_FREE_FLAG, slot));
+        }
+        if constexpr (WRITE_RIGHT) {
+            AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(
+                FwdHAivLocalFlag(FWD_H_RIGHT_READY_FLAG, slot));
+        }
+        if (chunk.first && (!CompilePolicy::STATE_FP32 || args_.tiling.useInitialState == 0)) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+            AscendC::GlobalTensor<bfloat16_t> h;
+            h.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.h));
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+            AscendC::DataCopy(h[HOffset(unit, chunk, head)], stateBf16_[slot], FWD_H_K * FWD_H_V);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        }
+    }
+
+    __aicore__ inline void RunStage1(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk)
+    {
+        // Stage1：V_new=cast_BF16(fp32(U)-fp32(P))；g-only 同时生成
+        // V_new_g=cast_BF16(E(g_last-g_i)*V_new_fp32)，gk-only 的右矩阵就是 V_new。
+        const bool hasP = !(chunk.first && args_.tiling.useInitialState == 0);
+        const bool writeRight = args_.tiling.storeFinalState != 0 || !chunk.last;
+        const uint32_t localHeads = FwdHAivHeadCount(unit.headRound.activeHeadCount, aiv_);
+        for (uint32_t coreHeadId = 0; coreHeadId < localHeads; ++coreHeadId) {
+            const FwdHHeadBinding &head = unit.headRound.heads[aiv_ + 2 * coreHeadId];
+            if (hasP) {
+                PrefetchStage1Head<true>(unit, chunk, head);
+            } else {
+                PrefetchStage1Head<false>(unit, chunk, head);
+            }
+            if (coreHeadId > 0) {
+                const FwdHHeadBinding &previous = unit.headRound.heads[aiv_ + 2 * (coreHeadId - 1)];
+                DispatchStage1(unit, chunk, previous, hasP, writeRight);
+            }
+        }
+        if (localHeads > 0) {
+            DispatchStage1(unit, chunk, unit.headRound.heads[aiv_ + 2 * (localHeads - 1)],
+                           hasP, writeRight);
+        }
+    }
+
+    __aicore__ inline void DispatchStage1(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                          const FwdHHeadBinding &head, bool hasP, bool writeRight)
+    {
+        if (hasP) {
+            writeRight ? ConsumeStage1Head<true, true>(unit, chunk, head)
+                       : ConsumeStage1Head<true, false>(unit, chunk, head);
+        } else {
+            writeRight ? ConsumeStage1Head<false, true>(unit, chunk, head)
+                       : ConsumeStage1Head<false, false>(unit, chunk, head);
+        }
+    }
+
+    __aicore__ inline void PrefetchStage3Head(const FwdHWorkUnit &unit,
+                                              const FwdHChunkSpan &chunk,
+                                              const FwdHHeadBinding &head)
+    {
+        const uint32_t slot = head.localSlot;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        AscendC::CrossCoreWaitFlag<0x2, PIPE_MTE2>(
+            FwdHAivLocalFlag(FWD_H_D_READY_FLAG, slot));
+        const uint64_t dByteOffset = ScratchByteOffset(args_.tiling.hWorkspaceOffset,
+                                                       head.roundHead,
+                                                       FWD_H_STATE_FP32_BYTES);
+        AscendC::GlobalTensor<float> d;
+        d.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.workspace + dByteOffset));
+        AscendC::DataCopy(raw_[slot].template ReinterpretCast<float>(), d, TILE_ELEMENTS);
+        if constexpr (CompilePolicy::STATE_FP32) {
+            AscendC::GlobalTensor<float> state;
+            uint64_t offset = 0;
+            if (chunk.first && args_.tiling.useInitialState != 0) {
+                state.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.initialState));
+                offset = FwdHStateOffset(args_.tiling, unit.sequence.sequence, head.hv, 0, 0);
+            } else {
+                state.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.workspace));
+                offset = args_.tiling.kDecayWorkspaceOffset / sizeof(float) +
+                    FwdHCoreSlotOffset(coreIdx_, head.roundHead, FWD_H_K * FWD_H_V);
+            }
+            if (!(chunk.first && args_.tiling.useInitialState == 0)) {
+                AscendC::DataCopy(calc_[slot], state[offset], TILE_ELEMENTS);
+            }
+        }
+        if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::KEY_GK) {
+            AscendC::GlobalTensor<GateT> gk;
+            gk.SetGlobalBuffer(reinterpret_cast<__gm__ GateT *>(args_.gk));
+            const uint64_t offset = GateOffset(unit, chunk, head) +
+                static_cast<uint64_t>(chunk.validTokens - 1) * FWD_H_K;
+            AscendC::DataCopy(gateRaw_[slot], gk[offset], FWD_H_K);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+    }
+
+    __aicore__ inline void LoadStage3Tile(const FwdHWorkUnit &unit,
+                                          const FwdHChunkSpan &chunk,
+                                          const FwdHHeadBinding &head,
+                                          uint32_t row)
+    {
+        const uint32_t slot = head.localSlot;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        const uint64_t dByteOffset = ScratchByteOffset(args_.tiling.hWorkspaceOffset,
+                                                       head.roundHead,
+                                                       FWD_H_STATE_FP32_BYTES);
+        AscendC::GlobalTensor<float> d;
+        d.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.workspace + dByteOffset));
+        AscendC::DataCopy(raw_[slot].template ReinterpretCast<float>(),
+                          d[row * FWD_H_V], TILE_ELEMENTS);
+        if constexpr (CompilePolicy::STATE_FP32) {
+            AscendC::GlobalTensor<float> state;
+            if (chunk.first) {
+                state.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.initialState));
+            } else {
+                state.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.workspace));
+            }
+            if (!(chunk.first && args_.tiling.useInitialState == 0)) {
+                const uint64_t base = chunk.first
+                    ? FwdHStateOffset(args_.tiling, unit.sequence.sequence, head.hv, 0, 0)
+                    : args_.tiling.kDecayWorkspaceOffset / sizeof(float) +
+                        FwdHCoreSlotOffset(coreIdx_, head.roundHead, FWD_H_K * FWD_H_V);
+                AscendC::DataCopy(calc_[slot], state[base + row * FWD_H_V], TILE_ELEMENTS);
+            }
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+    }
+
+    template <bool WRITE_H>
+    __aicore__ inline void ComputeStage3Tile(const FwdHWorkUnit &unit,
+                                             const FwdHChunkSpan &chunk,
+                                             const FwdHHeadBinding &head,
+                                             uint32_t row)
+    {
+        const uint32_t slot = head.localSlot;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+        if constexpr (CompilePolicy::STATE_FP32) {
+            if (chunk.first && args_.tiling.useInitialState == 0) {
+                AscendC::Duplicate(calc_[slot], 0.0f, TILE_ELEMENTS);
+            }
+        }
+        if constexpr (!CompilePolicy::STATE_FP32) {
+            AscendC::Cast(calc_[slot], stateBf16_[slot][row * FWD_H_V],
+                          AscendC::RoundMode::CAST_NONE, TILE_ELEMENTS);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G) {
+            const float factor = ReadScalar(alpha_[slot], 0, slot);
+            AscendC::Muls(calc_[slot], calc_[slot], factor, TILE_ELEMENTS);
+        } else if constexpr (STATE_V_FIRST) {
+            for (uint32_t localRow = 0; localRow < TILE_ROWS; ++localRow) {
+                AscendC::Mul(calc_[slot][localRow * FWD_H_V],
+                             calc_[slot][localRow * FWD_H_V], gateFp32_[slot], FWD_H_V);
+            }
+        } else {
+            uint32_t dstShape[2] = {TILE_ROWS, FWD_H_V};
+            uint32_t srcShape[2] = {TILE_ROWS, 1};
+            AscendC::Broadcast<float, 2, 1>(cast_[slot], gateFp32_[slot][row],
+                                            dstShape, srcShape, share_[slot]);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Mul(calc_[slot], calc_[slot], cast_[slot], TILE_ELEMENTS);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Add(calc_[slot], calc_[slot],
+                     raw_[slot].template ReinterpretCast<float>(), TILE_ELEMENTS);
+        AscendC::PipeBarrier<PIPE_V>();
+        if constexpr (CompilePolicy::STATE_FP32) {
+            AscendC::GlobalTensor<float> state;
+            state.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.workspace));
+            const uint64_t stateOffset = args_.tiling.kDecayWorkspaceOffset / sizeof(float) +
+                FwdHCoreSlotOffset(coreIdx_, head.roundHead, FWD_H_K * FWD_H_V) + row * FWD_H_V;
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+            AscendC::DataCopy(state[stateOffset], calc_[slot], TILE_ELEMENTS);
+            if constexpr (!WRITE_H) {
+                if (args_.tiling.storeFinalState != 0) {
+                    AscendC::GlobalTensor<float> finalState;
+                    finalState.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.finalState));
+                    const uint64_t finalOffset = FwdHStateOffset(
+                        args_.tiling, unit.sequence.sequence, head.hv, 0, 0) + row * FWD_H_V;
+                    AscendC::DataCopy(finalState[finalOffset], calc_[slot], TILE_ELEMENTS);
+                }
+            }
+        } else {
+            AscendC::Cast(stateBf16_[slot][row * FWD_H_V], calc_[slot],
+                          AscendC::RoundMode::CAST_RINT, TILE_ELEMENTS);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+        if constexpr (WRITE_H) {
+            AscendC::Cast(io_[slot], calc_[slot], AscendC::RoundMode::CAST_RINT, TILE_ELEMENTS);
+            AscendC::GlobalTensor<bfloat16_t> h;
+            h.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.h));
+            const FwdHChunkSpan next = FwdHBuildChunk(unit.sequence, chunk.chunk + 1);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+            AscendC::DataCopy(h[HOffset(unit, next, head) + row * FWD_H_V], io_[slot], TILE_ELEMENTS);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+    }
+
+    template <bool WRITE_H>
+    __aicore__ inline void ConsumeStage3Head(const FwdHWorkUnit &unit,
+                                             const FwdHChunkSpan &chunk,
+                                             const FwdHHeadBinding &head)
+    {
+        // Stage3：g-only 为 R_next=E(g_last)R+D；gk-only 为
+        // R_next[k,v]=E(gk_last[k])R[k,v]+D[k,v]，所有算术均为 FP32。
+        const uint32_t slot = head.localSlot;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+        if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::KEY_GK) {
+            PrepareKeyGate(slot);
+        }
+        ComputeStage3Tile<WRITE_H>(unit, chunk, head, 0);
+        for (uint32_t row = TILE_ROWS; row < FWD_H_K; row += TILE_ROWS) {
+            LoadStage3Tile(unit, chunk, head, row);
+            ComputeStage3Tile<WRITE_H>(unit, chunk, head, row);
+        }
+        AscendC::CrossCoreSetFlag<0x2, PIPE_V>(FwdHAivLocalFlag(FWD_H_D_FREE_FLAG, slot));
+        if constexpr (WRITE_H) {
+            AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(
+                FwdHAivLocalFlag(FWD_H_H_READY_FLAG, slot));
+        } else if (args_.tiling.storeFinalState != 0) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+            const uint64_t finalOffset = FwdHStateOffset(args_.tiling, unit.sequence.sequence,
+                                                         head.hv, 0, 0);
+            if constexpr (!CompilePolicy::STATE_FP32) {
+                AscendC::GlobalTensor<bfloat16_t> finalState;
+                finalState.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.finalState));
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+                AscendC::DataCopy(finalState[finalOffset], stateBf16_[slot], FWD_H_K * FWD_H_V);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        }
+    }
+
+    __aicore__ inline void RunStage3(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk)
+    {
+        // Stage3：g-only 为 R_next=E(g_last)R+D；gk-only 为
+        // R_next[k,v]=E(gk_last[k])R[k,v]+D[k,v]，并按需生成下一 H 或 final_state。
+        const bool writeH = !chunk.last;
+        const uint32_t localHeads = FwdHAivHeadCount(unit.headRound.activeHeadCount, aiv_);
+        for (uint32_t coreHeadId = 0; coreHeadId < localHeads; ++coreHeadId) {
+            const FwdHHeadBinding &head = unit.headRound.heads[aiv_ + 2 * coreHeadId];
+            PrefetchStage3Head(unit, chunk, head);
+            if (coreHeadId > 0) {
+                const FwdHHeadBinding &previous = unit.headRound.heads[aiv_ + 2 * (coreHeadId - 1)];
+                writeH ? ConsumeStage3Head<true>(unit, chunk, previous)
+                       : ConsumeStage3Head<false>(unit, chunk, previous);
+            }
+        }
+        if (localHeads > 0) {
+            const FwdHHeadBinding &last = unit.headRound.heads[aiv_ + 2 * (localHeads - 1)];
+            writeH ? ConsumeStage3Head<true>(unit, chunk, last)
+                   : ConsumeStage3Head<false>(unit, chunk, last);
+        }
+    }
+
+    __aicore__ inline void ProcessWorkUnit(const FwdHWorkUnit &unit)
+    {
+        const bool hasCubeWork = args_.tiling.useInitialState || args_.tiling.storeFinalState ||
+            args_.tiling.seqlen > static_cast<int64_t>(FWD_H_CHUNK);
+        const uint32_t localHeads = FwdHAivHeadCount(unit.headRound.activeHeadCount, aiv_);
+        if (args_.tiling.useInitialState == 0 && unit.sequence.chunkCount > 1) {
+            // 首 chunk 没有 Stage0/P 消费链。为第二个 chunk 的 Stage0 提供一次 P scratch
+            // 初始 free credit；后续 chunk 的 credit 都由前一 chunk 的 Stage1 产生。
+            for (uint32_t slot = 0; slot < localHeads; ++slot) {
+                AscendC::CrossCoreSetFlag<0x2, PIPE_V>(
+                    FwdHAivLocalFlag(FWD_H_P_FREE_FLAG, slot));
+            }
+        }
+        RunSMinusOne(unit);
+        for (uint32_t chunkId = 0; chunkId < unit.sequence.chunkCount; ++chunkId) {
+            const FwdHChunkSpan chunk = FwdHBuildChunk(unit.sequence, chunkId);
+            if (chunkId > 0) {
+                for (uint32_t slot = 0; slot < localHeads; ++slot) {
+                    AscendC::CrossCoreWaitFlag<0x2, PIPE_V>(
+                        FwdHAivLocalFlag(FWD_H_RIGHT_FREE_FLAG, slot));
+                }
+            }
+            RunStage1(unit, chunk);
+            if (args_.tiling.storeFinalState != 0 || !chunk.last) {
+                RunStage3(unit, chunk);
+            }
+        }
+        if (args_.tiling.storeFinalState != 0) {
+            for (uint32_t slot = 0; slot < localHeads; ++slot) {
+                AscendC::CrossCoreWaitFlag<0x2, PIPE_V>(
+                    FwdHAivLocalFlag(FWD_H_RIGHT_FREE_FLAG, slot));
+            }
+        }
+        // 跨 head_round 前必须把本轮所有 VEC->MTE3 写回收口。AIC 收到 ROUND_DONE 后
+        // 才能开始下一轮 kg/H/W 的 MTE2，避免上一轮 MTE3 与下一轮预取跨 round 交叠。
+        for (uint32_t slot = 0; slot < localHeads; ++slot) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        }
+        if (hasCubeWork) {
+            AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(FwdHAivLocalFlag(FWD_H_ROUND_DONE_FLAG, 0));
+            AscendC::CrossCoreWaitFlag<0x2, PIPE_V>(FwdHAivLocalFlag(FWD_H_H_READY_FLAG, 0));
+        }
+    }
+
+    FwdHKernelArgs args_{};
+    uint32_t coreIdx_ = 0;
+    uint32_t coreNum_ = 1;
+    uint32_t aiv_ = 0;
+    AscendC::TEventID ioFreeEvent_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::TEventID ioReadyEvent_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::TEventID ioDoneEvent_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::TEventID scalarReadEvent_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::TEventID scalarWriteEvent_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::TBuf<AscendC::TPosition::VECCALC> ubBuf_{};
+    AscendC::LocalTensor<uint8_t> raw_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::LocalTensor<float> cast_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::LocalTensor<float> calc_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> io_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> right_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::LocalTensor<GateT> gateRaw_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::LocalTensor<float> gateFp32_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::LocalTensor<float> alpha_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::LocalTensor<uint8_t> share_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> stateBf16_[FWD_H_AIV_HEAD_SLOTS]{};
+};
+
+} // namespace GDN
+
+#endif // ARCH22_CHUNK_FWD_H_VEC_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch22/chunk_fwd_h_vec.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch22/chunk_fwd_h_vec.h
@@ -32,11 +32,11 @@ public:
     __aicore__ inline void InitEvents()
     {
         for (uint32_t slot = 0; slot < FWD_H_AIV_HEAD_SLOTS; ++slot) {
-            ioFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE3_MTE2);
-            ioReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_V);
-            ioDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::V_MTE3);
-            scalarReadEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::V_S);
-            scalarWriteEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::S_V);
+            ioFreeEvent_[slot] = GetTPipePtr()->AllocEventID<AscendC::HardEvent::MTE3_MTE2>();
+            ioReadyEvent_[slot] = GetTPipePtr()->AllocEventID<AscendC::HardEvent::MTE2_V>();
+            ioDoneEvent_[slot] = GetTPipePtr()->AllocEventID<AscendC::HardEvent::V_MTE3>();
+            scalarReadEvent_[slot] = GetTPipePtr()->AllocEventID<AscendC::HardEvent::V_S>();
+            scalarWriteEvent_[slot] = GetTPipePtr()->AllocEventID<AscendC::HardEvent::S_V>();
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
         }
     }
@@ -73,7 +73,7 @@ public:
                                            : static_cast<uint32_t>(args_.tiling.shapeBatch);
         const uint32_t rounds = FwdHHeadRoundsPerSequence<CompilePolicy::GATE_MODE>(args_.tiling);
         // 同一 sequence 的所有 head-round 绑定到同一核，round 内串行收口；
-        // ProcessWorkUnit 返回时已完成本轮 ROUND_DONE/ACK，下一轮才允许预取。
+        // 本轮写回收口后才向 AIC 发布 ROUND_DONE，允许其开始下一轮预取。
         for (uint32_t sequence = coreIdx_; sequence < sequenceCount; sequence += coreNum_) {
             const FwdHSequenceSpan sequenceSpan = FwdHResolveSequence(args_, sequence);
             for (uint32_t round = 0; round < rounds; ++round) {
@@ -81,12 +81,19 @@ public:
                                         FwdHBuildHeadRound<CompilePolicy::GATE_MODE>(args_.tiling,
                                                                                       round)};
                 if (unit.sequence.chunkCount != 0 && unit.headRound.activeHeadCount != 0) {
-                    ProcessWorkUnit(unit);
+                    ProcessWorkUnit(unit, round + 1 < rounds);
                 }
             }
         }
         for (uint32_t slot = 0; slot < FWD_H_AIV_HEAD_SLOTS; ++slot) {
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        }
+        for (uint32_t slot = 0; slot < FWD_H_AIV_HEAD_SLOTS; ++slot) {
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::V_S>(ScalarReadEvent(slot));
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::S_V>(ScalarWriteEvent(slot));
         }
     }
 
@@ -189,9 +196,11 @@ private:
         AscendC::PipeBarrier<PIPE_V>();
         const float last = ReadScalar(gateFp32_[slot], validTokens - 1, slot);
         AscendC::Duplicate(cast_[slot], last, validTokens);
+        AscendC::PipeBarrier<PIPE_V>();
         AscendC::Sub(gateFp32_[slot], cast_[slot], gateFp32_[slot], validTokens);
         AscendC::Duplicate(alpha_[slot], last, 1);
         if constexpr (CompilePolicy::USE_EXP2) {
+            AscendC::PipeBarrier<PIPE_V>();
             AscendC::Muls(gateFp32_[slot], gateFp32_[slot], FWD_H_ARCH22_LN2, validTokens);
             AscendC::Muls(alpha_[slot], alpha_[slot], FWD_H_ARCH22_LN2, 1);
         }
@@ -232,27 +241,29 @@ private:
         AscendC::GlobalTensor<bfloat16_t> h;
         initial.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.initialState));
         h.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.h));
-        const uint32_t localHeads = FwdHAivHeadCount(unit.headRound.activeHeadCount, aiv_);
-        for (uint32_t coreHeadId = 0; coreHeadId < localHeads; ++coreHeadId) {
-            const FwdHHeadBinding &head = unit.headRound.heads[aiv_ + 2 * coreHeadId];
-            const uint32_t slot = head.localSlot;
-            const uint64_t stateBase = FwdHStateOffset(args_.tiling, unit.sequence.sequence,
-                                                       head.hv, 0, 0);
-            const FwdHChunkSpan first = FwdHBuildChunk(unit.sequence, 0);
-            for (uint32_t row = 0; row < FWD_H_K; row += TILE_ROWS) {
-                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
-                AscendC::DataCopy(calc_[slot], initial[stateBase + row * FWD_H_V], TILE_ELEMENTS);
-                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
-                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
-                AscendC::Cast(io_[slot], calc_[slot], AscendC::RoundMode::CAST_RINT, TILE_ELEMENTS);
-                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
-                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
-                AscendC::DataCopy(h[HOffset(unit, first, head) + row * FWD_H_V],
-                                  io_[slot], TILE_ELEMENTS);
-                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        const uint32_t pairCount = FwdHMode2PairCount(unit.headRound.activeHeadCount);
+        for (uint32_t pairSlot = 0; pairSlot < pairCount; ++pairSlot) {
+            if (FwdHMode2PairHasHead(unit.headRound.activeHeadCount, pairSlot, aiv_)) {
+                const FwdHHeadBinding &head = unit.headRound.heads[pairSlot * 2U + aiv_];
+                const uint32_t slot = head.localSlot;
+                const uint64_t stateBase = FwdHStateOffset(args_.tiling, unit.sequence.sequence,
+                                                           head.hv, 0, 0);
+                const FwdHChunkSpan first = FwdHBuildChunk(unit.sequence, 0);
+                for (uint32_t row = 0; row < FWD_H_K; row += TILE_ROWS) {
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+                    AscendC::DataCopy(calc_[slot], initial[stateBase + row * FWD_H_V], TILE_ELEMENTS);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+                    AscendC::Cast(io_[slot], calc_[slot], AscendC::RoundMode::CAST_RINT, TILE_ELEMENTS);
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+                    AscendC::DataCopy(h[HOffset(unit, first, head) + row * FWD_H_V],
+                                      io_[slot], TILE_ELEMENTS);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+                }
             }
             AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(
-                FwdHAivLocalFlag(FWD_H_H_READY_FLAG, slot));
+                FwdHAivLocalFlag(FWD_H_H_READY_FLAG, pairSlot));
         }
     }
 
@@ -268,8 +279,6 @@ private:
         const uint32_t firstRows = TileRows(chunk.validTokens);
         AscendC::DataCopy(io_[slot], u[UOffset(unit, chunk, head, 0)], firstRows * FWD_H_V);
         if constexpr (HAS_P) {
-            AscendC::CrossCoreWaitFlag<0x2, PIPE_MTE2>(
-                FwdHAivLocalFlag(FWD_H_P_READY_FLAG, slot));
             const uint64_t pByteOffset = ScratchByteOffset(args_.tiling.vWorkspaceOffset,
                                                            head.roundHead,
                                                            FWD_H_TOKEN_MATRIX_FP32_BYTES);
@@ -282,7 +291,10 @@ private:
             if (args_.tiling.storeFinalState != 0 || !chunk.last) {
                 AscendC::GlobalTensor<GateT> gate;
                 gate.SetGlobalBuffer(reinterpret_cast<__gm__ GateT *>(args_.g));
-                AscendC::DataCopy(gateRaw_[slot], gate[GateOffset(unit, chunk, head)], chunk.validTokens);
+                AscendC::DataCopyPadExtParams<GateT> pad{false, 0, 0, 0};
+                const uint32_t gateBytes = static_cast<uint32_t>(chunk.validTokens * sizeof(GateT));
+                AscendC::DataCopyExtParams copy{1, gateBytes, 0, 0, 0};
+                AscendC::DataCopyPad(gateRaw_[slot], gate[GateOffset(unit, chunk, head)], copy, pad);
             }
         }
         if (chunk.first && !CompilePolicy::STATE_FP32 && args_.tiling.useInitialState != 0) {
@@ -319,7 +331,7 @@ private:
         AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
     }
 
-    template <bool HAS_P, bool WRITE_RIGHT>
+    template <bool HAS_P, bool WRITE_RIGHT, bool WAIT_READY>
     __aicore__ inline void ComputeStage1Tile(const FwdHWorkUnit &unit,
                                              const FwdHChunkSpan &chunk,
                                              const FwdHHeadBinding &head,
@@ -328,8 +340,11 @@ private:
         const uint32_t slot = head.localSlot;
         const uint32_t rows = TileRows(chunk.validTokens - row);
         const uint32_t elements = rows * FWD_H_V;
-        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+        if constexpr (WAIT_READY) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+        }
         AscendC::Cast(calc_[slot], io_[slot], AscendC::RoundMode::CAST_NONE, elements);
+        AscendC::PipeBarrier<PIPE_V>();
         if constexpr (HAS_P) {
             if constexpr (std::is_same<PType, float>::value) {
                 AscendC::Sub(calc_[slot], calc_[slot], raw_[slot].template ReinterpretCast<float>(), elements);
@@ -386,7 +401,6 @@ private:
         // V_new_g=cast_BF16(E(g_last-g_i)*V_new_fp32)，gk-only 的 right 即 V_new。
         const uint32_t slot = head.localSlot;
         AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
-        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
         if constexpr (WRITE_RIGHT && CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G) {
             PrepareScalarGate(slot, chunk.validTokens);
         }
@@ -394,17 +408,10 @@ private:
             AscendC::Duplicate(stateBf16_[slot], static_cast<bfloat16_t>(0), FWD_H_K * FWD_H_V);
             AscendC::PipeBarrier<PIPE_V>();
         }
-        ComputeStage1Tile<HAS_P, WRITE_RIGHT>(unit, chunk, head, 0);
+        ComputeStage1Tile<HAS_P, WRITE_RIGHT, false>(unit, chunk, head, 0);
         for (uint32_t row = TILE_ROWS; row < chunk.validTokens; row += TILE_ROWS) {
             LoadStage1Tile<HAS_P>(unit, chunk, head, row);
-            ComputeStage1Tile<HAS_P, WRITE_RIGHT>(unit, chunk, head, row);
-        }
-        if constexpr (HAS_P) {
-            AscendC::CrossCoreSetFlag<0x2, PIPE_V>(FwdHAivLocalFlag(FWD_H_P_FREE_FLAG, slot));
-        }
-        if constexpr (WRITE_RIGHT) {
-            AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(
-                FwdHAivLocalFlag(FWD_H_RIGHT_READY_FLAG, slot));
+            ComputeStage1Tile<HAS_P, WRITE_RIGHT, true>(unit, chunk, head, row);
         }
         if (chunk.first && (!CompilePolicy::STATE_FP32 || args_.tiling.useInitialState == 0)) {
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
@@ -423,22 +430,50 @@ private:
         // V_new_g=cast_BF16(E(g_last-g_i)*V_new_fp32)，gk-only 的右矩阵就是 V_new。
         const bool hasP = !(chunk.first && args_.tiling.useInitialState == 0);
         const bool writeRight = args_.tiling.storeFinalState != 0 || !chunk.last;
-        const uint32_t localHeads = FwdHAivHeadCount(unit.headRound.activeHeadCount, aiv_);
-        for (uint32_t coreHeadId = 0; coreHeadId < localHeads; ++coreHeadId) {
-            const FwdHHeadBinding &head = unit.headRound.heads[aiv_ + 2 * coreHeadId];
-            if (hasP) {
-                PrefetchStage1Head<true>(unit, chunk, head);
-            } else {
-                PrefetchStage1Head<false>(unit, chunk, head);
+        const uint32_t pairCount = FwdHMode2PairCount(unit.headRound.activeHeadCount);
+        for (uint32_t pairSlot = 0; pairSlot < pairCount; ++pairSlot) {
+            if (hasP && pairSlot > 0) {
+                // A2/A3 的跨核 wait 会阻塞全部流水；先消费已 ready 的 ping，不能让它
+                // 等待下一个 pair 的 P_READY。无 P 时保留 pong MTE2 与 ping VEC 的重叠。
+                CompleteStage1Pair(unit, chunk, pairSlot - 1U, hasP, writeRight);
             }
-            if (coreHeadId > 0) {
-                const FwdHHeadBinding &previous = unit.headRound.heads[aiv_ + 2 * (coreHeadId - 1)];
-                DispatchStage1(unit, chunk, previous, hasP, writeRight);
+            if (hasP) {
+                AscendC::CrossCoreWaitFlag<0x2, PIPE_MTE2>(
+                    FwdHAivLocalFlag(FWD_H_P_READY_FLAG, pairSlot));
+            }
+            if (FwdHMode2PairHasHead(unit.headRound.activeHeadCount, pairSlot, aiv_)) {
+                const FwdHHeadBinding &head = unit.headRound.heads[pairSlot * 2U + aiv_];
+                if (hasP) {
+                    PrefetchStage1Head<true>(unit, chunk, head);
+                } else {
+                    PrefetchStage1Head<false>(unit, chunk, head);
+                }
+            }
+            if (!hasP && pairSlot > 0) {
+                CompleteStage1Pair(unit, chunk, pairSlot - 1U, hasP, writeRight);
             }
         }
-        if (localHeads > 0) {
-            DispatchStage1(unit, chunk, unit.headRound.heads[aiv_ + 2 * (localHeads - 1)],
-                           hasP, writeRight);
+        if (pairCount > 0) {
+            CompleteStage1Pair(unit, chunk, pairCount - 1U, hasP, writeRight);
+        }
+    }
+
+    __aicore__ inline void CompleteStage1Pair(const FwdHWorkUnit &unit,
+                                              const FwdHChunkSpan &chunk,
+                                              uint32_t pairSlot, bool hasP,
+                                              bool writeRight)
+    {
+        if (FwdHMode2PairHasHead(unit.headRound.activeHeadCount, pairSlot, aiv_)) {
+            const FwdHHeadBinding &head = unit.headRound.heads[pairSlot * 2U + aiv_];
+            DispatchStage1(unit, chunk, head, hasP, writeRight);
+        }
+        if (hasP) {
+            AscendC::CrossCoreSetFlag<0x2, PIPE_V>(
+                FwdHAivLocalFlag(FWD_H_P_FREE_FLAG, pairSlot));
+        }
+        if (writeRight) {
+            AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(
+                FwdHAivLocalFlag(FWD_H_RIGHT_READY_FLAG, pairSlot));
         }
     }
 
@@ -460,8 +495,6 @@ private:
     {
         const uint32_t slot = head.localSlot;
         AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
-        AscendC::CrossCoreWaitFlag<0x2, PIPE_MTE2>(
-            FwdHAivLocalFlag(FWD_H_D_READY_FLAG, slot));
         const uint64_t dByteOffset = ScratchByteOffset(args_.tiling.hWorkspaceOffset,
                                                        head.roundHead,
                                                        FWD_H_STATE_FP32_BYTES);
@@ -525,14 +558,16 @@ private:
         AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
     }
 
-    template <bool WRITE_H>
+    template <bool WRITE_H, bool WAIT_READY>
     __aicore__ inline void ComputeStage3Tile(const FwdHWorkUnit &unit,
                                              const FwdHChunkSpan &chunk,
                                              const FwdHHeadBinding &head,
                                              uint32_t row)
     {
         const uint32_t slot = head.localSlot;
-        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+        if constexpr (WAIT_READY) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+        }
         if constexpr (CompilePolicy::STATE_FP32) {
             if (chunk.first && args_.tiling.useInitialState == 0) {
                 AscendC::Duplicate(calc_[slot], 0.0f, TILE_ELEMENTS);
@@ -584,6 +619,12 @@ private:
             AscendC::Cast(stateBf16_[slot][row * FWD_H_V], calc_[slot],
                           AscendC::RoundMode::CAST_RINT, TILE_ELEMENTS);
             AscendC::PipeBarrier<PIPE_V>();
+            if constexpr (!WRITE_H) {
+                // Terminal BF16 state has no per-tile MTE3 copy. Bridge V to MTE3 before
+                // releasing the slot so the next MTE2 cannot overwrite raw_ early.
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+            }
         }
         if constexpr (WRITE_H) {
             AscendC::Cast(io_[slot], calc_[slot], AscendC::RoundMode::CAST_RINT, TILE_ELEMENTS);
@@ -606,31 +647,45 @@ private:
         // R_next[k,v]=E(gk_last[k])R[k,v]+D[k,v]，所有算术均为 FP32。
         const uint32_t slot = head.localSlot;
         AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
-        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
         if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::KEY_GK) {
             PrepareKeyGate(slot);
         }
-        ComputeStage3Tile<WRITE_H>(unit, chunk, head, 0);
+        ComputeStage3Tile<WRITE_H, false>(unit, chunk, head, 0);
         for (uint32_t row = TILE_ROWS; row < FWD_H_K; row += TILE_ROWS) {
             LoadStage3Tile(unit, chunk, head, row);
-            ComputeStage3Tile<WRITE_H>(unit, chunk, head, row);
+            ComputeStage3Tile<WRITE_H, true>(unit, chunk, head, row);
         }
-        AscendC::CrossCoreSetFlag<0x2, PIPE_V>(FwdHAivLocalFlag(FWD_H_D_FREE_FLAG, slot));
-        if constexpr (WRITE_H) {
-            AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(
-                FwdHAivLocalFlag(FWD_H_H_READY_FLAG, slot));
-        } else if (args_.tiling.storeFinalState != 0) {
-            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
-            const uint64_t finalOffset = FwdHStateOffset(args_.tiling, unit.sequence.sequence,
-                                                         head.hv, 0, 0);
-            if constexpr (!CompilePolicy::STATE_FP32) {
-                AscendC::GlobalTensor<bfloat16_t> finalState;
-                finalState.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.finalState));
-                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
-                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
-                AscendC::DataCopy(finalState[finalOffset], stateBf16_[slot], FWD_H_K * FWD_H_V);
+        if constexpr (!WRITE_H) {
+            if (args_.tiling.storeFinalState != 0) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+                const uint64_t finalOffset = FwdHStateOffset(args_.tiling, unit.sequence.sequence,
+                                                             head.hv, 0, 0);
+                if constexpr (!CompilePolicy::STATE_FP32) {
+                    AscendC::GlobalTensor<bfloat16_t> finalState;
+                    finalState.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.finalState));
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+                    AscendC::DataCopy(finalState[finalOffset], stateBf16_[slot], FWD_H_K * FWD_H_V);
+                }
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
             }
-            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        }
+    }
+
+    __aicore__ inline void CompleteStage3Pair(const FwdHWorkUnit &unit,
+                                              const FwdHChunkSpan &chunk,
+                                              uint32_t pairSlot, bool writeH)
+    {
+        if (FwdHMode2PairHasHead(unit.headRound.activeHeadCount, pairSlot, aiv_)) {
+            const FwdHHeadBinding &head = unit.headRound.heads[pairSlot * 2U + aiv_];
+            writeH ? ConsumeStage3Head<true>(unit, chunk, head)
+                   : ConsumeStage3Head<false>(unit, chunk, head);
+        }
+        AscendC::CrossCoreSetFlag<0x2, PIPE_V>(
+            FwdHAivLocalFlag(FWD_H_D_FREE_FLAG, pairSlot));
+        if (writeH) {
+            AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(
+                FwdHAivLocalFlag(FWD_H_H_READY_FLAG, pairSlot));
         }
     }
 
@@ -639,43 +694,45 @@ private:
         // Stage3：g-only 为 R_next=E(g_last)R+D；gk-only 为
         // R_next[k,v]=E(gk_last[k])R[k,v]+D[k,v]，并按需生成下一 H 或 final_state。
         const bool writeH = !chunk.last;
-        const uint32_t localHeads = FwdHAivHeadCount(unit.headRound.activeHeadCount, aiv_);
-        for (uint32_t coreHeadId = 0; coreHeadId < localHeads; ++coreHeadId) {
-            const FwdHHeadBinding &head = unit.headRound.heads[aiv_ + 2 * coreHeadId];
-            PrefetchStage3Head(unit, chunk, head);
-            if (coreHeadId > 0) {
-                const FwdHHeadBinding &previous = unit.headRound.heads[aiv_ + 2 * (coreHeadId - 1)];
-                writeH ? ConsumeStage3Head<true>(unit, chunk, previous)
-                       : ConsumeStage3Head<false>(unit, chunk, previous);
+        const uint32_t pairCount = FwdHMode2PairCount(unit.headRound.activeHeadCount);
+        for (uint32_t pairSlot = 0; pairSlot < pairCount; ++pairSlot) {
+            if (pairSlot > 0) {
+                // 先消费已完成 MTE2 的 ping，再等待下一 pair 的 D_READY。
+                CompleteStage3Pair(unit, chunk, pairSlot - 1U, writeH);
+            }
+            AscendC::CrossCoreWaitFlag<0x2, PIPE_MTE2>(
+                FwdHAivLocalFlag(FWD_H_D_READY_FLAG, pairSlot));
+            if (FwdHMode2PairHasHead(unit.headRound.activeHeadCount, pairSlot, aiv_)) {
+                const FwdHHeadBinding &head = unit.headRound.heads[pairSlot * 2U + aiv_];
+                PrefetchStage3Head(unit, chunk, head);
             }
         }
-        if (localHeads > 0) {
-            const FwdHHeadBinding &last = unit.headRound.heads[aiv_ + 2 * (localHeads - 1)];
-            writeH ? ConsumeStage3Head<true>(unit, chunk, last)
-                   : ConsumeStage3Head<false>(unit, chunk, last);
+        if (pairCount > 0) {
+            CompleteStage3Pair(unit, chunk, pairCount - 1U, writeH);
         }
     }
 
-    __aicore__ inline void ProcessWorkUnit(const FwdHWorkUnit &unit)
+    __aicore__ inline void ProcessWorkUnit(const FwdHWorkUnit &unit, bool hasNextRound)
     {
         const bool hasCubeWork = args_.tiling.useInitialState || args_.tiling.storeFinalState ||
             args_.tiling.seqlen > static_cast<int64_t>(FWD_H_CHUNK);
         const uint32_t localHeads = FwdHAivHeadCount(unit.headRound.activeHeadCount, aiv_);
+        const uint32_t pairCount = FwdHMode2PairCount(unit.headRound.activeHeadCount);
         if (args_.tiling.useInitialState == 0 && unit.sequence.chunkCount > 1) {
             // 首 chunk 没有 Stage0/P 消费链。为第二个 chunk 的 Stage0 提供一次 P scratch
             // 初始 free credit；后续 chunk 的 credit 都由前一 chunk 的 Stage1 产生。
-            for (uint32_t slot = 0; slot < localHeads; ++slot) {
+            for (uint32_t pairSlot = 0; pairSlot < pairCount; ++pairSlot) {
                 AscendC::CrossCoreSetFlag<0x2, PIPE_V>(
-                    FwdHAivLocalFlag(FWD_H_P_FREE_FLAG, slot));
+                    FwdHAivLocalFlag(FWD_H_P_FREE_FLAG, pairSlot));
             }
         }
         RunSMinusOne(unit);
         for (uint32_t chunkId = 0; chunkId < unit.sequence.chunkCount; ++chunkId) {
             const FwdHChunkSpan chunk = FwdHBuildChunk(unit.sequence, chunkId);
             if (chunkId > 0) {
-                for (uint32_t slot = 0; slot < localHeads; ++slot) {
+                for (uint32_t pairSlot = 0; pairSlot < pairCount; ++pairSlot) {
                     AscendC::CrossCoreWaitFlag<0x2, PIPE_V>(
-                        FwdHAivLocalFlag(FWD_H_RIGHT_FREE_FLAG, slot));
+                        FwdHAivLocalFlag(FWD_H_RIGHT_FREE_FLAG, pairSlot));
                 }
             }
             RunStage1(unit, chunk);
@@ -684,9 +741,9 @@ private:
             }
         }
         if (args_.tiling.storeFinalState != 0) {
-            for (uint32_t slot = 0; slot < localHeads; ++slot) {
+            for (uint32_t pairSlot = 0; pairSlot < pairCount; ++pairSlot) {
                 AscendC::CrossCoreWaitFlag<0x2, PIPE_V>(
-                    FwdHAivLocalFlag(FWD_H_RIGHT_FREE_FLAG, slot));
+                    FwdHAivLocalFlag(FWD_H_RIGHT_FREE_FLAG, pairSlot));
             }
         }
         // 跨 head_round 前必须把本轮所有 VEC->MTE3 写回收口。AIC 收到 ROUND_DONE 后
@@ -695,9 +752,9 @@ private:
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
         }
-        if (hasCubeWork) {
+        if (hasCubeWork && hasNextRound) {
             AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(FwdHAivLocalFlag(FWD_H_ROUND_DONE_FLAG, 0));
-            AscendC::CrossCoreWaitFlag<0x2, PIPE_V>(FwdHAivLocalFlag(FWD_H_H_READY_FLAG, 0));
+            AscendC::CrossCoreWaitFlag<0x2, PIPE_V>(FwdHAivLocalFlag(FWD_H_ROUND_ACK_FLAG, 0));
         }
     }
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch35/chunk_fwd_h_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch35/chunk_fwd_h_cube.h
@@ -39,7 +39,6 @@ public:
         if (!hasCubeWork_) {
             return;
         }
-        InitBuffers();
         InitEvents();
     }
 
@@ -50,7 +49,7 @@ public:
                                            : static_cast<uint32_t>(args_.tiling.shapeBatch);
         const uint32_t rounds = FwdHHeadRoundsPerSequence<CompilePolicy::GATE_MODE>(args_.tiling);
         // 同一 sequence 的所有 head-round 绑定到同一核，round 内串行收口；
-        // ProcessWorkUnit 返回时已完成本轮 ROUND_DONE/ACK，下一轮才允许预取。
+        // 只有存在下一轮消费者时才等待 ROUND_DONE，保证下一轮预取不越过本轮消费。
         for (uint32_t sequence = coreIdx_; sequence < sequenceCount; sequence += coreNum_) {
             const FwdHSequenceSpan sequenceSpan = FwdHResolveSequence(args_, sequence);
             for (uint32_t round = 0; round < rounds; ++round) {
@@ -58,7 +57,7 @@ public:
                                         FwdHBuildHeadRound<CompilePolicy::GATE_MODE>(args_.tiling,
                                                                                       round)};
                 if (unit.sequence.chunkCount != 0 && unit.headRound.activeHeadCount != 0) {
-                    ProcessWorkUnit(unit);
+                    ProcessWorkUnit(unit, round + 1 < rounds);
                 }
             }
         }
@@ -121,93 +120,125 @@ private:
     static constexpr uint32_t L0B_SLOT_BYTES = FWD_H_K * FWD_H_V * sizeof(bfloat16_t);
     static constexpr uint32_t L0C_SLOT_BYTES = FWD_H_K * FWD_H_V * sizeof(ElementAccumulator);
 
+    // 每种 HardEvent 拥有独立的事件空间，因此反向事件可以复用同一数值 ID。
+    // MTE1<->MTE2：W 使用 0..3，H/right 使用 4..7；MTE1<->M：L0A 使用
+    // 0..1、L0B 使用 2..3；M<->FIX：两个流水槽使用 0..1。
     __aicore__ inline AscendC::TEventID WReadyEvent(uint32_t slot) const
     {
-        return wReadyEvent_[slot];
+        return static_cast<AscendC::TEventID>(slot);
     }
 
     __aicore__ inline AscendC::TEventID WDoneEvent(uint32_t slot) const
     {
-        return wDoneEvent_[slot];
+        return static_cast<AscendC::TEventID>(slot);
     }
 
     __aicore__ inline AscendC::TEventID HRightReadyEvent(uint32_t slot) const
     {
-        return hRightReadyEvent_[slot];
+        return static_cast<AscendC::TEventID>(FWD_H_AIC_HEAD_SLOTS + slot);
     }
 
     __aicore__ inline AscendC::TEventID HRightDoneEvent(uint32_t slot) const
     {
-        return hRightDoneEvent_[slot];
+        return static_cast<AscendC::TEventID>(FWD_H_AIC_HEAD_SLOTS + slot);
     }
 
     __aicore__ inline AscendC::TEventID L0AFreeEvent(uint32_t slot) const
     {
-        return l0AFreeEvent_[slot];
+        return static_cast<AscendC::TEventID>(slot);
     }
 
     __aicore__ inline AscendC::TEventID L0AReadyEvent(uint32_t slot) const
     {
-        return l0AReadyEvent_[slot];
+        return static_cast<AscendC::TEventID>(slot);
     }
 
     __aicore__ inline AscendC::TEventID L0BFreeEvent(uint32_t slot) const
     {
-        return l0BFreeEvent_[slot];
+        return static_cast<AscendC::TEventID>(L0_SLOTS + slot);
     }
 
     __aicore__ inline AscendC::TEventID L0BReadyEvent(uint32_t slot) const
     {
-        return l0BReadyEvent_[slot];
+        return static_cast<AscendC::TEventID>(L0_SLOTS + slot);
     }
 
     __aicore__ inline AscendC::TEventID FixFreeEvent(uint32_t slot) const
     {
-        return fixFreeEvent_[slot];
+        return static_cast<AscendC::TEventID>(slot);
     }
 
     __aicore__ inline AscendC::TEventID FixDoneEvent(uint32_t slot) const
     {
-        return fixDoneEvent_[slot];
+        return static_cast<AscendC::TEventID>(slot);
     }
 
-    __aicore__ inline void InitBuffers()
+    __aicore__ inline AscendC::LocalTensor<uint8_t> L1Buffer() const
     {
-        GetTPipePtr()->InitBuffer(l1Buf_, ArchTag::L1_SIZE);
-        GetTPipePtr()->InitBuffer(l0ABuf_, ArchTag::L0A_SIZE);
-        GetTPipePtr()->InitBuffer(l0BBuf_, ArchTag::L0B_SIZE);
-        GetTPipePtr()->InitBuffer(l0CBuf_, ArchTag::L0C_SIZE);
-        GetTPipePtr()->InitBuffer(ubBuf_, ArchTag::UB_SIZE);
-        GetTPipePtr()->InitBuffer(fixBuf_, ArchTag::FIXBUF_SIZE);
-        for (uint32_t slot = 0; slot < FWD_H_AIC_HEAD_SLOTS; ++slot) {
-            l1W_[slot] = l1Buf_.Get<uint8_t>()[FWD_H_L1_W_BASE + slot * FWD_H_L1_W_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
-            l1HRight_[slot] = l1Buf_.Get<uint8_t>()[FWD_H_L1_H_RIGHT_BASE + slot * FWD_H_L1_H_RIGHT_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
-            l1Kg_[slot] = l1Buf_.Get<uint8_t>()[FWD_H_L1_KG_BASE + slot * FWD_H_L1_KG_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
-        }
-        for (uint32_t slot = 0; slot < L0_SLOTS; ++slot) {
-            l0A_[slot] = l0ABuf_.Get<uint8_t>()[slot * L0A_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
-            l0B_[slot] = l0BBuf_.Get<uint8_t>()[slot * L0B_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
-            l0C_[slot] = l0CBuf_.Get<uint8_t>()[slot * L0C_SLOT_BYTES].template ReinterpretCast<ElementAccumulator>();
-        }
+        return AscendC::LocalTensor<uint8_t>(AscendC::TPosition::A1, 0, ArchTag::L1_SIZE);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<uint8_t> L0ABuffer() const
+    {
+        return AscendC::LocalTensor<uint8_t>(AscendC::TPosition::A2, 0, ArchTag::L0A_SIZE);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<uint8_t> L0BBuffer() const
+    {
+        return AscendC::LocalTensor<uint8_t>(AscendC::TPosition::B2, 0, ArchTag::L0B_SIZE);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<uint8_t> L0CBuffer() const
+    {
+        return AscendC::LocalTensor<uint8_t>(AscendC::TPosition::CO1, 0, ArchTag::L0C_SIZE);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<uint8_t> UbBuffer() const
+    {
+        return AscendC::LocalTensor<uint8_t>(AscendC::TPosition::VECCALC, 0, ArchTag::UB_SIZE);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<bfloat16_t> L1W(uint32_t slot)
+    {
+        return L1Buffer()[FWD_H_L1_W_BASE + slot * FWD_H_L1_W_SLOT_BYTES]
+            .template ReinterpretCast<bfloat16_t>();
+    }
+
+    __aicore__ inline AscendC::LocalTensor<bfloat16_t> L1HRight(uint32_t slot)
+    {
+        return L1Buffer()[FWD_H_L1_H_RIGHT_BASE + slot * FWD_H_L1_H_RIGHT_SLOT_BYTES]
+            .template ReinterpretCast<bfloat16_t>();
+    }
+
+    __aicore__ inline AscendC::LocalTensor<bfloat16_t> L1Kg(uint32_t slot)
+    {
+        return L1Buffer()[FWD_H_L1_KG_BASE + slot * FWD_H_L1_KG_SLOT_BYTES]
+            .template ReinterpretCast<bfloat16_t>();
+    }
+
+    __aicore__ inline AscendC::LocalTensor<bfloat16_t> L0A(uint32_t slot)
+    {
+        return L0ABuffer()[slot * L0A_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
+    }
+
+    __aicore__ inline AscendC::LocalTensor<bfloat16_t> L0B(uint32_t slot)
+    {
+        return L0BBuffer()[slot * L0B_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
+    }
+
+    __aicore__ inline AscendC::LocalTensor<ElementAccumulator> L0C(uint32_t slot)
+    {
+        return L0CBuffer()[slot * L0C_SLOT_BYTES]
+            .template ReinterpretCast<ElementAccumulator>();
     }
 
     __aicore__ inline void InitEvents()
     {
         for (uint32_t slot = 0; slot < FWD_H_AIC_HEAD_SLOTS; ++slot) {
-            wReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE1_MTE2);
-            wDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_MTE1);
-            hRightReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE1_MTE2);
-            hRightDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_MTE1);
             AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(slot));
             AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(slot));
         }
         for (uint32_t slot = 0; slot < L0_SLOTS; ++slot) {
-            l0AFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::M_MTE1);
-            l0AReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE1_M);
-            l0BFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::M_MTE1);
-            l0BReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE1_M);
-            fixFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::FIX_M);
-            fixDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::M_FIX);
             AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(slot));
             AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(slot));
             AscendC::SetFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(slot));
@@ -225,6 +256,7 @@ private:
             AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(slot));
             AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(slot));
         }
+        // 固定 EventID 已全部回收到初始 free 状态，下一次 kernel launch 可重新使用。
     }
 
     __aicore__ inline uint64_t WOffset(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
@@ -248,8 +280,9 @@ private:
         return FwdHHOffset(args_.tiling, unit.sequence, head.hv, chunk.globalChunk);
     }
 
-    __aicore__ inline void LoadStage0Head(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
-                                          const FwdHHeadBinding &head)
+    // 保留 leaf stage 调用边界，使 TLA 临时对象在各 head/stage 之间复用标量栈区。
+    __aicore__ inline void LoadStage0Head(
+        const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk, const FwdHHeadBinding &head)
     {
         // Stage0 搬运：W_c,h[M,K] 和 canonical H_c,h[K,V] 从 GM 异步进入当前 roundHead 的 L1 槽。
         const uint32_t slot = head.roundHead;
@@ -259,13 +292,13 @@ private:
         AscendC::GlobalTensor<bfloat16_t> gmW;
         gmW.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.w) + WOffset(unit, chunk, head));
         if (chunk.validTokens < FWD_H_CHUNK) {
-            ClearL1(l1W_[slot], FWD_H_L1_W_SLOT_BYTES);
+            ClearL1(L1W(slot), FWD_H_L1_W_SLOT_BYTES);
         }
         auto gmWLayout = tla::MakeLayout<bfloat16_t, LayoutW>(chunk.validTokens, FWD_H_K);
         auto tensorW = tla::MakeTensor(gmW, gmWLayout, Catlass::Arch::PositionGM{});
         auto blockW = tla::GetTile(tensorW, tla::MakeCoord(0, 0),
                                    tla::MakeShape(chunk.validTokens, FWD_H_K));
-        auto tensorL1W = tla::MakeTensor(l1W_[slot], L1_W_LAYOUT, Catlass::Arch::PositionL1{});
+        auto tensorL1W = tla::MakeTensor(L1W(slot), L1_W_LAYOUT, Catlass::Arch::PositionL1{});
         CopyGmToL1AS0<decltype(blockW)> copyW;
         copyW(tensorL1W, blockW);
 
@@ -283,7 +316,7 @@ private:
         auto tensorH = tla::MakeTensor(gmH, gmHLayout, Catlass::Arch::PositionGM{});
         auto blockH = tla::GetTile(tensorH, tla::MakeCoord(0, 0),
                                    tla::MakeShape(FWD_H_K, FWD_H_V));
-        auto tensorL1H = tla::MakeTensor(l1HRight_[slot], L1_H_LAYOUT, Catlass::Arch::PositionL1{});
+        auto tensorL1H = tla::MakeTensor(L1HRight(slot), L1_H_LAYOUT, Catlass::Arch::PositionL1{});
         CopyGmToL1BS0<decltype(blockH)> copyH;
         copyH(tensorL1H, blockH);
 
@@ -291,21 +324,21 @@ private:
         AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(HRightDoneEvent(slot));
     }
 
-    __aicore__ inline void ComputeStage0Head(const FwdHChunkSpan &chunk,
-                                             const FwdHHeadBinding &head, uint32_t pipelineSlot)
+    __aicore__ inline void ComputeStage0Head(
+        const FwdHChunkSpan &chunk, const FwdHHeadBinding &head, uint32_t pipelineSlot)
     {
         // Stage0 计算：Pacc_c,h = W_c,h @ H_c,h，BF16 x BF16 -> FP32；
         // 随后按 StateT 转为 PType，Fixpipe 直接写入该 head 所属 AIV 的 local slot。
         const uint32_t slot = head.roundHead;
         const uint32_t m = FwdHAlignCube(chunk.validTokens);
-        auto tensorL1W = tla::MakeTensor(l1W_[slot], L1_W_LAYOUT, Catlass::Arch::PositionL1{});
-        auto tensorL1H = tla::MakeTensor(l1HRight_[slot], L1_H_LAYOUT, Catlass::Arch::PositionL1{});
+        auto tensorL1W = tla::MakeTensor(L1W(slot), L1_W_LAYOUT, Catlass::Arch::PositionL1{});
+        auto tensorL1H = tla::MakeTensor(L1HRight(slot), L1_H_LAYOUT, Catlass::Arch::PositionL1{});
         auto layoutL0A = tla::MakeLayout<bfloat16_t, typename TileS0::LayoutTagL0A>(m, FWD_H_K);
         auto layoutL0B = tla::MakeLayout<bfloat16_t, typename TileS0::LayoutTagL0B>(FWD_H_K, FWD_H_V);
         auto layoutL0C = tla::MakeLayoutL0C(m, FWD_H_V);
-        auto tensorL0A = tla::MakeTensor(l0A_[pipelineSlot], layoutL0A, Catlass::Arch::PositionL0A{});
-        auto tensorL0B = tla::MakeTensor(l0B_[pipelineSlot], layoutL0B, Catlass::Arch::PositionL0B{});
-        auto tensorL0C = tla::MakeTensor(l0C_[pipelineSlot], layoutL0C, Catlass::Arch::PositionL0C{});
+        auto tensorL0A = tla::MakeTensor(L0A(pipelineSlot), layoutL0A, Catlass::Arch::PositionL0A{});
+        auto tensorL0B = tla::MakeTensor(L0B(pipelineSlot), layoutL0B, Catlass::Arch::PositionL0B{});
+        auto tensorL0C = tla::MakeTensor(L0C(pipelineSlot), layoutL0C, Catlass::Arch::PositionL0C{});
 
         AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(WDoneEvent(slot));
         AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(HRightDoneEvent(slot));
@@ -324,7 +357,7 @@ private:
         AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0BReadyEvent(pipelineSlot));
         AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(pipelineSlot));
         TileMmadS0 mmad;
-        mmad(tensorL0C, tensorL0A, tensorL0B, true, 0b11);
+        mmad(tensorL0C, tensorL0A, tensorL0B, true, 0);
         AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(pipelineSlot));
         AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(pipelineSlot));
         AscendC::SetFlag<AscendC::HardEvent::M_FIX>(FixDoneEvent(pipelineSlot));
@@ -335,14 +368,14 @@ private:
                 FwdHAicPeerFlag(FWD_H_D_FREE_FLAG, head.localSlot, head.aiv));
         }
         AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(FixDoneEvent(pipelineSlot));
-        AscendC::LocalTensor<PType> pUb = ubBuf_.Get<uint8_t>()[
+        AscendC::LocalTensor<PType> pUb = UbBuffer()[
             FwdHLocalSlotBase(head.localSlot)].template ReinterpretCast<PType>();
         auto ubLayout = tla::MakeLayout<PType, LayoutOutput>(m, FWD_H_V);
         auto tensorUb = tla::MakeTensor(pUb, ubLayout, Catlass::Arch::PositionUB{});
         auto blockUb = tla::GetTile(tensorUb, tla::MakeCoord(0, 0),
                                     tla::MakeShape(chunk.validTokens, FWD_H_V));
         CopyL0CToUbS0<decltype(blockUb)> copyP;
-        copyP(blockUb, tensorL0C, static_cast<uint8_t>(head.aiv), 0b11);
+        copyP(blockUb, tensorL0C, static_cast<uint8_t>(head.aiv), 0);
         AscendC::CrossCoreSetFlag<0x4, PIPE_FIX>(
             FwdHAicPeerFlag(FWD_H_P_READY_FLAG, head.localSlot, head.aiv));
         AscendC::SetFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(pipelineSlot));
@@ -368,14 +401,14 @@ private:
         }
     }
 
-    __aicore__ inline void LoadKg(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
-                                  const FwdHKgBinding &binding)
+    __aicore__ inline void LoadKg(
+        const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk, const FwdHKgBinding &binding)
     {
         // Stage2 搬运：只加载本轮 requiredKh[] 中实际存在的 k_raw/kg；slot 不跨 round 保留。
         const uint32_t slot = binding.slot;
         AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(slot));
         if (chunk.validTokens < FWD_H_CHUNK) {
-            ClearL1(l1Kg_[slot], FWD_H_L1_KG_SLOT_BYTES);
+            ClearL1(L1Kg(slot), FWD_H_L1_KG_SLOT_BYTES);
         }
         AscendC::GlobalTensor<bfloat16_t> gmKg;
         const uint64_t offset = FwdHKOffset(args_.tiling, unit.sequence.physicalBatch,
@@ -386,7 +419,7 @@ private:
             auto tensorGm = tla::MakeTensor(gmKg, gmLayout, Catlass::Arch::PositionGM{});
             auto blockGm = tla::GetTile(tensorGm, tla::MakeCoord(0, 0),
                                         tla::MakeShape(FWD_H_K, chunk.validTokens));
-            auto tensorL1 = tla::MakeTensor(l1Kg_[slot], L1_LEFT_S2_LAYOUT,
+            auto tensorL1 = tla::MakeTensor(L1Kg(slot), L1_LEFT_S2_LAYOUT,
                                             Catlass::Arch::PositionL1{});
             CopyGmToL1AS2<decltype(blockGm)> copy;
             copy(tensorL1, blockGm);
@@ -395,7 +428,7 @@ private:
             auto tensorGm = tla::MakeTensor(gmKg, gmLayout, Catlass::Arch::PositionGM{});
             auto blockGm = tla::GetTile(tensorGm, tla::MakeCoord(0, 0),
                                         tla::MakeShape(chunk.validTokens, FWD_H_K));
-            auto tensorL1 = tla::MakeTensor(l1Kg_[slot], L1_RIGHT_S2_LAYOUT,
+            auto tensorL1 = tla::MakeTensor(L1Kg(slot), L1_RIGHT_S2_LAYOUT,
                                             Catlass::Arch::PositionL1{});
             CopyGmToL1BS2<decltype(blockGm)> copy;
             copy(tensorL1, blockGm);
@@ -403,7 +436,8 @@ private:
         AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(WDoneEvent(slot));
     }
 
-    __aicore__ inline void LoadRight(const FwdHChunkSpan &chunk, const FwdHHeadBinding &head)
+    __aicore__ inline void LoadRight(
+        const FwdHChunkSpan &chunk, const FwdHHeadBinding &head)
     {
         // Stage2 搬运：等待本 head 的 Stage1 MTE3 后，从 GM ND 搬入当前 H/right L1 槽。
         const uint32_t slot = head.roundHead;
@@ -411,7 +445,7 @@ private:
             FwdHAicPeerFlag(FWD_H_RIGHT_READY_FLAG, head.localSlot, head.aiv));
         AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(slot));
         if (chunk.validTokens < FWD_H_CHUNK) {
-            ClearL1(l1HRight_[slot], FWD_H_L1_KG_SLOT_BYTES);
+            ClearL1(L1HRight(slot), FWD_H_L1_KG_SLOT_BYTES);
         }
         AscendC::GlobalTensor<bfloat16_t> gmRight;
         const uint64_t offset = args_.tiling.vUpdateWorkspaceOffset / sizeof(bfloat16_t) +
@@ -422,7 +456,7 @@ private:
             auto tensorGm = tla::MakeTensor(gmRight, gmLayout, Catlass::Arch::PositionGM{});
             auto blockGm = tla::GetTile(tensorGm, tla::MakeCoord(0, 0),
                                         tla::MakeShape(chunk.validTokens, FWD_H_V));
-            auto tensorL1 = tla::MakeTensor(l1HRight_[slot], L1_RIGHT_S2_LAYOUT,
+            auto tensorL1 = tla::MakeTensor(L1HRight(slot), L1_RIGHT_S2_LAYOUT,
                                             Catlass::Arch::PositionL1{});
             CopyGmToL1BS2<decltype(blockGm)> copy;
             copy(tensorL1, blockGm);
@@ -431,7 +465,7 @@ private:
             auto tensorGm = tla::MakeTensor(gmRight, gmLayout, Catlass::Arch::PositionGM{});
             auto blockGm = tla::GetTile(tensorGm, tla::MakeCoord(0, 0),
                                         tla::MakeShape(FWD_H_V, chunk.validTokens));
-            auto tensorL1 = tla::MakeTensor(l1HRight_[slot], L1_LEFT_S2_LAYOUT,
+            auto tensorL1 = tla::MakeTensor(L1HRight(slot), L1_LEFT_S2_LAYOUT,
                                             Catlass::Arch::PositionL1{});
             CopyGmToL1AS2<decltype(blockGm)> copy;
             copy(tensorL1, blockGm);
@@ -439,23 +473,21 @@ private:
         AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(HRightDoneEvent(slot));
     }
 
-    __aicore__ inline void ComputeStage2Head(const FwdHWorkUnit &unit,
-                                             const FwdHChunkSpan &chunk,
-                                             const FwdHHeadBinding &head,
-                                             uint32_t pipelineSlot,
-                                             bool stage0Ran)
+    __aicore__ inline void ComputeStage2Head(
+        const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk, const FwdHHeadBinding &head,
+        uint32_t pipelineSlot, bool stage0Ran)
     {
         // Stage2 计算：state_v_first=false 时 D=kg^T@right，输出 [K,V]；
         // state_v_first=true 时交换两个输入，计算 right^T@kg，输出物理 [V,K]。
-        const FwdHKgBinding &binding = unit.headRound.kg[head.kgSlot];
+        const FwdHKgBinding binding = FwdHBuildKgBinding(unit.headRound, head.kgSlot);
         const uint32_t m = FWD_H_K;
         const uint32_t k = FwdHAlignCube(chunk.validTokens);
         auto layoutL0A = tla::MakeLayout<bfloat16_t, typename TileS2::LayoutTagL0A>(m, k);
         auto layoutL0B = tla::MakeLayout<bfloat16_t, typename TileS2::LayoutTagL0B>(k, FWD_H_V);
         auto layoutL0C = tla::MakeLayoutL0C(m, FWD_H_V);
-        auto tensorL0A = tla::MakeTensor(l0A_[pipelineSlot], layoutL0A, Catlass::Arch::PositionL0A{});
-        auto tensorL0B = tla::MakeTensor(l0B_[pipelineSlot], layoutL0B, Catlass::Arch::PositionL0B{});
-        auto tensorL0C = tla::MakeTensor(l0C_[pipelineSlot], layoutL0C, Catlass::Arch::PositionL0C{});
+        auto tensorL0A = tla::MakeTensor(L0A(pipelineSlot), layoutL0A, Catlass::Arch::PositionL0A{});
+        auto tensorL0B = tla::MakeTensor(L0B(pipelineSlot), layoutL0B, Catlass::Arch::PositionL0B{});
+        auto tensorL0C = tla::MakeTensor(L0C(pipelineSlot), layoutL0C, Catlass::Arch::PositionL0C{});
 
         AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(pipelineSlot));
         AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(pipelineSlot));
@@ -468,18 +500,18 @@ private:
         if constexpr (STATE_V_FIRST) {
             // LoadRight 已将 GM ND right[M,V] 按 ColumnMajor 映射为 L1[V,M]，
             // kg 保持 GM ND[M,K]，Cube 直接执行 [V,M]@[M,K] -> [V,K]。
-            auto tensorRight = tla::MakeTensor(l1HRight_[head.roundHead], L1_LEFT_S2_LAYOUT,
+            auto tensorRight = tla::MakeTensor(L1HRight(head.roundHead), L1_LEFT_S2_LAYOUT,
                                                Catlass::Arch::PositionL1{});
-            auto tensorKg = tla::MakeTensor(l1Kg_[binding.slot], L1_RIGHT_S2_LAYOUT,
+            auto tensorKg = tla::MakeTensor(L1Kg(binding.slot), L1_RIGHT_S2_LAYOUT,
                                             Catlass::Arch::PositionL1{});
             copyA(tensorL0A, tla::GetTile(tensorRight, tla::MakeCoord(0, 0),
                                           tla::MakeShape(m, k)));
             copyB(tensorL0B, tla::GetTile(tensorKg, tla::MakeCoord(0, 0),
                                           tla::MakeShape(k, FWD_H_V)));
         } else {
-            auto tensorKg = tla::MakeTensor(l1Kg_[binding.slot], L1_LEFT_S2_LAYOUT,
+            auto tensorKg = tla::MakeTensor(L1Kg(binding.slot), L1_LEFT_S2_LAYOUT,
                                             Catlass::Arch::PositionL1{});
-            auto tensorRight = tla::MakeTensor(l1HRight_[head.roundHead], L1_RIGHT_S2_LAYOUT,
+            auto tensorRight = tla::MakeTensor(L1HRight(head.roundHead), L1_RIGHT_S2_LAYOUT,
                                                Catlass::Arch::PositionL1{});
             copyA(tensorL0A, tla::GetTile(tensorKg, tla::MakeCoord(0, 0),
                                           tla::MakeShape(m, k)));
@@ -498,7 +530,7 @@ private:
         AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0BReadyEvent(pipelineSlot));
         AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(pipelineSlot));
         TileMmadS2 mmad;
-        mmad(tensorL0C, tensorL0A, tensorL0B, true, 0b11);
+        mmad(tensorL0C, tensorL0A, tensorL0B, true, 0);
         AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(pipelineSlot));
         AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(pipelineSlot));
         AscendC::SetFlag<AscendC::HardEvent::M_FIX>(FixDoneEvent(pipelineSlot));
@@ -509,11 +541,12 @@ private:
                 FwdHAicPeerFlag(FWD_H_P_FREE_FLAG, head.localSlot, head.aiv));
         }
         AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(FixDoneEvent(pipelineSlot));
-        AscendC::LocalTensor<float> dUb = ubBuf_.Get<uint8_t>()[FwdHLocalSlotBase(head.localSlot)].template ReinterpretCast<float>();
+        AscendC::LocalTensor<float> dUb =
+            UbBuffer()[FwdHLocalSlotBase(head.localSlot)].template ReinterpretCast<float>();
         auto ubLayout = tla::MakeLayout<float, LayoutOutput>(FWD_H_K, FWD_H_V);
         auto tensorUb = tla::MakeTensor(dUb, ubLayout, Catlass::Arch::PositionUB{});
         CopyL0CToUbS2<decltype(tensorUb)> copyD;
-        copyD(tensorUb, tensorL0C, static_cast<uint8_t>(head.aiv), 0b11);
+        copyD(tensorUb, tensorL0C, static_cast<uint8_t>(head.aiv), 0);
         AscendC::CrossCoreSetFlag<0x4, PIPE_FIX>(
             FwdHAicPeerFlag(FWD_H_D_READY_FLAG, head.localSlot, head.aiv));
         AscendC::SetFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(pipelineSlot));
@@ -524,7 +557,7 @@ private:
     {
         // Stage2：g-only 计算 D_c=k_raw_c^T@V_new_g；gk-only 计算 D_c=kg_c^T@V_new。
         for (uint32_t kgSlot = 0; kgSlot < unit.headRound.requiredKhCount; ++kgSlot) {
-            LoadKg(unit, chunk, unit.headRound.kg[kgSlot]);
+            LoadKg(unit, chunk, FwdHBuildKgBinding(unit.headRound, kgSlot));
         }
         for (uint32_t roundHead = 0; roundHead < unit.headRound.activeHeadCount; ++roundHead) {
             LoadRight(chunk, unit.headRound.heads[roundHead]);
@@ -539,7 +572,7 @@ private:
         }
     }
 
-    __aicore__ inline void ProcessWorkUnit(const FwdHWorkUnit &unit)
+    __aicore__ inline void ProcessWorkUnit(const FwdHWorkUnit &unit, bool hasNextRound)
     {
         if (!hasCubeWork_) {
             return;
@@ -567,38 +600,24 @@ private:
                     FwdHAicPeerFlag(FWD_H_P_FREE_FLAG, head.localSlot, head.aiv));
             }
         }
-        AscendC::CrossCoreWaitFlag<0x4, PIPE_FIX>(FwdHAicPeerFlag(FWD_H_ROUND_DONE_FLAG, 0, 0));
-        AscendC::CrossCoreWaitFlag<0x4, PIPE_FIX>(FwdHAicPeerFlag(FWD_H_ROUND_DONE_FLAG, 0, 1));
-        AscendC::CrossCoreSetFlag<0x4, PIPE_FIX>(FwdHAicPeerFlag(FWD_H_H_READY_FLAG, 0, 0));
-        AscendC::CrossCoreSetFlag<0x4, PIPE_FIX>(FwdHAicPeerFlag(FWD_H_H_READY_FLAG, 0, 1));
+        if (hasNextRound) {
+            // PIPE_S 将 round 握手放到控制流水，阻止下一轮 MTE2 预取越过 DONE/ACK。
+            AscendC::CrossCoreWaitFlag<0x4, PIPE_S>(
+                FwdHAicPeerFlag(FWD_H_ROUND_DONE_FLAG, 0, 0));
+            AscendC::CrossCoreWaitFlag<0x4, PIPE_S>(
+                FwdHAicPeerFlag(FWD_H_ROUND_DONE_FLAG, 0, 1));
+            // ACK 表示 AIC 已完成本轮消费；AIV 收到后才可复用下一轮的本地槽。
+            AscendC::CrossCoreSetFlag<0x4, PIPE_S>(
+                FwdHAicPeerFlag(FWD_H_ROUND_ACK_FLAG, 0, 0));
+            AscendC::CrossCoreSetFlag<0x4, PIPE_S>(
+                FwdHAicPeerFlag(FWD_H_ROUND_ACK_FLAG, 0, 1));
+        }
     }
 
     FwdHKernelArgs args_{};
     uint32_t coreIdx_ = 0;
     uint32_t coreNum_ = 1;
     bool hasCubeWork_ = false;
-    AscendC::TBuf<AscendC::TPosition::A1> l1Buf_{};
-    AscendC::TBuf<AscendC::TPosition::A2> l0ABuf_{};
-    AscendC::TBuf<AscendC::TPosition::B2> l0BBuf_{};
-    AscendC::TBuf<AscendC::TPosition::CO1> l0CBuf_{};
-    AscendC::TBuf<AscendC::TPosition::VECCALC> ubBuf_{};
-    AscendC::TBuf<AscendC::TPosition::C2PIPE2GM> fixBuf_{};
-    AscendC::TEventID wReadyEvent_[FWD_H_AIC_HEAD_SLOTS]{};
-    AscendC::TEventID wDoneEvent_[FWD_H_AIC_HEAD_SLOTS]{};
-    AscendC::TEventID hRightReadyEvent_[FWD_H_AIC_HEAD_SLOTS]{};
-    AscendC::TEventID hRightDoneEvent_[FWD_H_AIC_HEAD_SLOTS]{};
-    AscendC::TEventID l0AFreeEvent_[L0_SLOTS]{};
-    AscendC::TEventID l0AReadyEvent_[L0_SLOTS]{};
-    AscendC::TEventID l0BFreeEvent_[L0_SLOTS]{};
-    AscendC::TEventID l0BReadyEvent_[L0_SLOTS]{};
-    AscendC::TEventID fixFreeEvent_[L0_SLOTS]{};
-    AscendC::TEventID fixDoneEvent_[L0_SLOTS]{};
-    AscendC::LocalTensor<bfloat16_t> l1W_[FWD_H_AIC_HEAD_SLOTS]{};
-    AscendC::LocalTensor<bfloat16_t> l1HRight_[FWD_H_AIC_HEAD_SLOTS]{};
-    AscendC::LocalTensor<bfloat16_t> l1Kg_[FWD_H_AIC_HEAD_SLOTS]{};
-    AscendC::LocalTensor<bfloat16_t> l0A_[L0_SLOTS]{};
-    AscendC::LocalTensor<bfloat16_t> l0B_[L0_SLOTS]{};
-    AscendC::LocalTensor<ElementAccumulator> l0C_[L0_SLOTS]{};
 };
 
 } // namespace GDN

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch35/chunk_fwd_h_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch35/chunk_fwd_h_cube.h
@@ -1,0 +1,606 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ */
+
+#ifndef ARCH35_CHUNK_FWD_H_CUBE_H
+#define ARCH35_CHUNK_FWD_H_CUBE_H
+
+#ifndef CATLASS_ARCH
+#define CATLASS_ARCH 3510
+#endif
+
+#include <type_traits>
+
+#include "../chunk_fwd_h_policy.h"
+#include "../chunk_fwd_h_utils.h"
+#include "catlass/arch/arch.hpp"
+#include "catlass/arch/resource.hpp"
+#include "catlass/gemm/tile/tile_copy.hpp"
+#include "catlass/gemm/tile/tile_mmad.hpp"
+#include "catlass/layout/layout.hpp"
+#include "kernel_utils/tile/copy_l0c_to_ub.hpp"
+#include "tla/layout.hpp"
+#include "tla/tensor.hpp"
+
+namespace GDN {
+
+template <typename CompilePolicy, bool STATE_V_FIRST>
+class ChunkFwdHCubeArch35 {
+public:
+    __aicore__ inline void Init(const FwdHKernelArgs &args)
+    {
+        args_ = args;
+        coreIdx_ = AscendC::GetBlockIdx();
+        coreNum_ = AscendC::GetBlockNum();
+        hasCubeWork_ = args_.tiling.useInitialState || args_.tiling.storeFinalState ||
+            args_.tiling.seqlen > static_cast<int64_t>(FWD_H_CHUNK);
+        if (!hasCubeWork_) {
+            return;
+        }
+        InitBuffers();
+        InitEvents();
+    }
+
+    __aicore__ inline void Process()
+    {
+        const uint32_t sequenceCount = args_.tiling.isVariedLen != 0
+                                           ? static_cast<uint32_t>(args_.tiling.tokenBatch)
+                                           : static_cast<uint32_t>(args_.tiling.shapeBatch);
+        const uint32_t rounds = FwdHHeadRoundsPerSequence<CompilePolicy::GATE_MODE>(args_.tiling);
+        // 同一 sequence 的所有 head-round 绑定到同一核，round 内串行收口；
+        // ProcessWorkUnit 返回时已完成本轮 ROUND_DONE/ACK，下一轮才允许预取。
+        for (uint32_t sequence = coreIdx_; sequence < sequenceCount; sequence += coreNum_) {
+            const FwdHSequenceSpan sequenceSpan = FwdHResolveSequence(args_, sequence);
+            for (uint32_t round = 0; round < rounds; ++round) {
+                const FwdHWorkUnit unit{sequenceSpan,
+                                        FwdHBuildHeadRound<CompilePolicy::GATE_MODE>(args_.tiling,
+                                                                                      round)};
+                if (unit.sequence.chunkCount != 0 && unit.headRound.activeHeadCount != 0) {
+                    ProcessWorkUnit(unit);
+                }
+            }
+        }
+        if (hasCubeWork_) {
+            DrainEvents();
+        }
+    }
+
+private:
+    using ArchTag = Catlass::Arch::Ascend950;
+    using PType = std::conditional_t<CompilePolicy::STATE_FP32, float, bfloat16_t>;
+    using LayoutW = Catlass::layout::RowMajor;
+    using LayoutH = std::conditional_t<STATE_V_FIRST, Catlass::layout::ColumnMajor,
+                                       Catlass::layout::RowMajor>;
+    using LayoutLeftS2 = Catlass::layout::ColumnMajor;
+    using LayoutRightS2 = Catlass::layout::RowMajor;
+    using LayoutOutput = Catlass::layout::RowMajor;
+
+    using TileS0 = Common::Tile::PackedTileCopyTlaToUB<
+        ArchTag, bfloat16_t, LayoutW, bfloat16_t, LayoutH, PType, LayoutOutput>;
+    using TileS2 = Common::Tile::PackedTileCopyTlaToUB<
+        ArchTag, bfloat16_t, LayoutLeftS2, bfloat16_t, LayoutRightS2, float, LayoutOutput>;
+    using ElementAccumulator = typename TileS2::ElementAccumulator;
+
+    using CopyL1ToL0AS0 = typename TileS0::CopyL1ToL0A;
+    using CopyL1ToL0BS0 = typename TileS0::CopyL1ToL0B;
+    using CopyL1ToL0AS2 = typename TileS2::CopyL1ToL0A;
+    using CopyL1ToL0BS2 = typename TileS2::CopyL1ToL0B;
+    using TileMmadS0 = Catlass::Gemm::Tile::TileMmadTla<ArchTag, bfloat16_t,
+                                                        typename TileS0::LayoutTagL1A>;
+    using TileMmadS2 = Catlass::Gemm::Tile::TileMmadTla<ArchTag, bfloat16_t,
+                                                        typename TileS2::LayoutTagL1A>;
+
+    template <typename Tensor>
+    using CopyGmToL1AS0 = typename TileS0::template CopyGmToL1A<Tensor>;
+    template <typename Tensor>
+    using CopyGmToL1BS0 = typename TileS0::template CopyGmToL1B<Tensor>;
+    template <typename Tensor>
+    using CopyGmToL1AS2 = typename TileS2::template CopyGmToL1A<Tensor>;
+    template <typename Tensor>
+    using CopyGmToL1BS2 = typename TileS2::template CopyGmToL1B<Tensor>;
+    template <typename Tensor>
+    using CopyL0CToUbS0 = typename TileS0::template CopyL0CToDst<Tensor>;
+    template <typename Tensor>
+    using CopyL0CToUbS2 = typename TileS2::template CopyL0CToDst<Tensor>;
+
+    static constexpr auto L1_W_LAYOUT = tla::MakeLayout<bfloat16_t, typename TileS0::LayoutTagL1A>(
+        tla::Int<FWD_H_CHUNK>{}, tla::Int<FWD_H_K>{});
+    static constexpr auto L1_H_LAYOUT = tla::MakeLayout<bfloat16_t, typename TileS0::LayoutTagL1B>(
+        tla::Int<FWD_H_K>{}, tla::Int<FWD_H_V>{});
+    static constexpr auto L1_LEFT_S2_LAYOUT =
+        tla::MakeLayout<bfloat16_t, typename TileS2::LayoutTagL1A>(
+            tla::Int<FWD_H_K>{}, tla::Int<FWD_H_CHUNK>{});
+    static constexpr auto L1_RIGHT_S2_LAYOUT =
+        tla::MakeLayout<bfloat16_t, typename TileS2::LayoutTagL1B>(
+            tla::Int<FWD_H_CHUNK>{}, tla::Int<FWD_H_V>{});
+
+    static constexpr uint32_t L0_SLOTS = 2;
+    static constexpr uint32_t L0A_SLOT_BYTES = FWD_H_CHUNK * FWD_H_K * sizeof(bfloat16_t);
+    static constexpr uint32_t L0B_SLOT_BYTES = FWD_H_K * FWD_H_V * sizeof(bfloat16_t);
+    static constexpr uint32_t L0C_SLOT_BYTES = FWD_H_K * FWD_H_V * sizeof(ElementAccumulator);
+
+    __aicore__ inline AscendC::TEventID WReadyEvent(uint32_t slot) const
+    {
+        return wReadyEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID WDoneEvent(uint32_t slot) const
+    {
+        return wDoneEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID HRightReadyEvent(uint32_t slot) const
+    {
+        return hRightReadyEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID HRightDoneEvent(uint32_t slot) const
+    {
+        return hRightDoneEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID L0AFreeEvent(uint32_t slot) const
+    {
+        return l0AFreeEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID L0AReadyEvent(uint32_t slot) const
+    {
+        return l0AReadyEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID L0BFreeEvent(uint32_t slot) const
+    {
+        return l0BFreeEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID L0BReadyEvent(uint32_t slot) const
+    {
+        return l0BReadyEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID FixFreeEvent(uint32_t slot) const
+    {
+        return fixFreeEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID FixDoneEvent(uint32_t slot) const
+    {
+        return fixDoneEvent_[slot];
+    }
+
+    __aicore__ inline void InitBuffers()
+    {
+        GetTPipePtr()->InitBuffer(l1Buf_, ArchTag::L1_SIZE);
+        GetTPipePtr()->InitBuffer(l0ABuf_, ArchTag::L0A_SIZE);
+        GetTPipePtr()->InitBuffer(l0BBuf_, ArchTag::L0B_SIZE);
+        GetTPipePtr()->InitBuffer(l0CBuf_, ArchTag::L0C_SIZE);
+        GetTPipePtr()->InitBuffer(ubBuf_, ArchTag::UB_SIZE);
+        GetTPipePtr()->InitBuffer(fixBuf_, ArchTag::FIXBUF_SIZE);
+        for (uint32_t slot = 0; slot < FWD_H_AIC_HEAD_SLOTS; ++slot) {
+            l1W_[slot] = l1Buf_.Get<uint8_t>()[FWD_H_L1_W_BASE + slot * FWD_H_L1_W_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
+            l1HRight_[slot] = l1Buf_.Get<uint8_t>()[FWD_H_L1_H_RIGHT_BASE + slot * FWD_H_L1_H_RIGHT_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
+            l1Kg_[slot] = l1Buf_.Get<uint8_t>()[FWD_H_L1_KG_BASE + slot * FWD_H_L1_KG_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
+        }
+        for (uint32_t slot = 0; slot < L0_SLOTS; ++slot) {
+            l0A_[slot] = l0ABuf_.Get<uint8_t>()[slot * L0A_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
+            l0B_[slot] = l0BBuf_.Get<uint8_t>()[slot * L0B_SLOT_BYTES].template ReinterpretCast<bfloat16_t>();
+            l0C_[slot] = l0CBuf_.Get<uint8_t>()[slot * L0C_SLOT_BYTES].template ReinterpretCast<ElementAccumulator>();
+        }
+    }
+
+    __aicore__ inline void InitEvents()
+    {
+        for (uint32_t slot = 0; slot < FWD_H_AIC_HEAD_SLOTS; ++slot) {
+            wReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE1_MTE2);
+            wDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_MTE1);
+            hRightReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE1_MTE2);
+            hRightDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_MTE1);
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(slot));
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(slot));
+        }
+        for (uint32_t slot = 0; slot < L0_SLOTS; ++slot) {
+            l0AFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::M_MTE1);
+            l0AReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE1_M);
+            l0BFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::M_MTE1);
+            l0BReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE1_M);
+            fixFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::FIX_M);
+            fixDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::M_FIX);
+            AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(slot));
+            AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(slot));
+            AscendC::SetFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(slot));
+        }
+    }
+
+    __aicore__ inline void DrainEvents()
+    {
+        for (uint32_t slot = 0; slot < FWD_H_AIC_HEAD_SLOTS; ++slot) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(slot));
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(slot));
+        }
+        for (uint32_t slot = 0; slot < L0_SLOTS; ++slot) {
+            AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(slot));
+            AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(slot));
+            AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(slot));
+        }
+    }
+
+    __aicore__ inline uint64_t WOffset(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                       const FwdHHeadBinding &head) const
+    {
+        return FwdHInputOffset(args_.tiling, unit.sequence.physicalBatch, head.hv,
+                               chunk.tokenBegin, FWD_H_K);
+    }
+
+    __aicore__ inline void ClearL1(AscendC::LocalTensor<bfloat16_t> tensor,
+                                   uint32_t bytes) const
+    {
+        AscendC::InitConstValueParams<bfloat16_t> params(
+            1, static_cast<uint16_t>(bytes / 32U), 0, static_cast<bfloat16_t>(0));
+        AscendC::InitConstValue(tensor, params);
+    }
+
+    __aicore__ inline uint64_t HOffset(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                       const FwdHHeadBinding &head) const
+    {
+        return FwdHHOffset(args_.tiling, unit.sequence, head.hv, chunk.globalChunk);
+    }
+
+    __aicore__ inline void LoadStage0Head(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                          const FwdHHeadBinding &head)
+    {
+        // Stage0 搬运：W_c,h[M,K] 和 canonical H_c,h[K,V] 从 GM 异步进入当前 roundHead 的 L1 槽。
+        const uint32_t slot = head.roundHead;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(slot));
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(slot));
+
+        AscendC::GlobalTensor<bfloat16_t> gmW;
+        gmW.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.w) + WOffset(unit, chunk, head));
+        if (chunk.validTokens < FWD_H_CHUNK) {
+            ClearL1(l1W_[slot], FWD_H_L1_W_SLOT_BYTES);
+        }
+        auto gmWLayout = tla::MakeLayout<bfloat16_t, LayoutW>(chunk.validTokens, FWD_H_K);
+        auto tensorW = tla::MakeTensor(gmW, gmWLayout, Catlass::Arch::PositionGM{});
+        auto blockW = tla::GetTile(tensorW, tla::MakeCoord(0, 0),
+                                   tla::MakeShape(chunk.validTokens, FWD_H_K));
+        auto tensorL1W = tla::MakeTensor(l1W_[slot], L1_W_LAYOUT, Catlass::Arch::PositionL1{});
+        CopyGmToL1AS0<decltype(blockW)> copyW;
+        copyW(tensorL1W, blockW);
+
+        AscendC::GlobalTensor<bfloat16_t> gmH;
+        if (chunk.first && args_.tiling.useInitialState != 0 && !CompilePolicy::STATE_FP32) {
+            const uint64_t stateOffset = FwdHStateOffset(args_.tiling, unit.sequence.sequence,
+                                                         head.hv, 0, 0);
+            gmH.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.initialState) + stateOffset);
+        } else {
+            AscendC::CrossCoreWaitFlag<0x4, PIPE_MTE2>(
+                FwdHAicPeerFlag(FWD_H_H_READY_FLAG, head.localSlot, head.aiv));
+            gmH.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.h) + HOffset(unit, chunk, head));
+        }
+        auto gmHLayout = tla::MakeLayout<bfloat16_t, LayoutH>(FWD_H_K, FWD_H_V);
+        auto tensorH = tla::MakeTensor(gmH, gmHLayout, Catlass::Arch::PositionGM{});
+        auto blockH = tla::GetTile(tensorH, tla::MakeCoord(0, 0),
+                                   tla::MakeShape(FWD_H_K, FWD_H_V));
+        auto tensorL1H = tla::MakeTensor(l1HRight_[slot], L1_H_LAYOUT, Catlass::Arch::PositionL1{});
+        CopyGmToL1BS0<decltype(blockH)> copyH;
+        copyH(tensorL1H, blockH);
+
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(WDoneEvent(slot));
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(HRightDoneEvent(slot));
+    }
+
+    __aicore__ inline void ComputeStage0Head(const FwdHChunkSpan &chunk,
+                                             const FwdHHeadBinding &head, uint32_t pipelineSlot)
+    {
+        // Stage0 计算：Pacc_c,h = W_c,h @ H_c,h，BF16 x BF16 -> FP32；
+        // 随后按 StateT 转为 PType，Fixpipe 直接写入该 head 所属 AIV 的 local slot。
+        const uint32_t slot = head.roundHead;
+        const uint32_t m = FwdHAlignCube(chunk.validTokens);
+        auto tensorL1W = tla::MakeTensor(l1W_[slot], L1_W_LAYOUT, Catlass::Arch::PositionL1{});
+        auto tensorL1H = tla::MakeTensor(l1HRight_[slot], L1_H_LAYOUT, Catlass::Arch::PositionL1{});
+        auto layoutL0A = tla::MakeLayout<bfloat16_t, typename TileS0::LayoutTagL0A>(m, FWD_H_K);
+        auto layoutL0B = tla::MakeLayout<bfloat16_t, typename TileS0::LayoutTagL0B>(FWD_H_K, FWD_H_V);
+        auto layoutL0C = tla::MakeLayoutL0C(m, FWD_H_V);
+        auto tensorL0A = tla::MakeTensor(l0A_[pipelineSlot], layoutL0A, Catlass::Arch::PositionL0A{});
+        auto tensorL0B = tla::MakeTensor(l0B_[pipelineSlot], layoutL0B, Catlass::Arch::PositionL0B{});
+        auto tensorL0C = tla::MakeTensor(l0C_[pipelineSlot], layoutL0C, Catlass::Arch::PositionL0C{});
+
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(WDoneEvent(slot));
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(HRightDoneEvent(slot));
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(pipelineSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(pipelineSlot));
+        CopyL1ToL0AS0 copyA;
+        CopyL1ToL0BS0 copyB;
+        copyA(tensorL0A, tla::GetTile(tensorL1W, tla::MakeCoord(0, 0), tla::MakeShape(m, FWD_H_K)));
+        copyB(tensorL0B, tla::GetTile(tensorL1H, tla::MakeCoord(0, 0),
+                                     tla::MakeShape(FWD_H_K, FWD_H_V)));
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(slot));
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(slot));
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0AReadyEvent(pipelineSlot));
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0BReadyEvent(pipelineSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0AReadyEvent(pipelineSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0BReadyEvent(pipelineSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(pipelineSlot));
+        TileMmadS0 mmad;
+        mmad(tensorL0C, tensorL0A, tensorL0B, true, 0b11);
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(pipelineSlot));
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(pipelineSlot));
+        AscendC::SetFlag<AscendC::HardEvent::M_FIX>(FixDoneEvent(pipelineSlot));
+
+        if (!chunk.first) {
+            // 首 chunk 的 initial_state 还没有前序消费者；后续 chunk 复用的是前一轮的 D slot。
+            AscendC::CrossCoreWaitFlag<0x4, PIPE_FIX>(
+                FwdHAicPeerFlag(FWD_H_D_FREE_FLAG, head.localSlot, head.aiv));
+        }
+        AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(FixDoneEvent(pipelineSlot));
+        AscendC::LocalTensor<PType> pUb = ubBuf_.Get<uint8_t>()[
+            FwdHLocalSlotBase(head.localSlot)].template ReinterpretCast<PType>();
+        auto ubLayout = tla::MakeLayout<PType, LayoutOutput>(m, FWD_H_V);
+        auto tensorUb = tla::MakeTensor(pUb, ubLayout, Catlass::Arch::PositionUB{});
+        auto blockUb = tla::GetTile(tensorUb, tla::MakeCoord(0, 0),
+                                    tla::MakeShape(chunk.validTokens, FWD_H_V));
+        CopyL0CToUbS0<decltype(blockUb)> copyP;
+        copyP(blockUb, tensorL0C, static_cast<uint8_t>(head.aiv), 0b11);
+        AscendC::CrossCoreSetFlag<0x4, PIPE_FIX>(
+            FwdHAicPeerFlag(FWD_H_P_READY_FLAG, head.localSlot, head.aiv));
+        AscendC::SetFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(pipelineSlot));
+    }
+
+    __aicore__ inline void RunStage0(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk)
+    {
+        // Stage0：H_c=cast_BF16(R_c)，P_c=W_c@H_c；Cube 使用 BF16 输入、FP32 累加。
+        if (chunk.first && args_.tiling.useInitialState == 0) {
+            return;
+        }
+        for (uint32_t roundHead = 0; roundHead < unit.headRound.activeHeadCount; ++roundHead) {
+            const FwdHHeadBinding &head = unit.headRound.heads[roundHead];
+            LoadStage0Head(unit, chunk, head);
+            if (roundHead > 0) {
+                ComputeStage0Head(chunk, unit.headRound.heads[roundHead - 1],
+                                  (roundHead - 1) & 1U);
+            }
+        }
+        if (unit.headRound.activeHeadCount > 0) {
+            const uint32_t last = unit.headRound.activeHeadCount - 1;
+            ComputeStage0Head(chunk, unit.headRound.heads[last], last & 1U);
+        }
+    }
+
+    __aicore__ inline void LoadKg(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                  const FwdHKgBinding &binding)
+    {
+        // Stage2 搬运：只加载本轮 requiredKh[] 中实际存在的 k_raw/kg；slot 不跨 round 保留。
+        const uint32_t slot = binding.slot;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(slot));
+        if (chunk.validTokens < FWD_H_CHUNK) {
+            ClearL1(l1Kg_[slot], FWD_H_L1_KG_SLOT_BYTES);
+        }
+        AscendC::GlobalTensor<bfloat16_t> gmKg;
+        const uint64_t offset = FwdHKOffset(args_.tiling, unit.sequence.physicalBatch,
+                                            binding.kh, chunk.tokenBegin);
+        gmKg.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.k) + offset);
+        if constexpr (!STATE_V_FIRST) {
+            auto gmLayout = tla::MakeLayout<bfloat16_t, LayoutLeftS2>(FWD_H_K, chunk.validTokens);
+            auto tensorGm = tla::MakeTensor(gmKg, gmLayout, Catlass::Arch::PositionGM{});
+            auto blockGm = tla::GetTile(tensorGm, tla::MakeCoord(0, 0),
+                                        tla::MakeShape(FWD_H_K, chunk.validTokens));
+            auto tensorL1 = tla::MakeTensor(l1Kg_[slot], L1_LEFT_S2_LAYOUT,
+                                            Catlass::Arch::PositionL1{});
+            CopyGmToL1AS2<decltype(blockGm)> copy;
+            copy(tensorL1, blockGm);
+        } else {
+            auto gmLayout = tla::MakeLayout<bfloat16_t, LayoutRightS2>(chunk.validTokens, FWD_H_K);
+            auto tensorGm = tla::MakeTensor(gmKg, gmLayout, Catlass::Arch::PositionGM{});
+            auto blockGm = tla::GetTile(tensorGm, tla::MakeCoord(0, 0),
+                                        tla::MakeShape(chunk.validTokens, FWD_H_K));
+            auto tensorL1 = tla::MakeTensor(l1Kg_[slot], L1_RIGHT_S2_LAYOUT,
+                                            Catlass::Arch::PositionL1{});
+            CopyGmToL1BS2<decltype(blockGm)> copy;
+            copy(tensorL1, blockGm);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(WDoneEvent(slot));
+    }
+
+    __aicore__ inline void LoadRight(const FwdHChunkSpan &chunk, const FwdHHeadBinding &head)
+    {
+        // Stage2 搬运：等待本 head 的 Stage1 MTE3 后，从 GM ND 搬入当前 H/right L1 槽。
+        const uint32_t slot = head.roundHead;
+        AscendC::CrossCoreWaitFlag<0x4, PIPE_MTE2>(
+            FwdHAicPeerFlag(FWD_H_RIGHT_READY_FLAG, head.localSlot, head.aiv));
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(slot));
+        if (chunk.validTokens < FWD_H_CHUNK) {
+            ClearL1(l1HRight_[slot], FWD_H_L1_KG_SLOT_BYTES);
+        }
+        AscendC::GlobalTensor<bfloat16_t> gmRight;
+        const uint64_t offset = args_.tiling.vUpdateWorkspaceOffset / sizeof(bfloat16_t) +
+            FwdHCoreSlotOffset(coreIdx_, head.roundHead, FWD_H_CHUNK * FWD_H_V);
+        gmRight.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.workspace) + offset);
+        if constexpr (!STATE_V_FIRST) {
+            auto gmLayout = tla::MakeLayout<bfloat16_t, LayoutRightS2>(chunk.validTokens, FWD_H_V);
+            auto tensorGm = tla::MakeTensor(gmRight, gmLayout, Catlass::Arch::PositionGM{});
+            auto blockGm = tla::GetTile(tensorGm, tla::MakeCoord(0, 0),
+                                        tla::MakeShape(chunk.validTokens, FWD_H_V));
+            auto tensorL1 = tla::MakeTensor(l1HRight_[slot], L1_RIGHT_S2_LAYOUT,
+                                            Catlass::Arch::PositionL1{});
+            CopyGmToL1BS2<decltype(blockGm)> copy;
+            copy(tensorL1, blockGm);
+        } else {
+            auto gmLayout = tla::MakeLayout<bfloat16_t, LayoutLeftS2>(FWD_H_V, chunk.validTokens);
+            auto tensorGm = tla::MakeTensor(gmRight, gmLayout, Catlass::Arch::PositionGM{});
+            auto blockGm = tla::GetTile(tensorGm, tla::MakeCoord(0, 0),
+                                        tla::MakeShape(FWD_H_V, chunk.validTokens));
+            auto tensorL1 = tla::MakeTensor(l1HRight_[slot], L1_LEFT_S2_LAYOUT,
+                                            Catlass::Arch::PositionL1{});
+            CopyGmToL1AS2<decltype(blockGm)> copy;
+            copy(tensorL1, blockGm);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(HRightDoneEvent(slot));
+    }
+
+    __aicore__ inline void ComputeStage2Head(const FwdHWorkUnit &unit,
+                                             const FwdHChunkSpan &chunk,
+                                             const FwdHHeadBinding &head,
+                                             uint32_t pipelineSlot,
+                                             bool stage0Ran)
+    {
+        // Stage2 计算：state_v_first=false 时 D=kg^T@right，输出 [K,V]；
+        // state_v_first=true 时交换两个输入，计算 right^T@kg，输出物理 [V,K]。
+        const FwdHKgBinding &binding = unit.headRound.kg[head.kgSlot];
+        const uint32_t m = FWD_H_K;
+        const uint32_t k = FwdHAlignCube(chunk.validTokens);
+        auto layoutL0A = tla::MakeLayout<bfloat16_t, typename TileS2::LayoutTagL0A>(m, k);
+        auto layoutL0B = tla::MakeLayout<bfloat16_t, typename TileS2::LayoutTagL0B>(k, FWD_H_V);
+        auto layoutL0C = tla::MakeLayoutL0C(m, FWD_H_V);
+        auto tensorL0A = tla::MakeTensor(l0A_[pipelineSlot], layoutL0A, Catlass::Arch::PositionL0A{});
+        auto tensorL0B = tla::MakeTensor(l0B_[pipelineSlot], layoutL0B, Catlass::Arch::PositionL0B{});
+        auto tensorL0C = tla::MakeTensor(l0C_[pipelineSlot], layoutL0C, Catlass::Arch::PositionL0C{});
+
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(pipelineSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(pipelineSlot));
+        if (head.roundHead == binding.firstConsumer) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(WDoneEvent(binding.slot));
+        }
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(HRightDoneEvent(head.roundHead));
+        CopyL1ToL0AS2 copyA;
+        CopyL1ToL0BS2 copyB;
+        if constexpr (STATE_V_FIRST) {
+            // LoadRight 已将 GM ND right[M,V] 按 ColumnMajor 映射为 L1[V,M]，
+            // kg 保持 GM ND[M,K]，Cube 直接执行 [V,M]@[M,K] -> [V,K]。
+            auto tensorRight = tla::MakeTensor(l1HRight_[head.roundHead], L1_LEFT_S2_LAYOUT,
+                                               Catlass::Arch::PositionL1{});
+            auto tensorKg = tla::MakeTensor(l1Kg_[binding.slot], L1_RIGHT_S2_LAYOUT,
+                                            Catlass::Arch::PositionL1{});
+            copyA(tensorL0A, tla::GetTile(tensorRight, tla::MakeCoord(0, 0),
+                                          tla::MakeShape(m, k)));
+            copyB(tensorL0B, tla::GetTile(tensorKg, tla::MakeCoord(0, 0),
+                                          tla::MakeShape(k, FWD_H_V)));
+        } else {
+            auto tensorKg = tla::MakeTensor(l1Kg_[binding.slot], L1_LEFT_S2_LAYOUT,
+                                            Catlass::Arch::PositionL1{});
+            auto tensorRight = tla::MakeTensor(l1HRight_[head.roundHead], L1_RIGHT_S2_LAYOUT,
+                                               Catlass::Arch::PositionL1{});
+            copyA(tensorL0A, tla::GetTile(tensorKg, tla::MakeCoord(0, 0),
+                                          tla::MakeShape(m, k)));
+            copyB(tensorL0B, tla::GetTile(tensorRight, tla::MakeCoord(0, 0),
+                                          tla::MakeShape(k, FWD_H_V)));
+        }
+        if (head.roundHead == binding.lastConsumer) {
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(binding.slot));
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(HRightReadyEvent(head.roundHead));
+        AscendC::CrossCoreSetFlag<0x4, PIPE_MTE1>(
+            FwdHAicPeerFlag(FWD_H_RIGHT_FREE_FLAG, head.localSlot, head.aiv));
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0AReadyEvent(pipelineSlot));
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(L0BReadyEvent(pipelineSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0AReadyEvent(pipelineSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(L0BReadyEvent(pipelineSlot));
+        AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(pipelineSlot));
+        TileMmadS2 mmad;
+        mmad(tensorL0C, tensorL0A, tensorL0B, true, 0b11);
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0AFreeEvent(pipelineSlot));
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0BFreeEvent(pipelineSlot));
+        AscendC::SetFlag<AscendC::HardEvent::M_FIX>(FixDoneEvent(pipelineSlot));
+
+        if (stage0Ran) {
+            // Stage0 写入 P 后由 Stage1 发布 P_FREE；只有此时 Stage2 才能复用同一 UB slot 写 D。
+            AscendC::CrossCoreWaitFlag<0x4, PIPE_FIX>(
+                FwdHAicPeerFlag(FWD_H_P_FREE_FLAG, head.localSlot, head.aiv));
+        }
+        AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(FixDoneEvent(pipelineSlot));
+        AscendC::LocalTensor<float> dUb = ubBuf_.Get<uint8_t>()[FwdHLocalSlotBase(head.localSlot)].template ReinterpretCast<float>();
+        auto ubLayout = tla::MakeLayout<float, LayoutOutput>(FWD_H_K, FWD_H_V);
+        auto tensorUb = tla::MakeTensor(dUb, ubLayout, Catlass::Arch::PositionUB{});
+        CopyL0CToUbS2<decltype(tensorUb)> copyD;
+        copyD(tensorUb, tensorL0C, static_cast<uint8_t>(head.aiv), 0b11);
+        AscendC::CrossCoreSetFlag<0x4, PIPE_FIX>(
+            FwdHAicPeerFlag(FWD_H_D_READY_FLAG, head.localSlot, head.aiv));
+        AscendC::SetFlag<AscendC::HardEvent::FIX_M>(FixFreeEvent(pipelineSlot));
+    }
+
+    __aicore__ inline void RunStage2(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                     bool stage0Ran)
+    {
+        // Stage2：g-only 计算 D_c=k_raw_c^T@V_new_g；gk-only 计算 D_c=kg_c^T@V_new。
+        for (uint32_t kgSlot = 0; kgSlot < unit.headRound.requiredKhCount; ++kgSlot) {
+            LoadKg(unit, chunk, unit.headRound.kg[kgSlot]);
+        }
+        for (uint32_t roundHead = 0; roundHead < unit.headRound.activeHeadCount; ++roundHead) {
+            LoadRight(chunk, unit.headRound.heads[roundHead]);
+            if (roundHead > 0) {
+                ComputeStage2Head(unit, chunk, unit.headRound.heads[roundHead - 1],
+                                  (roundHead - 1) & 1U, stage0Ran);
+            }
+        }
+        if (unit.headRound.activeHeadCount > 0) {
+            const uint32_t last = unit.headRound.activeHeadCount - 1;
+            ComputeStage2Head(unit, chunk, unit.headRound.heads[last], last & 1U, stage0Ran);
+        }
+    }
+
+    __aicore__ inline void ProcessWorkUnit(const FwdHWorkUnit &unit)
+    {
+        if (!hasCubeWork_) {
+            return;
+        }
+        for (uint32_t chunkId = 0; chunkId < unit.sequence.chunkCount; ++chunkId) {
+            const FwdHChunkSpan chunk = FwdHBuildChunk(unit.sequence, chunkId);
+            const bool stage0Ran = !(chunk.first && args_.tiling.useInitialState == 0);
+            if (stage0Ran) {
+                RunStage0(unit, chunk);
+            }
+            if (args_.tiling.storeFinalState != 0 || !chunk.last) {
+                RunStage2(unit, chunk, stage0Ran);
+            }
+        }
+
+        const bool terminalStage2 = args_.tiling.storeFinalState != 0;
+        const bool terminalStage0 = args_.tiling.useInitialState != 0 || unit.sequence.chunkCount > 1;
+        for (uint32_t roundHead = 0; roundHead < unit.headRound.activeHeadCount; ++roundHead) {
+            const FwdHHeadBinding &head = unit.headRound.heads[roundHead];
+            if (terminalStage2) {
+                AscendC::CrossCoreWaitFlag<0x4, PIPE_FIX>(
+                    FwdHAicPeerFlag(FWD_H_D_FREE_FLAG, head.localSlot, head.aiv));
+            } else if (terminalStage0) {
+                AscendC::CrossCoreWaitFlag<0x4, PIPE_FIX>(
+                    FwdHAicPeerFlag(FWD_H_P_FREE_FLAG, head.localSlot, head.aiv));
+            }
+        }
+        AscendC::CrossCoreWaitFlag<0x4, PIPE_FIX>(FwdHAicPeerFlag(FWD_H_ROUND_DONE_FLAG, 0, 0));
+        AscendC::CrossCoreWaitFlag<0x4, PIPE_FIX>(FwdHAicPeerFlag(FWD_H_ROUND_DONE_FLAG, 0, 1));
+        AscendC::CrossCoreSetFlag<0x4, PIPE_FIX>(FwdHAicPeerFlag(FWD_H_H_READY_FLAG, 0, 0));
+        AscendC::CrossCoreSetFlag<0x4, PIPE_FIX>(FwdHAicPeerFlag(FWD_H_H_READY_FLAG, 0, 1));
+    }
+
+    FwdHKernelArgs args_{};
+    uint32_t coreIdx_ = 0;
+    uint32_t coreNum_ = 1;
+    bool hasCubeWork_ = false;
+    AscendC::TBuf<AscendC::TPosition::A1> l1Buf_{};
+    AscendC::TBuf<AscendC::TPosition::A2> l0ABuf_{};
+    AscendC::TBuf<AscendC::TPosition::B2> l0BBuf_{};
+    AscendC::TBuf<AscendC::TPosition::CO1> l0CBuf_{};
+    AscendC::TBuf<AscendC::TPosition::VECCALC> ubBuf_{};
+    AscendC::TBuf<AscendC::TPosition::C2PIPE2GM> fixBuf_{};
+    AscendC::TEventID wReadyEvent_[FWD_H_AIC_HEAD_SLOTS]{};
+    AscendC::TEventID wDoneEvent_[FWD_H_AIC_HEAD_SLOTS]{};
+    AscendC::TEventID hRightReadyEvent_[FWD_H_AIC_HEAD_SLOTS]{};
+    AscendC::TEventID hRightDoneEvent_[FWD_H_AIC_HEAD_SLOTS]{};
+    AscendC::TEventID l0AFreeEvent_[L0_SLOTS]{};
+    AscendC::TEventID l0AReadyEvent_[L0_SLOTS]{};
+    AscendC::TEventID l0BFreeEvent_[L0_SLOTS]{};
+    AscendC::TEventID l0BReadyEvent_[L0_SLOTS]{};
+    AscendC::TEventID fixFreeEvent_[L0_SLOTS]{};
+    AscendC::TEventID fixDoneEvent_[L0_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> l1W_[FWD_H_AIC_HEAD_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> l1HRight_[FWD_H_AIC_HEAD_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> l1Kg_[FWD_H_AIC_HEAD_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> l0A_[L0_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> l0B_[L0_SLOTS]{};
+    AscendC::LocalTensor<ElementAccumulator> l0C_[L0_SLOTS]{};
+};
+
+} // namespace GDN
+
+#endif // ARCH35_CHUNK_FWD_H_CUBE_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch35/chunk_fwd_h_vec.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch35/chunk_fwd_h_vec.h
@@ -579,12 +579,17 @@ private:
         }
     }
 
-    template <bool WRITE_H, bool ZERO_STATE>
+    template <bool WRITE_H, bool WAIT_MTE2>
     __aicore__ inline void ConsumeStage3Head(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
                                              const FwdHHeadBinding &head)
     {
         const uint32_t slot = head.localSlot;
         AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(FwdHAivLocalFlag(FWD_H_D_READY_FLAG, slot));
+        if constexpr (WAIT_MTE2) {
+            // 只有本次 Stage3 确实从 GM 搬入 state/gk 时才等待 MTE2；BF16 g-only
+            // 直接消费 Stage1 已驻留的 stateBf16，不能等待不存在的 event credit。
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+        }
         __ubuf__ float *d = reinterpret_cast<__ubuf__ float *>(local_[slot].GetPhyAddr());
         __ubuf__ bfloat16_t *hNext = nullptr;
         if constexpr (CompilePolicy::STATE_FP32) {
@@ -706,19 +711,36 @@ private:
             const bool zeroState = chunk.first && args_.tiling.useInitialState == 0;
             if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::KEY_GK) {
                 AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
-                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
             } else if constexpr (CompilePolicy::STATE_FP32) {
                 if (!zeroState) {
                     AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
-                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
                 }
             }
-            if (writeH) {
-                zeroState ? ConsumeStage3Head<true, true>(unit, chunk, head)
-                          : ConsumeStage3Head<true, false>(unit, chunk, head);
+            if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::KEY_GK) {
+                // gk-only 每个 Stage3 都搬入 gk_last，必须等待该 MTE2。
+                if (writeH) {
+                    ConsumeStage3Head<true, true>(unit, chunk, head);
+                } else {
+                    ConsumeStage3Head<false, true>(unit, chunk, head);
+                }
+            } else if constexpr (CompilePolicy::STATE_FP32) {
+                if (zeroState) {
+                    // 首 chunk 无 initial_state 时 state 为 VF 内构造的零值，没有 MTE2 输入。
+                    if (writeH) {
+                        ConsumeStage3Head<true, false>(unit, chunk, head);
+                    } else {
+                        ConsumeStage3Head<false, false>(unit, chunk, head);
+                    }
+                } else if (writeH) {
+                    ConsumeStage3Head<true, true>(unit, chunk, head);
+                } else {
+                    ConsumeStage3Head<false, true>(unit, chunk, head);
+                }
+            } else if (writeH) {
+                // BF16 g-only 的 stateBf16 由 Stage1 写入并由 right-ready 链路保护。
+                ConsumeStage3Head<true, false>(unit, chunk, head);
             } else {
-                zeroState ? ConsumeStage3Head<false, true>(unit, chunk, head)
-                          : ConsumeStage3Head<false, false>(unit, chunk, head);
+                ConsumeStage3Head<false, false>(unit, chunk, head);
             }
         }
     }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch35/chunk_fwd_h_vec.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch35/chunk_fwd_h_vec.h
@@ -322,6 +322,7 @@ private:
             ioFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE3_MTE2);
             ioReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_V);
             ioDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::V_MTE3);
+            hWriteDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE3_MTE2);
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
         }
     }
@@ -339,6 +340,11 @@ private:
     __aicore__ inline AscendC::TEventID IoDoneEvent(uint32_t slot) const
     {
         return ioDoneEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID HWriteDoneEvent(uint32_t slot) const
+    {
+        return hWriteDoneEvent_[slot];
     }
 
     __aicore__ inline void DrainLocalEvents()
@@ -623,6 +629,8 @@ private:
                     local_[slot].template ReinterpretCast<bfloat16_t>();
                 AscendC::DataCopy(h[HOffset(unit, next, head)], hLocal, FWD_H_K * FWD_H_V);
                 // H 的 MTE3 完成前，D slot 仍是 MTE3 输入，不能交给下一 Stage0/Stage2。
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(HWriteDoneEvent(slot));
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(HWriteDoneEvent(slot));
                 AscendC::CrossCoreSetFlag<0x4, PIPE_MTE3>(
                     FwdHAivLocalFlag(FWD_H_D_FREE_FLAG, slot));
             } else {
@@ -760,6 +768,7 @@ private:
     AscendC::TEventID ioFreeEvent_[FWD_H_AIV_HEAD_SLOTS]{};
     AscendC::TEventID ioReadyEvent_[FWD_H_AIV_HEAD_SLOTS]{};
     AscendC::TEventID ioDoneEvent_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::TEventID hWriteDoneEvent_[FWD_H_AIV_HEAD_SLOTS]{};
     AscendC::TBuf<AscendC::TPosition::VECCALC> ubBuf_{};
     AscendC::LocalTensor<uint8_t> local_[FWD_H_AIV_HEAD_SLOTS]{};
     AscendC::LocalTensor<bfloat16_t> right_[FWD_H_AIV_HEAD_SLOTS]{};

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch35/chunk_fwd_h_vec.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch35/chunk_fwd_h_vec.h
@@ -1,0 +1,777 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ */
+
+#ifndef ARCH35_CHUNK_FWD_H_VEC_H
+#define ARCH35_CHUNK_FWD_H_VEC_H
+
+#include <type_traits>
+
+#include "../chunk_fwd_h_policy.h"
+#include "../chunk_fwd_h_utils.h"
+#include "kernel_utils/vector/regbase.hpp"
+
+namespace GDN {
+
+using namespace AscendC::MicroAPI;
+
+constexpr float FWD_H_LN2 = 0.69314718055994530942f;
+
+template <typename T>
+__simd_callee__ inline void FwdHLoadAsFloat(RegTensor<float> &zero, RegTensor<float> &one,
+                                             __ubuf__ T *src, MaskReg &mask16)
+{
+    RegTensor<T> raw;
+    LoadIn<T, false>(raw, src);
+    CastHalf2Float<T>(zero, one, raw, mask16);
+}
+
+template <typename T>
+__simd_callee__ inline void FwdHLoadScalar(RegTensor<float> &dst, __ubuf__ T *src,
+                                            MaskReg &mask16, MaskReg &mask32)
+{
+    if constexpr (std::is_same<T, float>::value) {
+        LoadIn<float, true>(dst, src);
+    } else {
+        RegTensor<T> raw;
+        RegTensor<float> unused;
+        LoadIn<T, true>(raw, src);
+        CastHalf2Float<T>(dst, unused, raw, mask16);
+    }
+    (void)mask32;
+}
+
+__simd_callee__ inline void FwdHStoreBf16(__ubuf__ bfloat16_t *dst,
+                                          RegTensor<float> &zero, RegTensor<float> &one,
+                                          MaskReg &mask32, MaskReg &mask16)
+{
+    RegTensor<bfloat16_t> output;
+    CastFloat2Half<bfloat16_t>(output, zero, one, mask32);
+    StoreAlign(dst, output, mask16);
+}
+
+template <bool HAS_P, bool SCALAR_G, bool WRITE_RIGHT, bool ZERO_STATE, bool USE_EXP2,
+          typename PType, typename GateT>
+__simd_vf__ inline void FwdHStage1Arch35Vf(__ubuf__ bfloat16_t *uAndVNew,
+                                           __ubuf__ PType *p,
+                                           __ubuf__ GateT *gate,
+                                           __ubuf__ bfloat16_t *right,
+                                           __ubuf__ bfloat16_t *state,
+                                           __ubuf__ float *alpha,
+                                           uint16_t validTokens)
+{
+    // Stage1:
+    //   V_new_fp32[i,:] = fp32(U[i,:]) - fp32(P[i,:])，HAS_P=false 时 P=0；
+    //   V_new[i,:] = cast_BF16(V_new_fp32[i,:])；
+    //   g-only: right[i,:] = cast_BF16(E(g_last-g_i) * V_new_fp32[i,:])，alpha=E(g_last)；
+    //   gk-only: right=V_new。E 由 USE_EXP2 在编译期选择。
+    // 本 VF 覆盖当前 head 的全部 MTE2 后向量计算，内部没有运行期分支。
+    constexpr uint16_t FP32_PER_REG = AscendC::VECTOR_REG_WIDTH / sizeof(float);
+    constexpr uint16_t BF16_PER_REG = AscendC::VECTOR_REG_WIDTH / sizeof(bfloat16_t);
+    constexpr uint16_t STATE_ROWS = FWD_H_STATE_BF16_BYTES / sizeof(bfloat16_t) / BF16_PER_REG;
+    MaskReg mask16 = CreateMask<bfloat16_t, MaskPattern::ALL>();
+    MaskReg mask32 = CreateMask<float, MaskPattern::ALL>();
+
+    RegTensor<float> lastGate;
+    if constexpr (SCALAR_G && WRITE_RIGHT) {
+        FwdHLoadScalar<GateT>(lastGate, gate + validTokens - 1, mask16, mask32);
+        RegTensor<float> alphaReg;
+        FwdHLoadScalar<GateT>(alphaReg, gate + validTokens - 1, mask16, mask32);
+        if constexpr (USE_EXP2) {
+            Muls(alphaReg, alphaReg, FWD_H_LN2, mask32);
+        }
+        Exp(alphaReg, alphaReg, mask32);
+        uint32_t scalarCount = 1;
+        MaskReg scalarMask = UpdateMask<float>(scalarCount);
+        StoreAlign(alpha, alphaReg, scalarMask);
+    }
+
+    if constexpr (ZERO_STATE) {
+        RegTensor<bfloat16_t> zeroState;
+        Duplicate(zeroState, static_cast<bfloat16_t>(0), mask16);
+        #pragma unroll 2
+        for (uint16_t row = 0; row < STATE_ROWS; ++row) {
+            StoreAlign(state + static_cast<uint32_t>(row) * BF16_PER_REG, zeroState, mask16);
+        }
+    }
+
+    RegTensor<float> u0;
+    RegTensor<float> u1;
+    RegTensor<float> p0;
+    RegTensor<float> p1;
+    RegTensor<float> gateReg;
+    #pragma unroll 2
+    for (uint16_t row = 0; row < validTokens; ++row) {
+        const uint32_t rowBf16Offset = static_cast<uint32_t>(row) * FWD_H_V;
+        const uint32_t rowFp32Offset = static_cast<uint32_t>(row) * FWD_H_V;
+        for (uint16_t col = 0; col < FWD_H_V; col += BF16_PER_REG) {
+            const uint32_t bf16Offset = rowBf16Offset + col;
+            const uint32_t fp32Offset = rowFp32Offset + col;
+            FwdHLoadAsFloat<bfloat16_t>(u0, u1, uAndVNew + bf16Offset, mask16);
+            if constexpr (HAS_P) {
+                if constexpr (std::is_same<PType, float>::value) {
+                    LoadAlign(p0, p + fp32Offset);
+                    LoadAlign(p1, p + fp32Offset + FP32_PER_REG);
+                } else {
+                    FwdHLoadAsFloat<PType>(p0, p1, p + bf16Offset, mask16);
+                }
+            } else {
+                Duplicate(p0, 0.0f, mask32);
+                Duplicate(p1, 0.0f, mask32);
+            }
+            Sub(u0, u0, p0, mask32);
+            Sub(u1, u1, p1, mask32);
+            FwdHStoreBf16(uAndVNew + bf16Offset, u0, u1, mask32, mask16);
+
+            if constexpr (WRITE_RIGHT) {
+                if constexpr (SCALAR_G) {
+                    FwdHLoadScalar<GateT>(gateReg, gate + row, mask16, mask32);
+                    Sub(gateReg, lastGate, gateReg, mask32);
+                    if constexpr (USE_EXP2) {
+                        Muls(gateReg, gateReg, FWD_H_LN2, mask32);
+                    }
+                    Exp(gateReg, gateReg, mask32);
+                    Mul(u0, u0, gateReg, mask32);
+                    Mul(u1, u1, gateReg, mask32);
+                }
+                FwdHStoreBf16(right + bf16Offset, u0, u1, mask32, mask16);
+            }
+        }
+    }
+}
+
+template <bool STATE_FP32, bool SCALAR_G, bool STATE_V_FIRST, bool WRITE_H,
+          bool ZERO_STATE, bool USE_EXP2, typename GateT>
+__simd_vf__ inline void FwdHStage3Arch35Vf(__ubuf__ bfloat16_t *stateBf16,
+                                           __ubuf__ float *stateFp32,
+                                           __ubuf__ float *d,
+                                           __ubuf__ GateT *gkLast,
+                                           __ubuf__ float *alpha,
+                                           __ubuf__ bfloat16_t *hNext)
+{
+    // Stage3:
+    //   g-only: R_next = alpha * R + D，alpha=E(g_last)；
+    //   gk-only: R_next[k,v] = E(gk_last[k]) * R[k,v] + D[k,v]；
+    //   WRITE_H 时 H_next = cast_BF16(R_next)。
+    // STATE_V_FIRST=true 时 state、D 和 H 都以物理 [V,K] 顺序处理，公式语义仍为 [K,V]。
+    constexpr uint16_t FP32_PER_REG = AscendC::VECTOR_REG_WIDTH / sizeof(float);
+    constexpr uint16_t BF16_PER_REG = AscendC::VECTOR_REG_WIDTH / sizeof(bfloat16_t);
+    constexpr uint16_t ROWS = 128;
+    MaskReg mask16 = CreateMask<bfloat16_t, MaskPattern::ALL>();
+    MaskReg mask32 = CreateMask<float, MaskPattern::ALL>();
+    RegTensor<float> state0;
+    RegTensor<float> state1;
+    RegTensor<float> d0;
+    RegTensor<float> d1;
+    RegTensor<float> gate0;
+    RegTensor<float> gate1;
+
+    if constexpr (SCALAR_G) {
+        LoadIn<float, true>(gate0, alpha);
+        Adds(gate1, gate0, 0.0f, mask32);
+    }
+
+    #pragma unroll 2
+    for (uint16_t row = 0; row < ROWS; ++row) {
+        for (uint16_t col = 0; col < FWD_H_V; col += BF16_PER_REG) {
+            const uint32_t bf16Offset = static_cast<uint32_t>(row) * FWD_H_V + col;
+            const uint32_t fp32Offset = static_cast<uint32_t>(row) * FWD_H_V + col;
+            if constexpr (STATE_FP32) {
+                if constexpr (ZERO_STATE) {
+                    Duplicate(state0, 0.0f, mask32);
+                    Duplicate(state1, 0.0f, mask32);
+                } else {
+                    LoadAlign(state0, stateFp32 + fp32Offset);
+                    LoadAlign(state1, stateFp32 + fp32Offset + FP32_PER_REG);
+                }
+            } else {
+                FwdHLoadAsFloat<bfloat16_t>(state0, state1, stateBf16 + bf16Offset, mask16);
+            }
+            LoadAlign(d0, d + fp32Offset);
+            LoadAlign(d1, d + fp32Offset + FP32_PER_REG);
+
+            if constexpr (!SCALAR_G) {
+                if constexpr (STATE_V_FIRST) {
+                    if constexpr (std::is_same<GateT, float>::value) {
+                        LoadAlign(gate0, gkLast + col);
+                        LoadAlign(gate1, gkLast + col + FP32_PER_REG);
+                    } else {
+                        FwdHLoadAsFloat<GateT>(gate0, gate1, gkLast + col, mask16);
+                    }
+                    if constexpr (USE_EXP2) {
+                        Muls(gate0, gate0, FWD_H_LN2, mask32);
+                        Muls(gate1, gate1, FWD_H_LN2, mask32);
+                    }
+                    Exp(gate0, gate0, mask32);
+                    Exp(gate1, gate1, mask32);
+                } else {
+                    FwdHLoadScalar<GateT>(gate0, gkLast + row, mask16, mask32);
+                    if constexpr (USE_EXP2) {
+                        Muls(gate0, gate0, FWD_H_LN2, mask32);
+                    }
+                    Exp(gate0, gate0, mask32);
+                    Adds(gate1, gate0, 0.0f, mask32);
+                }
+            }
+            Mul(state0, state0, gate0, mask32);
+            Mul(state1, state1, gate1, mask32);
+            Add(state0, state0, d0, mask32);
+            Add(state1, state1, d1, mask32);
+
+            if constexpr (STATE_FP32) {
+                StoreAlign(stateFp32 + fp32Offset, state0, mask32);
+                StoreAlign(stateFp32 + fp32Offset + FP32_PER_REG, state1, mask32);
+            } else {
+                FwdHStoreBf16(stateBf16 + bf16Offset, state0, state1, mask32, mask16);
+            }
+            if constexpr (WRITE_H && STATE_FP32) {
+                // FP32 state 没有独立的 32 KiB H bank。当前 D 行读入寄存器后，允许把
+                // BF16 H 原位写到 D slot 的低半区；写地址只覆盖已经消费的 D 行。
+                FwdHStoreBf16(hNext + bf16Offset, state0, state1, mask32, mask16);
+            }
+        }
+    }
+}
+
+__simd_vf__ inline void FwdHSMinusOneArch35Vf(__ubuf__ float *state,
+                                               __ubuf__ bfloat16_t *h)
+{
+    // S-1: H0 = cast_BF16(initial_state)。输入和输出保持 state_v_first 指定的同一物理顺序。
+    constexpr uint16_t FP32_PER_REG = AscendC::VECTOR_REG_WIDTH / sizeof(float);
+    constexpr uint16_t BF16_PER_REG = AscendC::VECTOR_REG_WIDTH / sizeof(bfloat16_t);
+    MaskReg mask16 = CreateMask<bfloat16_t, MaskPattern::ALL>();
+    MaskReg mask32 = CreateMask<float, MaskPattern::ALL>();
+    RegTensor<float> state0;
+    RegTensor<float> state1;
+    #pragma unroll 2
+    for (uint16_t row = 0; row < 128; ++row) {
+        for (uint16_t col = 0; col < FWD_H_V; col += BF16_PER_REG) {
+            const uint32_t fp32Offset = static_cast<uint32_t>(row) * FWD_H_V + col;
+            const uint32_t bf16Offset = static_cast<uint32_t>(row) * FWD_H_V + col;
+            LoadAlign(state0, state + fp32Offset);
+            LoadAlign(state1, state + fp32Offset + FP32_PER_REG);
+            FwdHStoreBf16(h + bf16Offset, state0, state1, mask32, mask16);
+        }
+    }
+}
+
+template <typename GateT, typename CompilePolicy, bool STATE_V_FIRST>
+class ChunkFwdHVecArch35 {
+public:
+    __aicore__ inline void Init(const FwdHKernelArgs &args)
+    {
+        args_ = args;
+        coreIdx_ = AscendC::GetBlockIdx() / AscendC::GetSubBlockNum();
+        coreNum_ = AscendC::GetBlockNum();
+        aiv_ = AscendC::GetSubBlockIdx();
+        InitBuffers();
+        InitLocalEvents();
+    }
+
+    __aicore__ inline void Process()
+    {
+        const uint32_t sequenceCount = args_.tiling.isVariedLen != 0
+                                           ? static_cast<uint32_t>(args_.tiling.tokenBatch)
+                                           : static_cast<uint32_t>(args_.tiling.shapeBatch);
+        const uint32_t rounds = FwdHHeadRoundsPerSequence<CompilePolicy::GATE_MODE>(args_.tiling);
+        // 同一 sequence 的所有 head-round 绑定到同一核，round 内串行收口；
+        // ProcessWorkUnit 返回时已完成本轮 ROUND_DONE/ACK，下一轮才允许预取。
+        for (uint32_t sequence = coreIdx_; sequence < sequenceCount; sequence += coreNum_) {
+            const FwdHSequenceSpan sequenceSpan = FwdHResolveSequence(args_, sequence);
+            for (uint32_t round = 0; round < rounds; ++round) {
+                const FwdHWorkUnit unit{sequenceSpan,
+                                        FwdHBuildHeadRound<CompilePolicy::GATE_MODE>(args_.tiling,
+                                                                                      round)};
+                if (unit.sequence.chunkCount != 0 && unit.headRound.activeHeadCount != 0) {
+                    ProcessWorkUnit(unit);
+                }
+            }
+        }
+        DrainLocalEvents();
+    }
+
+private:
+    __aicore__ inline void InitBuffers()
+    {
+        GetTPipePtr()->InitBuffer(ubBuf_, 248 * 1024);
+        AscendC::LocalTensor<uint8_t> ub = ubBuf_.Get<uint8_t>();
+        local_[0] = ub[FWD_H_UB_LOCAL0_BASE].template ReinterpretCast<uint8_t>();
+        local_[1] = ub[FWD_H_UB_LOCAL1_BASE].template ReinterpretCast<uint8_t>();
+        right_[0] = ub[FWD_H_UB_LOCAL0_BASE + FWD_H_TOKEN_MATRIX_FP32_BYTES].template ReinterpretCast<bfloat16_t>();
+        right_[1] = ub[FWD_H_UB_LOCAL1_BASE + FWD_H_TOKEN_MATRIX_FP32_BYTES].template ReinterpretCast<bfloat16_t>();
+        stateBf16_[0] = ub[FWD_H_UB_BF16_STATE_BASE].template ReinterpretCast<bfloat16_t>();
+        stateBf16_[1] = ub[FWD_H_UB_BF16_STATE_BASE + FWD_H_STATE_BF16_BYTES].template ReinterpretCast<bfloat16_t>();
+        workBf16_[0] = ub[FWD_H_UB_BF16_WORK_BASE].template ReinterpretCast<bfloat16_t>();
+        workBf16_[1] = ub[FWD_H_UB_BF16_WORK_BASE + FWD_H_TOKEN_MATRIX_BF16_BYTES].template ReinterpretCast<bfloat16_t>();
+        stateFp32_ = ub[FWD_H_UB_FP32_STATE_BASE].template ReinterpretCast<float>();
+        for (uint32_t slot = 0; slot < FWD_H_AIV_HEAD_SLOTS; ++slot) {
+            sminusH_[slot] = ub[slot * FWD_H_STATE_BF16_BYTES].template ReinterpretCast<bfloat16_t>();
+            sminusState_[slot] = ub[64 * 1024 + slot * FWD_H_STATE_FP32_BYTES].template ReinterpretCast<float>();
+        }
+        gate_[0] = ub[FWD_H_UB_GATE_BASE].template ReinterpretCast<GateT>();
+        gate_[1] = ub[FWD_H_UB_GATE_BASE + 512].template ReinterpretCast<GateT>();
+        alpha_[0] = ub[FWD_H_UB_GATE_BASE + 1024].template ReinterpretCast<float>();
+        alpha_[1] = ub[FWD_H_UB_GATE_BASE + 1056].template ReinterpretCast<float>();
+    }
+
+    __aicore__ inline void InitLocalEvents()
+    {
+        for (uint32_t slot = 0; slot < FWD_H_AIV_HEAD_SLOTS; ++slot) {
+            ioFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE3_MTE2);
+            ioReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_V);
+            ioDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::V_MTE3);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        }
+    }
+
+    __aicore__ inline AscendC::TEventID IoFreeEvent(uint32_t slot) const
+    {
+        return ioFreeEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID IoReadyEvent(uint32_t slot) const
+    {
+        return ioReadyEvent_[slot];
+    }
+
+    __aicore__ inline AscendC::TEventID IoDoneEvent(uint32_t slot) const
+    {
+        return ioDoneEvent_[slot];
+    }
+
+    __aicore__ inline void DrainLocalEvents()
+    {
+        for (uint32_t slot = 0; slot < FWD_H_AIV_HEAD_SLOTS; ++slot) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        }
+    }
+
+    __aicore__ inline uint64_t HOffset(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                       const FwdHHeadBinding &head) const
+    {
+        return FwdHHOffset(args_.tiling, unit.sequence, head.hv, chunk.globalChunk);
+    }
+
+    __aicore__ inline uint64_t UOffset(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                       const FwdHHeadBinding &head) const
+    {
+        return FwdHInputOffset(args_.tiling, unit.sequence.physicalBatch, head.hv,
+                               chunk.tokenBegin, FWD_H_V);
+    }
+
+    __aicore__ inline uint64_t GateOffset(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                          const FwdHHeadBinding &head) const
+    {
+        const uint32_t dim = CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G ? 1 : FWD_H_K;
+        return FwdHInputOffset(args_.tiling, unit.sequence.physicalBatch, head.hv,
+                               chunk.tokenBegin, dim);
+    }
+
+    __aicore__ inline void CopyGateToUb(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                        const FwdHHeadBinding &head)
+    {
+        AscendC::GlobalTensor<GateT> gateGm;
+        gateGm.SetGlobalBuffer(reinterpret_cast<__gm__ GateT *>(
+            CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G ? args_.g : args_.gk));
+        if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G) {
+            AscendC::DataCopyPadExtParams<GateT> pad{false, 0, 0, 0};
+            const uint32_t gateBytes = static_cast<uint32_t>(chunk.validTokens * sizeof(GateT));
+            AscendC::DataCopyExtParams copy{1, gateBytes, 0, 0, 0};
+            AscendC::DataCopyPad(gate_[head.localSlot], gateGm[GateOffset(unit, chunk, head)], copy, pad);
+        } else {
+            const uint64_t lastOffset = GateOffset(unit, chunk, head) +
+                                        static_cast<uint64_t>(chunk.validTokens - 1) * FWD_H_K;
+            AscendC::DataCopy(gate_[head.localSlot], gateGm[lastOffset], FWD_H_K);
+        }
+    }
+
+    __aicore__ inline void PrefetchSMinusOneHead(const FwdHWorkUnit &unit,
+                                                 const FwdHHeadBinding &head)
+    {
+        const uint32_t slot = head.localSlot;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        AscendC::GlobalTensor<float> initial;
+        initial.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.initialState));
+        const uint64_t stateBase = FwdHStateOffset(args_.tiling, unit.sequence.sequence,
+                                                   head.hv, 0, 0);
+        AscendC::DataCopy(sminusState_[slot], initial[stateBase], FWD_H_K * FWD_H_V);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+    }
+
+    __aicore__ inline void ConsumeSMinusOneHead(const FwdHWorkUnit &unit,
+                                                const FwdHHeadBinding &head)
+    {
+        // S-1：H0=cast_BF16(initial_state)。输入输出保持 state_v_first 指定的物理顺序。
+        const uint32_t slot = head.localSlot;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+        AscendC::VF_CALL<FwdHSMinusOneArch35Vf>(
+            reinterpret_cast<__ubuf__ float *>(sminusState_[slot].GetPhyAddr()),
+            reinterpret_cast<__ubuf__ bfloat16_t *>(sminusH_[slot].GetPhyAddr()));
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+        AscendC::GlobalTensor<bfloat16_t> h;
+        h.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.h));
+        const FwdHChunkSpan firstChunk = FwdHBuildChunk(unit.sequence, 0);
+        AscendC::DataCopy(h[HOffset(unit, firstChunk, head)], sminusH_[slot],
+                          FWD_H_K * FWD_H_V);
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+    }
+
+    __aicore__ inline void RunSMinusOne(const FwdHWorkUnit &unit)
+    {
+        // S-1：StateT=FP32 且存在 initial_state 时，H0=cast_BF16(R0)；
+        // 输入输出保持 state_v_first 指定的物理顺序，不依赖外部转置。
+        if constexpr (!CompilePolicy::STATE_FP32) {
+            return;
+        }
+        if (args_.tiling.useInitialState == 0) {
+            return;
+        }
+        const uint32_t localHeads = FwdHAivHeadCount(unit.headRound.activeHeadCount, aiv_);
+        for (uint32_t coreHeadId = 0; coreHeadId < localHeads; ++coreHeadId) {
+            const FwdHHeadBinding &head = unit.headRound.heads[aiv_ + 2 * coreHeadId];
+            PrefetchSMinusOneHead(unit, head);
+            if (coreHeadId > 0) {
+                ConsumeSMinusOneHead(
+                    unit, unit.headRound.heads[aiv_ + 2 * (coreHeadId - 1)]);
+            }
+        }
+        if (localHeads > 0) {
+            ConsumeSMinusOneHead(
+                unit, unit.headRound.heads[aiv_ + 2 * (localHeads - 1)]);
+        }
+        // S-1 与主循环复用 [0,192) KiB。先 drain 全部 active bank，再统一发布 H ready。
+        for (uint32_t slot = 0; slot < localHeads; ++slot) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        }
+        for (uint32_t coreHeadId = 0; coreHeadId < localHeads; ++coreHeadId) {
+            const FwdHHeadBinding &head = unit.headRound.heads[aiv_ + 2 * coreHeadId];
+            AscendC::CrossCoreSetFlag<0x4, PIPE_MTE3>(
+                FwdHAivLocalFlag(FWD_H_H_READY_FLAG, head.localSlot));
+        }
+    }
+
+    template <bool HAS_P, bool WRITE_RIGHT, bool ZERO_STATE>
+    __aicore__ inline void ConsumeStage1Head(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                             const FwdHHeadBinding &head)
+    {
+        const uint32_t slot = head.localSlot;
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+        if constexpr (HAS_P) {
+            AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(FwdHAivLocalFlag(FWD_H_P_READY_FLAG, slot));
+        }
+        using PType = std::conditional_t<CompilePolicy::STATE_FP32, float, bfloat16_t>;
+        __ubuf__ PType *p = reinterpret_cast<__ubuf__ PType *>(local_[slot].GetPhyAddr());
+        __ubuf__ bfloat16_t *right = reinterpret_cast<__ubuf__ bfloat16_t *>(right_[slot].GetPhyAddr());
+        __ubuf__ bfloat16_t *state = reinterpret_cast<__ubuf__ bfloat16_t *>(stateBf16_[slot].GetPhyAddr());
+        if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G) {
+            AscendC::VF_CALL<FwdHStage1Arch35Vf<HAS_P, true, WRITE_RIGHT, ZERO_STATE,
+                                                CompilePolicy::USE_EXP2, PType, GateT>>(
+                reinterpret_cast<__ubuf__ bfloat16_t *>(workBf16_[slot].GetPhyAddr()), p,
+                reinterpret_cast<__ubuf__ GateT *>(gate_[slot].GetPhyAddr()), right, state,
+                reinterpret_cast<__ubuf__ float *>(alpha_[slot].GetPhyAddr()),
+                static_cast<uint16_t>(chunk.validTokens));
+        } else {
+            AscendC::VF_CALL<FwdHStage1Arch35Vf<HAS_P, false, WRITE_RIGHT, ZERO_STATE,
+                                                CompilePolicy::USE_EXP2, PType, GateT>>(
+                reinterpret_cast<__ubuf__ bfloat16_t *>(workBf16_[slot].GetPhyAddr()), p,
+                reinterpret_cast<__ubuf__ GateT *>(gate_[slot].GetPhyAddr()), right, state,
+                reinterpret_cast<__ubuf__ float *>(alpha_[slot].GetPhyAddr()),
+                static_cast<uint16_t>(chunk.validTokens));
+        }
+        if constexpr (HAS_P) {
+            AscendC::CrossCoreSetFlag<0x4, PIPE_V>(FwdHAivLocalFlag(FWD_H_P_FREE_FLAG, slot));
+        }
+
+        AscendC::GlobalTensor<bfloat16_t> vNew;
+        AscendC::GlobalTensor<bfloat16_t> rightGm;
+        AscendC::GlobalTensor<bfloat16_t> h;
+        vNew.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.vNew));
+        rightGm.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(
+            args_.workspace + args_.tiling.vUpdateWorkspaceOffset));
+        h.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.h));
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+        AscendC::DataCopy(vNew[UOffset(unit, chunk, head)], workBf16_[slot],
+                          chunk.validTokens * FWD_H_V);
+        if constexpr (WRITE_RIGHT) {
+            const uint64_t rightOffset = FwdHCoreSlotOffset(coreIdx_, head.roundHead,
+                                                            FWD_H_CHUNK * FWD_H_V);
+            AscendC::DataCopy(rightGm[rightOffset], right_[slot], chunk.validTokens * FWD_H_V);
+            AscendC::CrossCoreSetFlag<0x4, PIPE_MTE3>(
+                FwdHAivLocalFlag(FWD_H_RIGHT_READY_FLAG, slot));
+        }
+        if constexpr (!CompilePolicy::STATE_FP32) {
+            if (chunk.first) {
+                AscendC::DataCopy(h[HOffset(unit, chunk, head)], stateBf16_[slot], FWD_H_K * FWD_H_V);
+            }
+        } else if constexpr (ZERO_STATE) {
+            AscendC::DataCopy(h[HOffset(unit, chunk, head)], stateBf16_[slot], FWD_H_K * FWD_H_V);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+    }
+
+    __aicore__ inline void RunStage1(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk)
+    {
+        // Stage1：V_new=cast_BF16(fp32(U)-fp32(P))；g-only 同时生成
+        // V_new_g=cast_BF16(E(g_last-g_i)*V_new_fp32)，gk-only 的右矩阵就是 V_new。
+        const bool hasP = !(chunk.first && args_.tiling.useInitialState == 0);
+        const bool writeRight = args_.tiling.storeFinalState != 0 || !chunk.last;
+        const bool zeroState = chunk.first && args_.tiling.useInitialState == 0;
+        const uint32_t localHeads = FwdHAivHeadCount(unit.headRound.activeHeadCount, aiv_);
+        for (uint32_t coreHeadId = 0; coreHeadId < localHeads; ++coreHeadId) {
+            const FwdHHeadBinding &head = unit.headRound.heads[aiv_ + 2 * coreHeadId];
+            const uint32_t slot = head.localSlot;
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+            AscendC::GlobalTensor<bfloat16_t> u;
+            u.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.u));
+            AscendC::DataCopy(workBf16_[slot], u[UOffset(unit, chunk, head)], chunk.validTokens * FWD_H_V);
+            if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G) {
+                if (writeRight) {
+                    CopyGateToUb(unit, chunk, head);
+                }
+            }
+            if (!CompilePolicy::STATE_FP32 && chunk.first && args_.tiling.useInitialState != 0) {
+                AscendC::GlobalTensor<bfloat16_t> initial;
+                initial.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.initialState));
+                const uint64_t stateOffset = FwdHStateOffset(args_.tiling, unit.sequence.sequence, head.hv, 0, 0);
+                AscendC::DataCopy(stateBf16_[slot], initial[stateOffset], FWD_H_K * FWD_H_V);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+            if (coreHeadId > 0) {
+                const FwdHHeadBinding &previous = unit.headRound.heads[aiv_ + 2 * (coreHeadId - 1)];
+                DispatchStage1(unit, chunk, previous, hasP, writeRight, zeroState);
+            }
+        }
+        if (localHeads > 0) {
+            const FwdHHeadBinding &last = unit.headRound.heads[aiv_ + 2 * (localHeads - 1)];
+            DispatchStage1(unit, chunk, last, hasP, writeRight, zeroState);
+        }
+    }
+
+    __aicore__ inline void DispatchStage1(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                          const FwdHHeadBinding &head, bool hasP,
+                                          bool writeRight, bool zeroState)
+    {
+        if (hasP) {
+            if (writeRight) {
+                zeroState ? ConsumeStage1Head<true, true, true>(unit, chunk, head)
+                          : ConsumeStage1Head<true, true, false>(unit, chunk, head);
+            } else {
+                zeroState ? ConsumeStage1Head<true, false, true>(unit, chunk, head)
+                          : ConsumeStage1Head<true, false, false>(unit, chunk, head);
+            }
+        } else if (writeRight) {
+            zeroState ? ConsumeStage1Head<false, true, true>(unit, chunk, head)
+                      : ConsumeStage1Head<false, true, false>(unit, chunk, head);
+        } else {
+            zeroState ? ConsumeStage1Head<false, false, true>(unit, chunk, head)
+                      : ConsumeStage1Head<false, false, false>(unit, chunk, head);
+        }
+    }
+
+    template <bool WRITE_H, bool ZERO_STATE>
+    __aicore__ inline void ConsumeStage3Head(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
+                                             const FwdHHeadBinding &head)
+    {
+        const uint32_t slot = head.localSlot;
+        AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(FwdHAivLocalFlag(FWD_H_D_READY_FLAG, slot));
+        __ubuf__ float *d = reinterpret_cast<__ubuf__ float *>(local_[slot].GetPhyAddr());
+        __ubuf__ bfloat16_t *hNext = nullptr;
+        if constexpr (CompilePolicy::STATE_FP32) {
+            hNext = reinterpret_cast<__ubuf__ bfloat16_t *>(local_[slot].GetPhyAddr());
+        } else {
+            hNext = reinterpret_cast<__ubuf__ bfloat16_t *>(stateBf16_[slot].GetPhyAddr());
+        }
+        if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G) {
+            AscendC::VF_CALL<FwdHStage3Arch35Vf<CompilePolicy::STATE_FP32, true, STATE_V_FIRST,
+                                                WRITE_H, ZERO_STATE, CompilePolicy::USE_EXP2, GateT>>(
+                reinterpret_cast<__ubuf__ bfloat16_t *>(stateBf16_[slot].GetPhyAddr()),
+                reinterpret_cast<__ubuf__ float *>(stateFp32_.GetPhyAddr()), d,
+                reinterpret_cast<__ubuf__ GateT *>(gate_[slot].GetPhyAddr()),
+                reinterpret_cast<__ubuf__ float *>(alpha_[slot].GetPhyAddr()), hNext);
+        } else {
+            AscendC::VF_CALL<FwdHStage3Arch35Vf<CompilePolicy::STATE_FP32, false, STATE_V_FIRST,
+                                                WRITE_H, ZERO_STATE, CompilePolicy::USE_EXP2, GateT>>(
+                reinterpret_cast<__ubuf__ bfloat16_t *>(stateBf16_[slot].GetPhyAddr()),
+                reinterpret_cast<__ubuf__ float *>(stateFp32_.GetPhyAddr()), d,
+                reinterpret_cast<__ubuf__ GateT *>(gate_[slot].GetPhyAddr()),
+                reinterpret_cast<__ubuf__ float *>(alpha_[slot].GetPhyAddr()), hNext);
+        }
+        if constexpr (!WRITE_H || !CompilePolicy::STATE_FP32) {
+            AscendC::CrossCoreSetFlag<0x4, PIPE_V>(FwdHAivLocalFlag(FWD_H_D_FREE_FLAG, slot));
+        }
+
+        AscendC::GlobalTensor<bfloat16_t> h;
+        h.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.h));
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
+        if constexpr (WRITE_H) {
+            if constexpr (CompilePolicy::STATE_FP32) {
+                AscendC::GlobalTensor<float> state;
+                state.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.workspace));
+                const uint64_t stateOffset = args_.tiling.kDecayWorkspaceOffset / sizeof(float) +
+                    FwdHCoreSlotOffset(coreIdx_, head.roundHead, FWD_H_K * FWD_H_V);
+                AscendC::DataCopy(state[stateOffset], stateFp32_, FWD_H_K * FWD_H_V);
+            }
+            const FwdHChunkSpan next = FwdHBuildChunk(unit.sequence, chunk.chunk + 1);
+            if constexpr (CompilePolicy::STATE_FP32) {
+                AscendC::LocalTensor<bfloat16_t> hLocal =
+                    local_[slot].template ReinterpretCast<bfloat16_t>();
+                AscendC::DataCopy(h[HOffset(unit, next, head)], hLocal, FWD_H_K * FWD_H_V);
+                // H 的 MTE3 完成前，D slot 仍是 MTE3 输入，不能交给下一 Stage0/Stage2。
+                AscendC::CrossCoreSetFlag<0x4, PIPE_MTE3>(
+                    FwdHAivLocalFlag(FWD_H_D_FREE_FLAG, slot));
+            } else {
+                AscendC::DataCopy(h[HOffset(unit, next, head)], stateBf16_[slot],
+                                  FWD_H_K * FWD_H_V);
+            }
+            AscendC::CrossCoreSetFlag<0x4, PIPE_MTE3>(FwdHAivLocalFlag(FWD_H_H_READY_FLAG, slot));
+        } else {
+            if (args_.tiling.storeFinalState != 0) {
+                if constexpr (CompilePolicy::STATE_FP32) {
+                    AscendC::GlobalTensor<float> finalState;
+                    finalState.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.finalState));
+                    const uint64_t offset = FwdHStateOffset(args_.tiling, unit.sequence.sequence, head.hv, 0, 0);
+                    AscendC::DataCopy(finalState[offset], stateFp32_, FWD_H_K * FWD_H_V);
+                } else {
+                    AscendC::GlobalTensor<bfloat16_t> finalState;
+                    finalState.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.finalState));
+                    const uint64_t offset = FwdHStateOffset(args_.tiling, unit.sequence.sequence, head.hv, 0, 0);
+                    AscendC::DataCopy(finalState[offset], stateBf16_[slot], FWD_H_K * FWD_H_V);
+                }
+            }
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+    }
+
+    __aicore__ inline void RunStage3(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk)
+    {
+        // Stage3：g-only 为 R_next=E(g_last)R+D；gk-only 为
+        // R_next[k,v]=E(gk_last[k])R[k,v]+D[k,v]，并按需生成下一 H 或 final_state。
+        const bool writeH = !chunk.last;
+        const uint32_t localHeads = FwdHAivHeadCount(unit.headRound.activeHeadCount, aiv_);
+        if constexpr (CompilePolicy::STATE_FP32) {
+            // FP32 state 与仅用于 H0 的两个 BF16 state slot 复用 [128,192) KiB。
+            // 首个 head 覆写共享区前，必须确认本 AIV 当前 round 的全部 MTE3 已完成。
+            for (uint32_t slot = 0; slot < localHeads; ++slot) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+            }
+        }
+        for (uint32_t coreHeadId = 0; coreHeadId < localHeads; ++coreHeadId) {
+            const FwdHHeadBinding &head = unit.headRound.heads[aiv_ + 2 * coreHeadId];
+            const uint32_t slot = head.localSlot;
+            if constexpr (CompilePolicy::STATE_FP32) {
+                if (coreHeadId > 0) {
+                    const uint32_t previousSlot = unit.headRound.heads[
+                        aiv_ + 2 * (coreHeadId - 1)].localSlot;
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(previousSlot));
+                    AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(previousSlot));
+                }
+            }
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+            if constexpr (CompilePolicy::STATE_FP32) {
+                AscendC::GlobalTensor<float> state;
+                const uint64_t workspaceBase = args_.tiling.kDecayWorkspaceOffset / sizeof(float);
+                state.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.workspace));
+                const uint64_t offset = workspaceBase +
+                    FwdHCoreSlotOffset(coreIdx_, head.roundHead, FWD_H_K * FWD_H_V);
+                if (chunk.first) {
+                    if (args_.tiling.useInitialState != 0) {
+                        AscendC::GlobalTensor<float> initial;
+                        initial.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.initialState));
+                        const uint64_t initialOffset = FwdHStateOffset(args_.tiling, unit.sequence.sequence,
+                                                                      head.hv, 0, 0);
+                        AscendC::DataCopy(stateFp32_, initial[initialOffset], FWD_H_K * FWD_H_V);
+                    }
+                } else {
+                    AscendC::DataCopy(stateFp32_, state[offset], FWD_H_K * FWD_H_V);
+                }
+            }
+            if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::KEY_GK) {
+                CopyGateToUb(unit, chunk, head);
+            }
+            const bool zeroState = chunk.first && args_.tiling.useInitialState == 0;
+            if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::KEY_GK) {
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+            } else if constexpr (CompilePolicy::STATE_FP32) {
+                if (!zeroState) {
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
+                }
+            }
+            if (writeH) {
+                zeroState ? ConsumeStage3Head<true, true>(unit, chunk, head)
+                          : ConsumeStage3Head<true, false>(unit, chunk, head);
+            } else {
+                zeroState ? ConsumeStage3Head<false, true>(unit, chunk, head)
+                          : ConsumeStage3Head<false, false>(unit, chunk, head);
+            }
+        }
+    }
+
+    __aicore__ inline void ProcessWorkUnit(const FwdHWorkUnit &unit)
+    {
+        const bool hasCubeWork = args_.tiling.useInitialState || args_.tiling.storeFinalState ||
+            args_.tiling.seqlen > static_cast<int64_t>(FWD_H_CHUNK);
+        const uint32_t localHeads = FwdHAivHeadCount(unit.headRound.activeHeadCount, aiv_);
+        RunSMinusOne(unit);
+        for (uint32_t chunkId = 0; chunkId < unit.sequence.chunkCount; ++chunkId) {
+            const FwdHChunkSpan chunk = FwdHBuildChunk(unit.sequence, chunkId);
+            if (chunkId > 0) {
+                for (uint32_t slot = 0; slot < localHeads; ++slot) {
+                    AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(
+                        FwdHAivLocalFlag(FWD_H_RIGHT_FREE_FLAG, slot));
+                }
+            }
+            RunStage1(unit, chunk);
+            if (args_.tiling.storeFinalState != 0 || !chunk.last) {
+                RunStage3(unit, chunk);
+            }
+        }
+        const bool lastHasStage2 = args_.tiling.storeFinalState != 0;
+        if (lastHasStage2) {
+            for (uint32_t slot = 0; slot < localHeads; ++slot) {
+                AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(
+                    FwdHAivLocalFlag(FWD_H_RIGHT_FREE_FLAG, slot));
+            }
+        }
+        // 跨 head_round 前必须把本轮所有 VEC->MTE3 写回收口。AIC 收到 ROUND_DONE 后
+        // 才能开始下一轮 kg/H/W 的 MTE2，避免上一轮 MTE3 与下一轮预取跨 round 交叠。
+        for (uint32_t slot = 0; slot < localHeads; ++slot) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
+        }
+        if (hasCubeWork) {
+            AscendC::CrossCoreSetFlag<0x4, PIPE_MTE3>(FwdHAivLocalFlag(FWD_H_ROUND_DONE_FLAG, 0));
+            AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(FwdHAivLocalFlag(FWD_H_H_READY_FLAG, 0));
+        }
+    }
+
+    FwdHKernelArgs args_{};
+    uint32_t coreIdx_ = 0;
+    uint32_t coreNum_ = 1;
+    uint32_t aiv_ = 0;
+    AscendC::TEventID ioFreeEvent_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::TEventID ioReadyEvent_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::TEventID ioDoneEvent_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::TBuf<AscendC::TPosition::VECCALC> ubBuf_{};
+    AscendC::LocalTensor<uint8_t> local_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> right_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> stateBf16_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> workBf16_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::LocalTensor<bfloat16_t> sminusH_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::LocalTensor<float> sminusState_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::LocalTensor<float> stateFp32_{};
+    AscendC::LocalTensor<GateT> gate_[FWD_H_AIV_HEAD_SLOTS]{};
+    AscendC::LocalTensor<float> alpha_[FWD_H_AIV_HEAD_SLOTS]{};
+};
+
+} // namespace GDN
+
+#endif // ARCH35_CHUNK_FWD_H_VEC_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch35/chunk_fwd_h_vec.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch35/chunk_fwd_h_vec.h
@@ -19,6 +19,19 @@ using namespace AscendC::MicroAPI;
 
 constexpr float FWD_H_LN2 = 0.69314718055994530942f;
 
+__simd_callee__ inline void FwdHLoadFloatPair(RegTensor<float> &zero, RegTensor<float> &one,
+                                               __ubuf__ float *src)
+{
+    LoadAlign<float, LoadDist::DIST_DINTLV_B32>(zero, one, src);
+}
+
+__simd_callee__ inline void FwdHStoreFloatPair(__ubuf__ float *dst,
+                                                RegTensor<float> &zero, RegTensor<float> &one,
+                                                MaskReg &mask32)
+{
+    StoreAlign<float, StoreDist::DIST_INTLV_B32>(dst, zero, one, mask32);
+}
+
 template <typename T>
 __simd_callee__ inline void FwdHLoadAsFloat(RegTensor<float> &zero, RegTensor<float> &one,
                                              __ubuf__ T *src, MaskReg &mask16)
@@ -68,7 +81,6 @@ __simd_vf__ inline void FwdHStage1Arch35Vf(__ubuf__ bfloat16_t *uAndVNew,
     //   g-only: right[i,:] = cast_BF16(E(g_last-g_i) * V_new_fp32[i,:])，alpha=E(g_last)；
     //   gk-only: right=V_new。E 由 USE_EXP2 在编译期选择。
     // 本 VF 覆盖当前 head 的全部 MTE2 后向量计算，内部没有运行期分支。
-    constexpr uint16_t FP32_PER_REG = AscendC::VECTOR_REG_WIDTH / sizeof(float);
     constexpr uint16_t BF16_PER_REG = AscendC::VECTOR_REG_WIDTH / sizeof(bfloat16_t);
     constexpr uint16_t STATE_ROWS = FWD_H_STATE_BF16_BYTES / sizeof(bfloat16_t) / BF16_PER_REG;
     MaskReg mask16 = CreateMask<bfloat16_t, MaskPattern::ALL>();
@@ -112,8 +124,7 @@ __simd_vf__ inline void FwdHStage1Arch35Vf(__ubuf__ bfloat16_t *uAndVNew,
             FwdHLoadAsFloat<bfloat16_t>(u0, u1, uAndVNew + bf16Offset, mask16);
             if constexpr (HAS_P) {
                 if constexpr (std::is_same<PType, float>::value) {
-                    LoadAlign(p0, p + fp32Offset);
-                    LoadAlign(p1, p + fp32Offset + FP32_PER_REG);
+                    FwdHLoadFloatPair(p0, p1, p + fp32Offset);
                 } else {
                     FwdHLoadAsFloat<PType>(p0, p1, p + bf16Offset, mask16);
                 }
@@ -156,7 +167,6 @@ __simd_vf__ inline void FwdHStage3Arch35Vf(__ubuf__ bfloat16_t *stateBf16,
     //   gk-only: R_next[k,v] = E(gk_last[k]) * R[k,v] + D[k,v]；
     //   WRITE_H 时 H_next = cast_BF16(R_next)。
     // STATE_V_FIRST=true 时 state、D 和 H 都以物理 [V,K] 顺序处理，公式语义仍为 [K,V]。
-    constexpr uint16_t FP32_PER_REG = AscendC::VECTOR_REG_WIDTH / sizeof(float);
     constexpr uint16_t BF16_PER_REG = AscendC::VECTOR_REG_WIDTH / sizeof(bfloat16_t);
     constexpr uint16_t ROWS = 128;
     MaskReg mask16 = CreateMask<bfloat16_t, MaskPattern::ALL>();
@@ -183,20 +193,17 @@ __simd_vf__ inline void FwdHStage3Arch35Vf(__ubuf__ bfloat16_t *stateBf16,
                     Duplicate(state0, 0.0f, mask32);
                     Duplicate(state1, 0.0f, mask32);
                 } else {
-                    LoadAlign(state0, stateFp32 + fp32Offset);
-                    LoadAlign(state1, stateFp32 + fp32Offset + FP32_PER_REG);
+                    FwdHLoadFloatPair(state0, state1, stateFp32 + fp32Offset);
                 }
             } else {
                 FwdHLoadAsFloat<bfloat16_t>(state0, state1, stateBf16 + bf16Offset, mask16);
             }
-            LoadAlign(d0, d + fp32Offset);
-            LoadAlign(d1, d + fp32Offset + FP32_PER_REG);
+            FwdHLoadFloatPair(d0, d1, d + fp32Offset);
 
             if constexpr (!SCALAR_G) {
                 if constexpr (STATE_V_FIRST) {
                     if constexpr (std::is_same<GateT, float>::value) {
-                        LoadAlign(gate0, gkLast + col);
-                        LoadAlign(gate1, gkLast + col + FP32_PER_REG);
+                        FwdHLoadFloatPair(gate0, gate1, gkLast + col);
                     } else {
                         FwdHLoadAsFloat<GateT>(gate0, gate1, gkLast + col, mask16);
                     }
@@ -221,8 +228,7 @@ __simd_vf__ inline void FwdHStage3Arch35Vf(__ubuf__ bfloat16_t *stateBf16,
             Add(state1, state1, d1, mask32);
 
             if constexpr (STATE_FP32) {
-                StoreAlign(stateFp32 + fp32Offset, state0, mask32);
-                StoreAlign(stateFp32 + fp32Offset + FP32_PER_REG, state1, mask32);
+                FwdHStoreFloatPair(stateFp32 + fp32Offset, state0, state1, mask32);
             } else {
                 FwdHStoreBf16(stateBf16 + bf16Offset, state0, state1, mask32, mask16);
             }
@@ -239,7 +245,6 @@ __simd_vf__ inline void FwdHSMinusOneArch35Vf(__ubuf__ float *state,
                                                __ubuf__ bfloat16_t *h)
 {
     // S-1: H0 = cast_BF16(initial_state)。输入和输出保持 state_v_first 指定的同一物理顺序。
-    constexpr uint16_t FP32_PER_REG = AscendC::VECTOR_REG_WIDTH / sizeof(float);
     constexpr uint16_t BF16_PER_REG = AscendC::VECTOR_REG_WIDTH / sizeof(bfloat16_t);
     MaskReg mask16 = CreateMask<bfloat16_t, MaskPattern::ALL>();
     MaskReg mask32 = CreateMask<float, MaskPattern::ALL>();
@@ -250,8 +255,7 @@ __simd_vf__ inline void FwdHSMinusOneArch35Vf(__ubuf__ float *state,
         for (uint16_t col = 0; col < FWD_H_V; col += BF16_PER_REG) {
             const uint32_t fp32Offset = static_cast<uint32_t>(row) * FWD_H_V + col;
             const uint32_t bf16Offset = static_cast<uint32_t>(row) * FWD_H_V + col;
-            LoadAlign(state0, state + fp32Offset);
-            LoadAlign(state1, state + fp32Offset + FP32_PER_REG);
+            FwdHLoadFloatPair(state0, state1, state + fp32Offset);
             FwdHStoreBf16(h + bf16Offset, state0, state1, mask32, mask16);
         }
     }
@@ -266,7 +270,9 @@ public:
         coreIdx_ = AscendC::GetBlockIdx() / AscendC::GetSubBlockNum();
         coreNum_ = AscendC::GetBlockNum();
         aiv_ = AscendC::GetSubBlockIdx();
-        InitBuffers();
+        AscendC::LocalMemAllocator<AscendC::Hardware::UB> allocator;
+        ub_ = allocator.Alloc<AscendC::TPosition::VECCALC, uint8_t>(
+            AscendC::GetRuntimeUBSize());
         InitLocalEvents();
     }
 
@@ -277,7 +283,7 @@ public:
                                            : static_cast<uint32_t>(args_.tiling.shapeBatch);
         const uint32_t rounds = FwdHHeadRoundsPerSequence<CompilePolicy::GATE_MODE>(args_.tiling);
         // 同一 sequence 的所有 head-round 绑定到同一核，round 内串行收口；
-        // ProcessWorkUnit 返回时已完成本轮 ROUND_DONE/ACK，下一轮才允许预取。
+        // 本轮写回收口后才向 AIC 发布 ROUND_DONE，允许其开始下一轮预取。
         for (uint32_t sequence = coreIdx_; sequence < sequenceCount; sequence += coreNum_) {
             const FwdHSequenceSpan sequenceSpan = FwdHResolveSequence(args_, sequence);
             for (uint32_t round = 0; round < rounds; ++round) {
@@ -285,7 +291,7 @@ public:
                                         FwdHBuildHeadRound<CompilePolicy::GATE_MODE>(args_.tiling,
                                                                                       round)};
                 if (unit.sequence.chunkCount != 0 && unit.headRound.activeHeadCount != 0) {
-                    ProcessWorkUnit(unit);
+                    ProcessWorkUnit(unit, round + 1 < rounds);
                 }
             }
         }
@@ -293,58 +299,77 @@ public:
     }
 
 private:
-    __aicore__ inline void InitBuffers()
+    template <typename T>
+    __aicore__ inline AscendC::LocalTensor<T> UbAt(uint32_t byteOffset)
     {
-        GetTPipePtr()->InitBuffer(ubBuf_, 248 * 1024);
-        AscendC::LocalTensor<uint8_t> ub = ubBuf_.Get<uint8_t>();
-        local_[0] = ub[FWD_H_UB_LOCAL0_BASE].template ReinterpretCast<uint8_t>();
-        local_[1] = ub[FWD_H_UB_LOCAL1_BASE].template ReinterpretCast<uint8_t>();
-        right_[0] = ub[FWD_H_UB_LOCAL0_BASE + FWD_H_TOKEN_MATRIX_FP32_BYTES].template ReinterpretCast<bfloat16_t>();
-        right_[1] = ub[FWD_H_UB_LOCAL1_BASE + FWD_H_TOKEN_MATRIX_FP32_BYTES].template ReinterpretCast<bfloat16_t>();
-        stateBf16_[0] = ub[FWD_H_UB_BF16_STATE_BASE].template ReinterpretCast<bfloat16_t>();
-        stateBf16_[1] = ub[FWD_H_UB_BF16_STATE_BASE + FWD_H_STATE_BF16_BYTES].template ReinterpretCast<bfloat16_t>();
-        workBf16_[0] = ub[FWD_H_UB_BF16_WORK_BASE].template ReinterpretCast<bfloat16_t>();
-        workBf16_[1] = ub[FWD_H_UB_BF16_WORK_BASE + FWD_H_TOKEN_MATRIX_BF16_BYTES].template ReinterpretCast<bfloat16_t>();
-        stateFp32_ = ub[FWD_H_UB_FP32_STATE_BASE].template ReinterpretCast<float>();
-        for (uint32_t slot = 0; slot < FWD_H_AIV_HEAD_SLOTS; ++slot) {
-            sminusH_[slot] = ub[slot * FWD_H_STATE_BF16_BYTES].template ReinterpretCast<bfloat16_t>();
-            sminusState_[slot] = ub[64 * 1024 + slot * FWD_H_STATE_FP32_BYTES].template ReinterpretCast<float>();
-        }
-        gate_[0] = ub[FWD_H_UB_GATE_BASE].template ReinterpretCast<GateT>();
-        gate_[1] = ub[FWD_H_UB_GATE_BASE + 512].template ReinterpretCast<GateT>();
-        alpha_[0] = ub[FWD_H_UB_GATE_BASE + 1024].template ReinterpretCast<float>();
-        alpha_[1] = ub[FWD_H_UB_GATE_BASE + 1056].template ReinterpretCast<float>();
+        return ub_[byteOffset].template ReinterpretCast<T>();
+    }
+
+    __aicore__ inline AscendC::LocalTensor<uint8_t> LocalSlot(uint32_t slot)
+    {
+        return UbAt<uint8_t>(slot * FWD_H_UB_LOCAL_SLOT_BYTES);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<bfloat16_t> RightSlot(uint32_t slot)
+    {
+        return UbAt<bfloat16_t>(slot * FWD_H_UB_LOCAL_SLOT_BYTES + FWD_H_TOKEN_MATRIX_FP32_BYTES);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<bfloat16_t> StateBf16Slot(uint32_t slot)
+    {
+        return UbAt<bfloat16_t>(FWD_H_UB_BF16_STATE_BASE + slot * FWD_H_STATE_BF16_BYTES);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<bfloat16_t> WorkBf16Slot(uint32_t slot)
+    {
+        return UbAt<bfloat16_t>(FWD_H_UB_BF16_WORK_BASE + slot * FWD_H_TOKEN_MATRIX_BF16_BYTES);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<bfloat16_t> SminusHSlot(uint32_t slot)
+    {
+        return UbAt<bfloat16_t>(slot * FWD_H_STATE_BF16_BYTES);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float> SminusStateSlot(uint32_t slot)
+    {
+        return UbAt<float>(64 * 1024 + slot * FWD_H_STATE_FP32_BYTES);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float> StateFp32()
+    {
+        return UbAt<float>(FWD_H_UB_FP32_STATE_BASE);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<GateT> GateSlot(uint32_t slot)
+    {
+        return UbAt<GateT>(FWD_H_UB_GATE_BASE + slot * 512);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float> AlphaSlot(uint32_t slot)
+    {
+        return UbAt<float>(FWD_H_UB_GATE_BASE + 1024 + slot * 32);
     }
 
     __aicore__ inline void InitLocalEvents()
     {
         for (uint32_t slot = 0; slot < FWD_H_AIV_HEAD_SLOTS; ++slot) {
-            ioFreeEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE3_MTE2);
-            ioReadyEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_V);
-            ioDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::V_MTE3);
-            hWriteDoneEvent_[slot] = GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE3_MTE2);
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
         }
     }
 
     __aicore__ inline AscendC::TEventID IoFreeEvent(uint32_t slot) const
     {
-        return ioFreeEvent_[slot];
+        return static_cast<AscendC::TEventID>(slot);
     }
 
     __aicore__ inline AscendC::TEventID IoReadyEvent(uint32_t slot) const
     {
-        return ioReadyEvent_[slot];
+        return static_cast<AscendC::TEventID>(slot);
     }
 
     __aicore__ inline AscendC::TEventID IoDoneEvent(uint32_t slot) const
     {
-        return ioDoneEvent_[slot];
-    }
-
-    __aicore__ inline AscendC::TEventID HWriteDoneEvent(uint32_t slot) const
-    {
-        return hWriteDoneEvent_[slot];
+        return static_cast<AscendC::TEventID>(slot);
     }
 
     __aicore__ inline void DrainLocalEvents()
@@ -352,6 +377,7 @@ private:
         for (uint32_t slot = 0; slot < FWD_H_AIV_HEAD_SLOTS; ++slot) {
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
         }
+        // 三种 HardEvent 分属独立事件空间，均固定使用与 ping/pong 槽一致的 0/1。
     }
 
     __aicore__ inline uint64_t HOffset(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
@@ -385,11 +411,11 @@ private:
             AscendC::DataCopyPadExtParams<GateT> pad{false, 0, 0, 0};
             const uint32_t gateBytes = static_cast<uint32_t>(chunk.validTokens * sizeof(GateT));
             AscendC::DataCopyExtParams copy{1, gateBytes, 0, 0, 0};
-            AscendC::DataCopyPad(gate_[head.localSlot], gateGm[GateOffset(unit, chunk, head)], copy, pad);
+            AscendC::DataCopyPad(GateSlot(head.localSlot), gateGm[GateOffset(unit, chunk, head)], copy, pad);
         } else {
             const uint64_t lastOffset = GateOffset(unit, chunk, head) +
                                         static_cast<uint64_t>(chunk.validTokens - 1) * FWD_H_K;
-            AscendC::DataCopy(gate_[head.localSlot], gateGm[lastOffset], FWD_H_K);
+            AscendC::DataCopy(GateSlot(head.localSlot), gateGm[lastOffset], FWD_H_K);
         }
     }
 
@@ -402,25 +428,25 @@ private:
         initial.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.initialState));
         const uint64_t stateBase = FwdHStateOffset(args_.tiling, unit.sequence.sequence,
                                                    head.hv, 0, 0);
-        AscendC::DataCopy(sminusState_[slot], initial[stateBase], FWD_H_K * FWD_H_V);
+        AscendC::DataCopy(SminusStateSlot(slot), initial[stateBase], FWD_H_K * FWD_H_V);
         AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
     }
 
-    __aicore__ inline void ConsumeSMinusOneHead(const FwdHWorkUnit &unit,
-                                                const FwdHHeadBinding &head)
+    __aicore__ inline void ConsumeSMinusOneHead(
+        const FwdHWorkUnit &unit, const FwdHHeadBinding &head)
     {
         // S-1：H0=cast_BF16(initial_state)。输入输出保持 state_v_first 指定的物理顺序。
         const uint32_t slot = head.localSlot;
         AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
         AscendC::VF_CALL<FwdHSMinusOneArch35Vf>(
-            reinterpret_cast<__ubuf__ float *>(sminusState_[slot].GetPhyAddr()),
-            reinterpret_cast<__ubuf__ bfloat16_t *>(sminusH_[slot].GetPhyAddr()));
+            reinterpret_cast<__ubuf__ float *>(SminusStateSlot(slot).GetPhyAddr()),
+            reinterpret_cast<__ubuf__ bfloat16_t *>(SminusHSlot(slot).GetPhyAddr()));
         AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
         AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
         AscendC::GlobalTensor<bfloat16_t> h;
         h.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.h));
         const FwdHChunkSpan firstChunk = FwdHBuildChunk(unit.sequence, 0);
-        AscendC::DataCopy(h[HOffset(unit, firstChunk, head)], sminusH_[slot],
+        AscendC::DataCopy(h[HOffset(unit, firstChunk, head)], SminusHSlot(slot),
                           FWD_H_K * FWD_H_V);
         AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
     }
@@ -460,9 +486,10 @@ private:
         }
     }
 
+    // 保留 leaf stage 调用边界，使各 stage 的临时标量对象复用同一栈区。
     template <bool HAS_P, bool WRITE_RIGHT, bool ZERO_STATE>
-    __aicore__ inline void ConsumeStage1Head(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
-                                             const FwdHHeadBinding &head)
+    __aicore__ inline void ConsumeStage1Head(
+        const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk, const FwdHHeadBinding &head)
     {
         const uint32_t slot = head.localSlot;
         AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
@@ -470,22 +497,22 @@ private:
             AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(FwdHAivLocalFlag(FWD_H_P_READY_FLAG, slot));
         }
         using PType = std::conditional_t<CompilePolicy::STATE_FP32, float, bfloat16_t>;
-        __ubuf__ PType *p = reinterpret_cast<__ubuf__ PType *>(local_[slot].GetPhyAddr());
-        __ubuf__ bfloat16_t *right = reinterpret_cast<__ubuf__ bfloat16_t *>(right_[slot].GetPhyAddr());
-        __ubuf__ bfloat16_t *state = reinterpret_cast<__ubuf__ bfloat16_t *>(stateBf16_[slot].GetPhyAddr());
+        __ubuf__ PType *p = reinterpret_cast<__ubuf__ PType *>(LocalSlot(slot).GetPhyAddr());
+        __ubuf__ bfloat16_t *right = reinterpret_cast<__ubuf__ bfloat16_t *>(RightSlot(slot).GetPhyAddr());
+        __ubuf__ bfloat16_t *state = reinterpret_cast<__ubuf__ bfloat16_t *>(StateBf16Slot(slot).GetPhyAddr());
         if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G) {
             AscendC::VF_CALL<FwdHStage1Arch35Vf<HAS_P, true, WRITE_RIGHT, ZERO_STATE,
                                                 CompilePolicy::USE_EXP2, PType, GateT>>(
-                reinterpret_cast<__ubuf__ bfloat16_t *>(workBf16_[slot].GetPhyAddr()), p,
-                reinterpret_cast<__ubuf__ GateT *>(gate_[slot].GetPhyAddr()), right, state,
-                reinterpret_cast<__ubuf__ float *>(alpha_[slot].GetPhyAddr()),
+                reinterpret_cast<__ubuf__ bfloat16_t *>(WorkBf16Slot(slot).GetPhyAddr()), p,
+                reinterpret_cast<__ubuf__ GateT *>(GateSlot(slot).GetPhyAddr()), right, state,
+                reinterpret_cast<__ubuf__ float *>(AlphaSlot(slot).GetPhyAddr()),
                 static_cast<uint16_t>(chunk.validTokens));
         } else {
             AscendC::VF_CALL<FwdHStage1Arch35Vf<HAS_P, false, WRITE_RIGHT, ZERO_STATE,
                                                 CompilePolicy::USE_EXP2, PType, GateT>>(
-                reinterpret_cast<__ubuf__ bfloat16_t *>(workBf16_[slot].GetPhyAddr()), p,
-                reinterpret_cast<__ubuf__ GateT *>(gate_[slot].GetPhyAddr()), right, state,
-                reinterpret_cast<__ubuf__ float *>(alpha_[slot].GetPhyAddr()),
+                reinterpret_cast<__ubuf__ bfloat16_t *>(WorkBf16Slot(slot).GetPhyAddr()), p,
+                reinterpret_cast<__ubuf__ GateT *>(GateSlot(slot).GetPhyAddr()), right, state,
+                reinterpret_cast<__ubuf__ float *>(AlphaSlot(slot).GetPhyAddr()),
                 static_cast<uint16_t>(chunk.validTokens));
         }
         if constexpr (HAS_P) {
@@ -501,21 +528,21 @@ private:
         h.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.h));
         AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
         AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(IoDoneEvent(slot));
-        AscendC::DataCopy(vNew[UOffset(unit, chunk, head)], workBf16_[slot],
+        AscendC::DataCopy(vNew[UOffset(unit, chunk, head)], WorkBf16Slot(slot),
                           chunk.validTokens * FWD_H_V);
         if constexpr (WRITE_RIGHT) {
             const uint64_t rightOffset = FwdHCoreSlotOffset(coreIdx_, head.roundHead,
                                                             FWD_H_CHUNK * FWD_H_V);
-            AscendC::DataCopy(rightGm[rightOffset], right_[slot], chunk.validTokens * FWD_H_V);
+            AscendC::DataCopy(rightGm[rightOffset], RightSlot(slot), chunk.validTokens * FWD_H_V);
             AscendC::CrossCoreSetFlag<0x4, PIPE_MTE3>(
                 FwdHAivLocalFlag(FWD_H_RIGHT_READY_FLAG, slot));
         }
         if constexpr (!CompilePolicy::STATE_FP32) {
             if (chunk.first) {
-                AscendC::DataCopy(h[HOffset(unit, chunk, head)], stateBf16_[slot], FWD_H_K * FWD_H_V);
+                AscendC::DataCopy(h[HOffset(unit, chunk, head)], StateBf16Slot(slot), FWD_H_K * FWD_H_V);
             }
         } else if constexpr (ZERO_STATE) {
-            AscendC::DataCopy(h[HOffset(unit, chunk, head)], stateBf16_[slot], FWD_H_K * FWD_H_V);
+            AscendC::DataCopy(h[HOffset(unit, chunk, head)], StateBf16Slot(slot), FWD_H_K * FWD_H_V);
         }
         AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
     }
@@ -534,7 +561,7 @@ private:
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
             AscendC::GlobalTensor<bfloat16_t> u;
             u.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.u));
-            AscendC::DataCopy(workBf16_[slot], u[UOffset(unit, chunk, head)], chunk.validTokens * FWD_H_V);
+            AscendC::DataCopy(WorkBf16Slot(slot), u[UOffset(unit, chunk, head)], chunk.validTokens * FWD_H_V);
             if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G) {
                 if (writeRight) {
                     CopyGateToUb(unit, chunk, head);
@@ -544,7 +571,7 @@ private:
                 AscendC::GlobalTensor<bfloat16_t> initial;
                 initial.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.initialState));
                 const uint64_t stateOffset = FwdHStateOffset(args_.tiling, unit.sequence.sequence, head.hv, 0, 0);
-                AscendC::DataCopy(stateBf16_[slot], initial[stateOffset], FWD_H_K * FWD_H_V);
+                AscendC::DataCopy(StateBf16Slot(slot), initial[stateOffset], FWD_H_K * FWD_H_V);
             }
             AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
             if (coreHeadId > 0) {
@@ -579,9 +606,9 @@ private:
         }
     }
 
-    template <bool WRITE_H, bool WAIT_MTE2>
-    __aicore__ inline void ConsumeStage3Head(const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk,
-                                             const FwdHHeadBinding &head)
+    template <bool WRITE_H, bool WAIT_MTE2, bool ZERO_INIT>
+    __aicore__ inline void ConsumeStage3Head(
+        const FwdHWorkUnit &unit, const FwdHChunkSpan &chunk, const FwdHHeadBinding &head)
     {
         const uint32_t slot = head.localSlot;
         AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(FwdHAivLocalFlag(FWD_H_D_READY_FLAG, slot));
@@ -590,27 +617,30 @@ private:
             // 直接消费 Stage1 已驻留的 stateBf16，不能等待不存在的 event credit。
             AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(IoReadyEvent(slot));
         }
-        __ubuf__ float *d = reinterpret_cast<__ubuf__ float *>(local_[slot].GetPhyAddr());
+        __ubuf__ float *d = reinterpret_cast<__ubuf__ float *>(LocalSlot(slot).GetPhyAddr());
         __ubuf__ bfloat16_t *hNext = nullptr;
         if constexpr (CompilePolicy::STATE_FP32) {
-            hNext = reinterpret_cast<__ubuf__ bfloat16_t *>(local_[slot].GetPhyAddr());
+            // D 使用完整 64 KiB local slot；right 只是其中高半区的地址别名。
+            // VF 逐行加载对应的 FP32 D 后，再从低地址向高地址写 BF16 H；
+            // 因此每次写入只复用已经消费完成的 D 行。
+            hNext = reinterpret_cast<__ubuf__ bfloat16_t *>(LocalSlot(slot).GetPhyAddr());
         } else {
-            hNext = reinterpret_cast<__ubuf__ bfloat16_t *>(stateBf16_[slot].GetPhyAddr());
+            hNext = reinterpret_cast<__ubuf__ bfloat16_t *>(StateBf16Slot(slot).GetPhyAddr());
         }
         if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G) {
             AscendC::VF_CALL<FwdHStage3Arch35Vf<CompilePolicy::STATE_FP32, true, STATE_V_FIRST,
-                                                WRITE_H, ZERO_STATE, CompilePolicy::USE_EXP2, GateT>>(
-                reinterpret_cast<__ubuf__ bfloat16_t *>(stateBf16_[slot].GetPhyAddr()),
-                reinterpret_cast<__ubuf__ float *>(stateFp32_.GetPhyAddr()), d,
-                reinterpret_cast<__ubuf__ GateT *>(gate_[slot].GetPhyAddr()),
-                reinterpret_cast<__ubuf__ float *>(alpha_[slot].GetPhyAddr()), hNext);
+                                                WRITE_H, ZERO_INIT, CompilePolicy::USE_EXP2, GateT>>(
+                reinterpret_cast<__ubuf__ bfloat16_t *>(StateBf16Slot(slot).GetPhyAddr()),
+                reinterpret_cast<__ubuf__ float *>(StateFp32().GetPhyAddr()), d,
+                reinterpret_cast<__ubuf__ GateT *>(GateSlot(slot).GetPhyAddr()),
+                reinterpret_cast<__ubuf__ float *>(AlphaSlot(slot).GetPhyAddr()), hNext);
         } else {
             AscendC::VF_CALL<FwdHStage3Arch35Vf<CompilePolicy::STATE_FP32, false, STATE_V_FIRST,
-                                                WRITE_H, ZERO_STATE, CompilePolicy::USE_EXP2, GateT>>(
-                reinterpret_cast<__ubuf__ bfloat16_t *>(stateBf16_[slot].GetPhyAddr()),
-                reinterpret_cast<__ubuf__ float *>(stateFp32_.GetPhyAddr()), d,
-                reinterpret_cast<__ubuf__ GateT *>(gate_[slot].GetPhyAddr()),
-                reinterpret_cast<__ubuf__ float *>(alpha_[slot].GetPhyAddr()), hNext);
+                                                WRITE_H, ZERO_INIT, CompilePolicy::USE_EXP2, GateT>>(
+                reinterpret_cast<__ubuf__ bfloat16_t *>(StateBf16Slot(slot).GetPhyAddr()),
+                reinterpret_cast<__ubuf__ float *>(StateFp32().GetPhyAddr()), d,
+                reinterpret_cast<__ubuf__ GateT *>(GateSlot(slot).GetPhyAddr()),
+                reinterpret_cast<__ubuf__ float *>(AlphaSlot(slot).GetPhyAddr()), hNext);
         }
         if constexpr (!WRITE_H || !CompilePolicy::STATE_FP32) {
             AscendC::CrossCoreSetFlag<0x4, PIPE_V>(FwdHAivLocalFlag(FWD_H_D_FREE_FLAG, slot));
@@ -626,20 +656,19 @@ private:
                 state.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.workspace));
                 const uint64_t stateOffset = args_.tiling.kDecayWorkspaceOffset / sizeof(float) +
                     FwdHCoreSlotOffset(coreIdx_, head.roundHead, FWD_H_K * FWD_H_V);
-                AscendC::DataCopy(state[stateOffset], stateFp32_, FWD_H_K * FWD_H_V);
+                AscendC::DataCopy(state[stateOffset], StateFp32(), FWD_H_K * FWD_H_V);
             }
             const FwdHChunkSpan next = FwdHBuildChunk(unit.sequence, chunk.chunk + 1);
             if constexpr (CompilePolicy::STATE_FP32) {
                 AscendC::LocalTensor<bfloat16_t> hLocal =
-                    local_[slot].template ReinterpretCast<bfloat16_t>();
+                    LocalSlot(slot).template ReinterpretCast<bfloat16_t>();
                 AscendC::DataCopy(h[HOffset(unit, next, head)], hLocal, FWD_H_K * FWD_H_V);
-                // H 的 MTE3 完成前，D slot 仍是 MTE3 输入，不能交给下一 Stage0/Stage2。
-                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(HWriteDoneEvent(slot));
-                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(HWriteDoneEvent(slot));
+                // PIPE_MTE3 的跨核通知排在 H 写回之后；AIC 收到 D_FREE 时，D slot
+                // 已不再作为 MTE3 输入，可以安全进入下一次 Stage0/Stage2。
                 AscendC::CrossCoreSetFlag<0x4, PIPE_MTE3>(
                     FwdHAivLocalFlag(FWD_H_D_FREE_FLAG, slot));
             } else {
-                AscendC::DataCopy(h[HOffset(unit, next, head)], stateBf16_[slot],
+                AscendC::DataCopy(h[HOffset(unit, next, head)], StateBf16Slot(slot),
                                   FWD_H_K * FWD_H_V);
             }
             AscendC::CrossCoreSetFlag<0x4, PIPE_MTE3>(FwdHAivLocalFlag(FWD_H_H_READY_FLAG, slot));
@@ -649,12 +678,12 @@ private:
                     AscendC::GlobalTensor<float> finalState;
                     finalState.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.finalState));
                     const uint64_t offset = FwdHStateOffset(args_.tiling, unit.sequence.sequence, head.hv, 0, 0);
-                    AscendC::DataCopy(finalState[offset], stateFp32_, FWD_H_K * FWD_H_V);
+                    AscendC::DataCopy(finalState[offset], StateFp32(), FWD_H_K * FWD_H_V);
                 } else {
                     AscendC::GlobalTensor<bfloat16_t> finalState;
                     finalState.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.finalState));
                     const uint64_t offset = FwdHStateOffset(args_.tiling, unit.sequence.sequence, head.hv, 0, 0);
-                    AscendC::DataCopy(finalState[offset], stateBf16_[slot], FWD_H_K * FWD_H_V);
+                    AscendC::DataCopy(finalState[offset], StateBf16Slot(slot), FWD_H_K * FWD_H_V);
                 }
             }
         }
@@ -699,10 +728,10 @@ private:
                         initial.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(args_.initialState));
                         const uint64_t initialOffset = FwdHStateOffset(args_.tiling, unit.sequence.sequence,
                                                                       head.hv, 0, 0);
-                        AscendC::DataCopy(stateFp32_, initial[initialOffset], FWD_H_K * FWD_H_V);
+                        AscendC::DataCopy(StateFp32(), initial[initialOffset], FWD_H_K * FWD_H_V);
                     }
                 } else {
-                    AscendC::DataCopy(stateFp32_, state[offset], FWD_H_K * FWD_H_V);
+                    AscendC::DataCopy(StateFp32(), state[offset], FWD_H_K * FWD_H_V);
                 }
             }
             if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::KEY_GK) {
@@ -718,34 +747,40 @@ private:
             }
             if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::KEY_GK) {
                 // gk-only 每个 Stage3 都搬入 gk_last，必须等待该 MTE2。
-                if (writeH) {
-                    ConsumeStage3Head<true, true>(unit, chunk, head);
+                if (zeroState) {
+                    if (writeH) {
+                        ConsumeStage3Head<true, true, true>(unit, chunk, head);
+                    } else {
+                        ConsumeStage3Head<false, true, true>(unit, chunk, head);
+                    }
+                } else if (writeH) {
+                    ConsumeStage3Head<true, true, false>(unit, chunk, head);
                 } else {
-                    ConsumeStage3Head<false, true>(unit, chunk, head);
+                    ConsumeStage3Head<false, true, false>(unit, chunk, head);
                 }
             } else if constexpr (CompilePolicy::STATE_FP32) {
                 if (zeroState) {
                     // 首 chunk 无 initial_state 时 state 为 VF 内构造的零值，没有 MTE2 输入。
                     if (writeH) {
-                        ConsumeStage3Head<true, false>(unit, chunk, head);
+                        ConsumeStage3Head<true, false, true>(unit, chunk, head);
                     } else {
-                        ConsumeStage3Head<false, false>(unit, chunk, head);
+                        ConsumeStage3Head<false, false, true>(unit, chunk, head);
                     }
                 } else if (writeH) {
-                    ConsumeStage3Head<true, true>(unit, chunk, head);
+                    ConsumeStage3Head<true, true, false>(unit, chunk, head);
                 } else {
-                    ConsumeStage3Head<false, true>(unit, chunk, head);
+                    ConsumeStage3Head<false, true, false>(unit, chunk, head);
                 }
             } else if (writeH) {
                 // BF16 g-only 的 stateBf16 由 Stage1 写入并由 right-ready 链路保护。
-                ConsumeStage3Head<true, false>(unit, chunk, head);
+                ConsumeStage3Head<true, false, false>(unit, chunk, head);
             } else {
-                ConsumeStage3Head<false, false>(unit, chunk, head);
+                ConsumeStage3Head<false, false, false>(unit, chunk, head);
             }
         }
     }
 
-    __aicore__ inline void ProcessWorkUnit(const FwdHWorkUnit &unit)
+    __aicore__ inline void ProcessWorkUnit(const FwdHWorkUnit &unit, bool hasNextRound)
     {
         const bool hasCubeWork = args_.tiling.useInitialState || args_.tiling.storeFinalState ||
             args_.tiling.seqlen > static_cast<int64_t>(FWD_H_CHUNK);
@@ -777,9 +812,10 @@ private:
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
         }
-        if (hasCubeWork) {
+        if (hasCubeWork && hasNextRound) {
             AscendC::CrossCoreSetFlag<0x4, PIPE_MTE3>(FwdHAivLocalFlag(FWD_H_ROUND_DONE_FLAG, 0));
-            AscendC::CrossCoreWaitFlag<0x4, PIPE_V>(FwdHAivLocalFlag(FWD_H_H_READY_FLAG, 0));
+            // DONE 仍由 MTE3 发布以保证写回完成；ACK 用 PIPE_S gate 下一轮全部指令下发。
+            AscendC::CrossCoreWaitFlag<0x4, PIPE_S>(FwdHAivLocalFlag(FWD_H_ROUND_ACK_FLAG, 0));
         }
     }
 
@@ -787,20 +823,9 @@ private:
     uint32_t coreIdx_ = 0;
     uint32_t coreNum_ = 1;
     uint32_t aiv_ = 0;
-    AscendC::TEventID ioFreeEvent_[FWD_H_AIV_HEAD_SLOTS]{};
-    AscendC::TEventID ioReadyEvent_[FWD_H_AIV_HEAD_SLOTS]{};
-    AscendC::TEventID ioDoneEvent_[FWD_H_AIV_HEAD_SLOTS]{};
-    AscendC::TEventID hWriteDoneEvent_[FWD_H_AIV_HEAD_SLOTS]{};
-    AscendC::TBuf<AscendC::TPosition::VECCALC> ubBuf_{};
-    AscendC::LocalTensor<uint8_t> local_[FWD_H_AIV_HEAD_SLOTS]{};
-    AscendC::LocalTensor<bfloat16_t> right_[FWD_H_AIV_HEAD_SLOTS]{};
-    AscendC::LocalTensor<bfloat16_t> stateBf16_[FWD_H_AIV_HEAD_SLOTS]{};
-    AscendC::LocalTensor<bfloat16_t> workBf16_[FWD_H_AIV_HEAD_SLOTS]{};
-    AscendC::LocalTensor<bfloat16_t> sminusH_[FWD_H_AIV_HEAD_SLOTS]{};
-    AscendC::LocalTensor<float> sminusState_[FWD_H_AIV_HEAD_SLOTS]{};
-    AscendC::LocalTensor<float> stateFp32_{};
-    AscendC::LocalTensor<GateT> gate_[FWD_H_AIV_HEAD_SLOTS]{};
-    AscendC::LocalTensor<float> alpha_[FWD_H_AIV_HEAD_SLOTS]{};
+    // allocator 从 dynamicStartUB 分配 GetRuntimeUBSize()，保留 split-core AIV 的
+    // 高端 8 KiB VF 栈，不假设运行时 UB 起始地址为 0。
+    AscendC::LocalTensor<uint8_t> ub_{};
 };
 
 } // namespace GDN

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h.cpp
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ */
+
+#include "chunk_fwd_h_tiling_key.h"
+#include "chunk_fwd_h_policy.h"
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#include "arch35/chunk_fwd_h_cube.h"
+#include "arch35/chunk_fwd_h_vec.h"
+#else
+#include "arch22/chunk_fwd_h_cube.h"
+#include "arch22/chunk_fwd_h_vec.h"
+#endif
+
+#include "kernel_operator.h"
+#include "lib/matmul_intf.h"
+
+namespace GDN {
+
+template <typename GateT, typename CompilePolicy, bool STATE_V_FIRST>
+__aicore__ inline void RunFwdHTyped(const FwdHKernelArgs &args)
+{
+    if ASCEND_IS_AIC {
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+        ChunkFwdHCubeArch35<CompilePolicy, STATE_V_FIRST> cube;
+#else
+        ChunkFwdHCubeArch22<CompilePolicy, STATE_V_FIRST> cube;
+#endif
+        cube.Init(args);
+        cube.Process();
+    }
+    if ASCEND_IS_AIV {
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+        ChunkFwdHVecArch35<GateT, CompilePolicy, STATE_V_FIRST> vec;
+#else
+        ChunkFwdHVecArch22<GateT, CompilePolicy, STATE_V_FIRST> vec;
+#endif
+        vec.Init(args);
+        vec.Process();
+    }
+}
+
+template <typename GateT, FwdHGateMode GATE_MODE, bool STATE_FP32>
+__aicore__ inline void DispatchExpAndLayout(const FwdHKernelArgs &args)
+{
+    if (args.tiling.useExp2) {
+        using Policy = FwdHCompilePolicy<GATE_MODE, true, STATE_FP32>;
+        if (args.tiling.stateVFirst) {
+            RunFwdHTyped<GateT, Policy, true>(args);
+        } else {
+            RunFwdHTyped<GateT, Policy, false>(args);
+        }
+    } else {
+        using Policy = FwdHCompilePolicy<GATE_MODE, false, STATE_FP32>;
+        if (args.tiling.stateVFirst) {
+            RunFwdHTyped<GateT, Policy, true>(args);
+        } else {
+            RunFwdHTyped<GateT, Policy, false>(args);
+        }
+    }
+}
+
+template <typename GateT, FwdHGateMode GATE_MODE>
+__aicore__ inline void DispatchState(const FwdHKernelArgs &args)
+{
+    if (args.tiling.stateDataType == FWD_H_DTYPE_FP32) {
+        DispatchExpAndLayout<GateT, GATE_MODE, true>(args);
+    } else {
+        DispatchExpAndLayout<GateT, GATE_MODE, false>(args);
+    }
+}
+
+template <typename GateT>
+__aicore__ inline void DispatchGateMode(const FwdHKernelArgs &args)
+{
+    if (args.tiling.useGk) {
+        DispatchState<GateT, FwdHGateMode::KEY_GK>(args);
+    } else {
+        DispatchState<GateT, FwdHGateMode::SCALAR_G>(args);
+    }
+}
+
+__aicore__ inline void DispatchFwdH(const FwdHKernelArgs &args)
+{
+    if (args.tiling.gDataType == FWD_H_DTYPE_FP32) {
+        DispatchGateMode<float>(args);
+    } else {
+        DispatchGateMode<bfloat16_t>(args);
+    }
+}
+
+} // namespace GDN
+
+extern "C" __global__ __aicore__ void chunk_fwd_h(
+    GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g, GM_ADDR gk, GM_ADDR initial_state,
+    GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR h, GM_ADDR v_new,
+    GM_ADDR final_state, GM_ADDR workspace, GM_ADDR tiling)
+{
+    if (TILING_KEY_IS(1)) {
+        KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+        GDN::FwdHKernelArgs args{};
+        args.k = k;
+        args.w = w;
+        args.u = u;
+        args.g = g;
+        args.gk = gk;
+        args.initialState = initial_state;
+        args.cuSeqlens = cu_seqlens;
+        args.chunkIndices = chunk_indices;
+        args.h = h;
+        args.vNew = v_new;
+        args.finalState = final_state;
+        args.workspace = AscendC::GetUserWorkspace(workspace);
+        __gm__ const ChunkFwdHTilingData *tilingData =
+            reinterpret_cast<__gm__ const ChunkFwdHTilingData *>(tiling);
+        args.tiling.batch = tilingData->batch;
+        args.tiling.seqlen = tilingData->seqlen;
+        args.tiling.kNumHead = tilingData->kNumHead;
+        args.tiling.vNumHead = tilingData->vNumHead;
+        args.tiling.kHeadDim = tilingData->kHeadDim;
+        args.tiling.vHeadDim = tilingData->vHeadDim;
+        args.tiling.chunkSize = tilingData->chunkSize;
+        args.tiling.useInitialState = tilingData->useInitialState;
+        args.tiling.storeFinalState = tilingData->storeFinalState;
+        args.tiling.dataType = tilingData->dataType;
+        args.tiling.gDataType = tilingData->gDataType;
+        args.tiling.stateDataType = tilingData->stateDataType;
+        args.tiling.isVariedLen = tilingData->isVariedLen;
+        args.tiling.shapeBatch = tilingData->shapeBatch;
+        args.tiling.tokenBatch = tilingData->tokenBatch;
+        args.tiling.useG = tilingData->useG;
+        args.tiling.useGk = tilingData->useGk;
+        args.tiling.useExp2 = tilingData->useExp2;
+        args.tiling.stateVFirst = tilingData->stateVFirst;
+        args.tiling.vWorkspaceOffset = tilingData->vWorkspaceOffset;
+        args.tiling.vUpdateWorkspaceOffset = tilingData->vUpdateWorkspaceOffset;
+        args.tiling.kDecayWorkspaceOffset = tilingData->kDecayWorkspaceOffset;
+        args.tiling.hWorkspaceOffset = tilingData->hWorkspaceOffset;
+        args.tiling.numSeqWorkspaceOffset = tilingData->numSeqWorkspaceOffset;
+        args.tiling.numChunksWorkspaceOffset = tilingData->numChunksWorkspaceOffset;
+        GDN::DispatchFwdH(args);
+    }
+}

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h.cpp
@@ -24,9 +24,15 @@ template <typename GateT, typename CompilePolicy, bool STATE_V_FIRST>
 __aicore__ inline void RunFwdHTyped(const FwdHKernelArgs &args)
 {
     if ASCEND_IS_AIC {
+        const bool hasCubeWork = args.tiling.useInitialState || args.tiling.storeFinalState ||
+            args.tiling.seqlen > static_cast<uint32_t>(FWD_H_CHUNK);
+        if (!hasCubeWork) {
+            return;
+        }
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
         ChunkFwdHCubeArch35<CompilePolicy, STATE_V_FIRST> cube;
 #else
+        AscendC::TPipe pipe;
         ChunkFwdHCubeArch22<CompilePolicy, STATE_V_FIRST> cube;
 #endif
         cube.Init(args);
@@ -35,10 +41,12 @@ __aicore__ inline void RunFwdHTyped(const FwdHKernelArgs &args)
     if ASCEND_IS_AIV {
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
         ChunkFwdHVecArch35<GateT, CompilePolicy, STATE_V_FIRST> vec;
-#else
-        ChunkFwdHVecArch22<GateT, CompilePolicy, STATE_V_FIRST> vec;
-#endif
         vec.Init(args);
+#else
+        AscendC::TPipe pipe;
+        ChunkFwdHVecArch22<GateT, CompilePolicy, STATE_V_FIRST> vec;
+        vec.Init(args);
+#endif
         vec.Process();
     }
 }
@@ -116,31 +124,29 @@ extern "C" __global__ __aicore__ void chunk_fwd_h(
         args.workspace = AscendC::GetUserWorkspace(workspace);
         __gm__ const ChunkFwdHTilingData *tilingData =
             reinterpret_cast<__gm__ const ChunkFwdHTilingData *>(tiling);
-        args.tiling.batch = tilingData->batch;
-        args.tiling.seqlen = tilingData->seqlen;
-        args.tiling.kNumHead = tilingData->kNumHead;
-        args.tiling.vNumHead = tilingData->vNumHead;
-        args.tiling.kHeadDim = tilingData->kHeadDim;
-        args.tiling.vHeadDim = tilingData->vHeadDim;
-        args.tiling.chunkSize = tilingData->chunkSize;
+        args.tiling.batch = static_cast<uint32_t>(tilingData->batch);
+        args.tiling.seqlen = static_cast<uint32_t>(tilingData->seqlen);
+        args.tiling.kNumHead = static_cast<uint32_t>(tilingData->kNumHead);
+        args.tiling.vNumHead = static_cast<uint32_t>(tilingData->vNumHead);
+        args.tiling.kHeadDim = static_cast<uint32_t>(tilingData->kHeadDim);
+        args.tiling.vHeadDim = static_cast<uint32_t>(tilingData->vHeadDim);
+        args.tiling.chunkSize = static_cast<uint32_t>(tilingData->chunkSize);
         args.tiling.useInitialState = tilingData->useInitialState;
         args.tiling.storeFinalState = tilingData->storeFinalState;
-        args.tiling.dataType = tilingData->dataType;
-        args.tiling.gDataType = tilingData->gDataType;
-        args.tiling.stateDataType = tilingData->stateDataType;
+        args.tiling.dataType = static_cast<uint8_t>(tilingData->dataType);
+        args.tiling.gDataType = static_cast<uint8_t>(tilingData->gDataType);
+        args.tiling.stateDataType = static_cast<uint8_t>(tilingData->stateDataType);
         args.tiling.isVariedLen = tilingData->isVariedLen;
-        args.tiling.shapeBatch = tilingData->shapeBatch;
-        args.tiling.tokenBatch = tilingData->tokenBatch;
+        args.tiling.shapeBatch = static_cast<uint32_t>(tilingData->shapeBatch);
+        args.tiling.tokenBatch = static_cast<uint32_t>(tilingData->tokenBatch);
         args.tiling.useG = tilingData->useG;
         args.tiling.useGk = tilingData->useGk;
         args.tiling.useExp2 = tilingData->useExp2;
         args.tiling.stateVFirst = tilingData->stateVFirst;
-        args.tiling.vWorkspaceOffset = tilingData->vWorkspaceOffset;
-        args.tiling.vUpdateWorkspaceOffset = tilingData->vUpdateWorkspaceOffset;
-        args.tiling.kDecayWorkspaceOffset = tilingData->kDecayWorkspaceOffset;
-        args.tiling.hWorkspaceOffset = tilingData->hWorkspaceOffset;
-        args.tiling.numSeqWorkspaceOffset = tilingData->numSeqWorkspaceOffset;
-        args.tiling.numChunksWorkspaceOffset = tilingData->numChunksWorkspaceOffset;
+        args.tiling.vWorkspaceOffset = static_cast<uint64_t>(tilingData->vWorkspaceOffset);
+        args.tiling.vUpdateWorkspaceOffset = static_cast<uint64_t>(tilingData->vUpdateWorkspaceOffset);
+        args.tiling.kDecayWorkspaceOffset = static_cast<uint64_t>(tilingData->kDecayWorkspaceOffset);
+        args.tiling.hWorkspaceOffset = static_cast<uint64_t>(tilingData->hWorkspaceOffset);
         GDN::DispatchFwdH(args);
     }
 }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h_policy.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h_policy.h
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ */
+
+#ifndef CHUNK_FWD_H_POLICY_H
+#define CHUNK_FWD_H_POLICY_H
+
+#include <cstdint>
+
+#include "chunk_fwd_h_tiling_key.h"
+#include "kernel_operator.h"
+
+namespace GDN {
+
+constexpr uint32_t FWD_H_CHUNK = 64;
+constexpr uint32_t FWD_H_K = 128;
+constexpr uint32_t FWD_H_V = 128;
+constexpr uint32_t FWD_H_AIC_HEAD_SLOTS = 4;
+constexpr uint32_t FWD_H_AIV_COUNT = 2;
+constexpr uint32_t FWD_H_AIV_HEAD_SLOTS = 2;
+constexpr uint32_t FWD_H_FLAG_SUBBLOCK_STRIDE = 16;
+
+constexpr uint32_t FWD_H_TOKEN_MATRIX_BF16_BYTES = FWD_H_CHUNK * FWD_H_V * sizeof(bfloat16_t);
+constexpr uint32_t FWD_H_TOKEN_MATRIX_FP32_BYTES = FWD_H_CHUNK * FWD_H_V * sizeof(float);
+constexpr uint32_t FWD_H_STATE_BF16_BYTES = FWD_H_K * FWD_H_V * sizeof(bfloat16_t);
+constexpr uint32_t FWD_H_STATE_FP32_BYTES = FWD_H_K * FWD_H_V * sizeof(float);
+
+// AIC L1 固定布局。四个 W、四个 H/right、四个 kg 槽都按 roundHead 绑定，round 内不复用。
+constexpr uint32_t FWD_H_L1_W_BASE = 0;
+constexpr uint32_t FWD_H_L1_W_SLOT_BYTES = 16 * 1024;
+constexpr uint32_t FWD_H_L1_H_RIGHT_BASE = 128 * 1024;
+constexpr uint32_t FWD_H_L1_H_RIGHT_SLOT_BYTES = 32 * 1024;
+constexpr uint32_t FWD_H_L1_KG_BASE = 256 * 1024;
+constexpr uint32_t FWD_H_L1_KG_SLOT_BYTES = 16 * 1024;
+constexpr uint32_t FWD_H_L1_USED_BYTES = 320 * 1024;
+
+// 每个 AIV 的两个 local slot 固定为 64 KiB。P 使用低 32 KiB，Stage1 可在高 32 KiB
+// 生成 BF16 右操作数；D 使用完整 64 KiB。
+constexpr uint32_t FWD_H_UB_LOCAL_SLOT_BYTES = 64 * 1024;
+constexpr uint32_t FWD_H_UB_LOCAL0_BASE = 0;
+constexpr uint32_t FWD_H_UB_LOCAL1_BASE = 64 * 1024;
+constexpr uint32_t FWD_H_UB_BF16_STATE_BASE = 128 * 1024;
+constexpr uint32_t FWD_H_UB_FP32_STATE_BASE = 128 * 1024;
+constexpr uint32_t FWD_H_UB_BF16_WORK_BASE = 192 * 1024;
+constexpr uint32_t FWD_H_UB_GATE_BASE = 224 * 1024;
+constexpr uint32_t FWD_H_UB_SHARE_BASE = 226 * 1024;
+
+// ready/free 始终成对，且同一 ID 在复用前必须已被上一代 wait 消费。
+// A5 的 mode=0x4 是 split AIC/AIV 子块同步，flagId 可通过 16-ID 步长区分两个 AIV。
+// A2/A3 的 mode=0x2 只保留低 4 位 flagId，因此每类信号用 aiv 选择 0/1 两个 ID；
+// localSlot 按各 AIV 固定的 slot 顺序形成计数事件，不能让两个 AIV 共用同一个 ID。
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+constexpr uint32_t FWD_H_AIV_FLAG_STRIDE = 16;
+#else
+constexpr uint32_t FWD_H_AIV_FLAG_STRIDE = 0;
+#endif
+constexpr uint32_t FWD_H_P_FREE_FLAG = 0;
+constexpr uint32_t FWD_H_P_READY_FLAG = 2;
+constexpr uint32_t FWD_H_D_FREE_FLAG = 4;
+constexpr uint32_t FWD_H_D_READY_FLAG = 6;
+constexpr uint32_t FWD_H_RIGHT_FREE_FLAG = 8;
+constexpr uint32_t FWD_H_RIGHT_READY_FLAG = 10;
+constexpr uint32_t FWD_H_H_READY_FLAG = 12;
+constexpr uint32_t FWD_H_ROUND_DONE_FLAG = 14;
+
+struct FwdHSequenceSpan {
+    uint32_t sequence = 0;
+    uint32_t physicalBatch = 0;
+    uint32_t tokenBegin = 0;
+    uint32_t length = 0;
+    uint32_t chunkPrefix = 0;
+    uint32_t chunkCount = 0;
+    uint32_t totalChunks = 0;
+};
+
+struct FwdHChunkSpan {
+    uint32_t chunk = 0;
+    uint32_t globalChunk = 0;
+    uint32_t tokenBegin = 0;
+    uint32_t validTokens = 0;
+    bool first = false;
+    bool last = false;
+};
+
+struct FwdHHeadBinding {
+    uint32_t roundHead = 0;
+    uint32_t hv = 0;
+    uint32_t kh = 0;
+    uint32_t kgSlot = 0;
+    uint32_t aiv = 0;
+    uint32_t localSlot = 0;
+};
+
+struct FwdHKgBinding {
+    uint32_t kh = 0;
+    uint32_t slot = 0;
+    uint32_t firstConsumer = 0;
+    uint32_t lastConsumer = 0;
+};
+
+struct FwdHHeadRoundPlan {
+    uint32_t round = 0;
+    uint32_t activeHeadCount = 0;
+    uint32_t requiredKhCount = 0;
+    FwdHHeadBinding heads[FWD_H_AIC_HEAD_SLOTS]{};
+    FwdHKgBinding kg[FWD_H_AIC_HEAD_SLOTS]{};
+};
+
+struct FwdHWorkUnit {
+    FwdHSequenceSpan sequence{};
+    FwdHHeadRoundPlan headRound{};
+};
+
+struct FwdHWorkspace {
+    __gm__ uint8_t *base = nullptr;
+    int64_t pOffset = 0;
+    int64_t rightOffset = 0;
+    int64_t stateOffset = 0;
+    int64_t dOffset = 0;
+};
+
+// Kernel 入口一次性从 GM tiling 读取这些标量，后续调度和各 stage 只访问寄存器/栈上的副本。
+struct FwdHRuntimeTiling {
+    int64_t batch = 0;
+    int64_t seqlen = 0;
+    int64_t kNumHead = 0;
+    int64_t vNumHead = 0;
+    int64_t kHeadDim = 0;
+    int64_t vHeadDim = 0;
+    int64_t chunkSize = 0;
+    bool useInitialState = false;
+    bool storeFinalState = false;
+    int64_t dataType = 0;
+    int64_t gDataType = 0;
+    int64_t stateDataType = 0;
+    int64_t isVariedLen = 0;
+    int64_t shapeBatch = 0;
+    int64_t tokenBatch = 0;
+    bool useG = false;
+    bool useGk = false;
+    bool useExp2 = false;
+    bool stateVFirst = false;
+    int64_t vWorkspaceOffset = 0;
+    int64_t vUpdateWorkspaceOffset = 0;
+    int64_t kDecayWorkspaceOffset = 0;
+    int64_t hWorkspaceOffset = 0;
+    int64_t numSeqWorkspaceOffset = 0;
+    int64_t numChunksWorkspaceOffset = 0;
+};
+
+struct FwdHKernelArgs {
+    GM_ADDR k = nullptr;
+    GM_ADDR w = nullptr;
+    GM_ADDR u = nullptr;
+    GM_ADDR g = nullptr;
+    GM_ADDR gk = nullptr;
+    GM_ADDR initialState = nullptr;
+    GM_ADDR cuSeqlens = nullptr;
+    GM_ADDR chunkIndices = nullptr;
+    GM_ADDR h = nullptr;
+    GM_ADDR vNew = nullptr;
+    GM_ADDR finalState = nullptr;
+    GM_ADDR workspace = nullptr;
+    FwdHRuntimeTiling tiling{};
+};
+
+// AIC 侧选择配对 AIV。A2/A3 的低 4 位 flag 按 aiv 区分，A5 的每个 subblock
+// 拥有独立 16-ID 空间，因此再按 subblock stride 区分两个 AIV。
+__aicore__ inline uint32_t FwdHAicPeerFlag(uint32_t base, uint32_t localSlot, uint32_t aiv)
+{
+    (void)localSlot;
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    return base + localSlot + aiv * FWD_H_AIV_FLAG_STRIDE;
+#else
+    return base + aiv;
+#endif
+}
+
+// AIV 侧已经处于具体 subblock。A2/A3 按 subblock 选择 flag，localSlot
+// 通过同一 ID 的 ready/free 计数顺序复用；A5 在本 subblock 内再按 localSlot 区分。
+__aicore__ inline uint32_t FwdHAivLocalFlag(uint32_t base, uint32_t localSlot)
+{
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    return base + localSlot;
+#else
+    (void)localSlot;
+    return base + AscendC::GetSubBlockIdx();
+#endif
+}
+
+__aicore__ inline uint32_t FwdHLocalSlotBase(uint32_t localSlot)
+{
+    return localSlot == 0 ? FWD_H_UB_LOCAL0_BASE : FWD_H_UB_LOCAL1_BASE;
+}
+
+__aicore__ inline uint32_t FwdHAivHeadCount(uint32_t activeHeadCount, uint32_t aiv)
+{
+    return activeHeadCount > aiv ? (activeHeadCount - aiv + 1) / 2 : 0;
+}
+
+} // namespace GDN
+
+#endif // CHUNK_FWD_H_POLICY_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h_policy.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h_policy.h
@@ -47,23 +47,23 @@ constexpr uint32_t FWD_H_UB_BF16_WORK_BASE = 192 * 1024;
 constexpr uint32_t FWD_H_UB_GATE_BASE = 224 * 1024;
 constexpr uint32_t FWD_H_UB_SHARE_BASE = 226 * 1024;
 
-// ready/free 始终成对，且同一 ID 在复用前必须已被上一代 wait 消费。
-// A5 的 mode=0x4 是 split AIC/AIV 子块同步，flagId 可通过 16-ID 步长区分两个 AIV。
-// A2/A3 的 mode=0x2 只保留低 4 位 flagId，因此每类信号用 aiv 选择 0/1 两个 ID；
-// localSlot 按各 AIV 固定的 slot 顺序形成计数事件，不能让两个 AIV 共用同一个 ID。
+// ready/free 使用同一 ID 的双向计数器，且复用前必须由上一代 wait 消费。
+// 目标 CANN 9.1 的 A5 mode=0x4 仅支持 AIV 本地 ID 0..10；AIC 侧通过 16-ID
+// 步长选择 AIV0/AIV1。各协议使用互不重叠的本地 ID，最大 ID 为 8。
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
 constexpr uint32_t FWD_H_AIV_FLAG_STRIDE = 16;
 #else
 constexpr uint32_t FWD_H_AIV_FLAG_STRIDE = 0;
 #endif
 constexpr uint32_t FWD_H_P_FREE_FLAG = 0;
-constexpr uint32_t FWD_H_P_READY_FLAG = 2;
-constexpr uint32_t FWD_H_D_FREE_FLAG = 4;
-constexpr uint32_t FWD_H_D_READY_FLAG = 6;
-constexpr uint32_t FWD_H_RIGHT_FREE_FLAG = 8;
-constexpr uint32_t FWD_H_RIGHT_READY_FLAG = 10;
-constexpr uint32_t FWD_H_H_READY_FLAG = 12;
-constexpr uint32_t FWD_H_ROUND_DONE_FLAG = 14;
+constexpr uint32_t FWD_H_P_READY_FLAG = 0;
+constexpr uint32_t FWD_H_D_FREE_FLAG = 2;
+constexpr uint32_t FWD_H_D_READY_FLAG = 2;
+constexpr uint32_t FWD_H_RIGHT_FREE_FLAG = 4;
+constexpr uint32_t FWD_H_RIGHT_READY_FLAG = 4;
+constexpr uint32_t FWD_H_H_READY_FLAG = 6;
+constexpr uint32_t FWD_H_ROUND_DONE_FLAG = 8;
+constexpr uint32_t FWD_H_ROUND_ACK_FLAG = 8;
 
 struct FwdHSequenceSpan {
     uint32_t sequence = 0;
@@ -85,27 +85,26 @@ struct FwdHChunkSpan {
 };
 
 struct FwdHHeadBinding {
-    uint32_t roundHead = 0;
     uint32_t hv = 0;
     uint32_t kh = 0;
-    uint32_t kgSlot = 0;
-    uint32_t aiv = 0;
-    uint32_t localSlot = 0;
+    uint8_t roundHead = 0;
+    uint8_t kgSlot = 0;
+    uint8_t aiv = 0;
+    uint8_t localSlot = 0;
 };
 
 struct FwdHKgBinding {
     uint32_t kh = 0;
-    uint32_t slot = 0;
-    uint32_t firstConsumer = 0;
-    uint32_t lastConsumer = 0;
+    uint8_t slot = 0;
+    uint8_t firstConsumer = 0;
+    uint8_t lastConsumer = 0;
+    uint8_t reserved = 0;
 };
 
 struct FwdHHeadRoundPlan {
-    uint32_t round = 0;
-    uint32_t activeHeadCount = 0;
-    uint32_t requiredKhCount = 0;
+    uint8_t activeHeadCount = 0;
+    uint8_t requiredKhCount = 0;
     FwdHHeadBinding heads[FWD_H_AIC_HEAD_SLOTS]{};
-    FwdHKgBinding kg[FWD_H_AIC_HEAD_SLOTS]{};
 };
 
 struct FwdHWorkUnit {
@@ -123,31 +122,29 @@ struct FwdHWorkspace {
 
 // Kernel 入口一次性从 GM tiling 读取这些标量，后续调度和各 stage 只访问寄存器/栈上的副本。
 struct FwdHRuntimeTiling {
-    int64_t batch = 0;
-    int64_t seqlen = 0;
-    int64_t kNumHead = 0;
-    int64_t vNumHead = 0;
-    int64_t kHeadDim = 0;
-    int64_t vHeadDim = 0;
-    int64_t chunkSize = 0;
+    uint32_t batch = 0;
+    uint32_t seqlen = 0;
+    uint32_t kNumHead = 0;
+    uint32_t vNumHead = 0;
+    uint32_t kHeadDim = 0;
+    uint32_t vHeadDim = 0;
+    uint32_t chunkSize = 0;
+    uint32_t shapeBatch = 0;
+    uint32_t tokenBatch = 0;
+    uint64_t vWorkspaceOffset = 0;
+    uint64_t vUpdateWorkspaceOffset = 0;
+    uint64_t kDecayWorkspaceOffset = 0;
+    uint64_t hWorkspaceOffset = 0;
     bool useInitialState = false;
     bool storeFinalState = false;
-    int64_t dataType = 0;
-    int64_t gDataType = 0;
-    int64_t stateDataType = 0;
-    int64_t isVariedLen = 0;
-    int64_t shapeBatch = 0;
-    int64_t tokenBatch = 0;
+    uint8_t dataType = 0;
+    uint8_t gDataType = 0;
+    uint8_t stateDataType = 0;
+    bool isVariedLen = false;
     bool useG = false;
     bool useGk = false;
     bool useExp2 = false;
     bool stateVFirst = false;
-    int64_t vWorkspaceOffset = 0;
-    int64_t vUpdateWorkspaceOffset = 0;
-    int64_t kDecayWorkspaceOffset = 0;
-    int64_t hWorkspaceOffset = 0;
-    int64_t numSeqWorkspaceOffset = 0;
-    int64_t numChunksWorkspaceOffset = 0;
 };
 
 struct FwdHKernelArgs {
@@ -166,28 +163,23 @@ struct FwdHKernelArgs {
     FwdHRuntimeTiling tiling{};
 };
 
-// AIC 侧选择配对 AIV。A2/A3 的低 4 位 flag 按 aiv 区分，A5 的每个 subblock
-// 拥有独立 16-ID 空间，因此再按 subblock stride 区分两个 AIV。
+// A5 mode=0x4 按 subblock stride 选择配对 AIV；A2/A3 mode=0x2 是 AIC:2*AIV
+// 集合同步，同一 localSlot 的两个 AIV 必须使用同一 ID。
 __aicore__ inline uint32_t FwdHAicPeerFlag(uint32_t base, uint32_t localSlot, uint32_t aiv)
 {
-    (void)localSlot;
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
     return base + localSlot + aiv * FWD_H_AIV_FLAG_STRIDE;
 #else
-    return base + aiv;
+    (void)aiv;
+    return base + localSlot;
 #endif
 }
 
-// AIV 侧已经处于具体 subblock。A2/A3 按 subblock 选择 flag，localSlot
-// 通过同一 ID 的 ready/free 计数顺序复用；A5 在本 subblock 内再按 localSlot 区分。
+// AIV 侧已经处于具体 subblock；两种架构都按 localSlot 选择本地 ID。A2/A3 的
+// 两个 subblock 必须各自执行同一 ID 的 wait/set，缺失 head 的 subblock 也做 dummy 同步。
 __aicore__ inline uint32_t FwdHAivLocalFlag(uint32_t base, uint32_t localSlot)
 {
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
     return base + localSlot;
-#else
-    (void)localSlot;
-    return base + AscendC::GetSubBlockIdx();
-#endif
 }
 
 __aicore__ inline uint32_t FwdHLocalSlotBase(uint32_t localSlot)
@@ -198,6 +190,17 @@ __aicore__ inline uint32_t FwdHLocalSlotBase(uint32_t localSlot)
 __aicore__ inline uint32_t FwdHAivHeadCount(uint32_t activeHeadCount, uint32_t aiv)
 {
     return activeHeadCount > aiv ? (activeHeadCount - aiv + 1) / 2 : 0;
+}
+
+__aicore__ inline uint32_t FwdHMode2PairCount(uint32_t activeHeadCount)
+{
+    return (activeHeadCount + 1U) / 2U;
+}
+
+__aicore__ inline bool FwdHMode2PairHasHead(uint32_t activeHeadCount, uint32_t pairSlot,
+                                           uint32_t aiv)
+{
+    return pairSlot * 2U + aiv < activeHeadCount;
 }
 
 } // namespace GDN

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h_struct.h
@@ -44,8 +44,6 @@ struct ChunkFwdHPlainTilingData {
     int64_t vUpdateWorkspaceOffset;
     int64_t kDecayWorkspaceOffset;
     int64_t hWorkspaceOffset;
-    int64_t numSeqWorkspaceOffset;
-    int64_t numChunksWorkspaceOffset;
 };
 
 #endif // CHUNK_FWD_H_STRUCT_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h_struct.h
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_fwd_h_struct.h
+ * \brief Host-side plain tiling data used by the framework-independent size calculator.
+ *
+ * Kernel code uses the framework-generated ChunkFwdHTilingData. Keeping
+ * a differently named host structure avoids shadowing that generated type.
+ */
+
+#ifndef CHUNK_FWD_H_STRUCT_H
+#define CHUNK_FWD_H_STRUCT_H
+
+#include <cstdint>
+
+struct ChunkFwdHPlainTilingData {
+    int64_t batch;
+    int64_t seqlen;
+    int64_t kNumHead;
+    int64_t vNumHead;
+    int64_t kHeadDim;
+    int64_t vHeadDim;
+    int64_t chunkSize;
+    bool useInitialState;
+    bool storeFinalState;
+    int64_t dataType;
+    int64_t gDataType;
+    int64_t stateDataType;
+    int64_t isVariedLen;
+    int64_t shapeBatch;
+    int64_t tokenBatch;
+    bool useG;
+    bool useGk;
+    bool useExp2;
+    bool stateVFirst;
+    int64_t vWorkspaceOffset;
+    int64_t vUpdateWorkspaceOffset;
+    int64_t kDecayWorkspaceOffset;
+    int64_t hWorkspaceOffset;
+    int64_t numSeqWorkspaceOffset;
+    int64_t numChunksWorkspaceOffset;
+};
+
+#endif // CHUNK_FWD_H_STRUCT_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h_tiling_key.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h_tiling_key.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ */
+
+#ifndef CHUNK_FWD_H_TILING_KEY_H
+#define CHUNK_FWD_H_TILING_KEY_H
+
+#include <cstdint>
+
+namespace GDN {
+
+constexpr uint32_t FWD_H_TILING_KEY = 1;
+constexpr int64_t FWD_H_DTYPE_BF16 = 1;
+constexpr int64_t FWD_H_DTYPE_FP32 = 2;
+
+enum class FwdHGateMode : uint8_t {
+    SCALAR_G = 0,
+    KEY_GK = 1,
+};
+
+template <FwdHGateMode GATE_MODE_, bool USE_EXP2_, bool STATE_FP32_>
+struct FwdHCompilePolicy {
+    static constexpr FwdHGateMode GATE_MODE = GATE_MODE_;
+    static constexpr bool USE_EXP2 = USE_EXP2_;
+    static constexpr bool STATE_FP32 = STATE_FP32_;
+};
+
+} // namespace GDN
+
+#endif // CHUNK_FWD_H_TILING_KEY_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h_utils.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h_utils.h
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ */
+
+#ifndef CHUNK_FWD_H_UTILS_H
+#define CHUNK_FWD_H_UTILS_H
+
+#include "chunk_fwd_h_policy.h"
+
+namespace GDN {
+
+__aicore__ inline uint32_t FwdHCeilDiv(uint32_t value, uint32_t divisor)
+{
+    return (value + divisor - 1) / divisor;
+}
+
+__aicore__ inline uint32_t FwdHAlignCube(uint32_t value)
+{
+    return (value + 15U) & ~15U;
+}
+
+__aicore__ inline FwdHSequenceSpan FwdHResolveSequence(const FwdHKernelArgs &args, uint32_t sequence)
+{
+    FwdHSequenceSpan span{};
+    span.sequence = sequence;
+    if (args.tiling.isVariedLen == 0) {
+        span.physicalBatch = sequence;
+        span.tokenBegin = 0;
+        span.length = static_cast<uint32_t>(args.tiling.seqlen);
+        span.chunkCount = FwdHCeilDiv(span.length, FWD_H_CHUNK);
+        span.chunkPrefix = sequence * span.chunkCount;
+        span.totalChunks = static_cast<uint32_t>(args.tiling.shapeBatch) * span.chunkCount;
+        return span;
+    }
+
+    AscendC::GlobalTensor<int64_t> cu;
+    cu.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(args.cuSeqlens));
+    const int64_t begin = cu.GetValue(sequence);
+    const int64_t end = cu.GetValue(sequence + 1);
+    span.physicalBatch = 0;
+    span.tokenBegin = static_cast<uint32_t>(begin);
+    span.length = static_cast<uint32_t>(end - begin);
+    span.chunkCount = FwdHCeilDiv(span.length, FWD_H_CHUNK);
+    uint32_t prefix = 0;
+    uint32_t totalChunks = 0;
+    for (uint32_t seq = 0; seq < static_cast<uint32_t>(args.tiling.tokenBatch); ++seq) {
+        const int64_t seqBegin = cu.GetValue(seq);
+        const int64_t seqEnd = cu.GetValue(seq + 1);
+        const uint32_t chunks = FwdHCeilDiv(static_cast<uint32_t>(seqEnd - seqBegin), FWD_H_CHUNK);
+        if (seq < sequence) {
+            prefix += chunks;
+        }
+        totalChunks += chunks;
+    }
+    span.chunkPrefix = prefix;
+    span.totalChunks = totalChunks;
+    return span;
+}
+
+template <FwdHGateMode GATE_MODE>
+__aicore__ inline uint32_t FwdHHeadRoundsPerSequence(const FwdHRuntimeTiling &tiling)
+{
+    if constexpr (GATE_MODE == FwdHGateMode::KEY_GK) {
+        return FwdHCeilDiv(static_cast<uint32_t>(tiling.vNumHead), FWD_H_AIC_HEAD_SLOTS);
+    }
+
+    const uint32_t hk = static_cast<uint32_t>(tiling.kNumHead);
+    const uint32_t groupSize = static_cast<uint32_t>(tiling.vNumHead) / hk;
+    if (groupSize >= FWD_H_AIC_HEAD_SLOTS) {
+        return hk * FwdHCeilDiv(groupSize, FWD_H_AIC_HEAD_SLOTS);
+    }
+    const uint32_t keysPerRound = FWD_H_AIC_HEAD_SLOTS / groupSize;
+    return FwdHCeilDiv(hk, keysPerRound);
+}
+
+template <FwdHGateMode GATE_MODE>
+__aicore__ inline FwdHHeadRoundPlan FwdHBuildHeadRound(const FwdHRuntimeTiling &tiling,
+                                                       uint32_t round)
+{
+    FwdHHeadRoundPlan plan{};
+    plan.round = round;
+    const uint32_t hv = static_cast<uint32_t>(tiling.vNumHead);
+    const uint32_t hk = static_cast<uint32_t>(tiling.kNumHead);
+    const uint32_t groupSize = GATE_MODE == FwdHGateMode::SCALAR_G ? hv / hk : 1;
+    uint32_t hvBegin = round * FWD_H_AIC_HEAD_SLOTS;
+    if constexpr (GATE_MODE == FwdHGateMode::SCALAR_G) {
+        if (groupSize >= FWD_H_AIC_HEAD_SLOTS) {
+            const uint32_t roundsPerKey = FwdHCeilDiv(groupSize, FWD_H_AIC_HEAD_SLOTS);
+            const uint32_t kh = round / roundsPerKey;
+            const uint32_t groupRound = round % roundsPerKey;
+            hvBegin = kh * groupSize + groupRound * FWD_H_AIC_HEAD_SLOTS;
+            const uint32_t groupRemain = groupSize - groupRound * FWD_H_AIC_HEAD_SLOTS;
+            plan.activeHeadCount = groupRemain < FWD_H_AIC_HEAD_SLOTS
+                                       ? groupRemain
+                                       : FWD_H_AIC_HEAD_SLOTS;
+        } else {
+            const uint32_t keysPerRound = FWD_H_AIC_HEAD_SLOTS / groupSize;
+            const uint32_t khBegin = round * keysPerRound;
+            const uint32_t activeKeys = hk - khBegin < keysPerRound ? hk - khBegin : keysPerRound;
+            hvBegin = khBegin * groupSize;
+            plan.activeHeadCount = activeKeys * groupSize;
+        }
+    } else {
+        plan.activeHeadCount = hv > hvBegin ? hv - hvBegin : 0;
+        if (plan.activeHeadCount > FWD_H_AIC_HEAD_SLOTS) {
+            plan.activeHeadCount = FWD_H_AIC_HEAD_SLOTS;
+        }
+    }
+
+    for (uint32_t roundHead = 0; roundHead < plan.activeHeadCount; ++roundHead) {
+        FwdHHeadBinding &head = plan.heads[roundHead];
+        head.roundHead = roundHead;
+        head.hv = hvBegin + roundHead;
+        head.kh = GATE_MODE == FwdHGateMode::SCALAR_G ? head.hv / groupSize : head.hv;
+        head.aiv = roundHead & 1U;
+        head.localSlot = roundHead >> 1U;
+
+        uint32_t kgSlot = plan.requiredKhCount;
+        for (uint32_t slot = 0; slot < plan.requiredKhCount; ++slot) {
+            if (plan.kg[slot].kh == head.kh) {
+                kgSlot = slot;
+                break;
+            }
+        }
+        if (kgSlot == plan.requiredKhCount) {
+            FwdHKgBinding &kg = plan.kg[kgSlot];
+            kg.kh = head.kh;
+            kg.slot = kgSlot;
+            kg.firstConsumer = roundHead;
+            kg.lastConsumer = roundHead;
+            ++plan.requiredKhCount;
+        } else {
+            plan.kg[kgSlot].lastConsumer = roundHead;
+        }
+        head.kgSlot = kgSlot;
+    }
+    return plan;
+}
+
+__aicore__ inline FwdHChunkSpan FwdHBuildChunk(const FwdHSequenceSpan &sequence, uint32_t chunk)
+{
+    FwdHChunkSpan span{};
+    span.chunk = chunk;
+    span.globalChunk = sequence.chunkPrefix + chunk;
+    span.tokenBegin = sequence.tokenBegin + chunk * FWD_H_CHUNK;
+    span.validTokens = sequence.length - chunk * FWD_H_CHUNK;
+    if (span.validTokens > FWD_H_CHUNK) {
+        span.validTokens = FWD_H_CHUNK;
+    }
+    span.first = chunk == 0;
+    span.last = chunk + 1 == sequence.chunkCount;
+    return span;
+}
+
+template <FwdHGateMode GATE_MODE>
+__aicore__ inline FwdHWorkUnit FwdHResolveWorkUnit(const FwdHKernelArgs &args, uint32_t workUnitId)
+{
+    const uint32_t rounds = FwdHHeadRoundsPerSequence<GATE_MODE>(args.tiling);
+    const uint32_t sequence = workUnitId / rounds;
+    const uint32_t round = workUnitId % rounds;
+    return {FwdHResolveSequence(args, sequence), FwdHBuildHeadRound<GATE_MODE>(args.tiling, round)};
+}
+
+template <FwdHGateMode GATE_MODE>
+__aicore__ inline uint32_t FwdHTotalWorkUnits(const FwdHRuntimeTiling &tiling)
+{
+    const uint32_t sequenceCount = tiling.isVariedLen != 0
+                                       ? static_cast<uint32_t>(tiling.tokenBatch)
+                                       : static_cast<uint32_t>(tiling.shapeBatch);
+    return sequenceCount * FwdHHeadRoundsPerSequence<GATE_MODE>(tiling);
+}
+
+__aicore__ inline uint64_t FwdHInputOffset(const FwdHRuntimeTiling &tiling,
+                                           uint32_t physicalBatch, uint32_t head,
+                                           uint32_t tokenBegin, uint32_t dim)
+{
+    return ((static_cast<uint64_t>(physicalBatch) * tiling.vNumHead + head) * tiling.seqlen +
+            tokenBegin) * dim;
+}
+
+__aicore__ inline uint64_t FwdHKOffset(const FwdHRuntimeTiling &tiling,
+                                       uint32_t physicalBatch, uint32_t kh,
+                                       uint32_t tokenBegin)
+{
+    return ((static_cast<uint64_t>(physicalBatch) * tiling.kNumHead + kh) * tiling.seqlen +
+            tokenBegin) * FWD_H_K;
+}
+
+__aicore__ inline uint64_t FwdHHOffset(const FwdHRuntimeTiling &tiling,
+                                       const FwdHSequenceSpan &sequence, uint32_t hv,
+                                       uint32_t globalChunk)
+{
+    if (tiling.isVariedLen != 0) {
+        return (static_cast<uint64_t>(hv) * sequence.totalChunks +
+                globalChunk) * FWD_H_K * FWD_H_V;
+    }
+    const uint32_t chunksPerSequence = FwdHCeilDiv(static_cast<uint32_t>(tiling.seqlen), FWD_H_CHUNK);
+    return ((static_cast<uint64_t>(sequence.physicalBatch) * tiling.vNumHead + hv) *
+                chunksPerSequence + globalChunk - sequence.chunkPrefix) * FWD_H_K * FWD_H_V;
+}
+
+__aicore__ inline uint64_t FwdHStateOffset(const FwdHRuntimeTiling &tiling,
+                                           uint32_t sequence, uint32_t hv, uint32_t k, uint32_t v)
+{
+    const uint64_t base = (static_cast<uint64_t>(sequence) * tiling.vNumHead + hv) * FWD_H_K * FWD_H_V;
+    return base + (tiling.stateVFirst ? static_cast<uint64_t>(v) * FWD_H_K + k
+                                      : static_cast<uint64_t>(k) * FWD_H_V + v);
+}
+
+__aicore__ inline uint64_t FwdHCoreSlotOffset(uint32_t core, uint32_t slot, uint32_t slotElements)
+{
+    return (static_cast<uint64_t>(core) * FWD_H_AIC_HEAD_SLOTS + slot) * slotElements;
+}
+
+} // namespace GDN
+
+#endif // CHUNK_FWD_H_UTILS_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h_utils.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/chunk_fwd_h_utils.h
@@ -77,10 +77,9 @@ __aicore__ inline uint32_t FwdHHeadRoundsPerSequence(const FwdHRuntimeTiling &ti
 
 template <FwdHGateMode GATE_MODE>
 __aicore__ inline FwdHHeadRoundPlan FwdHBuildHeadRound(const FwdHRuntimeTiling &tiling,
-                                                       uint32_t round)
+    uint32_t round)
 {
     FwdHHeadRoundPlan plan{};
-    plan.round = round;
     const uint32_t hv = static_cast<uint32_t>(tiling.vNumHead);
     const uint32_t hk = static_cast<uint32_t>(tiling.kNumHead);
     const uint32_t groupSize = GATE_MODE == FwdHGateMode::SCALAR_G ? hv / hk : 1;
@@ -118,25 +117,39 @@ __aicore__ inline FwdHHeadRoundPlan FwdHBuildHeadRound(const FwdHRuntimeTiling &
         head.localSlot = roundHead >> 1U;
 
         uint32_t kgSlot = plan.requiredKhCount;
-        for (uint32_t slot = 0; slot < plan.requiredKhCount; ++slot) {
-            if (plan.kg[slot].kh == head.kh) {
-                kgSlot = slot;
+        for (uint32_t consumer = 0; consumer < roundHead; ++consumer) {
+            if (plan.heads[consumer].kh == head.kh) {
+                kgSlot = plan.heads[consumer].kgSlot;
                 break;
             }
         }
         if (kgSlot == plan.requiredKhCount) {
-            FwdHKgBinding &kg = plan.kg[kgSlot];
-            kg.kh = head.kh;
-            kg.slot = kgSlot;
-            kg.firstConsumer = roundHead;
-            kg.lastConsumer = roundHead;
             ++plan.requiredKhCount;
-        } else {
-            plan.kg[kgSlot].lastConsumer = roundHead;
         }
         head.kgSlot = kgSlot;
     }
     return plan;
+}
+
+__aicore__ inline FwdHKgBinding FwdHBuildKgBinding(const FwdHHeadRoundPlan &plan,
+                                                   uint32_t kgSlot)
+{
+    FwdHKgBinding binding{};
+    binding.slot = static_cast<uint8_t>(kgSlot);
+    bool found = false;
+    for (uint32_t consumer = 0; consumer < plan.activeHeadCount; ++consumer) {
+        const FwdHHeadBinding &head = plan.heads[consumer];
+        if (head.kgSlot != kgSlot) {
+            continue;
+        }
+        if (!found) {
+            binding.kh = head.kh;
+            binding.firstConsumer = static_cast<uint8_t>(consumer);
+            found = true;
+        }
+        binding.lastConsumer = static_cast<uint8_t>(consumer);
+    }
+    return binding;
 }
 
 __aicore__ inline FwdHChunkSpan FwdHBuildChunk(const FwdHSequenceSpan &sequence, uint32_t chunk)

--- a/scripts/check_packaged_wheel_api.py
+++ b/scripts/check_packaged_wheel_api.py
@@ -27,11 +27,15 @@ ASCENDC_NAMES = (
     "chunk_fwd_o",
     "chunk_gated_delta_rule_bwd_dhu",
     "chunk_gated_delta_rule_fwd_h",
+    "chunk_fwd_h",
     "prepare_wy_repr_bwd_da",
     "prepare_wy_repr_bwd_full",
     "recompute_w_u_fwd",
     "recurrent_gated_delta_rule",
     "solve_tri",
+)
+LEGACY_COMPAT_ASCENDC_NAMES = tuple(
+    name for name in ASCENDC_NAMES if name != "chunk_fwd_h"
 )
 
 TRITON_NAMES = (
@@ -192,7 +196,7 @@ def main() -> int:
         import torch_npu
 
         ascendc.install_torch_npu_ops_compat()
-        for name in ASCENDC_NAMES:
+        for name in LEGACY_COMPAT_ASCENDC_NAMES:
             _require_attr(torch_npu.ops, name, "torch_npu.ops")
             _require_attr(torch_npu.ops, f"npu_{name}", "torch_npu.ops")
 

--- a/scripts/check_packaged_wheel_api.py
+++ b/scripts/check_packaged_wheel_api.py
@@ -64,6 +64,10 @@ REQUIRED_ASCENDC_CONFIGS = (
 FORBIDDEN_ASCENDC_NAMES = (
     "recompute_wu_fwd",
 )
+FORBIDDEN_LEGACY_ASCENDC_NAMES = (
+    "chunk_fwd_h",
+    "npu_chunk_fwd_h",
+)
 FORBIDDEN_ASCENDC_CONFIGS = (
     "recompute_wu_fwd.json",
 )
@@ -193,12 +197,18 @@ def main() -> int:
             )
 
     if args.check_legacy_torch_npu:
+        import torch
         import torch_npu
 
         ascendc.install_torch_npu_ops_compat()
         for name in LEGACY_COMPAT_ASCENDC_NAMES:
             _require_attr(torch_npu.ops, name, "torch_npu.ops")
             _require_attr(torch_npu.ops, f"npu_{name}", "torch_npu.ops")
+        for name in FORBIDDEN_LEGACY_ASCENDC_NAMES:
+            if hasattr(torch_npu.ops, name):
+                raise AssertionError(f"torch_npu.ops.{name} must not be registered")
+            if hasattr(torch.ops.npu, name):
+                raise AssertionError(f"torch.ops.npu.{name} must not be registered")
 
     _require_packaged_opp_configs(fla_npu)
     _require_safe_packaged_opapi(fla_npu)

--- a/tests/op_cases/chunk_fwd_h.json
+++ b/tests/op_cases/chunk_fwd_h.json
@@ -121,38 +121,568 @@
       "state_v_first": true,
       "provide_chunk_indices": true,
       "seed": 17
+    },
+    {
+      "id": "g_round_heads_1_bf16_initial",
+      "mode": "g",
+      "batch": 1,
+      "seqlen": 65,
+      "k_heads": 1,
+      "v_heads": 1,
+      "gate_dtype": "bfloat16",
+      "state_dtype": "bfloat16",
+      "output_final_state": true,
+      "use_exp2": false,
+      "state_v_first": false,
+      "provide_chunk_indices": false,
+      "seed": 19
+    },
+    {
+      "id": "gk_round_heads_1_fp32_initial_v_first",
+      "mode": "gk",
+      "batch": 1,
+      "seqlen": 65,
+      "k_heads": 1,
+      "v_heads": 1,
+      "gate_dtype": "float32",
+      "state_dtype": "float32",
+      "output_final_state": true,
+      "use_exp2": true,
+      "state_v_first": true,
+      "provide_chunk_indices": false,
+      "seed": 20
+    },
+    {
+      "id": "g_ratio_1_to_5_tail_one",
+      "mode": "g",
+      "batch": 1,
+      "seqlen": 65,
+      "k_heads": 1,
+      "v_heads": 5,
+      "gate_dtype": "bfloat16",
+      "state_dtype": null,
+      "output_final_state": false,
+      "use_exp2": false,
+      "state_v_first": false,
+      "provide_chunk_indices": false,
+      "seed": 21
+    },
+    {
+      "id": "g_ratio_1_to_7_tail_three",
+      "mode": "g",
+      "batch": 1,
+      "seqlen": 65,
+      "k_heads": 1,
+      "v_heads": 7,
+      "gate_dtype": "float32",
+      "state_dtype": null,
+      "output_final_state": false,
+      "use_exp2": false,
+      "state_v_first": true,
+      "provide_chunk_indices": false,
+      "seed": 22
+    },
+    {
+      "id": "gk_varlen_auto_chunk_indices",
+      "mode": "gk",
+      "batch": 1,
+      "seqlens": [1, 65],
+      "k_heads": 2,
+      "v_heads": 2,
+      "gate_dtype": "bfloat16",
+      "state_dtype": "float32",
+      "output_final_state": true,
+      "use_exp2": false,
+      "state_v_first": false,
+      "provide_chunk_indices": false,
+      "seed": 23
+    },
+    {
+      "id": "g_long_credit_reuse",
+      "mode": "g",
+      "batch": 1,
+      "seqlen": 1025,
+      "k_heads": 1,
+      "v_heads": 4,
+      "gate_dtype": "bfloat16",
+      "state_dtype": "bfloat16",
+      "output_final_state": true,
+      "use_exp2": false,
+      "state_v_first": false,
+      "provide_chunk_indices": false,
+      "seed": 24
+    },
+    {
+      "id": "g_dense_batch_reuse",
+      "mode": "g",
+      "batch": 2,
+      "seqlen": 129,
+      "k_heads": 1,
+      "v_heads": 3,
+      "gate_dtype": "float32",
+      "state_dtype": "float32",
+      "output_final_state": true,
+      "use_exp2": true,
+      "state_v_first": true,
+      "provide_chunk_indices": false,
+      "seed": 25
+    },
+    {
+      "id": "g_non_contiguous_u_view",
+      "mode": "g",
+      "batch": 1,
+      "seqlen": 65,
+      "k_heads": 1,
+      "v_heads": 1,
+      "gate_dtype": "bfloat16",
+      "state_dtype": null,
+      "output_final_state": true,
+      "use_exp2": false,
+      "state_v_first": false,
+      "provide_chunk_indices": false,
+      "non_contiguous_u": true,
+      "seed": 26
+    }
+  ],
+  "performance_cases": [
+    {
+      "id": "a5_g_h4_t512",
+      "mode": "g",
+      "batch": 1,
+      "seqlen": 512,
+      "k_heads": 4,
+      "v_heads": 4,
+      "gate_dtype": "bfloat16",
+      "state_dtype": null,
+      "output_final_state": false,
+      "use_exp2": false,
+      "state_v_first": false,
+      "seed": 101
+    },
+    {
+      "id": "a5_g_gva_1_to_6_t2048",
+      "mode": "g",
+      "batch": 1,
+      "seqlen": 2048,
+      "k_heads": 1,
+      "v_heads": 6,
+      "gate_dtype": "bfloat16",
+      "state_dtype": "float32",
+      "output_final_state": true,
+      "use_exp2": false,
+      "state_v_first": false,
+      "seed": 102
+    },
+    {
+      "id": "a5_gk_h4_t2048",
+      "mode": "gk",
+      "batch": 1,
+      "seqlen": 2048,
+      "k_heads": 4,
+      "v_heads": 4,
+      "gate_dtype": "float32",
+      "state_dtype": "bfloat16",
+      "output_final_state": true,
+      "use_exp2": true,
+      "state_v_first": true,
+      "seed": 103
+    },
+    {
+      "id": "a5_b2_hk16_hv32_t11264",
+      "mode": "g",
+      "batch": 2,
+      "seqlen": 11264,
+      "k_heads": 16,
+      "v_heads": 32,
+      "gate_dtype": "float32",
+      "state_dtype": null,
+      "output_final_state": true,
+      "use_exp2": true,
+      "state_v_first": true,
+      "seed": 201
+    },
+    {
+      "id": "a5_varlen_h32_t65536_s64",
+      "mode": "g",
+      "batch": 1,
+      "seqlen": 65536,
+      "k_heads": 32,
+      "v_heads": 32,
+      "gate_dtype": "float32",
+      "state_dtype": null,
+      "output_final_state": true,
+      "use_exp2": true,
+      "state_v_first": true,
+      "cu_seqlens_seed": 202,
+      "cu_seqlens": [
+        0,
+        2365,
+        2409,
+        2536,
+        3008,
+        3681,
+        6545,
+        8416,
+        11615,
+        12599,
+        12844,
+        12982,
+        13209,
+        15561,
+        16291,
+        16669,
+        17755,
+        21365,
+        21416,
+        25267,
+        26084,
+        26364,
+        26833,
+        27900,
+        28033,
+        29011,
+        29291,
+        29576,
+        30471,
+        30733,
+        30906,
+        31202,
+        32264,
+        32393,
+        34233,
+        34274,
+        34589,
+        40060,
+        41075,
+        41272,
+        42123,
+        42257,
+        43054,
+        44349,
+        46396,
+        46875,
+        48850,
+        49338,
+        49457,
+        50062,
+        50509,
+        54275,
+        55763,
+        56093,
+        56473,
+        56941,
+        56964,
+        57218,
+        57274,
+        58855,
+        58926,
+        60953,
+        63436,
+        63524,
+        65536
+      ],
+      "provide_chunk_indices": true,
+      "seed": 202
+    },
+    {
+      "id": "a5_b4_hk96_hv96_t128",
+      "mode": "g",
+      "batch": 4,
+      "seqlen": 128,
+      "k_heads": 96,
+      "v_heads": 96,
+      "gate_dtype": "float32",
+      "state_dtype": null,
+      "output_final_state": true,
+      "use_exp2": true,
+      "state_v_first": true,
+      "seed": 203
+    },
+    {
+      "id": "a5_b1_hk32_hv32_t160",
+      "mode": "g",
+      "batch": 1,
+      "seqlen": 160,
+      "k_heads": 32,
+      "v_heads": 32,
+      "gate_dtype": "float32",
+      "state_dtype": null,
+      "output_final_state": true,
+      "use_exp2": true,
+      "state_v_first": true,
+      "seed": 204
+    },
+    {
+      "id": "a5_b6_hk6_hv6_t1084",
+      "mode": "g",
+      "batch": 6,
+      "seqlen": 1084,
+      "k_heads": 6,
+      "v_heads": 6,
+      "gate_dtype": "float32",
+      "state_dtype": null,
+      "output_final_state": true,
+      "use_exp2": true,
+      "state_v_first": true,
+      "seed": 205
+    },
+    {
+      "id": "a5_b1_hk12_hv12_t1084",
+      "mode": "g",
+      "batch": 1,
+      "seqlen": 1084,
+      "k_heads": 12,
+      "v_heads": 12,
+      "gate_dtype": "float32",
+      "state_dtype": null,
+      "output_final_state": true,
+      "use_exp2": true,
+      "state_v_first": true,
+      "seed": 206
+    }
+  ],
+  "call_path_cases": [
+    {
+      "id": "aclnn_zero_initial_bf16_final",
+      "batch": 1,
+      "seqlen": 64,
+      "k_heads": 1,
+      "v_heads": 1,
+      "gate_dtype": "float32",
+      "state_dtype": "bfloat16",
+      "output_final_state": true,
+      "state_v_first": false,
+      "k_value": 0.01,
+      "u_value": 0.02,
+      "seed": 104
     }
   ],
   "negative_cases": [
     {
       "id": "both_gate_inputs",
       "mutation": "both_gate_inputs",
-      "expected_message": "exactly one of g and gk"
+      "expected_message": "exactly one of g and gk",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
     },
     {
       "id": "unsupported_chunk_size",
       "mutation": "unsupported_chunk_size",
-      "expected_message": "chunk_size must be 64"
+      "expected_message": "chunk_size must be 64",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
     },
     {
       "id": "invalid_g_head_ratio",
       "mutation": "invalid_g_head_ratio",
-      "expected_message": "HV >= HK and HV % HK == 0"
+      "expected_message": "HV >= HK and HV % HK == 0",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
     },
     {
       "id": "invalid_gk_shape",
       "mutation": "invalid_gk_shape",
-      "expected_message": "gk must be [B, HV, T, K]"
+      "expected_message": "gk must be [B, HV, T, K]",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
     },
     {
       "id": "varlen_batch_not_one",
       "mutation": "varlen_batch_not_one",
-      "expected_message": "variable-length BNSD input requires B=1"
+      "expected_message": "variable-length BNSD input requires B=1",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
     },
     {
       "id": "invalid_state_v_first_shape",
       "mutation": "invalid_state_v_first_shape",
-      "expected_message": "initial_state shape does not match state_v_first"
+      "expected_message": "initial_state shape does not match state_v_first",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "missing_gate_inputs",
+      "mutation": "missing_gate_inputs",
+      "expected_message": "exactly one of g and gk",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "unsupported_input_dtype",
+      "mutation": "unsupported_input_dtype",
+      "expected_message": "k, w and u must all use bfloat16",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "save_new_value_false",
+      "mutation": "save_new_value_false",
+      "expected_message": "save_new_value must be True",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "chunk_indices_without_cu",
+      "mutation": "chunk_indices_without_cu",
+      "expected_message": "chunk_indices must use canonical sequence-major order",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "invalid_input_rank",
+      "mutation": "invalid_input_rank",
+      "expected_message": "k, w and u must be rank-4 BNSD tensors",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "non_positive_dimension",
+      "mutation": "non_positive_dimension",
+      "expected_message": "B, HK, HV and T must all be positive",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "mismatched_w_u_shape",
+      "mutation": "mismatched_w_u_shape",
+      "expected_message": "w/u must be [B, HV, T, K/V]",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "unsupported_kv_dimension",
+      "mutation": "unsupported_kv_dimension",
+      "expected_message": "K and V must both be 128",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "invalid_g_shape",
+      "mutation": "invalid_g_shape",
+      "expected_message": "g must be [B, HV, T]",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "unsupported_gate_dtype",
+      "mutation": "unsupported_gate_dtype",
+      "expected_message": "g/gk must use bfloat16 or float32",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "mismatched_input_dtype",
+      "mutation": "mismatched_input_dtype",
+      "expected_message": "k, w and u must all use bfloat16",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "invalid_cu_size",
+      "mutation": "invalid_cu_size",
+      "expected_message": "cu_seqlens must be strictly increasing, start at 0 and end at T",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "invalid_cu_start",
+      "mutation": "invalid_cu_start",
+      "expected_message": "cu_seqlens must be strictly increasing, start at 0 and end at T",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "invalid_cu_end",
+      "mutation": "invalid_cu_end",
+      "expected_message": "cu_seqlens must be strictly increasing, start at 0 and end at T",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "non_increasing_cu",
+      "mutation": "non_increasing_cu",
+      "expected_message": "cu_seqlens must be strictly increasing, start at 0 and end at T",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "invalid_chunk_indices_length",
+      "mutation": "invalid_chunk_indices_length",
+      "expected_message": "chunk_indices must use canonical sequence-major order",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "invalid_chunk_indices_order",
+      "mutation": "invalid_chunk_indices_order",
+      "expected_message": "chunk_indices must use canonical sequence-major order",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "unsupported_state_dtype",
+      "mutation": "unsupported_state_dtype",
+      "expected_message": "initial_state must use bfloat16 or float32",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    }
+  ],
+  "host_negative_cases": [
+    {
+      "id": "null_k",
+      "mutation": "null_k",
+      "expected_return_code": "ACLNN_ERR_PARAM_NULLPTR"
+    },
+    {
+      "id": "null_w",
+      "mutation": "null_w",
+      "expected_return_code": "ACLNN_ERR_PARAM_NULLPTR"
+    },
+    {
+      "id": "null_u",
+      "mutation": "null_u",
+      "expected_return_code": "ACLNN_ERR_PARAM_NULLPTR"
+    },
+    {
+      "id": "null_h",
+      "mutation": "null_h",
+      "expected_return_code": "ACLNN_ERR_PARAM_NULLPTR"
+    },
+    {
+      "id": "null_v_new",
+      "mutation": "null_v_new",
+      "expected_return_code": "ACLNN_ERR_PARAM_NULLPTR"
+    },
+    {
+      "id": "missing_final_output",
+      "mutation": "missing_final_output",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "unexpected_final_output",
+      "mutation": "unexpected_final_output",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "non_contiguous_h",
+      "mutation": "non_contiguous_h",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "non_contiguous_v_new",
+      "mutation": "non_contiguous_v_new",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "non_contiguous_final",
+      "mutation": "non_contiguous_final",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "invalid_h_shape",
+      "mutation": "invalid_h_shape",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "invalid_v_new_shape",
+      "mutation": "invalid_v_new_shape",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "invalid_final_shape",
+      "mutation": "invalid_final_shape",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "invalid_output_dtype",
+      "mutation": "invalid_output_dtype",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "invalid_final_dtype",
+      "mutation": "invalid_final_dtype",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
+    },
+    {
+      "id": "mismatched_final_dtype",
+      "mutation": "mismatched_final_dtype",
+      "expected_return_code": "ACLNN_ERR_PARAM_INVALID"
     }
   ]
 }

--- a/tests/op_cases/chunk_fwd_h.json
+++ b/tests/op_cases/chunk_fwd_h.json
@@ -1,0 +1,158 @@
+{
+  "operator": "chunk_fwd_h",
+  "entry": "fla_npu.ops.ascendc.chunk_fwd_h",
+  "cases": [
+    {
+      "id": "g_round_heads_3",
+      "mode": "g",
+      "batch": 1,
+      "seqlen": 65,
+      "k_heads": 1,
+      "v_heads": 3,
+      "gate_dtype": "bfloat16",
+      "state_dtype": null,
+      "output_final_state": false,
+      "use_exp2": false,
+      "state_v_first": false,
+      "provide_chunk_indices": false,
+      "seed": 11
+    },
+    {
+      "id": "g_round_heads_4_two_keys",
+      "mode": "g",
+      "batch": 1,
+      "seqlen": 128,
+      "k_heads": 2,
+      "v_heads": 4,
+      "gate_dtype": "float32",
+      "state_dtype": "bfloat16",
+      "output_final_state": true,
+      "use_exp2": false,
+      "state_v_first": false,
+      "provide_chunk_indices": false,
+      "seed": 12
+    },
+    {
+      "id": "g_ratio_1_to_3_two_groups",
+      "mode": "g",
+      "batch": 1,
+      "seqlen": 65,
+      "k_heads": 2,
+      "v_heads": 6,
+      "gate_dtype": "bfloat16",
+      "state_dtype": null,
+      "output_final_state": false,
+      "use_exp2": false,
+      "state_v_first": false,
+      "provide_chunk_indices": false,
+      "seed": 18
+    },
+    {
+      "id": "g_ratio_1_to_6_cross_round",
+      "mode": "g",
+      "batch": 1,
+      "seqlen": 129,
+      "k_heads": 1,
+      "v_heads": 6,
+      "gate_dtype": "float32",
+      "state_dtype": "float32",
+      "output_final_state": true,
+      "use_exp2": true,
+      "state_v_first": true,
+      "provide_chunk_indices": false,
+      "seed": 13
+    },
+    {
+      "id": "g_round_heads_1_terminal_v_new_only",
+      "mode": "g",
+      "batch": 2,
+      "seqlen": 1,
+      "k_heads": 1,
+      "v_heads": 1,
+      "gate_dtype": "bfloat16",
+      "state_dtype": null,
+      "output_final_state": false,
+      "use_exp2": false,
+      "state_v_first": true,
+      "provide_chunk_indices": false,
+      "seed": 14
+    },
+    {
+      "id": "gk_round_heads_2",
+      "mode": "gk",
+      "batch": 1,
+      "seqlen": 65,
+      "k_heads": 2,
+      "v_heads": 2,
+      "gate_dtype": "bfloat16",
+      "state_dtype": null,
+      "output_final_state": true,
+      "use_exp2": false,
+      "state_v_first": false,
+      "provide_chunk_indices": false,
+      "seed": 15
+    },
+    {
+      "id": "gk_round_heads_4_v_first",
+      "mode": "gk",
+      "batch": 1,
+      "seqlen": 128,
+      "k_heads": 4,
+      "v_heads": 4,
+      "gate_dtype": "float32",
+      "state_dtype": "bfloat16",
+      "output_final_state": true,
+      "use_exp2": true,
+      "state_v_first": true,
+      "provide_chunk_indices": false,
+      "seed": 16
+    },
+    {
+      "id": "g_varlen_round_heads_3",
+      "mode": "g",
+      "batch": 1,
+      "seqlens": [1, 64, 65],
+      "k_heads": 1,
+      "v_heads": 3,
+      "gate_dtype": "float32",
+      "state_dtype": "float32",
+      "output_final_state": true,
+      "use_exp2": false,
+      "state_v_first": true,
+      "provide_chunk_indices": true,
+      "seed": 17
+    }
+  ],
+  "negative_cases": [
+    {
+      "id": "both_gate_inputs",
+      "mutation": "both_gate_inputs",
+      "expected_message": "exactly one of g and gk"
+    },
+    {
+      "id": "unsupported_chunk_size",
+      "mutation": "unsupported_chunk_size",
+      "expected_message": "chunk_size must be 64"
+    },
+    {
+      "id": "invalid_g_head_ratio",
+      "mutation": "invalid_g_head_ratio",
+      "expected_message": "HV >= HK and HV % HK == 0"
+    },
+    {
+      "id": "invalid_gk_shape",
+      "mutation": "invalid_gk_shape",
+      "expected_message": "gk must be [B, HV, T, K]"
+    },
+    {
+      "id": "varlen_batch_not_one",
+      "mutation": "varlen_batch_not_one",
+      "expected_message": "variable-length BNSD input requires B=1"
+    },
+    {
+      "id": "invalid_state_v_first_shape",
+      "mutation": "invalid_state_v_first_shape",
+      "expected_message": "initial_state shape does not match state_v_first"
+    }
+  ]
+}

--- a/tests/operators/chunk_fwd_h/README.md
+++ b/tests/operators/chunk_fwd_h/README.md
@@ -13,6 +13,15 @@ python tests/operators/chunk_fwd_h/accuracy/test_chunk_fwd_h.py
 pytest -q tests/operators/chunk_fwd_h/ut/test_chunk_fwd_h_validation.py
 ```
 
+独立 aclnn C ABI 通路校验会直接解析并调用
+`aclnnChunkFwdHGetWorkspaceSize/aclnnChunkFwdH`，不经过公开 Python wrapper。测试包含零输入
+正向 launch、空 `workspaceSize` 的 `ACLNN_ERR_PARAM_NULLPTR` 和私有 format 的
+`ACLNN_ERR_PARAM_INVALID`：
+
+```bash
+pytest -q tests/operators/chunk_fwd_h/call_path/test_chunk_fwd_h_aclnn.py
+```
+
 可通过 `CHUNK_FWD_H_CASE_IDS` 仅运行逗号分隔的指定 case：
 
 ```bash
@@ -20,8 +29,26 @@ CHUNK_FWD_H_CASE_IDS=g_ratio_1_to_6_cross_round \
 python tests/operators/chunk_fwd_h/accuracy/test_chunk_fwd_h.py
 ```
 
-覆盖范围包括：每轮 1/2/3/4 个 head、`HK:HV=1:2/1:3/1:6`、跨 round
-重读 raw K、g/gk、BF16/FP32 rolling state、`state_v_first` 两种布局、
-`exp/exp2`、定长/变长、尾 chunk 和最终 `v_new-only` 分支。
-反向用例覆盖 gate 二选一、固定 chunk size、g/gk head 约束、varlen batch 和
-`state_v_first` 对应的 state shape。
+覆盖范围包括：每轮 1/2/3/4 个 head、`HK:HV=1:2/1:3/1:5/1:6/1:7`、跨 round
+重读 raw K、奇数 tail pair、长序列 credit 复用、g/gk、BF16/FP32 rolling state、
+`state_v_first` 两种布局、`exp/exp2`、dense 多 batch、定长/变长、显式/自动
+chunk indices、尾 chunk 和最终 `v_new-only` 分支。
+反向用例覆盖 gate 二选一、输入/输出 shape 与 dtype、固定 chunk size、g/gk head
+约束、varlen 元数据、canonical chunk indices、state shape/layout、ND/连续输出、可选
+final-state 物理存在性和必选 tensor 空指针，并校验对应 aclnn 返回码。
+
+性能用例同样定义在 `tests/op_cases/chunk_fwd_h.json` 的 `performance_cases`，runner
+只负责 warmup 和重复 launch。性能结论使用 `msprof` 的目标 kernel 记录，不使用 Python
+wall time：
+
+```bash
+python tests/operators/chunk_fwd_h/performance/run_chunk_fwd_h.py \
+  --case-id a5_g_h4_t512 --warmup 5 --iterations 50
+```
+
+六条 A5 性能场景的 case id 为：`a5_b2_hk16_hv32_t11264`、
+`a5_varlen_h32_t65536_s64`、`a5_b4_hk96_hv96_t128`、
+`a5_b1_hk32_hv32_t160`、`a5_b6_hk6_hv6_t1084` 和
+`a5_b1_hk12_hv12_t1084`。变长场景的 65 个 `cu_seqlens` 边界由 seed 202
+随机生成后固化在用例 JSON 中，runner 根据这些边界生成 sequence-major canonical
+`chunk_indices`。

--- a/tests/operators/chunk_fwd_h/README.md
+++ b/tests/operators/chunk_fwd_h/README.md
@@ -1,0 +1,27 @@
+# chunk_fwd_h 测试
+
+用例定义唯一来源为 `tests/op_cases/chunk_fwd_h.json`。精度脚本通过独立稳定入口
+`fla_npu.ops.ascendc.chunk_fwd_h` 调用算子，不加载旧算子或 legacy `torch.ops.npu` 接口。
+
+```bash
+python tests/operators/chunk_fwd_h/accuracy/test_chunk_fwd_h.py
+```
+
+接口反向校验：
+
+```bash
+pytest -q tests/operators/chunk_fwd_h/ut/test_chunk_fwd_h_validation.py
+```
+
+可通过 `CHUNK_FWD_H_CASE_IDS` 仅运行逗号分隔的指定 case：
+
+```bash
+CHUNK_FWD_H_CASE_IDS=g_ratio_1_to_6_cross_round \
+python tests/operators/chunk_fwd_h/accuracy/test_chunk_fwd_h.py
+```
+
+覆盖范围包括：每轮 1/2/3/4 个 head、`HK:HV=1:2/1:3/1:6`、跨 round
+重读 raw K、g/gk、BF16/FP32 rolling state、`state_v_first` 两种布局、
+`exp/exp2`、定长/变长、尾 chunk 和最终 `v_new-only` 分支。
+反向用例覆盖 gate 二选一、固定 chunk size、g/gk head 约束、varlen batch 和
+`state_v_first` 对应的 state shape。

--- a/tests/operators/chunk_fwd_h/accuracy/test_chunk_fwd_h.py
+++ b/tests/operators/chunk_fwd_h/accuracy/test_chunk_fwd_h.py
@@ -202,10 +202,22 @@ def run_case(case: Dict) -> None:
         if seqlens is not None and case["provide_chunk_indices"]
         else None
     )
+    u_npu = inputs["u"].npu()
+    if case.get("non_contiguous_u", False):
+        padded_u = torch.empty(
+            (*u_npu.shape[:-1], u_npu.shape[-1] * 2),
+            dtype=u_npu.dtype,
+            device=u_npu.device,
+        )
+        padded_u[..., ::2].copy_(u_npu)
+        u_npu = padded_u[..., ::2]
+        if u_npu.is_contiguous():
+            raise AssertionError(f"{case['id']}: u must remain a non-contiguous NPU view")
+
     actual = chunk_fwd_h(
         inputs["k"].npu(),
         inputs["w"].npu(),
-        inputs["u"].npu(),
+        u_npu,
         g=inputs["g"].npu() if inputs["g"] is not None else None,
         gk=inputs["gk"].npu() if inputs["gk"] is not None else None,
         initial_state=(

--- a/tests/operators/chunk_fwd_h/accuracy/test_chunk_fwd_h.py
+++ b/tests/operators/chunk_fwd_h/accuracy/test_chunk_fwd_h.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# the BSD 3-Clause License (the "License").
+
+import json
+import math
+import os
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import torch
+import torch_npu
+
+from fla_npu.ops.ascendc import chunk_fwd_h
+
+
+CHUNK_SIZE = 64
+K_DIM = 128
+V_DIM = 128
+CASE_FILE = Path(__file__).resolve().parents[3] / "op_cases" / "chunk_fwd_h.json"
+DTYPES = {
+    "bfloat16": torch.bfloat16,
+    "float32": torch.float32,
+}
+
+
+def _canonical_chunk_indices(seqlens: Sequence[int]) -> Tuple[int, ...]:
+    result: List[int] = []
+    for sequence, length in enumerate(seqlens):
+        for chunk in range((length + CHUNK_SIZE - 1) // CHUNK_SIZE):
+            result.extend((sequence, chunk))
+    return tuple(result)
+
+
+def _cu_seqlens(seqlens: Sequence[int]) -> Tuple[int, ...]:
+    result = [0]
+    for length in seqlens:
+        result.append(result[-1] + length)
+    return tuple(result)
+
+
+def _gate_exp(value: torch.Tensor, use_exp2: bool) -> torch.Tensor:
+    if use_exp2:
+        return torch.exp(value * math.log(2.0))
+    return torch.exp(value)
+
+
+def _to_logical_state(state: torch.Tensor, state_v_first: bool) -> torch.Tensor:
+    return state.transpose(-1, -2).contiguous() if state_v_first else state.contiguous()
+
+
+def _to_physical_state(state: torch.Tensor, state_v_first: bool) -> torch.Tensor:
+    return state.transpose(-1, -2).contiguous() if state_v_first else state.contiguous()
+
+
+def _reference(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: Optional[torch.Tensor],
+    gk: Optional[torch.Tensor],
+    initial_state: Optional[torch.Tensor],
+    output_final_state: bool,
+    use_exp2: bool,
+    state_v_first: bool,
+    seqlens: Optional[Sequence[int]],
+) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    batch, _, total_tokens, _ = k.shape
+    v_heads = u.shape[1]
+    if seqlens is None:
+        sequence_spans = [(batch_id, 0, total_tokens) for batch_id in range(batch)]
+    else:
+        cu = _cu_seqlens(seqlens)
+        sequence_spans = [(0, cu[idx], cu[idx + 1]) for idx in range(len(seqlens))]
+
+    total_chunks = sum((end - begin + CHUNK_SIZE - 1) // CHUNK_SIZE
+                       for _, begin, end in sequence_spans)
+    h_chunk_count = (
+        total_chunks if seqlens is not None else (total_tokens + CHUNK_SIZE - 1) // CHUNK_SIZE
+    )
+    h_logical = torch.empty((batch, v_heads, h_chunk_count, K_DIM, V_DIM), dtype=torch.bfloat16)
+    v_new = torch.empty_like(u)
+    state_dtype = initial_state.dtype if initial_state is not None else torch.float32
+    final_logical = torch.empty(
+        (len(sequence_spans), v_heads, K_DIM, V_DIM), dtype=state_dtype
+    ) if output_final_state else None
+    initial_logical = (
+        _to_logical_state(initial_state, state_v_first) if initial_state is not None else None
+    )
+
+    global_chunk = 0
+    for sequence, (physical_batch, begin, end) in enumerate(sequence_spans):
+        for hv in range(v_heads):
+            state = (
+                initial_logical[sequence, hv].clone()
+                if initial_logical is not None
+                else torch.zeros((K_DIM, V_DIM), dtype=state_dtype)
+            )
+            sequence_chunk = 0
+            for token_begin in range(begin, end, CHUNK_SIZE):
+                token_end = min(token_begin + CHUNK_SIZE, end)
+                chunk_slot = global_chunk + sequence_chunk if seqlens is not None else sequence_chunk
+                h_current = state.to(torch.bfloat16)
+                h_logical[physical_batch, hv, chunk_slot] = h_current
+
+                w_chunk = w[physical_batch, hv, token_begin:token_end]
+                p_acc = w_chunk.float() @ h_current.float()
+                p = p_acc.to(state_dtype)
+                v_new_fp32 = u[physical_batch, hv, token_begin:token_end].float() - p.float()
+                v_new_chunk = v_new_fp32.to(torch.bfloat16)
+                v_new[physical_batch, hv, token_begin:token_end] = v_new_chunk
+
+                is_last = token_end == end
+                if not is_last or output_final_state:
+                    if g is not None:
+                        gate = g[physical_batch, hv, token_begin:token_end].float()
+                        right = (
+                            v_new_fp32 * _gate_exp(gate[-1] - gate, use_exp2).unsqueeze(-1)
+                        ).to(torch.bfloat16)
+                        group_size = v_heads // k.shape[1]
+                        key_head = hv // group_size
+                        left = k[physical_batch, key_head, token_begin:token_end]
+                        decay = _gate_exp(gate[-1], use_exp2)
+                        next_state = decay * state.float() + left.float().transpose(0, 1) @ right.float()
+                    else:
+                        gate = gk[physical_batch, hv, token_end - 1].float()
+                        left = k[physical_batch, hv, token_begin:token_end]
+                        next_state = (
+                            _gate_exp(gate, use_exp2).unsqueeze(-1) * state.float()
+                            + left.float().transpose(0, 1) @ v_new_chunk.float()
+                        )
+                    state = next_state.to(state_dtype)
+                sequence_chunk += 1
+
+            if final_logical is not None:
+                final_logical[sequence, hv] = state
+        if seqlens is not None:
+            global_chunk += (end - begin + CHUNK_SIZE - 1) // CHUNK_SIZE
+
+    return (
+        _to_physical_state(h_logical, state_v_first),
+        v_new,
+        _to_physical_state(final_logical, state_v_first) if final_logical is not None else None,
+    )
+
+
+def _make_inputs(case: Dict) -> Tuple[Dict, Optional[Sequence[int]]]:
+    torch.manual_seed(case["seed"])
+    batch = case["batch"]
+    seqlens = case.get("seqlens")
+    total_tokens = sum(seqlens) if seqlens is not None else case["seqlen"]
+    k_heads = case["k_heads"]
+    v_heads = case["v_heads"]
+    gate_dtype = DTYPES[case["gate_dtype"]]
+
+    k = (torch.randn(batch, k_heads, total_tokens, K_DIM) * 0.05).to(torch.bfloat16)
+    w = (torch.randn(batch, v_heads, total_tokens, K_DIM) * 0.05).to(torch.bfloat16)
+    u = (torch.randn(batch, v_heads, total_tokens, V_DIM) * 0.05).to(torch.bfloat16)
+    g = None
+    gk = None
+    if case["mode"] == "g":
+        gate_step = -torch.rand(batch, v_heads, total_tokens) * 0.02
+        g = torch.cumsum(gate_step, dim=2).to(gate_dtype)
+    else:
+        gate_step = -torch.rand(batch, v_heads, total_tokens, K_DIM) * 0.02
+        gk = torch.cumsum(gate_step, dim=2).to(gate_dtype)
+
+    initial_state = None
+    if case["state_dtype"] is not None:
+        sequences = len(seqlens) if seqlens is not None else batch
+        logical_state = torch.randn(sequences, v_heads, K_DIM, V_DIM) * 0.05
+        initial_state = _to_physical_state(
+            logical_state.to(DTYPES[case["state_dtype"]]), case["state_v_first"]
+        )
+    return {
+        "k": k,
+        "w": w,
+        "u": u,
+        "g": g,
+        "gk": gk,
+        "initial_state": initial_state,
+    }, seqlens
+
+
+def _assert_close(name: str, actual: torch.Tensor, expected: torch.Tensor) -> None:
+    rtol, atol = (0.03, 0.03) if expected.dtype == torch.float32 else (0.02, 0.02)
+    torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol, msg=lambda msg: f"{name}: {msg}")
+
+
+def run_case(case: Dict) -> None:
+    inputs, seqlens = _make_inputs(case)
+    expected = _reference(
+        **inputs,
+        output_final_state=case["output_final_state"],
+        use_exp2=case["use_exp2"],
+        state_v_first=case["state_v_first"],
+        seqlens=seqlens,
+    )
+    cu = _cu_seqlens(seqlens) if seqlens is not None else None
+    indices = (
+        _canonical_chunk_indices(seqlens)
+        if seqlens is not None and case["provide_chunk_indices"]
+        else None
+    )
+    actual = chunk_fwd_h(
+        inputs["k"].npu(),
+        inputs["w"].npu(),
+        inputs["u"].npu(),
+        g=inputs["g"].npu() if inputs["g"] is not None else None,
+        gk=inputs["gk"].npu() if inputs["gk"] is not None else None,
+        initial_state=(
+            inputs["initial_state"].npu() if inputs["initial_state"] is not None else None
+        ),
+        output_final_state=case["output_final_state"],
+        chunk_size=CHUNK_SIZE,
+        save_new_value=True,
+        cu_seqlens=cu,
+        chunk_indices=indices,
+        use_exp2=case["use_exp2"],
+        state_v_first=case["state_v_first"],
+    )
+    actual_cpu = tuple(value.cpu() if value is not None else None for value in actual)
+    _assert_close(f"{case['id']}: h", actual_cpu[0], expected[0])
+    _assert_close(f"{case['id']}: v_new", actual_cpu[1], expected[1])
+    if case["output_final_state"]:
+        if actual_cpu[2] is None or expected[2] is None:
+            raise AssertionError(f"{case['id']}: final_state must be present")
+        _assert_close(f"{case['id']}: final_state", actual_cpu[2], expected[2])
+    elif actual_cpu[2] is not None:
+        raise AssertionError(f"{case['id']}: final_state must be None")
+    print(f"[PASS] {case['id']}")
+
+
+def main() -> None:
+    torch.npu.set_device(int(os.environ.get("TEST_DEVICE_ID", "0")))
+    data = json.loads(CASE_FILE.read_text(encoding="utf-8"))
+    selected = {
+        case_id.strip()
+        for case_id in os.environ.get("CHUNK_FWD_H_CASE_IDS", "").split(",")
+        if case_id.strip()
+    }
+    cases = [case for case in data["cases"] if not selected or case["id"] in selected]
+    if selected and len(cases) != len(selected):
+        found = {case["id"] for case in cases}
+        raise ValueError(f"unknown case ids: {sorted(selected - found)}")
+    for case in cases:
+        run_case(case)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/operators/chunk_fwd_h/call_path/test_chunk_fwd_h_aclnn.py
+++ b/tests/operators/chunk_fwd_h/call_path/test_chunk_fwd_h_aclnn.py
@@ -1,0 +1,453 @@
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# the BSD 3-Clause License (the "License").
+
+"""Direct C ABI tests for aclnnChunkFwdH.
+
+These tests intentionally bypass ``fla_npu.ops.ascendc.chunk_fwd_h``.  They
+construct aclTensor descriptors and call both aclnn stages through ctypes so
+that symbol resolution, the public aclnn ABI and exact host-side status codes
+are covered independently from the Python argument validation layer.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import os
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+import torch
+
+import fla_npu.ops.ascendc._aclnn_ctypes as aclnn_ctypes
+import fla_npu.ops.ascendc._runtime as aclnn_runtime
+
+
+ACLNN_ERR_PARAM_NULLPTR = 161001
+ACLNN_ERR_PARAM_INVALID = 161002
+PRIVATE_NPU_FORMAT = 29
+CASE_FILE = Path(__file__).resolve().parents[3] / "op_cases" / "chunk_fwd_h.json"
+CASE_DATA = json.loads(CASE_FILE.read_text(encoding="utf-8"))
+NEGATIVE_CASES = CASE_DATA["negative_cases"]
+HOST_NEGATIVE_CASES = CASE_DATA["host_negative_cases"]
+CALL_PATH_CASES = {case["id"]: case for case in CASE_DATA["call_path_cases"]}
+
+
+def _npu_is_available() -> bool:
+    try:
+        import torch_npu  # noqa: F401
+
+        return bool(torch.npu.is_available())
+    except (ImportError, AttributeError, RuntimeError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _npu_is_available(), reason="NPU device not found")
+
+
+def _device() -> torch.device:
+    device = torch.device(os.getenv("FLA_NPU_TEST_DEVICE", "npu:0"))
+    torch.npu.set_device(device)
+    return device
+
+
+def _nd_tensor(ctx, tensor, name: str, *, acl_format: int = aclnn_runtime.ACL_FORMAT_ND):
+    if tensor is None:
+        return ctx.tensor(None, name)
+    storage_shape = (
+        tuple(int(dim) for dim in tensor.shape)
+        if tensor.is_contiguous() and int(tensor.storage_offset()) == 0
+        else None
+    )
+    return ctx.tensor(
+        tensor,
+        name,
+        acl_format_override=acl_format,
+        storage_shape_override=storage_shape,
+    )
+
+
+@contextmanager
+def _direct_call_args(
+    *,
+    private_k_format: bool = False,
+    mutation: str | None = None,
+    output_final_state: bool = True,
+    final_state_dtype: torch.dtype = torch.float32,
+    k_value: float = 0.0,
+    u_value: float = 0.0,
+):
+    device = _device()
+    runtime = aclnn_runtime.runtime()
+    ctx = aclnn_runtime._CallContext(runtime, device)
+
+    batch, k_heads, v_heads, tokens, dim = 1, 1, 1, 64, 128
+    input_dtype = torch.bfloat16
+    use_g = True
+    use_gk = False
+    gk_heads = v_heads
+    chunk_size = 64
+    save_new_value = True
+    state_v_first = False
+    initial_shape = None
+    initial_dtype = torch.bfloat16
+    cu_values = None
+    chunk_indices_values = None
+    k_rank3 = False
+    w_tokens = tokens
+    g_tokens = tokens
+    gate_dtype = torch.float32
+    w_dtype = None
+    h_shape = None
+    v_new_shape = None
+    final_shape = None
+    h_dtype = None
+    final_present = output_final_state
+    null_tensor = None
+    non_contiguous_output = None
+
+    if mutation == "both_gate_inputs":
+        use_gk = True
+    elif mutation == "unsupported_chunk_size":
+        chunk_size = 32
+    elif mutation == "invalid_g_head_ratio":
+        k_heads, v_heads = 2, 3
+    elif mutation == "invalid_gk_shape":
+        k_heads, v_heads = 2, 2
+        use_g = False
+        use_gk = True
+        gk_heads = 1
+    elif mutation == "varlen_batch_not_one":
+        batch = 2
+        cu_values = (0, tokens)
+    elif mutation == "invalid_state_v_first_shape":
+        state_v_first = True
+        initial_shape = (1, 1, 127, 128)
+    elif mutation == "missing_gate_inputs":
+        use_g = False
+    elif mutation == "unsupported_input_dtype":
+        input_dtype = torch.float32
+    elif mutation == "save_new_value_false":
+        save_new_value = False
+    elif mutation == "chunk_indices_without_cu":
+        chunk_indices_values = (0, 0)
+    elif mutation == "invalid_input_rank":
+        k_rank3 = True
+    elif mutation == "non_positive_dimension":
+        batch = 0
+    elif mutation == "mismatched_w_u_shape":
+        w_tokens = tokens + 1
+    elif mutation == "unsupported_kv_dimension":
+        dim = 64
+    elif mutation == "invalid_g_shape":
+        g_tokens = tokens + 1
+    elif mutation == "unsupported_gate_dtype":
+        gate_dtype = torch.float16
+    elif mutation == "mismatched_input_dtype":
+        w_dtype = torch.float32
+    elif mutation == "invalid_cu_size":
+        cu_values = (0,)
+    elif mutation == "invalid_cu_start":
+        cu_values = (1, tokens)
+    elif mutation == "invalid_cu_end":
+        cu_values = (0, tokens + 1)
+    elif mutation == "non_increasing_cu":
+        cu_values = (0, tokens, tokens)
+    elif mutation == "invalid_chunk_indices_length":
+        cu_values = (0, tokens)
+        chunk_indices_values = (0,)
+    elif mutation == "invalid_chunk_indices_order":
+        tokens = 65
+        w_tokens = tokens
+        g_tokens = tokens
+        cu_values = (0, tokens)
+        chunk_indices_values = (0, 1, 0, 0)
+    elif mutation == "unsupported_state_dtype":
+        initial_shape = (1, 1, dim, dim)
+        initial_dtype = torch.float16
+    elif mutation in {"null_k", "null_w", "null_u", "null_h", "null_v_new"}:
+        null_tensor = mutation[len("null_"):]
+    elif mutation == "missing_final_output":
+        final_present = False
+    elif mutation == "unexpected_final_output":
+        output_final_state = False
+        final_present = True
+    elif mutation in {"non_contiguous_h", "non_contiguous_v_new", "non_contiguous_final"}:
+        non_contiguous_output = mutation[len("non_contiguous_"):]
+    elif mutation == "invalid_h_shape":
+        h_shape = (batch, v_heads, 2, dim, dim)
+    elif mutation == "invalid_v_new_shape":
+        v_new_shape = (batch, v_heads, tokens + 1, dim)
+    elif mutation == "invalid_final_shape":
+        final_shape = (batch, v_heads, dim, dim - 1)
+    elif mutation == "invalid_output_dtype":
+        h_dtype = torch.float32
+    elif mutation == "invalid_final_dtype":
+        final_state_dtype = torch.float16
+    elif mutation == "mismatched_final_dtype":
+        initial_shape = (1, 1, dim, dim)
+        initial_dtype = torch.bfloat16
+        final_state_dtype = torch.float32
+    elif mutation is not None:
+        raise AssertionError(f"unknown negative mutation: {mutation}")
+
+    k_shape = (batch, k_heads, dim) if k_rank3 else (batch, k_heads, tokens, dim)
+    k = torch.full(
+        k_shape, k_value, dtype=input_dtype, device=device
+    )
+    w = torch.zeros(
+        (batch, v_heads, w_tokens, dim),
+        dtype=w_dtype if w_dtype is not None else input_dtype,
+        device=device,
+    )
+    u = torch.full(
+        (batch, v_heads, tokens, dim), u_value, dtype=input_dtype, device=device
+    )
+    g = (
+        torch.zeros((batch, v_heads, g_tokens), dtype=gate_dtype, device=device)
+        if use_g
+        else None
+    )
+    gk = (
+        torch.zeros((batch, gk_heads, tokens, dim), dtype=gate_dtype, device=device)
+        if use_gk
+        else None
+    )
+    initial_state = (
+        torch.zeros(initial_shape, dtype=initial_dtype, device=device)
+        if initial_shape is not None
+        else None
+    )
+    h = torch.full(
+        h_shape if h_shape is not None else (batch, v_heads, 1, dim, dim),
+        3,
+        dtype=h_dtype if h_dtype is not None else input_dtype,
+        device=device,
+    )
+    v_new = torch.full(
+        v_new_shape if v_new_shape is not None else tuple(u.shape),
+        5,
+        dtype=input_dtype,
+        device=device,
+    )
+    final_state = (
+        torch.full(
+            final_shape if final_shape is not None else (batch, v_heads, dim, dim),
+            7,
+            dtype=final_state_dtype,
+            device=device,
+        )
+        if final_present
+        else None
+    )
+
+    def make_non_contiguous(tensor):
+        padded = torch.empty(
+            (*tensor.shape[:-1], tensor.shape[-1] * 2),
+            dtype=tensor.dtype,
+            device=tensor.device,
+        )
+        padded[..., ::2].copy_(tensor)
+        return padded[..., ::2]
+
+    if non_contiguous_output == "h":
+        h = make_non_contiguous(h)
+    elif non_contiguous_output == "v_new":
+        v_new = make_non_contiguous(v_new)
+    elif non_contiguous_output == "final":
+        final_state = make_non_contiguous(final_state)
+
+    k_format = PRIVATE_NPU_FORMAT if private_k_format else aclnn_runtime.ACL_FORMAT_ND
+    args = [
+        _nd_tensor(ctx, None if null_tensor == "k" else k, "k", acl_format=k_format),
+        _nd_tensor(ctx, None if null_tensor == "w" else w, "w"),
+        _nd_tensor(ctx, None if null_tensor == "u" else u, "u"),
+        _nd_tensor(ctx, g, "g"),
+        _nd_tensor(ctx, gk, "gk"),
+        _nd_tensor(ctx, initial_state, "initial_state"),
+        ctypes.c_bool(output_final_state),
+        ctypes.c_int64(chunk_size),
+        ctypes.c_bool(save_new_value),
+        ctx.int_array(cu_values),
+        ctx.int_array(chunk_indices_values),
+        ctypes.c_bool(False),
+        ctypes.c_bool(state_v_first),
+        _nd_tensor(ctx, None if null_tensor == "h" else h, "h"),
+        _nd_tensor(ctx, None if null_tensor == "v_new" else v_new, "v_new"),
+        _nd_tensor(ctx, final_state, "final_state"),
+    ]
+    try:
+        yield runtime, device, args, (h, v_new, final_state)
+    finally:
+        ctx.destroy()
+
+
+def _get_workspace_symbol(runtime):
+    symbol = runtime.symbol("aclnnChunkFwdHGetWorkspaceSize")
+    symbol.argtypes = aclnn_ctypes._GET_WORKSPACE_ARGTYPES["aclnnChunkFwdH"]
+    symbol.restype = ctypes.c_int
+    return symbol
+
+
+def test_aclnn_chunk_fwd_h_direct_positive_zero_input():
+    with _direct_call_args() as (runtime, device, args, outputs):
+        assert runtime.symbol("aclnnChunkFwdH") is not None
+        workspace = runtime.call(
+            "aclnnChunkFwdH",
+            args,
+            device,
+            get_workspace_argtypes=aclnn_ctypes._GET_WORKSPACE_ARGTYPES[
+                "aclnnChunkFwdH"
+            ],
+        )
+        torch.npu.synchronize()
+        # Keep the workspace alive through synchronization even though the
+        # runtime allocator is stream aware.
+        assert workspace is not None
+        for output in outputs:
+            assert torch.count_nonzero(output).item() == 0
+
+
+def test_aclnn_chunk_fwd_h_direct_terminal_without_final_state():
+    with _direct_call_args(output_final_state=False) as (
+        runtime,
+        device,
+        args,
+        outputs,
+    ):
+        workspace = runtime.call(
+            "aclnnChunkFwdH",
+            args,
+            device,
+            get_workspace_argtypes=aclnn_ctypes._GET_WORKSPACE_ARGTYPES[
+                "aclnnChunkFwdH"
+            ],
+        )
+        torch.npu.synchronize()
+        assert workspace is not None
+        assert outputs[2] is None
+        assert torch.count_nonzero(outputs[0]).item() == 0
+        assert torch.count_nonzero(outputs[1]).item() == 0
+
+
+def test_aclnn_chunk_fwd_h_zero_initial_bf16_final_state():
+    case = CALL_PATH_CASES["aclnn_zero_initial_bf16_final"]
+    with _direct_call_args(
+        final_state_dtype=torch.bfloat16,
+        k_value=case["k_value"],
+        u_value=case["u_value"],
+    ) as (runtime, device, args, outputs):
+        workspace = runtime.call(
+            "aclnnChunkFwdH",
+            args,
+            device,
+            get_workspace_argtypes=aclnn_ctypes._GET_WORKSPACE_ARGTYPES[
+                "aclnnChunkFwdH"
+            ],
+        )
+        torch.npu.synchronize()
+        assert workspace is not None
+
+        h, v_new, final_state = outputs
+        assert final_state is not None
+        assert final_state.dtype == torch.bfloat16
+        assert torch.count_nonzero(h).item() == 0
+        torch.testing.assert_close(
+            v_new,
+            torch.full_like(v_new, case["u_value"]),
+            rtol=0,
+            atol=0,
+        )
+
+        k_bf16 = torch.tensor(case["k_value"], dtype=torch.bfloat16).float()
+        u_bf16 = torch.tensor(case["u_value"], dtype=torch.bfloat16).float()
+        expected_value = (case["seqlen"] * k_bf16 * u_bf16).to(torch.bfloat16)
+        torch.testing.assert_close(
+            final_state,
+            torch.full_like(final_state, expected_value.item()),
+            rtol=0.02,
+            atol=0.002,
+        )
+
+
+def test_aclnn_chunk_fwd_h_null_workspace_size_returns_nullptr():
+    with _direct_call_args() as (runtime, _device_value, args, _outputs):
+        get_workspace = _get_workspace_symbol(runtime)
+        executor = ctypes.c_void_p()
+        status = get_workspace(*args, None, ctypes.byref(executor))
+
+    assert status == ACLNN_ERR_PARAM_NULLPTR
+    assert not executor.value
+
+
+def test_aclnn_chunk_fwd_h_null_executor_returns_nullptr():
+    with _direct_call_args() as (runtime, _device_value, args, _outputs):
+        get_workspace = _get_workspace_symbol(runtime)
+        workspace_size = ctypes.c_uint64(0xA5A5A5A5)
+        status = get_workspace(*args, ctypes.byref(workspace_size), None)
+
+    assert status == ACLNN_ERR_PARAM_NULLPTR
+    assert workspace_size.value == 0xA5A5A5A5
+
+
+def test_aclnn_chunk_fwd_h_private_format_returns_invalid():
+    with _direct_call_args(private_k_format=True) as (
+        runtime,
+        _device_value,
+        args,
+        _outputs,
+    ):
+        get_workspace = _get_workspace_symbol(runtime)
+        workspace_size = ctypes.c_uint64(0)
+        executor = ctypes.c_void_p()
+        status = get_workspace(
+            *args, ctypes.byref(workspace_size), ctypes.byref(executor)
+        )
+
+    assert status == ACLNN_ERR_PARAM_INVALID
+    assert not executor.value
+
+
+@pytest.mark.parametrize("case", NEGATIVE_CASES, ids=lambda case: case["id"])
+def test_aclnn_chunk_fwd_h_host_validation_returns_invalid(case):
+    assert case["expected_return_code"] == "ACLNN_ERR_PARAM_INVALID"
+    with _direct_call_args(mutation=case["mutation"]) as (
+        runtime,
+        _device_value,
+        args,
+        _outputs,
+    ):
+        get_workspace = _get_workspace_symbol(runtime)
+        workspace_size = ctypes.c_uint64(0)
+        executor = ctypes.c_void_p()
+        status = get_workspace(
+            *args, ctypes.byref(workspace_size), ctypes.byref(executor)
+        )
+
+    assert status == ACLNN_ERR_PARAM_INVALID
+    assert not executor.value
+
+
+@pytest.mark.parametrize("case", HOST_NEGATIVE_CASES, ids=lambda case: case["id"])
+def test_aclnn_chunk_fwd_h_host_only_validation(case):
+    expected_status = {
+        "ACLNN_ERR_PARAM_NULLPTR": ACLNN_ERR_PARAM_NULLPTR,
+        "ACLNN_ERR_PARAM_INVALID": ACLNN_ERR_PARAM_INVALID,
+    }[case["expected_return_code"]]
+    with _direct_call_args(mutation=case["mutation"]) as (
+        runtime,
+        _device_value,
+        args,
+        _outputs,
+    ):
+        get_workspace = _get_workspace_symbol(runtime)
+        workspace_size = ctypes.c_uint64(0)
+        executor = ctypes.c_void_p()
+        status = get_workspace(
+            *args, ctypes.byref(workspace_size), ctypes.byref(executor)
+        )
+
+    assert status == expected_status
+    assert not executor.value

--- a/tests/operators/chunk_fwd_h/performance/run_chunk_fwd_h.py
+++ b/tests/operators/chunk_fwd_h/performance/run_chunk_fwd_h.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# the BSD 3-Clause License (the "License").
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+import torch_npu
+
+from fla_npu.ops.ascendc import chunk_fwd_h
+
+
+CHUNK_SIZE = 64
+K_DIM = 128
+V_DIM = 128
+CASE_FILE = Path(__file__).resolve().parents[3] / "op_cases" / "chunk_fwd_h.json"
+DTYPES = {
+    "bfloat16": torch.bfloat16,
+    "float32": torch.float32,
+}
+
+
+def _load_case(case_id):
+    data = json.loads(CASE_FILE.read_text(encoding="utf-8"))
+    cases = {case["id"]: case for case in data["performance_cases"]}
+    if case_id not in cases:
+        raise ValueError(f"unknown performance case: {case_id}; available={sorted(cases)}")
+    return cases[case_id]
+
+
+def _canonical_chunk_indices(cu_seqlens):
+    result = []
+    for sequence, (begin, end) in enumerate(zip(cu_seqlens, cu_seqlens[1:])):
+        chunk_count = (end - begin + CHUNK_SIZE - 1) // CHUNK_SIZE
+        for chunk in range(chunk_count):
+            result.extend((sequence, chunk))
+    return tuple(result)
+
+
+def _make_varlen_metadata(case):
+    raw_cu_seqlens = case.get("cu_seqlens")
+    if raw_cu_seqlens is None:
+        return None, None
+    cu_seqlens = tuple(raw_cu_seqlens)
+    if case["batch"] != 1:
+        raise ValueError("variable-length performance cases require batch=1")
+    if len(cu_seqlens) < 2 or cu_seqlens[0] != 0 or cu_seqlens[-1] != case["seqlen"]:
+        raise ValueError("cu_seqlens must contain 0 and seqlen as its endpoints")
+    if any(begin >= end for begin, end in zip(cu_seqlens, cu_seqlens[1:])):
+        raise ValueError("cu_seqlens must be strictly increasing")
+    if not case.get("provide_chunk_indices", False):
+        return cu_seqlens, None
+    return cu_seqlens, _canonical_chunk_indices(cu_seqlens)
+
+
+def _make_inputs(case, device):
+    torch.manual_seed(case["seed"])
+    batch = case["batch"]
+    seqlen = case["seqlen"]
+    k_heads = case["k_heads"]
+    v_heads = case["v_heads"]
+
+    def random_bf16(shape):
+        return (torch.randn(shape) * 0.05).to(torch.bfloat16).to(device)
+
+    k = random_bf16((batch, k_heads, seqlen, K_DIM))
+    w = random_bf16((batch, v_heads, seqlen, K_DIM))
+    u = random_bf16((batch, v_heads, seqlen, V_DIM))
+    gate_dtype = DTYPES[case["gate_dtype"]]
+    g = None
+    gk = None
+    if case["mode"] == "g":
+        gate_step = -torch.rand(batch, v_heads, seqlen) * 0.02
+        g = torch.cumsum(gate_step, dim=2).to(gate_dtype).to(device)
+    else:
+        gate_step = -torch.rand(batch, v_heads, seqlen, K_DIM) * 0.02
+        gk = torch.cumsum(gate_step, dim=2).to(gate_dtype).to(device)
+
+    initial_state = None
+    if case["state_dtype"] is not None:
+        state = (torch.randn(batch, v_heads, K_DIM, V_DIM) * 0.05).to(
+            DTYPES[case["state_dtype"]]
+        )
+        if case["state_v_first"]:
+            state = state.transpose(-1, -2).contiguous()
+        initial_state = state.to(device)
+    cu_seqlens, chunk_indices = _make_varlen_metadata(case)
+    return k, w, u, g, gk, initial_state, cu_seqlens, chunk_indices
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--case-id", default="a5_g_h4_t512")
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iterations", type=int, default=50)
+    args = parser.parse_args()
+    if args.warmup < 0 or args.iterations <= 0:
+        raise ValueError("warmup must be non-negative and iterations must be positive")
+
+    torch.npu.set_device(args.device)
+    device = torch.device(f"npu:{args.device}")
+    case = _load_case(args.case_id)
+    inputs = _make_inputs(case, device)
+
+    def launch():
+        return chunk_fwd_h(
+            inputs[0],
+            inputs[1],
+            inputs[2],
+            g=inputs[3],
+            gk=inputs[4],
+            initial_state=inputs[5],
+            output_final_state=case["output_final_state"],
+            chunk_size=CHUNK_SIZE,
+            save_new_value=True,
+            cu_seqlens=inputs[6],
+            chunk_indices=inputs[7],
+            use_exp2=case["use_exp2"],
+            state_v_first=case["state_v_first"],
+        )
+
+    outputs = None
+    for _ in range(args.warmup):
+        outputs = launch()
+    torch.npu.synchronize()
+    varlen = ""
+    if inputs[6] is not None:
+        chunk_count = len(inputs[7]) // 2 if inputs[7] is not None else "auto"
+        varlen = f" sequences={len(inputs[6]) - 1} chunks={chunk_count}"
+    print(f"[PERF_READY] case={args.case_id} warmup={args.warmup}{varlen}", flush=True)
+    for _ in range(args.iterations):
+        outputs = launch()
+    torch.npu.synchronize()
+    if outputs is None:
+        raise AssertionError("performance runner did not launch the operator")
+    print(f"[PERF_DONE] case={args.case_id} launches={args.iterations}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/operators/chunk_fwd_h/ut/test_chunk_fwd_h_validation.py
+++ b/tests/operators/chunk_fwd_h/ut/test_chunk_fwd_h_validation.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026 Tianjin University, Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# the BSD 3-Clause License (the "License").
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import torch
+
+from fla_npu.ops.ascendc import chunk_fwd_h
+
+
+CASE_FILE = Path(__file__).resolve().parents[3] / "op_cases" / "chunk_fwd_h.json"
+NEGATIVE_CASES = json.loads(CASE_FILE.read_text(encoding="utf-8"))["negative_cases"]
+
+
+def _base_inputs(batch=1, k_heads=1, v_heads=1, tokens=1):
+    return {
+        "k": torch.empty(batch, k_heads, tokens, 128, dtype=torch.bfloat16),
+        "w": torch.empty(batch, v_heads, tokens, 128, dtype=torch.bfloat16),
+        "u": torch.empty(batch, v_heads, tokens, 128, dtype=torch.bfloat16),
+        "g": torch.empty(batch, v_heads, tokens, dtype=torch.bfloat16),
+    }
+
+
+@pytest.mark.parametrize("case", NEGATIVE_CASES, ids=lambda case: case["id"])
+def test_chunk_fwd_h_validation(case):
+    mutation = case["mutation"]
+    inputs = _base_inputs()
+    kwargs = {}
+
+    if mutation == "both_gate_inputs":
+        kwargs["gk"] = torch.empty(1, 1, 1, 128, dtype=torch.bfloat16)
+    elif mutation == "unsupported_chunk_size":
+        kwargs["chunk_size"] = 32
+    elif mutation == "invalid_g_head_ratio":
+        inputs = _base_inputs(k_heads=2, v_heads=3)
+    elif mutation == "invalid_gk_shape":
+        inputs = _base_inputs(k_heads=2, v_heads=2)
+        inputs.pop("g")
+        kwargs["gk"] = torch.empty(1, 1, 1, 128, dtype=torch.bfloat16)
+    elif mutation == "varlen_batch_not_one":
+        inputs = _base_inputs(batch=2)
+        kwargs["cu_seqlens"] = (0, 1)
+    elif mutation == "invalid_state_v_first_shape":
+        kwargs["state_v_first"] = True
+        kwargs["initial_state"] = torch.empty(1, 1, 127, 128, dtype=torch.bfloat16)
+    else:
+        raise AssertionError(f"unknown negative mutation: {mutation}")
+
+    with pytest.raises(RuntimeError, match=re.escape(case["expected_message"])):
+        chunk_fwd_h(**inputs, **kwargs)

--- a/tests/operators/chunk_fwd_h/ut/test_chunk_fwd_h_validation.py
+++ b/tests/operators/chunk_fwd_h/ut/test_chunk_fwd_h_validation.py
@@ -4,12 +4,15 @@
 
 import json
 import re
+import sys
+import types
 from pathlib import Path
 
 import pytest
 import torch
 
 from fla_npu.ops.ascendc import chunk_fwd_h
+import fla_npu.ops.ascendc._aclnn_ctypes as aclnn_ctypes
 
 
 CASE_FILE = Path(__file__).resolve().parents[3] / "op_cases" / "chunk_fwd_h.json"
@@ -27,6 +30,7 @@ def _base_inputs(batch=1, k_heads=1, v_heads=1, tokens=1):
 
 @pytest.mark.parametrize("case", NEGATIVE_CASES, ids=lambda case: case["id"])
 def test_chunk_fwd_h_validation(case):
+    assert case["expected_return_code"] == "ACLNN_ERR_PARAM_INVALID"
     mutation = case["mutation"]
     inputs = _base_inputs()
     kwargs = {}
@@ -47,8 +51,138 @@ def test_chunk_fwd_h_validation(case):
     elif mutation == "invalid_state_v_first_shape":
         kwargs["state_v_first"] = True
         kwargs["initial_state"] = torch.empty(1, 1, 127, 128, dtype=torch.bfloat16)
+    elif mutation == "missing_gate_inputs":
+        inputs.pop("g")
+    elif mutation == "unsupported_input_dtype":
+        inputs["k"] = inputs["k"].float()
+        inputs["w"] = inputs["w"].float()
+        inputs["u"] = inputs["u"].float()
+    elif mutation == "save_new_value_false":
+        kwargs["save_new_value"] = False
+    elif mutation == "chunk_indices_without_cu":
+        kwargs["chunk_indices"] = (0, 0)
+    elif mutation == "invalid_input_rank":
+        inputs["k"] = torch.empty(1, 1, 128, dtype=torch.bfloat16)
+    elif mutation == "non_positive_dimension":
+        inputs = _base_inputs(batch=0)
+    elif mutation == "mismatched_w_u_shape":
+        inputs["w"] = torch.empty(1, 1, 2, 128, dtype=torch.bfloat16)
+    elif mutation == "unsupported_kv_dimension":
+        inputs["k"] = torch.empty(1, 1, 1, 64, dtype=torch.bfloat16)
+        inputs["w"] = torch.empty(1, 1, 1, 64, dtype=torch.bfloat16)
+    elif mutation == "invalid_g_shape":
+        inputs["g"] = torch.empty(1, 1, 2, dtype=torch.bfloat16)
+    elif mutation == "unsupported_gate_dtype":
+        inputs["g"] = inputs["g"].to(torch.float16)
+    elif mutation == "mismatched_input_dtype":
+        inputs["w"] = inputs["w"].float()
+    elif mutation == "invalid_cu_size":
+        kwargs["cu_seqlens"] = (0,)
+    elif mutation == "invalid_cu_start":
+        kwargs["cu_seqlens"] = (1, 2)
+    elif mutation == "invalid_cu_end":
+        kwargs["cu_seqlens"] = (0, 2)
+    elif mutation == "non_increasing_cu":
+        kwargs["cu_seqlens"] = (0, 1, 1)
+    elif mutation == "invalid_chunk_indices_length":
+        kwargs["cu_seqlens"] = (0, 1)
+        kwargs["chunk_indices"] = (0,)
+    elif mutation == "invalid_chunk_indices_order":
+        inputs = _base_inputs(tokens=65)
+        kwargs["cu_seqlens"] = (0, 65)
+        kwargs["chunk_indices"] = (0, 1, 0, 0)
+    elif mutation == "unsupported_state_dtype":
+        kwargs["initial_state"] = torch.empty(1, 1, 128, 128, dtype=torch.float16)
     else:
         raise AssertionError(f"unknown negative mutation: {mutation}")
 
     with pytest.raises(RuntimeError, match=re.escape(case["expected_message"])):
         chunk_fwd_h(**inputs, **kwargs)
+
+
+class _FakeCallContext:
+    def __init__(self):
+        self.tensors = {}
+
+    def tensor(self, tensor, name, **kwargs):
+        self.tensors[name] = (tensor, kwargs)
+        return object()
+
+    def int_array(self, values):
+        return object()
+
+
+def _capture_direct_call(monkeypatch):
+    captured = {}
+
+    def fake_call(name, build_args, outputs):
+        ctx = _FakeCallContext()
+        captured["name"] = name
+        captured["args"] = build_args(ctx)
+        captured["ctx"] = ctx
+        return outputs
+
+    monkeypatch.setattr(aclnn_ctypes, "_call_aclnn", fake_call)
+    _set_mock_npu_format(monkeypatch, aclnn_ctypes.ACL_FORMAT_ND)
+    return captured
+
+
+def _set_mock_npu_format(monkeypatch, acl_format):
+    monkeypatch.setattr(aclnn_ctypes, "_acl_format", lambda tensor: acl_format)
+    loaded_torch_npu = sys.modules.get("torch_npu")
+    if loaded_torch_npu is not None:
+        monkeypatch.setattr(
+            loaded_torch_npu, "get_npu_format", lambda tensor: acl_format
+        )
+
+
+def test_non_contiguous_input_uses_truthful_storage_and_contiguous_output(monkeypatch):
+    captured = _capture_direct_call(monkeypatch)
+    inputs = _base_inputs()
+    inputs["u"] = torch.empty(1, 1, 1, 256, dtype=torch.bfloat16)[..., ::2]
+
+    _, v_new, _ = aclnn_ctypes.npu_chunk_fwd_h(**inputs)
+
+    assert captured["name"] == "aclnnChunkFwdH"
+    assert captured["ctx"].tensors["u"][1]["storage_shape_override"] is None
+    assert v_new.is_contiguous()
+    assert captured["ctx"].tensors["v_new"][1]["storage_shape_override"] == (1, 1, 1, 128)
+
+
+def test_private_npu_format_is_rejected_before_descriptor_override(monkeypatch):
+    _capture_direct_call(monkeypatch)
+    _set_mock_npu_format(monkeypatch, 29)
+
+    with pytest.raises(RuntimeError, match="private NPU format 29 is not supported"):
+        aclnn_ctypes.npu_chunk_fwd_h(**_base_inputs())
+
+
+def test_loaded_torch_npu_format_query_failure_is_not_guessed_from_rank(monkeypatch):
+    _capture_direct_call(monkeypatch)
+
+    def fail_format_query(tensor):
+        raise RuntimeError("format metadata unavailable")
+
+    fake_torch_npu = types.SimpleNamespace(get_npu_format=fail_format_query)
+    monkeypatch.setitem(sys.modules, "torch_npu", fake_torch_npu)
+
+    with pytest.raises(RuntimeError, match="cannot determine the real NPU format of k"):
+        aclnn_ctypes.npu_chunk_fwd_h(**_base_inputs())
+
+
+def test_loaded_torch_npu_format_is_queried_once_per_tensor(monkeypatch):
+    _capture_direct_call(monkeypatch)
+    queried = set()
+
+    def one_shot_format_query(tensor):
+        tensor_id = id(tensor)
+        if tensor_id in queried:
+            raise RuntimeError("format metadata queried twice")
+        queried.add(tensor_id)
+        return aclnn_ctypes.ACL_FORMAT_ND
+
+    fake_torch_npu = types.SimpleNamespace(get_npu_format=one_shot_format_query)
+    monkeypatch.setitem(sys.modules, "torch_npu", fake_torch_npu)
+
+    aclnn_ctypes.npu_chunk_fwd_h(**_base_inputs())
+    assert queried

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/__init__.py
@@ -38,6 +38,7 @@ _ASCENDC_OPS = (
     "npu_chunk_bwd_dqkwg",
     "npu_chunk_fwd_o",
     "npu_chunk_gated_delta_rule_fwd_h",
+    "npu_chunk_fwd_h",
     "npu_recompute_w_u_fwd",
     "npu_recurrent_gated_delta_rule",
     "npu_chunk_local_cumsum",
@@ -47,6 +48,12 @@ _ASCENDC_OPS = (
     "npu_chunk_kda_bwd_intra",
     "npu_kda_gate_cumsum",
     "npu_recurrent_kda",
+)
+
+# ChunkFwdH 仅提供解耦 ctypes 稳定入口，不注册 torch.ops.npu，也不挂到
+# torch_npu.ops 的可选兼容命名空间。
+_TORCH_NPU_COMPAT_OPS = tuple(
+    name for name in _ASCENDC_OPS if name != "npu_chunk_fwd_h"
 )
 
 BACKWARD_OPS = {
@@ -405,7 +412,7 @@ def install_torch_npu_ops_compat() -> None:
         ops = types.SimpleNamespace()
         setattr(torch_npu, "ops", ops)
 
-    for name in _ASCENDC_OPS:
+    for name in _TORCH_NPU_COMPAT_OPS:
         setattr(ops, name, globals()[name])
         setattr(ops, _strip_npu_prefix(name), globals()[_strip_npu_prefix(name)])
 
@@ -414,7 +421,7 @@ def install_legacy_torch_ops_warning() -> None:
     """Warn when users call legacy ``torch.ops.npu`` FLA NPU operators."""
 
     namespace = _torch_npu_namespace()
-    for name in _ASCENDC_OPS:
+    for name in _TORCH_NPU_COMPAT_OPS:
         if not hasattr(namespace, name):
             continue
         current = getattr(namespace, name)

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
@@ -221,6 +221,21 @@ _GET_WORKSPACE_ARGTYPES = {
         ctypes.POINTER(ctypes.c_uint64),
         ctypes.POINTER(ctypes.c_void_p),
     ],
+    "aclnnChunkFwdH": [
+        *([ctypes.c_void_p] * 6),
+        ctypes.c_bool,
+        ctypes.c_int64,
+        ctypes.c_bool,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_bool,
+        ctypes.c_bool,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_uint64),
+        ctypes.POINTER(ctypes.c_void_p),
+    ],
 }
 
 
@@ -626,6 +641,140 @@ def npu_chunk_gated_delta_rule_fwd_h(
             ctx.tensor(h_out, "h"),
             ctx.tensor(v_new_out, "v_new"),
             ctx.tensor(final_state_out, "final_state"),
+        ],
+        outputs,
+    )
+
+
+def npu_chunk_fwd_h(
+    k,
+    w,
+    u,
+    *,
+    g=None,
+    gk=None,
+    initial_state=None,
+    output_final_state=False,
+    chunk_size=64,
+    save_new_value=True,
+    cu_seqlens=None,
+    chunk_indices=None,
+    use_exp2=False,
+    state_v_first=False,
+):
+    import torch
+
+    op_name = "npu_chunk_fwd_h"
+    if (g is None) == (gk is None):
+        raise RuntimeError(f"{op_name}: exactly one of g and gk must be provided.")
+    output_final_state = _optional_bool(output_final_state, False)
+    save_new_value = _optional_bool(save_new_value, True)
+    use_exp2 = _optional_bool(use_exp2, False)
+    state_v_first = _optional_bool(state_v_first, False)
+    chunk_size = _optional_int(chunk_size, 64)
+    if chunk_size != 64:
+        raise RuntimeError(f"{op_name}: chunk_size must be 64.")
+    if not save_new_value:
+        raise RuntimeError(f"{op_name}: save_new_value must be True.")
+    if len(_shape(k)) != 4 or len(_shape(w)) != 4 or len(_shape(u)) != 4:
+        raise RuntimeError(f"{op_name}: k, w and u must be rank-4 BNSD tensors.")
+
+    batch, k_heads, seqlen, k_dim = _shape(k)
+    _, v_heads, _, v_dim = _shape(u)
+    if batch <= 0 or k_heads <= 0 or v_heads <= 0 or seqlen <= 0:
+        raise RuntimeError(f"{op_name}: B, HK, HV and T must all be positive.")
+    if k.dtype != torch.bfloat16 or w.dtype != k.dtype or u.dtype != k.dtype:
+        raise RuntimeError(f"{op_name}: k, w and u must all use bfloat16.")
+    if k_dim != 128 or v_dim != 128:
+        raise RuntimeError(f"{op_name}: K and V must both be 128.")
+    if _shape(w) != (batch, v_heads, seqlen, k_dim) or _shape(u) != (
+        batch,
+        v_heads,
+        seqlen,
+        v_dim,
+    ):
+        raise RuntimeError(f"{op_name}: w/u must be [B, HV, T, K/V].")
+
+    gate_dtype = g.dtype if g is not None else gk.dtype
+    if gate_dtype not in {torch.bfloat16, torch.float32}:
+        raise RuntimeError(f"{op_name}: g/gk must use bfloat16 or float32.")
+    if g is not None:
+        if v_heads < k_heads or v_heads % k_heads != 0:
+            raise RuntimeError(f"{op_name}: g-only mode requires HV >= HK and HV % HK == 0.")
+        if _shape(g) != (batch, v_heads, seqlen):
+            raise RuntimeError(f"{op_name}: g must be [B, HV, T].")
+    else:
+        if k_heads != v_heads:
+            raise RuntimeError(f"{op_name}: gk-only mode requires prepared kg to have HV heads.")
+        if _shape(gk) != (batch, v_heads, seqlen, k_dim):
+            raise RuntimeError(f"{op_name}: gk must be [B, HV, T, K].")
+
+    cu = None if cu_seqlens is None else tuple(int(value) for value in cu_seqlens)
+    if cu is not None:
+        if batch != 1:
+            raise RuntimeError(f"{op_name}: variable-length BNSD input requires B=1.")
+        if len(cu) < 2 or cu[0] != 0 or cu[-1] != seqlen or any(a >= b for a, b in zip(cu, cu[1:])):
+            raise RuntimeError(
+                f"{op_name}: cu_seqlens must be strictly increasing, start at 0 and end at T."
+            )
+    canonical_indices = _kda_build_chunk_indices(cu, chunk_size)
+    indices = canonical_indices if chunk_indices is None else tuple(int(value) for value in chunk_indices)
+    if indices is not None and indices != canonical_indices:
+        raise RuntimeError(f"{op_name}: chunk_indices must use canonical sequence-major order.")
+
+    total_chunks = _kda_total_chunks(batch, seqlen, chunk_size, cu, indices)
+    sequences = len(cu) - 1 if cu is not None else batch
+    state_tail = (v_dim, k_dim) if state_v_first else (k_dim, v_dim)
+    if initial_state is not None:
+        if _shape(initial_state) != (sequences, v_heads, *state_tail):
+            raise RuntimeError(f"{op_name}: initial_state shape does not match state_v_first.")
+        if initial_state.dtype not in {torch.bfloat16, torch.float32}:
+            raise RuntimeError(f"{op_name}: initial_state must use bfloat16 or float32.")
+
+    h_out = _empty((batch, v_heads, total_chunks, *state_tail), k)
+    v_new_out = _empty_like(u)
+    if output_final_state:
+        state_template = initial_state if initial_state is not None else k
+        state_dtype = initial_state.dtype if initial_state is not None else torch.float32
+        final_state_out = _empty(
+            (sequences, v_heads, *state_tail), state_template, dtype=state_dtype
+        )
+    else:
+        final_state_out = None
+    outputs = (h_out, v_new_out, final_state_out if output_final_state else None)
+
+    # ChunkFwdH 的公开布局契约是 ND。标准连续 rank-4/5 NPU tensor 的物理存储
+    # 仍是行主序，但通用 runtime 会按维数推断 NCHW/NCDHW，因此这里由本算子
+    # 显式覆盖 descriptor 元数据，不触发格式转换或额外数据搬运。
+    def nd_tensor(ctx, tensor, name):
+        if tensor is None:
+            return ctx.tensor(None, name)
+        return ctx.tensor(
+            tensor,
+            name,
+            acl_format_override=ACL_FORMAT_ND,
+            storage_shape_override=_shape(tensor),
+        )
+
+    return _call_aclnn(
+        "aclnnChunkFwdH",
+        lambda ctx: [
+            nd_tensor(ctx, k, "k"),
+            nd_tensor(ctx, w, "w"),
+            nd_tensor(ctx, u, "u"),
+            nd_tensor(ctx, g, "g"),
+            nd_tensor(ctx, gk, "gk"),
+            nd_tensor(ctx, initial_state, "initial_state"),
+            ctypes.c_bool(output_final_state),
+            ctypes.c_int64(chunk_size),
+            ctypes.c_bool(save_new_value),
+            ctx.int_array(cu),
+            ctx.int_array(indices),
+            ctypes.c_bool(use_exp2),
+            ctypes.c_bool(state_v_first),
+            nd_tensor(ctx, h_out, "h"),
+            nd_tensor(ctx, v_new_out, "v_new"),
+            nd_tensor(ctx, final_state_out, "final_state"),
         ],
         outputs,
     )

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
@@ -19,10 +19,15 @@ signature here.
 from __future__ import annotations
 
 import ctypes
+import sys
 
 from ._kda_policy import kda_fwd_optional_output_mask
 from ._runtime import (
+    ACL_FORMAT_NCDHW,
+    ACL_FORMAT_NCHW,
+    ACL_FORMAT_NCL,
     ACL_FORMAT_ND,
+    acl_format as _acl_format,
     call_aclnn as _runtime_call_aclnn,
     chunk_num as _chunk_num,
     empty as _empty,
@@ -646,6 +651,33 @@ def npu_chunk_gated_delta_rule_fwd_h(
     )
 
 
+def _chunk_fwd_h_ceil_div(value: int, divisor: int) -> int:
+    return (int(value) + int(divisor) - 1) // int(divisor)
+
+
+def _chunk_fwd_h_build_chunk_indices(cu_seqlens, chunk_size: int):
+    if cu_seqlens is None:
+        return None
+    cu = tuple(int(value) for value in cu_seqlens)
+    indices = []
+    for sequence, (begin, end) in enumerate(zip(cu, cu[1:])):
+        for chunk in range(_chunk_fwd_h_ceil_div(end - begin, chunk_size)):
+            indices.extend((sequence, chunk))
+    return tuple(indices)
+
+
+def _chunk_fwd_h_total_chunks(seqlen: int, chunk_size: int, cu_seqlens, chunk_indices) -> int:
+    if chunk_indices is not None:
+        return len(tuple(chunk_indices)) // 2
+    if cu_seqlens is None:
+        return _chunk_fwd_h_ceil_div(seqlen, chunk_size)
+    cu = tuple(int(value) for value in cu_seqlens)
+    return sum(
+        _chunk_fwd_h_ceil_div(end - begin, chunk_size)
+        for begin, end in zip(cu, cu[1:])
+    )
+
+
 def npu_chunk_fwd_h(
     k,
     w,
@@ -717,12 +749,12 @@ def npu_chunk_fwd_h(
             raise RuntimeError(
                 f"{op_name}: cu_seqlens must be strictly increasing, start at 0 and end at T."
             )
-    canonical_indices = _kda_build_chunk_indices(cu, chunk_size)
+    canonical_indices = _chunk_fwd_h_build_chunk_indices(cu, chunk_size)
     indices = canonical_indices if chunk_indices is None else tuple(int(value) for value in chunk_indices)
     if indices is not None and indices != canonical_indices:
         raise RuntimeError(f"{op_name}: chunk_indices must use canonical sequence-major order.")
 
-    total_chunks = _kda_total_chunks(batch, seqlen, chunk_size, cu, indices)
+    total_chunks = _chunk_fwd_h_total_chunks(seqlen, chunk_size, cu, indices)
     sequences = len(cu) - 1 if cu is not None else batch
     state_tail = (v_dim, k_dim) if state_v_first else (k_dim, v_dim)
     if initial_state is not None:
@@ -732,7 +764,7 @@ def npu_chunk_fwd_h(
             raise RuntimeError(f"{op_name}: initial_state must use bfloat16 or float32.")
 
     h_out = _empty((batch, v_heads, total_chunks, *state_tail), k)
-    v_new_out = _empty_like(u)
+    v_new_out = _empty(_shape(u), u)
     if output_final_state:
         state_template = initial_state if initial_state is not None else k
         state_dtype = initial_state.dtype if initial_state is not None else torch.float32
@@ -749,11 +781,37 @@ def npu_chunk_fwd_h(
     def nd_tensor(ctx, tensor, name):
         if tensor is None:
             return ctx.tensor(None, name)
+        loaded_torch_npu = sys.modules.get("torch_npu")
+        if loaded_torch_npu is not None:
+            try:
+                actual_format = int(loaded_torch_npu.get_npu_format(tensor))
+            except Exception as exc:
+                raise RuntimeError(
+                    f"{op_name}: cannot determine the real NPU format of {name}."
+                ) from exc
+        else:
+            actual_format = _acl_format(tensor)
+        standard_formats = {
+            ACL_FORMAT_NCHW,
+            ACL_FORMAT_ND,
+            ACL_FORMAT_NCDHW,
+            ACL_FORMAT_NCL,
+        }
+        if actual_format not in standard_formats:
+            raise RuntimeError(
+                f"{op_name}: {name} must use a standard contiguous-compatible layout; "
+                f"private NPU format {actual_format} is not supported."
+            )
+        storage_shape = (
+            _shape(tensor)
+            if tensor.is_contiguous() and int(tensor.storage_offset()) == 0
+            else None
+        )
         return ctx.tensor(
             tensor,
             name,
             acl_format_override=ACL_FORMAT_ND,
-            storage_shape_override=_shape(tensor),
+            storage_shape_override=storage_shape,
         )
 
     return _call_aclnn(


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

本 PR 为文档与伪代码蓝图变更。伪代码目录明确排除在 CMake 构建目标之外，不改变现有算子接口和运行行为。

## 关联 Issue / 背景

- 关联 Issue: 无；本 PR 仅整理设计文档对应的实现蓝图，不涉及运行代码或公开接口变更。
- 背景与目标: 按实际 `op_kernel` 工程结构整理 FwdH 的 Stage0-Stage3、round 规划、内存生命周期和时序控制。
- 本 PR 解决的问题: 明确每轮实际需要的 kg 份数、每个 H_v slot 与 H_k/kg 的映射、跨 round 释放与预取屏障，以及 state_v_first=true/false 的原生读写语义。

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `chunk_gated_delta_rule_fwd_h`
- 涉及目录 / 文件: `fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_kernel/pseudocode/`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 伪代码固定说明 A5、BT=64、K=V=128 的设计约束，并覆盖 BF16/FP32 初态、GVA head 映射和 `state_v_first` 两种物理布局。
- 明确不包含的范围: 不修改现有 kernel、Host/API、Tiling、Python 入口、测试用例和构建配置；不引入 16 份跨 round 常驻 kg。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 不适用。

## 版本与产品编译矩阵

本 PR 不产生可编译算子产物。伪代码目录未加入构建目标，因此 A2/A3/A5 编译验证不适用。

## 验证方法

- 静态检查: `git diff --check` 通过；新伪代码中未发现旧的 `Kstage`/`KStage`/`Kg`/独立 `Q` 命名。
- A2/A3/A5 编译: 未执行，原因是本 PR 仅新增不参与构建的伪代码。
- FwdH 单算子测试: 未执行，原因是没有修改运行 kernel。
- 整体 Example/ST: 未执行，原因是没有修改运行 kernel 或调用链。

## 修改算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | 未执行 | 仅文档/伪代码变更 |
| A3 | `ascend910_93` | 未执行 | 未执行 | 仅文档/伪代码变更 |
| A5 | `ascend950` | 未执行 | 未执行 | 仅文档/伪代码变更 |

- 精度对比: 未执行；不涉及运行实现。
- 性能对比: 未执行；不涉及运行实现。
- 边界 / 异常场景: 伪代码静态覆盖 GVA 比值 1:3、1:2、1:6，round 尾部和 final chunk 分支。
- 未覆盖风险: 伪代码尚未替换实际 Ascend C kernel，接口细节和硬件实测结果需在后续实现 PR 中验证。

## 整体 Example ST 验证

未执行。本 PR 不修改整体 example 或算子调用链。

## 兼容性、风险与回退

- 兼容性说明: 新增文件不参与构建，不改变现有二进制、API 或测试行为。
- 风险点: 后续按伪代码实现 kernel 时，需要依据目标 CANN 版本核对具体 Ascend C API 和事件语义。
- 回退方案: 删除本 PR 新增的伪代码目录即可恢复原仓库状态。
- 回退责任确认:
  - [x] 若本 PR 未满足准入要求或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过（不适用）
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过（不适用）
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过（不适用）
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过（不适用）
- [x] 已完成必要的静态检查
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关设计伪代码说明
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

评审重点：`chunk_gated_delta_rule_fwd_h_utils.h` 中的 round 级 kg 需求公式和 320 KiB L1 容量闭合证明；`chunk_gated_delta_rule_fwd_h_policy.h` 的槽位生命周期；arch22/arch35 Cube、Vec 文件的 Stage 分工；以及 final chunk 的 `v_new-only` 不写入无消费者的 L1 右操作数区域。
