### PR TITLE
fix: 回移植 chunk_bwd_dv_local GQA 同步死锁修复至 v26.9.0

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/README.md
@@ -181,6 +181,15 @@ B = 1
 
 ---
 
+### 4.5 核间同步与 QK 流水
+
+- Cube 通过 3 个 GM ring slot 预填 QK，并为每个 QK head 向两个 Vector 子核发送一次 ready。
+- 两个 Vector 子核消费 ready 后立即共同返回一个 QK free credit；Cube 在淘汰对应的旧 head 时消费该 credit。因此未消费的 QK ready 最多为 3 个，不会触及硬件 flag 计数上限。
+- QK free credit 只负责限制 ready 的在途数量；gated-ready 握手仍保证所有 `hRatio` 个 gated workspace 写回完成后，Cube 才复用对应的 QK slot。
+- QK 与 gated-ready 不使用相同的批量反向确认节奏，避免高 `hRatio` 下两条同步链在计数边界相互等待。
+
+---
+
 ## 5. Torch 测试调用示例
 
 ### 5.1 定长场景（Padding-mode）

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/arch35/chunk_bwd_dv_local_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/arch35/chunk_bwd_dv_local_vector.h
@@ -33,8 +33,8 @@ private:
     Strategy strategy;
     Catlass::Arch::CrossCoreFlagWithReverse<> aivToAicGatedReadyFlag{
         SYNC_AIV_AIC_GATED_READY_FLAG, SYNC_AIC_AIV_GATED_FREE_FLAG};
-    Catlass::Arch::CrossCoreFlagWithReverse<> aicToAivQkReadyFlag{
-        SYNC_AIC_AIV_QK_READY_FLAG, SYNC_AIV_AIC_QK_FREE_FLAG};
+    Catlass::Arch::CrossCoreFlag aicToAivQkReadyFlag{SYNC_AIC_AIV_QK_READY_FLAG};
+    Catlass::Arch::CrossCoreFlag aivToAicQkFreeFlag{SYNC_AIV_AIC_QK_FREE_FLAG};
 
 public:
     __aicore__ inline ChunkBwdDvLocalVector(const Strategy &s) : strategy(s)
