### PR TITLE
perf(chunk_fwd_h): 流式输入绕过 L2 cache

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/docs/design.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/docs/design.md
@@ -63,6 +63,12 @@ AIC 将当前 `W[M,K]` 与 `H[K,V]` 从 GM 搬到四个 round-head L1 槽，随�
 `P=W@H`。Stage0 不读取 kg/k_raw。tail chunk 先用 MTE2 `InitConstValue` 清零当前 W 槽，
 再覆盖有效 ND 行；Cube M 取 `AlignUp(valid_tokens,16)`。
 
+`W`、`U` 和 `g/gk` 的 GM 数据在一次算子执行中只消费一次，GM 读取使用 L2 cache bypass，
+避免流式数据挤占递推数据的缓存空间。若当前 work unit 完整覆盖一个 key head 的全部
+value-head consumer，则该份 `K` 只从 GM 读取一次并使用 bypass；consumer 跨 work unit 时
+保留默认 L2 策略。`initial_state`、递推 `H` 和 Stage1 `right` 存在跨 AIV/AIC 的重复读取
+或刚写即读关系，保留默认 L2 策略。
+
 - A2/A3：L0C 经 Fixpipe 将对齐后的 M 行写入 P GM scratch，补齐行恒为零；AIV 再以
   MTE2 只读取 `valid_tokens` 个有效行。
 - A5：L0C 经 Fixpipe 直接将有效行写入配对 AIV 的 local UB slot。

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch35/chunk_fwd_h_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch35/chunk_fwd_h_cube.h
@@ -313,6 +313,7 @@ private:
         AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(WReadyEvent(wSlot));
         AscendC::GlobalTensor<bfloat16_t> gmW;
         gmW.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.w) + WOffset(unit, chunk, head));
+        gmW.SetL2CacheHint(AscendC::CacheMode::CACHE_MODE_DISABLE);
         if (chunk.validTokens < FWD_H_CHUNK) {
             ClearL1(L1W(wSlot), FWD_H_L1_W_SLOT_BYTES);
         }
@@ -442,6 +443,18 @@ private:
         const uint64_t offset = FwdHKOffset(args_.tiling, unit.sequence.physicalBatch,
                                             binding.kh, chunk.tokenBegin);
         gmKg.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.k) + offset);
+        bool readOnce = true;
+        if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G) {
+            const uint32_t groupSize = static_cast<uint32_t>(args_.tiling.vNumHead) /
+                                       static_cast<uint32_t>(args_.tiling.kNumHead);
+            const uint32_t groupBegin = binding.kh * groupSize;
+            const uint32_t unitBegin = unit.headRound.heads[0].hv;
+            const uint32_t unitEnd = unitBegin + unit.headRound.activeHeadCount;
+            readOnce = unitBegin <= groupBegin && unitEnd >= groupBegin + groupSize;
+        }
+        if (readOnce) {
+            gmKg.SetL2CacheHint(AscendC::CacheMode::CACHE_MODE_DISABLE);
+        }
         if constexpr (!STATE_V_FIRST) {
             auto gmLayout = tla::MakeLayout<bfloat16_t, LayoutLeftS2>(FWD_H_K, chunk.validTokens);
             auto tensorGm = tla::MakeTensor(gmKg, gmLayout, Catlass::Arch::PositionGM{});

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch35/chunk_fwd_h_vec.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_h/op_kernel/arch35/chunk_fwd_h_vec.h
@@ -530,6 +530,7 @@ private:
         AscendC::GlobalTensor<GateT> gateGm;
         gateGm.SetGlobalBuffer(reinterpret_cast<__gm__ GateT *>(
             CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G ? args_.g : args_.gk));
+        gateGm.SetL2CacheHint(AscendC::CacheMode::CACHE_MODE_DISABLE);
         if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G) {
             const uint64_t gateOffset = GateOffset(unit, chunk, head);
             if (chunk.validTokens == FWD_H_CHUNK) {
@@ -711,6 +712,7 @@ private:
         }
         AscendC::GlobalTensor<bfloat16_t> u;
         u.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.u));
