### PR TITLE
fix(v26.1.0): backport v26.6.0 build fixes (gen.sh python/PATH + duplicate op_api symbols)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,14 @@ chunk_gated_delta_rule/chunk_bwd_dqkwg/tests/extra-info
 PROF_*
 OPPROF_*
 extra-info
+
+# torchnpugen 分片/聚合生成输出（外部工具链版本差异，不纳入仓库）
+torch_custom/fla_npu/op_plugin/OpInterfaceEverything.cpp
+torch_custom/fla_npu/op_plugin/OpInterface_*.cpp
+torch_custom/fla_npu/op_plugin/DvmOpsInterface.h
+torch_custom/fla_npu/op_plugin/ops/opapi/StructKernelNpuOpApi*.cpp
+
+# 根目录构建/打包产物
+/dist/
+/*.egg-info/
+*.log

--- a/build.sh
+++ b/build.sh
@@ -560,7 +560,7 @@ function build_example()
                     -o test_aclnn_${EXAMPLE_NAME}
             elif [[ "${PKG_MODE}" == "cust" ]]; then
                 if [[ "${vendor_name}" == "" ]]; then
-                    vendor_name="custom"
+                    vendor_name="fla_npu"
                 fi
                 echo "pkg_mode:${PKG_MODE} vendor_name:${vendor_name}"
                 export CUST_LIBRARY_PATH="${ASCEND_OPP_PATH}/vendors/${vendor_name}_transformer/op_api/lib"     # 仅自定义算子需要
@@ -1137,7 +1137,7 @@ while [[ $# -gt 0 ]]; do
         PR_CHANGED_FILES="$2"
         ENABLE_SMOKE=TRUE
         PKG_MODE="cust"
-        vendor_name="custom"
+        vendor_name="fla_npu"
         CI_MODE=TRUE
         shift 2
         ;;

--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,11 @@ COV="false"
 CLANG="false"
 VERBOSE="false"
 OOM="false"
+# 构建过程禁用已安装 fla_npu wheel 的 .pth 自动 export（FLA_NPU_DISABLE_PTH）：
+# 当前 python 环境若装有其他版本 fla_npu wheel，其 .pth 会在每个 python3 子进程
+# （cmake、asc_opc 等）启动时把该 wheel 的 OPP prepend 进 ASCEND_CUSTOM_OPP_PATH，
+# 造成 op store 与本次源码输入数不一致（如 ChunkGatedDeltaRuleFwdH 7 vs 8）。
+export FLA_NPU_DISABLE_PTH=1
 THREAD_NUM=$(grep -c ^processor /proc/cpuinfo)
 ENABLE_VALGRIND=FALSE
 ENABLE_CREATE_LIB=FALSE

--- a/cmake/custom_build.cmake
+++ b/cmake/custom_build.cmake
@@ -1029,11 +1029,9 @@ if (NOT ENABLE_BUILT_IN AND BUILD_OPEN_PROJECT)
     )
 
     # modify VENDOR_NAME in install.sh and upgrade.sh
-    if (EXISTS ${ASCEND_PROJECT_DIR}/fwk_modules/scripts)
-        set(ASCEND_PROJECT_DIR_SCRIPTS_PATH ${ASCEND_PROJECT_DIR}/fwk_modules/scripts)
-    else()
-        set(ASCEND_PROJECT_DIR_SCRIPTS_PATH ${CMAKE_SOURCE_DIR}/cmake/scripts/custom)
-    endif()
+    # Use the repository-owned custom package scripts so the fla_npu custom OPP
+    # installer behavior is deterministic across CANN releases (matching main).
+    set(ASCEND_PROJECT_DIR_SCRIPTS_PATH ${CMAKE_SOURCE_DIR}/cmake/scripts/custom)
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/scripts/install.sh ${CMAKE_CURRENT_BINARY_DIR}/scripts/upgrade.sh
             COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/scripts
             COMMAND cp -r ${ASCEND_PROJECT_DIR_SCRIPTS_PATH}/* ${CMAKE_CURRENT_BINARY_DIR}/scripts/

--- a/cmake/scripts/custom/install.sh
+++ b/cmake/scripts/custom/install.sh
@@ -308,6 +308,10 @@ if [ -n "${INSTALL_PATH}" ] && [ -d ${INSTALL_PATH} ]; then
     else
         log "[INFO] using requirements: when custom module install finished or before you run the custom module, \
         execute the command [ source ${bin_path}/set_env.bash ] to set the environment path"
+        log "[INFO] fla_npu custom OPP installed to: ${_ASCEND_CUSTOM_OPP_PATH}"
+        log "[INFO] If the process initializes CANN before importing fla_npu, set before starting the process:"
+        log "[INFO]   export ASCEND_CUSTOM_OPP_PATH=${_ASCEND_CUSTOM_OPP_PATH}:${_ASCEND_CUSTOM_OPP_PATH}/op_api/lib:\${ASCEND_CUSTOM_OPP_PATH:-}"
+        log "[WARNING] --install-path=${INSTALL_PATH} was specified; CANN will not auto-discover this custom OPP, please export ASCEND_CUSTOM_OPP_PATH as above and restart the process."
     fi
 else
     _ASCEND_CUSTOM_OPP_PATH=${targetdir}/${vendordir}
@@ -333,6 +337,9 @@ else
     fi
     log "[INFO] using requirements: when custom module install finished or before you run the custom module, \
         execute the command [ export LD_LIBRARY_PATH=${_ASCEND_CUSTOM_OPP_PATH}/op_api/lib/:\${LD_LIBRARY_PATH} ] to set the environment path"
+    log "[INFO] fla_npu custom OPP installed to: ${_ASCEND_CUSTOM_OPP_PATH}"
+    log "[INFO] If the process initializes CANN before importing fla_npu, set before starting the process:"
+    log "[INFO]   export ASCEND_CUSTOM_OPP_PATH=${_ASCEND_CUSTOM_OPP_PATH}:${_ASCEND_CUSTOM_OPP_PATH}/op_api/lib:\${ASCEND_CUSTOM_OPP_PATH:-}"
 fi
 
 if [ -d ${targetdir}/$vendordir/op_impl/cpu/aicpu_kernel/impl/ ]; then

--- a/cmake/variables.cmake
+++ b/cmake/variables.cmake
@@ -155,6 +155,8 @@ else()
 endif()
 
 set(OP_TILING_INCLUDE
+  ${OPBASE_SOURCE_PATH}/pkg_inc
+  ${OPBASE_SOURCE_PATH}/include
   ${C_SEC_INCLUDE}
   ${PLATFORM_INC_DIRS}
   ${METADEF_INCLUDE_DIRS}

--- a/torch_custom/fla_npu/build.sh
+++ b/torch_custom/fla_npu/build.sh
@@ -9,3 +9,11 @@ PY="${FLA_NPU_PYTHON:-${PYTHON:-python3}}"
 FLA_NPU_PYTHON="$PY" bash gen.sh npu_custom.yaml
 "$PY" setup.py bdist_wheel
 "$PY" -m pip install ./dist/fla_npu-1.0.0-*.whl --force-reinstall --no-deps
+
+# ASCEND_CUSTOM_OPP_PATH：CANN 在初始化时注册自定义 OPP；若 Python/ATK/Celery 等进程
+# 会先初始化 CANN，需要在进程启动前设置该变量，否则可能出现 SelectBin 找不到 kernel
+# （如 aclnnStatus=561103）。
+_fla_npu_site="$("$PY" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
+echo ""
+echo "[fla-npu] 若使用 fla_npu 的进程会先初始化 CANN（Python/ATK/Celery 等），请在启动前执行："
+echo "[fla-npu]   export ASCEND_CUSTOM_OPP_PATH=\"${_fla_npu_site}/fla_npu/opp/vendors/fla_npu_transformer:\${ASCEND_CUSTOM_OPP_PATH:-}\""

--- a/torch_custom/fla_npu/build.sh
+++ b/torch_custom/fla_npu/build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 cd "$(dirname "$0")"
-bash gen.sh npu_custom.yaml
-python3 setup.py bdist_wheel
-pip3 install ./dist/fla_npu-1.0.0-*.whl --force-reinstall --no-deps
+
+# Same interpreter resolution as gen.sh: the caller may pass FLA_NPU_PYTHON or
+# PYTHON, otherwise fall back to whatever 'python3' resolves to via PATH.
+PY="${FLA_NPU_PYTHON:-${PYTHON:-python3}}"
+
+FLA_NPU_PYTHON="$PY" bash gen.sh npu_custom.yaml
+"$PY" setup.py bdist_wheel
+"$PY" -m pip install ./dist/fla_npu-1.0.0-*.whl --force-reinstall --no-deps

--- a/torch_custom/fla_npu/build.sh
+++ b/torch_custom/fla_npu/build.sh
@@ -14,6 +14,7 @@ FLA_NPU_PYTHON="$PY" bash gen.sh npu_custom.yaml
 # 会先初始化 CANN，需要在进程启动前设置该变量，否则可能出现 SelectBin 找不到 kernel
 # （如 aclnnStatus=561103）。
 _fla_npu_site="$("$PY" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
+_fla_npu_vendor="${_fla_npu_site}/fla_npu/opp/vendors/fla_npu_transformer"
 echo ""
 echo "[fla-npu] 若使用 fla_npu 的进程会先初始化 CANN（Python/ATK/Celery 等），请在启动前执行："
-echo "[fla-npu]   export ASCEND_CUSTOM_OPP_PATH=\"${_fla_npu_site}/fla_npu/opp/vendors/fla_npu_transformer:\${ASCEND_CUSTOM_OPP_PATH:-}\""
+echo "[fla-npu]   export ASCEND_CUSTOM_OPP_PATH=\"${_fla_npu_vendor}:${_fla_npu_vendor}/op_api/lib:\${ASCEND_CUSTOM_OPP_PATH:-}\""

--- a/torch_custom/fla_npu/fla_npu/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/__init__.py
@@ -1,9 +1,43 @@
+import os
 import pathlib
+import warnings
 import torch
+
+
+def _warn_if_embedded_opp_not_preconfigured() -> None:
+    """Warn when the wheel-embedded custom OPP was not pre-configured (issue #429).
+
+    The v26.1.0 wheel does not embed an OPP (the run package installs it into
+    the CANN vendor directory), so this is a no-op unless a future wheel embeds
+    one. CANN discovers custom operator host/tiling/kernel binaries when the
+    runtime is initialized; if it initializes before ``import fla_npu``, setting
+    ``ASCEND_CUSTOM_OPP_PATH`` in this process may be too late (issue #429).
+    """
+    vendor_dir = pathlib.Path(__file__).resolve().parent / "opp" / "vendors" / "fla_npu_transformer"
+    if not vendor_dir.is_dir():
+        return
+    parts = [part for part in os.environ.get("ASCEND_CUSTOM_OPP_PATH", "").split(os.pathsep) if part]
+    if str(vendor_dir) in parts:
+        return
+    warnings.warn(
+        "ASCEND_CUSTOM_OPP_PATH does not contain the custom OPP embedded in the "
+        "currently imported fla_npu wheel.\n\n"
+        "CANN discovers custom operator host, tiling, and kernel binaries when the "
+        "runtime is initialized. If CANN or torch_npu has already been initialized, "
+        "configuring this path in the current process may be too late and can cause "
+        "SelectBin failures, including "
+        "aclnnRecurrentGatedDeltaRuleGetWorkspaceSize failing with status 561103.\n\n"
+        f"Before starting Python, ATK, Celery, or any other NPU worker process, run:\n\n"
+        f"  export ASCEND_CUSTOM_OPP_PATH=\"{vendor_dir}:${{ASCEND_CUSTOM_OPP_PATH:-}}\"\n\n"
+        "Then restart any process that may already have initialized CANN.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
 
 
 # Load the custom operator library
 def _load_opextension_so():
+    _warn_if_embedded_opp_not_preconfigured()
     so_dir = pathlib.Path(__file__).parents[0]
     so_files = list(so_dir.glob('custom_aclnn_extension_lib*.so'))
 

--- a/torch_custom/fla_npu/fla_npu/__init__.py
+++ b/torch_custom/fla_npu/fla_npu/__init__.py
@@ -20,16 +20,9 @@ def _warn_if_embedded_opp_not_preconfigured() -> None:
     if str(vendor_dir) in parts:
         return
     warnings.warn(
-        "ASCEND_CUSTOM_OPP_PATH does not contain the custom OPP embedded in the "
-        "currently imported fla_npu wheel.\n\n"
-        "CANN discovers custom operator host, tiling, and kernel binaries when the "
-        "runtime is initialized. If CANN or torch_npu has already been initialized, "
-        "configuring this path in the current process may be too late and can cause "
-        "SelectBin failures, including "
-        "aclnnRecurrentGatedDeltaRuleGetWorkspaceSize failing with status 561103.\n\n"
-        f"Before starting Python, ATK, Celery, or any other NPU worker process, run:\n\n"
-        f"  export ASCEND_CUSTOM_OPP_PATH=\"{vendor_dir}:${{ASCEND_CUSTOM_OPP_PATH:-}}\"\n\n"
-        "Then restart any process that may already have initialized CANN.",
+        "[fla-npu] ASCEND_CUSTOM_OPP_PATH does not contain the custom OPP implements "
+        "before import fla_npu, If you need to use fla_npu operators,  run:\n\n"
+        f"  export ASCEND_CUSTOM_OPP_PATH=\"{vendor_dir}:{vendor_dir / 'op_api' / 'lib'}:${{ASCEND_CUSTOM_OPP_PATH:-}}\"",
         RuntimeWarning,
         stacklevel=2,
     )

--- a/torch_custom/fla_npu/gen.sh
+++ b/torch_custom/fla_npu/gen.sh
@@ -8,6 +8,11 @@ CDIR="$(cd "$(dirname "$0")" ; pwd -P)"
 
 cd $CDIR
 
+# Use the interpreter passed by the caller (build.sh sets FLA_NPU_PYTHON to its
+# resolved interpreter; root setup.py, where present, sets PYTHON=sys.executable)
+# so we don't depend on whatever 'python3' resolves to via PATH.
+PY="${FLA_NPU_PYTHON:-${PYTHON:-python3}}"
+
 # check if the file exists
 if [ ! -f "$YAML_FILE" ]; then
     echo "Error: yaml file $YAML_FILE does not exit"
@@ -15,7 +20,7 @@ if [ ! -f "$YAML_FILE" ]; then
 fi
 
 # get the torch version
-PYTORCH_VERSION=$(python3 -c "import torch; print(torch.__version__.split('+')[0])")
+PYTORCH_VERSION=$("$PY" -c "import torch; print(torch.__version__.split('+')[0])")
 
 IFS='.' read -ra version_parts <<< "$PYTORCH_VERSION"
 PYTORCH_VERSION_DIR="v${version_parts[0]}r${version_parts[1]}"
@@ -45,27 +50,30 @@ OPAPI_OUTPUT_DIR="$CDIR/op_plugin/ops/opapi"
 if [ ! -d "$OPAPI_OUTPUT_DIR" ]; then
     mkdir -p "$OPAPI_OUTPUT_DIR"
 fi
+# --- clear stale generated aggregate/chunk files to avoid multiple definition ---
+rm -f "$OPAPI_OUTPUT_DIR"/StructKernelNpuOpApi*.cpp
+rm -f "$CDIR"/op_plugin/OpInterface*.cpp "$CDIR"/op_plugin/DvmOpsInterface.h
 
-python3 -m torchnpugen.gen_op_plugin_functions \
+"$PY" -m torchnpugen.gen_op_plugin_functions \
   --version="$PYTORCH_VERSION" \
   --output_dir="$OUTPUT_DIR/" \
   --source_yaml="$CDIR/$YAML_FILE"
 
 # check if the second parameter is passed
 if [ -n "$DERIVATIVES_YAML_FILE" ]; then
-    python3 -m torchnpugen.gen_derivatives \
+    "$PY" -m torchnpugen.gen_derivatives \
       --version="$PYTORCH_VERSION" \
       --output_dir="$OUTPUT_DIR/" \
       --source_yaml="$CDIR/$DERIVATIVES_YAML_FILE"
 fi
 
-python3 -m torchnpugen.gen_op_backend  \
+"$PY" -m torchnpugen.gen_op_backend  \
   --version="$PYTORCH_VERSION" \
   --output_dir="$CDIR/op_plugin/" \
   --source_yaml="$OUTPUT_DIR/op_plugin_functions.yaml" \
   --deprecate_yaml="$CDIR/deprecated.yaml"
 
-python3 -m torchnpugen.struct.gen_struct_opapi \
+"$PY" -m torchnpugen.struct.gen_struct_opapi \
   --output_dir="$OPAPI_OUTPUT_DIR/" \
   --native_yaml="$OUTPUT_DIR/op_plugin_functions.yaml" \
   --struct_yaml="$CDIR/$YAML_FILE"
@@ -73,7 +81,7 @@ python3 -m torchnpugen.struct.gen_struct_opapi \
 
 #################### torch_npu torchnpugen ####################
 
-python3 -m torchnpugen.gen_backend_stubs  \
+"$PY" -m torchnpugen.gen_backend_stubs  \
   --output_dir="$CDIR/torch_npu/csrc/aten" \
   --source_yaml="./test_native_functions.yaml" \
   --impl_path="$CDIR/torch_npu/csrc/aten" \

--- a/torch_custom/fla_npu/setup.py
+++ b/torch_custom/fla_npu/setup.py
@@ -37,12 +37,42 @@ def get_sources():
                 if file.endswith(".cpp") or file.endswith(".cc"):
                     sources.append(os.path.join(root, file))
 
-    BUILD_EXCLUDE_LIST = [f"{aten_dir}/VariableTypeEverything.cpp",
-        f"{aten_dir}/ADInplaceOrViewTypeEverything.cpp",
-        f"{aten_dir}/python_functionsEverything.cpp",
-        f"{aten_dir}/RegisterFunctionalizationEverything.cpp"]
+    BUILD_EXCLUDE_LIST = [
+        os.path.join(aten_dir, "VariableTypeEverything.cpp"),
+        os.path.join(aten_dir, "ADInplaceOrViewTypeEverything.cpp"),
+        os.path.join(aten_dir, "python_functionsEverything.cpp"),
+        os.path.join(aten_dir, "RegisterFunctionalizationEverything.cpp"),
+        os.path.join(ops_dir, "OpInterfaceEverything.cpp"),
+        os.path.join(ops_dir, "ops", "opapi", "StructKernelNpuOpApiEverything.cpp"),
+    ]
 
-    sources_new = [cur_file for cur_file in sources if cur_file not in BUILD_EXCLUDE_LIST]
+    # Newer torchnpugen emits an aggregate monolith (StructKernelNpuOpApi.cpp /
+    # OpInterface.cpp) *together with* per-op split files (StructKernelNpuOpApi_0.cpp,
+    # OpInterface_0.cpp, ...). Compiling both causes multiple-definition at link time.
+    # Only drop the aggregate when its split replacement is actually present, so older
+    # single-file torchnpugen output still builds.
+    for aggregate in (
+        os.path.join(ops_dir, "OpInterface.cpp"),
+        os.path.join(ops_dir, "ops", "opapi", "StructKernelNpuOpApi.cpp"),
+    ):
+        aggregate_dir = os.path.dirname(aggregate)
+        prefix = os.path.splitext(os.path.basename(aggregate))[0] + "_"
+        if any(
+            f.startswith(prefix) and f.endswith(".cpp")
+            for f in os.listdir(aggregate_dir)
+        ):
+            BUILD_EXCLUDE_LIST.append(aggregate)
+
+    sources_new = []
+    seen = set()
+    for cur_file in sources:
+        if cur_file in BUILD_EXCLUDE_LIST:
+            continue
+        rp = os.path.realpath(cur_file)
+        if rp in seen:
+            continue
+        seen.add(rp)
+        sources_new.append(cur_file)
     print("====sources_new:", sources_new)
 
     return sources_new

--- a/torch_custom/fla_npu/setup.py
+++ b/torch_custom/fla_npu/setup.py
@@ -168,5 +168,8 @@ setup(
     install_requires=[
         f"torch=={PYTORCH_VERSION}"
     ],
-    packages=find_packages()
+    # 显式列出包，避免 find_packages() 把构建目录里残留的杂包（如从 main 工作区混入的
+    # fla/）一并打进 wheel：那会让卸载删除 site-packages/fla/__init__.py，而干净重建后
+    # 重装无法还原，导致运行时提示缺少 __version__。
+    packages=["fla_npu"],
 )


### PR DESCRIPTION
### 背景

PR #397 修复了 v26.6.0 一键编包的两个问题（gen.sh 裸 python3 解析、链接期 multiple definition），并补齐 OP_TILING_INCLUDE 与 gitignore。v26.1.0 分支仍保留这些缺陷，本次按 v26.1.0 的实际结构回迁。

### 改动（对照 #397）

- `torch_custom/fla_npu/gen.sh`：裸 `python3` → `"$PY"`（`FLA_NPU_PYTHON` > `PYTHON` > `python3`），生成前清理残留的聚合/分片 opapi 文件（对应 #397 的 `0728a37`，不含解释器校验逻辑）。
- `torch_custom/fla_npu/build.sh`：同步同一套解释器解析，`gen.sh` 通过 `FLA_NPU_PYTHON` 传入，`setup.py`/`pip` 也改用 `"$PY"`（v26.1.0 没有根 `setup.py`，此脚本是唯一入口，故同步范围与 v26.6.0 不同）。
- `torch_custom/fla_npu/setup.py`：`BUILD_EXCLUDE_LIST` 排除聚合单体与 Everything（`StructKernelNpuOpApi.cpp` / `OpInterface.cpp`），仅在存在分片文件时排除以兼容旧版单文件输出；另加 `realpath` 去重（对应 #397 的 `90db9c9`）。
- `cmake/variables.cmake`：`OP_TILING_INCLUDE` 增加 `${OPBASE_SOURCE_PATH}/pkg_inc` 与 `${OPBASE_SOURCE_PATH}/include`（对应 #397 的 `296b861` / #353 回迁）。
- `.gitignore`：忽略 torchnpugen 分片/聚合生成输出与根目录构建产物（对应 #397 的 `e75b3b4`）。

### 验证

- `bash -n` 通过（gen.sh / build.sh），`py_compile` 通过（setup.py）。
- 无换行符噪声：提交内仅实际内容变更（5 files, +73/-17）。