@@ -165,7 +165,9 @@ __aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessChunk(c
         taskLineNum = taskEndLine - taskStartLine + 1;
         if (taskLineNum == 0) {
             if (doHead % hRatio == 0) {
-                Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(aicToAivQkReadyFlag);
+                Catlass::Arch::CrossCoreWaitFlag(aicToAivQkReadyFlag);
+                // Return the counter credit now; gated-ready still guards workspace reuse.
+                Catlass::Arch::CrossCoreSetFlag<0x2, PIPE_MTE2>(aivToAicQkFreeFlag);
             }
             Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(aivToAicGatedReadyFlag);
             continue;
@@ -188,7 +190,7 @@ __aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessChunk(c
         }
 
         if (doHead % hRatio == 0) {
-            Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(aicToAivQkReadyFlag);
+            Catlass::Arch::CrossCoreWaitFlag(aicToAivQkReadyFlag);
         }
 
         {
@@ -196,6 +198,10 @@ __aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessChunk(c
             copyParams.blockLen = taskLineNum * strategy.chunkSize * sizeof(QKVT);
             AscendC::DataCopyPad(kqLocalTensor, workspaceGm[taskReadOffset], copyParams, qkvPadParams);
             kqTQueIn.EnQue(kqLocalTensor);
+        }
+        if (doHead % hRatio == 0) {
+            // The QK slot is reusable after its data is queued into UB.
+            Catlass::Arch::CrossCoreSetFlag<0x2, PIPE_MTE2>(aivToAicQkFreeFlag);
         }
 
         {

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_cube.h
@@ -57,8 +57,8 @@ private:
     Strategy strategy;
     Catlass::Arch::CrossCoreFlagWithReverse<> aivToAicGatedReadyFlag{
         SYNC_AIV_AIC_GATED_READY_FLAG, SYNC_AIC_AIV_GATED_FREE_FLAG};
-    Catlass::Arch::CrossCoreFlagWithReverse<> aicToAivQkReadyFlag{
-        SYNC_AIC_AIV_QK_READY_FLAG, SYNC_AIV_AIC_QK_FREE_FLAG};
+    Catlass::Arch::CrossCoreFlag aicToAivQkReadyFlag{SYNC_AIC_AIV_QK_READY_FLAG};
+    Catlass::Arch::CrossCoreFlag aivToAicQkFreeFlag{SYNC_AIV_AIC_QK_FREE_FLAG};
 
 public:
     __aicore__ inline ChunkBwdDvLocalCube(const Strategy &s) : strategy(s)
@@ -167,6 +167,8 @@ __aicore__ inline void ChunkBwdDvLocalCube<QKVT, GT, Strategy, V>::Process()
             if (scheduleIdx >= p1SlotNum) {
                 int64_t qkHead = scheduleIdx - p1SlotNum;
                 if (qkHead < H_qk) {
+                    // Retire the QK credit before consuming the matching gated workspace.
+                    Catlass::Arch::CrossCoreWaitFlag(aivToAicQkFreeFlag);
                     for (int64_t doGroup = 0; doGroup < hRatio; doGroup++) {
                         Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_FIX>(aivToAicGatedReadyFlag);
                     }
@@ -214,7 +216,7 @@ __aicore__ inline void ChunkBwdDvLocalCube<QKVT, GT, Strategy, V>::Process()
                 auto tensorBlockC =
                     GetTile(tensorC, tla::MakeCoord(0, 0), tla::MakeShape(actualBlockShapeQK.m(), actualBlockShapeQK.n()));
                 blockMmadQK(tensorBlockA, tensorBlockB, tensorBlockC, actualBlockShapeQK);
-                Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(aicToAivQkReadyFlag);
+                Catlass::Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(aicToAivQkReadyFlag);
             }
         }
     }

--- a/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_bwd/chunk_bwd_dv_local/op_kernel/chunk_bwd_dv_local_vector.h
@@ -28,8 +28,8 @@ private:
     Strategy strategy;
     Catlass::Arch::CrossCoreFlagWithReverse<> aivToAicGatedReadyFlag{
         SYNC_AIV_AIC_GATED_READY_FLAG, SYNC_AIC_AIV_GATED_FREE_FLAG};
-    Catlass::Arch::CrossCoreFlagWithReverse<> aicToAivQkReadyFlag{
-        SYNC_AIC_AIV_QK_READY_FLAG, SYNC_AIV_AIC_QK_FREE_FLAG};
+    Catlass::Arch::CrossCoreFlag aicToAivQkReadyFlag{SYNC_AIC_AIV_QK_READY_FLAG};
+    Catlass::Arch::CrossCoreFlag aivToAicQkFreeFlag{SYNC_AIV_AIC_QK_FREE_FLAG};
 
 public:
     __aicore__ inline ChunkBwdDvLocalVector(const Strategy &s) : strategy(s)
@@ -204,7 +204,9 @@ __aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessChunk(c
         taskLineNum = taskEndLine - taskStartLine + 1;
         if (taskLineNum == 0) {
             if (doHead % hRatio == 0) {
-                Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(aicToAivQkReadyFlag);
+                Catlass::Arch::CrossCoreWaitFlag(aicToAivQkReadyFlag);
+                // Return the counter credit now; gated-ready still guards workspace reuse.
+                Catlass::Arch::CrossCoreSetFlag<0x2, PIPE_MTE2>(aivToAicQkFreeFlag);
             }
             Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(aivToAicGatedReadyFlag);
             continue;
@@ -296,7 +298,7 @@ __aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessChunk(c
         AscendC::PipeBarrier<PIPE_V>();
         AscendC::Muls(gFactorLocalTensor, gFactorLocalTensor, scale, taskLineNum * strategy.chunkSize);
         if (doHead % hRatio == 0) {
-            Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE2>(aicToAivQkReadyFlag);
+            Catlass::Arch::CrossCoreWaitFlag(aicToAivQkReadyFlag);
         }
 
         // 搬入 (k@q^T)
@@ -305,6 +307,10 @@ __aicore__ inline void ChunkBwdDvLocalVector<QKVT, GT, Strategy>::ProcessChunk(c
             copyParams.blockLen = taskLineNum * strategy.chunkSize * sizeof(QKVT);
             AscendC::DataCopyPad(kqLocalTensor, workspaceGm[taskReadOffset], copyParams, qkvPadParams);
             kqTQueIn.EnQue(kqLocalTensor);
+        }
+        if (doHead % hRatio == 0) {
+            // The QK slot is reusable after its data is queued into UB.
+            Catlass::Arch::CrossCoreSetFlag<0x2, PIPE_MTE2>(aivToAicQkFreeFlag);
         }
         AscendC::LocalTensor<QKVT> kqLocalTensor = kqTQueIn.DeQue<QKVT>();
         AscendC::Cast(kqFp32LocalTensor, kqLocalTensor, AscendC::RoundMode::CAST_NONE,


### PR DESCRIPTION
## 关联 Issue / 背景

- 关联 Issue: #462
- 背景与目标: 将主干 PR #465 的算子同步修复回移植到 `v26.9.0`。
- 本 PR 解决的问题: `chunk_bwd_dv_local` 在高 `hRatio` GQA 配置下可能发生 AIC/AIV 循环等待，导致 kernel hang。

## 变更类型

- [x] Bug 修复
- [x] 算子精度 / 稳定性修复
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `chunk_bwd_dv_local`
- 涉及目录 / 文件: 算子 README，以及 A2/A3 与 A5 arch35 的 Cube/Vector kernel 同步实现
- 责任人 / 提交人: @chen-linxin
- 修改范围:
  - [x] `op_kernel` / Ascend C Kernel
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不变。
- 明确不包含的范围: 不修改 Tiling、InferShape、算子接口、Torch 适配和计算公式；不回移植 PR #465 的 agents 文档调整。
- 是否影响公共模块或其他算子:
  - [x] 否
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
- ABI 不兼容风险说明: 无。

<details>
<summary>修改算子测试</summary>

### 编译与安装

| 产品 | `--soc` | CANN 实际版本 | 验证 | 结果 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0-beta.1 | 完整 wheel 编译、安装与打包 API 检查 | 通过 |
| A3 | `ascend910_93` | 9.1.0-beta.1 | `chunk_bwd_dv_local` 单算子包交叉编译 | 通过 |
| A5 | `ascend950` | 9.1.0 | 完整 wheel 编译、安装与打包 API 检查 | 通过 |

### 单算子测试结果

| 产品 | 测试项 | 结果 |
| --- | --- | --- |
| A2 | 混合容差精度 | 603/603 通过；包含 3 个 Issue 原始 `H_qk=15`、`H_do=120`、`hRatio=8` seed |
| A2 | 确定性 | 16/16 通过，每例循环 50 次 |
| A2 | mssanitizer 内存检测 | 16/16 通过，目标 kernel 未检测到非法访问 |
| A2 | 性能 | 8/8 完成；两轮均值由 4.4738 us 降至 4.3925 us，改善 1.82% |
| A5 | Issue 定向精度 | 3/3 通过混合容差，未出现 kernel hang |
| A5 | 性能 | 8/8 完成；三轮整组均值中位数由 5.461 us 变为 5.577 us，整体波动 +2.11% |

- 精度对比: 使用最新 ATK 用例矩阵、CPU FP64 标杆、校准值域与 `mixed_tolerance_bm`。
- 性能对比: 使用 ATK `performance_device` profiler；A2 两轮、A5 三轮。
- 边界 / 异常场景: 定向覆盖 `H_qk=15`、`H_do=120`、`hRatio=8`、`T=1` 的 3 个固定 seed。
- 未覆盖风险: A3 未进行硬件运行；A5 全量矩阵的 GM 初始化受当前 ATK 环境显存预填行为限制，因此 A5 运行验证采用 Issue 定向场景，完整 603+16+16 验收在 A2 完成。

</details>

<details>
<summary>整体 Example ST / NPU CI 验证</summary>

- 已触发 [`full` NPU CI](https://github.com/flashserve/flash-linear-attention-npu/actions/runs/34029586754)。A2/A3/A5 的整包与单算子编译 6/6 通过。
- full 流程的旧单测为 7/11 通过，除 `chunk_bwd_dv_local` 外另有 3 个未修改算子失败；`chunk_bwd_dv_local` 在 13 秒内返回失败，未复现 kernel hang。该旧测试使用未按当前规范校准的 gate 值域，结果与最新 ATK 混合容差 603/603 通过不一致。
- 流程随后因自定义 OPP `op_api` 安装路径未被主干可信 CI 识别而中止，Example ST 无法解析算子符号，精度报告未生成。因此线上两个 NPU CI 门禁保留失败状态，不将本次 full CI 表述为通过。
- 上述 full CI 同时暴露 v26.9 旧验证流程与主干可信 CI 的兼容问题；本 PR 按用户要求仅回移植算子同步修复，不混入构建、测试或 CI 修复。

</details>

## 兼容性、风险与回退

- 兼容性说明: 接口、shape、dtype、format、Tiling 和 ABI 均不变。
- 风险点: QK free 的返回时机由批量反向确认改为逐 head 信用同步；gated-ready 仍保证 ring slot 在全部输出写回后才复用。
- 回退方案: 回退本 PR 的单个提交即可恢复原同步协议。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [x] 已验证修改算子的对应 test
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过（本次按算子 ATK 验收，未单独执行）
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录
- [x] PR 标题已使用 `fix:` 类型标签
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- QK ready/free 改为逐 QK head 的 `CrossCoreFlag` 信用同步。
- 两个 AIV 子核把 QK 搬入 UB 后，通过 Mode 2 共同返回一份 QK free credit。
- gated ready/free 协议保持不变，继续负责 workspace 安全复用。
- 本 PR 仅包含算子修复和对应算子说明，主干已合入的流程文档不在本次回移植范围内。