### PR TITLE
perf: fuse recurrent gated delta rule into regbase vf

### DIFF
--- a/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_kernel/arch35/recurrent_gated_delta_rule.h
+++ b/fla/ops/ascendc/gdn/recurrent_gdn/recurrent_gated_delta_rule/op_kernel/arch35/recurrent_gated_delta_rule.h
@@ -17,6 +17,7 @@
 
 #include "kernel_operator.h"
 #include "lib/matmul_intf.h"
+#include "kernel_utils/vector/regbase.hpp"
 #include "../recurrent_gated_delta_rule_tiling_data.h"
 
 namespace RecurrentGatedDeltaRule {
@@ -29,18 +30,14 @@ constexpr uint32_t MAX_OUT_BUFFER_NUM = 2;
 constexpr uint64_t MAX_MTP = 8;
 constexpr uint64_t BF16_NUM_PER_BLOCK = 16;
 constexpr uint64_t FP32_NUM_PER_BLOCK = 8;
-constexpr uint32_t REPEAT_LENTH = 64; // 256Byte for float
-constexpr uint32_t MAX_REPEAT_TIME = 255;
-constexpr uint32_t ADD_FOLD_REDUCE_MIN_K = 128;
 constexpr uint16_t V_LENGTH = VECTOR_REG_WIDTH / sizeof(float);
-constexpr uint16_t TWO_V_LENGTH = 2 * V_LENGTH;
 
 constexpr CastTrait castTraitB16ToB32 = {
     RegLayout::ZERO, SatMode::UNKNOWN, MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
-
-#ifndef RGDR_ENABLE_ADD_FOLD_REDUCE
-#define RGDR_ENABLE_ADD_FOLD_REDUCE  1
-#endif
+constexpr static CastTrait castTraitFp32ToB16ZeroRint = {
+    RegLayout::ZERO, SatMode::NO_SAT, MaskMergeMode::MERGING, RoundMode::CAST_RINT};
+constexpr static CastTrait castTraitFp32ToB16OneRint = {
+    RegLayout::ONE, SatMode::NO_SAT, MaskMergeMode::ZEROING, RoundMode::CAST_RINT};
 struct RGDRInitParams {
     GM_ADDR query;
     GM_ADDR key;
@@ -55,6 +52,171 @@ struct RGDRInitParams {
     GM_ADDR attnOut;
     GM_ADDR finalState;
 };
+
+template <typename stateType, typename outType, bool hasGama, bool hasGamaK>
+__simd_vf__ inline void ComputeRecurrentGatedDeltaRuleVF(
+    __ubuf__ float *state, __ubuf__ float *key, __ubuf__ float *query, __ubuf__ float *value,
+    __ubuf__ float *gamaK, __ubuf__ stateType *stateOut, __ubuf__ outType *attnOut,
+    __ubuf__ float *attnTmp, uint16_t rows, uint16_t kLength, float gama, float beta,
+    bool runtimeHasGama, bool runtimeHasGamaK)
+{
+    // The public interface fixes Dk to 128, i.e. two FP32 vector registers on A5.
+    // Keeping the complete recurrence in one VF lets both state halves remain in registers
+    // across gate, dot-product, rank-one update, output projection and output conversion.
+    constexpr uint16_t FP32_PER_REG = VECTOR_REG_WIDTH / sizeof(float);
+    MaskReg fullFp32Mask = CreateMask<float, MaskPattern::ALL>();
+    MaskReg fullB16Mask = CreateMask<bfloat16_t, MaskPattern::ALL>();
+
+    RegTensor<float> key0;
+    RegTensor<float> key1;
+    RegTensor<float> query0;
+    RegTensor<float> query1;
+    if constexpr (std::is_same<stateType, float32_t>()) {
+        DataCopy(key0, key);
+        DataCopy(key1, key + FP32_PER_REG);
+        DataCopy(query0, query);
+        DataCopy(query1, query + FP32_PER_REG);
+    } else {
+        DataCopy<float, LoadDist::DIST_DINTLV_B32>(key0, key1, key);
+        DataCopy<float, LoadDist::DIST_DINTLV_B32>(query0, query1, query);
+    }
+
+    RegTensor<float> gamaK0;
+    RegTensor<float> gamaK1;
+    if constexpr (std::is_same<stateType, float32_t>()) {
+        if (runtimeHasGamaK) {
+            DataCopy(gamaK0, gamaK);
+            DataCopy(gamaK1, gamaK + FP32_PER_REG);
+        }
+    } else if constexpr (hasGamaK) {
+        DataCopy<float, LoadDist::DIST_DINTLV_B32>(gamaK0, gamaK1, gamaK);
+    }
+
+    for (uint16_t row = 0; row < rows; ++row) {
+        const uint32_t rowOffset = static_cast<uint32_t>(row) * kLength;
+        RegTensor<float> state0;
+        RegTensor<float> state1;
+        if constexpr (std::is_same<stateType, float32_t>()) {
+            DataCopy(state0, state + rowOffset);
+            DataCopy(state1, state + rowOffset + FP32_PER_REG);
+        } else {
+            DataCopy<float, LoadDist::DIST_DINTLV_B32>(state0, state1, state + rowOffset);
+        }
+
+        if constexpr (std::is_same<stateType, float32_t>()) {
+            if (runtimeHasGama) {
+                Muls(state0, state0, gama, fullFp32Mask);
+                Muls(state1, state1, gama, fullFp32Mask);
+            }
+            if (runtimeHasGamaK) {
+                Mul(state0, state0, gamaK0, fullFp32Mask);
+                Mul(state1, state1, gamaK1, fullFp32Mask);
+            }
+        } else {
+            if constexpr (hasGama) {
+                Muls(state0, state0, gama, fullFp32Mask);
+                Muls(state1, state1, gama, fullFp32Mask);
+            }
+            if constexpr (hasGamaK) {
+                Mul(state0, state0, gamaK0, fullFp32Mask);
+                Mul(state1, state1, gamaK1, fullFp32Mask);
+            }
+        }
+
+        RegTensor<float> dot0;
+        RegTensor<float> dot1;
+        RegTensor<float> dotSum;
+        Mul(dot0, state0, key0, fullFp32Mask);
+        Mul(dot1, state1, key1, fullFp32Mask);
+        Add(dot0, dot0, dot1, fullFp32Mask);
+        ReduceSum(dotSum, dot0, fullFp32Mask);
+        DataCopy<float, StoreDist::DIST_FIRST_ELEMENT_B32>(attnTmp + row, dotSum, fullFp32Mask);
+        if constexpr (std::is_same<stateType, float32_t>()) {
+            DataCopy(state + rowOffset, state0, fullFp32Mask);
+            DataCopy(state + rowOffset + FP32_PER_REG, state1, fullFp32Mask);
+        } else {
+            DataCopy<float, StoreDist::DIST_INTLV_B32>(state + rowOffset, state0, state1, fullFp32Mask);
+        }
+    }
+
+    LocalMemBar<MemType::VEC_STORE, MemType::VEC_LOAD>();
+    for (uint16_t row = 0; row < rows; ++row) {
+        const uint32_t rowOffset = static_cast<uint32_t>(row) * kLength;
+
+        RegTensor<float> attn;
+        RegTensor<float> delta;
+        DataCopy<float, LoadDist::DIST_BRC_B32>(attn, value + row);
+        RegTensor<float> dotSum;
+        DataCopy<float, LoadDist::DIST_BRC_B32>(dotSum, attnTmp + row);
+        Sub(attn, attn, dotSum, fullFp32Mask);
+        Muls(delta, attn, beta, fullFp32Mask);
+
+        RegTensor<float> state0;
+        RegTensor<float> state1;
+        if constexpr (std::is_same<stateType, float32_t>()) {
+            DataCopy(state0, state + rowOffset);
+            DataCopy(state1, state + rowOffset + FP32_PER_REG);
+        } else {
+            DataCopy<float, LoadDist::DIST_DINTLV_B32>(state0, state1, state + rowOffset);
+        }
+        RegTensor<float> update0;
+        RegTensor<float> update1;
+        Mul(update0, delta, key0, fullFp32Mask);
+        Mul(update1, delta, key1, fullFp32Mask);
+        Add(state0, state0, update0, fullFp32Mask);
+        Add(state1, state1, update1, fullFp32Mask);
+        if constexpr (std::is_same<stateType, float32_t>()) {
+            DataCopy(state + rowOffset, state0, fullFp32Mask);
+            DataCopy(state + rowOffset + FP32_PER_REG, state1, fullFp32Mask);
+        } else {
+            DataCopy<float, StoreDist::DIST_INTLV_B32>(state + rowOffset, state0, state1, fullFp32Mask);
+        }
+
+        RegTensor<float> out0;
+        RegTensor<float> out1;
+        RegTensor<float> outSum;
+        Mul(out0, state0, query0, fullFp32Mask);
+        Mul(out1, state1, query1, fullFp32Mask);
+        Add(out0, out0, out1, fullFp32Mask);
+        ReduceSum(outSum, out0, fullFp32Mask);
+        DataCopy<float, StoreDist::DIST_FIRST_ELEMENT_B32>(attnTmp + row, outSum, fullFp32Mask);
+
+        if constexpr (std::is_same<stateType, float32_t>()) {
+            DataCopy(stateOut + rowOffset, state0, fullFp32Mask);
+            DataCopy(stateOut + rowOffset + FP32_PER_REG, state1, fullFp32Mask);
+        } else {
+            RegTensor<stateType> stateOutReg;
+            Cast<stateType, float, castTraitFp32ToB16OneRint>(
+                stateOutReg, state1, fullFp32Mask);
+            Cast<stateType, float, castTraitFp32ToB16ZeroRint>(
+                stateOutReg, state0, fullFp32Mask);
+            StoreAlign(stateOut + rowOffset, stateOutReg, fullB16Mask);
+        }
+    }
+
+    LocalMemBar<MemType::VEC_STORE, MemType::VEC_LOAD>();
+    if constexpr (std::is_same<outType, float32_t>()) {
+        uint32_t remaining = rows;
+        for (uint16_t offset = 0; offset < rows; offset += FP32_PER_REG) {
+            MaskReg mask = UpdateMask<float>(remaining);
+            RegTensor<float> output;
+            DataCopy(output, attnTmp + offset);
+            DataCopy(attnOut + offset, output, mask);
+        }
+    } else {
+        RegTensor<float> output0;
+        RegTensor<float> output1;
+        RegTensor<outType> output;
+        DataCopy<float, LoadDist::DIST_DINTLV_B32>(output0, output1, attnTmp);
+        Cast<outType, float, castTraitFp32ToB16OneRint>(
+            output, output1, fullFp32Mask);
+        Cast<outType, float, castTraitFp32ToB16ZeroRint>(
+            output, output0, fullFp32Mask);
+        uint32_t remaining = rows;
+        MaskReg outputMask = UpdateMask<outType>(remaining);
+        StoreAlign(attnOut, output, outputMask);
+    }
+}
 
 template <typename inType, typename outType, typename stateType>
 class RGDR {
@@ -74,7 +236,6 @@ public:
         hasAcceptedTokens_ = (tilingData->hasAcceptedTokens == 1);
         hasGama_ = (tilingData->hasGama == 1);
         hasGamaK_ = (tilingData->hasGamaK == 1);
-        useAddFoldReduce_ = (RGDR_ENABLE_ADD_FOLD_REDUCE != 0);
         vStep_ = tilingData->vStep;
         stateOutBufferNum_ = (tilingData->stateOutBufferNum == MAX_OUT_BUFFER_NUM) ? MAX_OUT_BUFFER_NUM : BUFFER_NUM;
         attnOutBufferNum_ = (tilingData->attnOutBufferNum == MAX_OUT_BUFFER_NUM) ? MAX_OUT_BUFFER_NUM : BUFFER_NUM;
@@ -136,8 +297,6 @@ public:
         pipe_->InitBuffer(attnOutQueue_, attnOutBufferNum_, vStep_ * sizeof(outType));
         pipe_->InitBuffer(tmpBuff, restUbSize_);
         uint32_t buffOffset = 0;
-        deltaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(vStep_), buffOffset);
-        buffOffset += singleVSize;
         attnInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(vStep_), buffOffset);
         buffOffset += singleVSize;
         vInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignV_), buffOffset);
