### PR TITLE
fix(kda): 修复 ChunkKdaFwd 变长尾块输出不确定

### DIFF
--- a/fla/ops/ascendc/kda/chunk_kda_fwd/docs/design.md
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/docs/design.md
@@ -54,6 +54,10 @@ w, u, kg, v_new_seed
 
 `Akk` 的 head 循环按 `H_v` 执行，GQA 映射只在读取 q/k head 时换算，避免按 `H_k` 重复或漏算。
 
+变长尾块中 `w_seed` 与 `w` 可复用同一段 GM。两个 AIV 按 K 维列区间独占写回，并从高行向低行
+处理，保证下三角计算依赖的源行在最后一次读取前不会被原位覆盖。`u_seed` 与 `u` 使用独立存储，
+仍按行区间并行。
+
 ### FwdH state propagation
 
 读取 `kg/w/u/gk` 和可选 `initial_state`，计算 chunk 间递推：

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_post_wu.h
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_post_wu.h
@@ -1491,7 +1491,7 @@ private:
     template <typename SrcTensor, typename DstTensor>
     __aicore__ inline void ComputeTailWuRow(GlobalTensor<SrcTensor> &src, GlobalTensor<DstTensor> &dst,
                                             uint64_t akkBase, uint64_t srcBase, uint64_t dstBase, uint64_t curT,
-                                            uint64_t dim)
+                                            uint64_t dim, uint64_t rowStride)
     {
         LocalTensor<float> acc = vecBuf_.Get<float>();
         LocalTensor<float> value = vecBuf_.Get<float>()[512];
@@ -1506,7 +1506,7 @@ private:
         SetFlag<HardEvent::V_S>(EXP2_EVENT_ID);
         WaitFlag<HardEvent::V_S>(EXP2_EVENT_ID);
         for (uint64_t j = 0; j < curT; ++j) {
-            LoadAsFloatVector(src, srcBase + j * dim, value, typed, dim);
+            LoadAsFloatVector(src, srcBase + j * rowStride, value, typed, dim);
             float coefficient = coefficients.GetValue(j);
             SetFlag<HardEvent::S_V>(EXP2_EVENT_ID);
             WaitFlag<HardEvent::S_V>(EXP2_EVENT_ID);
@@ -1530,15 +1530,24 @@ private:
     __aicore__ inline void ComputeTailWuVector(uint64_t b, uint64_t hv, uint64_t chunkIdx, uint64_t start,
                                                uint64_t curT, uint64_t subBlockIdx, uint64_t subBlockNum)
     {
+        // preparedQG_ and w_ alias. Each subblock owns disjoint columns and
+        // writes rows from last to first, so every lower-triangular source row
+        // remains live through its final use without desynchronizing the AIVs.
+        uint64_t colBegin = (K_ * subBlockIdx) / subBlockNum;
+        uint64_t colEnd = (K_ * (subBlockIdx + 1)) / subBlockNum;
+        for (uint64_t row = curT; row > 0; --row) {
+            uint64_t rowIdx = row - 1;
+            ComputeTailWuRow(
+                preparedQG_, w_, AOffset(b, hv, start + rowIdx, 0), KVOffset(b, hv, start, colBegin, K_),
+                KVOffset(b, hv, start + rowIdx, colBegin, K_), curT, colEnd - colBegin, K_);
+        }
+
         uint64_t rowBegin = (curT * subBlockIdx) / subBlockNum;
         uint64_t rowEnd = (curT * (subBlockIdx + 1)) / subBlockNum;
         for (uint64_t row = rowBegin; row < rowEnd; ++row) {
             ComputeTailWuRow(
-                preparedQG_, w_, AOffset(b, hv, start + row, 0), KVOffset(b, hv, start, 0, K_),
-                KVOffset(b, hv, start + row, 0, K_), curT, K_);
-            ComputeTailWuRow(
                 propagatedVNew_, u_, AOffset(b, hv, start + row, 0), KVOffset(b, hv, start, 0, V_),
-                KVOffset(b, hv, start + row, 0, V_), curT, V_);
+                KVOffset(b, hv, start + row, 0, V_), curT, V_, V_);
         }
     }
 #endif

--- a/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/chunk_kda_fwd_post_wu.h
+++ b/fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/chunk_kda_fwd_post_wu.h
@@ -710,7 +710,7 @@ private:
     template <typename SrcTensor, typename DstTensor>
     __aicore__ inline void ComputeTailWuRow(GlobalTensor<SrcTensor> &src, GlobalTensor<DstTensor> &dst,
                                             uint64_t akkBase, uint64_t srcBase, uint64_t dstBase, uint64_t curT,
-                                            uint64_t dim)
+                                            uint64_t dim, uint64_t rowStride)
     {
         LocalTensor<float> acc = vecBuf_.Get<float>();
         LocalTensor<float> value = vecBuf_.Get<float>()[512];
@@ -725,7 +725,7 @@ private:
         SetFlag<HardEvent::V_S>(EXP2_EVENT_ID);
         WaitFlag<HardEvent::V_S>(EXP2_EVENT_ID);
         for (uint64_t j = 0; j < curT; ++j) {
-            LoadAsFloatVector(src, srcBase + j * dim, value, typed, dim);
+            LoadAsFloatVector(src, srcBase + j * rowStride, value, typed, dim);
             float coefficient = coefficients.GetValue(j);
             SetFlag<HardEvent::S_V>(EXP2_EVENT_ID);
             WaitFlag<HardEvent::S_V>(EXP2_EVENT_ID);
@@ -749,15 +749,24 @@ private:
     __aicore__ inline void ComputeTailWuVector(uint64_t b, uint64_t hv, uint64_t start, uint64_t curT,
                                                uint64_t subBlockIdx, uint64_t subBlockNum)
     {
+        // preparedQG_ and w_ alias. Each subblock owns disjoint columns and
+        // writes rows from last to first, so every lower-triangular source row
+        // remains live through its final use without desynchronizing the AIVs.
+        uint64_t colBegin = (K_ * subBlockIdx) / subBlockNum;
+        uint64_t colEnd = (K_ * (subBlockIdx + 1)) / subBlockNum;
+        for (uint64_t row = curT; row > 0; --row) {
+            uint64_t rowIdx = row - 1;
+            ComputeTailWuRow(
+                preparedQG_, w_, AOffset(b, hv, start + rowIdx, 0), KVOffset(b, hv, start, colBegin, K_),
+                KVOffset(b, hv, start + rowIdx, colBegin, K_), curT, colEnd - colBegin, K_);
+        }
+
         uint64_t rowBegin = (curT * subBlockIdx) / subBlockNum;
         uint64_t rowEnd = (curT * (subBlockIdx + 1)) / subBlockNum;
         for (uint64_t row = rowBegin; row < rowEnd; ++row) {
             ComputeTailWuRow(
-                preparedQG_, w_, AOffset(b, hv, start + row, 0), KVOffset(b, hv, start, 0, K_),
-                KVOffset(b, hv, start + row, 0, K_), curT, K_);
-            ComputeTailWuRow(
                 propagatedVNew_, u_, AOffset(b, hv, start + row, 0), KVOffset(b, hv, start, 0, V_),
-                KVOffset(b, hv, start + row, 0, V_), curT, V_);
+                KVOffset(b, hv, start + row, 0, V_), curT, V_, V_);
         }
     }
 

--- a/tests/atk/chunk_kda_fwd/README.md
+++ b/tests/atk/chunk_kda_fwd/README.md
@@ -43,4 +43,13 @@ CASE_START=0 CASE_END=5 \
 bash tests/atk/run_test_cpu.sh -op=chunk_kda_fwd -npu_device_id=0 -scope=accuracy
 ```
 
+确定性回归会重复运行 MSS 用例并逐位比较全部可见输出。MSS 包含 #440 的 63-token 单序列
+尾块场景，通过 96 个 value heads 放大并行调度覆盖，同时启用 `disable_recompute=true`、最终状态
+和全部中间量：
+
+```bash
+DC_LOOP_NUMS=100 \
+bash tests/atk/run_test_cpu.sh -op=chunk_kda_fwd -npu_device_id=0 -scope=determinism
+```
+
 性能、确定性、mssanitizer 和用例生成均通过统一脚本的对应 `-scope` 执行。

--- a/tests/atk/chunk_kda_fwd/atk_chunk_kda_fwd_mss.json
+++ b/tests/atk/chunk_kda_fwd/atk_chunk_kda_fwd_mss.json
@@ -261,5 +261,268 @@
       }
     ],
     "save_name": "chunk_kda_fwd"
+  },
+  {
+    "id": 298,
+    "default_seed": 4,
+    "name": "chunk_kda_fwd",
+    "aclnn_name": "ChunkKdaFwd",
+    "version": "v2.1",
+    "api": "pytorch",
+    "api_type": "executor_chunk_kda_fwd",
+    "expected_error_msg": null,
+    "backward": false,
+    "standard": {
+      "acc": "mixed_tolerance_bm",
+      "perf": "not_key"
+    },
+    "outputs": null,
+    "inputs": [
+      {
+        "name": "low_precision_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "bf16",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "fp32_marker",
+        "type": "tensor",
+        "required": true,
+        "dtype": "fp32",
+        "shape": [
+          1
+        ],
+        "range_values": [
+          0,
+          0
+        ],
+        "backward": false
+      },
+      {
+        "name": "case_spec",
+        "type": "attr",
+        "required": true,
+        "dtype": "non_param",
+        "shape": null,
+        "range_values": "{\"B\":1,\"H\":2,\"HV\":96,\"K\":128,\"T\":63,\"V\":128,\"a_log_scale\":0.12,\"beta_bias\":1.5,\"beta_dtype\":\"fp32\",\"beta_scale\":0.35,\"case_key\":\"ascend910b_issue440_h2_hv96_t63_c64_single_tail_export\",\"chunk_size\":64,\"cu_seqlens\":\"0,63\",\"data_profile\":\"model_h96\",\"disable_recompute\":true,\"distribution\":\"single_tail\",\"dt_bias\":true,\"dt_bias_mean\":-3.0,\"dt_bias_scale\":1.65,\"explicit_chunk_indices\":false,\"g_dtype\":\"fp32\",\"gate_scale\":1.25,\"initial_state\":false,\"layout\":\"BSND\",\"lower_bound\":-5.0,\"optional_spec\":\"initial=False,final=True,varlen=True,disable_recompute=True\",\"output_final_state\":true,\"profile\":\"determinism_regression\",\"q_dtype\":\"bf16\",\"qk_scale\":0.05,\"return_intermediate_states\":true,\"route\":\"ascendc\",\"safe_gate\":true,\"scale\":0.08838834764831843,\"seed\":4,\"shape_spec\":\"B=1,H=2,HV=96,T=63,K=128,V=128\",\"soc\":\"ascend910b\",\"state_v_first\":false,\"tags\":\"accuracy,determinism,mssanitizer,regression,boundary,varlen,issue440\",\"use_gate_in_kernel\":true,\"v_scale\":0.05}",
+        "backward": false
+      },
+      {
+        "name": "soc",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascend910b",
+        "backward": false
+      },
+      {
+        "name": "route",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "ascendc",
+        "backward": false
+      },
+      {
+        "name": "batch",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 1,
+        "backward": false
+      },
+      {
+        "name": "head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 2,
+        "backward": false
+      },
+      {
+        "name": "value_head",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 96,
+        "backward": false
+      },
+      {
+        "name": "total_tokens",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 63,
+        "backward": false
+      },
+      {
+        "name": "key_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "value_dim",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 128,
+        "backward": false
+      },
+      {
+        "name": "chunk_size",
+        "type": "attr",
+        "required": true,
+        "dtype": "int",
+        "shape": null,
+        "range_values": 64,
+        "backward": false
+      },
+      {
+        "name": "layout",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "BSND",
+        "backward": false
+      },
+      {
+        "name": "q_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "bf16",
+        "backward": false
+      },
+      {
+        "name": "g_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "fp32",
+        "backward": false
+      },
+      {
+        "name": "beta_dtype",
+        "type": "attr",
+        "required": true,
+        "dtype": "string",
+        "shape": null,
+        "range_values": "fp32",
+        "backward": false
+      },
+      {
+        "name": "initial_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "output_final_state",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "varlen",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "safe_gate",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "lower_bound",
+        "type": "attr",
+        "required": true,
+        "dtype": "float",
+        "shape": null,
+        "range_values": -5.0,
+        "backward": false
+      },
+      {
+        "name": "use_gate_in_kernel",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "disable_recompute",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "return_intermediate_states",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": true,
+        "backward": false
+      },
+      {
+        "name": "state_v_first",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      },
+      {
+        "name": "negative_case",
+        "type": "attr",
+        "required": true,
+        "dtype": "bool",
+        "shape": null,
+        "range_values": false,
+        "backward": false
+      }
+    ],
+    "save_name": "chunk_kda_fwd"
   }
 ]

--- a/tests/atk/chunk_kda_fwd/chunk_kda_fwd.yaml
+++ b/tests/atk/chunk_kda_fwd/chunk_kda_fwd.yaml
@@ -107,7 +107,7 @@ inputs:
       values: [int]
     ranges:
       valid:
-        values: [128, 8192, 16384]
+        values: [63, 128, 8192, 16384]
       invalid:
         values: []
   - name: key_dim


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: Fixes #440
- 背景与目标: `ChunkKdaFwd` 的变长序列尾块路径在相同输入下可能产生 bitwise 不一致输出，需要消除 PostWU 阶段的跨 AIV 原地读写竞争，并补充对应回归覆盖。
- 本 PR 解决的问题: `preparedQG` 与 `w` 复用同一段 GM 时，原实现按行划分 AIV 任务，一个 AIV 提前写回的行仍可能被另一个 AIV 当作输入读取。本 PR 改为按 K 维列区间分工，并从高行向低行写回，使各 AIV 写区间互斥且源行保持到最后一次使用；同时新增全可见输出的尾块确定性回归。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: `chunk_kda_fwd`
- 涉及目录 / 文件:
  - `fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/chunk_kda_fwd_post_wu.h`
  - `fla/ops/ascendc/kda/chunk_kda_fwd/op_kernel/arch35/chunk_kda_fwd_post_wu.h`
  - `fla/ops/ascendc/kda/chunk_kda_fwd/docs/design.md`
  - `tests/atk/chunk_kda_fwd/README.md`
  - `tests/atk/chunk_kda_fwd/atk_chunk_kda_fwd_mss.json`
  - `tests/atk/chunk_kda_fwd/chunk_kda_fwd.yaml`
- 责任人 / 提交人: @weinachuan
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不变；修复现有 `chunk_kda_fwd` 变长序列尾块路径，不新增或收紧公开接口约束。
- 明确不包含的范围: 不修改 ABI、参数校验、InferShape、Tiling、aclnn/Python 接口语义；不处理 A5 `K=V=16` 尾块的既有超时，也不处理与 #440 无关的其他 KDA 问题。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无 ABI 或公开接口变化。

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
# 默认 CANN 安装路径；自定义安装路径时替换为实际路径下对应的 set_env.sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本: A2/A3 构建使用 CANN 9.1.0-beta.1；A5 构建与运行使用 CANN 9.1.0。
- 产品 / 芯片类型: A2、A5 已运行；A3 已交叉编译，运行验证待 CI。
- 机器或 CI 链接: A2/A5 实机验证已完成；GitHub NPU CI 待 PR 创建后触发。

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=chunk_kda_fwd --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=chunk_kda_fwd --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
FLA_NPU_SOC=ascend910b FLA_NPU_OPS=chunk_kda_fwd \
python -m pip wheel --no-build-isolation --no-deps . -w dist
FLA_NPU_SOC=ascend910_93 FLA_NPU_OPS=chunk_kda_fwd \
python -m pip wheel --no-build-isolation --no-deps . -w dist
FLA_NPU_SOC=ascend950 FLA_NPU_OPS=chunk_kda_fwd \
python -m pip wheel --no-build-isolation --no-deps . -w dist
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包，或 `dist/` 下生成对应 wheel
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

ATK 确定性验证:

```sh
DC_LOOP_NUMS=100 bash tests/atk/run_test_cpu.sh \
  -op=chunk_kda_fwd -npu_device_id=0 -soc=ascend950 -scope=determinism
```

A2 补充验证使用 #440 原始 shape、固定 seed、高 value-head 尾块、dense 和 64 对齐变长对照，对每个非空输出执行 raw-byte 比较，并检查 finite 与输入未改写。

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh chunk_kda_fwd
```

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | `bash build.sh --pkg --soc=ascend910b --ops=chunk_kda_fwd --vendor_name=fla_npu` | 未执行 | 当前无 CANN 8.5 验证环境，待 CI 补齐 |
| A3 | `ascend910_93` | 未执行 | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_kda_fwd --vendor_name=fla_npu` | 未执行 | 当前无 CANN 8.5 验证环境，待 CI 补齐 |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0-beta.1 | `FLA_NPU_SOC=ascend910b FLA_NPU_OPS=chunk_kda_fwd python -m pip wheel --no-build-isolation --no-deps . -w dist` | 通过 | 单算子 wheel 构建、隔离安装和入口加载通过 |
| A3 | `ascend910_93` | 9.1.0-beta.1 | `FLA_NPU_SOC=ascend910_93 FLA_NPU_OPS=chunk_kda_fwd python -m pip wheel --no-build-isolation --no-deps . -w dist` | 通过 | 单算子 wheel 交叉编译通过；运行待 CI |
| A5 | `ascend950` | 9.1.0 | `FLA_NPU_SOC=ascend950 FLA_NPU_OPS=chunk_kda_fwd python -m pip wheel --no-build-isolation --no-deps . -w dist` | 通过 | 单算子 wheel 构建、隔离安装和对象命中核验通过 |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | #440 原始 shape 与固定输入全输出确定性矩阵 | 通过 | 未修基线原始随机用例 20 轮有 2 轮漂移。A/B 定位阶段的目标补丁在原始用例 20/20、seed 4/11 各 100/100、短段压力 200/200 中均逐输出 bitwise 稳定；最终 PR head 的 T63 100 轮、原始 T2048 20 轮、dense 与 64 对齐变长各 20 轮均无漂移、non-finite 或输入改写 |
| A3 | `ascend910_93` | #440 原始复现与新增确定性回归 | 未执行 | 已完成交叉编译；运行验证待 GitHub NPU CI |
| A5 | `ascend950` | `DC_LOOP_NUMS=100 bash tests/atk/run_test_cpu.sh -op=chunk_kda_fwd -npu_device_id=0 -soc=ascend950 -scope=determinism` | 确定性通过；补充精度未通过 | 未修基线同 case 的 `w` 在后续 19/19 轮变化；修复后 100 轮 11 个输出全部 bitwise 稳定且 finite。补充 CPU golden 比较仅 `final_state` 未达标，但完全相同输入下 base/fix 的 `final_state` 逐字节相同，确认不是本补丁回退 |

- 精度对比: A2 的 K/V=16、48 边界完成 CPU FP64 补充对照，shape 与 finite 检查一致，不作为 ATK 精度通过结论。A5 新增 case 的 10/11 输出通过 `mixed_tolerance_bm`，仅 `final_state` matched ratio 为 0.82158（门限 0.99）；50 轮 `accuracy_lt` 均执行成功且仍仅该输出未达标，但固定 seed 实际重复同一输入，单标杆结果无法由 `ct dual analyze` 形成有效双标杆结论，因此不声明精度复检通过。
- 性能对比: 未执行；本 PR 不以性能优化为目标。
- 边界 / 异常场景: A2 已覆盖单尾块、原始多段变长、短段压力、dense、64 对齐变长、K/V=16/48 和 `disable_recompute` true/false。A5 已覆盖 K/V=128 单尾块；A5 K=V=16 在 base/fix 上均出现既有超时，本 PR 不作通过声明。
- 未覆盖风险: A2 ATK 正式入口因版本门槛未执行；A3 实机、CANN 8.5、A5 全量 accuracy、K48、Example/ST、性能及 sanitizer 尚未完成。当前产物不是已确认命中的 sanitizer debug 对象，不作 racecheck 阴性结论。

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | PR 创建后触发 GitHub NPU CI |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | PR 创建后触发 GitHub NPU CI |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | PR 创建后触发 GitHub NPU CI |

- 端到端场景说明: 按 `ci/example_st_cases.json` 执行仓库启用的 Example/ST 场景。
- 与本 PR 修改算子的关联: 确认 GDN/KDA 端到端调用链、打包和运行时未受影响。
- 未覆盖原因及补充计划: 当前完成单算子构建与针对性回归；PR 创建后触发 NPU CI 补齐 A2/A3/A5 Example ST。

</details>

## 兼容性、风险与回退

- 兼容性说明: 不改变输入输出、shape、dtype、layout、属性、返回值或 ABI；仅修正 generic/arch35 PostWU 尾块内部任务划分和写回顺序。
- 风险点: 尾块任务从按行分工改为 W 按列分工、逆序写回；A3 实机和完整性能尚待 CI。A5 K=V=16 的既有超时与补充 final_state 精度差距不在本 PR 处理范围内，均未作为通过项。
- 回退方案: 如出现阻塞性回归，回退本 PR 的 kernel、测试和文档提交，恢复原尾块实现，并保留 #440 继续定位。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 重点检视 PostWU 尾块中 `preparedQG` 与 `w` 复用同一 GM 区域时的生命周期，以及按 K 维切分、逆序行写回是否完整覆盖全部元素。
- 当前 CANN 9.1 的 `DataCopyPad` 契约支持 UB 到 GM 的非 32B 有效长度搬运；GM 地址按字节对齐，UB 侧补读的 dummy 不写入 GM。
- sanitizer 尚未执行；只有在 debug 对象包含 sanitizer 符号且运行日志实际命中目标 kernel 后，才会报告 racecheck 结果。