+        u.SetL2CacheHint(AscendC::CacheMode::CACHE_MODE_DISABLE);
         AscendC::DataCopy(WorkBf16Slot(inputSlot), u[UOffset(unit, chunk, head)],
                           chunk.validTokens * FWD_H_V);
         if (writeRight) {
@@ -742,6 +744,7 @@ private:
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(IoFreeEvent(slot));
             AscendC::GlobalTensor<bfloat16_t> u;
             u.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(args_.u));
+            u.SetL2CacheHint(AscendC::CacheMode::CACHE_MODE_DISABLE);
             AscendC::DataCopy(WorkBf16Slot(slot), u[UOffset(unit, chunk, head)], chunk.validTokens * FWD_H_V);
             if constexpr (CompilePolicy::GATE_MODE == FwdHGateMode::SCALAR_G) {
                 if (writeRight) {


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> 本 PR 遵循仓库 NPU CI 手动验证与合入门禁要求。

## 关联 Issue / 背景

- 关联 Issue: #488
- 背景与目标: `chunk_fwd_h` 的 A5 长序列场景受 MTE2 搬运限制，需要减少无复用流式输入对 L2 cache 的占用。
- 本 PR 解决的问题: 对只读取一次的输入设置 L2 cache bypass，同时保留递推数据和跨 work unit 复用数据的默认缓存策略。

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [x] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `chunk_fwd_h`
- 涉及目录 / 文件: `chunk_fwd_h` 的 A5 Cube/Vector kernel 与设计文档
- 责任人 / 提交人: @zhangshuolei-hfut
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不改变现有支持范围。
- 明确不包含的范围: 不修改接口、tiling、数值计算、物理布局和 A2/A3 kernel。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=chunk_fwd_h --vendor_name=fla_npu` | 未执行 | 本次仅修改 A5 kernel |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_fwd_h --vendor_name=fla_npu` | 未执行 | 本次仅修改 A5 kernel |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=chunk_fwd_h --vendor_name=fla_npu` | 未执行 | 本次仅修改 A5 kernel |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_fwd_h --vendor_name=fla_npu` | 未执行 | 本次仅修改 A5 kernel |
| A5 | `ascend950` | CANN 9.1 | `bash build.sh --pkg --soc=ascend950 --ops=chunk_fwd_h --vendor_name=fla_npu -j64` | 通过 | scoped run 包生成成功 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 未执行 | 本次仅修改 A5 kernel |
| A3 | `ascend910_93` |  | 未执行 | 本次仅修改 A5 kernel |
| A5 | `ascend950` | `ATK chunk_fwd_h 精度烟测` | 通过 | 1 条用例通过 |

- 精度对比: ATK 精度烟测通过。
- 性能对比: `B=1, T=11264, HK=16, HV=32` 下，5 次 `msprof` 平均任务耗时由 597.309 us 降至 579.652 us，提升 2.96%；AIC MTE2 由 475.755 us 降至 448.012 us。
- 边界 / 异常场景: K 的 bypass 根据当前 work unit 是否完整覆盖 consumer group 动态选择。
- 未覆盖风险: A2/A3 未执行，整体 Example ST 尚未执行，等待 NPU CI 补充验证。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 等待 NPU CI |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 等待 NPU CI |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 未执行 | 等待 NPU CI |

- 端到端场景说明: 等待 NPU CI 补充。
- 与本 PR 修改算子的关联: 验证 GDN 端到端调用链未受 cache hint 调整影响。
- 未覆盖原因及补充计划: 创建 PR 后触发 NPU CI。

</details>

## 兼容性、风险与回退

- 兼容性说明: 不改变接口、shape、dtype、format、tiling 或数值计算。
- 风险点: cache hint 仅影响 A5 的缓存策略；K 是否 bypass 依赖 work unit consumer 覆盖关系。
- 回退方案: 移除新增的 `SetL2CacheHint` 调用和 K consumer 覆盖判断。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

`W`、`U`、`g/gk` 作为单次消费的流式输入绕过 L2。K 仅在当前 work unit 完整覆盖该 key head 的全部 value-head consumer 时绕过 L2。`initial_state`、递推 `H` 和 Stage1 `right` 保留默认 L2 策略。
