### PR TITLE
fix(opapi): align L2 DFX arguments with API signatures

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_api/aclnn_chunk_bwd_dqkwg.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dqkwg/op_host/op_api/aclnn_chunk_bwd_dqkwg.cpp
@@ -194,8 +194,11 @@ aclnnStatus aclnnChunkBwdDqkwgGetWorkspaceSize(
     CHECK_COND(use_exp2 == false && transpose_state_layout == false, ACLNN_ERR_INNER,
                "use_exp2 and transpose_state_layout must be false.");
     // Standard syntax, Check parameters.
-    L2_DFX_PHASE_1(aclnnChunkBwdDqkwg, DFX_IN(q, k, v, g, h, dox, dh, dv, cuSeqlensOptional, chunkIndicesOptional, w, gGamma),
-                   DFX_OUT(dqOut, dkOut, dwOut, dgOut));
+    L2_DFX_PHASE_1(
+        aclnnChunkBwdDqkwg,
+        DFX_IN(q, k, v, g, h, dox, dh, dv, cuSeqlensOptional, chunkIndicesOptional, w, gGamma, scale, chunkSize,
+               use_exp2, transpose_state_layout),
+        DFX_OUT(dqOut, dkOut, dwOut, dgOut));
 
     // 固定写法，创建OpExecutor
     auto uniqueExecutor = CREATE_EXECUTOR();

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/op_api/aclnn_prepare_wy_repr_bwd.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/prepare_wy_repr_bwd/op_host/op_api/aclnn_prepare_wy_repr_bwd.cpp
@@ -130,7 +130,8 @@ aclnnStatus aclnnPrepareWyReprBwdGetWorkspaceSize(
     PrepareWyReprBwdParams params{k, v, beta, a, dw, du, g, cuSeqlensOptional, chunkIndicesOptional, chunkSize,
                                   dkOut, dvOut, dbetaOut, dgOut};
     L2_DFX_PHASE_1_WITHOUT_CACHE(
-        aclnnPrepareWyReprBwd, DFX_IN(k, v, beta, a, dw, du, g, cuSeqlensOptional, chunkIndicesOptional),
+        aclnnPrepareWyReprBwd,
+        DFX_IN(k, v, beta, a, dw, du, g, cuSeqlensOptional, chunkIndicesOptional, chunkSize),
         DFX_OUT(dkOut, dvOut, dbetaOut, dgOut));
 
     auto uniqueExecutor = CREATE_EXECUTOR();

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/op_api/aclnn_chunk_fwd_h.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_host/op_api/aclnn_chunk_fwd_h.cpp
@@ -426,9 +426,8 @@ aclnnStatus aclnnChunkFwdHGetWorkspaceSize(
                                          finalStateOut};
     // Standard syntax, Check parameters.
     L2_DFX_PHASE_1(aclnnChunkFwdH,
-                   DFX_IN(k, w, u, gOptional, gkOptional, initialStateOptional, cuSeqlensOptional,
-                          chunkIndicesOptional, outputFinalState, chunkSize, saveNewValue, useExp2,
-                          stateVFirst),
+                   DFX_IN(k, w, u, gOptional, gkOptional, initialStateOptional, outputFinalState, chunkSize,
+                          saveNewValue, cuSeqlensOptional, chunkIndicesOptional, useExp2, stateVFirst),
                    DFX_OUT(hOut, vNewOut, finalStateOut));
     auto uniqueExecutor = CREATE_EXECUTOR();
     CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/op_api/aclnn_chunk_gated_delta_rule_fwd_h.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_h/op_host/op_api/aclnn_chunk_gated_delta_rule_fwd_h.cpp
@@ -300,8 +300,8 @@ aclnnStatus aclnnChunkGatedDeltaRuleFwdHGetWorkspaceSize(
                                          finalStateOut};
     // Standard syntax, Check parameters.
     L2_DFX_PHASE_1(aclnnChunkGatedDeltaRuleFwdH,
-                   DFX_IN(k, w, u, gOptional, gkOptional, initialStateOptional, cuSeqlensOptional,
-                          chunkIndicesOptional, outputFinalState, chunkSize, stateVFirst),
+                   DFX_IN(k, w, u, gOptional, gkOptional, initialStateOptional, outputFinalState, chunkSize,
+                          cuSeqlensOptional, chunkIndicesOptional, stateVFirst),
                    DFX_OUT(hOut, vNewOut, finalStateOut));
     auto uniqueExecutor = CREATE_EXECUTOR();
     CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_w_u_fwd/op_host/op_api/aclnn_recompute_w_u_fwd.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_w_u_fwd/op_host/op_api/aclnn_recompute_w_u_fwd.cpp
@@ -127,7 +127,8 @@ aclnnStatus aclnnRecomputeWUFwdGetWorkspaceSize(
 {
     RecomputeWUFwdParams params{k, v, beta, a, g, gk,cuSeqlensOptional, chunkIndicesOptional, chunkSize, wOut, uOut};
     // Standard syntax, Check parameters.
-    L2_DFX_PHASE_1(aclnnRecomputeWUFwd, DFX_IN(k, v, beta, a, g, gk, cuSeqlensOptional, chunkIndicesOptional),
+    L2_DFX_PHASE_1(aclnnRecomputeWUFwd,
+                   DFX_IN(k, v, beta, a, g, gk, cuSeqlensOptional, chunkIndicesOptional, chunkSize),
                    DFX_OUT(wOut, uOut));
     // 固定写法，创建OpExecutor
     auto uniqueExecutor = CREATE_EXECUTOR();

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_host/op_api/aclnn_solve_tri.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/solve_tri/op_host/op_api/aclnn_solve_tri.cpp
@@ -68,7 +68,7 @@
  {
      SolveTriParams params{x, cuSeqlens, chunkIndices, layout, xOut};
  
-     L2_DFX_PHASE_1(aclnnSolveTri, DFX_IN(x, cuSeqlens, chunkIndices), DFX_OUT(xOut));
+     L2_DFX_PHASE_1(aclnnSolveTri, DFX_IN(x, cuSeqlens, chunkIndices, layout), DFX_OUT(xOut));
  
      auto uniqueExecutor = CREATE_EXECUTOR();
      CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);

--- a/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_host/op_api/aclnn_recurrent_gated_delta_rule.cpp
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_host/op_api/aclnn_recurrent_gated_delta_rule.cpp
@@ -147,7 +147,7 @@ aclnnStatus aclnnRecurrentGatedDeltaRuleGetWorkspaceSize(const aclTensor *query,
     L2_DFX_PHASE_1(aclnnRecurrentGatedDeltaRule,
                    DFX_IN(query, key, value, beta, stateRef, actualSeqLengths, ssmStateIndices, g, gk,
                           numAcceptedTokens, scaleValue),
-                   DFX_OUT(out, stateRef));
+                   DFX_OUT(stateRef, out));
 
     auto uniqueExecutor = CREATE_EXECUTOR();
     CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);

--- a/fla/ops/ascendc/kda/recurrent_kda/op_host/op_api/aclnn_recurrent_kda.cpp
+++ b/fla/ops/ascendc/kda/recurrent_kda/op_host/op_api/aclnn_recurrent_kda.cpp
@@ -514,7 +514,7 @@ aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
                           layout, scale, outputFinalState, inplaceFinalState, useQkL2normInKernel,
                           useGateInKernel, useBetaSigmoidInKernel, allowNegEigval, safeGate, lowerBound,
                           stateVFirst),
-                   DFX_OUT(attnOut, initialStateRef, finalState));
+                   DFX_OUT(initialStateRef, attnOut, finalState));
 
     auto uniqueExecutor = CREATE_EXECUTOR();
     CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);


### PR DESCRIPTION
## 关联 Issue / 背景

- Fixes #445
- Eight GDN/KDA wrappers had missing or misordered `L2_DFX_PHASE_1` arguments.

## 修改内容

- Complete missing scalar and attribute inputs for four APIs.
- Align `DFX_IN` order with two forward API signatures.
- Align in-place state outputs with two recurrent API signatures.

## 兼容性

No public API/ABI, operator semantics, tiling, or kernel changes.

## 验证

- CANN 9.1 full package build for `ascend910b`: passed.
- CANN 9.1 full package build for `ascend950`: passed.