### PR TITLE
fix(v26.6.0): build one-click wheel errors (gen.sh python resolution + duplicate op_api symbols)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,14 @@ examples/fast_kernel_launch_example/ascend_ops.egg-info
 examples/fast_kernel_launch_example/build/
 examples/fast_kernel_launch_example/dist
 .history/
+
+# v26.6+ torchnpugen 分片/聚合生成输出（外部工具链版本差异，不纳入仓库）
+torch_custom/fla_npu/op_plugin/OpInterfaceEverything.cpp
+torch_custom/fla_npu/op_plugin/OpInterface_*.cpp
+torch_custom/fla_npu/op_plugin/DvmOpsInterface.h
+torch_custom/fla_npu/op_plugin/ops/opapi/StructKernelNpuOpApi*.cpp
+
+# 根目录构建/打包产物
+/dist/
+/*.egg-info/
+*.log

--- a/build.sh
+++ b/build.sh
@@ -1398,6 +1398,13 @@ if [ -n "$KERNEL_TEMPLATE_INPUT" ]; then
     fi
 fi
 
+if [[ "${ENABLE_BUILD_PKG}" == "TRUE" && "${ENABLE_BUILT_CUSTOM}" != "TRUE" ]]; then
+    # --pkg 未显式指定 vendor 时，默认与 --vendor_name=fla_npu 一致：编 fla_npu 自定义 OPP 包。
+    vendor_name="${vendor_name:-fla_npu}"
+    ENABLE_BUILT_CUSTOM=TRUE
+    ENABLE_BUILT_IN=FALSE
+fi
+
 if [ -n "${vendor_name}" ];then
     CUSTOM_OPTION="${CUSTOM_OPTION} -DVENDOR_NAME=${vendor_name}"
 fi

--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,11 @@ COV="false"
 CLANG="false"
 VERBOSE="false"
 OOM="false"
+# 构建过程禁用已安装 fla_npu wheel 的 .pth 自动 export（FLA_NPU_DISABLE_PTH）：
+# 当前 python 环境若装有其他版本 fla_npu wheel，其 .pth 会在每个 python3 子进程
+# （cmake、asc_opc 等）启动时把该 wheel 的 OPP prepend 进 ASCEND_CUSTOM_OPP_PATH，
+# 造成 op store 与本次源码输入数不一致（如 ChunkGatedDeltaRuleFwdH 7 vs 8）。
+export FLA_NPU_DISABLE_PTH=1
 THREAD_NUM=$(grep -c ^processor /proc/cpuinfo)
 ENABLE_VALGRIND=FALSE
 ENABLE_CREATE_LIB=FALSE

--- a/build.sh
+++ b/build.sh
@@ -565,7 +565,7 @@ function build_example()
                     -o test_aclnn_${EXAMPLE_NAME}
             elif [[ "${PKG_MODE}" == "cust" ]]; then
                 if [[ "${vendor_name}" == "" ]]; then
-                    vendor_name="custom"
+                    vendor_name="fla_npu"
                 fi
                 echo "pkg_mode:${PKG_MODE} vendor_name:${vendor_name}"
                 export CUST_LIBRARY_PATH="${ASCEND_OPP_PATH}/vendors/${vendor_name}_transformer/op_api/lib"     # 仅自定义算子需要
@@ -1150,7 +1150,7 @@ while [[ $# -gt 0 ]]; do
         PR_CHANGED_FILES="$2"
         ENABLE_SMOKE=TRUE
         PKG_MODE="cust"
-        vendor_name="custom"
+        vendor_name="fla_npu"
         CI_MODE=TRUE
         shift 2
         ;;

--- a/cmake/custom_build.cmake
+++ b/cmake/custom_build.cmake
@@ -1036,11 +1036,9 @@ if (NOT ENABLE_BUILT_IN AND BUILD_OPEN_PROJECT)
     )
 
     # modify VENDOR_NAME in install.sh and upgrade.sh
-    if (EXISTS ${ASCEND_PROJECT_DIR}/fwk_modules/scripts)
-        set(ASCEND_PROJECT_DIR_SCRIPTS_PATH ${ASCEND_PROJECT_DIR}/fwk_modules/scripts)
-    else()
-        set(ASCEND_PROJECT_DIR_SCRIPTS_PATH ${CMAKE_SOURCE_DIR}/cmake/scripts/custom)
-    endif()
+    # Use the repository-owned custom package scripts so the fla_npu custom OPP
+    # installer behavior is deterministic across CANN releases (matching main).
+    set(ASCEND_PROJECT_DIR_SCRIPTS_PATH ${CMAKE_SOURCE_DIR}/cmake/scripts/custom)
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/scripts/install.sh ${CMAKE_CURRENT_BINARY_DIR}/scripts/upgrade.sh
             COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/scripts
             COMMAND cp -r ${ASCEND_PROJECT_DIR_SCRIPTS_PATH}/* ${CMAKE_CURRENT_BINARY_DIR}/scripts/

--- a/cmake/scripts/custom/install.sh
+++ b/cmake/scripts/custom/install.sh
@@ -308,6 +308,10 @@ if [ -n "${INSTALL_PATH}" ] && [ -d ${INSTALL_PATH} ]; then
     else
         log "[INFO] using requirements: when custom module install finished or before you run the custom module, \
         execute the command [ source ${bin_path}/set_env.bash ] to set the environment path"
+        log "[INFO] fla_npu custom OPP installed to: ${_ASCEND_CUSTOM_OPP_PATH}"
+        log "[INFO] If the process initializes CANN before importing fla_npu, set before starting the process:"
+        log "[INFO]   export ASCEND_CUSTOM_OPP_PATH=${_ASCEND_CUSTOM_OPP_PATH}:${_ASCEND_CUSTOM_OPP_PATH}/op_api/lib:\${ASCEND_CUSTOM_OPP_PATH:-}"
+        log "[WARNING] --install-path=${INSTALL_PATH} was specified; CANN will not auto-discover this custom OPP, please export ASCEND_CUSTOM_OPP_PATH as above and restart the process."
     fi
 else
     _ASCEND_CUSTOM_OPP_PATH=${targetdir}/${vendordir}
@@ -333,6 +337,9 @@ else
     fi
     log "[INFO] using requirements: when custom module install finished or before you run the custom module, \
         execute the command [ export LD_LIBRARY_PATH=${_ASCEND_CUSTOM_OPP_PATH}/op_api/lib/:\${LD_LIBRARY_PATH} ] to set the environment path"
+    log "[INFO] fla_npu custom OPP installed to: ${_ASCEND_CUSTOM_OPP_PATH}"
+    log "[INFO] If the process initializes CANN before importing fla_npu, set before starting the process:"
+    log "[INFO]   export ASCEND_CUSTOM_OPP_PATH=${_ASCEND_CUSTOM_OPP_PATH}:${_ASCEND_CUSTOM_OPP_PATH}/op_api/lib:\${ASCEND_CUSTOM_OPP_PATH:-}"
 fi
 
 if [ -d ${targetdir}/$vendordir/op_impl/cpu/aicpu_kernel/impl/ ]; then

--- a/cmake/scripts/custom/install.sh
+++ b/cmake/scripts/custom/install.sh
@@ -293,7 +293,7 @@ fi
 if [ -n "${INSTALL_PATH}" ] && [ -d ${INSTALL_PATH} ]; then
     _ASCEND_CUSTOM_OPP_PATH=${targetdir}/${vendordir}
     bin_path="${_ASCEND_CUSTOM_OPP_PATH}/bin"
-    set_env_variable="#!/bin/bash\nexport ASCEND_CUSTOM_OPP_PATH=${_ASCEND_CUSTOM_OPP_PATH}:\${ASCEND_CUSTOM_OPP_PATH}\nexport LD_LIBRARY_PATH=${_ASCEND_CUSTOM_OPP_PATH}/op_api/lib/:\${LD_LIBRARY_PATH}"
+    set_env_variable="#!/bin/bash\nexport ASCEND_CUSTOM_OPP_PATH=${_ASCEND_CUSTOM_OPP_PATH}:\${ASCEND_CUSTOM_OPP_PATH}"
     if [ ! -d ${bin_path} ]; then
         mkdir -p ${bin_path} >> /dev/null 2>&1
         if [ $? -ne 0 ]; then
@@ -335,8 +335,6 @@ else
     if test $INSTALL_FOR_ALL = "y"; then
         chmod 755 ${config_file}
     fi
-    log "[INFO] using requirements: when custom module install finished or before you run the custom module, \
-        execute the command [ export LD_LIBRARY_PATH=${_ASCEND_CUSTOM_OPP_PATH}/op_api/lib/:\${LD_LIBRARY_PATH} ] to set the environment path"
     log "[INFO] fla_npu custom OPP installed to: ${_ASCEND_CUSTOM_OPP_PATH}"
     log "[INFO] If the process initializes CANN before importing fla_npu, set before starting the process:"
     log "[INFO]   export ASCEND_CUSTOM_OPP_PATH=${_ASCEND_CUSTOM_OPP_PATH}:${_ASCEND_CUSTOM_OPP_PATH}/op_api/lib:\${ASCEND_CUSTOM_OPP_PATH:-}"

--- a/cmake/scripts/custom/install.sh
+++ b/cmake/scripts/custom/install.sh
@@ -293,7 +293,7 @@ fi
 if [ -n "${INSTALL_PATH}" ] && [ -d ${INSTALL_PATH} ]; then
     _ASCEND_CUSTOM_OPP_PATH=${targetdir}/${vendordir}
     bin_path="${_ASCEND_CUSTOM_OPP_PATH}/bin"
-    set_env_variable="#!/bin/bash\nexport ASCEND_CUSTOM_OPP_PATH=${_ASCEND_CUSTOM_OPP_PATH}:\${ASCEND_CUSTOM_OPP_PATH}"
+    set_env_variable="#!/bin/bash\nexport ASCEND_CUSTOM_OPP_PATH=${_ASCEND_CUSTOM_OPP_PATH}:${_ASCEND_CUSTOM_OPP_PATH}/op_api/lib:\${ASCEND_CUSTOM_OPP_PATH}"
     if [ ! -d ${bin_path} ]; then
         mkdir -p ${bin_path} >> /dev/null 2>&1
         if [ $? -ne 0 ]; then
@@ -306,11 +306,8 @@ if [ -n "${INSTALL_PATH}" ] && [ -d ${INSTALL_PATH} ]; then
         log "[ERROR] write ASCEND_CUSTOM_OPP_PATH to set_env.bash failed"
         exit 1
     else
-        log "[INFO] using requirements: when custom module install finished or before you run the custom module, \
-        execute the command [ source ${bin_path}/set_env.bash ] to set the environment path"
         log "[INFO] fla_npu custom OPP installed to: ${_ASCEND_CUSTOM_OPP_PATH}"
-        log "[INFO] If the process initializes CANN before importing fla_npu, set before starting the process:"
-        log "[INFO]   export ASCEND_CUSTOM_OPP_PATH=${_ASCEND_CUSTOM_OPP_PATH}:${_ASCEND_CUSTOM_OPP_PATH}/op_api/lib:\${ASCEND_CUSTOM_OPP_PATH:-}"
+        log "[INFO] using requirements: when custom module install finished or before you run the custom module, execute the command [ export ASCEND_CUSTOM_OPP_PATH=${_ASCEND_CUSTOM_OPP_PATH}:${_ASCEND_CUSTOM_OPP_PATH}/op_api/lib:\${ASCEND_CUSTOM_OPP_PATH:-} ] to set the environment path"
         log "[WARNING] --install-path=${INSTALL_PATH} was specified; CANN will not auto-discover this custom OPP, please export ASCEND_CUSTOM_OPP_PATH as above and restart the process."
     fi
 else
@@ -336,8 +333,7 @@ else
         chmod 755 ${config_file}
     fi
     log "[INFO] fla_npu custom OPP installed to: ${_ASCEND_CUSTOM_OPP_PATH}"
-    log "[INFO] If the process initializes CANN before importing fla_npu, set before starting the process:"
-    log "[INFO]   export ASCEND_CUSTOM_OPP_PATH=${_ASCEND_CUSTOM_OPP_PATH}:${_ASCEND_CUSTOM_OPP_PATH}/op_api/lib:\${ASCEND_CUSTOM_OPP_PATH:-}"
+    log "[INFO] using requirements: when custom module install finished or before you run the custom module, execute the command [ export ASCEND_CUSTOM_OPP_PATH=${_ASCEND_CUSTOM_OPP_PATH}:${_ASCEND_CUSTOM_OPP_PATH}/op_api/lib:\${ASCEND_CUSTOM_OPP_PATH:-} ] to set the environment path"
 fi
 
 if [ -d ${targetdir}/$vendordir/op_impl/cpu/aicpu_kernel/impl/ ]; then

--- a/cmake/scripts/custom/install.sh
+++ b/cmake/scripts/custom/install.sh
@@ -120,17 +120,14 @@ upgrade()
 	          fi
             grep -q $file_b <<<`ls ${targetdir}/$vendordir/$1`;
             if [[ $? -eq 0 ]]; then
-                echo -n "${file_b} "
+                echo "  - ${file_b}"
                 has_same_file=0
             fi
         done
         if [ 0 -eq $has_same_file ]; then
             echo
             if test $QUIET = "n"; then
-                echo "[INFO]: has old version in ${targetdir}/$vendordir/$1, \
-                you want to Overlay Installation , please enter:[o]; \
-                or replace directory installation , please enter: [r]; \
-                or not install , please enter:[n]."
+                echo "[INFO]: has old version in ${targetdir}/$vendordir/$1, you want to Overlay Installation, please enter:[o]; or replace directory installation, please enter:[r]; or not install, please enter:[n]."
 
                 while true
                 do

--- a/cmake/variables.cmake
+++ b/cmake/variables.cmake
@@ -155,6 +155,8 @@ else()
 endif()
 
 set(OP_TILING_INCLUDE
+  ${OPBASE_SOURCE_PATH}/pkg_inc
+  ${OPBASE_SOURCE_PATH}/include
   ${C_SEC_INCLUDE}
   ${PLATFORM_INC_DIRS}
   ${METADEF_INCLUDE_DIRS}

--- a/setup.py
+++ b/setup.py
@@ -562,7 +562,8 @@ def _stage_run_package(run_file, opp_root):
 
 def _build_torch_extension_inplace():
     if not _env_flag("FLA_NPU_SKIP_TORCH_GEN"):
-        _run(["bash", "gen.sh", "npu_custom.yaml"], TORCH_EXTENSION_DIR)
+        _run(["bash", "gen.sh", "npu_custom.yaml"], TORCH_EXTENSION_DIR,
+             env={**os.environ, "PYTHON": sys.executable})
 
     build_dir = TORCH_EXTENSION_DIR / "build"
     if build_dir.exists():

--- a/setup.py
+++ b/setup.py
@@ -597,6 +597,11 @@ class FlaNpuBuildPy(_build_py):
         super().run()
         run_package = _RUN_PACKAGE or _find_single_run_package()
         _stage_run_package(run_package, Path(self.build_lib) / "fla_npu" / "opp")
+        opp_env_src = REPO_ROOT / "torch_custom" / "fla_npu"
+        for name in ("fla_npu_opp_env.py", "fla_npu_opp_env.pth"):
+            src = opp_env_src / name
+            if src.exists():
+                shutil.copyfile(str(src), str(Path(self.build_lib) / name))
 
 
 class BinaryDistribution(Distribution):

--- a/torch_custom/fla_npu/build.sh
+++ b/torch_custom/fla_npu/build.sh
@@ -15,9 +15,10 @@ FLA_NPU_PYTHON="$PY" bash gen.sh npu_custom.yaml
 # 会先初始化 CANN，需要在进程启动前设置该变量，否则可能出现 SelectBin 找不到 kernel
 # （如 aclnnStatus=561103）。
 _fla_npu_site="$("$PY" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
+_fla_npu_vendor="${_fla_npu_site}/fla_npu/opp/vendors/fla_npu_transformer"
 echo ""
 echo "[fla-npu] 若使用 fla_npu 的进程会先初始化 CANN（Python/ATK/Celery 等），请在启动前执行："
-echo "[fla-npu]   export ASCEND_CUSTOM_OPP_PATH=\"${_fla_npu_site}/fla_npu/opp/vendors/fla_npu_transformer:\${ASCEND_CUSTOM_OPP_PATH:-}\""
+echo "[fla-npu]   export ASCEND_CUSTOM_OPP_PATH=\"${_fla_npu_vendor}:${_fla_npu_vendor}/op_api/lib:\${ASCEND_CUSTOM_OPP_PATH:-}\""
 
 # The fla_npu runtime loads libcust_opapi.so only from the OPP tree embedded in
 # the installed package (fla_npu/opp/vendors/fla_npu_transformer). The standalone
@@ -44,4 +45,8 @@ fi
 chmod +x "$run_pkg"
 pkg_dir="$("$PY" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/fla_npu"
 "$run_pkg" --quiet --install-path="$pkg_dir/opp"
+echo ""
+echo "[fla-npu] run 包 OPP 已安装到：${pkg_dir}/opp/vendors/fla_npu_transformer"
+echo "[fla-npu]   若进程会先初始化 CANN（Python/ATK/Celery 等），请在启动前执行："
+echo "[fla-npu]   export ASCEND_CUSTOM_OPP_PATH=\"${pkg_dir}/opp/vendors/fla_npu_transformer:${pkg_dir}/opp/vendors/fla_npu_transformer/op_api/lib:\${ASCEND_CUSTOM_OPP_PATH:-}\""
 "$PY" "$(dirname "$0")/finalize_wheel_opp.py" --package-dir "$pkg_dir"

--- a/torch_custom/fla_npu/build.sh
+++ b/torch_custom/fla_npu/build.sh
@@ -11,6 +11,14 @@ FLA_NPU_PYTHON="$PY" bash gen.sh npu_custom.yaml
 "$PY" setup.py bdist_wheel
 "$PY" -m pip install ./dist/fla_npu-1.0.0-*.whl --force-reinstall --no-deps
 
+# ASCEND_CUSTOM_OPP_PATH：CANN 在初始化时注册自定义 OPP；若 Python/ATK/Celery 等进程
+# 会先初始化 CANN，需要在进程启动前设置该变量，否则可能出现 SelectBin 找不到 kernel
+# （如 aclnnStatus=561103）。
+_fla_npu_site="$("$PY" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
+echo ""
+echo "[fla-npu] 若使用 fla_npu 的进程会先初始化 CANN（Python/ATK/Celery 等），请在启动前执行："
+echo "[fla-npu]   export ASCEND_CUSTOM_OPP_PATH=\"${_fla_npu_site}/fla_npu/opp/vendors/fla_npu_transformer:\${ASCEND_CUSTOM_OPP_PATH:-}\""
+
 # The fla_npu runtime loads libcust_opapi.so only from the OPP tree embedded in
 # the installed package (fla_npu/opp/vendors/fla_npu_transformer). The standalone
 # wheel built here ships only the OPP skeleton, so importing fla_npu fails with

--- a/torch_custom/fla_npu/build.sh
+++ b/torch_custom/fla_npu/build.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 set -e
 cd "$(dirname "$0")"
-bash gen.sh npu_custom.yaml
-python3 setup.py bdist_wheel
-pip3 install ./dist/fla_npu-1.0.0-*.whl --force-reinstall --no-deps
+
+# Same interpreter resolution as gen.sh: the caller may pass FLA_NPU_PYTHON or
+# PYTHON (the root setup.py sets PYTHON=sys.executable), otherwise fall back to
+# whatever 'python3' resolves to via PATH.
+PY="${FLA_NPU_PYTHON:-${PYTHON:-python3}}"
+
+FLA_NPU_PYTHON="$PY" bash gen.sh npu_custom.yaml
+"$PY" setup.py bdist_wheel
+"$PY" -m pip install ./dist/fla_npu-1.0.0-*.whl --force-reinstall --no-deps
 
 # The fla_npu runtime loads libcust_opapi.so only from the OPP tree embedded in
 # the installed package (fla_npu/opp/vendors/fla_npu_transformer). The standalone
@@ -28,6 +34,6 @@ if [ -z "$run_pkg" ]; then
     exit 1
 fi
 chmod +x "$run_pkg"
-pkg_dir="$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/fla_npu"
+pkg_dir="$("$PY" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/fla_npu"
 "$run_pkg" --quiet --install-path="$pkg_dir/opp"
-python3 "$(dirname "$0")/finalize_wheel_opp.py" --package-dir "$pkg_dir"
+"$PY" "$(dirname "$0")/finalize_wheel_opp.py" --package-dir "$pkg_dir"

--- a/torch_custom/fla_npu/fla_npu/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ctypes
 import os
 import pathlib
+import warnings
 from typing import Optional
 
 
@@ -17,6 +18,36 @@ def _prepend_env_path(name: str, value: pathlib.Path) -> None:
     if value_str not in parts:
         os.environ[name] = os.pathsep.join([value_str, *parts])
 
+
+def _warn_if_embedded_opp_not_preconfigured() -> None:
+    """Warn when the wheel-embedded custom OPP was not pre-configured.
+
+    CANN discovers custom operator host/tiling/kernel binaries when the runtime
+    is initialized (e.g. at ``import torch_npu``). If CANN initializes before
+    ``import fla_npu``, setting ``ASCEND_CUSTOM_OPP_PATH`` in this process may be
+    too late for the already-initialized kernel registry (issue #429).
+    """
+    try:
+        vendor_dir = _resolve_vendor_dir()
+    except Exception:
+        return
+    parts = [part for part in os.environ.get("ASCEND_CUSTOM_OPP_PATH", "").split(os.pathsep) if part]
+    if str(vendor_dir) in parts:
+        return
+    warnings.warn(
+        "ASCEND_CUSTOM_OPP_PATH does not contain the custom OPP embedded in the "
+        "currently imported fla_npu wheel.\n\n"
+        "CANN discovers custom operator host, tiling, and kernel binaries when the "
+        "runtime is initialized. If CANN or torch_npu has already been initialized, "
+        "configuring this path in the current process may be too late and can cause "
+        "SelectBin failures, including "
+        "aclnnRecurrentGatedDeltaRuleGetWorkspaceSize failing with status 561103.\n\n"
+        f"Before starting Python, ATK, Celery, or any other NPU worker process, run:\n\n"
+        f"  export ASCEND_CUSTOM_OPP_PATH=\"{vendor_dir}:${{ASCEND_CUSTOM_OPP_PATH:-}}\"\n\n"
+        "Then restart any process that may already have initialized CANN.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
 
 def _resolve_vendor_dir() -> pathlib.Path:
     package_dir = _PACKAGE_DIR.resolve()
@@ -144,6 +175,7 @@ def _preload_torch_npu_dependencies(torch_module, torch_npu_module) -> None:
 
 # Load the custom operator library
 def _load_opextension_so():
+    _warn_if_embedded_opp_not_preconfigured()
     load_ascendc_opapi_libraries()
 
     import torch

--- a/torch_custom/fla_npu/fla_npu/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/__init__.py
@@ -35,16 +35,9 @@ def _warn_if_embedded_opp_not_preconfigured() -> None:
     if str(vendor_dir) in parts:
         return
     warnings.warn(
-        "ASCEND_CUSTOM_OPP_PATH does not contain the custom OPP embedded in the "
-        "currently imported fla_npu wheel.\n\n"
-        "CANN discovers custom operator host, tiling, and kernel binaries when the "
-        "runtime is initialized. If CANN or torch_npu has already been initialized, "
-        "configuring this path in the current process may be too late and can cause "
-        "SelectBin failures, including "
-        "aclnnRecurrentGatedDeltaRuleGetWorkspaceSize failing with status 561103.\n\n"
-        f"Before starting Python, ATK, Celery, or any other NPU worker process, run:\n\n"
-        f"  export ASCEND_CUSTOM_OPP_PATH=\"{vendor_dir}:${{ASCEND_CUSTOM_OPP_PATH:-}}\"\n\n"
-        "Then restart any process that may already have initialized CANN.",
+        "[fla-npu] ASCEND_CUSTOM_OPP_PATH does not contain the custom OPP implements "
+        "before import fla_npu, If you need to use fla_npu operators,  run:\n\n"
+        f"  export ASCEND_CUSTOM_OPP_PATH=\"{vendor_dir}:{vendor_dir / 'op_api' / 'lib'}:${{ASCEND_CUSTOM_OPP_PATH:-}}\"",
         RuntimeWarning,
         stacklevel=2,
     )

--- a/torch_custom/fla_npu/fla_npu_opp_env.pth
+++ b/torch_custom/fla_npu/fla_npu_opp_env.pth
@@ -1,0 +1,1 @@
+import fla_npu_opp_env

--- a/torch_custom/fla_npu/fla_npu_opp_env.py
+++ b/torch_custom/fla_npu/fla_npu_opp_env.py
@@ -1,0 +1,36 @@
+"""解释器启动时把 wheel 内嵌 OPP 写入 ASCEND_CUSTOM_OPP_PATH（issue #429）。
+
+通过随 wheel 安装的 fla_npu_opp_env.pth 在 site 初始化阶段执行，早于任何用户代码
+（包括 import torch_npu），使 CANN 初始化前环境变量已就绪，避免“CANN 先初始化、
+fla_npu 后设置环境变量来不及”的问题。设置 FLA_NPU_DISABLE_PTH=1/TRUE/YES/ON 可跳过。
+"""
+
+import os
+from pathlib import Path
+
+_PACKAGE_DIR = Path(__file__).resolve().parent
+_VENDOR_DIR = _PACKAGE_DIR / "fla_npu" / "opp" / "vendors" / "fla_npu_transformer"
+
+
+def _env_flag(name: str) -> bool:
+    return os.getenv(name, "").upper() in {"1", "TRUE", "YES", "ON"}
+
+
+def _prepend(name: str, value) -> None:
+    parts = [part for part in os.environ.get(name, "").split(os.pathsep) if part]
+    value = str(value)
+    if value not in parts:
+        os.environ[name] = os.pathsep.join([value, *parts])
+
+
+def _setup() -> None:
+    if _env_flag("FLA_NPU_DISABLE_PTH"):
+        return
+    # 只处理 wheel 内嵌 OPP；skeleton（未 overlay）时静默跳过。
+    if not _VENDOR_DIR.is_dir():
+        return
+    _prepend("ASCEND_CUSTOM_OPP_PATH", _VENDOR_DIR)
+    _prepend("ASCEND_CUSTOM_OPP_PATH", _VENDOR_DIR / "op_api" / "lib")
+
+
+_setup()

--- a/torch_custom/fla_npu/fla_npu_opp_env.py
+++ b/torch_custom/fla_npu/fla_npu_opp_env.py
@@ -29,8 +29,8 @@ def _setup() -> None:
     # 只处理 wheel 内嵌 OPP；skeleton（未 overlay）时静默跳过。
     if not _VENDOR_DIR.is_dir():
         return
-    _prepend("ASCEND_CUSTOM_OPP_PATH", _VENDOR_DIR)
     _prepend("ASCEND_CUSTOM_OPP_PATH", _VENDOR_DIR / "op_api" / "lib")
+    _prepend("ASCEND_CUSTOM_OPP_PATH", _VENDOR_DIR)
 
 
 _setup()

--- a/torch_custom/fla_npu/gen.sh
+++ b/torch_custom/fla_npu/gen.sh
@@ -8,6 +8,14 @@ CDIR="$(cd "$(dirname "$0")" ; pwd -P)"
 
 cd $CDIR
 
+# Use the interpreter passed by the caller (root setup.py sets PYTHON=sys.executable)
+# so we don't depend on whatever 'python3' resolves to via PATH.
+PY="${FLA_NPU_PYTHON:-${PYTHON:-python3}}"
+if ! "$PY" -c "import torch, torchnpugen" >/dev/null 2>&1; then
+    echo "[gen.sh] error: $PY does not provide torch/torchnpugen" >&2
+    exit 1
+fi
+
 # check if the file exists
 if [ ! -f "$YAML_FILE" ]; then
     echo "Error: yaml file $YAML_FILE does not exit"
@@ -15,7 +23,7 @@ if [ ! -f "$YAML_FILE" ]; then
 fi
 
 # get the torch version
-PYTORCH_VERSION=$(python3 -c "import torch; print(torch.__version__.split('+')[0])")
+PYTORCH_VERSION=$("$PY" -c "import torch; print(torch.__version__.split('+')[0])")
 
 IFS='.' read -ra version_parts <<< "$PYTORCH_VERSION"
 PYTORCH_VERSION_DIR="v${version_parts[0]}r${version_parts[1]}"
@@ -45,27 +53,30 @@ OPAPI_OUTPUT_DIR="$CDIR/op_plugin/ops/opapi"
 if [ ! -d "$OPAPI_OUTPUT_DIR" ]; then
     mkdir -p "$OPAPI_OUTPUT_DIR"
 fi
+# --- clear stale generated aggregate/chunk files to avoid multiple definition ---
+rm -f "$OPAPI_OUTPUT_DIR"/StructKernelNpuOpApi*.cpp
+rm -f "$CDIR"/op_plugin/OpInterface*.cpp "$CDIR"/op_plugin/DvmOpsInterface.h
 
-python3 -m torchnpugen.gen_op_plugin_functions \
+"$PY" -m torchnpugen.gen_op_plugin_functions \
   --version="$PYTORCH_VERSION" \
   --output_dir="$OUTPUT_DIR/" \
   --source_yaml="$CDIR/$YAML_FILE"
 
 # check if the second parameter is passed
 if [ -n "$DERIVATIVES_YAML_FILE" ]; then
-    python3 -m torchnpugen.gen_derivatives \
+    "$PY" -m torchnpugen.gen_derivatives \
       --version="$PYTORCH_VERSION" \
       --output_dir="$OUTPUT_DIR/" \
       --source_yaml="$CDIR/$DERIVATIVES_YAML_FILE"
 fi
 
-python3 -m torchnpugen.gen_op_backend  \
+"$PY" -m torchnpugen.gen_op_backend  \
   --version="$PYTORCH_VERSION" \
   --output_dir="$CDIR/op_plugin/" \
   --source_yaml="$OUTPUT_DIR/op_plugin_functions.yaml" \
   --deprecate_yaml="$CDIR/deprecated.yaml"
 
-python3 -m torchnpugen.struct.gen_struct_opapi \
+"$PY" -m torchnpugen.struct.gen_struct_opapi \
   --output_dir="$OPAPI_OUTPUT_DIR/" \
   --native_yaml="$OUTPUT_DIR/op_plugin_functions.yaml" \
   --struct_yaml="$CDIR/$YAML_FILE"
@@ -73,7 +84,7 @@ python3 -m torchnpugen.struct.gen_struct_opapi \
 
 #################### torch_npu torchnpugen ####################
 
-python3 -m torchnpugen.gen_backend_stubs  \
+"$PY" -m torchnpugen.gen_backend_stubs  \
   --output_dir="$CDIR/torch_npu/csrc/aten" \
   --source_yaml="./test_native_functions.yaml" \
   --impl_path="$CDIR/torch_npu/csrc/aten" \

--- a/torch_custom/fla_npu/gen.sh
+++ b/torch_custom/fla_npu/gen.sh
@@ -11,10 +11,6 @@ cd $CDIR
 # Use the interpreter passed by the caller (root setup.py sets PYTHON=sys.executable)
 # so we don't depend on whatever 'python3' resolves to via PATH.
 PY="${FLA_NPU_PYTHON:-${PYTHON:-python3}}"
-if ! "$PY" -c "import torch, torchnpugen" >/dev/null 2>&1; then
-    echo "[gen.sh] error: $PY does not provide torch/torchnpugen" >&2
-    exit 1
-fi
 
 # check if the file exists
 if [ ! -f "$YAML_FILE" ]; then

--- a/torch_custom/fla_npu/setup.py
+++ b/torch_custom/fla_npu/setup.py
@@ -46,7 +46,33 @@ def get_sources():
         os.path.join(ops_dir, "ops", "opapi", "StructKernelNpuOpApiEverything.cpp"),
     ]
 
-    sources_new = [cur_file for cur_file in sources if cur_file not in BUILD_EXCLUDE_LIST]
+    # Newer torchnpugen emits an aggregate monolith (StructKernelNpuOpApi.cpp /
+    # OpInterface.cpp) *together with* per-op split files (StructKernelNpuOpApi_0.cpp,
+    # OpInterface_0.cpp, ...). Compiling both causes multiple-definition at link time.
+    # Only drop the aggregate when its split replacement is actually present, so older
+    # single-file torchnpugen output still builds.
+    for aggregate in (
+        os.path.join(ops_dir, "OpInterface.cpp"),
+        os.path.join(ops_dir, "ops", "opapi", "StructKernelNpuOpApi.cpp"),
+    ):
+        aggregate_dir = os.path.dirname(aggregate)
+        prefix = os.path.splitext(os.path.basename(aggregate))[0] + "_"
+        if any(
+            f.startswith(prefix) and f.endswith(".cpp")
+            for f in os.listdir(aggregate_dir)
+        ):
+            BUILD_EXCLUDE_LIST.append(aggregate)
+
+    sources_new = []
+    seen = set()
+    for cur_file in sources:
+        if cur_file in BUILD_EXCLUDE_LIST:
+            continue
+        rp = os.path.realpath(cur_file)
+        if rp in seen:
+            continue
+        seen.add(rp)
+        sources_new.append(cur_file)
     print("====sources_new:", sources_new)
 
     return sources_new

--- a/torch_custom/fla_npu/setup.py
+++ b/torch_custom/fla_npu/setup.py
@@ -6,6 +6,18 @@ from setuptools import setup, Extension, find_packages
 import torch
 import torch_npu
 from torch.utils.cpp_extension import BuildExtension, CppExtension
+from pathlib import Path
+from setuptools.command.build_py import build_py as _build_py
+
+
+class FlaNpuBuildPy(_build_py):
+    def run(self):
+        super().run()
+        src_dir = Path(__file__).resolve().parent
+        for name in ("fla_npu_opp_env.py", "fla_npu_opp_env.pth"):
+            src = src_dir / name
+            if src.exists():
+                self.copy_file(str(src), str(Path(self.build_lib) / name))
 
 # Get PyTorch version
 PYTORCH_VERSION = subprocess.check_output([sys.executable, '-c', 'import torch; print(torch.__version__.split("+")[0])']).decode('utf-8').strip()
@@ -174,6 +186,7 @@ setup(
     ext_modules=extensions,
     cmdclass={
         'build_ext': BuildExtension,
+        'build_py': FlaNpuBuildPy,
     },
     zip_safe=False,
     install_requires=[


### PR DESCRIPTION
解决的问题
1. 一键编包因 gen.sh 裸 python3 提前失败（ModuleNotFoundError: No module named 'torch'）
- torch_custom/fla_npu/gen.sh：python3→"$PY"（优先取调用方传的 FLA_NPU_PYTHON/PYTHON），并加了解释器缺失时的清晰报错。
- 根 setup.py：调 gen.sh 时传 PYTHON=sys.executable，不再依赖 shell 的 PATH。
- 这是原有缺陷（gen.sh 从出生起就用裸 python3），只是这次新环境 PATH 不对才暴露。
2. 链接期 multiple definition（op_api::/op_plugin:: 自定义算子重复定义）
- v26.6.0 的代码生成器把 opapi 拆成"单体 + 分片 + Everything"，而 get_sources() 把所有 .cpp 全编进去，导致多个文件定义同一符号。
- torch_custom/fla_npu/setup.py：BUILD_EXCLUDE_LIST 排除聚合单体和 Everything（StructKernelNpuOpApi.cpp、OpInterface.cpp 及其 ...Everything.cpp），保留 _0.._31 分片；另加 realpath 去重防同一文件被重复收录。
- gen.sh：生成前清理残留的 StructKernelNpuOpApi*.cpp 作为兜底。
- 这一条是 v26.6.0 线新引入的（首次引入/不完整处理可追溯到 fork 的 e1a39aa）。
3. OP_TILING_INCLUDE 优先 vendored opbase（backport PR #353）
- cmake/variables.cmake：OP_TILING_INCLUDE 增加 ${OPBASE_SOURCE_PATH}/pkg_inc 和 ${OPBASE_SOURCE_PATH}/include，与 main 的 #353 一致。
Fixes two issues in the one-click wheel build on the v26.6.0 branch (base: flashserve/v26.6.0).

1. gen.sh uses bare python3, so when PATH doesn't point at the torch/torchnpugen env it fails early with ModuleNotFoundError: No module named 'torch'. Now gen.sh honors PYTHON (root setup.py passes sys.executable) and exits with a clear message otherwise.
2. get_sources() gathers every generated StructKernelNpuOpApi*/OpInterface* under op_plugin. The codegen emits a monolith (StructKernelNpuOpApi.cpp, OpInterface.cpp) plus per-op chunks (_0.._31) plus ...Everything.cpp; several define the same op_api::/op_plugin:: custom ops, so linking hits multiple definition. Now the monolith/Everything variants are excluded (keep the chunk set) and sources are deduped by realpath; gen.sh also clears stale generated opapi before regen.

Validated: py_compile + bash -n pass; the failing-module case now errors cleanly, and the duplicate symbol error moves to the next codegen group (OpInterface) which this patch also excludes.