### PR TITLE
fix(chunk_fwd_o): include attrs in L2 DFX

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_host/op_api/aclnn_chunk_fwd_o.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_host/op_api/aclnn_chunk_fwd_o.cpp
@@ -133,7 +133,8 @@ aclnnStatus aclnnChunkFwdOGetWorkspaceSize(
 {
     ChunkFwdOParams params{q, k, v, h, g, cuSeqlensOptional, chunkOffsetsOptional, scale, chunkSize, oOut};
     // Standard syntax, Check parameters.
-    L2_DFX_PHASE_1(aclnnChunkFwdO, DFX_IN(q, k, v, h, g, cuSeqlensOptional, chunkOffsetsOptional),
+    L2_DFX_PHASE_1(aclnnChunkFwdO,
+                   DFX_IN(q, k, v, h, g, cuSeqlensOptional, chunkOffsetsOptional, scale, chunkSize),
                    DFX_OUT(oOut));
     // 固定写法，创建OpExecutor
     auto uniqueExecutor = CREATE_EXECUTOR();


### PR DESCRIPTION
## 关联 Issue / 背景

- 关联 Issue: 无；这是一个局部 DFX 参数登记修复，不涉及功能设计或接口变更。
- 背景与目标: `aclnnChunkFwdOGetWorkspaceSize` 接收 `scale` 和 `chunkSize`，但 L2 DFX 输入列表未登记这两个属性。
- 本 PR 解决的问题: 将 `scale` 和 `chunkSize` 加入 `DFX_IN`，使诊断信息与实际 ACLNN 参数一致。

## 变更类型

- [x] Bug 修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: ChunkFwdO / aclnnChunkFwdO
- 涉及目录 / 文件: `fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_host/op_api/aclnn_chunk_fwd_o.cpp`
- 责任人 / 提交人: @Ensley0304
- 修改范围:
  - [x] `op_api` / aclnn 接口的 DFX 元数据
  - [ ] `op_host` / 算子定义
  - [ ] InferShape / 参数校验
  - [ ] Tiling 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `torch_custom` 适配
  - [ ] Triton 算子
  - [ ] 单算子测试
  - [ ] example / ST 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不变。
- 明确不包含的范围: 不修改计算、tiling、kernel、schema 或公开接口。
- 是否影响公共模块或其他算子: 否。
- ABI / 接口兼容性: 不改变 ACLNN 函数签名、参数数量/顺序/类型、算子定义或 torch schema；ABI 不变。
- ABI 不兼容风险说明: 无。

## 验证方法

- `git diff --check`: 通过。
- 静态一致性检查: 确认 `DFX_IN` 现在包含 `scale` 和 `chunkSize`。
- CANN/NPU 编译及设备测试: 未执行；当前环境为 Windows 且无 CANN/NPU。本次变更仅补充 DFX 参数登记，不触及计算路径。

## 兼容性、风险与回退

- 兼容性说明: 完全兼容；仅增加缺失的诊断参数记录。
- 风险点: 低风险，不改变执行语义。
- 回退方案: 回退本 PR 的单个提交。
- 回退责任确认:
  - [x] 如引入阻塞问题，将第一时间回退或配合维护者完成回退。
  - [x] 回退后会同步说明影响范围、恢复版本与后续修复计划。

## Checklist

- [x] 已说明无需 Issue 的原因。
- [x] 已明确责任范围和不包含范围。
- [x] 已完成必要的静态验证。
- [x] 已确认没有无关格式化或大规模重构。
- [x] ABI 与公开接口不变。
- [x] PR 标题使用 `fix:` 类型标签。
- [x] 已明确未执行 CANN/NPU 测试及原因。