### PR TITLE
fix(recurrent_kda): reuse state output UB on legacy path

### DIFF
--- a/fla/ops/ascendc/kda/recurrent_kda/op_host/op_api/aclnn_recurrent_kda.cpp
+++ b/fla/ops/ascendc/kda/recurrent_kda/op_host/op_api/aclnn_recurrent_kda.cpp
@@ -102,6 +102,35 @@ static bool SameShape(const aclTensor *lhs, const aclTensor *rhs)
     return true;
 }
 
+static bool SameViewStrides(const aclTensor *lhs, const aclTensor *rhs)
+{
+    const auto &lhsStrides = lhs->GetViewStrides();
+    const auto &rhsStrides = rhs->GetViewStrides();
+    if (lhsStrides.size() != rhsStrides.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < lhsStrides.size(); ++i) {
+        if (lhsStrides[i] != rhsStrides[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool SameTensorView(const aclTensor *lhs, const aclTensor *rhs)
+{
+    if (lhs == rhs) {
+        return true;
+    }
+    void *lhsStorage = lhs->GetStorageAddr();
+    if (lhsStorage == nullptr || lhsStorage != rhs->GetStorageAddr()) {
+        return false;
+    }
+    return lhs->GetStorageOffset() == rhs->GetStorageOffset() &&
+           lhs->GetViewOffset() == rhs->GetViewOffset() && SameShape(lhs, rhs) &&
+           SameViewStrides(lhs, rhs);
+}
+
 static bool ParseLayout(const char *layout, RecurrentKdaLayout &parsed)
 {
     if (layout == nullptr || std::strcmp(layout, "BSND") == 0) {
@@ -589,7 +618,7 @@ aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     CHECK_RET(result[0] != nullptr && result[1] != nullptr && result[2] != nullptr,
               ACLNN_ERR_INNER_NULLPTR);
     if (params.inplaceFinalState && params.outputFinalState &&
-        params.finalState != params.initialStateRef) {
+        !SameTensorView(params.finalState, params.initialStateRef)) {
         CHECK_RET(l0op::ViewCopy(result[1], params.finalState, executorPtr) != nullptr,
                   ACLNN_ERR_INNER_NULLPTR);
     }

--- a/fla/ops/ascendc/kda/recurrent_kda/op_host/recurrent_kda_tiling_processor.h
+++ b/fla/ops/ascendc/kda/recurrent_kda/op_host/recurrent_kda_tiling_processor.h
@@ -681,7 +681,7 @@ private:
         int64_t stateDtypeSize = (ctx_.stateDtype == ge::DT_FLOAT) ? 4 : 2;
         int64_t coeff = RKDA_INPUT_BUFFER_NUM * stateDtypeSize * aDk; // state input queue.
         if (ctx_.stateVFirst == 0) {
-            coeff += stateDtypeSize * aDk; // K-first state transpose buffer.
+            coeff += 2 * stateDtypeSize * aDk; // K-first input/output transpose buffers.
         }
         coeff += static_cast<int64_t>(stateOutBufferNum) * stateDtypeSize * aDk;
         coeff += static_cast<int64_t>(attnOutBufferNum) * 2;

--- a/fla/ops/ascendc/kda/recurrent_kda/op_kernel/arch35/recurrent_kda.h
+++ b/fla/ops/ascendc/kda/recurrent_kda/op_kernel/arch35/recurrent_kda.h
@@ -173,6 +173,7 @@ public:
         pipe_->InitBuffer(stateOutQueue_, stateOutBufferNum_, alignK_ * vStep_ * sizeof(stateType));
         if (!stateVFirst_) {
             pipe_->InitBuffer(stateTransposeBuf_, alignK_ * vStep_ * sizeof(stateType));
+            pipe_->InitBuffer(stateOutTransposeQueue_, BUFFER_NUM, alignK_ * vStep_ * sizeof(stateType));
         }
         pipe_->InitBuffer(attnOutQueue_, attnOutBufferNum_, vStep_ * sizeof(outType));
         pipe_->InitBuffer(tmpBuff, restUbSize_);
@@ -1091,9 +1092,10 @@ private:
                                           static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0};
             DataCopyPad(finalStateGm_[stateOffset], stateOutLocal, stateOutParams);
         } else {
-            LocalTensor<stateType> stateTransposeLocal = stateTransposeBuf_.Get<stateType>();
+            LocalTensor<stateType> stateTransposeLocal = stateOutTransposeQueue_.AllocTensor<stateType>();
             TransposeVFirstToKFirst(stateTransposeLocal, stateOutLocal, curSingleV);
-            SyncVToMte3();
+            stateOutTransposeQueue_.EnQue<stateType>(stateTransposeLocal);
+            LocalTensor<stateType> stateCopyLocal = stateOutTransposeQueue_.DeQue<stateType>();
             uint64_t stateOffset = stateOutStride0_ * stateSlot + stateOutStride1_ * head +
                                    stateOutStride3_ * vOffset;
             int64_t srcStride = static_cast<int64_t>(
@@ -1103,8 +1105,8 @@ private:
             DataCopyExtParams stateOutParams{static_cast<uint16_t>(realK_),
                                              static_cast<uint32_t>(curSingleV * sizeof(stateType)),
                                              srcStride, dstStride, 0};
-            DataCopyPad(finalStateGm_[stateOffset], stateTransposeLocal, stateOutParams);
-            SyncMte3ToV();
+            DataCopyPad(finalStateGm_[stateOffset], stateCopyLocal, stateOutParams);
+            stateOutTransposeQueue_.FreeTensor(stateCopyLocal);
         }
         stateOutQueue_.FreeTensor(stateOutLocal);
     }
@@ -1289,6 +1291,7 @@ private:
     TQue<QuePosition::VECIN, INPUT_BUFFER_NUM> stateInQueue_;
     TQue<QuePosition::VECOUT, MAX_OUT_BUFFER_NUM> attnOutQueue_;
     TQue<QuePosition::VECOUT, MAX_OUT_BUFFER_NUM> stateOutQueue_;
+    TQue<QuePosition::VECOUT, 1> stateOutTransposeQueue_;
     TBuf<TPosition::VECCALC> tmpBuff;
     TBuf<TPosition::VECCALC> stateTransposeBuf_;
     TBuf<TPosition::VECCALC> scalarBuf_;

--- a/fla/ops/ascendc/kda/recurrent_kda/op_kernel/recurrent_kda.h
+++ b/fla/ops/ascendc/kda/recurrent_kda/op_kernel/recurrent_kda.h
@@ -188,8 +188,10 @@ public:
         buffOffset += kSize;
         stateInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
         buffOffset += cubeSize;
-        broadTmpInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
-        buffOffset += cubeSize;
+        if (alignK_ != ADD_FOLD_REDUCE_MIN_K) {
+            broadTmpInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
+            buffOffset += cubeSize;
+        }
         betaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(betaUbSize / sizeof(float)), buffOffset);
         buffOffset += betaUbSize;
         gateInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignK_), buffOffset);
@@ -489,20 +491,28 @@ private:
         }
 
         if (safeGate_) {
-            Muls(gateInUb, gateInUb, expA, total);
-            PipeBarrier<PIPE_V>();
-            Muls(broadTmpInUb, gateInUb, -1.0f, total);
-            PipeBarrier<PIPE_V>();
-            Exp(broadTmpInUb, broadTmpInUb, total);
-            PipeBarrier<PIPE_V>();
-            Adds(broadTmpInUb, broadTmpInUb, 1.0f, total);
-            PipeBarrier<PIPE_V>();
-            Duplicate(gateInUb, 1.0f, total);
-            PipeBarrier<PIPE_V>();
-            Div(gateInUb, gateInUb, broadTmpInUb, total);
-            PipeBarrier<PIPE_V>();
-            Muls(gateInUb, gateInUb, lowerBound_, total);
-            PipeBarrier<PIPE_V>();
+            uint32_t scratchRows = alignK_ == ADD_FOLD_REDUCE_MIN_K
+                                       ? vStep_ * sizeof(stateType) / sizeof(float)
+                                       : vStep_;
+            for (uint32_t row = 0; row < static_cast<uint32_t>(seqLen); row += scratchRows) {
+                uint32_t rows = Std::min(scratchRows, static_cast<uint32_t>(seqLen) - row);
+                uint32_t offset = row * alignK_;
+                uint32_t chunkTotal = rows * alignK_;
+                Muls(gateInUb[offset], gateInUb[offset], expA, chunkTotal);
+                PipeBarrier<PIPE_V>();
+                Muls(broadTmpInUb, gateInUb[offset], -1.0f, chunkTotal);
+                PipeBarrier<PIPE_V>();
+                Exp(broadTmpInUb, broadTmpInUb, chunkTotal);
+                PipeBarrier<PIPE_V>();
+                Adds(broadTmpInUb, broadTmpInUb, 1.0f, chunkTotal);
+                PipeBarrier<PIPE_V>();
+                Duplicate(gateInUb[offset], 1.0f, chunkTotal);
+                PipeBarrier<PIPE_V>();
+                Div(gateInUb[offset], gateInUb[offset], broadTmpInUb, chunkTotal);
+                PipeBarrier<PIPE_V>();
+                Muls(gateInUb[offset], gateInUb[offset], lowerBound_, chunkTotal);
+                PipeBarrier<PIPE_V>();
+            }
         } else {
             Exp(gateInUb, gateInUb, total);
             PipeBarrier<PIPE_V>();
@@ -551,6 +561,13 @@ private:
         LocalTensor<inType> qLocal = qInQueue_.AllocTensor<inType>();
         LocalTensor<inType> kLocal = kInQueue_.AllocTensor<inType>();
         LocalTensor<inType> vLocal = vInQueue_.AllocTensor<inType>();
+        LocalTensor<stateType> preprocessScratchLocal;
+        bool needPreprocessScratch = useQkL2norm_ ||
+                                     (useGateInKernel_ && (hasDtBias_ || safeGate_));
+        if (alignK_ == ADD_FOLD_REDUCE_MIN_K && needPreprocessScratch) {
+            preprocessScratchLocal = stateOutQueue_.AllocTensor<stateType>();
+            broadTmpInUb = preprocessScratchLocal.template ReinterpretCast<float>();
+        }
 
         DataCopyExtParams qInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
                                     static_cast<uint32_t>((queryTokenStride_ - realK_) * sizeof(inType)), 0, 0};
