### PR TITLE
feat(recurrent-kda): support non-contiguous qkv views

### DIFF
--- a/fla/ops/ascendc/kda/recurrent_kda/README.md
+++ b/fla/ops/ascendc/kda/recurrent_kda/README.md
@@ -3,7 +3,8 @@
 `RecurrentKda` 是 KDA 的 fused recurrent 前向算子。算子在一个 AICore kernel 内完成 recurrent state decay、delta 更新和输出计算；`raw gate -> log gate` 和 `beta sigmoid` 可以在 kernel 内完成，不依赖 `KdaGateCumsum` 或 GDN recurrent 的接口。
 
 完整接口和调用示例见 [API 文档](docs/api.md)，实现方案见 [设计文档](docs/design.md)，非连续 state
-的 stride 约束与数据流见 [专项设计](docs/non_contiguous_state_design.md)。Shape 符号统一引用
+的 stride 约束与数据流见 [专项设计](docs/non_contiguous_state_design.md)，非连续 Q/K/V 的支持边界、
+回退策略与实测结果见 [QKV 专项设计](docs/non_contiguous_qkv_design.md)。Shape 符号统一引用
 [KDA 模型符号表](../README.md#model-shape-symbols)。
 
 ## Python 接口
@@ -45,6 +46,8 @@ out, final_state = recurrent_kda(
   `state_v_first=True` 对应 `[state_capacity,HV,V,K]`，`state_v_first=False` 对应
   `[state_capacity,HV,K,V]`。支持 slot/head 维带间隔的非连续 view，但内部二维 state
   矩阵必须稠密。
+- Q/K/V 支持融合 storage 切片形成的规则非连续 view；算子保留各自 storage offset，并按 token/head
+  stride 直接读取。不满足直接访问约束的 view 在 ACLNN 侧自动回退连续化。
 - `scale=None` 时，Python wrapper 使用 `K ** -0.5`。
 - `use_qk_l2norm_in_kernel=True` 时，kernel 内对每个 token 的 `q/k` 做 L2 normalize，然后对 `q` 乘 `scale`。
 - `use_gate_in_kernel=False` 时，`g` 被视为已经预计算好的 step log gate，kernel 使用 `exp(g)` 做 state decay。
@@ -72,10 +75,14 @@ o_t = S @ (q_t * scale)
 ## 当前限制
 
 - `q/k/v/out` 仅支持 `BF16`。
+- Q/K/V 直接非连续访问要求 feature stride 为 1、head 间不重叠、token 间不重叠且 stride 为正；
+  BSND 在 `B>1` 时还要求 `batchStride == T * tokenStride`。已验证的 feature-gap、zero-stride
+  与 batch-gap view 自动回退连续化；token/head 置换或正 stride 重叠 descriptor 明确拒绝。
 - `g/beta` Python 入口支持 `FP32/BF16/FP16`，aclnn 预处理后以 `FP32` 输入 kernel。
 - `A_log/dt_bias` 支持 `FP32`。
 - `cu_seqlens` 为必传、与 q 同设备的 INT32/INT64 Tensor；offset 必须单调不减，末项不得超过输入
-  token capacity，各相邻差值必须不超过 8。末项小于 capacity 时，仅有效 token 对应的输出和 state
+  token capacity，各相邻差值必须不超过 8。接口面向 decode / MTP 短序列，dense 单序列与 varlen
+  每段序列长度均必须小于等于 8。末项小于 capacity 时，仅有效 token 对应的输出和 state
   更新有定义，padding tail 输出不作保证。
 - 仅支持 `layout="BSND"` 和 `layout="TND"`。
 - 支持 V-first `[state_capacity,HV,V,K]` 和 K-first `[state_capacity,HV,K,V]`，state dtype 为

--- a/fla/ops/ascendc/kda/recurrent_kda/docs/api.md
+++ b/fla/ops/ascendc/kda/recurrent_kda/docs/api.md
@@ -91,8 +91,9 @@ aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
 aclnnStatus aclnnRecurrentKda(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor, aclrtStream stream);
 ```
 
-`GetWorkspaceSize` 完成参数校验、非 state tensor 连续化预处理和 executor 创建；第二段在传入
-stream 上异步执行。非连续 state 通过 `CreateView` 保留 shape、storage、stride 和 offset，kernel 按 tiling
+`GetWorkspaceSize` 完成参数校验、Q/K/V stride 判定、其余非 state tensor 连续化预处理和 executor
+创建；第二段在传入 stream 上异步执行。满足约束的非连续 Q/K/V 与 state 均通过 `CreateView` 保留
+shape、storage、stride 和 offset，kernel 按 tiling
 中的真实 stride 直接访问。原位模式直接写回输入 view；非原位模式直接写入 `finalState` view。原位模式若调用者
 另外传入独立的 `finalState` 输出，仅为该输出保留一次必要的 `ViewCopy`。`cuSeqlensOptional` 为空时，BSND
 按 batch 行划分序列，TND 视为一条序列；提供时仅在 host 检查 rank/dtype，具体 offset 值由 device kernel 读取，
@@ -136,8 +137,9 @@ recurrent_kda(q, k, v, g, beta, initial_state=None, *,
 
 稳定入口通过 ctypes 直调 aclnn，不依赖 `torch.ops.npu` 注册。`initial_state=None` 仅在
 `inplace_final_state=False` 时有效，此时 wrapper 创建与 `state_v_first` 对应布局的全零 FP32 状态；原位模式必须
-显式传入 state。显式传入的非连续 state view 由 kernel 按真实 stride 直接
-访问；原位模式返回与输入相同 storage/stride 的 state，非原位模式保持输入不变并返回独立 state。
+显式传入 state。显式传入的非连续 state view 由 kernel 按真实 stride 直接访问；满足第 7 节约束的 Q/K/V view
+同样保留 storage offset 并直接读取，不满足时自动连续化。原位模式返回与输入相同 storage/stride
+的 state，非原位模式保持输入不变并返回独立 state。
 
 ### 4.2 调用示例
 
@@ -173,8 +175,8 @@ recurrent_kda<<<blockDim, nullptr, stream>>>(
     aLog, dtBias, numAcceptedTokens, out, initialStateOut, finalState, workspace, tiling);
 ```
 
-直调通路只作为 route/诊断入口；公开 Python 和 aclnn API 负责完整参数校验。直调通路按连续物理
-或 tiling data 中的 state stride 解释 GM 地址；非连续直调必须使用与实际 view 匹配的 host tiling 结果。
+直调通路只作为 route/诊断入口；公开 Python 和 aclnn API 负责完整参数校验。直调通路按连续物理地址或 tiling data 中的 Q/K/V/state stride 解释 GM 地址；非连续直调必须使用
+与实际 view shape、stride 和首地址匹配的 host tiling 结果。
 
 ## 6. legacy `torch.ops.npu` 通路
 
@@ -185,7 +187,10 @@ recurrent_kda<<<blockDim, nullptr, stream>>>(
 
 - `q/k/v/out` 当前仅支持 BF16。
 - `K/V` 当前仅支持 `K=128,V=128` 或 `K=128,V=256` 两档枚举。
-- Python/aclnn 入口支持符合 stride 约束的非连续 `initial_state`。
+- Python/aclnn 入口支持符合 stride 约束的非连续 Q/K/V 与 `initial_state`。
+- Q/K/V 直接访问要求 feature stride=1、head/token 区间不重叠、stride 为正；BSND `B>1` 时
+  `batchStride == T * tokenStride`。已验证的 feature-gap、zero-stride、batch-gap view 由 ACLNN
+  回退连续化；token/head 置换或正 stride 重叠 descriptor 返回参数错误。
 - 未传 `ssm_state_indices` 时 `state_capacity=seq_num`；传入后容量可大于序列数，所有有效 slot 必须位于 `[0,state_capacity)`。
 - `ssm_state_indices` 支持 packed `[T]` 和 speculative `[seq_num,max_step]`；活跃序列不得共享正在写入的 state slot。
 - 空序列不读取 `ssm_state_indices/num_accepted_tokens`，也不读写 state pool。
@@ -195,7 +200,7 @@ recurrent_kda<<<blockDim, nullptr, stream>>>(
 - 末项小于 capacity 时，kernel 仅处理有效前缀并逐行跳过零长度序列；padding tail 输出不作保证。
 - state 支持 V-first 与 K-first，支持 FP32/BF16，以及原位/非原位 final state。
 - 非连续 state 仅允许 slot/head 外层维存在间隔，最后两维必须为行主序稠密矩阵，且外层地址区间不得重叠。
-- 每条 recurrent 有效序列长度必须 `<=8`。
+- 接口面向 decode / MTP 短序列；dense 单序列长度与 varlen 每段有效序列长度均必须 `<=8`。
 - 仅支持 `layout="BSND"` 和 `layout="TND"`。
 - `use_gate_in_kernel=false` 时 `A_log/dt_bias/safe_gate` 必须为空或 false。
 

--- a/fla/ops/ascendc/kda/recurrent_kda/docs/design.md
+++ b/fla/ops/ascendc/kda/recurrent_kda/docs/design.md
@@ -73,9 +73,11 @@ o_t = S @ q_t
 ## 5. 整体架构
 
 - `op_host/op_api/aclnn_recurrent_kda.cpp`：校验 dtype、layout、shape、可选输入组合；不读取 device metadata 的值；
-  对非 state tensor 做连续化；非连续 state 以 `CreateView` 保留真实存储信息；创建 L0 executor。
-- `op_host/recurrent_kda_tiling.cpp`：读取输入/输出 state stride、shape、属性和可选输入存在性，填充
-  `RecurrentKdaTilingData`，计算 block dim 与 UB 切分。
+  对规则非连续 Q/K/V 保留 stride/storage offset，已验证布局回退连续化，token/head 置换或
+  正 stride 重叠 descriptor 明确拒绝；非连续 state 以
+  `CreateView` 保留真实存储信息；创建 L0 executor。
+- `op_host/recurrent_kda_tiling.cpp`：读取 Q/K/V 与输入/输出 state stride、shape、属性和可选输入存在性，
+  填充 `RecurrentKdaTilingData`，计算 block dim 与 UB 切分。
 - `op_kernel/recurrent_kda.cpp`：单个 AIV kernel 完成 q/k normalize、raw gate 转换、state decay、delta 更新、输出和最终状态写回。
 - `torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py`：提供解耦 Python ctypes 入口，不注册 `torch.ops.npu`。
 - legacy `torch.ops.npu.npu_recurrent_kda` 不属于当前支持范围，不作为公共接口维护。
@@ -86,8 +88,8 @@ o_t = S @ q_t
 
 Tiling 按逻辑序列和 value head 拆分任务。提供 `cu_seqlens` 时，`seq_num=len(cu_seqlens)-1`，使用与
 fla-org 一致的累计边界语义，第 `i` 条序列范围为 `[cu_seqlens[i], cu_seqlens[i+1])`；未提供时，
-BSND 按 batch 行划分序列，TND 视为一条序列。当前单任务面向 recurrent 小步长，每个相邻 offset
-的差值或 dense 序列长度限制为 `<=8`。提供 `cu_seqlens` 时，末项表示有效 token 数，可小于图捕获的
+BSND 按 batch 行划分序列，TND 视为一条序列。接口面向 decode / MTP 短序列：每个相邻 offset
+的差值（varlen 每段长度）与 dense 单序列长度均限制为 `<=8`。提供 `cu_seqlens` 时，末项表示有效 token 数，可小于图捕获的
 token capacity。
 
 ### 6.2 Tiling Data
@@ -101,6 +103,8 @@ token capacity。
 | `nv` / `dv` | `uint32_t` | value head 数与 V 维 |
 | `sBlockNum` / `b` | `uint32_t` | state pool 容量与逻辑序列数 |
 | `ssmStateStride` | `uint32_t` | 二维 speculative state 索引的行 stride；packed 一维索引时为 0 |
+| `query/key/value TokenStride` | `uint64_t` | Q/K/V 相邻逻辑 token 的元素 stride |
+| `query/key/value HeadStride` | `uint64_t` | Q/K/V 相邻 head 的元素 stride |
 | `vStep` | `uint32_t` | 单次处理的 V 方向步长 |
 | `stateOutBufferNum` / `attnOutBufferNum` | `uint32_t` | UB ring buffer 数 |
 | `scale` / `lowerBound` | `float` | query scale 与 safe gate 下界 |
@@ -120,7 +124,8 @@ tiling data 驱动，避免把 runtime shape 组合扩张到 tiling key。
 
 1. 解析当前任务对应的逻辑序列、value head、query/key head 和状态槽。
 2. 加载初始状态到 UB 工作区；Python 仅在非原位模式下允许 `initial_state=None`，并预先创建全零状态。
-3. 对每个 token 加载 `q/k/v/g/beta`，按属性执行 q/k normalize、raw gate 转换和 beta sigmoid。
+3. 按 Q/K/V 各自 token/head stride 计算 GM 首地址并二维搬运到紧凑 UB；随后按属性执行 q/k
+   normalize、raw gate 转换和 beta sigmoid。
 4. 对状态做 gate decay，计算 `S @ k`、delta 和 outer 更新。
 5. 计算 `S @ q` 写回 `out`，并把状态原位写回命中的 state pool 槽。
 
@@ -195,6 +200,9 @@ A2/A5 精度验证过程中修复以下问题：
 ## 13. 已知限制与演进计划
 
 - 当前仅支持 BF16 QKV。
+- Q/K/V 直接非连续访问仅支持 feature 致密、head/token 不重叠的正 stride；BSND `B>1` 还要求
+  batch 维可按 `T * tokenStride` 扁平化。已验证的 feature-gap、zero-stride、batch-gap view
+  自动回退连续化；token/head 置换或正 stride 重叠 descriptor 明确拒绝。
 - 当前 `K/V` 仅支持 `K=128,V=128` 或 `K=128,V=256`。
 - 当前每段 recurrent 序列长度限制为 `<=8`。
 - state 最后两维必须为行主序稠密矩阵；slot/head 维可有间隔但不得重叠。

--- a/fla/ops/ascendc/kda/recurrent_kda/op_host/op_api/aclnn_recurrent_kda.cpp
+++ b/fla/ops/ascendc/kda/recurrent_kda/op_host/op_api/aclnn_recurrent_kda.cpp
@@ -23,6 +23,7 @@
 #include "opdev/tensor_view_utils.h"
 
 #include <cstring>
+#include <limits>
 
 using namespace op;
 
@@ -113,6 +114,87 @@ static bool ParseLayout(const char *layout, RecurrentKdaLayout &parsed)
     }
     OP_LOGE(ACLNN_ERR_PARAM_INVALID, "npu_recurrent_kda: layout must be BSND or TND.");
     return false;
+}
+
+bool IsSupportedQkvView(const aclTensor *tensor, RecurrentKdaLayout layout)
+{
+    if (tensor == nullptr) {
+        return false;
+    }
+    const size_t expectedRank = layout == RecurrentKdaLayout::TND ? 3 : 4;
+    const auto &strides = tensor->GetViewStrides();
+    if (Rank(tensor) != expectedRank || strides.size() != expectedRank) {
+        return false;
+    }
+    for (size_t i = 0; i < expectedRank; ++i) {
+        if (strides[i] <= 0) {
+            return false;
+        }
+    }
+
+    const size_t tokenDim = layout == RecurrentKdaLayout::TND ? DIM0 : DIM1;
+    const size_t headDim = layout == RecurrentKdaLayout::TND ? DIM1 : DIM2;
+    const size_t featureDim = layout == RecurrentKdaLayout::TND ? DIM2 : DIM3;
+    const int64_t headCount = Dim(tensor, headDim);
+    const int64_t featureCount = Dim(tensor, featureDim);
+    const int64_t tokenStride = strides[tokenDim];
+    const int64_t headStride = strides[headDim];
+    if (strides[featureDim] != 1 || headStride < featureCount) {
+        return false;
+    }
+    const int64_t maxInt64 = std::numeric_limits<int64_t>::max();
+    if (headCount > 1 && headStride > (maxInt64 - featureCount) / (headCount - 1)) {
+        return false;
+    }
+    const int64_t minTokenStride = (headCount - 1) * headStride + featureCount;
+    if (tokenStride < minTokenStride) {
+        return false;
+    }
+    const uint64_t srcGapElements = static_cast<uint64_t>(tokenStride - featureCount);
+    if (srcGapElements > std::numeric_limits<uint32_t>::max() / sizeof(uint16_t)) {
+        return false;
+    }
+
+    if (layout == RecurrentKdaLayout::BSND && Dim(tensor, DIM0) > 1) {
+        const int64_t seqLen = Dim(tensor, DIM1);
+        if (tokenStride > maxInt64 / seqLen || strides[DIM0] != seqLen * tokenStride) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool CheckQkvMaterializationSafety(
+    const aclTensor *tensor, RecurrentKdaLayout layout, const char *name)
+{
+    const size_t expectedRank = layout == RecurrentKdaLayout::TND ? 3 : 4;
+    const auto &strides = tensor->GetViewStrides();
+    if (Rank(tensor) != expectedRank || strides.size() != expectedRank) {
+        return true;
+    }
+    const size_t tokenDim = layout == RecurrentKdaLayout::TND ? DIM0 : DIM1;
+    const size_t headDim = layout == RecurrentKdaLayout::TND ? DIM1 : DIM2;
+    const size_t featureDim = layout == RecurrentKdaLayout::TND ? DIM2 : DIM3;
+    const int64_t headCount = Dim(tensor, headDim);
+    const int64_t featureCount = Dim(tensor, featureDim);
+    const int64_t tokenStride = strides[tokenDim];
+    const int64_t headStride = strides[headDim];
+    if (strides[featureDim] != 1 || tokenStride <= 0 || headStride <= 0 ||
+        tokenStride < featureCount || headStride < featureCount) {
+        return true;
+    }
+    const int64_t maxInt64 = std::numeric_limits<int64_t>::max();
+    if (headCount > 1 && headStride > (maxInt64 - featureCount) / (headCount - 1)) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "npu_recurrent_kda: %s head span overflows.", name);
+        return false;
+    }
+    const int64_t minTokenStride = (headCount - 1) * headStride + featureCount;
+    if (tokenStride < minTokenStride) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID,
+                "npu_recurrent_kda: %s token/head axis order or overlap is unsupported.", name);
+        return false;
+    }
+    return true;
 }
 
 bool CheckCuSeqlensShape(const aclTensor *cuSeqlens, const char *opName)
