### PR TITLE
perf: optimize recurrent gated delta rule on A5

### DIFF
--- a/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.cpp
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.cpp
@@ -45,6 +45,7 @@ void RecurrentGatedDeltaRuleTiling::InitCompileInfo()
     const auto &ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
     ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, compileInfo_.ubSize);
     compileInfo_.aivNum = ascendcPlatform.GetCoreNumAiv();
+    compileInfo_.isRegBase = (ascendcPlatform.GetCurNpuArch() == NpuArch::DAV_3510);
 
     if (compileInfo_.aivNum <= 0) {
         OP_LOGE(context_->GetNodeName(), "aivNum <= 0");
@@ -66,6 +67,7 @@ RecurrentGatedDeltaRuleTilingContext RecurrentGatedDeltaRuleTiling::BuildProcess
     ctx.ssmStateShape = &context_->GetInputShape(SSM_STATE_INDICES_INDEX)->GetOriginShape();
     ctx.aivNum = compileInfo_.aivNum;
     ctx.ubSize = compileInfo_.ubSize;
+    ctx.isRegBase = compileInfo_.isRegBase;
     ctx.stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
     ctx.scale = tilingData_.scale;
     ctx.hasGama = tilingData_.hasGama;

--- a/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.h
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.h
@@ -26,6 +26,7 @@ using namespace RecurrentGatedDeltaRule;
 struct RecurrentGatedDeltaRuleCompileInfo {
     uint64_t aivNum{0UL};
     uint64_t ubSize{0UL};
+    bool isRegBase{false};
 };
 
 struct RecurrentGatedDeltaRuleInfo {

--- a/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling_processor.h
@@ -44,6 +44,8 @@ static constexpr size_t RGDR_DIM_3 = 3;
 static constexpr size_t RGDR_MAX_MTP = 8;
 static constexpr size_t RGDR_SYS_WORKSPACE_SIZE = 16U * 1024U * 1024U;
 static constexpr uint32_t RGDR_REQUIRED_DIM = 128;
+static constexpr int64_t RGDR_UB_BLOCK_BYTES = 32;
+static constexpr int64_t RGDR_UB_SAFETY_BYTES = 128;
 
 struct RecurrentGatedDeltaRuleTilingContext {
     const char *nodeName = "RecurrentGatedDeltaRule";
@@ -61,6 +63,7 @@ struct RecurrentGatedDeltaRuleTilingContext {
     ge::DataType stateDtype = ge::DT_BF16;
     uint64_t aivNum = 0;
     uint64_t ubSize = 0;
+    bool isRegBase = false;
 };
 
 class RecurrentGatedDeltaRuleTilingProcessor {
@@ -274,32 +277,57 @@ private:
 
     int64_t CalcFixedUbBytes(int64_t aNv, int64_t aDv, int64_t aDk, const RecurrentGatedDeltaRuleTilingData &tiling) const
     {
+        (void)aNv;
+        // Persistent MTE2 banks: BF16 Q/K/V and beta, plus the enabled FP32 gate banks.
         int64_t usedUbBytes = RGDR_MAX_MTP * (4 * aDk + 2 * aDv);
-        usedUbBytes += 128;
+        usedUbBytes += RGDR_UB_SAFETY_BYTES;
         if (tiling.hasGamaK) {
             usedUbBytes += RGDR_MAX_MTP * 4 * aDk;
         }
         if (tiling.hasGama) {
-            usedUbBytes += RGDR_MAX_MTP * 4 * aNv;
+            usedUbBytes += RGDR_MAX_MTP * 4 * static_cast<int64_t>(tiling.nv);
         }
-        usedUbBytes += RGDR_MAX_MTP * 2 * aNv;
+        const int64_t betaBytes = RGDR_MAX_MTP * 2 * static_cast<int64_t>(tiling.nv);
+        usedUbBytes += Ops::Base::CeilAlign(betaBytes, RGDR_UB_BLOCK_BYTES);
         return usedUbBytes;
+    }
+
+    int64_t CalcLegacyTmpFixedBytes(int64_t aDv, int64_t aDk,
+                                    const RecurrentGatedDeltaRuleTilingData &tiling) const
+    {
+        const int64_t scalarMirrorElements =
+            Ops::Base::CeilAlign(static_cast<int64_t>(RGDR_MAX_MTP) * static_cast<int64_t>(tiling.nv),
+                                 static_cast<int64_t>(16));
+        // FP32 Q/K/V mirrors plus the beta scalar mirror used by the A2/A3 kernel. The former arch35
+        // implementation also created a gamma mirror, but DAV_3510 now takes the RegBase branch above.
+        return RGDR_MAX_MTP * (8 * aDk + 4 * aDv) + 4 * scalarMirrorElements;
     }
 
     int64_t CalcWorkingUbBytes(int64_t aNv, int64_t aDv, int64_t aDk,
                                const RecurrentGatedDeltaRuleTilingData &tiling) const
     {
         int64_t usedUbBytes = CalcFixedUbBytes(aNv, aDv, aDk, tiling);
-        usedUbBytes += RGDR_MAX_MTP * (8 * aDk + 4 * aDv + 4 * aNv);
+        if (!ctx_.isRegBase) {
+            usedUbBytes += CalcLegacyTmpFixedBytes(aDv, aDk, tiling);
+        }
+        // RegBase consumes raw inputs directly, so it has no fixed FP32 mirrors in tmpBuffer.
         return usedUbBytes;
+    }
+
+    int64_t CalcTmpVStepCoeff(int64_t aDk) const
+    {
+        if (ctx_.isRegBase) {
+            return 4 * aDk; // FP32 recurrence bank only.
+        }
+        return 8 * aDk + 8; // FP32 state, K-wide product scratch, delta and attention vectors.
     }
 
     int64_t CalcVStepCoeff(int64_t aDk, uint32_t stateOutBufferNum, uint32_t attnOutBufferNum) const
     {
         int64_t stateDtypeSize = (ctx_.stateDtype == ge::DT_FLOAT) ? 4 : 2;
         int64_t coeff = (stateDtypeSize + static_cast<int64_t>(stateDtypeSize * stateOutBufferNum)) * aDk +
-                        static_cast<int64_t>(4 * attnOutBufferNum);
-        coeff += (4 + 4) * aDk + 4 + 4;
+                        static_cast<int64_t>(2 * attnOutBufferNum);
+        coeff += CalcTmpVStepCoeff(aDk);
         return coeff;
     }
 
@@ -377,10 +405,19 @@ private:
 
         int64_t stateDtypeSize = (ctx_.stateDtype == ge::DT_FLOAT) ? 4 : 2;
         int64_t queueCoeff = (stateDtypeSize + static_cast<int64_t>(stateDtypeSize * selected.stateOutBufferNum)) * aDk +
-                             static_cast<int64_t>(4 * selected.attnOutBufferNum);
+                             static_cast<int64_t>(2 * selected.attnOutBufferNum);
         int64_t ubRestBytes = ubSize - ubCalcCtx.fixedUbBytes - queueCoeff * static_cast<int64_t>(selected.vStep);
         if (ubRestBytes < 0) {
             OP_LOGE(ctx_.nodeName, "ubRestBytes should be non-negative, but got %ld", ubRestBytes);
+            return ge::GRAPH_FAILED;
+        }
+        const int64_t tmpFixedBytes = ubCalcCtx.workingUbBytes - ubCalcCtx.fixedUbBytes;
+        const int64_t requiredTmpBytes =
+            tmpFixedBytes + CalcTmpVStepCoeff(aDk) * static_cast<int64_t>(selected.vStep);
+        if (ubRestBytes < requiredTmpBytes) {
+            OP_LOGE(ctx_.nodeName,
+                    "ubRestBytes [%ld] is smaller than required tmpBuffer [%ld] for vStep [%u], regbase [%d]",
+                    ubRestBytes, requiredTmpBytes, selected.vStep, ctx_.isRegBase);
             return ge::GRAPH_FAILED;
         }
         tiling.ubCalSize = static_cast<uint32_t>(ctx_.ubSize);

--- a/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_kernel/arch35/recurrent_gated_delta_rule.h
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_kernel/arch35/recurrent_gated_delta_rule.h
@@ -9,7 +9,7 @@
 
 /*!
  * \file recurrent_gated_delta_rule.h
- * \brief
+ * \brief Ascend 950 RegBase implementation.
  */
 
 #ifndef __RECURRENT_GATED_DELTA_RULE_KERNEL_H_
@@ -18,29 +18,18 @@
 #include "kernel_operator.h"
 #include "lib/matmul_intf.h"
 #include "../recurrent_gated_delta_rule_tiling_data.h"
+#include "recurrent_gated_delta_rule_regbase.h"
 
 namespace RecurrentGatedDeltaRule {
 
 using namespace matmul;
 using namespace AscendC;
-using namespace AscendC::MicroAPI;
-constexpr uint64_t BUFFER_NUM = 1;
+
+constexpr uint32_t BUFFER_NUM = 1;
 constexpr uint32_t MAX_OUT_BUFFER_NUM = 2;
-constexpr uint64_t MAX_MTP = 8;
-constexpr uint64_t BF16_NUM_PER_BLOCK = 16;
-constexpr uint64_t FP32_NUM_PER_BLOCK = 8;
-constexpr uint32_t REPEAT_LENTH = 64; // 256Byte for float
-constexpr uint32_t MAX_REPEAT_TIME = 255;
-constexpr uint32_t ADD_FOLD_REDUCE_MIN_K = 128;
-constexpr uint16_t V_LENGTH = VECTOR_REG_WIDTH / sizeof(float);
-constexpr uint16_t TWO_V_LENGTH = 2 * V_LENGTH;
+constexpr uint32_t MAX_MTP = 8;
+constexpr uint32_t BF16_NUM_PER_BLOCK = 16;
 
-constexpr CastTrait castTraitB16ToB32 = {
-    RegLayout::ZERO, SatMode::UNKNOWN, MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
-
-#ifndef RGDR_ENABLE_ADD_FOLD_REDUCE
-#define RGDR_ENABLE_ADD_FOLD_REDUCE  1
-#endif
 struct RGDRInitParams {
     GM_ADDR query;
     GM_ADDR key;
@@ -74,22 +63,23 @@ public:
         hasAcceptedTokens_ = (tilingData->hasAcceptedTokens == 1);
         hasGama_ = (tilingData->hasGama == 1);
         hasGamaK_ = (tilingData->hasGamaK == 1);
-        useAddFoldReduce_ = (RGDR_ENABLE_ADD_FOLD_REDUCE != 0);
         vStep_ = tilingData->vStep;
-        stateOutBufferNum_ = (tilingData->stateOutBufferNum == MAX_OUT_BUFFER_NUM) ? MAX_OUT_BUFFER_NUM : BUFFER_NUM;
-        attnOutBufferNum_ = (tilingData->attnOutBufferNum == MAX_OUT_BUFFER_NUM) ? MAX_OUT_BUFFER_NUM : BUFFER_NUM;
+        stateOutBufferNum_ =
+            (tilingData->stateOutBufferNum == MAX_OUT_BUFFER_NUM) ? MAX_OUT_BUFFER_NUM : BUFFER_NUM;
+        attnOutBufferNum_ =
+            (tilingData->attnOutBufferNum == MAX_OUT_BUFFER_NUM) ? MAX_OUT_BUFFER_NUM : BUFFER_NUM;
         restUbSize_ = tilingData->ubRestBytes;
         alignK_ = Ceil(tilingData->dk, BF16_NUM_PER_BLOCK) * BF16_NUM_PER_BLOCK;
         alignV_ = Ceil(tilingData->dv, BF16_NUM_PER_BLOCK) * BF16_NUM_PER_BLOCK;
-        load = 0;
-        usedblk = 0;
+        load_ = 0;
+        usedBlock_ = 0;
     }
 
     __aicore__ inline void Init(const RGDRInitParams &initParams, TPipe *pipe)
     {
-        uint64_t blockDim = GetBlockNum();
-        blockIdx = GetBlockIdx();
-        if (blockIdx >= blockDim) {
+        const uint64_t blockDim = GetBlockNum();
+        blockIdx_ = GetBlockIdx();
+        if (blockIdx_ >= blockDim) {
             return;
         }
         pipe_ = pipe;
@@ -97,6 +87,51 @@ public:
         InitLocalBuffers();
     }
 
+    __aicore__ inline void Process()
+    {
+        ComputeAvgLoad();
+        int32_t seq1 = cuSeqlensGm_.GetValue(0);
+        for (uint64_t batch = 0; batch < B_; ++batch) {
+            const int32_t seqLen = cuSeqlensGm_.GetValue(batch + 1);
+            if (seqLen <= 0) {
+                continue;
+            }
+            if (seqLen > static_cast<int32_t>(MAX_MTP)) {
+                return;
+            }
+            if (seq1 < 0 || seq1 > static_cast<int32_t>(T_) || (seq1 + seqLen) > static_cast<int32_t>(T_)) {
+                return;
+            }
+            const int32_t seq0 = seq1;
+            seq1 += seqLen;
+            uint32_t localHeadCount = 0;
+            uint64_t stateOffset = 0;
+            for (uint64_t head = 0; head < NV_; ++head) {
+                if (!IsCurrentBlock(seqLen)) {
+                    continue;
+                }
+                ++localHeadCount;
+                if (localHeadCount == 1) {
+                    int32_t stateTokenIdx = seq0;
+                    if (hasAcceptedTokens_) {
+                        const int32_t acceptedTokenNum = numAcceptedTokensGm_.GetValue(batch);
+                        if (acceptedTokenNum <= 0 || acceptedTokenNum > seqLen) {
+                            return;
+                        }
+                        stateTokenIdx = seq0 + acceptedTokenNum - 1;
+                    }
+                    stateOffset = ssmStateIndicesGm_.GetValue(stateTokenIdx);
+                    CopyInGamaBeta(seq0, seq1);
+                }
+                ProcessHead(seq0, seq1, head, stateOffset);
+            }
+            if (localHeadCount > 0) {
+                ReleaseGamaBeta();
+            }
+        }
+    }
+
+private:
     __aicore__ inline void SetGlobalTensors(const RGDRInitParams &initParams)
     {
         queryGm_.SetGlobalBuffer((__gm__ inType *)initParams.query);
@@ -115,12 +150,6 @@ public:
 
     __aicore__ inline void InitLocalBuffers()
     {
-        uint32_t cubeSize = alignK_ * vStep_ * sizeof(float);
-        uint32_t singleVSize = vStep_ * sizeof(float);
-        uint32_t vSize = MAX_MTP * alignV_ * sizeof(float);
-        uint32_t kSize = MAX_MTP * alignK_ * sizeof(float);
-        uint32_t betaNumAlign = Ceil(MAX_MTP * NV_, BF16_NUM_PER_BLOCK) * BF16_NUM_PER_BLOCK;
-        uint32_t betaUbSize = betaNumAlign * sizeof(float); //  8: 8 * 4 = 32B;
         pipe_->InitBuffer(qInQueue_, BUFFER_NUM, MAX_MTP * alignK_ * sizeof(inType));
         pipe_->InitBuffer(kInQueue_, BUFFER_NUM, MAX_MTP * alignK_ * sizeof(inType));
         pipe_->InitBuffer(vInQueue_, BUFFER_NUM, MAX_MTP * alignV_ * sizeof(inType));
@@ -131,489 +160,279 @@ public:
         if (hasGamaK_) {
             pipe_->InitBuffer(gamaKInQueue_, BUFFER_NUM, MAX_MTP * alignK_ * sizeof(float));
         }
-        pipe_->InitBuffer(betaInQueue_, BUFFER_NUM, MAX_MTP * NV_ * sizeof(inType));
+        const uint32_t betaElements = Ceil(MAX_MTP * NV_, BF16_NUM_PER_BLOCK) * BF16_NUM_PER_BLOCK;
+        pipe_->InitBuffer(betaInQueue_, BUFFER_NUM, betaElements * sizeof(inType));
         pipe_->InitBuffer(stateOutQueue_, stateOutBufferNum_, alignK_ * vStep_ * sizeof(stateType));
         pipe_->InitBuffer(attnOutQueue_, attnOutBufferNum_, vStep_ * sizeof(outType));
-        pipe_->InitBuffer(tmpBuff, restUbSize_);
-        uint32_t buffOffset = 0;
-        deltaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(vStep_), buffOffset);
-        buffOffset += singleVSize;
-        attnInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(vStep_), buffOffset);
-        buffOffset += singleVSize;
-        vInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignV_), buffOffset);
-        buffOffset += vSize;
-        qInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignK_), buffOffset);
-        buffOffset += kSize;
-        kInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignK_), buffOffset);
-        buffOffset += kSize;
-        stateInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
-        buffOffset += cubeSize;
-        broadTmpInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
-        buffOffset += cubeSize;
-        betaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(betaNumAlign), buffOffset);
-        buffOffset += betaUbSize;
-        gamaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(betaNumAlign), buffOffset);
+        pipe_->InitBuffer(tmpBuffer_, restUbSize_);
+        recurrentStateUb_ = tmpBuffer_.Get<float>();
     }
 