@@ -593,6 +610,9 @@ private:
         }
         Exp(gateInUb, gateInUb, alignK_ * seqLen);
         AscendC::PipeBarrier<PIPE_V>();
+        if (alignK_ == ADD_FOLD_REDUCE_MIN_K && needPreprocessScratch) {
+            stateOutQueue_.FreeTensor(preprocessScratchLocal);
+        }
 
         qInQueue_.FreeTensor(qLocal);
         kInQueue_.FreeTensor(kLocal);
@@ -798,34 +818,59 @@ private:
 
     __aicore__ inline void Compute(uint32_t curSingleV, uint64_t curQKOffset, uint64_t curVOffset)
     {
-        uint32_t stateShape[2] = {curSingleV, alignK_};
-        uint32_t deltaShape[2] = {curSingleV, 1};
+        LocalTensor<stateType> stateOutLocal;
+        bool reuseStateOut = alignK_ == ADD_FOLD_REDUCE_MIN_K;
+        if (reuseStateOut) {
+            stateOutLocal = stateOutQueue_.AllocTensor<stateType>();
+            broadTmpInUb = stateOutLocal.template ReinterpretCast<float>();
+        }
+        uint32_t scratchRows = reuseStateOut ? vStep_ * sizeof(stateType) / sizeof(float) : vStep_;
+
         MatVecMul(stateInUb, gateInUb[curQKOffset], stateInUb, curSingleV, false);
         AscendC::PipeBarrier<PIPE_V>();
-        MatVecMul(stateInUb, kInUb[curQKOffset], broadTmpInUb, curSingleV, false);
-        AscendC::PipeBarrier<PIPE_V>();
-        ReduceSumDispatch(deltaInUb, broadTmpInUb, curSingleV);
-        AscendC::PipeBarrier<PIPE_V>();
+        for (uint32_t row = 0; row < curSingleV; row += scratchRows) {
+            uint32_t rows = Std::min(scratchRows, curSingleV - row);
+            uint32_t stateOffset = row * alignK_;
+            MatVecMul(stateInUb[stateOffset], kInUb[curQKOffset], broadTmpInUb, rows, false);
+            AscendC::PipeBarrier<PIPE_V>();
+            ReduceSumDispatch(deltaInUb[row], broadTmpInUb, rows);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
         deltaInUb = vInUb[curVOffset] - deltaInUb;
         AscendC::PipeBarrier<PIPE_V>();
         Muls(deltaInUb, deltaInUb, beta_, curSingleV);
         AscendC::PipeBarrier<PIPE_V>();
-        Broadcast<float, 2, 1>(broadTmpInUb, deltaInUb, stateShape, deltaShape);
-        AscendC::PipeBarrier<PIPE_V>();
-        MatVecMul(broadTmpInUb, kInUb[curQKOffset], stateInUb, curSingleV, true);
-        AscendC::PipeBarrier<PIPE_V>();
-        MatVecMul(stateInUb, qInUb[curQKOffset], broadTmpInUb, curSingleV, false);
-        AscendC::PipeBarrier<PIPE_V>();
-        ReduceSumDispatch(attnInUb, broadTmpInUb, curSingleV);
+        for (uint32_t row = 0; row < curSingleV; row += scratchRows) {
+            uint32_t rows = Std::min(scratchRows, curSingleV - row);
+            uint32_t stateOffset = row * alignK_;
+            uint32_t stateShape[2] = {rows, alignK_};
+            uint32_t deltaShape[2] = {rows, 1};
+            Broadcast<float, 2, 1>(broadTmpInUb, deltaInUb[row], stateShape, deltaShape);
+            AscendC::PipeBarrier<PIPE_V>();
+            MatVecMul(broadTmpInUb, kInUb[curQKOffset], stateInUb[stateOffset], rows, true);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+        for (uint32_t row = 0; row < curSingleV; row += scratchRows) {
+            uint32_t rows = Std::min(scratchRows, curSingleV - row);
+            uint32_t stateOffset = row * alignK_;
+            MatVecMul(stateInUb[stateOffset], qInUb[curQKOffset], broadTmpInUb, rows, false);
+            AscendC::PipeBarrier<PIPE_V>();
+            ReduceSumDispatch(attnInUb[row], broadTmpInUb, rows);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
         LocalTensor<outType> attnOutLocal = attnOutQueue_.AllocTensor<outType>();
         if (shouldStoreState_) {
-            LocalTensor<stateType> stateOutLocal = stateOutQueue_.AllocTensor<stateType>();
+            if (!reuseStateOut) {
+                stateOutLocal = stateOutQueue_.AllocTensor<stateType>();
+            }
             if constexpr (std::is_same<stateType, float32_t>()) {
                 DataCopy(stateOutLocal, stateInUb, alignK_ * curSingleV);
             } else {
                 Cast(stateOutLocal, stateInUb, AscendC::RoundMode::CAST_RINT, alignK_ * curSingleV);
             }
             stateOutQueue_.EnQue<stateType>(stateOutLocal);
+        } else if (reuseStateOut) {
+            stateOutQueue_.FreeTensor(stateOutLocal);
         }
         Cast(attnOutLocal, attnInUb, AscendC::RoundMode::CAST_RINT, curSingleV);
         attnOutQueue_.EnQue<outType>(attnOutLocal);

--- a/fla/ops/ascendc/kda/recurrent_kda/op_kernel/recurrent_kda.h
+++ b/fla/ops/ascendc/kda/recurrent_kda/op_kernel/recurrent_kda.h
@@ -170,6 +170,7 @@ public:
         pipe_->InitBuffer(stateOutQueue_, stateOutBufferNum_, alignK_ * vStep_ * sizeof(stateType));
         if (!stateVFirst_) {
             pipe_->InitBuffer(stateTransposeBuf_, alignK_ * vStep_ * sizeof(stateType));
+            pipe_->InitBuffer(stateOutTransposeQueue_, BUFFER_NUM, alignK_ * vStep_ * sizeof(stateType));
         }
         pipe_->InitBuffer(attnOutQueue_, attnOutBufferNum_, vStep_ * sizeof(outType));
         pipe_->InitBuffer(tmpBuff, restUbSize_);
@@ -833,7 +834,8 @@ private:
             uint32_t stateOffset = row * alignK_;
             MatVecMul(stateInUb[stateOffset], kInUb[curQKOffset], broadTmpInUb, rows, false);
             AscendC::PipeBarrier<PIPE_V>();
-            ReduceSumDispatch(deltaInUb[row], broadTmpInUb, rows);
+            LocalTensor<float> deltaRow = deltaInUb[row];
+            ReduceSumDispatch(deltaRow, broadTmpInUb, rows);
             AscendC::PipeBarrier<PIPE_V>();
         }
         deltaInUb = vInUb[curVOffset] - deltaInUb;
@@ -847,7 +849,8 @@ private:
             uint32_t deltaShape[2] = {rows, 1};
             Broadcast<float, 2, 1>(broadTmpInUb, deltaInUb[row], stateShape, deltaShape);
             AscendC::PipeBarrier<PIPE_V>();
-            MatVecMul(broadTmpInUb, kInUb[curQKOffset], stateInUb[stateOffset], rows, true);
+            LocalTensor<float> stateRow = stateInUb[stateOffset];
+            MatVecMul(broadTmpInUb, kInUb[curQKOffset], stateRow, rows, true);
             AscendC::PipeBarrier<PIPE_V>();
         }
         for (uint32_t row = 0; row < curSingleV; row += scratchRows) {
@@ -855,7 +858,8 @@ private:
             uint32_t stateOffset = row * alignK_;
             MatVecMul(stateInUb[stateOffset], qInUb[curQKOffset], broadTmpInUb, rows, false);
             AscendC::PipeBarrier<PIPE_V>();
-            ReduceSumDispatch(attnInUb[row], broadTmpInUb, rows);
+            LocalTensor<float> attnRow = attnInUb[row];
+            ReduceSumDispatch(attnRow, broadTmpInUb, rows);
             AscendC::PipeBarrier<PIPE_V>();
         }
         LocalTensor<outType> attnOutLocal = attnOutQueue_.AllocTensor<outType>();
@@ -895,9 +899,10 @@ private:
                                           static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0};
             DataCopyPad(finalStateGm_[stateOffset], stateOutLocal, stateOutParams);
         } else {
-            LocalTensor<stateType> stateTransposeLocal = stateTransposeBuf_.Get<stateType>();
+            LocalTensor<stateType> stateTransposeLocal = stateOutTransposeQueue_.AllocTensor<stateType>();
             TransposeVFirstToKFirst(stateTransposeLocal, stateOutLocal, curSingleV);
-            SyncVToMte3();
+            stateOutTransposeQueue_.EnQue<stateType>(stateTransposeLocal);
+            LocalTensor<stateType> stateCopyLocal = stateOutTransposeQueue_.DeQue<stateType>();
             uint64_t stateOffset = stateOutStride0_ * stateSlot + stateOutStride1_ * head +
                                    stateOutStride3_ * vOffset;
             uint32_t srcStride = static_cast<uint32_t>(
@@ -907,8 +912,8 @@ private:
             DataCopyExtParams stateOutParams{static_cast<uint16_t>(realK_),
                                              static_cast<uint32_t>(curSingleV * sizeof(stateType)),
                                              srcStride, dstStride, 0};
-            DataCopyPad(finalStateGm_[stateOffset], stateTransposeLocal, stateOutParams);
-            SyncMte3ToV();
+            DataCopyPad(finalStateGm_[stateOffset], stateCopyLocal, stateOutParams);
+            stateOutTransposeQueue_.FreeTensor(stateCopyLocal);
         }
         stateOutQueue_.FreeTensor(stateOutLocal);
     }
@@ -1096,6 +1101,7 @@ private:
     TQue<QuePosition::VECIN, INPUT_BUFFER_NUM> stateInQueue_;
     TQue<QuePosition::VECOUT, MAX_OUT_BUFFER_NUM> attnOutQueue_;
     TQue<QuePosition::VECOUT, MAX_OUT_BUFFER_NUM> stateOutQueue_;
+    TQue<QuePosition::VECOUT, 1> stateOutTransposeQueue_;
     TBuf<TPosition::VECCALC> tmpBuff;
     TBuf<TPosition::VECCALC> stateTransposeBuf_;
     TBuf<TPosition::VECCALC> scalarBuf_;


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @WOE-Y
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
# 默认 CANN 安装路径；自定义安装路径时替换为实际路径下对应的 set_env.sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