@@ -324,6 +406,28 @@ aclnnStatus DataContiguous(const aclTensor *&tensor, aclOpExecutor *executor)
     return ACLNN_SUCCESS;
 }
 
+aclnnStatus DataContiguousIfNeeded(
+    const aclTensor *&tensor, bool needsContiguous, aclOpExecutor *executor)
+{
+    if (!needsContiguous) {
+        return ACLNN_SUCCESS;
+    }
+    return DataContiguous(tensor, executor);
+}
+
+aclnnStatus CreateViewIfNonContiguous(const aclTensor *&tensor, aclOpExecutor *executor)
+{
+    if (tensor == nullptr || IsContiguous(tensor)) {
+        return ACLNN_SUCCESS;
+    }
+    const aclTensor *view = executor->CreateView(
+        tensor, tensor->GetViewShape(), tensor->GetStorageShape(),
+        tensor->GetViewStrides(), tensor->GetViewOffset());
+    CHECK_RET(view != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    tensor = view;
+    return ACLNN_SUCCESS;
+}
+
 void SetTensorOriginalShape(const aclTensor *tensor)
 {
     if (tensor != nullptr) {
@@ -346,12 +450,20 @@ void SetInputOriginalShape(RecurrentKdaParams &params)
     SetTensorOriginalShape(params.numAcceptedTokensOptional);
 }
 
-aclnnStatus PreProcess(RecurrentKdaParams &params, aclOpExecutor *executor)
+aclnnStatus PreProcess(
+    RecurrentKdaParams &params,
+    bool queryNeedsContiguous,
+    bool keyNeedsContiguous,
+    bool valueNeedsContiguous,
+    aclOpExecutor *executor)
 {
     SetInputOriginalShape(params);
-    CHECK_RET(DataContiguous(params.query, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
-    CHECK_RET(DataContiguous(params.key, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
-    CHECK_RET(DataContiguous(params.value, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
+    CHECK_RET(DataContiguousIfNeeded(params.query, queryNeedsContiguous, executor) == ACLNN_SUCCESS,
+              ACLNN_ERR_INNER_NULLPTR);
+    CHECK_RET(DataContiguousIfNeeded(params.key, keyNeedsContiguous, executor) == ACLNN_SUCCESS,
+              ACLNN_ERR_INNER_NULLPTR);
+    CHECK_RET(DataContiguousIfNeeded(params.value, valueNeedsContiguous, executor) == ACLNN_SUCCESS,
+              ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.gate, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.beta, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.cuSeqlensOptional, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
@@ -419,7 +531,31 @@ aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     RecurrentKdaLayout parsedLayout = RecurrentKdaLayout::BSND;
     CHECK_RET(ParseLayout(params.layout, parsedLayout), ACLNN_ERR_PARAM_INVALID);
     CHECK_RET(CheckShape(params, parsedLayout), ACLNN_ERR_PARAM_INVALID);
-    CHECK_RET(PreProcess(params, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(CheckQkvMaterializationSafety(params.query, parsedLayout, "query") &&
+                  CheckQkvMaterializationSafety(params.key, parsedLayout, "key") &&
+                  CheckQkvMaterializationSafety(params.value, parsedLayout, "value"),
+              ACLNN_ERR_PARAM_INVALID);
+    const bool querySupportsDirect = IsSupportedQkvView(params.query, parsedLayout);
+    const bool keySupportsDirect = IsSupportedQkvView(params.key, parsedLayout);
+    const bool valueSupportsDirect = IsSupportedQkvView(params.value, parsedLayout);
+    const bool queryUsesDirectView = !IsContiguous(params.query) && querySupportsDirect;
+    const bool keyUsesDirectView = !IsContiguous(params.key) && keySupportsDirect;
+    const bool valueUsesDirectView = !IsContiguous(params.value) && valueSupportsDirect;
+    const bool queryNeedsContiguous = !querySupportsDirect;
+    const bool keyNeedsContiguous = !keySupportsDirect;
+    const bool valueNeedsContiguous = !valueSupportsDirect;
+    CHECK_RET(PreProcess(params, queryNeedsContiguous, keyNeedsContiguous, valueNeedsContiguous, executorPtr) ==
+                  ACLNN_SUCCESS,
+              ACLNN_ERR_PARAM_INVALID);
+    if (queryUsesDirectView) {
+        CHECK_RET(CreateViewIfNonContiguous(params.query, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
+    }
+    if (keyUsesDirectView) {
+        CHECK_RET(CreateViewIfNonContiguous(params.key, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
+    }
+    if (valueUsesDirectView) {
+        CHECK_RET(CreateViewIfNonContiguous(params.value, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
+    }
 
     aclTensor *initialStateForKernel = params.initialStateRef;
     if (!IsContiguous(initialStateForKernel)) {

--- a/fla/ops/ascendc/kda/recurrent_kda/op_host/recurrent_kda_def.cpp
+++ b/fla/ops/ascendc/kda/recurrent_kda/op_host/recurrent_kda_def.cpp
@@ -23,9 +23,12 @@ public:
         const std::initializer_list<ge::DataType> stateTypes = {ge::DT_BF16, ge::DT_FLOAT};
         const std::initializer_list<ge::Format> formats = {ge::FORMAT_ND, ge::FORMAT_ND};
 
-        this->Input("query").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats);
-        this->Input("key").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats);
-        this->Input("value").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Input("query").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats)
+            .IgnoreContiguous();
+        this->Input("key").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats)
+            .IgnoreContiguous();
+        this->Input("value").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats)
+            .IgnoreContiguous();
         this->Input("gate").ParamType(REQUIRED)
             .DataTypeList({ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16}).FormatList({ge::FORMAT_ND});
         this->Input("beta").ParamType(REQUIRED)

--- a/fla/ops/ascendc/kda/recurrent_kda/op_host/recurrent_kda_def.cpp
+++ b/fla/ops/ascendc/kda/recurrent_kda/op_host/recurrent_kda_def.cpp
@@ -18,16 +18,16 @@ class RecurrentKda : public OpDef {
 public:
     explicit RecurrentKda(const char *name) : OpDef(name)
     {
-        const std::initializer_list<ge::DataType> qkvTypes = {ge::DT_BF16, ge::DT_BF16};
-        const std::initializer_list<ge::DataType> floatTypes = {ge::DT_FLOAT, ge::DT_FLOAT};
+        const std::initializer_list<ge::DataType> qkvTypes = {ge::DT_BF16};
+        const std::initializer_list<ge::DataType> floatTypes = {ge::DT_FLOAT};
         const std::initializer_list<ge::DataType> stateTypes = {ge::DT_BF16, ge::DT_FLOAT};
-        const std::initializer_list<ge::Format> formats = {ge::FORMAT_ND, ge::FORMAT_ND};
+        const std::initializer_list<ge::Format> formats = {ge::FORMAT_ND};
 
-        this->Input("query").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats)
+        this->Input("query").ParamType(REQUIRED).DataTypeList(qkvTypes).FormatList(formats)
             .IgnoreContiguous();
-        this->Input("key").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats)
+        this->Input("key").ParamType(REQUIRED).DataTypeList(qkvTypes).FormatList(formats)
             .IgnoreContiguous();
-        this->Input("value").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats)
+        this->Input("value").ParamType(REQUIRED).DataTypeList(qkvTypes).FormatList(formats)
             .IgnoreContiguous();
         this->Input("gate").ParamType(REQUIRED)
             .DataTypeList({ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16}).FormatList({ge::FORMAT_ND});
@@ -35,9 +35,8 @@ public:
             .DataTypeList({ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16}).FormatList({ge::FORMAT_ND});
         this->Input("initial_state")
             .ParamType(REQUIRED)
-            .DataType(stateTypes)
-            .Format(formats)
-            .UnknownShapeFormat(formats)
+            .DataTypeList(stateTypes)
+            .FormatList(formats)
             .IgnoreContiguous();
         this->Input("cu_seqlens")
             .ParamType(OPTIONAL)
@@ -47,24 +46,22 @@ public:
             .ParamType(OPTIONAL)
             .DataTypeList({ge::DT_INT32, ge::DT_INT64})
             .FormatList({ge::FORMAT_ND});
-        this->Input("A_log").ParamType(OPTIONAL).DataType(floatTypes).Format(formats).UnknownShapeFormat(formats);
-        this->Input("dt_bias").ParamType(OPTIONAL).DataType(floatTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Input("A_log").ParamType(OPTIONAL).DataTypeList(floatTypes).FormatList(formats);
+        this->Input("dt_bias").ParamType(OPTIONAL).DataTypeList(floatTypes).FormatList(formats);
         this->Input("num_accepted_tokens")
             .ParamType(OPTIONAL)
             .DataTypeList({ge::DT_INT32, ge::DT_INT64})
             .FormatList({ge::FORMAT_ND});
-        this->Output("attn_out").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats);
+        this->Output("attn_out").ParamType(REQUIRED).DataTypeList(qkvTypes).FormatList(formats);
         this->Output("initial_state")
             .ParamType(REQUIRED)
-            .DataType(stateTypes)
-            .Format(formats)
-            .UnknownShapeFormat(formats)
+            .DataTypeList(stateTypes)
+            .FormatList(formats)
             .IgnoreContiguous();
         this->Output("final_state")
             .ParamType(REQUIRED)
-            .DataType(stateTypes)
-            .Format(formats)
-            .UnknownShapeFormat(formats)
+            .DataTypeList(stateTypes)
+            .FormatList(formats)
             .IgnoreContiguous();
 
         this->Attr("layout").AttrType(OPTIONAL).String("BSND");

--- a/fla/ops/ascendc/kda/recurrent_kda/op_host/recurrent_kda_tiling.cpp
+++ b/fla/ops/ascendc/kda/recurrent_kda/op_host/recurrent_kda_tiling.cpp
@@ -90,6 +90,20 @@ void CopyStateStrides(const StrideType *src, std::array<int64_t, RKDA_STATE_DIM_
     }
     hasStrides = true;
 }
+
+template <typename StrideType>
+void CopyQkvStrides(const StrideType *src, size_t expectedDimNum,
+                    std::array<int64_t, RKDA_RANK4_QKV_DIM_NUM> &dst, bool &hasStrides)
+{
+    if (src == nullptr || src->GetDimNum() != expectedDimNum ||
+        expectedDimNum > RKDA_RANK4_QKV_DIM_NUM) {
+        return;
+    }
+    for (size_t i = 0; i < expectedDimNum; ++i) {
+        dst[i] = src->GetStride(i);
+    }
+    hasStrides = true;
+}
 } // namespace
 
 RecurrentKdaTilingContext RecurrentKdaTiling::BuildProcessorContext() const
@@ -99,6 +113,12 @@ RecurrentKdaTilingContext RecurrentKdaTiling::BuildProcessorContext() const
     ctx.queryShape = context_->GetInputShape(QUERY_INDEX)->GetOriginShape();
     ctx.keyShape = context_->GetInputShape(KEY_INDEX)->GetOriginShape();
     ctx.valueShape = context_->GetInputShape(VALUE_INDEX)->GetOriginShape();
+    CopyQkvStrides(context_->GetInputStride(QUERY_INDEX), ctx.queryShape.GetDimNum(),
+                   ctx.queryStrides, ctx.hasQueryStrides);
+    CopyQkvStrides(context_->GetInputStride(KEY_INDEX), ctx.keyShape.GetDimNum(),
+                   ctx.keyStrides, ctx.hasKeyStrides);
+    CopyQkvStrides(context_->GetInputStride(VALUE_INDEX), ctx.valueShape.GetDimNum(),
+                   ctx.valueStrides, ctx.hasValueStrides);
     ctx.gateShape = context_->GetInputShape(GATE_INDEX)->GetOriginShape();
     ctx.betaShape = context_->GetInputShape(BETA_INDEX)->GetOriginShape();
     ctx.stateShape = context_->GetInputShape(STATE_INDEX)->GetOriginShape();
@@ -405,6 +425,18 @@ void RecurrentKdaTiling::PrintTilingData()
     OP_LOGD(context_->GetNodeName(), "cuSeqlensDtype: [%u]", tilingData_.cuSeqlensDtype);
     OP_LOGD(context_->GetNodeName(), "ssmStateIndicesDtype: [%u]", tilingData_.ssmStateIndicesDtype);
     OP_LOGD(context_->GetNodeName(), "acceptedTokensDtype: [%u]", tilingData_.acceptedTokensDtype);
+    OP_LOGD(context_->GetNodeName(), "queryTokenStride: [%llu]",
+            static_cast<unsigned long long>(tilingData_.queryTokenStride));
+    OP_LOGD(context_->GetNodeName(), "queryHeadStride: [%llu]",
+            static_cast<unsigned long long>(tilingData_.queryHeadStride));
+    OP_LOGD(context_->GetNodeName(), "keyTokenStride: [%llu]",
+            static_cast<unsigned long long>(tilingData_.keyTokenStride));
+    OP_LOGD(context_->GetNodeName(), "keyHeadStride: [%llu]",
+            static_cast<unsigned long long>(tilingData_.keyHeadStride));
+    OP_LOGD(context_->GetNodeName(), "valueTokenStride: [%llu]",
+            static_cast<unsigned long long>(tilingData_.valueTokenStride));
+    OP_LOGD(context_->GetNodeName(), "valueHeadStride: [%llu]",
+            static_cast<unsigned long long>(tilingData_.valueHeadStride));
 }
 
 ge::graphStatus RecurrentKdaTiling::CalUbSize()

--- a/fla/ops/ascendc/kda/recurrent_kda/op_host/recurrent_kda_tiling_processor.h
+++ b/fla/ops/ascendc/kda/recurrent_kda/op_host/recurrent_kda_tiling_processor.h
@@ -24,6 +24,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <string>
 
 using RecurrentKdaTilingData = RecurrentKda::RecurrentKdaTilingData;
@@ -86,6 +87,12 @@ struct RecurrentKdaTilingContext {
     ge::DataType cuSeqlensDtype = ge::DT_INT64;
     ge::DataType ssmStateIndicesDtype = ge::DT_INT64;
     ge::DataType acceptedTokensDtype = ge::DT_INT64;
+    std::array<int64_t, RKDA_RANK4_QKV_DIM_NUM> queryStrides = {};
+    std::array<int64_t, RKDA_RANK4_QKV_DIM_NUM> keyStrides = {};
+    std::array<int64_t, RKDA_RANK4_QKV_DIM_NUM> valueStrides = {};
+    bool hasQueryStrides = false;
+    bool hasKeyStrides = false;
+    bool hasValueStrides = false;
     std::array<int64_t, RKDA_STATE_DIM_NUM> stateInStrides = {};
     std::array<int64_t, RKDA_STATE_DIM_NUM> stateOutStrides = {};
     bool hasStateInStrides = false;
@@ -176,6 +183,101 @@ private:
         strides[RKDA_DIM_1] = shape.GetDim(RKDA_DIM_2) * strides[RKDA_DIM_2];
         strides[RKDA_DIM_0] = shape.GetDim(RKDA_DIM_1) * strides[RKDA_DIM_1];
         return strides;
+    }
+
+    std::array<int64_t, RKDA_RANK4_QKV_DIM_NUM> ResolveQkvStrides(
+        const gert::Shape &shape,
+        const std::array<int64_t, RKDA_RANK4_QKV_DIM_NUM> &viewStrides,
+        bool hasStrides) const
+    {
+        if (hasStrides) {
+            return viewStrides;
+        }
+        std::array<int64_t, RKDA_RANK4_QKV_DIM_NUM> strides = {};
+        int64_t denseStride = 1;
+        for (size_t dim = shape.GetDimNum(); dim > 0; --dim) {
+            const size_t index = dim - 1;
+            strides[index] = denseStride;
+            denseStride *= shape.GetDim(index);
+        }
+        return strides;
+    }
+
+    ge::graphStatus ValidateQkvStrides(
+        const gert::Shape &shape,
+        const std::array<int64_t, RKDA_RANK4_QKV_DIM_NUM> &strides,
+        const char *name) const
+    {
+        const size_t rank = shape.GetDimNum();
+        for (size_t i = 0; i < rank; ++i) {
+            OP_CHECK_IF(strides[i] <= 0,
+                        OP_LOGE(ctx_.nodeName, "%s stride[%zu] must be positive, but it is %ld.",
+                                name, i, strides[i]),
+                        return ge::GRAPH_FAILED);
+        }
+
+        const size_t tokenDim = rank == RKDA_RANK3_QKV_DIM_NUM ? RKDA_DIM_0 : RKDA_DIM_1;
+        const size_t headDim = rank == RKDA_RANK3_QKV_DIM_NUM ? RKDA_DIM_1 : RKDA_DIM_2;
+        const size_t featureDim = rank == RKDA_RANK3_QKV_DIM_NUM ? RKDA_DIM_2 : RKDA_DIM_3;
+        const uint64_t headCount = static_cast<uint64_t>(shape.GetDim(headDim));
+        const uint64_t featureCount = static_cast<uint64_t>(shape.GetDim(featureDim));
+        const uint64_t tokenStride = static_cast<uint64_t>(strides[tokenDim]);
+        const uint64_t headStride = static_cast<uint64_t>(strides[headDim]);
+        OP_CHECK_IF(strides[featureDim] != 1 || headStride < featureCount,
+                    OP_LOGE(ctx_.nodeName,
+                            "%s must keep feature elements dense and non-overlapping: "
+                            "feature stride=1 and head stride>=%llu.",
+                            name, static_cast<unsigned long long>(featureCount)),
+                    return ge::GRAPH_FAILED);
+
+        const uint64_t maxUint64 = std::numeric_limits<uint64_t>::max();
+        OP_CHECK_IF(headCount > 1 &&
+                        headStride > (maxUint64 - featureCount) / (headCount - 1),
+                    OP_LOGE(ctx_.nodeName, "%s head stride calculation overflows.", name),
+                    return ge::GRAPH_FAILED);
+        const uint64_t minTokenStride = (headCount - 1) * headStride + featureCount;
+        OP_CHECK_IF(tokenStride < minTokenStride,
+                    OP_LOGE(ctx_.nodeName,
+                            "%s token stride overlaps heads: token stride=%llu, minimum=%llu.",
+                            name, static_cast<unsigned long long>(tokenStride),
+                            static_cast<unsigned long long>(minTokenStride)),
+                    return ge::GRAPH_FAILED);
+
+        const uint64_t srcGapElements = tokenStride - featureCount;
+        OP_CHECK_IF(srcGapElements > std::numeric_limits<uint32_t>::max() / sizeof(uint16_t),
+                    OP_LOGE(ctx_.nodeName,
+                            "%s token gap exceeds DataCopy source-stride range: %llu elements.",
+                            name, static_cast<unsigned long long>(srcGapElements)),
+                    return ge::GRAPH_FAILED);
+
+        if (rank == RKDA_RANK4_QKV_DIM_NUM && shape.GetDim(RKDA_DIM_0) > 1) {
+            const uint64_t seqLen = static_cast<uint64_t>(shape.GetDim(RKDA_DIM_1));
+            OP_CHECK_IF(tokenStride > maxUint64 / seqLen,
+                        OP_LOGE(ctx_.nodeName, "%s batch stride calculation overflows.", name),
+                        return ge::GRAPH_FAILED);
+            const uint64_t expectedBatchStride = seqLen * tokenStride;
+            OP_CHECK_IF(static_cast<uint64_t>(strides[RKDA_DIM_0]) != expectedBatchStride,
+                        OP_LOGE(ctx_.nodeName,
+                                "%s batch stride must equal T * token stride for flattened BSND, "
+                                "but got %llu and expected %llu.",
+                                name, static_cast<unsigned long long>(strides[RKDA_DIM_0]),
+                                static_cast<unsigned long long>(expectedBatchStride)),
+                        return ge::GRAPH_FAILED);
+        }
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus CheckQkvStrides() const
+    {
+        const auto queryStrides = ResolveQkvStrides(ctx_.queryShape, ctx_.queryStrides, ctx_.hasQueryStrides);
+        const auto keyStrides = ResolveQkvStrides(ctx_.keyShape, ctx_.keyStrides, ctx_.hasKeyStrides);
+        const auto valueStrides = ResolveQkvStrides(ctx_.valueShape, ctx_.valueStrides, ctx_.hasValueStrides);
+        if (ValidateQkvStrides(ctx_.queryShape, queryStrides, "query") != ge::GRAPH_SUCCESS ||
+            ValidateQkvStrides(ctx_.keyShape, keyStrides, "key") != ge::GRAPH_SUCCESS ||
+            ValidateQkvStrides(ctx_.valueShape, valueStrides, "value") != ge::GRAPH_SUCCESS) {
+            return ge::GRAPH_FAILED;
+        }
+        return ge::GRAPH_SUCCESS;
     }
 
     ge::graphStatus ValidateStateStrides(
@@ -407,6 +509,10 @@ private:
                             "state_capacity must equal seq_num."),
                     return ge::GRAPH_FAILED);
 
+        if (CheckQkvStrides() != ge::GRAPH_SUCCESS) {
+            return ge::GRAPH_FAILED;
+        }
+
         if (CheckStateStrides() != ge::GRAPH_SUCCESS) {
             return ge::GRAPH_FAILED;
         }
@@ -442,6 +548,17 @@ private:
         tiling.sBlockNum = static_cast<uint32_t>(stateShape.GetDim(RKDA_DIM_0));
         tiling.ssmStateStride = (ctx_.hasSsmStateIndices && ctx_.ssmStateShape.GetDimNum() == RKDA_METADATA_RANK2) ?
                                 static_cast<uint32_t>(ctx_.ssmStateShape.GetDim(RKDA_DIM_1)) : 0;
+        const auto queryStrides = ResolveQkvStrides(queryShape, ctx_.queryStrides, ctx_.hasQueryStrides);
+        const auto keyStrides = ResolveQkvStrides(ctx_.keyShape, ctx_.keyStrides, ctx_.hasKeyStrides);
+        const auto valueStrides = ResolveQkvStrides(valueShape, ctx_.valueStrides, ctx_.hasValueStrides);
+        const size_t tokenDim = ctx_.layout == RKDA_LAYOUT_TND ? RKDA_DIM_0 : RKDA_DIM_1;
+        const size_t headDim = ctx_.layout == RKDA_LAYOUT_TND ? RKDA_DIM_1 : RKDA_DIM_2;
+        tiling.queryTokenStride = static_cast<uint64_t>(queryStrides[tokenDim]);
+        tiling.queryHeadStride = static_cast<uint64_t>(queryStrides[headDim]);
+        tiling.keyTokenStride = static_cast<uint64_t>(keyStrides[tokenDim]);
+        tiling.keyHeadStride = static_cast<uint64_t>(keyStrides[headDim]);
+        tiling.valueTokenStride = static_cast<uint64_t>(valueStrides[tokenDim]);
+        tiling.valueHeadStride = static_cast<uint64_t>(valueStrides[headDim]);
         const auto stateInStrides = ResolveStateStrides(false);
         const auto stateOutStrides = ResolveStateStrides(true);
         tiling.stateInStride0 = static_cast<uint64_t>(stateInStrides[RKDA_DIM_0]);

--- a/fla/ops/ascendc/kda/recurrent_kda/op_kernel/arch35/recurrent_kda.h
+++ b/fla/ops/ascendc/kda/recurrent_kda/op_kernel/arch35/recurrent_kda.h
@@ -162,7 +162,8 @@ public:
         uint32_t singleVSize = vStep_ * sizeof(float);
         uint32_t vSize = MAX_MTP * alignV_ * sizeof(float);
         uint32_t kSize = MAX_MTP * alignK_ * sizeof(float);
-        uint32_t betaUbSize = MAX_MTP * FP32_NUM_PER_BLOCK * sizeof(float);
+        // FP16/BF16 beta rows expand to 16 FP32 values after Cast.
+        uint32_t betaUbSize = MAX_MTP * BF16_NUM_PER_BLOCK * sizeof(float);
         pipe_->InitBuffer(qInQueue_, BUFFER_NUM, MAX_MTP * alignK_ * sizeof(inType));
         pipe_->InitBuffer(kInQueue_, BUFFER_NUM, MAX_MTP * alignK_ * sizeof(inType));
         pipe_->InitBuffer(vInQueue_, BUFFER_NUM, MAX_MTP * alignV_ * sizeof(inType));

--- a/fla/ops/ascendc/kda/recurrent_kda/op_kernel/arch35/recurrent_kda.h
+++ b/fla/ops/ascendc/kda/recurrent_kda/op_kernel/arch35/recurrent_kda.h
@@ -72,6 +72,12 @@ public:
         NV_ = tilingData->nv;
         realV_ = tilingData->dv;
         stateCapacity_ = tilingData->sBlockNum;
+        queryTokenStride_ = tilingData->queryTokenStride;
+        queryHeadStride_ = tilingData->queryHeadStride;
+        keyTokenStride_ = tilingData->keyTokenStride;
+        keyHeadStride_ = tilingData->keyHeadStride;
+        valueTokenStride_ = tilingData->valueTokenStride;
+        valueHeadStride_ = tilingData->valueHeadStride;
         ssmStateStride_ = tilingData->ssmStateStride;
         stateInStride0_ = tilingData->stateInStride0;
         stateInStride1_ = tilingData->stateInStride1;
@@ -585,22 +591,24 @@ private:
         PipeBarrier<PIPE_V>();
     }
 
-    __aicore__ inline void CopyInQKVGate(uint64_t vOffset, uint64_t qkOffset, uint64_t gateOffset, int32_t seqLen,
-                                         uint64_t head)
+    __aicore__ inline void CopyInQKVGate(uint64_t qOffset, uint64_t kOffset, uint64_t vOffset,
+                                         uint64_t gateOffset, int32_t seqLen, uint64_t head)
     {
         LocalTensor<inType> qLocal = qInQueue_.AllocTensor<inType>();
         LocalTensor<inType> kLocal = kInQueue_.AllocTensor<inType>();
         LocalTensor<inType> vLocal = vInQueue_.AllocTensor<inType>();
 
-        DataCopyExtParams qkInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
-                                     static_cast<uint32_t>((NK_ - 1) * realK_ * sizeof(inType)), 0, 0};
+        DataCopyExtParams qInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
+                                    static_cast<uint32_t>((queryTokenStride_ - realK_) * sizeof(inType)), 0, 0};
+        DataCopyExtParams kInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
+                                    static_cast<uint32_t>((keyTokenStride_ - realK_) * sizeof(inType)), 0, 0};
         DataCopyExtParams vInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realV_ * sizeof(inType)),
-                                    static_cast<uint32_t>((NV_ - 1) * realV_ * sizeof(inType)), 0, 0};
+                                    static_cast<uint32_t>((valueTokenStride_ - realV_) * sizeof(inType)), 0, 0};
         DataCopyPadExtParams<inType> qkPadParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
         DataCopyPadExtParams<inType> vPadParams{true, 0, static_cast<uint8_t>(alignV_ - realV_), 0};
 
-        DataCopyPad(qLocal, queryGm_[qkOffset], qkInParams, qkPadParams);
-        DataCopyPad(kLocal, keyGm_[qkOffset], qkInParams, qkPadParams);
+        DataCopyPad(qLocal, queryGm_[qOffset], qInParams, qkPadParams);
+        DataCopyPad(kLocal, keyGm_[kOffset], kInParams, qkPadParams);
         DataCopyPad(vLocal, valueGm_[vOffset], vInParams, vPadParams);
         qInQueue_.EnQue<inType>(qLocal);
         kInQueue_.EnQue<inType>(kLocal);
@@ -1171,10 +1179,13 @@ private:
                                       uint64_t head_i, uint64_t stateSlot, bool statePrefetched,
                                       bool hasNextTask, uint64_t nextStateSlot, uint64_t nextHead)
     {
-        uint64_t vOffset = (static_cast<uint64_t>(seq0) * NV_ + head_i) * realV_;
-        uint64_t qkOffset = (static_cast<uint64_t>(seq0) * NK_ + head_i / (NV_ / NK_)) * realK_;
+        uint64_t qkHead = head_i / (NV_ / NK_);
+        uint64_t qOffset = static_cast<uint64_t>(seq0) * queryTokenStride_ + qkHead * queryHeadStride_;
+        uint64_t kOffset = static_cast<uint64_t>(seq0) * keyTokenStride_ + qkHead * keyHeadStride_;
+        uint64_t vOffset = static_cast<uint64_t>(seq0) * valueTokenStride_ + head_i * valueHeadStride_;
         uint64_t gateOffset = (static_cast<uint64_t>(seq0) * NV_ + head_i) * realK_;
-        CopyInQKVGate(vOffset, qkOffset, gateOffset, static_cast<int32_t>(seq1 - seq0), head_i);
+        CopyInQKVGate(
+            qOffset, kOffset, vOffset, gateOffset, static_cast<int32_t>(seq1 - seq0), head_i);
         if (realV_ == 0) {
             return false;
         }
@@ -1310,6 +1321,12 @@ private:
     uint32_t realV_;
     uint32_t stateCapacity_;
     uint32_t ssmStateStride_;
+    uint64_t queryTokenStride_;
+    uint64_t queryHeadStride_;
+    uint64_t keyTokenStride_;
+    uint64_t keyHeadStride_;
+    uint64_t valueTokenStride_;
+    uint64_t valueHeadStride_;
     uint64_t stateInStride0_;
     uint64_t stateInStride1_;
     uint64_t stateInStride2_;

--- a/fla/ops/ascendc/kda/recurrent_kda/op_kernel/recurrent_kda.h
+++ b/fla/ops/ascendc/kda/recurrent_kda/op_kernel/recurrent_kda.h
@@ -69,6 +69,12 @@ public:
         NV_ = tilingData->nv;
         realV_ = tilingData->dv;
         stateCapacity_ = tilingData->sBlockNum;
+        queryTokenStride_ = tilingData->queryTokenStride;
+        queryHeadStride_ = tilingData->queryHeadStride;
+        keyTokenStride_ = tilingData->keyTokenStride;
+        keyHeadStride_ = tilingData->keyHeadStride;
+        valueTokenStride_ = tilingData->valueTokenStride;
+        valueHeadStride_ = tilingData->valueHeadStride;
         ssmStateStride_ = tilingData->ssmStateStride;
         stateInStride0_ = tilingData->stateInStride0;
         stateInStride1_ = tilingData->stateInStride1;
@@ -539,22 +545,24 @@ private:
         PipeBarrier<PIPE_V>();
     }
 
-    __aicore__ inline void CopyInQKVGate(uint64_t vOffset, uint64_t qkOffset, uint64_t gateOffset, int32_t seqLen,
-                                         uint64_t head)
+    __aicore__ inline void CopyInQKVGate(uint64_t qOffset, uint64_t kOffset, uint64_t vOffset,
+                                         uint64_t gateOffset, int32_t seqLen, uint64_t head)
     {
         LocalTensor<inType> qLocal = qInQueue_.AllocTensor<inType>();
         LocalTensor<inType> kLocal = kInQueue_.AllocTensor<inType>();
         LocalTensor<inType> vLocal = vInQueue_.AllocTensor<inType>();
 
-        DataCopyExtParams qkInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
-                                     static_cast<uint32_t>((NK_ - 1) * realK_ * sizeof(inType)), 0, 0};
+        DataCopyExtParams qInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
+                                    static_cast<uint32_t>((queryTokenStride_ - realK_) * sizeof(inType)), 0, 0};
+        DataCopyExtParams kInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
+                                    static_cast<uint32_t>((keyTokenStride_ - realK_) * sizeof(inType)), 0, 0};
         DataCopyExtParams vInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realV_ * sizeof(inType)),