-    __aicore__ inline void ComputeAvgload()
+    __aicore__ inline void ComputeAvgLoad()
     {
         uint64_t realT = 0;
-        for (uint64_t batch_i = 1; batch_i < B_ + 1; batch_i++) {
-            realT += cuSeqlensGm_.GetValue(batch_i);
+        for (uint64_t batch = 1; batch < B_ + 1; ++batch) {
+            realT += cuSeqlensGm_.GetValue(batch);
         }
-        avgload = Ceil(realT * NV_, GetBlockNum());
+        avgLoad_ = Ceil(realT * NV_, GetBlockNum());
     }
 
-    __aicore__ inline void Process()
+    __aicore__ inline bool IsCurrentBlock(int32_t seqLen)
     {
-        ComputeAvgload();
-        int32_t seq1 = cuSeqlensGm_.GetValue(0);
-        for (uint64_t batch_i = 0; batch_i < B_; batch_i++) {
-            int32_t seqLen = cuSeqlensGm_.GetValue(batch_i+1);
-            if (seqLen <= 0) {
-                continue;
-            }
-            if (seqLen > static_cast<int32_t>(MAX_MTP)) {
-                return;
-            }
-            if (seq1 < 0 || seq1 > static_cast<int32_t>(T_) || (seq1 + seqLen) > static_cast<int32_t>(T_)) {
-                return;
-            }
-            int32_t seq0 = seq1;
-            seq1 += seqLen;
-            uint32_t copyFlag = 0;
-            uint64_t stateOffset;
-            for (uint64_t head_i = 0; head_i < NV_; head_i++) {
-                if (!IsCurrentBlock(seq1 - seq0)) {
-                    continue;
-                }
-                copyFlag++;
-                if (copyFlag == 1) {
-                    int32_t stateTokenIdx = seq0;
-                    if (hasAcceptedTokens_) {
-                        int32_t acceptedTokenNum = numAcceptedTokensGm_.GetValue(batch_i);
-                        if (acceptedTokenNum <= 0 || acceptedTokenNum > seqLen) {
-                            return;
-                        }
-                        stateTokenIdx = seq0 + acceptedTokenNum - 1;
-                    }
-                    stateOffset = ssmStateIndicesGm_.GetValue(stateTokenIdx);
-                    CopyInGamaBeta(seq0, seq1);
-                }
-                ProcessHead(seq0, seq1, head_i, stateOffset);
-            }
+        load_ += seqLen;
+        const bool current = (blockIdx_ == usedBlock_ && seqLen > 0);
+        if (load_ >= avgLoad_) {
+            load_ = 0;
+            ++usedBlock_;
         }
-    }
-
-private:
-    __aicore__ inline void CopyInQKV(uint64_t vOffset, uint64_t qkOffset, int32_t seqLen)
-    {
-        LocalTensor<inType> qLocal = qInQueue_.AllocTensor<inType>();
-        LocalTensor<inType> kLocal = kInQueue_.AllocTensor<inType>();
-        LocalTensor<inType> vLocal = vInQueue_.AllocTensor<inType>();
-        DataCopyExtParams qkInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
-                                     static_cast<uint32_t>((NK_ - 1) * realK_ * sizeof(inType)), 0, 0};
-        DataCopyExtParams vInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realV_ * sizeof(inType)),
-                                    static_cast<uint32_t>((NV_ - 1) * realV_ * sizeof(inType)), 0, 0};
-        DataCopyPadExtParams<inType> qkPadParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
-        DataCopyPadExtParams<inType> vPadParams{true, 0, static_cast<uint8_t>(alignV_ - realV_), 0};
-        if (hasGamaK_) {
-            uint32_t alignKGamma = Ceil(realK_, FP32_NUM_PER_BLOCK) * FP32_NUM_PER_BLOCK;
-            uint32_t stride = alignKGamma < alignK_ ? 1 : 0;
-            DataCopyExtParams gkInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(float)),
-                                     static_cast<uint32_t>((NV_ - 1) * realK_ * sizeof(float)), stride, 0};
-            DataCopyPadExtParams<float> gkPadParams{true, 0, static_cast<uint8_t>(alignKGamma - realK_), 0};
-            LocalTensor<float> gamaKLocal = gamaKInQueue_.AllocTensor<float>();
-            Duplicate<float>(gamaKLocal, 0, alignK_ * seqLen);
-            TEventID evevtIdVtoMte2 = GetTPipePtr()->FetchEventID(HardEvent::V_MTE2);
-            SetFlag<HardEvent::V_MTE2>(evevtIdVtoMte2);
-            WaitFlag<HardEvent::V_MTE2>(evevtIdVtoMte2);
-            DataCopyPad(gamaKLocal, gamaKGm_[vOffset / realV_ * realK_], gkInParams, gkPadParams);
-            gamaKInQueue_.EnQue<float>(gamaKLocal);
-            gamaKInUb = gamaKInQueue_.DeQue<float>();
-            ExpMasked(gamaKInUb, gamaKInUb, alignK_ * seqLen);
-            AscendC::PipeBarrier<PIPE_V>();
-        }
-        DataCopyPad(qLocal, queryGm_[qkOffset], qkInParams, qkPadParams);
-        DataCopyPad(kLocal, keyGm_[qkOffset], qkInParams, qkPadParams);
-        DataCopyPad(vLocal, valueGm_[vOffset], vInParams, vPadParams);
-        qInQueue_.EnQue<inType>(qLocal);
-        kInQueue_.EnQue<inType>(kLocal);
-        vInQueue_.EnQue<inType>(vLocal);
-        qLocal = qInQueue_.DeQue<inType>();
-        kLocal = kInQueue_.DeQue<inType>();
-        vLocal = vInQueue_.DeQue<inType>();
-        Cast(qInUb, qLocal, AscendC::RoundMode::CAST_NONE, alignK_ * seqLen);
-        Cast(kInUb, kLocal, AscendC::RoundMode::CAST_NONE, alignK_ * seqLen);
-        Cast(vInUb, vLocal, AscendC::RoundMode::CAST_NONE, alignV_ * seqLen);
-        AscendC::PipeBarrier<PIPE_V>();
-        Muls(qInUb, qInUb, scale_, seqLen * alignK_);
-        qInQueue_.FreeTensor(qLocal);
-        kInQueue_.FreeTensor(kLocal);
-        vInQueue_.FreeTensor(vLocal);
-    }
-
-    __aicore__ inline void PrefetchState(uint64_t stateOffest, uint32_t curSingleV)
-    {
-        LocalTensor<stateType> stateLocal = stateInQueue_.AllocTensor<stateType>();
-        DataCopyExtParams stateInParams{static_cast<uint16_t>(curSingleV),
-                                        static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0, 0};
-        DataCopyPadExtParams<stateType> padParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
-        DataCopyPad(stateLocal, initStateGm_[stateOffest], stateInParams, padParams);
-        stateInQueue_.EnQue<stateType>(stateLocal);
-    }
-
-    __aicore__ inline void LoadPrefetchedState(uint32_t curSingleV)
-    {
-        LocalTensor<stateType> stateLocal = stateInQueue_.DeQue<stateType>();
-        if constexpr (std::is_same<stateType, float32_t>()) {
-            DataCopy(stateInUb, stateLocal, alignK_ * curSingleV);
-        } else {
-            Cast(stateInUb, stateLocal, AscendC::RoundMode::CAST_NONE, alignK_ * curSingleV);
-        }
-        stateInQueue_.FreeTensor(stateLocal);
-    }
-
-    __aicore__ inline void MatVecMul(const LocalTensor<float> &cubeTensor, const LocalTensor<float> &vecTensor,
-                                          LocalTensor<float> &dstTensor, uint32_t rows)
-    {
-        __ubuf__ float* cubeAddr = (__ubuf__ float*)cubeTensor.GetPhyAddr();
-        __ubuf__ float* vecAddr = (__ubuf__ float*)vecTensor.GetPhyAddr();
-        __ubuf__ float* dstAddr = (__ubuf__ float*)dstTensor.GetPhyAddr();
-
-        uint16_t rowNum = static_cast<uint16_t>(rows);
-        uint16_t colLoopTimes = static_cast<uint16_t>(Ceil(alignK_, V_LENGTH));
-        uint32_t colLength = alignK_;
-        __VEC_SCOPE__
-        {
-            RegTensor<float> cube;
-            RegTensor<float> vec;
-            RegTensor<float> dst;
-            MaskReg pregLoop;
-            for (uint16_t j = 0; j < colLoopTimes; j++) {
-                pregLoop = UpdateMask<float>(colLength);
-                DataCopy(vec, vecAddr + j * V_LENGTH);
-                for (uint16_t i = 0; i < rowNum; i ++) {
-                    DataCopy(cube, cubeAddr + i * alignK_ + j * V_LENGTH);
-                    Mul(dst, cube, vec, pregLoop);
-                    DataCopy(dstAddr + i * alignK_ + j * V_LENGTH, dst, pregLoop);
-                }
-            }
-        }
-    }
-
-    __aicore__ inline void ProcessKQ(const LocalTensor<float> &cubeTensor, const LocalTensor<float> &vec1Tensor,
-                                          LocalTensor<float> &dst1Tensor, const LocalTensor<float> &vec2Tensor,
-                                          LocalTensor<float> &dst2Tensor, uint32_t rows)
-    {
-        __ubuf__ float* cubeAddr = (__ubuf__ float*)cubeTensor.GetPhyAddr();
-        __ubuf__ float* vec1Addr = (__ubuf__ float*)vec1Tensor.GetPhyAddr();
-        __ubuf__ float* vec2Addr = (__ubuf__ float*)vec2Tensor.GetPhyAddr();
-        __ubuf__ float* dst1Addr = (__ubuf__ float*)dst1Tensor.GetPhyAddr();
-        __ubuf__ float* dst2Addr = (__ubuf__ float*)dst2Tensor.GetPhyAddr();
-
-        uint16_t rowNum = static_cast<uint16_t>(rows);
-        uint16_t colLoopTimes = static_cast<uint16_t>(Ceil(alignK_, V_LENGTH));
-        uint32_t colLength = alignK_;
-        __VEC_SCOPE__
-        {
-            RegTensor<float> cube;
-            RegTensor<float> vec1;
-            RegTensor<float> vec2;
-            RegTensor<float> dst1;
-            RegTensor<float> dst2;
-            MaskReg pregLoop;
-            for (uint16_t j = 0; j < colLoopTimes; j++) {
-                pregLoop = UpdateMask<float>(colLength);
-                DataCopy(vec1, vec1Addr + j * V_LENGTH);
-                DataCopy(vec2, vec2Addr + j * V_LENGTH);
-                for (uint16_t i = 0; i < rowNum; i ++) {
-                    DataCopy<float, LoadDist::DIST_BRC_B32>(cube, cubeAddr + i);
-                    DataCopy(dst1, dst1Addr + i * alignK_ + j * V_LENGTH);
-                    Mul(cube, cube, vec1, pregLoop);
-                    Add(dst1, dst1, cube, pregLoop);
-                    Mul(dst2, dst1, vec2, pregLoop);
-                    DataCopy(dst1Addr + i * alignK_ + j * V_LENGTH, dst1, pregLoop);
-                    DataCopy(dst2Addr + i * alignK_ + j * V_LENGTH, dst2, pregLoop);
-                }
-            }
-        }
-    }
-
-    __aicore__ inline void ReduceSum64(__ubuf__ float* dstAddr, __ubuf__ float* srcAddr, uint16_t rowNum)
-    {
-        uint32_t colLength = alignK_;
-        __VEC_SCOPE__
-        {
-            RegTensor<float> src;
-            RegTensor<float> sum;
-            MaskReg pregLoop = UpdateMask<float>(colLength);
-            for (uint16_t i = 0;i < rowNum;i ++) {
-                DataCopy(src, srcAddr + i * alignK_);
-                ReduceSum(sum, src, pregLoop);
-                DataCopy<float, StoreDist::DIST_FIRST_ELEMENT_B32>(dstAddr + i, sum, pregLoop);
-            }
-        }
-    }
-
-    __aicore__ inline void ReduceSum128(__ubuf__ float* dstAddr, __ubuf__ float* srcAddr, uint16_t rowNum)
-    {
-        uint32_t colLength = alignK_ - V_LENGTH;
-        __VEC_SCOPE__
-        {
-            RegTensor<float> src1;
-            RegTensor<float> src2;
-            RegTensor<float> sum;
-            MaskReg pregFull = CreateMask<float, MaskPattern::ALL>();
-            MaskReg pregLoop = UpdateMask<float>(colLength);
-            for (uint16_t i = 0;i < rowNum;i ++) {
-                DataCopy(src1, srcAddr + i * alignK_);
-                DataCopy(src2, srcAddr + i * alignK_ + V_LENGTH);
-                Add<float, MaskMergeMode::MERGING>(src1, src1, src2, pregLoop);
-                ReduceSum(sum, src1, pregFull);
-                DataCopy<float, StoreDist::DIST_FIRST_ELEMENT_B32>(dstAddr + i, sum, pregFull);
-            }
-        }
-    }
-
-    __aicore__ inline void ReduceSumVF(__ubuf__ float* dstAddr, __ubuf__ float* srcAddr, uint16_t rowNum)
-    {
-        uint16_t colLoopTimes = static_cast<uint16_t>(Ceil(alignK_, V_LENGTH));
-        __VEC_SCOPE__
-        {
-            RegTensor<float> src;
-            RegTensor<float> tmp;
-            RegTensor<float> sum;
-            MaskReg pregFull = CreateMask<float, MaskPattern::ALL>();
-            MaskReg pregLoop;
-            for (uint16_t i = 0;i < rowNum;i ++) {
-                uint32_t colLength = alignK_;
-                Duplicate(tmp, 0.0f);
-                for (uint16_t j = 0; j < colLoopTimes; j++) {
-                    pregLoop = UpdateMask<float>(colLength);
-                    DataCopy(src, srcAddr + i * alignK_ + j * V_LENGTH);
-                    Add<float, MaskMergeMode::MERGING>(tmp, tmp, src, pregLoop);
-                }
-                ReduceSum(sum, tmp, pregFull);
-                DataCopy<float, StoreDist::DIST_FIRST_ELEMENT_B32>(dstAddr + i, sum, pregFull);
-            }
-        }
-    }
-
-    __aicore__ inline void ReduceSumDispatch(LocalTensor<float> &dstTensor, LocalTensor<float> &srcTensor,
-                                             uint32_t rows)
-    {
-        __ubuf__ float* srcAddr = (__ubuf__ float*)srcTensor.GetPhyAddr();
-        __ubuf__ float* dstAddr = (__ubuf__ float*)dstTensor.GetPhyAddr();
-        uint16_t rowNum = static_cast<uint16_t>(rows);
-        if (alignK_ <= V_LENGTH) {
-            ReduceSum64(dstAddr, srcAddr, rowNum);
-        } else if (alignK_ <= TWO_V_LENGTH) {
-            ReduceSum128(dstAddr, srcAddr, rowNum);
-        } else {
-            ReduceSumVF(dstAddr, srcAddr, rowNum);
-        }
-    }
-
-    __aicore__ inline void SubMasked(LocalTensor<float> &dstTensor, const LocalTensor<float> &src0Tensor,
-                                    const LocalTensor<float> &src1Tensor, uint32_t count)
-    {
-        BinaryRepeatParams repeatParams{1, 1, 1, FP32_NUM_PER_BLOCK, FP32_NUM_PER_BLOCK, FP32_NUM_PER_BLOCK};
-        uint8_t repeatTime = static_cast<uint8_t>(count / V_LENGTH);
-        uint32_t tailCount = count % V_LENGTH;
-        if (repeatTime > 0) {
-            Sub(dstTensor, src0Tensor, src1Tensor, static_cast<uint64_t>(V_LENGTH), repeatTime, repeatParams);
-        }
-        if (tailCount > 0) {
-            uint32_t tailOffset = count - tailCount;
-            Sub(dstTensor[tailOffset], src0Tensor[tailOffset], src1Tensor[tailOffset],
-                static_cast<uint64_t>(tailCount), 1, repeatParams);
-        }
-    }
-
-    __aicore__ inline void MulsMasked(LocalTensor<float> &dstTensor, const LocalTensor<float> &srcTensor,
-                                     float scalar, uint32_t count)
-    {
-        UnaryRepeatParams repeatParams{1, 1, FP32_NUM_PER_BLOCK, FP32_NUM_PER_BLOCK};
-        uint8_t repeatTime = static_cast<uint8_t>(count / V_LENGTH);
-        uint32_t tailCount = count % V_LENGTH;
-        if (repeatTime > 0) {
-            Muls(dstTensor, srcTensor, scalar, static_cast<uint64_t>(V_LENGTH), repeatTime, repeatParams);
-        }
-        if (tailCount > 0) {
-            uint32_t tailOffset = count - tailCount;
-            Muls(dstTensor[tailOffset], srcTensor[tailOffset], scalar, static_cast<uint64_t>(tailCount), 1,
-                 repeatParams);
-        }
-    }
-
-    __aicore__ inline void ExpMasked(LocalTensor<float> &dstTensor, const LocalTensor<float> &srcTensor,
-                                    uint32_t count)
-    {
-        UnaryRepeatParams repeatParams{1, 1, FP32_NUM_PER_BLOCK, FP32_NUM_PER_BLOCK};
-        uint8_t repeatTime = static_cast<uint8_t>(count / V_LENGTH);
-        uint32_t tailCount = count % V_LENGTH;
-        if (repeatTime > 0) {
-            Exp(dstTensor, srcTensor, static_cast<uint64_t>(V_LENGTH), repeatTime, repeatParams);
-        }
-        if (tailCount > 0) {
-            uint32_t tailOffset = count - tailCount;
-            Exp(dstTensor[tailOffset], srcTensor[tailOffset], static_cast<uint64_t>(tailCount), 1, repeatParams);
-        }
-    }
-
-    __aicore__ inline void Compute(uint32_t curSingleV, uint64_t curQKOffset, uint64_t curVOffset)
-    {
-        if (hasGama_) {
-            Muls(stateInUb, stateInUb, gama_, alignK_ * curSingleV);
-        }
-        if (hasGamaK_) {
-            MatVecMul(stateInUb, gamaKInUb[curQKOffset], stateInUb, curSingleV);
-        }
-        if (hasGama_ || hasGamaK_) {
-            AscendC::PipeBarrier<PIPE_V>();
-        }
-        MatVecMul(stateInUb, kInUb[curQKOffset], broadTmpInUb, curSingleV);
-        AscendC::PipeBarrier<PIPE_V>();
-        ReduceSumDispatch(deltaInUb, broadTmpInUb, curSingleV);
-        AscendC::PipeBarrier<PIPE_V>();
-        SubMasked(attnInUb, vInUb[curVOffset], deltaInUb, curSingleV);
-        AscendC::PipeBarrier<PIPE_V>();
-        MulsMasked(deltaInUb, attnInUb, beta_, curSingleV);
-        AscendC::PipeBarrier<PIPE_V>();
-        ProcessKQ(deltaInUb, kInUb[curQKOffset], stateInUb, qInUb[curQKOffset], broadTmpInUb, curSingleV);
-        AscendC::PipeBarrier<PIPE_V>();
-        ReduceSumDispatch(attnInUb, broadTmpInUb, curSingleV);
-        LocalTensor<stateType> stateOutLocal = stateOutQueue_.AllocTensor<stateType>();
-        LocalTensor<outType> attnOutLocal = attnOutQueue_.AllocTensor<outType>();
-        if constexpr (std::is_same<stateType, float32_t>()) {
-            DataCopy(stateOutLocal, stateInUb, alignK_ * curSingleV);
-        } else {
-            Cast(stateOutLocal, stateInUb, AscendC::RoundMode::CAST_RINT, alignK_ * curSingleV);
-        }
-        stateOutQueue_.EnQue<stateType>(stateOutLocal);
-        Cast(attnOutLocal, attnInUb, AscendC::RoundMode::CAST_RINT, curSingleV);
-        attnOutQueue_.EnQue<outType>(attnOutLocal);
-    }
-
-    __aicore__ inline void CopyOutAttn(uint64_t attnOffset, uint32_t curSingleV)
-    {
-        LocalTensor<outType> attnLocal = attnOutQueue_.DeQue<outType>();
-        DataCopyParams attnOutParams{1, static_cast<uint16_t>(curSingleV * sizeof(outType)), 0, 0};
-        DataCopyPad(attnOutGm_[attnOffset], attnLocal, attnOutParams);
-        attnOutQueue_.FreeTensor(attnLocal);
-    }
-
-    __aicore__ inline void CopyOutState(uint64_t stateOffset, uint32_t curSingleV)
-    {
-        LocalTensor<stateType> stateOutLocal = stateOutQueue_.DeQue<stateType>();
-        DataCopyParams stateOutParams{static_cast<uint16_t>(curSingleV),
-                                      static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0};
-        DataCopyPad(finalStateGm_[stateOffset], stateOutLocal, stateOutParams);
-        stateOutQueue_.FreeTensor(stateOutLocal);
+        return current;
     }
 
     __aicore__ inline void CopyInGamaBeta(int32_t seq0, int32_t seq1)
     {
-        int32_t seqLen = seq1 - seq0;
-        LocalTensor<inType> betaLocal = betaInQueue_.AllocTensor<inType>();
-        DataCopyParams betaInParams{1, static_cast<uint16_t>(seqLen * NV_ * sizeof(inType)), 0, 0};
+        const int32_t seqLen = seq1 - seq0;
         DataCopyPadParams padParams;
-        DataCopyPad(betaLocal, betaGm_[seq0 * NV_], betaInParams, padParams);
-        betaInQueue_.EnQue<inType>(betaLocal);
-        betaLocal = betaInQueue_.DeQue<inType>();
-        Cast(betaInUb, betaLocal, AscendC::RoundMode::CAST_NONE, seqLen * NV_);
-        betaInQueue_.FreeTensor(betaLocal);
+        betaInUb_ = betaInQueue_.AllocTensor<inType>();
+        DataCopyParams betaParams{1, static_cast<uint16_t>(seqLen * NV_ * sizeof(inType)), 0, 0};
+        DataCopyPad(betaInUb_, betaGm_[seq0 * NV_], betaParams, padParams);
+        betaInQueue_.EnQue<inType>(betaInUb_);
+        betaInUb_ = betaInQueue_.DeQue<inType>();
+
         if (hasGama_) {
-            LocalTensor<float> gamaLocal = gamaInQueue_.AllocTensor<float>();
-            DataCopyParams gamaInParams{1, static_cast<uint16_t>(seqLen * NV_ * sizeof(float)), 0, 0};
-            DataCopyPad(gamaLocal, gamaGm_[seq0 * NV_], gamaInParams, padParams);
-            gamaInQueue_.EnQue<float>(gamaLocal);
-            gamaLocal = gamaInQueue_.DeQue<float>();
-            ExpMasked(gamaInUb, gamaLocal, seqLen * NV_);
-            gamaInQueue_.FreeTensor(gamaLocal);
+            gamaInUb_ = gamaInQueue_.AllocTensor<float>();
+            DataCopyParams gamaParams{1, static_cast<uint16_t>(seqLen * NV_ * sizeof(float)), 0, 0};
+            DataCopyPad(gamaInUb_, gamaGm_[seq0 * NV_], gamaParams, padParams);
+            gamaInQueue_.EnQue<float>(gamaInUb_);
+            gamaInUb_ = gamaInQueue_.DeQue<float>();
         }
     }
 
