### PR TITLE
8 17 26

### DIFF
--- a/examples/flash_gated_delta_rule.py
+++ b/examples/flash_gated_delta_rule.py
@@ -1143,15 +1143,18 @@ def flash_gated_delta_rule(
     r"""
     Flash-linear-attention NPU port of xtuner's GDN entry.
 
-    This port keeps the xtuner NPU layout:
-        q, k: [B, H, T, K]
-        v:    [B, H, T, V]
-        g:    [B, T, H]
-        beta: [B, T, H]
+    This port keeps the xtuner NPU layout and supports grouped value attention:
+        q, k: [B, Hk, T, K]
+        v:    [B, Hv, T, V]
+        g:    [B, T, Hv]
+        beta: [B, T, Hv]
+
+    Hv must be an integer multiple of Hk. Value head hv reuses query/key
+    head ``hk = hv // (Hv // Hk)``.
 
     It returns:
-        o: [B, T, H, V]
-        final_state: [N, H, K, V] when output_final_state=True, else None
+        o: [B, T, Hv, V]
+        final_state: [N, Hv, K, V] when output_final_state=True, else None
     """
     if q.dtype != k.dtype or k.dtype != v.dtype:
         raise ValueError(
@@ -1161,22 +1164,29 @@ def flash_gated_delta_rule(
     if q.dtype == torch.float32:
         raise ValueError("ChunkGatedDeltaRuleFunction does not support float32. Please use float16/bfloat16.")
     if beta.ndim != 3 or g.ndim != 3:
-        raise ValueError("g and beta must be rank-3 tensors with shape [B, T, H].")
+        raise ValueError("g and beta must be rank-3 tensors with shape [B, T, Hv].")
     if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
-        raise ValueError("q, k and v must be rank-4 tensors with shape [B, H, T, D].")
-    if q.shape[:3] != k.shape[:3] or q.shape[:3] != v.shape[:3]:
-        raise ValueError(f"q/k/v shape prefixes must match, got {q.shape}, {k.shape}, {v.shape}.")
+        raise ValueError("q/k and v must be rank-4 tensors with shapes [B, Hk, T, K] and [B, Hv, T, V].")
+    if q.shape != k.shape:
+        raise ValueError(f"q and k shapes must match, got q={q.shape}, k={k.shape}.")
+    if q.shape[0] != v.shape[0] or q.shape[2] != v.shape[2]:
+        raise ValueError(f"q/k/v batch and sequence dimensions must match, got q={q.shape}, v={v.shape}.")
+    if v.shape[1] % q.shape[1] != 0:
+        raise ValueError(
+            f"value heads must be a multiple of query heads, got q_heads={q.shape[1]}, v_heads={v.shape[1]}."
+        )
     if g.shape != beta.shape:
         raise ValueError(f"g and beta shapes must match, got {g.shape} and {beta.shape}.")
-    if g.shape[0] != q.shape[0] or g.shape[1] != q.shape[2] or g.shape[2] != q.shape[1]:
+    if g.shape[0] != q.shape[0] or g.shape[1] != q.shape[2] or g.shape[2] != v.shape[1]:
         raise ValueError(
-            "Expected q/k/v in [B, H, T, D] and g/beta in [B, T, H]; "
-            f"got q={tuple(q.shape)}, g={tuple(g.shape)}."
+            "Expected q/k in [B, Hk, T, K], v in [B, Hv, T, V], and g/beta in [B, T, Hv]; "
+            f"got q={tuple(q.shape)}, v={tuple(v.shape)}, g={tuple(g.shape)}."
         )
 
     if head_first:
         warnings.warn(
-            "head_first is kept only for API compatibility. This NPU port always expects q/k/v as [B, H, T, D].",
+            "head_first is kept only for API compatibility. This NPU port expects q/k as [B, Hk, T, K] "
+            "and v as [B, Hv, T, V].",
             stacklevel=2,
         )
     if chunk_size != 2 ** (chunk_size.bit_length() - 1):
@@ -1265,8 +1275,8 @@ class DemoGatedDeltaNet(nn.Module):
         self.num_k_heads = num_key_heads
         if self.num_v_heads % self.num_k_heads != 0:
             raise ValueError(
-                "num_value_heads must be an integer multiple of num_key_heads "
-                f"for the current grouped-value smoke path, got {self.num_v_heads} and {self.num_k_heads}."
+                "DemoGatedDeltaNet requires num_value_heads to be a multiple of num_key_heads; "
+                f"got {self.num_v_heads} and {self.num_k_heads}."
             )
         if key_head_dim != value_head_dim:
             raise ValueError(
@@ -1334,11 +1344,6 @@ class DemoGatedDeltaNet(nn.Module):
 
         beta = b.sigmoid()
         g = -self.A_log.float().exp() * torch.nn.functional.softplus(a.float() + self.dt_bias)
-
-        repeat = self.num_v_heads // self.num_k_heads
-        if repeat > 1:
-            query = query.repeat_interleave(repeat, dim=1)
-            key = key.repeat_interleave(repeat, dim=1)
 
         cu_list = cu_seqlens.detach().tolist() if cu_seqlens is not None else None
         cu_seqlens_list: Optional[list[int]] = cu_list if cu_list is not None else None
@@ -1552,14 +1557,18 @@ def _naive_recurrent_gated_delta_rule_cpu(
     scale: float,
 ) -> torch.Tensor:
     q, k, v, beta, g = [x.transpose(1, 2).contiguous().float() for x in (q, k, v, beta, g)]
-    B, H, T, K = q.shape
+    B, Hk, T, K = q.shape
+    Hv = v.shape[1]
+    if Hv % Hk != 0:
+        raise ValueError(f"value heads must be a multiple of query heads, got Hk={Hk}, Hv={Hv}")
+    head_map = torch.arange(Hv, device=q.device) // (Hv // Hk)
     V = v.shape[-1]
-    state = q.new_zeros(B, H, K, V)
-    o = q.new_empty(B, H, T, V)
+    state = q.new_zeros(B, Hv, K, V)
+    o = q.new_empty(B, Hv, T, V)
     q = q * scale
     for idx in range(T):
-        q_i = q[:, :, idx]
-        k_i = k[:, :, idx]
+        q_i = q[:, head_map, idx]
+        k_i = k[:, head_map, idx]
         v_i = v[:, :, idx]
         beta_i = beta[:, :, idx]
         g_i = g[:, :, idx].exp()
@@ -1574,8 +1583,6 @@ def _naive_recurrent_gated_delta_rule_cpu(
 def _run_cpu_accuracy_reference(
     inputs: dict[str, torch.Tensor],
     *,
-    query_heads: int,
-    value_heads: int,
     scale: float,
     qk_l2norm: bool,
     cu_seqlens: Optional[list[int]],
@@ -1588,14 +1595,9 @@ def _run_cpu_accuracy_reference(
     g = inputs["g"].detach().float().requires_grad_("dg" in tensors)
     do = inputs["do"].detach().float()
 
-    repeat = value_heads // query_heads
-
     def run_slice(start: int, end: int) -> torch.Tensor:
         q_i = q[:, :, start:end, :].transpose(1, 2)
         k_i = k[:, :, start:end, :].transpose(1, 2)
-        if repeat != 1:
-            q_i = q_i.repeat_interleave(repeat, dim=2)
-            k_i = k_i.repeat_interleave(repeat, dim=2)
         if qk_l2norm:
             q_i = F.normalize(q_i, p=2, dim=-1)
             k_i = F.normalize(k_i, p=2, dim=-1)
@@ -1636,8 +1638,6 @@ def _load_or_create_accuracy_golden(
     path: Path,
     config: dict,
     inputs: dict[str, torch.Tensor],
-    query_heads: int,
-    value_heads: int,
     scale: float,
     qk_l2norm: bool,
     cu_seqlens: Optional[list[int]],
@@ -1653,8 +1653,6 @@ def _load_or_create_accuracy_golden(
     path.parent.mkdir(parents=True, exist_ok=True)
     tensors = _run_cpu_accuracy_reference(
         inputs,
-        query_heads=query_heads,
-        value_heads=value_heads,
         scale=scale,
         qk_l2norm=qk_l2norm,
         cu_seqlens=cu_seqlens,
@@ -1669,8 +1667,6 @@ def _run_npu_accuracy_candidate(
     inputs: dict[str, torch.Tensor],
     *,
     device: str,
-    query_heads: int,
-    value_heads: int,
     scale: float,
     qk_l2norm: bool,
     cu_seqlens: Optional[torch.LongTensor],
@@ -1686,11 +1682,6 @@ def _run_npu_accuracy_candidate(
 
     attn_q = q
     attn_k = k
-    if query_heads != value_heads:
-        repeat = value_heads // query_heads
-        attn_q = q.repeat_interleave(repeat, dim=1)
-        attn_k = k.repeat_interleave(repeat, dim=1)
-
     o, _ = flash_gated_delta_rule(
         attn_q,
         attn_k,
@@ -1808,8 +1799,6 @@ def _run_accuracy_check(
         path=golden_path,
         config=config,
         inputs=inputs,
-        query_heads=query_heads,
-        value_heads=value_heads,
         scale=scale,
         qk_l2norm=args.qk_l2norm,
         cu_seqlens=cu_list,
@@ -1818,8 +1807,6 @@ def _run_accuracy_check(
     candidate = _run_npu_accuracy_candidate(
         inputs,
         device=device,
-        query_heads=query_heads,
-        value_heads=value_heads,
         scale=scale,
         qk_l2norm=args.qk_l2norm,
         cu_seqlens=cu_seqlens,
@@ -1931,7 +1918,7 @@ def _main():
         raise ValueError("varlen smoke currently requires batch=1. Use --no-varlen for B > 1 cases.")
     if value_heads % query_heads != 0:
         raise ValueError(
-            "value_heads must be an integer multiple of query_heads for the current grouped-value smoke path, "
+            "value_heads must be a multiple of query_heads for GVA; "
             f"got query_heads={query_heads}, value_heads={value_heads}."
         )
     if args.gate_source != "g":
@@ -2060,11 +2047,9 @@ def _main():
     torch.npu.synchronize()
     attn_q = q
     attn_k = k
-    if query_heads != value_heads:
-        repeat = value_heads // query_heads
-        attn_q = q.repeat_interleave(repeat, dim=1)
-        attn_k = k.repeat_interleave(repeat, dim=1)
-        print("grouped value heads:", f"repeat={repeat}", f"attn_heads={attn_q.shape[1]}")
+    # Keep the original query/key head count. GVA maps each value head to its
+    # corresponding key head in the underlying operators.
+    print("actual operator heads:", f"q={attn_q.shape[1]}", f"k={attn_k.shape[1]}", f"v={v.shape[1]}")
     initial_state = None
     if args.initial_state != "none":
         state_count = len(cu_seqlens) - 1 if cu_seqlens is not None else batch

--- a/examples/flash_gated_delta_rule.py
+++ b/examples/flash_gated_delta_rule.py
@@ -23,7 +23,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch_npu
 
-from fla_npu.ops import ascendc as ascendc_ops
 from fla_npu.ops.ascendc import (
     causal_conv1d as ascendc_causal_conv1d,
     causal_conv1d_bwd as ascendc_causal_conv1d_bwd,
@@ -32,6 +31,8 @@ from fla_npu.ops.ascendc import (
     chunk_fwd_o as ascendc_chunk_fwd_o,
     chunk_gated_delta_rule_bwd_dhu as ascendc_chunk_gated_delta_rule_bwd_dhu,
     chunk_gated_delta_rule_fwd_h as ascendc_chunk_gated_delta_rule_fwd_h,
+    chunk_local_cumsum as ascendc_chunk_local_cumsum,
+    chunk_scaled_dot_kkt as ascendc_chunk_scaled_dot_kkt,
     prepare_wy_repr_bwd_da as ascendc_prepare_wy_repr_bwd_da,
     prepare_wy_repr_bwd_full as ascendc_prepare_wy_repr_bwd_full,
     recompute_w_u_fwd as ascendc_recompute_w_u_fwd,
@@ -40,7 +41,6 @@ from fla_npu.ops.ascendc import (
 from fla_npu.ops.triton import (
     autocast_custom_bwd,
     autocast_custom_fwd,
-    chunk_local_cumsum as triton_chunk_local_cumsum,
     chunk_scaled_dot_kkt_fwd as triton_chunk_scaled_dot_kkt_fwd,
     input_guard,
     l2norm_bwd,
@@ -106,10 +106,6 @@ def _as_int_list(value: Optional[list[int] | torch.Tensor]) -> Optional[list[int
     if isinstance(value, torch.Tensor):
         return [int(x) for x in value.detach().cpu().flatten().tolist()]
     return [int(x) for x in value]
-
-
-def _is_power_of_two(value: int) -> bool:
-    return value > 0 and (value & (value - 1)) == 0
 
 
 def _activation_mode(activation: Optional[str]) -> int:
@@ -606,7 +602,7 @@ def chunk_local_cumsum_ascendc(
     if cu_list is not None or chunk_list is not None:
         op_kwargs["cu_seqlens"] = cu_list
         op_kwargs["chunk_indices_out"] = chunk_list
-    out = ascendc_ops.chunk_local_cumsum(g.contiguous().float(), chunk_size, **op_kwargs)
+    out = ascendc_chunk_local_cumsum(g.contiguous().float(), chunk_size, **op_kwargs)
     return out
 
 
@@ -638,28 +634,13 @@ def chunk_scaled_dot_kkt_fwd_ascendc(
     if cu_list is not None or chunk_list is not None:
         op_kwargs["cu_seqlens"] = cu_list
         op_kwargs["chunk_indices"] = chunk_list
-    A = ascendc_ops.chunk_scaled_dot_kkt(
+    A = ascendc_chunk_scaled_dot_kkt(
         k,
         g.contiguous().float(),
         beta.contiguous().float(),
         **op_kwargs,
     )
     return A
-
-
-def _should_use_ascendc_cumsum(
-    g: torch.Tensor,
-    *,
-    chunk_size: int,
-    output_dtype: torch.dtype,
-) -> bool:
-    if not _is_power_of_two(int(chunk_size)):
-        return False
-    if g.dim() != 3:
-        return False
-    if output_dtype not in (torch.float, torch.float32):
-        return False
-    return True
 
 
 def _should_use_ascendc_kkt(
@@ -695,28 +676,15 @@ def chunk_local_cumsum_auto(
     chunk_size: int,
     output_dtype: torch.dtype,
 ) -> torch.Tensor:
-    if _should_use_ascendc_cumsum(
-        g,
-        chunk_size=chunk_size,
-        output_dtype=output_dtype,
-    ):
-        g_ascendc = g.transpose(1, 2).contiguous()
-        return chunk_local_cumsum_ascendc(
-            g_ascendc,
-            chunk_size=chunk_size,
-            cu_seqlens=cu_seqlens,
-            chunk_indices_out=chunk_indices,
-            head_first=True,
-            output_dtype=output_dtype,
-        )
-
-    return triton_chunk_local_cumsum(
-        g,
+    g_ascendc = g.transpose(1, 2).contiguous()
+    return chunk_local_cumsum_ascendc(
+        g_ascendc,
         chunk_size=chunk_size,
         cu_seqlens=cu_seqlens,
         chunk_indices_out=chunk_indices,
-        head_first=False,
-    ).transpose(1, 2).contiguous()
+        head_first=True,
+        output_dtype=output_dtype,
+    )
 
 
 def chunk_scaled_dot_kkt_fwd_auto(
@@ -766,31 +734,17 @@ def chunk_local_cumsum_bwd_auto(
     chunk_indices: Optional[Dict[str, Optional[torch.LongTensor]]],
     chunk_size: int,
 ) -> torch.Tensor:
-    if (
-        dg.dim() == 3
-        and dg.dtype == torch.float32
-        and _is_power_of_two(int(chunk_size))
-    ):
-        dg_ascendc = dg.transpose(1, 2).contiguous()
-        dg_ascendc = chunk_local_cumsum_ascendc(
-            dg_ascendc,
-            chunk_size=chunk_size,
-            reverse=True,
-            cu_seqlens=cu_seqlens,
-            chunk_indices_out=chunk_indices,
-            head_first=True,
-            output_dtype=torch.float32,
-        )
-        return dg_ascendc.transpose(1, 2).contiguous()
-
-    return triton_chunk_local_cumsum(
-        dg,
+    dg_ascendc = dg.transpose(1, 2).contiguous()
+    dg_ascendc = chunk_local_cumsum_ascendc(
+        dg_ascendc,
         chunk_size=chunk_size,
         reverse=True,
         cu_seqlens=cu_seqlens,
         chunk_indices_out=chunk_indices,
-        head_first=False,
+        head_first=True,
+        output_dtype=torch.float32,
     )
+    return dg_ascendc.transpose(1, 2).contiguous()
 
 
 def flash_chunk_gated_delta_rule_fwd(


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @fazhenyao
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
# 默认 CANN 安装路径；自定义安装路径时替换为实际路径下对应的 set_env.sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
