### PR TITLE
fix(chunk_bwd_dv_local): clarify cumulative gate semantics

### DIFF
--- a/examples/fast_kernel_launch_example/tests/chunk_bwd_dv_local/test_chunk_bwd_dv_local.py
+++ b/examples/fast_kernel_launch_example/tests/chunk_bwd_dv_local/test_chunk_bwd_dv_local.py
@@ -125,7 +125,7 @@ def chunk_bwd_dv_local_fix(
                 m_A = pos_mask & valid_mask
                 g_i = b_g.unsqueeze(1)
                 g_j = b_g.unsqueeze(0)
-                g_factor = torch.exp(g_j - g_i) * scale
+                g_factor = torch.exp(torch.clamp(g_j - g_i, max=0.0)) * scale
                 b_A_gated = torch.zeros_like(b_A)
                 b_A_gated[:chunk_len, :chunk_len] = b_A[:chunk_len, :chunk_len] * g_factor
                 b_A_masked = torch.where(m_A, b_A_gated, torch.zeros_like(b_A_gated))
@@ -203,7 +203,7 @@ def chunk_bwd_dv_local_variable(
                 m_A = pos_mask & valid_mask
                 g_i = b_g.unsqueeze(1)
                 g_j = b_g.unsqueeze(0)
-                g_factor = torch.exp(g_j - g_i)
+                g_factor = torch.exp(torch.clamp(g_j - g_i, max=0.0))
                 b_A_gated = torch.zeros_like(b_A)
                 b_A_gated[:chunk_len, :chunk_len] = b_A[:chunk_len, :chunk_len] * g_factor * scale
                 b_A_masked = torch.where(m_A, b_A_gated, torch.zeros_like(b_A_gated))

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/README.md
@@ -27,7 +27,7 @@ $$dV_{\text{local}}[doHead] = \left(\text{mask}\!\left(\exp(g[doHead]_{\text{col
 | 阶段 | 执行单元 | 计算 | 说明 |
 |------|----------|------|------|
 | Phase 1 | Cube (AIC) | $W_s[qkHead] = K[qkHead] \times Q[qkHead]^T$ | 对每个 Q/K head 生成 chunk 内 attention score 矩阵 |
-| Phase 1.5 | Vector (AIV) | $W_{s\_gated}[doHead] = \text{mask}(\exp(g[doHead])) \odot W_s[qkHead]$ | 每个 dO head 使用映射到的 Q/K score 做 gating：exp、上三角含对角线 mask、逐元素乘 |
+| Phase 1.5 | Vector (AIV) | $W_{s\_gated}[doHead] = \text{mask}(\exp(g_{col} - g_{row})) \odot W_s[qkHead]$ | 每个 dO head 使用映射到的 Q/K score 做 gating：差值、exp、上三角含对角线 mask、逐元素乘 |
 | Phase 2 | Cube (AIC) | $dV[doHead] = W_{s\_gated}[doHead] \times dO[doHead]$ | 矩阵乘，生成最终梯度输出 |
 
 ---
@@ -81,7 +81,7 @@ aclnnStatus aclnnChunkBwdDvLocal(
 | `q` | 输入 | 必选 | Query 输入张量 | 参与反向计算，使用 Q/K head 数 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H_qk, T, K]` | 支持 |
 | `k` | 输入 | 必选 | Key 输入张量 | 参与反向计算，形状必须与 `q` 一致 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H_qk, T, K]` | 支持 |
 | `dO` | 输入 | 必选 | 前向输出的梯度张量 | 参与反向计算，使用 dO/dV head 数 | `FLOAT16`、`BFLOAT16` | `ND` | `[B, H_do, T, V]` | 支持 |
-| `g` | 输入 | 必选 | Gate 输入张量（门控衰减系数） | 参与 gating 计算，H 轴与 `dO` 一致 | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, H_do, T]` | 支持 |
+| `g` | 输入 | 必选 | chunk 内累计 log-decay | H 轴与 `dO` 一致；每个序列的每个有效 chunk 内沿 T 维单调不增 | `FLOAT16`、`BFLOAT16`、`FLOAT` | `ND` | `[B, H_do, T]` | 支持 |
 | `gGammaOptional` | 输入 | 可选 | 预留门控参数输入 | 当前版本不支持，须传 `None` | `FLOAT` | `ND` | - | - |
 | `aOptional` | 输入 | 可选 | 预留参数输入 | 当前版本不支持，须传 `None` | `FLOAT16`、`BFLOAT16` | `ND` | - | - |
 | `cuSeqlensOptional` | 输入 | 可选 | 变长序列的累计长度信息 | 变长模式输入，形如 `[0, T1, T1+T2, ...]`，形状为 `[N+1]`（N 为 batch 内序列段数，等于 B） | `INT64` | `ND` | 1 维 | - |
@@ -171,6 +171,9 @@ B = 1
 
 ### 4.4 数值语义
 
+- `g` 是 GDN gate activation 后按 chunk 累计得到的 log-decay；在每个序列的每个有效 chunk 内沿 T 维单调不增，序列边界和 chunk 边界重新累计。
+- 对上三角 mask 保留的位置，`g_col - g_row <= 0`，门控因子 `exp(g_col - g_row)` 的取值不超过 1。
+- 非单调 `g` 不满足算子输入契约，不在支持范围内。
 - `scale`：
   - 必须显式传入
   - 推荐设置为：

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/tests/test.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/tests/test.py
@@ -166,7 +166,7 @@ def chunk_bwd_dv_local_fix(
                 m_A = pos_mask & valid_mask
                 g_i = b_g.unsqueeze(1)
                 g_j = b_g.unsqueeze(0)
-                g_factor = torch.exp(g_j - g_i) * scale
+                g_factor = torch.exp(torch.clamp(g_j - g_i, max=0.0)) * scale
                 b_A_gated = torch.zeros_like(b_A)
                 b_A_gated[:chunk_len, :chunk_len] = b_A[:chunk_len, :chunk_len] * g_factor
                 b_A_masked = torch.where(m_A, b_A_gated, torch.zeros_like(b_A_gated))
@@ -241,7 +241,7 @@ def chunk_bwd_dv_local_fix_high_precision(
                 m_A = pos_mask & valid_mask
                 g_i = b_g.unsqueeze(1)
                 g_j = b_g.unsqueeze(0)
-                g_factor = torch.exp(g_j - g_i) * scale
+                g_factor = torch.exp(torch.clamp(g_j - g_i, max=0.0)) * scale
                 b_A_gated = torch.zeros_like(b_A)
                 b_A_gated[:chunk_len, :chunk_len] = b_A[:chunk_len, :chunk_len] * g_factor
                 b_A_masked = torch.where(m_A, b_A_gated, torch.zeros_like(b_A_gated))
@@ -321,7 +321,7 @@ def chunk_bwd_dv_local_variable(
                 m_A = pos_mask & valid_mask
                 g_i = b_g.unsqueeze(1)
                 g_j = b_g.unsqueeze(0)
-                g_factor = torch.exp(g_j - g_i)
+                g_factor = torch.exp(torch.clamp(g_j - g_i, max=0.0))
                 b_A_gated = torch.zeros_like(b_A)
                 b_A_gated[:chunk_len, :chunk_len] = b_A[:chunk_len, :chunk_len] * g_factor * scale
                 b_A_masked = torch.where(m_A, b_A_gated, torch.zeros_like(b_A_gated))
@@ -400,7 +400,7 @@ def chunk_bwd_dv_local_variable_high_precision(
                 m_A = pos_mask & valid_mask
                 g_i = b_g.unsqueeze(1)
                 g_j = b_g.unsqueeze(0)
-                g_factor = torch.exp(g_j - g_i)
+                g_factor = torch.exp(torch.clamp(g_j - g_i, max=0.0))
                 b_A_gated = torch.zeros_like(b_A)
                 b_A_gated[:chunk_len, :chunk_len] = b_A[:chunk_len, :chunk_len] * g_factor * scale
                 b_A_masked = torch.where(m_A, b_A_gated, torch.zeros_like(b_A_gated))

--- a/tests/atk/chunk_bwd_dv_local/README.md
+++ b/tests/atk/chunk_bwd_dv_local/README.md
@@ -9,6 +9,7 @@
 - `q/k` 与 `dO/g/out` 的 `B`、`T` 必须一致；`H_do` 必须能被 `H_qk` 整除。
 - `K` 固定为 `128`，`V` 支持 `128/256`，`chunk_size` 仅支持 `64/128`。
 - `q/k/dO/out` 支持 `BFLOAT16/FLOAT16`；`g` 支持 `FLOAT/FLOAT16/BFLOAT16`。
+- `g` 为 chunk 内累计 log-decay，每个序列的每个有效 chunk 内沿 T 维单调不增；非单调 `g` 不在支持范围内。
 - `gGammaOptional` 和 `aOptional` 当前未启用，必须传 `None`；变长模式下 `cu_seqlens` 与 `chunk_indices` 必须同时提供且 `B=1`。
 - 当前 ATK 用例遵循上述约束，并通过 `case_spec` 固定具体取值；扩展用例时应继续满足这些限制。
 

--- a/tests/atk/chunk_bwd_dv_local/executor_chunk_bwd_dv_local.py
+++ b/tests/atk/chunk_bwd_dv_local/executor_chunk_bwd_dv_local.py
@@ -72,7 +72,7 @@ def _chunk_bwd_dv_local_ref(inputs):
             for start, end in _chunks(T, chunk_size):
                 score = torch.matmul(k[b, hk, start:end].to(calc), q[b, hk, start:end].to(calc).t()) * float(inputs["scale"])
                 g_chunk = g[b, hv, start:end].to(calc)
-                gate = torch.exp(g_chunk[None, :] - g_chunk[:, None])
+                gate = torch.exp(torch.clamp(g_chunk[None, :] - g_chunk[:, None], max=0.0))
                 mask = torch.triu(torch.ones_like(score))
                 out[b, hv, start:end] = torch.matmul(score * gate * mask, do[b, hv, start:end].to(calc))
     return out.to(do.dtype)

--- a/torch_custom/fla_npu/test/golden.py
+++ b/torch_custom/fla_npu/test/golden.py
@@ -2,6 +2,7 @@ import torch
 from typing import Optional
 import math
 
+
 def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
     return cu_seqlens[1:] - cu_seqlens[:-1]
 
@@ -81,7 +82,7 @@ def chunk_bwd_dv_local_fix(
             m_A = pos_mask & valid_mask  # [BT, BT]
             g_i = b_g.unsqueeze(1)   # [chunk_len, 1]
             g_j = b_g.unsqueeze(0)  # [1, chunk_len]
-            g_factor = torch.exp(g_j - g_i)  * scale  # [chunk_len, chunk_len]
+            g_factor = torch.exp(torch.clamp(g_j - g_i, max=0.0)) * scale  # [chunk_len, chunk_len]
             b_A_gated = torch.zeros_like(b_A)
             b_A_gated[:chunk_len, :chunk_len] = b_A[:chunk_len, :chunk_len] * g_factor # [BT, BT] 门控缩放后的注意力核矩阵
             # 应用掩码
@@ -168,7 +169,7 @@ def chunk_bwd_dv_local_variable(
             m_A = pos_mask & valid_mask  # [BT, BT]
             g_i = b_g.unsqueeze(1)  # [chunk_len, 1]
             g_j = b_g.unsqueeze(0)  # [1, chunk_len]
-            g_factor = torch.exp(g_j - g_i)  # [chunk_len, chunk_len]
+            g_factor = torch.exp(torch.clamp(g_j - g_i, max=0.0))  # [chunk_len, chunk_len]
             b_A_gated = torch.zeros_like(b_A)
             # print(f"==== g_factor.shape = {g_factor.shape} ")
             # for i in range(g_factor.shape[0]):


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并满足 GitHub 分支保护要求。更新 PR 后将按仓库流程请求维护者触发 NPU CI。

## 关联 Issue / 背景

- 关联 Issue: Fixes #456
- 背景与目标: fla-org 的 GDN 调用链先生成非正的 gate activation，再按 chunk 做局部累加。因此传入 `chunk_bwd_dv_local` 的 `g` 是累计 log-decay，在每个序列的每个有效 chunk 内沿 T 维单调不增。Issue 中直接构造的非单调 `g` 不满足该输入契约，使 benchmark 的原始指数计算与 Kernel 的防御性截断出现差异。
- 本 PR 解决的问题: 在算子文档中明确累计 gate 的单调约束，并统一 benchmark/golden 的防御性处理。Kernel 与 golden 保留正差值截断，但不将非单调 `g` 纳入支持范围。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `chunk_bwd_dv_local`
- 涉及目录 / 文件: 算子 README 与测试参考、ATK README 与执行器、`torch_custom` golden、fast-kernel-launch 示例测试参考
- 责任人 / 提交人: @chen-linxin
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [x] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不改变既有接口与 shape/dtype/format 支持范围；`g` 必须是 chunk 内累计 log-decay，在每个序列的每个有效 chunk 内沿 T 维单调不增；序列边界和 chunk 边界重新累计。非单调 `g` 不在支持范围内。
- 明确不包含的范围: Kernel、Tiling、InferShape、aclnn/torch 接口、ABI、性能路径修改。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

本 PR 已实际执行以下本地验证：

```sh
python3 -m py_compile <本 PR 修改的 Python 文件>
python3 -m json.tool tests/atk/chunk_bwd_dv_local/atk_chunk_bwd_dv_local.json
git diff --check
```

更新后的 NPU 与 ATK 验证将在新 head 发布后执行：

```sh
python3 torch_custom/fla_npu/test/test_npu_chunk_bwd_dv_local.py
bash tests/atk/run_test_cpu.sh -op=chunk_bwd_dv_local -scope=accuracy
```

- CANN 版本: 待 NPU CI 回填
- 产品 / 芯片类型: A2 / A3 / A5
- CI 链接: 更新 PR 后补充当前 head 的 GitHub NPU CI 链接

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | - | `bash build.sh --pkg --soc=ascend910b --ops=chunk_bwd_dv_local --vendor_name=fla_npu` | 未执行 | 本 PR 未修改编译或运行时代码，待 NPU CI 补齐 |
| A3 | `ascend910_93` | - | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_bwd_dv_local --vendor_name=fla_npu` | 未执行 | 待 NPU CI 补齐 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | - | `bash build.sh --pkg --soc=ascend910b --ops=chunk_bwd_dv_local --vendor_name=fla_npu` | 未执行 | 本 PR 未修改编译或运行时代码，待 NPU CI 补齐 |
| A3 | `ascend910_93` | - | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_bwd_dv_local --vendor_name=fla_npu` | 未执行 | 待 NPU CI 补齐 |
| A5 | `ascend950` | - | `bash build.sh --pkg --soc=ascend950 --ops=chunk_bwd_dv_local --vendor_name=fla_npu` | 未执行 | 待 NPU CI 补齐 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 torch_custom/fla_npu/test/test_npu_chunk_bwd_dv_local.py` | 待执行 | 沿用现有固定长度与变长算子测试，需在更新后的 PR head 上重跑 |
| A2 | `ascend910b` | `bash tests/atk/run_test_cpu.sh -op=chunk_bwd_dv_local -scope=accuracy` | 待执行 | 需在更新后的 PR head 上重跑 |
| A3 | `ascend910_93` | - | 未执行 | 待 NPU CI 补齐 |
| A5 | `ascend950` | - | 未执行 | 待 NPU CI 补齐 |

- 精度对比: 更新后的 NPU 与 ATK 结果待当前 head 验证。
- 性能对比: 未执行；本 PR 不修改 Kernel 或运行时路径。
- 边界 / 异常场景: 沿用现有固定长度、变长序列及 ATK 用例，不新增独立语义测试文件。
- 未覆盖风险: A2/A3/A5 NPU、ATK 和整体 Example ST 尚未在更新后的 head 上执行，需由当前 PR head 的 NPU CI 补齐。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 本 PR 未修改 Kernel；待 NPU CI 补齐 |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐 |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 待 NPU CI 补齐 |

- 端到端场景说明: GDN 正常调用链先生成非正 gate activation，再按 chunk 局部累加；传入本算子的 `g` 在每个有效 chunk 内单调不增。
- 与本 PR 修改算子的关联: 本 PR 修正 benchmark/golden 的防御性处理、测试数据和输入契约说明，不改变端到端执行逻辑。
- 未覆盖原因及补充计划: 更新 PR 后请求维护者对当前 head 触发 NPU CI。

</details>

## 兼容性、风险与回退

- 兼容性说明: 不改变 Kernel、接口或 ABI；符合累计 gate 契约的现有结果保持不变。
- 风险点: 直接向底层算子传入非单调 `g` 的外部测试不符合输入契约，不提供兼容性承诺；A2/A3/A5 与整体 Example ST 仍需 NPU CI 验证。
- 回退方案: 回退本 PR commit 即可，不涉及二进制接口或数据迁移。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的 NPU 精度与回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- fla-org 上游依据：GDN gate activation 为非正值，随后按 chunk 做局部累加；`chunk_bwd_dv_local` 消费的是累计后的 `g`。
- Kernel 保留正差值截断，golden 同步保留防御性截断；这不表示支持非单调输入。
- 本 PR 不新增测试文件，不修改 `ci/run_checks.sh`，也不新增 `ct` 导入或依赖。
- 更新 PR 后需由仓库 Admin 对当前 head 触发 `NPU CI / 手动验证`。