-    __aicore__ inline void ProcessHead(int32_t seq0, int32_t seq1, uint64_t head_i, uint64_t stateOffset)
+    __aicore__ inline void ReleaseGamaBeta()
     {
-        uint64_t vOffset = (seq0 * NV_ + head_i) * realV_;
-        uint64_t qkOffset = (seq0 * NK_ + head_i / (NV_ / NK_)) * realK_;
-        CopyInQKV(vOffset, qkOffset, seq1 - seq0);
-        if (realV_ == 0) {
+        betaInQueue_.FreeTensor(betaInUb_);
+        if (hasGama_) {
+            gamaInQueue_.FreeTensor(gamaInUb_);
+        }
+    }
+
+    __aicore__ inline void CopyInQKV(uint64_t vOffset, uint64_t qkOffset, int32_t seqLen)
+    {
+        qInUb_ = qInQueue_.AllocTensor<inType>();
+        kInUb_ = kInQueue_.AllocTensor<inType>();
+        vInUb_ = vInQueue_.AllocTensor<inType>();
+        DataCopyExtParams qkParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
+                                   static_cast<uint32_t>((NK_ - 1) * realK_ * sizeof(inType)), 0, 0};
+        DataCopyExtParams vParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realV_ * sizeof(inType)),
+                                  static_cast<uint32_t>((NV_ - 1) * realV_ * sizeof(inType)), 0, 0};
+        DataCopyPadExtParams<inType> qkPad{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
+        DataCopyPadExtParams<inType> vPad{true, 0, static_cast<uint8_t>(alignV_ - realV_), 0};
+        DataCopyPad(qInUb_, queryGm_[qkOffset], qkParams, qkPad);
+        DataCopyPad(kInUb_, keyGm_[qkOffset], qkParams, qkPad);
+        DataCopyPad(vInUb_, valueGm_[vOffset], vParams, vPad);
+        qInQueue_.EnQue<inType>(qInUb_);
+        kInQueue_.EnQue<inType>(kInUb_);
+        vInQueue_.EnQue<inType>(vInUb_);
+        qInUb_ = qInQueue_.DeQue<inType>();
+        kInUb_ = kInQueue_.DeQue<inType>();
+        vInUb_ = vInQueue_.DeQue<inType>();
+
+        if (hasGamaK_) {
+            gamaKInUb_ = gamaKInQueue_.AllocTensor<float>();
+            DataCopyExtParams gkParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(float)),
+                                       static_cast<uint32_t>((NV_ - 1) * realK_ * sizeof(float)), 0, 0};
+            DataCopyPadExtParams<float> gkPad{true, 0, 0, 0};
+            DataCopyPad(gamaKInUb_, gamaKGm_[vOffset / realV_ * realK_], gkParams, gkPad);
+            gamaKInQueue_.EnQue<float>(gamaKInUb_);
+            gamaKInUb_ = gamaKInQueue_.DeQue<float>();
+        }
+    }
+
+    __aicore__ inline void ReleaseQKV()
+    {
+        qInQueue_.FreeTensor(qInUb_);
+        kInQueue_.FreeTensor(kInUb_);
+        vInQueue_.FreeTensor(vInUb_);
+        if (hasGamaK_) {
+            gamaKInQueue_.FreeTensor(gamaKInUb_);
+        }
+    }
+
+    __aicore__ inline void PrefetchState(uint64_t stateOffset, uint32_t rows)
+    {
+        LocalTensor<stateType> stateLocal = stateInQueue_.AllocTensor<stateType>();
+        DataCopyExtParams stateParams{static_cast<uint16_t>(rows),
+                                      static_cast<uint32_t>(realK_ * sizeof(stateType)), 0, 0, 0};
+        DataCopyPadExtParams<stateType> statePad{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
+        DataCopyPad(stateLocal, initStateGm_[stateOffset], stateParams, statePad);
+        stateInQueue_.EnQue<stateType>(stateLocal);
+    }
+
+    template <bool HAS_G, bool HAS_GK, bool READ_INITIAL, bool WRITE_RECURRENT>
+    __aicore__ inline void CallTokenVf(
+        uint32_t rows, uint64_t qkOffset, uint64_t vOffset, uint64_t gbOffset,
+        LocalTensor<stateType> &initialState, LocalTensor<stateType> &stateOut, LocalTensor<outType> &attnOut)
+    {
+        __ubuf__ float *stateAddr = reinterpret_cast<__ubuf__ float *>(recurrentStateUb_.GetPhyAddr());
+        __ubuf__ stateType *initialAddr;
+        if constexpr (READ_INITIAL) {
+            initialAddr = reinterpret_cast<__ubuf__ stateType *>(initialState.GetPhyAddr());
+        } else {
+            initialAddr = reinterpret_cast<__ubuf__ stateType *>(stateAddr);
+        }
+        __ubuf__ float *gamaAddr = stateAddr;
+        __ubuf__ float *gamaKAddr = stateAddr;
+        if constexpr (HAS_G) {
+            gamaAddr = reinterpret_cast<__ubuf__ float *>(gamaInUb_.GetPhyAddr()) + gbOffset;
+        }
+        if constexpr (HAS_GK) {
+            gamaKAddr = reinterpret_cast<__ubuf__ float *>(gamaKInUb_.GetPhyAddr()) + qkOffset;
+        }
+        AscendC::VF_CALL<RgdrRecurrentToken128Vf<stateType, outType, HAS_G, HAS_GK,
+                                                  READ_INITIAL, WRITE_RECURRENT>>(
+            stateAddr, initialAddr, reinterpret_cast<__ubuf__ stateType *>(stateOut.GetPhyAddr()),
+            reinterpret_cast<__ubuf__ outType *>(attnOut.GetPhyAddr()),
+            reinterpret_cast<__ubuf__ bfloat16_t *>(qInUb_.GetPhyAddr()) + qkOffset,
+            reinterpret_cast<__ubuf__ bfloat16_t *>(kInUb_.GetPhyAddr()) + qkOffset,
+            reinterpret_cast<__ubuf__ bfloat16_t *>(vInUb_.GetPhyAddr()) + vOffset,
+            gamaAddr, gamaKAddr,
+            reinterpret_cast<__ubuf__ bfloat16_t *>(betaInUb_.GetPhyAddr()) + gbOffset,
+            scale_, static_cast<uint16_t>(rows));
+    }
+
+    template <bool READ_INITIAL, bool WRITE_RECURRENT>
+    __aicore__ inline void Compute(
+        uint32_t rows, uint64_t qkOffset, uint64_t vOffset, uint64_t gbOffset,
+        LocalTensor<stateType> &initialState)
+    {
+        LocalTensor<stateType> stateOut = stateOutQueue_.AllocTensor<stateType>();
+        LocalTensor<outType> attnOut = attnOutQueue_.AllocTensor<outType>();
+        if (hasGama_) {
             if (hasGamaK_) {
-                gamaKInQueue_.FreeTensor(gamaKInUb);
+                CallTokenVf<true, true, READ_INITIAL, WRITE_RECURRENT>(
+                    rows, qkOffset, vOffset, gbOffset, initialState, stateOut, attnOut);
+            } else {
+                CallTokenVf<true, false, READ_INITIAL, WRITE_RECURRENT>(
+                    rows, qkOffset, vOffset, gbOffset, initialState, stateOut, attnOut);
             }
+        } else if (hasGamaK_) {
+            CallTokenVf<false, true, READ_INITIAL, WRITE_RECURRENT>(
+                rows, qkOffset, vOffset, gbOffset, initialState, stateOut, attnOut);
+        } else {
+            CallTokenVf<false, false, READ_INITIAL, WRITE_RECURRENT>(
+                rows, qkOffset, vOffset, gbOffset, initialState, stateOut, attnOut);
+        }
+        if constexpr (WRITE_RECURRENT) {
+            // The next token reloads this FP32 bank in a new VF call. Keep the sole recurrent store->load
+            // dependency explicit; all intra-token intermediates stay in registers and need no PIPE_V barrier.
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+        stateOutQueue_.EnQue<stateType>(stateOut);
+        attnOutQueue_.EnQue<outType>(attnOut);
+    }
+
+    __aicore__ inline void CopyOutAttn(uint64_t attnOffset, uint32_t rows)
+    {
+        LocalTensor<outType> attn = attnOutQueue_.DeQue<outType>();
+        DataCopyParams params{1, static_cast<uint16_t>(rows * sizeof(outType)), 0, 0};
+        DataCopyPad(attnOutGm_[attnOffset], attn, params);
+        attnOutQueue_.FreeTensor(attn);
+    }
+
+    __aicore__ inline void CopyOutState(uint64_t stateOffset, uint32_t rows)
+    {
+        LocalTensor<stateType> state = stateOutQueue_.DeQue<stateType>();
+        DataCopyParams params{static_cast<uint16_t>(rows),
+                              static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0};
+        DataCopyPad(finalStateGm_[stateOffset], state, params);
+        stateOutQueue_.FreeTensor(state);
+    }
+
+    __aicore__ inline void ProcessHead(int32_t seq0, int32_t seq1, uint64_t head, uint64_t stateOffset)
+    {
+        const uint64_t vBase = (seq0 * NV_ + head) * realV_;
+        const uint64_t qkBase = (seq0 * NK_ + head / (NV_ / NK_)) * realK_;
+        CopyInQKV(vBase, qkBase, seq1 - seq0);
+        if (realV_ == 0) {
+            ReleaseQKV();
             return;
         }
-        uint64_t nextVOffset = 0;
-        uint32_t nextSingleV = realV_ > vStep_ ? vStep_ : realV_;
-        uint64_t nextStateOffset = stateStride0_ * stateOffset + stateStride1_ * head_i;
-        PrefetchState(nextStateOffset, nextSingleV);
-        for (uint64_t v_i = 0; v_i < realV_; v_i += vStep_) {
-            uint32_t curSingleV = v_i + vStep_ > realV_ ? realV_ - v_i : vStep_;
-            LoadPrefetchedState(curSingleV);
-            nextVOffset = v_i + vStep_;
-            if (nextVOffset < realV_) {
-                nextSingleV = nextVOffset + vStep_ > realV_ ? realV_ - nextVOffset : vStep_;
-                nextStateOffset = stateStride0_ * stateOffset + stateStride1_ * head_i + stateStride2_ * nextVOffset;
-                PrefetchState(nextStateOffset, nextSingleV);
-            }
+
+        const uint32_t firstRows = realV_ > vStep_ ? vStep_ : realV_;
+        const uint64_t firstStateOffset = stateStride0_ * stateOffset + stateStride1_ * head;
+        PrefetchState(firstStateOffset, firstRows);
+        for (uint64_t v = 0; v < realV_; v += vStep_) {
+            const uint32_t rows = v + vStep_ > realV_ ? realV_ - v : vStep_;
+            LocalTensor<stateType> initialState = stateInQueue_.DeQue<stateType>();
+            const uint64_t nextV = v + vStep_;
+            bool initialStateReleased = false;
+
             uint64_t pendingAttnOffset = 0;
             uint64_t pendingStateOffset = 0;
             bool hasPendingAttn = false;
             bool hasPendingState = false;
-            for (uint64_t seq_i = seq0; seq_i < seq1; seq_i++) {
-                uint64_t gbOffset = head_i + (seq_i - seq0) * NV_;
-                uint64_t curQKOffset = (seq_i - seq0) * alignK_;
-                uint64_t curVOffset = (seq_i - seq0) * alignV_ + v_i;
-                uint64_t attnOffset = (seq_i * NV_ + head_i) * realV_ + v_i;
-                uint64_t curStateOutOffset =
-                    stateStride0_ * ssmStateIndicesGm_.GetValue(seq_i) +
-                    stateStride1_ * head_i + stateStride2_ * v_i;
-                gama_ = hasGama_ ? gamaInUb.GetValue(gbOffset) : 1;
-                beta_ = betaInUb.GetValue(gbOffset);
-                Compute(curSingleV, curQKOffset, curVOffset);
+            for (int32_t seq = seq0; seq < seq1; ++seq) {
+                const uint64_t localSeq = static_cast<uint64_t>(seq - seq0);
+                const uint64_t gbOffset = head + localSeq * NV_;
+                const uint64_t qkOffset = localSeq * alignK_;
+                const uint64_t valueOffset = localSeq * alignV_ + v;
+                const uint64_t attnOffset = (static_cast<uint64_t>(seq) * NV_ + head) * realV_ + v;
+                const uint64_t stateOutOffset =
+                    stateStride0_ * ssmStateIndicesGm_.GetValue(seq) +
+                    stateStride1_ * head + stateStride2_ * v;
+                const bool firstToken = (seq == seq0);
+                const bool lastToken = (seq + 1 == seq1);
+
+                if (firstToken) {
+                    if (lastToken) {
+                        Compute<true, false>(rows, qkOffset, valueOffset, gbOffset, initialState);
+                    } else {
+                        Compute<true, true>(rows, qkOffset, valueOffset, gbOffset, initialState);
+                    }
+                    stateInQueue_.FreeTensor(initialState);
+                    initialStateReleased = true;
+                    // Token 0 releases the MTE2 slot. The next V tile can overlap later recurrent tokens.
+                    if (nextV < realV_) {
+                        const uint32_t nextRows = nextV + vStep_ > realV_ ? realV_ - nextV : vStep_;
+                        const uint64_t nextStateOffset =
+                            stateStride0_ * stateOffset + stateStride1_ * head + stateStride2_ * nextV;
+                        PrefetchState(nextStateOffset, nextRows);
+                    }
+                } else if (lastToken) {
+                    Compute<false, false>(rows, qkOffset, valueOffset, gbOffset, initialState);
+                } else {
+                    Compute<false, true>(rows, qkOffset, valueOffset, gbOffset, initialState);
+                }
+
                 if (attnOutBufferNum_ == BUFFER_NUM) {
-                    CopyOutAttn(attnOffset, curSingleV);
+                    CopyOutAttn(attnOffset, rows);
                 } else {
                     if (hasPendingAttn) {
-                        CopyOutAttn(pendingAttnOffset, curSingleV);
+                        CopyOutAttn(pendingAttnOffset, rows);
                     }
                     pendingAttnOffset = attnOffset;
                     hasPendingAttn = true;
                 }
                 if (stateOutBufferNum_ == BUFFER_NUM) {
-                    CopyOutState(curStateOutOffset, curSingleV);
+                    CopyOutState(stateOutOffset, rows);
                 } else {
                     if (hasPendingState) {
-                        CopyOutState(pendingStateOffset, curSingleV);
+                        CopyOutState(pendingStateOffset, rows);
                     }
-                    pendingStateOffset = curStateOutOffset;
+                    pendingStateOffset = stateOutOffset;
                     hasPendingState = true;
                 }
             }
+            if (!initialStateReleased) {
+                stateInQueue_.FreeTensor(initialState);
+            }
             if (hasPendingAttn) {
-                CopyOutAttn(pendingAttnOffset, curSingleV);
+                CopyOutAttn(pendingAttnOffset, rows);
             }
             if (hasPendingState) {
-                CopyOutState(pendingStateOffset, curSingleV);
+                CopyOutState(pendingStateOffset, rows);
             }
         }
-        if (hasGamaK_) {
-            gamaKInQueue_.FreeTensor(gamaKInUb);
-        }
-    }
-
-    __aicore__ inline bool IsCurrentBlock(int32_t seqlen)
-    {
-        load += seqlen;
-        bool ret = (blockIdx == usedblk && seqlen > 0);
-        if (load >= avgload) {
-            load = 0;
-            usedblk++;
-        }
-        return ret;
+        ReleaseQKV();
     }
 
 private:
@@ -639,17 +458,14 @@ private:
     TQue<QuePosition::VECIN, 1> stateInQueue_;
     TQue<QuePosition::VECOUT, MAX_OUT_BUFFER_NUM> attnOutQueue_;
     TQue<QuePosition::VECOUT, MAX_OUT_BUFFER_NUM> stateOutQueue_;
-    TBuf<TPosition::VECCALC> tmpBuff;
-    LocalTensor<float> qInUb;
-    LocalTensor<float> kInUb;
-    LocalTensor<float> vInUb;
-    LocalTensor<float> gamaInUb;
-    LocalTensor<float> gamaKInUb;
-    LocalTensor<float> betaInUb;
-    LocalTensor<float> deltaInUb;
-    LocalTensor<float> broadTmpInUb;
-    LocalTensor<float> attnInUb;
-    LocalTensor<float> stateInUb;
+    TBuf<TPosition::VECCALC> tmpBuffer_;
+    LocalTensor<inType> qInUb_;
+    LocalTensor<inType> kInUb_;
+    LocalTensor<inType> vInUb_;
+    LocalTensor<float> gamaInUb_;
+    LocalTensor<float> gamaKInUb_;
+    LocalTensor<inType> betaInUb_;
+    LocalTensor<float> recurrentStateUb_;
     uint32_t B_;
     uint32_t T_;
     uint32_t NK_;
@@ -662,20 +478,19 @@ private:
     uint32_t stateOutBufferNum_;
     uint32_t attnOutBufferNum_;
     uint32_t restUbSize_;
-    uint32_t load;
-    uint32_t usedblk;
-    uint32_t avgload;
+    uint32_t load_;
+    uint32_t usedBlock_;
+    uint32_t avgLoad_;
     bool hasAcceptedTokens_;
     bool hasGama_;
     bool hasGamaK_;
-    bool useAddFoldReduce_;
-    float gama_;
-    float beta_;
     float scale_;
-    uint64_t blockIdx;
+    uint64_t blockIdx_;
     uint32_t stateStride0_;
     uint32_t stateStride1_;
     uint32_t stateStride2_;
 };
+
 } // namespace RecurrentGatedDeltaRule
-#endif
+
+#endif // __RECURRENT_GATED_DELTA_RULE_KERNEL_H_

--- a/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_kernel/arch35/recurrent_gated_delta_rule_regbase.h
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_kernel/arch35/recurrent_gated_delta_rule_regbase.h
@@ -1,0 +1,204 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef RECURRENT_GATED_DELTA_RULE_REGBASE_H
+#define RECURRENT_GATED_DELTA_RULE_REGBASE_H
+
+#include <type_traits>
+
+#include "kernel_operator.h"
+#include "kernel_utils/vector/regbase.hpp"
+
+namespace RecurrentGatedDeltaRule {
+
+using namespace AscendC;
+using namespace AscendC::MicroAPI;
+
+constexpr uint16_t RGDR_K128 = 128;
+constexpr CastTrait RGDR_F32_TO_B16_ZERO = {
+    RegLayout::ZERO, SatMode::NO_SAT, MaskMergeMode::MERGING, AscendC::RoundMode::CAST_RINT};
+constexpr CastTrait RGDR_F32_TO_B16_ONE = {
+    RegLayout::ONE, SatMode::NO_SAT, MaskMergeMode::ZEROING, AscendC::RoundMode::CAST_RINT};
+
+template <typename T>
+__simd_callee__ inline void RgdrLoadPairAsFloat(RegTensor<float> &zero, RegTensor<float> &one,
+                                                __ubuf__ T *src, MaskReg &mask16)
+{
+    if constexpr (std::is_same<T, float>::value) {
+        (void)mask16;
+        LoadAlign<float, LoadDist::DIST_DINTLV_B32>(zero, one, src);
+    } else {
+        RegTensor<T> raw;
+        LoadIn<T, false>(raw, src);
+        CastHalf2Float<T>(zero, one, raw, mask16);
+    }
+}
+
+template <typename T>
+__simd_callee__ inline void RgdrLoadScalarAsFloat(RegTensor<float> &dst, __ubuf__ T *src,
+                                                  MaskReg &mask16)
+{
+    if constexpr (std::is_same<T, float>::value) {
+        (void)mask16;
+        LoadIn<float, true>(dst, src);
+    } else {
+        RegTensor<T> raw;
+        RegTensor<float> unused;
+        LoadIn<T, true>(raw, src);
+        CastHalf2Float<T>(dst, unused, raw, mask16);
+    }
+}
+
+template <typename T>
+__simd_callee__ inline void RgdrStorePairFromFloat(__ubuf__ T *dst, RegTensor<float> &zero,
+                                                   RegTensor<float> &one, MaskReg &mask32, MaskReg &mask16)
+{
+    if constexpr (std::is_same<T, float>::value) {
+        (void)mask16;
+        StoreAlign<float, StoreDist::DIST_INTLV_B32>(dst, zero, one, mask32);
+    } else {
+        RegTensor<T> raw;
+        Cast<T, float, RGDR_F32_TO_B16_ONE>(raw, one, mask32);
+        Cast<T, float, RGDR_F32_TO_B16_ZERO>(raw, zero, mask32);
+        StoreAlign(dst, raw, mask16);
+    }
+}
+
+template <typename T>
+__simd_callee__ inline void RgdrStoreScalarFromFloat(__ubuf__ T *&dst, RegTensor<float> &src,
+                                                     MaskReg &mask32, UnalignRegForStore &unalignStore)
+{
+    RegTensor<T> raw;
+    Cast<T, float, RGDR_F32_TO_B16_ZERO>(raw, src, mask32);
+    StoreUnAlign(dst, raw, unalignStore, 1);
+}
+
+template <typename StateT, typename OutT, bool HAS_G, bool HAS_GK, bool READ_INITIAL, bool WRITE_RECURRENT>
+__simd_callee__ inline void RgdrProcessK128Row(
+    __ubuf__ float *recurrentState, __ubuf__ StateT *initialState, __ubuf__ StateT *stateOut,
+    __ubuf__ OutT *&attnOut, __ubuf__ bfloat16_t *value, uint16_t row,
+    RegTensor<float> &query0, RegTensor<float> &query1, RegTensor<float> &key0, RegTensor<float> &key1,
+    RegTensor<float> &gk0, RegTensor<float> &gk1, RegTensor<float> &gamma, RegTensor<float> &beta,
+    MaskReg &mask32, MaskReg &mask16, UnalignRegForStore &unalignStore)
+{
+    const uint32_t stateOffset = static_cast<uint32_t>(row) * RGDR_K128;
+    RegTensor<float> state0;
+    RegTensor<float> state1;
+    if constexpr (READ_INITIAL) {
+        RgdrLoadPairAsFloat<StateT>(state0, state1, initialState + stateOffset, mask16);
+    } else {
+        LoadAlign<float, LoadDist::DIST_DINTLV_B32>(state0, state1, recurrentState + stateOffset);
+    }
+
+    if constexpr (HAS_G) {
+        Mul(state0, state0, gamma, mask32);
+        Mul(state1, state1, gamma, mask32);
+    }
+    if constexpr (HAS_GK) {
+        Mul(state0, state0, gk0, mask32);
+        Mul(state1, state1, gk1, mask32);
+    }
+
+    RegTensor<float> work0;
+    RegTensor<float> work1;
+    RegTensor<float> dotK;
+    RegTensor<float> dotKBroadcast;
+    Mul(work0, state0, key0, mask32);
+    Mul(work1, state1, key1, mask32);
+    Add(work0, work0, work1, mask32);
+    ReduceSum(dotK, work0, mask32);
+    Duplicate(dotKBroadcast, dotK, mask32);
+
+    RegTensor<float> valueScalar;
+    RgdrLoadScalarAsFloat<bfloat16_t>(valueScalar, value + row, mask16);
+    RegTensor<float> delta;
+    Sub(delta, valueScalar, dotKBroadcast, mask32);
+    Mul(delta, delta, beta, mask32);
+
+    Mul(work0, delta, key0, mask32);
+    Mul(work1, delta, key1, mask32);
+    Add(state0, state0, work0, mask32);
+    Add(state1, state1, work1, mask32);
+
+    RegTensor<float> attn;
+    Mul(work0, state0, query0, mask32);
+    Mul(work1, state1, query1, mask32);
+    Add(work0, work0, work1, mask32);
+    ReduceSum(attn, work0, mask32);
+
+    if constexpr (WRITE_RECURRENT) {
+        StoreAlign<float, StoreDist::DIST_INTLV_B32>(recurrentState + stateOffset, state0, state1, mask32);
+    }
+    RgdrStorePairFromFloat<StateT>(stateOut + stateOffset, state0, state1, mask32, mask16);
+    RgdrStoreScalarFromFloat<OutT>(attnOut, attn, mask32, unalignStore);
+}
+
+/**
+ * K=128 recurrent token hot path.
+ *
+ * Q/K/GK are loaded once and retained in registers while two V rows are consumed per loop. Gate mode and
+ * first/last-token state behavior are compile-time policies, so the VF body has no runtime feature branch.
+ */
+template <typename StateT, typename OutT, bool HAS_G, bool HAS_GK, bool READ_INITIAL, bool WRITE_RECURRENT>
+__simd_vf__ inline void RgdrRecurrentToken128Vf(
+    __ubuf__ float *recurrentState, __ubuf__ StateT *initialState, __ubuf__ StateT *stateOut,
+    __ubuf__ OutT *attnOut, __ubuf__ bfloat16_t *query, __ubuf__ bfloat16_t *key,
+    __ubuf__ bfloat16_t *value, __ubuf__ float *gammaInput, __ubuf__ float *gkInput,
+    __ubuf__ bfloat16_t *betaInput, float scale, uint16_t rows)
+{
+    MaskReg mask16 = CreateMask<bfloat16_t, MaskPattern::ALL>();
+    MaskReg mask32 = CreateMask<float, MaskPattern::ALL>();
+
+    RegTensor<float> query0;
+    RegTensor<float> query1;
+    RegTensor<float> key0;
+    RegTensor<float> key1;
+    RgdrLoadPairAsFloat<bfloat16_t>(query0, query1, query, mask16);
+    RgdrLoadPairAsFloat<bfloat16_t>(key0, key1, key, mask16);
+    Muls(query0, query0, scale, mask32);
+    Muls(query1, query1, scale, mask32);
+
+    RegTensor<float> gamma;
+    if constexpr (HAS_G) {
+        RgdrLoadScalarAsFloat<float>(gamma, gammaInput, mask16);
+        Exp(gamma, gamma, mask32);
+    }
+
+    RegTensor<float> gk0;
+    RegTensor<float> gk1;
+    if constexpr (HAS_GK) {
+        RgdrLoadPairAsFloat<float>(gk0, gk1, gkInput, mask16);
+        Exp(gk0, gk0, mask32);
+        Exp(gk1, gk1, mask32);
+    }
+
+    RegTensor<float> beta;
+    RgdrLoadScalarAsFloat<bfloat16_t>(beta, betaInput, mask16);
+    UnalignRegForStore unalignStore;
+    __ubuf__ OutT *attnCursor = attnOut;
+
+    // Keep the VF loop in the compiler-preferred uint16/start-0/step-1 form. vStep is 8-element aligned,
+    // therefore each logical iteration can consume two rows without a runtime tail branch.
+    const uint16_t rowPairs = rows >> 1;
+    for (uint16_t pair = 0; pair < rowPairs; ++pair) {
+        const uint16_t row = pair << 1;
+        RgdrProcessK128Row<StateT, OutT, HAS_G, HAS_GK, READ_INITIAL, WRITE_RECURRENT>(
+            recurrentState, initialState, stateOut, attnCursor, value, row,
+            query0, query1, key0, key1, gk0, gk1, gamma, beta, mask32, mask16, unalignStore);
+        RgdrProcessK128Row<StateT, OutT, HAS_G, HAS_GK, READ_INITIAL, WRITE_RECURRENT>(
+            recurrentState, initialState, stateOut, attnCursor, value, static_cast<uint16_t>(row + 1),
+            query0, query1, key0, key1, gk0, gk1, gamma, beta, mask32, mask16, unalignStore);
+    }
+    // Preserve the unaligned-store cache across all contiguous scalar outputs and flush the tail only once.
+    StoreUnAlignPost(attnCursor, unalignStore, 0);
+}
+
+} // namespace RecurrentGatedDeltaRule
+
+#endif // RECURRENT_GATED_DELTA_RULE_REGBASE_H


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [x] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @Canzovo
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
# 默认 CANN 安装路径；自定义安装路径时替换为实际路径下对应的 set_env.sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