@@ -147,8 +306,6 @@ public:
         kInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignK_), buffOffset);
         buffOffset += kSize;
         stateInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
-        buffOffset += cubeSize;
-        broadTmpInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
         buffOffset += cubeSize;
         betaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(betaNumAlign), buffOffset);
         buffOffset += betaUbSize;
@@ -274,179 +431,6 @@ private:
         stateInQueue_.FreeTensor(stateLocal);
     }
 
-    __aicore__ inline void MatVecMul(const LocalTensor<float> &cubeTensor, const LocalTensor<float> &vecTensor,
-                                          LocalTensor<float> &dstTensor, uint32_t rows)
-    {
-        __ubuf__ float* cubeAddr = (__ubuf__ float*)cubeTensor.GetPhyAddr();
-        __ubuf__ float* vecAddr = (__ubuf__ float*)vecTensor.GetPhyAddr();
-        __ubuf__ float* dstAddr = (__ubuf__ float*)dstTensor.GetPhyAddr();
-
-        uint16_t rowNum = static_cast<uint16_t>(rows);
-        uint16_t colLoopTimes = static_cast<uint16_t>(Ceil(alignK_, V_LENGTH));
-        uint32_t colLength = alignK_;
-        __VEC_SCOPE__
-        {
-            RegTensor<float> cube;
-            RegTensor<float> vec;
-            RegTensor<float> dst;
-            MaskReg pregLoop;
-            for (uint16_t j = 0; j < colLoopTimes; j++) {
-                pregLoop = UpdateMask<float>(colLength);
-                DataCopy(vec, vecAddr + j * V_LENGTH);
-                for (uint16_t i = 0; i < rowNum; i ++) {
-                    DataCopy(cube, cubeAddr + i * alignK_ + j * V_LENGTH);
-                    Mul(dst, cube, vec, pregLoop);
-                    DataCopy(dstAddr + i * alignK_ + j * V_LENGTH, dst, pregLoop);
-                }
-            }
-        }
-    }
-
-    __aicore__ inline void ProcessKQ(const LocalTensor<float> &cubeTensor, const LocalTensor<float> &vec1Tensor,
-                                          LocalTensor<float> &dst1Tensor, const LocalTensor<float> &vec2Tensor,
-                                          LocalTensor<float> &dst2Tensor, uint32_t rows)
-    {
-        __ubuf__ float* cubeAddr = (__ubuf__ float*)cubeTensor.GetPhyAddr();
-        __ubuf__ float* vec1Addr = (__ubuf__ float*)vec1Tensor.GetPhyAddr();
-        __ubuf__ float* vec2Addr = (__ubuf__ float*)vec2Tensor.GetPhyAddr();
-        __ubuf__ float* dst1Addr = (__ubuf__ float*)dst1Tensor.GetPhyAddr();
-        __ubuf__ float* dst2Addr = (__ubuf__ float*)dst2Tensor.GetPhyAddr();
-
-        uint16_t rowNum = static_cast<uint16_t>(rows);
-        uint16_t colLoopTimes = static_cast<uint16_t>(Ceil(alignK_, V_LENGTH));
-        uint32_t colLength = alignK_;
-        __VEC_SCOPE__
-        {
-            RegTensor<float> cube;
-            RegTensor<float> vec1;
-            RegTensor<float> vec2;
-            RegTensor<float> dst1;
-            RegTensor<float> dst2;
-            MaskReg pregLoop;
-            for (uint16_t j = 0; j < colLoopTimes; j++) {
-                pregLoop = UpdateMask<float>(colLength);
-                DataCopy(vec1, vec1Addr + j * V_LENGTH);
-                DataCopy(vec2, vec2Addr + j * V_LENGTH);
-                for (uint16_t i = 0; i < rowNum; i ++) {
-                    DataCopy<float, LoadDist::DIST_BRC_B32>(cube, cubeAddr + i);
-                    DataCopy(dst1, dst1Addr + i * alignK_ + j * V_LENGTH);
-                    Mul(cube, cube, vec1, pregLoop);
-                    Add(dst1, dst1, cube, pregLoop);
-                    Mul(dst2, dst1, vec2, pregLoop);
-                    DataCopy(dst1Addr + i * alignK_ + j * V_LENGTH, dst1, pregLoop);
-                    DataCopy(dst2Addr + i * alignK_ + j * V_LENGTH, dst2, pregLoop);
-                }
-            }
-        }
-    }
-
-    __aicore__ inline void ReduceSum64(__ubuf__ float* dstAddr, __ubuf__ float* srcAddr, uint16_t rowNum)
-    {
-        uint32_t colLength = alignK_;
-        __VEC_SCOPE__
-        {
-            RegTensor<float> src;
-            RegTensor<float> sum;
-            MaskReg pregLoop = UpdateMask<float>(colLength);
-            for (uint16_t i = 0;i < rowNum;i ++) {
-                DataCopy(src, srcAddr + i * alignK_);
-                ReduceSum(sum, src, pregLoop);
-                DataCopy<float, StoreDist::DIST_FIRST_ELEMENT_B32>(dstAddr + i, sum, pregLoop);
-            }
-        }
-    }
-
-    __aicore__ inline void ReduceSum128(__ubuf__ float* dstAddr, __ubuf__ float* srcAddr, uint16_t rowNum)
-    {
-        uint32_t colLength = alignK_ - V_LENGTH;
-        __VEC_SCOPE__
-        {
-            RegTensor<float> src1;
-            RegTensor<float> src2;
-            RegTensor<float> sum;
-            MaskReg pregFull = CreateMask<float, MaskPattern::ALL>();
-            MaskReg pregLoop = UpdateMask<float>(colLength);
-            for (uint16_t i = 0;i < rowNum;i ++) {
-                DataCopy(src1, srcAddr + i * alignK_);
-                DataCopy(src2, srcAddr + i * alignK_ + V_LENGTH);
-                Add<float, MaskMergeMode::MERGING>(src1, src1, src2, pregLoop);
-                ReduceSum(sum, src1, pregFull);
-                DataCopy<float, StoreDist::DIST_FIRST_ELEMENT_B32>(dstAddr + i, sum, pregFull);
-            }
-        }
-    }
-
-    __aicore__ inline void ReduceSumVF(__ubuf__ float* dstAddr, __ubuf__ float* srcAddr, uint16_t rowNum)
-    {
-        uint16_t colLoopTimes = static_cast<uint16_t>(Ceil(alignK_, V_LENGTH));
-        __VEC_SCOPE__
-        {
-            RegTensor<float> src;
-            RegTensor<float> tmp;
-            RegTensor<float> sum;
-            MaskReg pregFull = CreateMask<float, MaskPattern::ALL>();
-            MaskReg pregLoop;
-            for (uint16_t i = 0;i < rowNum;i ++) {
-                uint32_t colLength = alignK_;
-                Duplicate(tmp, 0.0f);
-                for (uint16_t j = 0; j < colLoopTimes; j++) {
-                    pregLoop = UpdateMask<float>(colLength);
-                    DataCopy(src, srcAddr + i * alignK_ + j * V_LENGTH);
-                    Add<float, MaskMergeMode::MERGING>(tmp, tmp, src, pregLoop);
-                }
-                ReduceSum(sum, tmp, pregFull);
-                DataCopy<float, StoreDist::DIST_FIRST_ELEMENT_B32>(dstAddr + i, sum, pregFull);
-            }
-        }
-    }
-
-    __aicore__ inline void ReduceSumDispatch(LocalTensor<float> &dstTensor, LocalTensor<float> &srcTensor,
-                                             uint32_t rows)
-    {
-        __ubuf__ float* srcAddr = (__ubuf__ float*)srcTensor.GetPhyAddr();
-        __ubuf__ float* dstAddr = (__ubuf__ float*)dstTensor.GetPhyAddr();
-        uint16_t rowNum = static_cast<uint16_t>(rows);
-        if (alignK_ <= V_LENGTH) {
-            ReduceSum64(dstAddr, srcAddr, rowNum);
-        } else if (alignK_ <= TWO_V_LENGTH) {
-            ReduceSum128(dstAddr, srcAddr, rowNum);
-        } else {
-            ReduceSumVF(dstAddr, srcAddr, rowNum);
-        }
-    }
-
-    __aicore__ inline void SubMasked(LocalTensor<float> &dstTensor, const LocalTensor<float> &src0Tensor,
-                                    const LocalTensor<float> &src1Tensor, uint32_t count)
-    {
-        BinaryRepeatParams repeatParams{1, 1, 1, FP32_NUM_PER_BLOCK, FP32_NUM_PER_BLOCK, FP32_NUM_PER_BLOCK};
-        uint8_t repeatTime = static_cast<uint8_t>(count / V_LENGTH);
-        uint32_t tailCount = count % V_LENGTH;
-        if (repeatTime > 0) {
-            Sub(dstTensor, src0Tensor, src1Tensor, static_cast<uint64_t>(V_LENGTH), repeatTime, repeatParams);
-        }
-        if (tailCount > 0) {
-            uint32_t tailOffset = count - tailCount;
-            Sub(dstTensor[tailOffset], src0Tensor[tailOffset], src1Tensor[tailOffset],
-                static_cast<uint64_t>(tailCount), 1, repeatParams);
-        }
-    }
-
-    __aicore__ inline void MulsMasked(LocalTensor<float> &dstTensor, const LocalTensor<float> &srcTensor,
-                                     float scalar, uint32_t count)
-    {
-        UnaryRepeatParams repeatParams{1, 1, FP32_NUM_PER_BLOCK, FP32_NUM_PER_BLOCK};
-        uint8_t repeatTime = static_cast<uint8_t>(count / V_LENGTH);
-        uint32_t tailCount = count % V_LENGTH;
-        if (repeatTime > 0) {
-            Muls(dstTensor, srcTensor, scalar, static_cast<uint64_t>(V_LENGTH), repeatTime, repeatParams);
-        }
-        if (tailCount > 0) {
-            uint32_t tailOffset = count - tailCount;
-            Muls(dstTensor[tailOffset], srcTensor[tailOffset], scalar, static_cast<uint64_t>(tailCount), 1,
-                 repeatParams);
-        }
-    }
-
     __aicore__ inline void ExpMasked(LocalTensor<float> &dstTensor, const LocalTensor<float> &srcTensor,
                                     uint32_t count)
     {
@@ -464,35 +448,48 @@ private:
 
     __aicore__ inline void Compute(uint32_t curSingleV, uint64_t curQKOffset, uint64_t curVOffset)
     {
-        if (hasGama_) {
-            Muls(stateInUb, stateInUb, gama_, alignK_ * curSingleV);
-        }
-        if (hasGamaK_) {
-            MatVecMul(stateInUb, gamaKInUb[curQKOffset], stateInUb, curSingleV);
-        }
-        if (hasGama_ || hasGamaK_) {
-            AscendC::PipeBarrier<PIPE_V>();
-        }
-        MatVecMul(stateInUb, kInUb[curQKOffset], broadTmpInUb, curSingleV);
-        AscendC::PipeBarrier<PIPE_V>();
-        ReduceSumDispatch(deltaInUb, broadTmpInUb, curSingleV);
-        AscendC::PipeBarrier<PIPE_V>();
-        SubMasked(attnInUb, vInUb[curVOffset], deltaInUb, curSingleV);
-        AscendC::PipeBarrier<PIPE_V>();
-        MulsMasked(deltaInUb, attnInUb, beta_, curSingleV);
-        AscendC::PipeBarrier<PIPE_V>();
-        ProcessKQ(deltaInUb, kInUb[curQKOffset], stateInUb, qInUb[curQKOffset], broadTmpInUb, curSingleV);
-        AscendC::PipeBarrier<PIPE_V>();
-        ReduceSumDispatch(attnInUb, broadTmpInUb, curSingleV);
         LocalTensor<stateType> stateOutLocal = stateOutQueue_.AllocTensor<stateType>();
         LocalTensor<outType> attnOutLocal = attnOutQueue_.AllocTensor<outType>();
+        __ubuf__ float *stateAddr = reinterpret_cast<__ubuf__ float *>(stateInUb.GetPhyAddr());
+        __ubuf__ float *keyAddr = reinterpret_cast<__ubuf__ float *>(kInUb[curQKOffset].GetPhyAddr());
+        __ubuf__ float *queryAddr = reinterpret_cast<__ubuf__ float *>(qInUb[curQKOffset].GetPhyAddr());
+        __ubuf__ float *valueAddr = reinterpret_cast<__ubuf__ float *>(vInUb[curVOffset].GetPhyAddr());
+        __ubuf__ float *gamaKAddr = hasGamaK_
+            ? reinterpret_cast<__ubuf__ float *>(gamaKInUb[curQKOffset].GetPhyAddr())
+            : stateAddr;
+        __ubuf__ stateType *stateOutAddr =
+            reinterpret_cast<__ubuf__ stateType *>(stateOutLocal.GetPhyAddr());
+        __ubuf__ outType *attnOutAddr = reinterpret_cast<__ubuf__ outType *>(attnOutLocal.GetPhyAddr());
+        __ubuf__ float *attnTmpAddr = reinterpret_cast<__ubuf__ float *>(attnInUb.GetPhyAddr());
         if constexpr (std::is_same<stateType, float32_t>()) {
-            DataCopy(stateOutLocal, stateInUb, alignK_ * curSingleV);
+            ComputeRecurrentGatedDeltaRuleVF<stateType, outType, false, false>(
+                stateAddr, keyAddr, queryAddr, valueAddr, gamaKAddr, stateOutAddr, attnOutAddr,
+                attnTmpAddr, static_cast<uint16_t>(curSingleV), static_cast<uint16_t>(alignK_),
+                gama_, beta_, hasGama_, hasGamaK_);
+        } else if (hasGama_) {
+            if (hasGamaK_) {
+                ComputeRecurrentGatedDeltaRuleVF<stateType, outType, true, true>(
+                    stateAddr, keyAddr, queryAddr, valueAddr, gamaKAddr, stateOutAddr, attnOutAddr,
+                    attnTmpAddr, static_cast<uint16_t>(curSingleV), static_cast<uint16_t>(alignK_),
+                    gama_, beta_, true, true);
+            } else {
+                ComputeRecurrentGatedDeltaRuleVF<stateType, outType, true, false>(
+                    stateAddr, keyAddr, queryAddr, valueAddr, gamaKAddr, stateOutAddr, attnOutAddr,
+                    attnTmpAddr, static_cast<uint16_t>(curSingleV), static_cast<uint16_t>(alignK_),
+                    gama_, beta_, true, false);
+            }
+        } else if (hasGamaK_) {
+            ComputeRecurrentGatedDeltaRuleVF<stateType, outType, false, true>(
+                stateAddr, keyAddr, queryAddr, valueAddr, gamaKAddr, stateOutAddr, attnOutAddr,
+                attnTmpAddr, static_cast<uint16_t>(curSingleV), static_cast<uint16_t>(alignK_),
+                gama_, beta_, false, true);
         } else {
-            Cast(stateOutLocal, stateInUb, AscendC::RoundMode::CAST_RINT, alignK_ * curSingleV);
+            ComputeRecurrentGatedDeltaRuleVF<stateType, outType, false, false>(
+                stateAddr, keyAddr, queryAddr, valueAddr, gamaKAddr, stateOutAddr, attnOutAddr,
+                attnTmpAddr, static_cast<uint16_t>(curSingleV), static_cast<uint16_t>(alignK_),
+                gama_, beta_, false, false);
         }
         stateOutQueue_.EnQue<stateType>(stateOutLocal);
-        Cast(attnOutLocal, attnInUb, AscendC::RoundMode::CAST_RINT, curSingleV);
         attnOutQueue_.EnQue<outType>(attnOutLocal);
     }
 
@@ -646,8 +643,6 @@ private:
     LocalTensor<float> gamaInUb;
     LocalTensor<float> gamaKInUb;
     LocalTensor<float> betaInUb;
-    LocalTensor<float> deltaInUb;
-    LocalTensor<float> broadTmpInUb;
     LocalTensor<float> attnInUb;
     LocalTensor<float> stateInUb;
     uint32_t B_;
@@ -668,7 +663,6 @@ private:
     bool hasAcceptedTokens_;
     bool hasGama_;
     bool hasGamaK_;
-    bool useAddFoldReduce_;
     float gama_;
     float beta_;
     float scale_;


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [x] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @Canzovo
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
# 默认 CANN 安装路径；自定义安装路径时替换为实际路径下对应的 set_env.sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
