### PR TITLE
fix(v26.1.0): backport #397 build fixes and pin wheel packages to fla_npu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,14 @@ chunk_gated_delta_rule/chunk_bwd_dqkwg/tests/extra-info
 PROF_*
 OPPROF_*
 extra-info
+
+# torchnpugen 分片/聚合生成输出（外部工具链版本差异，不纳入仓库）
+torch_custom/fla_npu/op_plugin/OpInterfaceEverything.cpp
+torch_custom/fla_npu/op_plugin/OpInterface_*.cpp
+torch_custom/fla_npu/op_plugin/DvmOpsInterface.h
+torch_custom/fla_npu/op_plugin/ops/opapi/StructKernelNpuOpApi*.cpp
+
+# 根目录构建/打包产物
+/dist/
+/*.egg-info/
+*.log

--- a/cmake/variables.cmake
+++ b/cmake/variables.cmake
@@ -155,6 +155,8 @@ else()
 endif()
 
 set(OP_TILING_INCLUDE
+  ${OPBASE_SOURCE_PATH}/pkg_inc
+  ${OPBASE_SOURCE_PATH}/include
   ${C_SEC_INCLUDE}
   ${PLATFORM_INC_DIRS}
   ${METADEF_INCLUDE_DIRS}

--- a/torch_custom/fla_npu/build.sh
+++ b/torch_custom/fla_npu/build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 cd "$(dirname "$0")"
-bash gen.sh npu_custom.yaml
-python3 setup.py bdist_wheel
-pip3 install ./dist/fla_npu-1.0.0-*.whl --force-reinstall --no-deps
+
+# Same interpreter resolution as gen.sh: the caller may pass FLA_NPU_PYTHON or
+# PYTHON, otherwise fall back to whatever 'python3' resolves to via PATH.
+PY="${FLA_NPU_PYTHON:-${PYTHON:-python3}}"
+
+FLA_NPU_PYTHON="$PY" bash gen.sh npu_custom.yaml
+"$PY" setup.py bdist_wheel
+"$PY" -m pip install ./dist/fla_npu-1.0.0-*.whl --force-reinstall --no-deps

--- a/torch_custom/fla_npu/gen.sh
+++ b/torch_custom/fla_npu/gen.sh
@@ -8,6 +8,11 @@ CDIR="$(cd "$(dirname "$0")" ; pwd -P)"
 
 cd $CDIR
 
+# Use the interpreter passed by the caller (build.sh sets FLA_NPU_PYTHON to its
+# resolved interpreter; root setup.py, where present, sets PYTHON=sys.executable)
+# so we don't depend on whatever 'python3' resolves to via PATH.
+PY="${FLA_NPU_PYTHON:-${PYTHON:-python3}}"
+
 # check if the file exists
 if [ ! -f "$YAML_FILE" ]; then
     echo "Error: yaml file $YAML_FILE does not exit"
@@ -15,7 +20,7 @@ if [ ! -f "$YAML_FILE" ]; then
 fi
 
 # get the torch version
-PYTORCH_VERSION=$(python3 -c "import torch; print(torch.__version__.split('+')[0])")
+PYTORCH_VERSION=$("$PY" -c "import torch; print(torch.__version__.split('+')[0])")
 
 IFS='.' read -ra version_parts <<< "$PYTORCH_VERSION"
 PYTORCH_VERSION_DIR="v${version_parts[0]}r${version_parts[1]}"
@@ -45,27 +50,30 @@ OPAPI_OUTPUT_DIR="$CDIR/op_plugin/ops/opapi"
 if [ ! -d "$OPAPI_OUTPUT_DIR" ]; then
     mkdir -p "$OPAPI_OUTPUT_DIR"
 fi
+# --- clear stale generated aggregate/chunk files to avoid multiple definition ---
+rm -f "$OPAPI_OUTPUT_DIR"/StructKernelNpuOpApi*.cpp
+rm -f "$CDIR"/op_plugin/OpInterface*.cpp "$CDIR"/op_plugin/DvmOpsInterface.h
 
-python3 -m torchnpugen.gen_op_plugin_functions \
+"$PY" -m torchnpugen.gen_op_plugin_functions \
   --version="$PYTORCH_VERSION" \
   --output_dir="$OUTPUT_DIR/" \
   --source_yaml="$CDIR/$YAML_FILE"
 
 # check if the second parameter is passed
 if [ -n "$DERIVATIVES_YAML_FILE" ]; then
-    python3 -m torchnpugen.gen_derivatives \
+    "$PY" -m torchnpugen.gen_derivatives \
       --version="$PYTORCH_VERSION" \
       --output_dir="$OUTPUT_DIR/" \
       --source_yaml="$CDIR/$DERIVATIVES_YAML_FILE"
 fi
 
-python3 -m torchnpugen.gen_op_backend  \
+"$PY" -m torchnpugen.gen_op_backend  \
   --version="$PYTORCH_VERSION" \
   --output_dir="$CDIR/op_plugin/" \
   --source_yaml="$OUTPUT_DIR/op_plugin_functions.yaml" \
   --deprecate_yaml="$CDIR/deprecated.yaml"
 
-python3 -m torchnpugen.struct.gen_struct_opapi \
+"$PY" -m torchnpugen.struct.gen_struct_opapi \
   --output_dir="$OPAPI_OUTPUT_DIR/" \
   --native_yaml="$OUTPUT_DIR/op_plugin_functions.yaml" \
   --struct_yaml="$CDIR/$YAML_FILE"
@@ -73,7 +81,7 @@ python3 -m torchnpugen.struct.gen_struct_opapi \
 
 #################### torch_npu torchnpugen ####################
 
-python3 -m torchnpugen.gen_backend_stubs  \
+"$PY" -m torchnpugen.gen_backend_stubs  \
   --output_dir="$CDIR/torch_npu/csrc/aten" \
   --source_yaml="./test_native_functions.yaml" \
   --impl_path="$CDIR/torch_npu/csrc/aten" \

--- a/torch_custom/fla_npu/setup.py
+++ b/torch_custom/fla_npu/setup.py
@@ -37,12 +37,42 @@ def get_sources():
                 if file.endswith(".cpp") or file.endswith(".cc"):
                     sources.append(os.path.join(root, file))
 
-    BUILD_EXCLUDE_LIST = [f"{aten_dir}/VariableTypeEverything.cpp",
-        f"{aten_dir}/ADInplaceOrViewTypeEverything.cpp",
-        f"{aten_dir}/python_functionsEverything.cpp",
-        f"{aten_dir}/RegisterFunctionalizationEverything.cpp"]
+    BUILD_EXCLUDE_LIST = [
+        os.path.join(aten_dir, "VariableTypeEverything.cpp"),
+        os.path.join(aten_dir, "ADInplaceOrViewTypeEverything.cpp"),
+        os.path.join(aten_dir, "python_functionsEverything.cpp"),
+        os.path.join(aten_dir, "RegisterFunctionalizationEverything.cpp"),
+        os.path.join(ops_dir, "OpInterfaceEverything.cpp"),
+        os.path.join(ops_dir, "ops", "opapi", "StructKernelNpuOpApiEverything.cpp"),
+    ]
 
-    sources_new = [cur_file for cur_file in sources if cur_file not in BUILD_EXCLUDE_LIST]
+    # Newer torchnpugen emits an aggregate monolith (StructKernelNpuOpApi.cpp /
+    # OpInterface.cpp) *together with* per-op split files (StructKernelNpuOpApi_0.cpp,
+    # OpInterface_0.cpp, ...). Compiling both causes multiple-definition at link time.
+    # Only drop the aggregate when its split replacement is actually present, so older
+    # single-file torchnpugen output still builds.
+    for aggregate in (
+        os.path.join(ops_dir, "OpInterface.cpp"),
+        os.path.join(ops_dir, "ops", "opapi", "StructKernelNpuOpApi.cpp"),
+    ):
+        aggregate_dir = os.path.dirname(aggregate)
+        prefix = os.path.splitext(os.path.basename(aggregate))[0] + "_"
+        if any(
+            f.startswith(prefix) and f.endswith(".cpp")
+            for f in os.listdir(aggregate_dir)
+        ):
+            BUILD_EXCLUDE_LIST.append(aggregate)
+
+    sources_new = []
+    seen = set()
+    for cur_file in sources:
+        if cur_file in BUILD_EXCLUDE_LIST:
+            continue
+        rp = os.path.realpath(cur_file)
+        if rp in seen:
+            continue
+        seen.add(rp)
+        sources_new.append(cur_file)
     print("====sources_new:", sources_new)
 
     return sources_new

--- a/torch_custom/fla_npu/setup.py
+++ b/torch_custom/fla_npu/setup.py
@@ -168,5 +168,8 @@ setup(
     install_requires=[
         f"torch=={PYTORCH_VERSION}"
     ],
-    packages=find_packages()
+    # 显式列出包，避免 find_packages() 把构建目录里残留的杂包（如从 main 工作区混入的
+    # fla/）一并打进 wheel：那会让卸载删除 site-packages/fla/__init__.py，而干净重建后
+    # 重装无法还原，导致运行时提示缺少 __version__。
+    packages=["fla_npu"],
 )


### PR DESCRIPTION
v26.1.0 构建修复，包含 PR #424 的前 2 个 commit：

1. `207d1cb` fix(v26.1.0): backport v26.6.0 build fixes (#397) to v26.1.0
2. `0171be5` fix(v26.1.0): pin wheel packages to fla_npu to keep stray packages out

### Commit 1 解决的问题与改动
- 独立 wheel 构建（`cd torch_custom/fla_npu && bash build.sh`）里裸 `python3` 依赖 PATH，可能解析到未装 torch/torchnpugen 的解释器而失败；新版 torchnpugen 会同时生成聚合单体与按算子分片源码，全部参与编译导致链接期 multiple definition；tiling 编译缺少 vendored opbase 头路径。
- `torch_custom/fla_npu/gen.sh`：解释器统一为 `$PY`（`FLA_NPU_PYTHON` > `PYTHON` > `python3`），torch 版本探测与所有 torchnpugen 调用走同一解释器；regen 前清理旧的 `StructKernelNpuOpApi*.cpp` / `OpInterface*.cpp` / `DvmOpsInterface.h`。
- `torch_custom/fla_npu/setup.py`：`BUILD_EXCLUDE_LIST` 增加 `OpInterfaceEverything.cpp` / `StructKernelNpuOpApiEverything.cpp`；存在分片文件时排除聚合单体（老版本单文件输出仍可构建）；`get_sources()` 增加 realpath 去重。
- `torch_custom/fla_npu/build.sh`：同解释器执行 gen / `setup.py bdist_wheel` / `pip install`。
- `cmake/variables.cmake`：`OP_TILING_INCLUDE` 增加 vendored opbase 的 `pkg_inc` / `include`。
- `.gitignore`：忽略 torchnpugen 分片/聚合生成输出与根目录构建产物。

### Commit 2 解决的问题与改动
- `find_packages()` 会把构建目录里残留的杂包（例如 main 工作区混入的顶层 `fla/`）也打进 `fla_npu-1.0.0` wheel；卸载时 RECORD 会删除 `site-packages/fla/__init__.py`，而干净重建后重装无法还原，运行时提示缺少 `__version__`。
- `torch_custom/fla_npu/setup.py`：`packages=find_packages()` → `packages=["fla_npu"]`，显式固定只打包 fla_npu。

其余 v26.1.0 修复见 PR #424。