-                                    static_cast<uint32_t>((NV_ - 1) * realV_ * sizeof(inType)), 0, 0};
+                                    static_cast<uint32_t>((valueTokenStride_ - realV_) * sizeof(inType)), 0, 0};
         DataCopyPadExtParams<inType> qkPadParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
         DataCopyPadExtParams<inType> vPadParams{true, 0, static_cast<uint8_t>(alignV_ - realV_), 0};
 
-        DataCopyPad(qLocal, queryGm_[qkOffset], qkInParams, qkPadParams);
-        DataCopyPad(kLocal, keyGm_[qkOffset], qkInParams, qkPadParams);
+        DataCopyPad(qLocal, queryGm_[qOffset], qInParams, qkPadParams);
+        DataCopyPad(kLocal, keyGm_[kOffset], kInParams, qkPadParams);
         DataCopyPad(vLocal, valueGm_[vOffset], vInParams, vPadParams);
         qInQueue_.EnQue<inType>(qLocal);
         kInQueue_.EnQue<inType>(kLocal);
@@ -921,10 +929,13 @@ private:
                                       uint64_t head_i, uint64_t stateSlot, bool statePrefetched,
                                       bool hasNextHead, uint64_t nextStateSlot, uint64_t nextHead)
     {
-        uint64_t vOffset = (static_cast<uint64_t>(seq0) * NV_ + head_i) * realV_;
-        uint64_t qkOffset = (static_cast<uint64_t>(seq0) * NK_ + head_i / (NV_ / NK_)) * realK_;
+        uint64_t qkHead = head_i / (NV_ / NK_);
+        uint64_t qOffset = static_cast<uint64_t>(seq0) * queryTokenStride_ + qkHead * queryHeadStride_;
+        uint64_t kOffset = static_cast<uint64_t>(seq0) * keyTokenStride_ + qkHead * keyHeadStride_;
+        uint64_t vOffset = static_cast<uint64_t>(seq0) * valueTokenStride_ + head_i * valueHeadStride_;
         uint64_t gateOffset = (static_cast<uint64_t>(seq0) * NV_ + head_i) * realK_;
-        CopyInQKVGate(vOffset, qkOffset, gateOffset, static_cast<int32_t>(seq1 - seq0), head_i);
+        CopyInQKVGate(
+            qOffset, kOffset, vOffset, gateOffset, static_cast<int32_t>(seq1 - seq0), head_i);
         if (realV_ == 0) {
             return false;
         }
@@ -1073,6 +1084,12 @@ private:
     uint32_t realV_;
     uint32_t stateCapacity_;
     uint32_t ssmStateStride_;
+    uint64_t queryTokenStride_;
+    uint64_t queryHeadStride_;
+    uint64_t keyTokenStride_;
+    uint64_t keyHeadStride_;
+    uint64_t valueTokenStride_;
+    uint64_t valueHeadStride_;
     uint64_t stateInStride0_;
     uint64_t stateInStride1_;
     uint64_t stateInStride2_;

--- a/fla/ops/ascendc/kda/recurrent_kda/op_kernel/recurrent_kda_struct.h
+++ b/fla/ops/ascendc/kda/recurrent_kda/op_kernel/recurrent_kda_struct.h
@@ -65,6 +65,12 @@ struct alignas(8) RecurrentKdaTilingData {
     uint64_t stateOutStride1;
     uint64_t stateOutStride2;
     uint64_t stateOutStride3;
+    uint64_t queryTokenStride;
+    uint64_t queryHeadStride;
+    uint64_t keyTokenStride;
+    uint64_t keyHeadStride;
+    uint64_t valueTokenStride;
+    uint64_t valueHeadStride;
 };
 #pragma pack(pop)
 


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @WOE-Y
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
# 默认 CANN 安装路径；自定义安装路径时替换为实际路径下对应的 set_env.sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
