### PR TITLE
perf(chunk_fwd_o): A5 arch35 拆相流水线重构与跨 Cube 重叠，l0c2ub 直通落地及同步修复

### DIFF
--- a/fla/ops/ascendc/common/kernel_utils/block/block_mmad_pingpong_tla_pipelined.hpp
+++ b/fla/ops/ascendc/common/kernel_utils/block/block_mmad_pingpong_tla_pipelined.hpp
@@ -1,0 +1,1181 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS FILE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CATLASS_GEMM_BLOCK_BLOCK_MMAD_PINGPONG_TLA_PIPELINED_HPP
+#define CATLASS_GEMM_BLOCK_BLOCK_MMAD_PINGPONG_TLA_PIPELINED_HPP
+
+#include "catlass/arch/resource.hpp"
+// ============================================================================
+// MmadPingpongTlaGdnFwdO dispatch policy + BlockMmadTla specialization
+// (merged from block_mmad_pingpong_tla_gdn_fwd_o.hpp — fwd_o-exclusive base of
+// BlockMmadTlaPipelined below; carries the SHARE_L1A cross-instance Q-reuse path)
+// ============================================================================
+namespace Catlass::Gemm {
+
+template <class ArchTag_, bool ENABLE_UNIT_FLAG_ = false, bool USE_HF32_MODE_ = false, uint32_t L0C_STAGES_ = 1,
+    bool ENABLE_L1_RESIDENT_ = false, bool SHARE_L1A_ = false,
+    uint32_t L1A_STAGES_ = 2, uint32_t L1B_STAGES_ = 2, uint32_t L0A_STAGES_ = 2,
+    uint32_t L0B_STAGES_ = 2>
+struct MmadPingpongTlaGdnFwdO : public MmadBase<ArchTag_, false> {
+    static constexpr uint32_t L1A_STAGES = L1A_STAGES_;
+    static constexpr uint32_t L1B_STAGES = L1B_STAGES_;
+    static constexpr uint32_t L0A_STAGES = L0A_STAGES_;
+    static constexpr uint32_t L0B_STAGES = L0B_STAGES_;
+    static constexpr uint32_t L0C_STAGES = L0C_STAGES_;
+    static constexpr bool ENABLE_UNIT_FLAG = ENABLE_UNIT_FLAG_;
+    static constexpr bool USE_HF32_MODE = USE_HF32_MODE_;
+    static constexpr bool ENABLE_L1_RESIDENT = ENABLE_L1_RESIDENT_;
+    static constexpr bool SHARE_L1A = SHARE_L1A_;
+};
+
+}  // namespace Catlass::Gemm
+
+namespace Catlass::Gemm::Block {
+
+template <
+    class ArchTag_,
+    bool ENABLE_UNIT_FLAG_,
+    bool USE_HF32_MODE_,
+    uint32_t L0C_STAGES_,
+    bool ENABLE_L1_RESIDENT_,
+    bool SHARE_L1A_,
+    uint32_t L1A_STAGES_,
+    uint32_t L1B_STAGES_,
+    uint32_t L0A_STAGES_,
+    uint32_t L0B_STAGES_,
+    class L1TileShape_,
+    class L0TileShape_,
+    class ElementA_,
+    class ElementB_,
+    class ElementC_,
+    class ElementBias_,
+    class TileCopy_,
+    class TileMmad_
+>
+struct BlockMmadTla <
+    MmadPingpongTlaGdnFwdO<ArchTag_, ENABLE_UNIT_FLAG_, USE_HF32_MODE_, L0C_STAGES_, ENABLE_L1_RESIDENT_, SHARE_L1A_,
+        L1A_STAGES_, L1B_STAGES_, L0A_STAGES_, L0B_STAGES_>,
+    L1TileShape_,
+    L0TileShape_,
+    ElementA_,
+    ElementB_,
+    ElementC_,
+    ElementBias_,
+    TileCopy_,
+    TileMmad_
+> {
+public:
+    // Type Aliases
+    using DispatchPolicy = MmadPingpongTlaGdnFwdO<ArchTag_, ENABLE_UNIT_FLAG_, USE_HF32_MODE_, L0C_STAGES_, ENABLE_L1_RESIDENT_,
+        SHARE_L1A_, L1A_STAGES_, L1B_STAGES_, L0A_STAGES_, L0B_STAGES_>;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+    using TileCopy = TileCopy_;
+    using L1TileShape = L1TileShape_;
+    using L0TileShape = L0TileShape_;
+    using ElementA = ElementA_;
+    using LayoutA = typename TileCopy::LayoutA;
+    using ElementB = ElementB_;
+    using LayoutB = typename TileCopy::LayoutB;
+    using ElementC = ElementC_;
+    using LayoutC = typename TileCopy::LayoutC;
+    using ElementBias = ElementBias_;
+
+    using TileMmad = TileMmad_;
+
+    using CopyL1ToL0A = typename TileCopy::CopyL1ToL0A;
+    using CopyL1ToL0B = typename TileCopy::CopyL1ToL0B;
+    using CopyL1ToBT = typename TileCopy::CopyL1ToBT;
+
+    using ElementAccumulator = typename TileCopy::ElementAccumulator;
+
+    static constexpr bool HAS_BIAS = TileCopy::HAS_BIAS;
+
+    using LayoutTagL1A = typename TileCopy::LayoutTagL1A;
+    using LayoutTagL1B = typename TileCopy::LayoutTagL1B;
+    using LayoutTagL0A = typename TileCopy::LayoutTagL0A;
+    using LayoutTagL0B = typename TileCopy::LayoutTagL0B;
+
+    using L1AAlignHelper = typename TileCopy_::L1AAlignHelper;
+    using L1BAlignHelper = typename TileCopy_::L1BAlignHelper;
+
+    static_assert(tla::is_tuple<L1TileShape>::value && tla::is_static<L1TileShape>::value,
+        "L1TileShape must be tla::tuple and static!");
+    static_assert(tla::is_tuple<L0TileShape>::value && tla::is_static<L0TileShape>::value,
+        "L0TileShape must be tla::tuple and static!");
+
+    static constexpr bool ENABLE_UNIT_FLAG = DispatchPolicy::ENABLE_UNIT_FLAG;
+    static constexpr bool USE_HF32_MODE = DispatchPolicy::USE_HF32_MODE;
+    static constexpr bool ENABLE_L1_RESIDENT = DispatchPolicy::ENABLE_L1_RESIDENT;
+    static constexpr bool SHARE_L1A = DispatchPolicy::SHARE_L1A;
+    static constexpr uint32_t L1A_STAGES = DispatchPolicy::L1A_STAGES;
+    static constexpr uint32_t L1B_STAGES = DispatchPolicy::L1B_STAGES;
+    static constexpr uint32_t L0A_STAGES = DispatchPolicy::L0A_STAGES;
+    static constexpr uint32_t L0B_STAGES = DispatchPolicy::L0B_STAGES;
+    static constexpr uint32_t L0C_STAGES = DispatchPolicy::L0C_STAGES;
+    static constexpr uint32_t L1_TILE_M = tla::get<0>(L1TileShape{});
+    static constexpr uint32_t L1_TILE_N = tla::get<1>(L1TileShape{});
+    static constexpr uint32_t L1_TILE_K = tla::get<2>(L1TileShape{});
+    static constexpr uint32_t L0_TILE_M = tla::get<0>(L0TileShape{});
+    static constexpr uint32_t L0_TILE_N = tla::get<1>(L0TileShape{});
+    static constexpr uint32_t L0_TILE_K = tla::get<2>(L0TileShape{});
+
+    // L1 tile size
+    static constexpr uint32_t L1A_TILE_SIZE = L1_TILE_M * L1_TILE_K * sizeof(ElementA);
+    static constexpr uint32_t L1B_TILE_SIZE = L1_TILE_N * L1_TILE_K * sizeof(ElementB);
+    // L0 tile size
+    static constexpr uint32_t L0A_TILE_SIZE = L0_TILE_M * L0_TILE_K * sizeof(ElementA);
+    static constexpr uint32_t L0B_TILE_SIZE = L0_TILE_K * L0_TILE_N * sizeof(ElementB);
+    static constexpr uint32_t L0C_TILE_SIZE = L1_TILE_M * L1_TILE_N * sizeof(ElementAccumulator);
+
+    // Check HF32_MODE
+    static_assert(
+        !USE_HF32_MODE || (USE_HF32_MODE && std::is_same_v<ElementA, float> && std::is_same_v<ElementB, float>),
+        "HF32 MODE only supports in float!"
+    );
+
+    // Check L0C_STAGES
+    static_assert(!(ENABLE_UNIT_FLAG && L0C_STAGES != 1), "L0C_STAGES must be 1 when UnitFlag is true!");
+
+    // Check LayoutC
+    static_assert(tla::detail::isRowMajor<LayoutC>::value ||
+                      ((std::is_same_v<ElementC, half> || std::is_same_v<ElementC, bfloat16_t> ||
+                          std::is_same_v<ElementC, float>) && tla::detail::iszN<ElementC, LayoutC>::value),
+        "LayoutC only supports zN in half or bfloat16 or float, RowMajor in all dtype yet!");
+
+    // Check L1TileShape
+    static_assert(L1A_TILE_SIZE * L1A_STAGES + L1B_TILE_SIZE * L1B_STAGES <= ArchTag::L1_SIZE,
+        "L1TileShape exceeding the L1 space!");
+
+    // Check L0TileShape
+    static_assert(L0A_TILE_SIZE * L0A_STAGES <= ArchTag::L0A_SIZE, "L0TileShape exceeding the L0A space!");
+    static_assert(L0B_TILE_SIZE * L0B_STAGES <= ArchTag::L0B_SIZE, "L0TileShape exceeding the L0B space!");
+    static_assert(L0C_TILE_SIZE * L0C_STAGES <= ArchTag::L0C_SIZE, "L0TileShape exceeding the L0C space!");
+
+    static constexpr uint32_t _32B = 32*8; // in bits
+    static_assert(L1_TILE_M == L0_TILE_M && L1_TILE_N == L0_TILE_N,
+        "The situation where the basic blocks of L1 and L0 differ on the m and n axes is not supported yet");
+    static_assert(L0_TILE_K <= L1_TILE_K, "L0TileShape::K cannot exceed L1TileShape::K");
+#if (defined (CATLASS_ARCH) && CATLASS_ARCH == 2201)
+    static_assert(L1_TILE_M * SizeOfBits<ElementA>::value % _32B == 0, "L1TileShape::M must be 32B aligned.");
+    static_assert(L1_TILE_K * SizeOfBits<ElementA>::value % _32B == 0, "L1TileShape::K must be 32B aligned.");
+    static_assert(L1_TILE_K * SizeOfBits<ElementB>::value % _32B == 0, "L1TileShape::K must be 32B aligned.");
+    static_assert(L1_TILE_N * SizeOfBits<ElementB>::value % _32B == 0, "L1TileShape::N must be 32B aligned.");
+    static_assert(L0_TILE_K * SizeOfBits<ElementB>::value % _32B == 0, "L0TileShape::K must be 32B aligned.");
+#endif
+
+    static_assert((!HAS_BIAS && (L1A_STAGES + L1B_STAGES) <= 8) || (HAS_BIAS && (L1A_STAGES + L1B_STAGES) <= 7),
+        "L1 Buffer overflow: Exceeds the supported range of EVENT(0~7)");
+
+    static_assert((!HAS_BIAS && (L0A_STAGES + L0B_STAGES) <= 8) || (HAS_BIAS && (L0A_STAGES + L0B_STAGES) <= 7),
+        "L0 Buffer overflow: Exceeds the supported range of EVENT_ID(0~7)");
+
+    static constexpr auto L1A_LAYOUT =
+        tla::MakeLayout<ElementA, LayoutTagL1A>(tla::Int<L1_TILE_M>{}, tla::Int<L1_TILE_K>{});
+    static constexpr auto L1B_LAYOUT =
+        tla::MakeLayout<ElementB, LayoutTagL1B>(tla::Int<L1_TILE_K>{}, tla::Int<L1_TILE_N>{});
+    static constexpr auto L1BIAS_LAYOUT = tla::MakeLayout(tla::Int<L1_TILE_N>{});
+    static constexpr auto L0BIAS_LAYOUT = tla::MakeLayout(tla::Int<L0_TILE_N>{});
+
+    // When enabling L1 resident mode, restore the pointer and coordinates that record the last state
+    // to the initial state. if two blockmmad instances need to be consecutively invoked at the kernel layer,
+    // RestoreStatus() must be inserted between them.
+    CATLASS_DEVICE
+    void RestoreStatus()
+    {
+        for (int i = 0; i < L1A_STAGES; ++i) {
+            lastAddrA[i] = nullptr;
+            lastCoordA[i] = MatrixCoord{0U, 0U};
+        }
+        for (int i = 0; i < L1B_STAGES; ++i) {
+            lastAddrB[i] = nullptr;
+            lastCoordB[i] = MatrixCoord{0U, 0U};
+        }
+    }
+
+    /// Construct
+    CATLASS_DEVICE
+    BlockMmadTla(Arch::Resource<ArchTag> &resource, uint32_t l1BufAddrStart = 0)
+    {
+        if ASCEND_IS_AIC {
+            uint32_t l1AOffset = l1BufAddrStart;
+            uint32_t l1BOffset = l1BufAddrStart + L1A_TILE_SIZE * L1A_STAGES;
+            // Init buffers
+            for (uint32_t i = 0; i < L1A_STAGES; i++) {
+                // Assign L1/L0A/L0B space for each stages
+                l1ATensorList[i] = resource.l1Buf.template GetBufferByByte<ElementA>(l1AOffset + L1A_TILE_SIZE * i);
+                // Assign event ID for each stages
+                l1AEventList[i] = i;
+            }
+            for (uint32_t i = 0; i < L1B_STAGES; i++) {
+                // Assign L1/L0A/L0B space for each stages
+                l1BTensorList[i] = resource.l1Buf.template GetBufferByByte<ElementB>(l1BOffset + L1B_TILE_SIZE * i);
+                // Assign event ID for each stages
+                l1BEventList[i] = i + L1A_STAGES;
+            }
+            for (uint32_t i = 0; i < L0A_STAGES; i++) {
+                // Assign L1/L0A/L0B space for each stages
+                l0ATensorList[i] = resource.l0ABuf.template GetBufferByByte<ElementA>(L0A_TILE_SIZE * i);
+                // Assign event ID for each stages
+                l0AEventList[i] = i;
+            }
+            for (uint32_t i = 0; i < L0B_STAGES; i++) {
+                // Assign L1/L0A/L0B space for each stages
+                l0BTensorList[i] = resource.l0BBuf.template GetBufferByByte<ElementB>(L0B_TILE_SIZE * i);
+                // Assign event ID for each stages
+                l0BEventList[i] = i + L0A_STAGES;
+            }
+            if constexpr(!ENABLE_UNIT_FLAG) {
+                for (uint32_t i = 0; i < L0C_STAGES; i++) {
+                    l0CTensorList[i] = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(L0C_TILE_SIZE * i);
+                    l0CEventList[i] = i;
+                }
+            } else {
+                l0CTensorList[0] = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(0);
+            }
+            if constexpr (HAS_BIAS) {
+                uint32_t l1BiasOffset = l1BOffset + L1B_TILE_SIZE * L1B_STAGES;
+                l1BiasTensor = resource.l1Buf.template GetBufferByByte<uint8_t>(l1BiasOffset);
+                l0BiasTensor = resource.btBuf.template GetBufferByByte<ElementAccumulator>(0);
+            }
+        }
+    }
+
+    /// Destructor
+    CATLASS_DEVICE
+    ~BlockMmadTla() {}
+
+    CATLASS_DEVICE
+    void preSetFlags() {
+
+        if ASCEND_IS_AIC {
+            // use HF32 when USE_HF32_MODE is true
+            if constexpr (USE_HF32_MODE) {
+                AscendC::SetHF32Mode(true);
+            } else {
+                AscendC::SetHF32Mode(false);
+            }
+            if constexpr (ENABLE_UNIT_FLAG && tla::detail::isRowMajor<LayoutC>::value) {
+                AscendC::SetMMLayoutTransform(true);
+            }
+            for (uint32_t i = 0; i < L1A_STAGES; i++) {
+                AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEventList[i]);
+            }
+            for (uint32_t i = 0; i < L1B_STAGES; i++) {
+                AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList[i]);
+            }
+            for (uint32_t i = 0; i < L0A_STAGES; i++) {
+                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0AEventList[i]);
+            }
+            for (uint32_t i = 0; i < L0B_STAGES; i++) {
+                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0BEventList[i]);
+            }
+            if constexpr(!ENABLE_UNIT_FLAG) {
+                for (uint32_t i = 0; i < L0C_STAGES; i++) {
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(l0CEventList[i]);
+                }
+            }
+            if constexpr (HAS_BIAS) {
+                AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(L1A_STAGES + L1B_STAGES);
+                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0A_STAGES + L0B_STAGES);
+            }
+
+            if constexpr (ENABLE_L1_RESIDENT) {
+                RestoreStatus();
+            }
+        }
+    }
+
+    CATLASS_DEVICE
+    void finalWaitFlags() {
+        if ASCEND_IS_AIC {
+            if constexpr (USE_HF32_MODE) {
+                AscendC::SetHF32Mode(false);
+            }
+            if constexpr (ENABLE_UNIT_FLAG && tla::detail::isRowMajor<LayoutC>::value) {
+                AscendC::SetMMLayoutTransform(false);
+            }
+            for (uint32_t i = 0; i < L1A_STAGES; i++) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEventList[i]);
+            }
+            for (uint32_t i = 0; i < L1B_STAGES; i++) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList[i]);
+            }
+            for (uint32_t i = 0; i < L0A_STAGES; i++) {
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0AEventList[i]);
+            }
+            for (uint32_t i = 0; i < L0B_STAGES; i++) {
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0BEventList[i]);
+            }
+            if constexpr(!ENABLE_UNIT_FLAG) {
+                for (uint32_t i = 0; i < L0C_STAGES; i++) {
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(l0CEventList[i]);
+                }
+            }
+            if constexpr (HAS_BIAS) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(L1A_STAGES + L1B_STAGES);
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0A_STAGES + L0B_STAGES);
+            }
+        }
+    }
+
+    /// Perform a block-scoped matrix multiply-accumulate
+    template <class TensorA, class TensorB, class TensorC, class TensorBias = EmptyClass>
+    CATLASS_DEVICE void operator()(TensorA &tensorA, TensorB &tensorB, TensorC &tensorC, GemmCoord const &actualShape,
+        TensorBias const &tensorBias = {})
+    {
+        // Check L1TileShape
+        if constexpr (HAS_BIAS) {
+            static constexpr uint32_t BIAS_BUF_SIZE = L0_TILE_N * sizeof(ElementAccumulator);
+            static constexpr uint32_t L1BIAS_SIZE = L1_TILE_N * sizeof(ElementBias);
+            static_assert(BIAS_BUF_SIZE <= ArchTag::BIAS_SIZE,
+                "BIAS_BUF_SIZE exceeding the BT space! Reduce L0_TILE_N");
+            static_assert(L1A_TILE_SIZE * L1A_STAGES + L1B_TILE_SIZE * L1B_STAGES + L1BIAS_SIZE <= ArchTag::L1_SIZE,
+                "L1TileShape exceeding the L1 space!");
+        }
+
+        using CopyGmToL1A = typename TileCopy_::template CopyGmToL1A<TensorA>;
+        using CopyGmToL1B = typename TileCopy_::template CopyGmToL1B<TensorB>;
+        CopyGmToL1A copyGmToL1A;
+        CopyGmToL1B copyGmToL1B;
+#if (defined (CATLASS_ARCH) && CATLASS_ARCH == 2201)
+        using CopyL0CToGm = typename TileCopy_::template CopyL0CToGm<TensorC>;
+        CopyL0CToGm copyL0CToDst;
+#endif
+#if (defined (CATLASS_ARCH) && CATLASS_ARCH == 3510)
+        using CopyL0CToDst = typename TileCopy_::template CopyL0CToDst<TensorC>;
+        CopyL0CToDst copyL0CToDst;
+#endif
+
+        uint32_t mBlockActual = actualShape.m();
+        uint32_t kBlockActual = actualShape.k();
+        uint32_t nBlockActual = actualShape.n();
+
+        uint32_t mL1Actual = mBlockActual;
+        if constexpr (std::is_same_v<ArchTag, Arch::AtlasA2>) {
+            // Avoid using the gemv mode in mmad
+            if (mL1Actual == 1) {
+                mL1Actual = 16;
+            }
+        }
+        uint32_t nL1Actual = nBlockActual;
+
+        auto layoutInL0C = tla::MakeLayoutL0C(mL1Actual, nL1Actual);
+        auto tensorL0C = tla::MakeTensor(l0CTensorList[l0CListId], layoutInL0C, Arch::PositionL0C{});
+        auto tensorL0Bias = tla::MakeTensor(l0BiasTensor, L0BIAS_LAYOUT, Arch::PositionBias{});
+
+        uint32_t kL1Actual = min(kBlockActual, L1_TILE_K);
+        // load first matrix A tile from GM to L1
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEventList[l1AListId]);
+        auto tensorL1A = tla::MakeTensor(l1ATensorList[l1AListId], L1A_LAYOUT, Arch::PositionL1{});
+        auto tensorTileA = GetTileA(tensorA, 0, 0, mBlockActual, kL1Actual);
+        if constexpr (SHARE_L1A) {
+            // L1A is shared from another BlockMmad instance; skip GM->L1A copy.
+        } else if constexpr (ENABLE_L1_RESIDENT) {
+            // If the currently loaded GM pointer and block coordinates are the same as the last loaded ones,
+            // skip this loading.
+            if (lastAddrA[l1AListId] != tensorTileA.data().GetPhyAddr()
+                || tla::get<0>(tensorTileA.coord()) != lastCoordA[l1AListId].row()
+                || tla::get<1>(tensorTileA.coord()) != lastCoordA[l1AListId].column()) {
+                copyGmToL1A(tensorL1A, tensorTileA);
+                lastCoordA[l1AListId] = MatrixCoord{tla::get<0>(tensorTileA.coord()), tla::get<1>(tensorTileA.coord())};
+                lastAddrA[l1AListId] = const_cast<__gm__ typename AscendC::GlobalTensor<ElementA>::PrimType *>(
+                    tensorTileA.data().GetPhyAddr()
+                );
+            }
+        } else {
+            copyGmToL1A(tensorL1A, tensorTileA);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1AEventList[l1AListId]);
+
+        // load first matrix B tile from GM to L1
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList[l1BListId]);
+        auto tensorL1B = tla::MakeTensor(l1BTensorList[l1BListId], L1B_LAYOUT, Arch::PositionL1{});
+        auto tensorTileB = GetTile(tensorB, tla::MakeCoord(0, 0), tla::MakeShape(kL1Actual, nBlockActual));
+        if constexpr (ENABLE_L1_RESIDENT) {
+            if (lastAddrB[l1BListId] != tensorTileB.data().GetPhyAddr()
+                || tla::get<0>(tensorTileB.coord()) != lastCoordB[l1BListId].row()
+                || tla::get<1>(tensorTileB.coord()) != lastCoordB[l1BListId].column()) {
+                copyGmToL1B(tensorL1B, tensorTileB);
+                lastCoordB[l1BListId] = MatrixCoord{tla::get<0>(tensorTileB.coord()), tla::get<1>(tensorTileB.coord())};
+                lastAddrB[l1BListId] = const_cast<__gm__ typename AscendC::GlobalTensor<ElementB>::PrimType *>(
+                    tensorTileB.data().GetPhyAddr()
+                );
+            }
+        } else {
+            copyGmToL1B(tensorL1B, tensorTileB);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1BEventList[l1BListId]);
+
+        if constexpr (HAS_BIAS && !std::is_same_v<TensorBias, EmptyClass>) {
+            using CopyGmToL1Bias = typename TileCopy::template CopyGmToL1Bias<TensorBias>;
+            CopyGmToL1Bias copyGmToL1Bias;
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(L1A_STAGES + L1B_STAGES);
+            auto l1Bias = l1BiasTensor.template ReinterpretCast<ElementBias>();
+            auto tensorL1Bias = tla::MakeTensor(l1Bias, L1BIAS_LAYOUT, Arch::PositionL1{});
+            copyGmToL1Bias(tensorL1Bias, tensorBias);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(L1A_STAGES + L1B_STAGES);
+        }
+
+        if constexpr (!ENABLE_UNIT_FLAG) {
+            AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(l0CEventList[l0CListId]);
+        }
+
+        uint32_t mL0Loop = CeilDiv<L0_TILE_M>(mL1Actual);
+        uint32_t nL0Loop = CeilDiv<L0_TILE_N>(nL1Actual);
+
+        // main loop
+        uint32_t kL1Loop = CeilDiv<L1_TILE_K>(kBlockActual);
+        for (uint32_t kL1Idx = 0; kL1Idx < kL1Loop; kL1Idx++) {
+            uint32_t l1AListIdNext = (l1AListId + 1 < L1A_STAGES) ? (l1AListId + 1) : 0;
+            uint32_t l1BListIdNext = (l1BListId + 1 < L1B_STAGES) ? (l1BListId + 1) : 0;
+            uint32_t kL1ActualNext{0};
+            // preload next tile from GM to L1
+            if (kL1Idx < kL1Loop - 1) {
+                uint32_t kL1IdxNext = kL1Idx + 1;
+                kL1ActualNext = (kL1IdxNext < kL1Loop - 1) ? L1_TILE_K : (kBlockActual - kL1IdxNext * L1_TILE_K);
+
+                // Get L1 tensor for next stage
+                auto l1ATensor = l1ATensorList[l1AListIdNext];
+                auto l1BTensor = l1BTensorList[l1BListIdNext];
+                auto tensorL1A = tla::MakeTensor(l1ATensor, L1A_LAYOUT, Arch::PositionL1{});
+                auto tensorL1B = tla::MakeTensor(l1BTensor, L1B_LAYOUT, Arch::PositionL1{});
+                // Get GM tile for next stage
+                auto tensorTileA = GetTileA(tensorA, 0, kL1IdxNext * L1_TILE_K, mBlockActual, kL1ActualNext);
+                auto tensorTileB = GetTile(tensorB, tla::MakeCoord(kL1IdxNext * L1_TILE_K, 0),
+                    tla::MakeShape(kL1ActualNext, nBlockActual));
+
+                // load next matrix A tile from GM to L1
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEventList[l1AListIdNext]);
+                if constexpr (SHARE_L1A) {
+                    // L1A is shared from another BlockMmad instance; skip GM->L1A copy.
+                } else if constexpr (ENABLE_L1_RESIDENT) {
+                    if (lastAddrA[l1AListIdNext] != tensorTileA.data().GetPhyAddr()
+                        || tla::get<0>(tensorTileA.coord()) != lastCoordA[l1AListIdNext].row()
+                        || tla::get<1>(tensorTileA.coord()) != lastCoordA[l1AListIdNext].column()) {
+                        copyGmToL1A(tensorL1A, tensorTileA);
+                        lastCoordA[l1AListIdNext] =
+                            MatrixCoord{tla::get<0>(tensorTileA.coord()), tla::get<1>(tensorTileA.coord())};
+                        lastAddrA[l1AListIdNext] =
+                            const_cast<__gm__ typename AscendC::GlobalTensor<ElementA>::PrimType *>(
+                                tensorTileA.data().GetPhyAddr()
+                            );
+                    }
+                } else {
+                    copyGmToL1A(tensorL1A, tensorTileA);
+                }
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1AEventList[l1AListIdNext]);
+
+                // load next matrix B tile from GM to L1
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList[l1BListIdNext]);
+                if constexpr (ENABLE_L1_RESIDENT) {
+                    if (lastAddrB[l1BListIdNext] != tensorTileB.data().GetPhyAddr()
+                        || tla::get<0>(tensorTileB.coord()) != lastCoordB[l1BListIdNext].row()
+                        || tla::get<1>(tensorTileB.coord()) != lastCoordB[l1BListIdNext].column()) {
+                        copyGmToL1B(tensorL1B, tensorTileB);
+                        lastCoordB[l1BListIdNext] =
+                            MatrixCoord{tla::get<0>(tensorTileB.coord()), tla::get<1>(tensorTileB.coord())};
+                        lastAddrB[l1BListIdNext] =
+                            const_cast<__gm__ typename AscendC::GlobalTensor<ElementB>::PrimType *>(
+                                tensorTileB.data().GetPhyAddr()
+                            );
+                    }
+                } else {
+                    copyGmToL1B(tensorL1B, tensorTileB);
+                }
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1BEventList[l1BListIdNext]);
+            }
+
+            // Get L1 tensor for current stage
+            auto l1ATensor = l1ATensorList[l1AListId];
+            auto l1BTensor = l1BTensorList[l1BListId];
+            tensorL1A = tla::MakeTensor(l1ATensor, L1A_LAYOUT, Arch::PositionL1{});
+            tensorL1B = tla::MakeTensor(l1BTensor, L1B_LAYOUT, Arch::PositionL1{});
+            // Get the loop nums on L0
+            uint32_t kL0Loop = CeilDiv<L0_TILE_K>(kL1Actual);
+
+            for (int mL0Idx = 0; mL0Idx < mL0Loop; mL0Idx++) {
+                uint32_t mL0Actual = (mL0Idx < mL0Loop - 1) ? L0_TILE_M : (mL1Actual - mL0Idx * L0_TILE_M);
+
+                for (int kL0Idx = 0; kL0Idx < kL0Loop; kL0Idx++) {
+                    uint32_t kL0Actual = (kL0Idx < kL0Loop - 1) ? L0_TILE_K : (kL1Actual - kL0Idx * L0_TILE_K);
+
+                    // Locate the current tile on L0A
+                    auto l0ATile = l0ATensorList[l0AListId];
+                    auto layoutAInL0 = tla::MakeLayout<ElementA, LayoutTagL0A>(mL0Actual, kL0Actual);
+                    auto tensorL0A = tla::MakeTensor(l0ATile, layoutAInL0, Arch::PositionL0A{});
+                    // Locate the current tile of matrix A on L1
+                    auto tensorTileL1A = GetTileA(tensorL1A, mL0Idx * L0_TILE_M, kL0Idx * L0_TILE_K, mL0Actual, kL0Actual);
+
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0AEventList[l0AListId]);
+                    if ((mL0Idx == 0) && (kL0Idx == 0)) {
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(l1AEventList[l1AListId]);
+                    }
+
+                    // Load current tile from L1 to L0A
+                    copyL1ToL0A(tensorL0A, tensorTileL1A);
+
+                    if ((mL0Idx == mL0Loop - 1) && (kL0Idx == kL0Loop - 1)) {
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEventList[l1AListId]);
+                    }
+
+                    bool initC = ((kL1Idx == 0) && (kL0Idx == 0));
+                    for (int nL0Idx = 0; nL0Idx < nL0Loop; nL0Idx++) {
+                        uint32_t nL0Actual = (nL0Idx < nL0Loop - 1) ? L0_TILE_N : (nL1Actual - nL0Idx * L0_TILE_N);
+
+                        // Locate the current tile on L0B
+                        auto l0BTile = l0BTensorList[l0BListId];
+                        auto layoutBInL0 = tla::MakeLayout<ElementB, LayoutTagL0B>(kL0Actual, nL0Actual);
+                        auto tensorL0B = tla::MakeTensor(l0BTile, layoutBInL0, Arch::PositionL0B{});
+                        // Locate the current tile of matrix B on L1
+                        auto tensorTileL1B = GetTile(tensorL1B,
+                                                     tla::MakeCoord(kL0Idx * L0_TILE_K, nL0Idx * L0_TILE_N),
+                                                     tla::MakeShape(kL0Actual, nL0Actual));
+
+                        // Wait for mmad finished
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0BEventList[l0BListId]);
+                        // If the current tile is the first one on the k&n axis, wait for loading matrix B from GM to L1
+                        if ((mL0Idx == 0) && (kL0Idx == 0) && (nL0Idx == 0)) {
+                            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(l1BEventList[l1BListId]);
+                        }
+
+                        // Load current tile from L1 to L0B
+                        copyL1ToL0B(tensorL0B, tensorTileL1B);
+
+                        // If the current tile is the last one on the k&n axis, notify to load matrix B from GM to L1
+                        if ((mL0Idx == mL0Loop - 1) && (kL0Idx == kL0Loop - 1) && (nL0Idx == nL0Loop - 1)) {
+                            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList[l1BListId]);
+                        }
+
+                        if constexpr (HAS_BIAS && !std::is_same_v<TensorBias, EmptyClass>) {
+                            if (initC) {
+                                if (nL0Idx == 0) {
+                                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(L1A_STAGES + L1B_STAGES);
+                                }
+                                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0A_STAGES + L0B_STAGES);
+                                auto l1Bias = l1BiasTensor.template ReinterpretCast<ElementBias>();
+                                auto tensorL1Bias = tla::MakeTensor(l1Bias, L1BIAS_LAYOUT, Arch::PositionL1{});
+                                auto tensorTileL1Bias = GetTile(tensorL1Bias,
+                                                                tla::MakeCoord(nL0Idx * L0_TILE_N),
+                                                                tla::MakeShape(nL0Actual));
+                                // Load bias to l0 biasTable
+                                copyL1ToBT(tensorL0Bias, tensorTileL1Bias);
+                                if (nL0Idx == nL0Loop - 1) {
+                                    AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(L1A_STAGES + L1B_STAGES);
+                                }
+                            }
+                        }
+
+                        // Notify to do mmad
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(l0CEventList[l0CListId]);
+
+                        // Locate the current tile on L0C
+                        auto tensorTileL0C = GetTile(tensorL0C,
+                                                     tla::MakeCoord(mL0Idx * L0_TILE_M, nL0Idx * L0_TILE_N),
+                                                     tla::MakeShape(mL0Actual, nL0Actual));
+
+                        // Compute the matrix multiplication on L0A and L0B and write the result to the accumulator
+                        // Wait for loading L0B
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(l0CEventList[l0CListId]);
+
+                        // If the unit flag is enabled, the unit flag is set according to the calculation progress
+                        uint8_t unitFlag = 0b00;
+                        if constexpr (ENABLE_UNIT_FLAG) {
+                            if ((kL1Idx == kL1Loop - 1) && (mL0Idx == mL0Loop - 1) &&
+                                (kL0Idx == kL0Loop - 1) && (nL0Idx == nL0Loop - 1)) {
+                                unitFlag = 0b11;
+                            } else {
+                                unitFlag = 0b10;
+                            }
+                        }
+
+                        if constexpr (HAS_BIAS && !std::is_same_v<TensorBias, EmptyClass>) {
+                            if (initC) {
+                                tileMmad(tensorTileL0C, tensorL0A, tensorL0B, tensorL0Bias,
+                                    mL0Actual, nL0Actual, kL0Actual, initC, unitFlag);
+                                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0A_STAGES + L0B_STAGES);
+                            } else {
+                                tileMmad(tensorTileL0C, tensorL0A, tensorL0B,
+                                    mL0Actual, nL0Actual, kL0Actual, initC, unitFlag);
+                            }
+                        } else {
+                            tileMmad(tensorTileL0C, tensorL0A, tensorL0B,
+                                mL0Actual, nL0Actual, kL0Actual, initC, unitFlag);
+                        }
+
+                        // Notify to move the next L0B tile
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0BEventList[l0BListId]);
+                        l0BListId = (l0BListId + 1 < L0B_STAGES) ? (l0BListId + 1) : 0;
+                    }
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0AEventList[l0AListId]);
+                    l0AListId = (l0AListId + 1 < L0A_STAGES) ? (l0AListId + 1) : 0;
+                }
+            }
+            l1AListId = l1AListIdNext;
+            l1BListId = l1BListIdNext;
+            kL1Actual = kL1ActualNext;
+        }
+
+        // copy block out
+        if constexpr (!ENABLE_UNIT_FLAG) {
+            AscendC::SetFlag<AscendC::HardEvent::M_FIX>(l0CEventList[l0CListId]);
+            AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(l0CEventList[l0CListId]);
+            copyL0CToDst(tensorC, tensorL0C);
+            AscendC::SetFlag<AscendC::HardEvent::FIX_M>(l0CEventList[l0CListId]);
+            l0CListId = (l0CListId + 1 < L0C_STAGES) ? (l0CListId + 1) : 0;
+        } else {
+            copyL0CToDst(tensorC, tensorL0C, 0b11);
+        }
+    }
+
+protected:
+    template<class TensorA>
+    CATLASS_DEVICE auto GetTileA(TensorA &tensorA, uint32_t mIndex, uint32_t kIndex, uint32_t mSize, uint32_t kSize)
+    {
+        if constexpr(tla::detail::isVector<LayoutA>::value) {
+            return GetTile(tensorA, tla::MakeCoord(kIndex), tla::MakeShape(kSize));
+        } else {
+            return GetTile(tensorA, tla::MakeCoord(mIndex, kIndex), tla::MakeShape(mSize, kSize));
+        }
+    }
+
+    // Multi-stage tensors list
+    AscendC::LocalTensor<ElementA> l1ATensorList[L1A_STAGES];
+    AscendC::LocalTensor<ElementB> l1BTensorList[L1B_STAGES];
+    AscendC::LocalTensor<ElementA> l0ATensorList[L0A_STAGES];
+    AscendC::LocalTensor<ElementB> l0BTensorList[L0B_STAGES];
+    AscendC::LocalTensor<ElementAccumulator> l0CTensorList[L0C_STAGES];
+    AscendC::LocalTensor<uint8_t> l1BiasTensor;
+    AscendC::LocalTensor<ElementAccumulator> l0BiasTensor;
+
+    // Multi-stage event id list
+    int32_t l1AEventList[L1A_STAGES];
+    int32_t l1BEventList[L1B_STAGES];
+    int32_t l0AEventList[L0A_STAGES];
+    int32_t l0BEventList[L0B_STAGES];
+    int32_t l0CEventList[L0C_STAGES];
+
+    __gm__ typename AscendC::GlobalTensor<ElementA>::PrimType* lastAddrA[L1A_STAGES];
+    __gm__ typename AscendC::GlobalTensor<ElementB>::PrimType* lastAddrB[L1B_STAGES];
+    MatrixCoord lastCoordA[L1A_STAGES];
+    MatrixCoord lastCoordB[L1B_STAGES];
+
+    // The id of current stage
+    uint32_t l1AListId{0};
+    uint32_t l1BListId{0};
+    uint32_t l0AListId{0};
+    uint32_t l0BListId{0};
+    uint32_t l0CListId{0};
+
+    TileMmad tileMmad;
+    CopyL1ToL0A copyL1ToL0A;
+    CopyL1ToL0B copyL1ToL0B;
+    CopyL1ToBT copyL1ToBT;
+};
+
+} // namespace Catlass::Gemm::Block
+
+#include "catlass/catlass.hpp"
+#include "catlass/coord.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/gemm/dispatch_policy.hpp"
+#include "catlass/gemm/helper.hpp"
+#include "catlass/gemm/tile/tile_copy.hpp"
+#include "catlass/gemm/tile/tile_mmad.hpp"
+#include "tla/layout.hpp"
+#include "tla/tensor.hpp"
+
+namespace Catlass::Gemm::Block {
+
+/// Pipelined version of BlockMmadTla that separates GM->L1 copy from
+/// L1->L0 + Mmad + L0C->GM.  This allows overlapping the GM->L1 phase of
+/// one instance with the Mmad phase of the previous instance, enabling
+/// cross-Gemm pipeline overlap on the same AIC core.
+///
+/// Usage pattern (overlapping instance A's Mmad with instance B's GM->L1):
+///
+///   // Instance A (e.g. Cube1)
+///   A.preSetFlags();                  // init all L1+L0 flags + HW mode
+///   A(tensorA, tensorB, tensorC, shape);  // full operator() internally
+///   A.waitL1Drained();                // wait only L1 flags (GM->L1 done)
+///
+///   // Instance B (e.g. Cube2) -- GM->L1 overlaps with A's Mmad
+///   B.preSetL1Flags();                // init L1 flags + HW mode only
+///   B.copyGmToL1(tensorA, tensorB, shape);  // GM->L1A/L1B (L1 flags only)
+///
+///   A.finalWaitFlags();               // wait A's L0 flags (Mmad done)
+///
+///   B.preSetL0Flags();                // init L0 flags (A's L0 now free)
+///   B.executeCompute(tensorC, shape); // L1->L0 + Mmad + L0C->GM
+///   B.finalWaitFlags();
+///
+/// Constraint: only valid when kL1Loop == 1 (kBlockActual <= L1_TILE_K),
+/// i.e. the K dimension fits in a single L1 tile.  When kL1Loop > 1 the
+/// original operator() interleaves GM->L1 preload with Mmad and cannot be
+/// split this way.
+template <
+    class DispatchPolicy,
+    class L1TileShape,
+    class L0TileShape,
+    class ElementA_,
+    class ElementB_,
+    class ElementC_,
+    class ElementBias_ = void,
+    class TileCopy_ = Catlass::Gemm::Tile::PackedTileCopyTla<
+        typename DispatchPolicy::ArchTag, ElementA_, Catlass::layout::RowMajor,
+        ElementB_, Catlass::layout::RowMajor, ElementC_, Catlass::layout::RowMajor, ElementBias_>,
+    class TileMmad_ = Catlass::Gemm::Tile::TileMmadTla<
+        typename DispatchPolicy::ArchTag, ElementA_, typename TileCopy_::LayoutTagL1A>
+>
+struct BlockMmadTlaPipelined : public BlockMmadTla<
+    DispatchPolicy, L1TileShape, L0TileShape,
+    ElementA_, ElementB_, ElementC_, ElementBias_, TileCopy_, TileMmad_
+> {
+    using Base = BlockMmadTla<
+        DispatchPolicy, L1TileShape, L0TileShape,
+        ElementA_, ElementB_, ElementC_, ElementBias_, TileCopy_, TileMmad_
+    >;
+
+    // Type aliases from Base
+    using typename Base::ElementA;
+    using typename Base::ElementB;
+    using typename Base::ElementC;
+    using typename Base::TileCopy;
+    using typename Base::ArchTag;
+    using typename Base::LayoutC;
+
+    // Compile-time constants from Base
+    using Base::L1_TILE_M;
+    using Base::L1_TILE_N;
+    using Base::L1_TILE_K;
+    using Base::L0_TILE_M;
+    using Base::L0_TILE_N;
+    using Base::L0_TILE_K;
+    using Base::L1A_STAGES;
+    using Base::L1B_STAGES;
+    using Base::L0A_STAGES;
+    using Base::L0B_STAGES;
+    using Base::L0C_STAGES;
+    using Base::ENABLE_UNIT_FLAG;
+    using Base::ENABLE_L1_RESIDENT;
+    using Base::SHARE_L1A;
+    using Base::HAS_BIAS;
+    using Base::L1A_TILE_SIZE;
+    using Base::L1B_TILE_SIZE;
+
+    // Layouts from Base
+    using Base::L1A_LAYOUT;
+    using Base::L1B_LAYOUT;
+
+    CATLASS_DEVICE
+    BlockMmadTlaPipelined(Arch::Resource<ArchTag> &resource, uint32_t l1BufAddrStart = 0,
+                          uint32_t l1AEventIdOffset = 0, uint32_t l1BEventIdOffset = 0,
+                          uint32_t l1ABufOffset = 0)
+        : Base(resource, l1BufAddrStart) {
+        if ASCEND_IS_AIC {
+            // Override L1A buffer offset (for SHARE_L1A: L1A at 0, L1B at l1BufAddrStart)
+            if (l1ABufOffset > 0 || (SHARE_L1A && l1BufAddrStart > 0)) {
+                uint32_t l1AOff = SHARE_L1A ? 0 : l1ABufOffset;
+                for (uint32_t i = 0; i < L1A_STAGES; i++) {
+                    this->l1ATensorList[i] = resource.l1Buf.template GetBufferByByte<ElementA>(l1AOff + L1A_TILE_SIZE * i);
+                }
+            }
+            // Override L1A eventIDs
+            if (l1AEventIdOffset > 0) {
+                for (uint32_t i = 0; i < L1A_STAGES; i++) {
+                    this->l1AEventList[i] = i + l1AEventIdOffset;
+                }
+            }
+            // Override L1B eventIDs
+            if (l1BEventIdOffset > 0) {
+                for (uint32_t i = 0; i < L1B_STAGES; i++) {
+                    this->l1BEventList[i] = i + l1BEventIdOffset;
+                }
+            }
+        }
+    }
+
+    /// Wait only for L1 flags to drain (GM->L1A/L1B complete).
+    /// L0A/L0B flags are NOT waited -- the caller may overlap the next
+    /// instance's GM->L1 with this instance's Mmad phase.
+    CATLASS_DEVICE
+    void waitL1Drained() {
+        if ASCEND_IS_AIC {
+            for (uint32_t i = 0; i < L1A_STAGES; i++) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(this->l1AEventList[i]);
+            }
+            for (uint32_t i = 0; i < L1B_STAGES; i++) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(this->l1BEventList[i]);
+            }
+        }
+    }
+
+    /// Consume an externally-provisioned L1A tensor (e.g. produced by a Vector
+    /// core via UB->L1 direct copy) instead of this instance's own L1A slots.
+    /// The next executeCompute() reads its A operand from l1ATensor; the
+    /// internal l1AListId stays untouched. One-shot: cleared after one call.
+    /// The caller must guarantee the external L1A data is fully written before
+    /// calling (e.g. a cross-core flag already waited on).
+    CATLASS_DEVICE
+    void UseExternalL1ATensor(AscendC::LocalTensor<ElementA> l1ATensor) {
+        externalL1ATensor = l1ATensor;
+        useExternalL1ATensor = true;
+    }
+
+    /// Wait only for L0A/L0B flags to drain (Mmad complete).
+    /// Use after waitL1Drained() to avoid double-waiting L1 flags.
+    CATLASS_DEVICE
+    void waitL0Drained() {
+        if ASCEND_IS_AIC {
+            for (uint32_t i = 0; i < L0A_STAGES; i++) {
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(this->l0AEventList[i]);
+            }
+            for (uint32_t i = 0; i < L0B_STAGES; i++) {
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(this->l0BEventList[i]);
+            }
+            if constexpr (HAS_BIAS) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(L1A_STAGES + L1B_STAGES);
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0A_STAGES + L0B_STAGES);
+            }
+        }
+    }
+
+    /// Initialize only L1 flags and hardware mode (HF32, LayoutTransform).
+    /// Does NOT touch L0A/L0B flags -- safe to call while another instance's
+    /// operator() or executeCompute() is still running.
+    CATLASS_DEVICE
+    void preSetL1Flags() {
+        if ASCEND_IS_AIC {
+            if constexpr (Base::USE_HF32_MODE) {
+                AscendC::SetHF32Mode(true);
+            } else {
+                AscendC::SetHF32Mode(false);
+            }
+            if constexpr (ENABLE_UNIT_FLAG && tla::detail::isRowMajor<LayoutC>::value) {
+                AscendC::SetMMLayoutTransform(true);
+            }
+            for (uint32_t i = 0; i < L1A_STAGES; i++) {
+                AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(this->l1AEventList[i]);
+            }
+            for (uint32_t i = 0; i < L1B_STAGES; i++) {
+                AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(this->l1BEventList[i]);
+            }
+            if constexpr (ENABLE_L1_RESIDENT) {
+                Base::RestoreStatus();
+            }
+        }
+    }
+
+    /// Initialize only L0A/L0B flags.  Must be called after the previous
+    /// instance's finalWaitFlags() has drained L0 flags.
+    CATLASS_DEVICE
+    void preSetL0Flags() {
+        if ASCEND_IS_AIC {
+            for (uint32_t i = 0; i < L0A_STAGES; i++) {
+                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(this->l0AEventList[i]);
+            }
+            for (uint32_t i = 0; i < L0B_STAGES; i++) {
+                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(this->l0BEventList[i]);
+            }
+        }
+    }
+
+    /// Phase 1: Copy GM->L1A/L1B.  Only uses L1 flags.
+    /// Requires preSetL1Flags() to have been called.
+    template <class TensorA, class TensorB>
+    CATLASS_DEVICE void copyGmToL1(TensorA &tensorA, TensorB &tensorB, GemmCoord const &actualShape)
+    {
+        using CopyGmToL1A = typename TileCopy::template CopyGmToL1A<TensorA>;
+        using CopyGmToL1B = typename TileCopy::template CopyGmToL1B<TensorB>;
+        CopyGmToL1A copyGmToL1A;
+        CopyGmToL1B copyGmToL1B;
+
+        uint32_t mBlockActual = actualShape.m();
+        uint32_t kBlockActual = actualShape.k();
+        uint32_t nBlockActual = actualShape.n();
+
+        uint32_t kL1Actual = min(kBlockActual, L1_TILE_K);
+
+        // load matrix A tile from GM to L1
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(this->l1AEventList[this->l1AListId]);
+        auto tensorL1A = tla::MakeTensor(this->l1ATensorList[this->l1AListId], L1A_LAYOUT, Arch::PositionL1{});
+        auto tensorTileA = this->GetTileA(tensorA, 0, 0, mBlockActual, kL1Actual);
+        if constexpr (SHARE_L1A) {
+            // L1A is shared from another BlockMmad instance; skip GM->L1A copy.
+        } else if constexpr (ENABLE_L1_RESIDENT) {
+            if (this->lastAddrA[this->l1AListId] != tensorTileA.data().GetPhyAddr()
+                || tla::get<0>(tensorTileA.coord()) != this->lastCoordA[this->l1AListId].row()
+                || tla::get<1>(tensorTileA.coord()) != this->lastCoordA[this->l1AListId].column()) {
+                copyGmToL1A(tensorL1A, tensorTileA);
+                this->lastCoordA[this->l1AListId] = MatrixCoord{tla::get<0>(tensorTileA.coord()), tla::get<1>(tensorTileA.coord())};
+                this->lastAddrA[this->l1AListId] = const_cast<__gm__ typename AscendC::GlobalTensor<ElementA>::PrimType *>(
+                    tensorTileA.data().GetPhyAddr()
+                );
+            }
+        } else {
+            copyGmToL1A(tensorL1A, tensorTileA);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(this->l1AEventList[this->l1AListId]);
+
+        // load matrix B tile from GM to L1
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(this->l1BEventList[this->l1BListId]);
+        auto tensorL1B = tla::MakeTensor(this->l1BTensorList[this->l1BListId], L1B_LAYOUT, Arch::PositionL1{});
+        auto tensorTileB = GetTile(tensorB, tla::MakeCoord(0, 0), tla::MakeShape(kL1Actual, nBlockActual));
+        if constexpr (ENABLE_L1_RESIDENT) {
+            if (this->lastAddrB[this->l1BListId] != tensorTileB.data().GetPhyAddr()
+                || tla::get<0>(tensorTileB.coord()) != this->lastCoordB[this->l1BListId].row()
+                || tla::get<1>(tensorTileB.coord()) != this->lastCoordB[this->l1BListId].column()) {
+                copyGmToL1B(tensorL1B, tensorTileB);
+                this->lastCoordB[this->l1BListId] = MatrixCoord{tla::get<0>(tensorTileB.coord()), tla::get<1>(tensorTileB.coord())};
+                this->lastAddrB[this->l1BListId] = const_cast<__gm__ typename AscendC::GlobalTensor<ElementB>::PrimType *>(
+                    tensorTileB.data().GetPhyAddr()
+                );
+            }
+        } else {
+            copyGmToL1B(tensorL1B, tensorTileB);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(this->l1BEventList[this->l1BListId]);
+    }
+
+    /// Phase 1a: Copy GM->L1A only.  Only uses L1A flags.
+    /// Requires preSetL1Flags() to have been called.
+    /// Useful when L1A and L1B have different cross-core dependencies and
+    /// should be loaded separately to maximize MTE2 overlap with M pipeline.
+    template <class TensorA>
+    CATLASS_DEVICE void copyGmToL1AOnly(TensorA &tensorA, GemmCoord const &actualShape)
+    {
+        using CopyGmToL1A = typename TileCopy::template CopyGmToL1A<TensorA>;
+        CopyGmToL1A copyGmToL1A;
+
+        uint32_t mBlockActual = actualShape.m();
+        uint32_t kBlockActual = actualShape.k();
+        uint32_t kL1Actual = min(kBlockActual, L1_TILE_K);
+
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(this->l1AEventList[this->l1AListId]);
+        auto tensorL1A = tla::MakeTensor(this->l1ATensorList[this->l1AListId], L1A_LAYOUT, Arch::PositionL1{});
+        auto tensorTileA = this->GetTileA(tensorA, 0, 0, mBlockActual, kL1Actual);
+        if constexpr (SHARE_L1A) {
+            // L1A is shared from another BlockMmad instance; skip GM->L1A copy.
+        } else if constexpr (ENABLE_L1_RESIDENT) {
+            if (this->lastAddrA[this->l1AListId] != tensorTileA.data().GetPhyAddr()
+                || tla::get<0>(tensorTileA.coord()) != this->lastCoordA[this->l1AListId].row()
+                || tla::get<1>(tensorTileA.coord()) != this->lastCoordA[this->l1AListId].column()) {
+                copyGmToL1A(tensorL1A, tensorTileA);
+                this->lastCoordA[this->l1AListId] = MatrixCoord{tla::get<0>(tensorTileA.coord()), tla::get<1>(tensorTileA.coord())};
+                this->lastAddrA[this->l1AListId] = const_cast<__gm__ typename AscendC::GlobalTensor<ElementA>::PrimType *>(
+                    tensorTileA.data().GetPhyAddr()
+                );
+            }
+        } else {
+            copyGmToL1A(tensorL1A, tensorTileA);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(this->l1AEventList[this->l1AListId]);
+    }
+
+    /// Phase 1b: Copy GM->L1B only.  Only uses L1B flags.
+    /// Requires preSetL1Flags() to have been called.
+    /// Useful when L1A and L1B have different cross-core dependencies and
+    /// should be loaded separately to maximize MTE2 overlap with M pipeline.
+    template <class TensorB>
+    CATLASS_DEVICE void copyGmToL1BOnly(TensorB &tensorB, GemmCoord const &actualShape)
+    {
+        using CopyGmToL1B = typename TileCopy::template CopyGmToL1B<TensorB>;
+        CopyGmToL1B copyGmToL1B;
+
+        uint32_t kBlockActual = actualShape.k();
+        uint32_t nBlockActual = actualShape.n();
+        uint32_t kL1Actual = min(kBlockActual, L1_TILE_K);
+
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(this->l1BEventList[this->l1BListId]);
+        auto tensorL1B = tla::MakeTensor(this->l1BTensorList[this->l1BListId], L1B_LAYOUT, Arch::PositionL1{});
+        auto tensorTileB = GetTile(tensorB, tla::MakeCoord(0, 0), tla::MakeShape(kL1Actual, nBlockActual));
+        if constexpr (ENABLE_L1_RESIDENT) {
+            if (this->lastAddrB[this->l1BListId] != tensorTileB.data().GetPhyAddr()
+                || tla::get<0>(tensorTileB.coord()) != this->lastCoordB[this->l1BListId].row()
+                || tla::get<1>(tensorTileB.coord()) != this->lastCoordB[this->l1BListId].column()) {
+                copyGmToL1B(tensorL1B, tensorTileB);
+                this->lastCoordB[this->l1BListId] = MatrixCoord{tla::get<0>(tensorTileB.coord()), tla::get<1>(tensorTileB.coord())};
+                this->lastAddrB[this->l1BListId] = const_cast<__gm__ typename AscendC::GlobalTensor<ElementB>::PrimType *>(
+                    tensorTileB.data().GetPhyAddr()
+                );
+            }
+        } else {
+            copyGmToL1B(tensorL1B, tensorTileB);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(this->l1BEventList[this->l1BListId]);
+    }
+
+    /// Phase 2: L1->L0 + Mmad + L0C->GM.  Requires preSetL0Flags() and
+    /// copyGmToL1() to have been called.
+    template <class TensorC>
+    CATLASS_DEVICE void executeCompute(TensorC &tensorC, GemmCoord const &actualShape)
+    {
+        uint32_t mBlockActual = actualShape.m();
+        uint32_t kBlockActual = actualShape.k();
+        uint32_t nBlockActual = actualShape.n();
+        // One-shot external-L1A consumption (see UseExternalL1ATensor).
+        bool useExternalL1AThisCall = false;
+        if ASCEND_IS_AIC {
+            if (useExternalL1ATensor) {
+                useExternalL1ATensor = false;
+                useExternalL1AThisCall = true;
+            }
+        }
+
+        uint32_t mL1Actual = mBlockActual;
+        if constexpr (std::is_same_v<ArchTag, Arch::AtlasA2>) {
+            if (mL1Actual == 1) {
+                mL1Actual = 16;
+            }
+        }
+        uint32_t nL1Actual = nBlockActual;
+
+        auto layoutInL0C = tla::MakeLayoutL0C(mL1Actual, nL1Actual);
+        auto tensorL0C = tla::MakeTensor(this->l0CTensorList[this->l0CListId], layoutInL0C, Arch::PositionL0C{});
+
+        uint32_t kL1Actual = min(kBlockActual, L1_TILE_K);
+
+        if constexpr (!ENABLE_UNIT_FLAG) {
+            AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(this->l0CEventList[this->l0CListId]);
+        }
+
+        uint32_t mL0Loop = CeilDiv<L0_TILE_M>(mL1Actual);
+        uint32_t nL0Loop = CeilDiv<L0_TILE_N>(nL1Actual);
+        uint32_t kL0Loop = CeilDiv<L0_TILE_K>(kL1Actual);
+
+        auto l1ATensor = useExternalL1AThisCall ? externalL1ATensor : this->l1ATensorList[this->l1AListId];
+        auto l1BTensor = this->l1BTensorList[this->l1BListId];
+        auto tensorL1A = tla::MakeTensor(l1ATensor, L1A_LAYOUT, Arch::PositionL1{});
+        auto tensorL1B = tla::MakeTensor(l1BTensor, L1B_LAYOUT, Arch::PositionL1{});
+
+        for (int mL0Idx = 0; mL0Idx < mL0Loop; mL0Idx++) {
+            uint32_t mL0Actual = (mL0Idx < mL0Loop - 1) ? L0_TILE_M : (mL1Actual - mL0Idx * L0_TILE_M);
+
+            for (int kL0Idx = 0; kL0Idx < kL0Loop; kL0Idx++) {
+                uint32_t kL0Actual = (kL0Idx < kL0Loop - 1) ? L0_TILE_K : (kL1Actual - kL0Idx * L0_TILE_K);
+
+                auto l0ATile = this->l0ATensorList[this->l0AListId];
+                auto layoutAInL0 = tla::MakeLayout<ElementA, typename Base::LayoutTagL0A>(mL0Actual, kL0Actual);
+                auto tensorL0A = tla::MakeTensor(l0ATile, layoutAInL0, Arch::PositionL0A{});
+                auto tensorTileL1A = this->GetTileA(tensorL1A, mL0Idx * L0_TILE_M, kL0Idx * L0_TILE_K, mL0Actual, kL0Actual);
+
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(this->l0AEventList[this->l0AListId]);
+                if ((mL0Idx == 0) && (kL0Idx == 0)) {
+                    if (useExternalL1AThisCall) {
+                        // External L1A was written cross-core (Vector MTE3), ordered by
+                        // the cross-core flag the caller waited on. The internal
+                        // GM->L1A copy (and its MTE2_MTE1 handshake) is skipped, so do
+                        // NOT wait on that event here — nobody sets it this round.
+                    } else {
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(this->l1AEventList[this->l1AListId]);
+                    }
+                }
+
+                this->copyL1ToL0A(tensorL0A, tensorTileL1A);
+
+                if ((mL0Idx == mL0Loop - 1) && (kL0Idx == kL0Loop - 1)) {
+                    if (useExternalL1AThisCall) {
+                        // Skip the MTE1_MTE2 release for external L1A: the flag pair is
+                        // owned by the (skipped) internal copy; touching it desyncs the
+                        // hardware event state and deadlocks the next regular round.
+                    } else {
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(this->l1AEventList[this->l1AListId]);
+                    }
+                }
+
+                bool initC = (kL0Idx == 0);
+                for (int nL0Idx = 0; nL0Idx < nL0Loop; nL0Idx++) {
+                    uint32_t nL0Actual = (nL0Idx < nL0Loop - 1) ? L0_TILE_N : (nL1Actual - nL0Idx * L0_TILE_N);
+
+                    auto l0BTile = this->l0BTensorList[this->l0BListId];
+                    auto layoutBInL0 = tla::MakeLayout<ElementB, typename Base::LayoutTagL0B>(kL0Actual, nL0Actual);
+                    auto tensorL0B = tla::MakeTensor(l0BTile, layoutBInL0, Arch::PositionL0B{});
+                    auto tensorTileL1B = GetTile(tensorL1B,
+                                                 tla::MakeCoord(kL0Idx * L0_TILE_K, nL0Idx * L0_TILE_N),
+                                                 tla::MakeShape(kL0Actual, nL0Actual));
+
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(this->l0BEventList[this->l0BListId]);
+                    if ((mL0Idx == 0) && (kL0Idx == 0) && (nL0Idx == 0)) {
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(this->l1BEventList[this->l1BListId]);
+                    }
+
+                    this->copyL1ToL0B(tensorL0B, tensorTileL1B);
+
+                    if ((mL0Idx == mL0Loop - 1) && (kL0Idx == kL0Loop - 1) && (nL0Idx == nL0Loop - 1)) {
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(this->l1BEventList[this->l1BListId]);
+                    }
+
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(this->l0CEventList[this->l0CListId]);
+
+                    auto tensorTileL0C = GetTile(tensorL0C,
+                                                 tla::MakeCoord(mL0Idx * L0_TILE_M, nL0Idx * L0_TILE_N),
+                                                 tla::MakeShape(mL0Actual, nL0Actual));
+
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(this->l0CEventList[this->l0CListId]);
+
+                    uint8_t unitFlag = 0b00;
+                    if constexpr (ENABLE_UNIT_FLAG) {
+                        if ((mL0Idx == mL0Loop - 1) && (kL0Idx == kL0Loop - 1) && (nL0Idx == nL0Loop - 1)) {
+                            unitFlag = 0b11;
+                        } else {
+                            unitFlag = 0b10;
+                        }
+                    }
+
+                    this->tileMmad(tensorTileL0C, tensorL0A, tensorL0B,
+                        mL0Actual, nL0Actual, kL0Actual, initC, unitFlag);
+
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(this->l0BEventList[this->l0BListId]);
+                    this->l0BListId = (this->l0BListId + 1 < L0B_STAGES) ? (this->l0BListId + 1) : 0;
+                }
+                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(this->l0AEventList[this->l0AListId]);
+                this->l0AListId = (this->l0AListId + 1 < L0A_STAGES) ? (this->l0AListId + 1) : 0;
+            }
+        }
+
+        // copy block out
+        if constexpr (!ENABLE_UNIT_FLAG) {
+            AscendC::SetFlag<AscendC::HardEvent::M_FIX>(this->l0CEventList[this->l0CListId]);
+            AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(this->l0CEventList[this->l0CListId]);
+            using CopyL0CToDst = typename TileCopy::template CopyL0CToDst<TensorC>;
+            CopyL0CToDst copyL0CToDst;
+            copyL0CToDst(tensorC, tensorL0C);
+            AscendC::SetFlag<AscendC::HardEvent::FIX_M>(this->l0CEventList[this->l0CListId]);
+            this->l0CListId = (this->l0CListId + 1 < L0C_STAGES) ? (this->l0CListId + 1) : 0;
+        } else {
+#if (defined (CATLASS_ARCH) && CATLASS_ARCH == 3510)
+            using CopyL0CToDst = typename TileCopy::template CopyL0CToDst<TensorC>;
+            CopyL0CToDst copyL0CToDst;
+            copyL0CToDst(tensorC, tensorL0C, 0b11);
+#else
+            using CopyL0CToDst = typename TileCopy::template CopyL0CToGm<TensorC>;
+            CopyL0CToDst copyL0CToDst;
+            copyL0CToDst(tensorC, tensorL0C);
+#endif
+        }
+
+        // Advance L1 ping-pong slot, matching the original operator() behavior
+        // where l1AListId/l1BListId are advanced at the end of the kL1Loop.
+        // This is critical for SHARE_L1A: without it, Cube2 would always read
+        // from slot 0 while Cube1 alternates between slot 0 and 1.
+        // External-L1A calls keep the internal slot cursor frozen so the next
+        // regular GM->L1A copy resumes the ping-pong sequence undisturbed.
+        if (!useExternalL1AThisCall) {
+            this->l1AListId = (this->l1AListId + 1 < L1A_STAGES) ? (this->l1AListId + 1) : 0;
+        }
+        this->l1BListId = (this->l1BListId + 1 < L1B_STAGES) ? (this->l1BListId + 1) : 0;
+    }
+
+private:
+    bool useExternalL1ATensor = false;
+    AscendC::LocalTensor<ElementA> externalL1ATensor;
+};
+
+} // namespace Catlass::Gemm::Block
+
+#endif // CATLASS_GEMM_BLOCK_BLOCK_MMAD_PINGPONG_TLA_PIPELINED_HPP

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdo_output.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdo_output.hpp
@@ -10,52 +10,155 @@
 #ifndef CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDO_OUTPUT_HPP
 #define CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDO_OUTPUT_HPP
 
-#include "kernel_operator.h"
 #include "catlass/catlass.hpp"
 #include "catlass/arch/resource.hpp"
 #include "../gdn_fwd_o_epilogue_policies.hpp"
 #include "catlass/gemm_coord.hpp"
 #include "catlass/matrix_coord.hpp"
 #include "catlass/epilogue/tile/tile_copy.hpp"
+// regbase.hpp 自身无 include guard，本算子 kernel 会同时包含 qkmask 与 output 两个
+// epilogue 头，此处用算子私有宏防止同一编译单元内重复包含（重定义 constexpr/inline 符号）
+#ifndef FLA_FWD_O_REGBASE_HPP_SEEN
+#define FLA_FWD_O_REGBASE_HPP_SEEN
+#include "kernel_utils/vector/regbase.hpp"
+#endif
 
-namespace Catlass::Epilogue::Block {
-
-static __simd_vf__ inline void GdnFwdoOutputMulAddScaleVf(__ubuf__ float *dst, __ubuf__ float *attn,
-                                                          __ubuf__ float *hidden, __ubuf__ float *gate, float scale,
-                                                          uint32_t elementCount)
+// RegBase VF 函数：Mul(H, exp(g)) → Add(attn) → Muls(scale) 全融合，逐行寄存器处理
+// nActual=128 时分两段各 64 列处理，与 qkmask 的 VF 结构对齐
+__simd_vf__ inline void OutputFusedVf(
+    __ubuf__ float* __restrict__ outAddr,       // outUbTensor 起始地址（输出）
+    __ubuf__ float* __restrict__ hAddr,          // hUbTensor 起始地址（H 数据）
+    __ubuf__ float* __restrict__ aAddr,          // aUbTensor 起始地址（attn 数据）
+    __ubuf__ float* __restrict__ brcExpAddr,     // gbrcLeftcastUbTensor[gbrcEffStart*nActual] 地址
+    uint32_t mActualThisStage,                   // 本 stage 行数
+    uint32_t nActual,                            // 列数（128）
+    float scale)
 {
-    AscendC::Reg::RegTensor<float> attnReg0;
-    AscendC::Reg::RegTensor<float> attnReg1;
-    AscendC::Reg::RegTensor<float> hiddenReg0;
-    AscendC::Reg::RegTensor<float> hiddenReg1;
-    AscendC::Reg::RegTensor<float> gateReg0;
-    AscendC::Reg::RegTensor<float> gateReg1;
-    AscendC::Reg::RegTensor<float> dstReg0;
-    AscendC::Reg::RegTensor<float> dstReg1;
-    constexpr uint32_t ELEMS_PER_REG = AscendC::VECTOR_REG_WIDTH / sizeof(float);
-    constexpr uint32_t ELEMS_PER_DUAL = ELEMS_PER_REG * 2;
-    auto maskFull = AscendC::Reg::CreateMask<float, AscendC::Reg::MaskPattern::ALL>();
-    uint16_t dualRepeats = static_cast<uint16_t>(elementCount / ELEMS_PER_DUAL);
+    using namespace AscendC::MicroAPI;
+    constexpr uint32_t VL = AscendC::VECTOR_REG_WIDTH / sizeof(float);  // 64
 
-    for (uint16_t i = 0; i < dualRepeats; ++i) {
-        uint32_t offset = static_cast<uint32_t>(i) * ELEMS_PER_DUAL;
-        AscendC::Reg::LoadAlign<float, AscendC::Reg::LoadDist::DIST_DINTLV_B32>(attnReg0, attnReg1, attn + offset);
-        AscendC::Reg::LoadAlign<float, AscendC::Reg::LoadDist::DIST_DINTLV_B32>(hiddenReg0, hiddenReg1,
-                                                                                hidden + offset);
-        AscendC::Reg::LoadAlign<float, AscendC::Reg::LoadDist::DIST_DINTLV_B32>(gateReg0, gateReg1, gate + offset);
-        AscendC::Reg::Mul(dstReg0, hiddenReg0, gateReg0, maskFull);
-        AscendC::Reg::Mul(dstReg1, hiddenReg1, gateReg1, maskFull);
-        AscendC::Reg::Add(dstReg0, attnReg0, dstReg0, maskFull);
-        AscendC::Reg::Add(dstReg1, attnReg1, dstReg1, maskFull);
-        AscendC::Reg::Muls(dstReg0, dstReg0, scale, maskFull);
-        AscendC::Reg::Muls(dstReg1, dstReg1, scale, maskFull);
-        AscendC::Reg::StoreAlign<float, AscendC::Reg::StoreDist::DIST_INTLV_B32>(dst + offset, dstReg0, dstReg1,
-                                                                                 maskFull);
+    // 使用两组寄存器，同类型指令连续执行，利用 RegBase 指令流水优化
+    RegTensor<float> vregH1, vregH2;
+    RegTensor<float> vregA1, vregA2;
+    RegTensor<float> vregExp1, vregExp2;
+    RegTensor<float> vregOut1, vregOut2;
+    MaskReg maskFull = CreateMask<float, MaskPattern::ALL>();
+
+    for (uint32_t row = 0; row < mActualThisStage; ++row) {
+        __ubuf__ float* rowH = hAddr + row * nActual;
+        __ubuf__ float* rowA = aAddr + row * nActual;
+        __ubuf__ float* rowOut = outAddr + row * nActual;
+
+        // 连续 Load
+        // 注意：brcExpAddr 是 gbrcLeftcastUbTensor 的行广播结果，每行 exp(g) 不同，需按行偏移
+        __ubuf__ float* rowExp = brcExpAddr + row * nActual;
+        LoadAlign<float, LoadDist::DIST_NORM>(vregH1, rowH);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregH2, rowH + VL);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregA1, rowA);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregA2, rowA + VL);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregExp1, rowExp);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregExp2, rowExp + VL);
+
+        // 连续 Mul: H * exp(g)
+        Mul(vregOut1, vregH1, vregExp1, maskFull);
+        Mul(vregOut2, vregH2, vregExp2, maskFull);
+
+        // 连续 Add: + attn
+        Add(vregOut1, vregOut1, vregA1, maskFull);
+        Add(vregOut2, vregOut2, vregA2, maskFull);
+
+        // 连续 Muls: * scale
+        Muls(vregOut1, vregOut1, scale, maskFull);
+        Muls(vregOut2, vregOut2, scale, maskFull);
+
+        // 连续 Store
+        StoreAlign(rowOut, vregOut1, maskFull);
+        StoreAlign(rowOut + VL, vregOut2, maskFull);
     }
 }
 
-template <class HOutputType_, class GInputType_, class AInputType_, class HInputType_>
-class BlockEpilogue<EpilogueAtlasGDNFwdOOutput, HOutputType_, GInputType_, AInputType_, HInputType_> {
+// RegBase VF 函数（Wide 版本）：Mul(H, exp(g)) → Add(attn) → Muls(scale) 全融合
+// nActual=256 时分四段各 64 列处理，使用四组寄存器最大化指令流水
+__simd_vf__ inline void OutputFusedVfWide(
+    __ubuf__ float* __restrict__ outAddr,       // outUbTensor 起始地址（输出）
+    __ubuf__ float* __restrict__ hAddr,          // hUbTensor 起始地址（H 数据）
+    __ubuf__ float* __restrict__ aAddr,          // aUbTensor 起始地址（attn 数据）
+    __ubuf__ float* __restrict__ brcExpAddr,     // gbrcLeftcastUbTensor[gbrcEffStart*nActual] 地址
+    uint32_t mActualThisStage,                   // 本 tile 行数
+    uint32_t nActual,                            // 列数（256）
+    float scale)
+{
+    using namespace AscendC::MicroAPI;
+    constexpr uint32_t VL = AscendC::VECTOR_REG_WIDTH / sizeof(float);  // 64
+
+    // 使用四组寄存器，同类型指令连续执行，利用 RegBase 指令流水优化
+    RegTensor<float> vregH1, vregH2, vregH3, vregH4;
+    RegTensor<float> vregA1, vregA2, vregA3, vregA4;
+    RegTensor<float> vregExp1, vregExp2, vregExp3, vregExp4;
+    RegTensor<float> vregOut1, vregOut2, vregOut3, vregOut4;
+    MaskReg maskFull = CreateMask<float, MaskPattern::ALL>();
+
+    for (uint32_t row = 0; row < mActualThisStage; ++row) {
+        __ubuf__ float* rowH = hAddr + row * nActual;
+        __ubuf__ float* rowA = aAddr + row * nActual;
+        __ubuf__ float* rowOut = outAddr + row * nActual;
+        __ubuf__ float* rowExp = brcExpAddr + row * nActual;
+
+        // 连续 Load（四段）
+        LoadAlign<float, LoadDist::DIST_NORM>(vregH1, rowH);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregH2, rowH + VL);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregH3, rowH + 2 * VL);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregH4, rowH + 3 * VL);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregA1, rowA);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregA2, rowA + VL);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregA3, rowA + 2 * VL);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregA4, rowA + 3 * VL);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregExp1, rowExp);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregExp2, rowExp + VL);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregExp3, rowExp + 2 * VL);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregExp4, rowExp + 3 * VL);
+
+        // 连续 Mul: H * exp(g)
+        Mul(vregOut1, vregH1, vregExp1, maskFull);
+        Mul(vregOut2, vregH2, vregExp2, maskFull);
+        Mul(vregOut3, vregH3, vregExp3, maskFull);
+        Mul(vregOut4, vregH4, vregExp4, maskFull);
+
+        // 连续 Add: + attn
+        Add(vregOut1, vregOut1, vregA1, maskFull);
+        Add(vregOut2, vregOut2, vregA2, maskFull);
+        Add(vregOut3, vregOut3, vregA3, maskFull);
+        Add(vregOut4, vregOut4, vregA4, maskFull);
+
+        // 连续 Muls: * scale
+        Muls(vregOut1, vregOut1, scale, maskFull);
+        Muls(vregOut2, vregOut2, scale, maskFull);
+        Muls(vregOut3, vregOut3, scale, maskFull);
+        Muls(vregOut4, vregOut4, scale, maskFull);
+
+        // 连续 Store（四段）
+        StoreAlign(rowOut, vregOut1, maskFull);
+        StoreAlign(rowOut + VL, vregOut2, maskFull);
+        StoreAlign(rowOut + 2 * VL, vregOut3, maskFull);
+        StoreAlign(rowOut + 3 * VL, vregOut4, maskFull);
+    }
+}
+
+namespace Catlass::Epilogue::Block {
+
+template <
+    class HOutputType_,
+    class GInputType_,
+    class AInputType_,
+    class HInputType_
+>
+class BlockEpilogue <
+    EpilogueAtlasGDNFwdOOutput,
+    HOutputType_,
+    GInputType_,
+    AInputType_,
+    HInputType_
+> {
 public:
     // Type aliases
     using DispatchPolicy = EpilogueAtlasGDNFwdOOutput;
@@ -66,20 +169,31 @@ public:
     using AElementInput = typename AInputType_::Element;
     using HElementInput = typename HInputType_::Element;
 
+    // using CopyGmToUbInput = Tile::CopyGm2Ub<ArchTag, InputType_>;
+    // using CopyUbToGmOutput = Tile::CopyUb2Gm<ArchTag, OutputType_>;
 
     static constexpr uint32_t HALF_ELENUM_PER_BLK = 16;
     static constexpr uint32_t FLOAT_ELENUM_PER_BLK = 8;
     static constexpr uint32_t HALF_ELENUM_PER_VECCALC = 128;
     static constexpr uint32_t FLOAT_ELENUM_PER_VECCALC = 64;
-    static constexpr uint32_t UB_TILE_SIZE = 16384;        // 64 * 128 * 2B
-    static constexpr uint32_t UB_LINE_SIZE = 512;          // 128 * 2 * 2B
-    static constexpr uint32_t HALF_ELENUM_PER_LINE = 256;  // 128 * 2
-    static constexpr uint32_t FLOAT_ELENUM_PER_LINE = 128; // 128
+    static constexpr uint32_t UB_TILE_SIZE = 16384;  // 64 * 128 * 2B
+    static constexpr uint32_t UB_LINE_SIZE = 512;   // 128 * 2 * 2B
+    static constexpr uint32_t HALF_ELENUM_PER_LINE = 256;    // 128 * 2
+    static constexpr uint32_t FLOAT_ELENUM_PER_LINE = 128;   // 128
     static constexpr uint32_t MULTIPLIER = 2;
 
     CATLASS_DEVICE
     BlockEpilogue(Arch::Resource<ArchTag> &resource)
     {
+        // UB layout (l0c2ub, shared contract with the kernel and qkmask epilogue —
+        // see docs/agents/chunk_fwd_o_l0c2ub_ub2l1_design.md §4.1):
+        //   [0, 71K)    base region (mask/gbrc/gcomp/share/g) — offsets identical to
+        //              the qkmask epilogue; maskUbTensor/gbrcUpUbTensor here are the
+        //              same physical bytes qkmask actively uses (do NOT reclaim).
+        //   [71K, 199K) Cube work slots: V/H ping + V/H pong (4 x 32KB), written by
+        //              Cube-side Fixpipe SPLIT_M while Vec1/Vec2 run — must stay
+        //              disjoint from every Vec buffer below.
+        //   [199K, 248K) Vec1/Vec2 time-shared scratch (out fp32 + out half).
         constexpr uint32_t BASE = 0;
         constexpr uint32_t MASK_UB_TENSOR_SIZE = 32 * UB_LINE_SIZE;
         constexpr uint32_t GBRCLEFTCAST_UB_TENSOR_SIZE = 40 * UB_LINE_SIZE;
@@ -93,74 +207,288 @@ public:
         constexpr uint32_t MASK_UB_TENSOR_OFFSET = BASE;
         constexpr uint32_t GBRCLEFTCAST_UB_TENSOR_OFFSET = MASK_UB_TENSOR_OFFSET + MASK_UB_TENSOR_SIZE;
         constexpr uint32_t GBRCUP_UB_TENSOR_OFFSET = GBRCLEFTCAST_UB_TENSOR_OFFSET + GBRCLEFTCAST_UB_TENSOR_SIZE;
-        constexpr uint32_t SHARE_UB_TENSOR_OFFSET = GBRCUP_UB_TENSOR_OFFSET + GBRCUP_UB_TENSOR_SIZE;
+        constexpr uint32_t GCOMP_UB_TENSOR_OFFSET = GBRCUP_UB_TENSOR_OFFSET + GBRCUP_UB_TENSOR_SIZE;
+        constexpr uint32_t SHARE_UB_TENSOR_OFFSET = GCOMP_UB_TENSOR_OFFSET + G_FLOAT_UB_TENSOR_SIZE;
 
         maskUbTensor = resource.ubBuf.template GetBufferByByte<float>(MASK_UB_TENSOR_OFFSET);
         gbrcLeftcastUbTensor = resource.ubBuf.template GetBufferByByte<float>(GBRCLEFTCAST_UB_TENSOR_OFFSET);
         gbrcUpUbTensor = resource.ubBuf.template GetBufferByByte<float>(GBRCUP_UB_TENSOR_OFFSET);
+        gcompUbTensor = resource.ubBuf.template GetBufferByByte<float>(GCOMP_UB_TENSOR_OFFSET);
         shareUbTensor = resource.ubBuf.template GetBufferByByte<uint8_t>(SHARE_UB_TENSOR_OFFSET);
 
-        constexpr uint32_t G_UB_TENSOR_OFFSET_PING = SHARE_UB_TENSOR_OFFSET + FLOAT_UB_TENSOR_SIZE;
-        constexpr uint32_t G_HALF_UB_TENSOR_OFFSET_PING = G_UB_TENSOR_OFFSET_PING + G_FLOAT_UB_TENSOR_SIZE;
-        constexpr uint32_t A_UB_TENSOR_OFFSET_PING = 71 * 1024;
-        constexpr uint32_t H_UB_TENSOR_OFFSET_PING = A_UB_TENSOR_OFFSET_PING + UB_WORK_SLOT_BYTES;
-        constexpr uint32_t A_UB_TENSOR_OFFSET_PONG = H_UB_TENSOR_OFFSET_PING + UB_WORK_SLOT_BYTES;
-        constexpr uint32_t H_UB_TENSOR_OFFSET_PONG = A_UB_TENSOR_OFFSET_PONG + UB_WORK_SLOT_BYTES;
-        constexpr uint32_t OUT_UB_TENSOR_OFFSET_PING = H_UB_TENSOR_OFFSET_PONG + UB_WORK_SLOT_BYTES;
-        constexpr uint32_t OUT_HALF_UB_TENSOR_OFFSET_PING = OUT_UB_TENSOR_OFFSET_PING + FLOAT_UB_TENSOR_SIZE;
+        // Cube2/Cube3 Fixpipe work slots (kernel owns the same constants).
+        constexpr uint32_t UB_V_WORK_PING_OFFSET = 71 * 1024;
+        constexpr uint32_t UB_H_WORK_PING_OFFSET = UB_V_WORK_PING_OFFSET + UB_WORK_SLOT_BYTES;
+        constexpr uint32_t UB_V_WORK_PONG_OFFSET = UB_H_WORK_PING_OFFSET + UB_WORK_SLOT_BYTES;
+        constexpr uint32_t UB_H_WORK_PONG_OFFSET = UB_V_WORK_PONG_OFFSET + UB_WORK_SLOT_BYTES;
 
-        gUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(G_UB_TENSOR_OFFSET_PING);
-        gUbFPTensorPing = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PING);
-        gUbBFTensorPing = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PING);
-        aUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(A_UB_TENSOR_OFFSET_PING);
-        hUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(H_UB_TENSOR_OFFSET_PING);
-        outUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(OUT_UB_TENSOR_OFFSET_PING);
-        outUbFPTensorPing = resource.ubBuf.template GetBufferByByte<HElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PING);
-        outUbBFTensorPing = resource.ubBuf.template GetBufferByByte<HElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PING);
+        // g buffers: single copy (read-only, no ping/pong needed).
+        constexpr uint32_t G_UB_TENSOR_OFFSET = SHARE_UB_TENSOR_OFFSET + FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t G_HALF_UB_TENSOR_OFFSET = G_UB_TENSOR_OFFSET + G_FLOAT_UB_TENSOR_SIZE;
 
-        constexpr uint32_t G_UB_TENSOR_OFFSET_PONG = G_UB_TENSOR_OFFSET_PING;
-        constexpr uint32_t G_HALF_UB_TENSOR_OFFSET_PONG = G_UB_TENSOR_OFFSET_PONG + G_FLOAT_UB_TENSOR_SIZE;
-        constexpr uint32_t OUT_UB_TENSOR_OFFSET_PONG = OUT_UB_TENSOR_OFFSET_PING;
-        constexpr uint32_t OUT_HALF_UB_TENSOR_OFFSET_PONG = OUT_UB_TENSOR_OFFSET_PONG + FLOAT_UB_TENSOR_SIZE;
+        // Vec scratch above the slot region, time-shared with Vec1's a/out tiles
+        // (Vec1 and Vec2 never run concurrently within one AIV subBlock).
+        // out fp32 + out half need REAL ping/pong copies: the MTE3 DataCopy that
+        // drains outUbB* is asynchronous, and the next stage's (or next task's)
+        // VF/Cast would overwrite the same bytes while the copy's tail rows are
+        // still in flight — observed as the last rows of one output segment
+        // carrying the next segment's data. g stays single-copy (its only
+        // consumer is V itself, serialized by the MTE2_V handshakes).
+        constexpr uint32_t OUT_UB_TENSOR_OFFSET = UB_H_WORK_PONG_OFFSET + UB_WORK_SLOT_BYTES;
+        constexpr uint32_t OUT_HALF_UB_TENSOR_OFFSET = OUT_UB_TENSOR_OFFSET + FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t OUT_UB_TENSOR_PONG_OFFSET = OUT_HALF_UB_TENSOR_OFFSET + HALF_UB_TENSOR_SIZE;
+        constexpr uint32_t OUT_HALF_UB_TENSOR_PONG_OFFSET = OUT_UB_TENSOR_PONG_OFFSET + FLOAT_UB_TENSOR_SIZE;
+        static_assert(OUT_HALF_UB_TENSOR_PONG_OFFSET + HALF_UB_TENSOR_SIZE <= 248 * 1024, "UB overflow");
 
-        gUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(G_UB_TENSOR_OFFSET_PONG);
-        gUbFPTensorPong = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PONG);
-        gUbBFTensorPong = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PONG);
-        aUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(A_UB_TENSOR_OFFSET_PONG);
-        hUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(H_UB_TENSOR_OFFSET_PONG);
-        outUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(OUT_UB_TENSOR_OFFSET_PONG);
-        outUbFPTensorPong = resource.ubBuf.template GetBufferByByte<HElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PONG);
-        outUbBFTensorPong = resource.ubBuf.template GetBufferByByte<HElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PONG);
+        gUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(G_UB_TENSOR_OFFSET);
+        gUbFPTensorPing = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET);
+        gUbBFTensorPing = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET);
+        outUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(OUT_UB_TENSOR_OFFSET);
+        outUbFPTensorPing = resource.ubBuf.template GetBufferByByte<HElementOutput>(OUT_HALF_UB_TENSOR_OFFSET);
+        outUbBFTensorPing = resource.ubBuf.template GetBufferByByte<HElementOutput>(OUT_HALF_UB_TENSOR_OFFSET);
+        outUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(OUT_UB_TENSOR_PONG_OFFSET);
+        outUbFPTensorPong = resource.ubBuf.template GetBufferByByte<HElementOutput>(OUT_HALF_UB_TENSOR_PONG_OFFSET);
+        outUbBFTensorPong = resource.ubBuf.template GetBufferByByte<HElementOutput>(OUT_HALF_UB_TENSOR_PONG_OFFSET);
+
+        // g buffers: single copy (read-only into V, no ping/pong needed).
+        gUbTensorPong = gUbTensorPing;
+        gUbFPTensorPong = gUbFPTensorPing;
+        gUbBFTensorPong = gUbBFTensorPing;
+
+        // Work-slot mirrors (only meaningful on the l0c2ub path where the kernel
+        // passes LocalTensor inputs; kept for the GM fallback path's DataCopy form).
+        aUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(UB_V_WORK_PING_OFFSET);
+        aUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(UB_V_WORK_PONG_OFFSET);
+        hUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(UB_H_WORK_PING_OFFSET);
+        hUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(UB_H_WORK_PONG_OFFSET);
     }
     CATLASS_DEVICE
     ~BlockEpilogue()
-    {
-    }
+    {}
 
     CATLASS_DEVICE
-    void CopyOutputToGm(AscendC::GlobalTensor<HElementOutput> output, AscendC::LocalTensor<HElementOutput> outputUb,
-                        uint32_t rows, uint32_t cols, uint32_t outputStride)
+    void CopyOutputToGm(
+        AscendC::GlobalTensor<HElementOutput> output,
+        AscendC::LocalTensor<HElementOutput> outputUb,
+        uint32_t rows,
+        uint32_t cols,
+        uint32_t outputStride)
     {
         if (cols == outputStride) {
             AscendC::DataCopy(output, outputUb, rows * cols);
             return;
         }
         AscendC::DataCopyExtParams outputParams{
-            static_cast<uint16_t>(rows), static_cast<uint32_t>(cols * sizeof(HElementOutput)), 0,
-            static_cast<uint32_t>((outputStride - cols) * sizeof(HElementOutput)), 0};
+            static_cast<uint16_t>(rows),
+            static_cast<uint32_t>(cols * sizeof(HElementOutput)),
+            0,
+            static_cast<uint32_t>((outputStride - cols) * sizeof(HElementOutput)),
+            0};
         AscendC::DataCopyPad(output, outputUb, outputParams);
     }
 
+    /// V256 wide path — always fed by the GM workspace path (nActual > 128 cannot
+    /// fit the 128-column UB slots), so the work inputs are GlobalTensor.
+    template <class WorkInputA, class WorkInputH>
     CATLASS_DEVICE
-    void operator()(AscendC::GlobalTensor<HElementOutput> hOutput, AscendC::GlobalTensor<GElementInput> gInput,
-                    AscendC::LocalTensor<AElementInput> attnInput, AscendC::LocalTensor<HElementInput> hInput,
-                    float scale, uint32_t chunkSize, uint32_t kHeadDim, uint32_t vBlockDim, uint32_t vHeadDim,
-                    uint32_t &pingpongFlag, bool &mte3Pending, uint32_t &mte3PendingEvent, uint32_t batchIdx,
-                    uint32_t headIdx, uint32_t chunkIdx)
+    void ProcessWideOutput(
+        AscendC::GlobalTensor<HElementOutput> hOutput,
+        AscendC::GlobalTensor<GElementInput> gInput,
+        WorkInputA attnInput,
+        WorkInputH hInput,
+        float scale,
+        uint32_t mActual,
+        uint32_t nActual,
+        uint32_t outputStride,
+        uint32_t &pingpongFlag,
+        Arch::CrossCoreFlag* waitFlag = nullptr,
+        Arch::CrossCoreFlag* setFlag = nullptr
+        )
     {
+        static constexpr uint32_t ROW_TILE = 16;
+        uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
+        uint32_t subBlockNum = AscendC::GetSubBlockNum();
+        uint32_t rowsPerSubBlock = CeilDiv(mActual, subBlockNum);
+        uint32_t rowBegin = subBlockIdx * rowsPerSubBlock;
+        uint32_t rowEnd = rowBegin + rowsPerSubBlock;
+        if (rowEnd > mActual) {
+            rowEnd = mActual;
+        }
+        if (rowBegin >= mActual) {
+            if (waitFlag) Arch::CrossCoreWaitFlag(*waitFlag);
+            if (setFlag) Arch::CrossCoreSetFlag<0x2, PIPE_MTE2>(*setFlag);
+            return;
+        }
+
+        AscendC::ResetMask();
+        AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
+        AscendC::DataCopyParams gfloatUbParams{1, static_cast<uint16_t>(mActual * sizeof(float)), 0, 0};
+        AscendC::DataCopyParams gInputUbParams{1, static_cast<uint16_t>(mActual * sizeof(GElementInput)), 0, 0};
+        AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
+
+        AscendC::LocalTensor<float> gUbTensor = (pingpongFlag == 0) ? gUbTensorPing : gUbTensorPong;
+        AscendC::LocalTensor<GElementInput> gUbFPTensor = (pingpongFlag == 0) ? gUbFPTensorPing : gUbFPTensorPong;
+
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0);
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+        if constexpr(std::is_same<GElementInput, float>::value) {
+            AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gfloatUbParams, gUbPadParams);
+        } else {
+            AscendC::DataCopyPad(gUbFPTensor, gInputThisSubBlock, gInputUbParams, gUbPadParams);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+        if constexpr(!std::is_same<GElementInput, float>::value) {
+            AscendC::Cast(gUbTensor, gUbFPTensor, AscendC::RoundMode::CAST_NONE, mActual);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+        AscendC::Copy(gcompUbTensor, gUbTensor, 64, 2, {1, 1, 8, 8});
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Exp(gcompUbTensor, gcompUbTensor, mActual);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        uint32_t rowStart = rowBegin;
+        while (rowStart < rowEnd) {
+            uint32_t alignExtra = rowStart & 7;
+            uint32_t maxRowsThisTile = ROW_TILE - alignExtra;
+            uint32_t rowsThisTile = rowEnd - rowStart;
+            if (rowsThisTile > maxRowsThisTile) {
+                rowsThisTile = maxRowsThisTile;
+            }
+
+            uint32_t gbrcRealStart = rowStart & ~7;
+            uint32_t gbrcRealProcess = alignExtra + rowsThisTile;
+            uint32_t gbrcEffStart = alignExtra;
+            uint32_t dstShape_[2] = {gbrcRealProcess, nActual};
+            uint32_t srcShape_[2] = {gbrcRealProcess, 1};
+
+            AscendC::GlobalTensor<HElementOutput> hOutputThisTile = hOutput[rowStart * outputStride];
+            auto attnInputThisTile = attnInput[rowStart * nActual];
+            auto hInputThisTile = hInput[rowStart * nActual];
+
+            AscendC::LocalTensor<float> aUbTensor = (pingpongFlag == 0) ? aUbTensorPing : aUbTensorPong;
+            AscendC::LocalTensor<float> hUbTensor = (pingpongFlag == 0) ? hUbTensorPing : hUbTensorPong;
+            AscendC::LocalTensor<float> outUbTensor = (pingpongFlag == 0) ? outUbTensorPing : outUbTensorPong;
+            AscendC::LocalTensor<HElementOutput> outUbFPTensor = (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
+            AscendC::LocalTensor<HElementOutput> outUbBFTensor = (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
+
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+            if (waitFlag && rowStart == rowBegin) Arch::CrossCoreWaitFlag(*waitFlag);
+            AscendC::DataCopy(hUbTensor, hInputThisTile, rowsThisTile * nActual);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
+            AscendC::DataCopy(aUbTensor, attnInputThisTile, rowsThisTile * nActual);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+            if (setFlag && rowStart + rowsThisTile >= rowEnd) {
+                Arch::CrossCoreSetFlag<0x2, PIPE_MTE2>(*setFlag);
+            }
+
+            AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gcompUbTensor[gbrcRealStart], dstShape_, srcShape_, shareUbTensor);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+            {
+                auto outAddr = reinterpret_cast<uint64_t>(outUbTensor.GetPhyAddr());
+                auto hAddr = reinterpret_cast<uint64_t>(hUbTensor.GetPhyAddr());
+                auto aAddr = reinterpret_cast<uint64_t>(aUbTensor.GetPhyAddr());
+                auto expAddr = reinterpret_cast<uint64_t>(gbrcLeftcastUbTensor.GetPhyAddr()) + gbrcEffStart * nActual * sizeof(float);
+                OutputFusedVfWide((__ubuf__ float*)outAddr,
+                                  (__ubuf__ float*)hAddr,
+                                  (__ubuf__ float*)aAddr,
+                                  (__ubuf__ float*)expAddr,
+                                  rowsThisTile, nActual, scale);
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0 + pingpongFlag);
+            if(std::is_same<HElementOutput, half>::value)
+            {
+                AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE, rowsThisTile * nActual);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                CopyOutputToGm(hOutputThisTile, outUbFPTensor, rowsThisTile, nActual, outputStride);
+            }
+            else
+            {
+                AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT, rowsThisTile * nActual);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                CopyOutputToGm(hOutputThisTile, outUbBFTensor, rowsThisTile, nActual, outputStride);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0 + pingpongFlag);
+            pingpongFlag = 1 - pingpongFlag;
+            rowStart += rowsThisTile;
+        }
+
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1);
+    }
+
+    /// Entry point, parameterized over the work-input storage class:
+    /// GlobalTensor (GM workspace path, V256 + fallback) or LocalTensor
+    /// (l0c2ub UB-slot path, V128). Reading a slot is only legal after
+    /// waitFlag (cube3Done) fires.
+    template <class WorkInputA, class WorkInputH>
+    CATLASS_DEVICE
+    void operator()(
+        AscendC::GlobalTensor<HElementOutput> hOutput,
+        AscendC::GlobalTensor<GElementInput> gInput,
+        WorkInputA attnInput,
+        WorkInputH hInput,
+        float scale,
+        uint32_t chunkSize,
+        uint32_t kHeadDim,
+        uint32_t vBlockDim,
+        uint32_t vHeadDim,
+        uint32_t &pingpongFlag
+        , uint32_t batchIdx, uint32_t headIdx, uint32_t chunkIdx,
+        Arch::CrossCoreFlag* waitFlag = nullptr,
+        Arch::CrossCoreFlag* setFlag = nullptr
+        )
+    {
+        static_assert(std::is_same_v<WorkInputA, AscendC::GlobalTensor<AElementInput>>
+            || std::is_same_v<WorkInputA, AscendC::LocalTensor<AElementInput>>,
+            "attnInput must be a GlobalTensor (GM path) or LocalTensor (l0c2ub slot)");
         uint32_t mActual = chunkSize;
         uint32_t nActual = vBlockDim;
-        uint32_t outputStride = vHeadDim;
+        if (nActual > 128) {
+            ProcessWideOutput(hOutput, gInput, attnInput, hInput, scale, mActual, nActual, vHeadDim, pingpongFlag, waitFlag, setFlag);
+            return;
+        }
+        ProcessOutput(hOutput, gInput, attnInput, hInput, scale, mActual, nActual, vHeadDim, pingpongFlag, waitFlag, setFlag);
+    }
+
+    /// V128 narrow path, parameterized over the work-input storage class:
+    /// GlobalTensor (GM workspace path) or LocalTensor (l0c2ub UB-slot path).
+    /// Reading the slot is only legal after waitFlag (cube3Done) fires.
+    template <class WorkInputA, class WorkInputH>
+    CATLASS_DEVICE
+    void ProcessOutput(
+        AscendC::GlobalTensor<HElementOutput> hOutput,
+        AscendC::GlobalTensor<GElementInput> gInput,
+        WorkInputA attnInput,
+        WorkInputH hInput,
+        float scale,
+        uint32_t mActual,
+        uint32_t nActual,
+        uint32_t outputStride,
+        uint32_t &pingpongFlag,
+        Arch::CrossCoreFlag* waitFlag = nullptr,
+        Arch::CrossCoreFlag* setFlag = nullptr
+        )
+    {
+        // l0c2ub: with LocalTensor work inputs the slot IS the a/h buffer — no GM->UB
+        // MTE2 copy (Fixpipe wrote the slot directly on the Cube side).
+        constexpr bool kWorkFromUb = std::is_same_v<WorkInputA, AscendC::LocalTensor<AElementInput>>;
         uint32_t alignedM = CeilDiv(nActual, 8) * 8;
         uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
         uint32_t subBlockNum = AscendC::GetSubBlockNum();
@@ -171,14 +499,17 @@ public:
         uint32_t nOffset = 0;
         int64_t offsetA = mOffset * nActual + nOffset;
 
-        uint32_t gbrcStart, gbrcRealStart, gbrcRealEnd, gbrcRealProcess, gbrcEffStart, gbrcEffEnd, mulsRemain,
-            mulsRemainIdx;
-        if (mActualThisSubBlock <= 32) {
-            if (subBlockIdx == 0) {
+        uint32_t gbrcStart, gbrcRealStart, gbrcRealEnd, gbrcRealProcess, gbrcEffStart, gbrcEffEnd, mulsRemain, mulsRemainIdx;
+        if(mActualThisSubBlock <= 32)
+        {
+            if(subBlockIdx == 0)
+            {
                 gbrcStart = 0;
                 gbrcRealStart = 0;
                 gbrcRealProcess = mActualThisSubBlock;
-            } else {
+            }
+            else
+            {
                 gbrcStart = mActualPerSubBlock;
                 gbrcRealStart = gbrcStart & ~7;
                 gbrcRealProcess = mActual - gbrcRealStart;
@@ -188,91 +519,139 @@ public:
             uint32_t srcShape_[2] = {gbrcRealProcess, 1};
 
             AscendC::ResetMask();
+            // l0c2ub slot inputs: Fixpipe SPLIT_M delivers each subBlock's own row
+            // half at ITS OWN UB slot base (subBlock0 rows -> UB[0:], subBlock1 rows
+            // -> UB[0:] of subBlock1's view). So the slot needs NO row offset here;
+            // attnInput/hInput must be taken at offset 0 on the UB path.
+            auto attnInputThisSubBlock = kWorkFromUb ? attnInput[0] : attnInput[gbrcStart * nActual];
+            auto hInputThisSubBlock = kWorkFromUb ? hInput[0] : hInput[gbrcStart * nActual];
             AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
-            AscendC::GlobalTensor<HElementOutput> hOutputThisSubBlock = hOutput[gbrcStart * outputStride];
+            AscendC::GlobalTensor<HElementOutput> hOutputThisSubBlock = hOutput[gbrcStart * nActual];
 
-            AscendC::DataCopyParams gfloatUbParams{1, (uint16_t)(mActual * sizeof(float)), 0, 0};
-            AscendC::DataCopyParams ghalfUbParams{1, (uint16_t)(mActual * sizeof(half)), 0, 0};
+            AscendC::DataCopyParams gfloatUbParams{1, (uint16_t)(mActual*sizeof(float)), 0, 0};
+            AscendC::DataCopyParams ghalfUbParams{1, (uint16_t)(mActual*sizeof(half)), 0, 0};
             AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
 
+            // With slot inputs, the ping/pong pair carries the same stage slot the Cube
+            // side just filled; subBlock rows live at the SPLIT_M half offset.
             AscendC::LocalTensor<float> aUbTensor = (pingpongFlag == 0) ? aUbTensorPing : aUbTensorPong;
             AscendC::LocalTensor<float> hUbTensor = (pingpongFlag == 0) ? hUbTensorPing : hUbTensorPong;
             AscendC::LocalTensor<float> outUbTensor = (pingpongFlag == 0) ? outUbTensorPing : outUbTensorPong;
-            AscendC::LocalTensor<HElementOutput> outUbFPTensor =
-                (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
-            AscendC::LocalTensor<HElementOutput> outUbBFTensor =
-                (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
+            AscendC::LocalTensor<HElementOutput> outUbFPTensor = (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
+            AscendC::LocalTensor<HElementOutput> outUbBFTensor = (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
             AscendC::LocalTensor<float> gUbTensor = (pingpongFlag == 0) ? gUbTensorPing : gUbTensorPong;
             AscendC::LocalTensor<GElementInput> gUbFPTensor = (pingpongFlag == 0) ? gUbFPTensorPing : gUbFPTensorPong;
             AscendC::LocalTensor<GElementInput> gUbBFTensor = (pingpongFlag == 0) ? gUbBFTensorPing : gUbBFTensorPong;
+            if constexpr (kWorkFromUb) {
+                // SPLIT_M wrote subBlock0's rows to slot[0:rows) and subBlock1's rows to
+                // slot[rows:2*rows) of this subBlock's own UB — no offset needed here.
+                aUbTensor = attnInputThisSubBlock;
+                hUbTensor = hInputThisSubBlock;
+            }
 
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
+
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
 
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
-            if constexpr (std::is_same_v<GElementInput, float>) {
+            if constexpr(std::is_same<GElementInput, float>::value) {
                 AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gfloatUbParams, gUbPadParams);
             } else {
                 AscendC::DataCopyPad(gUbFPTensor, gInputThisSubBlock, ghalfUbParams, gUbPadParams);
             }
             AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
             AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
-            if constexpr (!std::is_same_v<GElementInput, float>) {
+            if constexpr(!std::is_same<GElementInput, float>::value) {
                 AscendC::Cast(gUbTensor, gUbFPTensor, AscendC::RoundMode::CAST_NONE, mActual);
                 AscendC::PipeBarrier<PIPE_V>();
             }
-
-            AscendC::Exp(gUbTensor, gUbTensor, mActual);
-            AscendC::PipeBarrier<PIPE_V>();
-            AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gUbTensor[gbrcRealStart], dstShape_, srcShape_,
-                                            shareUbTensor);
+            AscendC::Copy(gcompUbTensor, gUbTensor, 64, 2, {1, 1, 8, 8});
             AscendC::PipeBarrier<PIPE_V>();
 
-            __ubuf__ float *outAddr = (__ubuf__ float *)outUbTensor.GetPhyAddr();
-            __ubuf__ float *attnAddr = (__ubuf__ float *)aUbTensor.GetPhyAddr();
-            __ubuf__ float *hiddenAddr = (__ubuf__ float *)hUbTensor.GetPhyAddr();
-            __ubuf__ float *gateAddr = (__ubuf__ float *)gbrcLeftcastUbTensor[gbrcEffStart * nActual].GetPhyAddr();
-            constexpr uint32_t VF_DUAL_ELEMENTS = 2 * AscendC::VECTOR_REG_WIDTH / sizeof(float);
-            uint32_t totalElements = mActualThisSubBlock * nActual;
-            uint32_t vfElements = totalElements / VF_DUAL_ELEMENTS * VF_DUAL_ELEMENTS;
-            if (vfElements != 0) {
-                AscendC::VF_CALL<GdnFwdoOutputMulAddScaleVf>(outAddr, attnAddr, hiddenAddr, gateAddr, (float)scale,
-                                                             vfElements);
-            }
-            uint32_t tailElements = totalElements - vfElements;
-            if (tailElements != 0) {
-                AscendC::Mul(outUbTensor[vfElements], hUbTensor[vfElements],
-                             gbrcLeftcastUbTensor[gbrcEffStart * nActual + vfElements], tailElements);
-                AscendC::PipeBarrier<PIPE_V>();
-                AscendC::Add(outUbTensor[vfElements], aUbTensor[vfElements], outUbTensor[vfElements], tailElements);
-                AscendC::PipeBarrier<PIPE_V>();
-                AscendC::Muls(outUbTensor[vfElements], outUbTensor[vfElements], (float)scale, tailElements);
-            }
-            AscendC::PipeBarrier<PIPE_V>();
-            if constexpr (std::is_same_v<HElementOutput, half>) {
-                AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nActual);
-                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-                CopyOutputToGm(hOutputThisSubBlock, outUbFPTensor, mActualThisSubBlock, nActual, outputStride);
-                AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0 + pingpongFlag);
-                mte3Pending = true;
-                mte3PendingEvent = EVENT_ID0 + pingpongFlag;
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+            if (waitFlag) Arch::CrossCoreWaitFlag(*waitFlag);
+            if constexpr (!kWorkFromUb) {
+                AscendC::DataCopy(hUbTensor, hInputThisSubBlock, mActualThisSubBlock * nActual);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
             } else {
-                AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
+                // Slot data is already in UB (Fixpipe wrote it); satisfy the tail's
+                // MTE2_V wait without an actual MTE2 transfer.
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+            }
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
+            if constexpr (!kWorkFromUb) {
+                AscendC::DataCopy(aUbTensor, attnInputThisSubBlock, mActualThisSubBlock * nActual);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+                // GM path: release the slot-ownership flag right after the copy is
+                // issued (early release, pre-existing behavior).
+                if (setFlag) Arch::CrossCoreSetFlag<0x2, PIPE_MTE2>(*setFlag);
+            } else {
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+                // l0c2ub path: do NOT release early — the Cube's next-round Fixpipe
+                // writes this very UB slot, racing the VF reads below (UB write vs
+                // vector read has no implicit ordering). Release after consumption.
+            }
+
+            AscendC::Exp(gcompUbTensor, gcompUbTensor, mActual);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gcompUbTensor[gbrcRealStart], dstShape_, srcShape_, shareUbTensor);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+            {
+                auto outAddr = reinterpret_cast<uint64_t>(outUbTensor.GetPhyAddr());
+                auto hAddr = reinterpret_cast<uint64_t>(hUbTensor.GetPhyAddr());
+                auto aAddr = reinterpret_cast<uint64_t>(aUbTensor.GetPhyAddr());
+                auto expAddr = reinterpret_cast<uint64_t>(gbrcLeftcastUbTensor.GetPhyAddr()) + gbrcEffStart * nActual * sizeof(float);
+                OutputFusedVf((__ubuf__ float*)outAddr,
+                               (__ubuf__ float*)hAddr,
+                               (__ubuf__ float*)aAddr,
+                               (__ubuf__ float*)expAddr,
+                               mActualThisSubBlock, nActual, scale);
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+            if constexpr (kWorkFromUb) {
+                // l0c2ub: slot fully consumed — release slot ownership now. The pipe
+                // template decides WHICH pipe must drain before the scheduler is
+                // notified: the slot is consumed by VECTOR reads (OutputFusedVf), so
+                // this must be PIPE_V. The previous PIPE_MTE2 reported completion as
+                // soon as the MTE2 queue drained, letting the AIC's next Fixpipe
+                // overwrite the UB slot while the slower subBlock's VF reads were
+                // still in flight — the intermittent garbage rows seen only under
+                // cross-device parallel load.
+                if (setFlag) Arch::CrossCoreSetFlag<0x2, PIPE_V>(*setFlag);
+            }
+            if(std::is_same<HElementOutput, half>::value)
+            {
+                AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nActual);
+                AscendC::PipeBarrier<PIPE_V>();
                 AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
                 AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-                CopyOutputToGm(hOutputThisSubBlock, outUbBFTensor, mActualThisSubBlock, nActual, outputStride);
-                AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0 + pingpongFlag);
-                mte3Pending = true;
-                mte3PendingEvent = EVENT_ID0 + pingpongFlag;
+                AscendC::DataCopy(hOutputThisSubBlock, outUbFPTensor, mActualThisSubBlock * nActual);
             }
-        } else {
+            else
+            {
+                AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::DataCopy(hOutputThisSubBlock, outUbBFTensor, mActualThisSubBlock * nActual);
+            }
+            pingpongFlag = 1 - pingpongFlag;
+        }
+        else
+        {
             AscendC::ResetMask();
             AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
 
-            AscendC::DataCopyParams gfloatUbParams{1, (uint16_t)(mActual * sizeof(float)), 0, 0};
-            AscendC::DataCopyParams ghalfUbParams{1, (uint16_t)(mActual * sizeof(half)), 0, 0};
+            AscendC::DataCopyParams gfloatUbParams{1, (uint16_t)(mActual*sizeof(float)), 0, 0};
+            AscendC::DataCopyParams ghalfUbParams{1, (uint16_t)(mActual*sizeof(half)), 0, 0};
             AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
 
             AscendC::LocalTensor<float> gUbTensor = (pingpongFlag == 0) ? gUbTensorPing : gUbTensorPong;
@@ -285,109 +664,154 @@ public:
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
 
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
-            if constexpr (std::is_same_v<GElementInput, float>) {
+            if constexpr(std::is_same<GElementInput, float>::value) {
                 AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gfloatUbParams, gUbPadParams);
             } else {
                 AscendC::DataCopyPad(gUbFPTensor, gInputThisSubBlock, ghalfUbParams, gUbPadParams);
             }
             AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
             AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
-            if constexpr (!std::is_same_v<GElementInput, float>) {
+            if constexpr(!std::is_same<GElementInput, float>::value) {
                 AscendC::Cast(gUbTensor, gUbFPTensor, AscendC::RoundMode::CAST_NONE, mActual);
                 AscendC::PipeBarrier<PIPE_V>();
             }
-            AscendC::Exp(gUbTensor, gUbTensor, mActual);
+            AscendC::Copy(gcompUbTensor, gUbTensor, 64, 2, {1, 1, 8, 8});
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Exp(gcompUbTensor, gcompUbTensor, mActual);
             AscendC::PipeBarrier<PIPE_V>();
             uint32_t mActualPerStage = CeilDiv(mActualThisSubBlock, 2);
             uint32_t mActualThisStage = 0;
-            for (uint32_t stage = 0; stage < 2; stage++) {
-                if (stage == 0)
-                    mActualThisStage = mActualPerStage;
-                else
-                    mActualThisStage = mActualThisSubBlock - mActualPerStage;
+            for(uint32_t stage = 0; stage < 2; stage++)
+            {
+                if(stage == 0) mActualThisStage = mActualPerStage;
+                else mActualThisStage = mActualThisSubBlock - mActualPerStage;
 
-                if (subBlockIdx == 0 && stage == 0) {
+                if(subBlockIdx == 0 && stage == 0)
+                {
                     gbrcStart = 0;
                     gbrcRealStart = 0;
                     gbrcRealProcess = mActualThisStage;
-                } else if (subBlockIdx == 0 && stage == 1) {
+                }
+                else if(subBlockIdx == 0 && stage == 1)
+                {
                     gbrcStart = mActualPerStage;
                     gbrcRealStart = gbrcStart & ~7;
                     gbrcRealProcess = mActualThisSubBlock - gbrcRealStart;
-                } else if (subBlockIdx == 1 && stage == 0) {
+                }
+                else if(subBlockIdx == 1 && stage == 0)
+                {
                     gbrcStart = mActualPerSubBlock;
                     gbrcRealStart = gbrcStart & ~7;
                     gbrcRealProcess = mActualPerSubBlock + mActualThisStage - gbrcRealStart;
-                } else if (subBlockIdx == 1 && stage == 1) {
+                }
+                else if(subBlockIdx == 1 && stage == 1)
+                {
                     gbrcStart = mActualPerSubBlock + mActualPerStage;
                     gbrcRealStart = gbrcStart & ~7;
                     gbrcRealProcess = mActual - gbrcRealStart;
                 }
                 gbrcEffStart = gbrcStart - gbrcRealStart;
-                uint32_t ubStageOffset = stage * mActualPerStage * nActual;
                 uint32_t dstShape_[2] = {gbrcRealProcess, nActual};
                 uint32_t srcShape_[2] = {gbrcRealProcess, 1};
 
-                AscendC::GlobalTensor<HElementOutput> hOutputThisSubBlock = hOutput[gbrcStart * outputStride];
+                AscendC::GlobalTensor<HElementOutput> hOutputThisSubBlock = hOutput[gbrcStart * nActual];
+                // l0c2ub: SPLIT_M already delivered this subBlock's row half at its own
+                // UB slot base — take the slot at offset 0; the stage loop below walks
+                // within the half via ubStageOffset.
+                auto attnInputThisSubBlock = kWorkFromUb ? attnInput[0] : attnInput[gbrcStart * nActual];
+                auto hInputThisSubBlock = kWorkFromUb ? hInput[0] : hInput[gbrcStart * nActual];
+
                 AscendC::LocalTensor<float> aUbTensor = (pingpongFlag == 0) ? aUbTensorPing : aUbTensorPong;
                 AscendC::LocalTensor<float> hUbTensor = (pingpongFlag == 0) ? hUbTensorPing : hUbTensorPong;
                 AscendC::LocalTensor<float> outUbTensor = (pingpongFlag == 0) ? outUbTensorPing : outUbTensorPong;
-                AscendC::LocalTensor<HElementOutput> outUbFPTensor =
-                    (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
-                AscendC::LocalTensor<HElementOutput> outUbBFTensor =
-                    (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
-
-                AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gUbTensor[gbrcRealStart], dstShape_, srcShape_,
-                                                shareUbTensor);
-                AscendC::PipeBarrier<PIPE_V>();
-
-                __ubuf__ float *outAddr = (__ubuf__ float *)outUbTensor.GetPhyAddr();
-                __ubuf__ float *attnAddr = (__ubuf__ float *)aUbTensor[ubStageOffset].GetPhyAddr();
-                __ubuf__ float *hiddenAddr = (__ubuf__ float *)hUbTensor[ubStageOffset].GetPhyAddr();
-                __ubuf__ float *gateAddr = (__ubuf__ float *)gbrcLeftcastUbTensor[gbrcEffStart * nActual].GetPhyAddr();
-                constexpr uint32_t VF_DUAL_ELEMENTS = 2 * AscendC::VECTOR_REG_WIDTH / sizeof(float);
-                uint32_t totalElements = mActualThisStage * nActual;
-                uint32_t vfElements = totalElements / VF_DUAL_ELEMENTS * VF_DUAL_ELEMENTS;
-                if (vfElements != 0) {
-                    AscendC::VF_CALL<GdnFwdoOutputMulAddScaleVf>(outAddr, attnAddr, hiddenAddr, gateAddr, (float)scale,
-                                                                 vfElements);
-                }
-                uint32_t tailElements = totalElements - vfElements;
-                if (tailElements != 0) {
-                    AscendC::Mul(outUbTensor[vfElements], hUbTensor[ubStageOffset + vfElements],
-                                 gbrcLeftcastUbTensor[gbrcEffStart * nActual + vfElements], tailElements);
-                    AscendC::PipeBarrier<PIPE_V>();
-                    AscendC::Add(outUbTensor[vfElements], aUbTensor[ubStageOffset + vfElements],
-                                 outUbTensor[vfElements], tailElements);
-                    AscendC::PipeBarrier<PIPE_V>();
-                    AscendC::Muls(outUbTensor[vfElements], outUbTensor[vfElements], (float)scale, tailElements);
-                }
-                AscendC::PipeBarrier<PIPE_V>();
-
-                if (mte3Pending) {
-                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(mte3PendingEvent);
-                    mte3Pending = false;
+                AscendC::LocalTensor<HElementOutput> outUbFPTensor = (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
+                AscendC::LocalTensor<HElementOutput> outUbBFTensor = (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
+                if constexpr (kWorkFromUb) {
+                    // Slot holds this subBlock's SPLIT_M half at [0, mActualThisSubBlock);
+                    // stage 0 reads rows [0, mActualPerStage), stage 1 the rest.
+                    uint32_t ubRowOffset = stage * mActualPerStage * nActual;
+                    aUbTensor = attnInputThisSubBlock[ubRowOffset];
+                    hUbTensor = hInputThisSubBlock[ubRowOffset];
                 }
 
-                if constexpr (std::is_same<HElementOutput, half>::value) {
-                    AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE,
-                                  mActualThisStage * nActual);
-                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-                    CopyOutputToGm(hOutputThisSubBlock, outUbFPTensor, mActualThisStage, nActual, outputStride);
-                    AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0 + pingpongFlag);
-                    mte3Pending = true;
-                    mte3PendingEvent = EVENT_ID0 + pingpongFlag;
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
+
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+                if (waitFlag && stage == 0) Arch::CrossCoreWaitFlag(*waitFlag);
+                if constexpr (!kWorkFromUb) {
+                    AscendC::DataCopy(hUbTensor, hInputThisSubBlock, mActualThisStage * nActual);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
                 } else {
-                    AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT,
-                                  mActualThisStage * nActual);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+                }
+
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
+                if constexpr (!kWorkFromUb) {
+                    AscendC::DataCopy(aUbTensor, attnInputThisSubBlock, mActualThisStage * nActual);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+                    // GM path: keep the pre-existing early release.
+                    if (setFlag && stage == 1) {
+                        Arch::CrossCoreSetFlag<0x2, PIPE_MTE2>(*setFlag);
+                    }
+                } else {
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+                    // l0c2ub: release after the final stage's VF consumption instead
+                    // (Cube's next-round Fixpipe would race the slot reads).
+                }
+
+                AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gcompUbTensor[gbrcRealStart], dstShape_, srcShape_, shareUbTensor);
+                AscendC::PipeBarrier<PIPE_V>();
+
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+                if (stage == 1) {
+                    // Stage 1 overwrites outUb* while stage 0's MTE3 DataCopy may still
+                    // be draining its tail rows — wait for stage 0's copy to complete
+                    // (signalled right after its DataCopy below).
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID2);
+                }
+                {
+                    auto outAddr = reinterpret_cast<uint64_t>(outUbTensor.GetPhyAddr());
+                    auto hAddr = reinterpret_cast<uint64_t>(hUbTensor.GetPhyAddr());
+                    auto aAddr = reinterpret_cast<uint64_t>(aUbTensor.GetPhyAddr());
+                    auto expAddr = reinterpret_cast<uint64_t>(gbrcLeftcastUbTensor.GetPhyAddr()) + gbrcEffStart * nActual * sizeof(float);
+                    OutputFusedVf((__ubuf__ float*)outAddr,
+                                   (__ubuf__ float*)hAddr,
+                                   (__ubuf__ float*)aAddr,
+                                   (__ubuf__ float*)expAddr,
+                                   mActualThisStage, nActual, scale);
+                    AscendC::PipeBarrier<PIPE_V>();
+                }
+                if constexpr (kWorkFromUb) {
+                    // l0c2ub: slot fully consumed at the end of the last stage.
+                    if (setFlag && stage == 1) {
+                        Arch::CrossCoreSetFlag<0x2, PIPE_MTE2>(*setFlag);
+                    }
+                }
+
+                if(std::is_same<HElementOutput, half>::value)
+                {
+                    AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisStage * nActual);
+                    AscendC::PipeBarrier<PIPE_V>();
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
                     AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-                    CopyOutputToGm(hOutputThisSubBlock, outUbBFTensor, mActualThisStage, nActual, outputStride);
-                    AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0 + pingpongFlag);
-                    mte3Pending = true;
-                    mte3PendingEvent = EVENT_ID0 + pingpongFlag;
+                    AscendC::DataCopy(hOutputThisSubBlock, outUbFPTensor, mActualThisStage * nActual);
                 }
+                else
+                {
+                    AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisStage * nActual);
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    AscendC::DataCopy(hOutputThisSubBlock, outUbBFTensor, mActualThisStage * nActual);
+                }
+                if (stage == 0) {
+                    // MTE3-V reverse sync: let stage 0's DataCopy finish before stage 1's
+                    // VF overwrites the (formerly shared) outUb* scratch rows.
+                    AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID2);
+                }
+                pingpongFlag = 1 - pingpongFlag;
             }
         }
     }
@@ -396,6 +820,7 @@ private:
     AscendC::LocalTensor<float> maskUbTensor;
     AscendC::LocalTensor<float> gbrcLeftcastUbTensor;
     AscendC::LocalTensor<float> gbrcUpUbTensor;
+    AscendC::LocalTensor<float> gcompUbTensor;
     AscendC::LocalTensor<uint8_t> shareUbTensor;
 
     AscendC::LocalTensor<float> gUbTensorPing;
@@ -415,7 +840,9 @@ private:
     AscendC::LocalTensor<float> outUbTensorPong;
     AscendC::LocalTensor<HElementOutput> outUbFPTensorPong;
     AscendC::LocalTensor<HElementOutput> outUbBFTensorPong;
+
+
 };
-} // namespace Catlass::Epilogue::Block
+}
 
 #endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdo_output.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdo_output.hpp
@@ -25,11 +25,13 @@
 
 // RegBase VF 函数：Mul(H, exp(g)) → Add(attn) → Muls(scale) 全融合，逐行寄存器处理
 // nActual=128 时分两段各 64 列处理，与 qkmask 的 VF 结构对齐
+// exp(g) 不物化到 UB：每行一条 DIST_BRC_B32 标量广播加载（地址仅需 4 字节对齐），
+// 两个列段共用同一广播寄存器（替代原 Broadcast 物化 + 逐行 DIST_NORM 读回）
 __simd_vf__ inline void OutputFusedVf(
     __ubuf__ float* __restrict__ outAddr,       // outUbTensor 起始地址（输出）
     __ubuf__ float* __restrict__ hAddr,          // hUbTensor 起始地址（H 数据）
     __ubuf__ float* __restrict__ aAddr,          // aUbTensor 起始地址（attn 数据）
-    __ubuf__ float* __restrict__ brcExpAddr,     // gbrcLeftcastUbTensor[gbrcEffStart*nActual] 地址
+    __ubuf__ float* __restrict__ gExpScalarAddr, // exp(g) 标量数组地址（每行一个 fp32）
     uint32_t mActualThisStage,                   // 本 stage 行数
     uint32_t nActual,                            // 列数（128）
     float scale)
@@ -40,28 +42,27 @@ __simd_vf__ inline void OutputFusedVf(
     // 使用两组寄存器，同类型指令连续执行，利用 RegBase 指令流水优化
     RegTensor<float> vregH1, vregH2;
     RegTensor<float> vregA1, vregA2;
-    RegTensor<float> vregExp1, vregExp2;
+    RegTensor<float> vregExp;
     RegTensor<float> vregOut1, vregOut2;
     MaskReg maskFull = CreateMask<float, MaskPattern::ALL>();
 
-    for (uint32_t row = 0; row < mActualThisStage; ++row) {
+    // Hardware Loop 规范：uint16_t 零基归纳变量 + 边界外提（mActualThisStage ≤ 64）
+    const uint16_t rowCnt = static_cast<uint16_t>(mActualThisStage);
+    for (uint16_t row = 0; row < rowCnt; ++row) {
         __ubuf__ float* rowH = hAddr + row * nActual;
         __ubuf__ float* rowA = aAddr + row * nActual;
         __ubuf__ float* rowOut = outAddr + row * nActual;
 
-        // 连续 Load
-        // 注意：brcExpAddr 是 gbrcLeftcastUbTensor 的行广播结果，每行 exp(g) 不同，需按行偏移
-        __ubuf__ float* rowExp = brcExpAddr + row * nActual;
+        // 连续 Load；exp(g) 逐行标量广播（BRC_B32），两段共用同一寄存器
+        LoadAlign<float, LoadDist::DIST_BRC_B32>(vregExp, gExpScalarAddr + row);
         LoadAlign<float, LoadDist::DIST_NORM>(vregH1, rowH);
         LoadAlign<float, LoadDist::DIST_NORM>(vregH2, rowH + VL);
         LoadAlign<float, LoadDist::DIST_NORM>(vregA1, rowA);
         LoadAlign<float, LoadDist::DIST_NORM>(vregA2, rowA + VL);
-        LoadAlign<float, LoadDist::DIST_NORM>(vregExp1, rowExp);
-        LoadAlign<float, LoadDist::DIST_NORM>(vregExp2, rowExp + VL);
 
         // 连续 Mul: H * exp(g)
-        Mul(vregOut1, vregH1, vregExp1, maskFull);
-        Mul(vregOut2, vregH2, vregExp2, maskFull);
+        Mul(vregOut1, vregH1, vregExp, maskFull);
+        Mul(vregOut2, vregH2, vregExp, maskFull);
 
         // 连续 Add: + attn
         Add(vregOut1, vregOut1, vregA1, maskFull);
@@ -79,6 +80,8 @@ __simd_vf__ inline void OutputFusedVf(
 
 // RegBase VF 函数（Wide 版本）：Mul(H, exp(g)) → Add(attn) → Muls(scale) 全融合
 // nActual=256 时分四段各 64 列处理，使用四组寄存器最大化指令流水
+// V256(Wide/GM) 路径保留 Broadcast 物化：其发出位置与 h/a 的 GM→UB MTE2 传输
+// 重叠（免费），VF 直接读物化结果；V128 路径见 OutputFusedVf 的 BRC_B32 说明
 __simd_vf__ inline void OutputFusedVfWide(
     __ubuf__ float* __restrict__ outAddr,       // outUbTensor 起始地址（输出）
     __ubuf__ float* __restrict__ hAddr,          // hUbTensor 起始地址（H 数据）
@@ -98,7 +101,9 @@ __simd_vf__ inline void OutputFusedVfWide(
     RegTensor<float> vregOut1, vregOut2, vregOut3, vregOut4;
     MaskReg maskFull = CreateMask<float, MaskPattern::ALL>();
 
-    for (uint32_t row = 0; row < mActualThisStage; ++row) {
+    // Hardware Loop 规范：uint16_t 零基归纳变量 + 边界外提（mActualThisStage ≤ 16）
+    const uint16_t rowCnt = static_cast<uint16_t>(mActualThisStage);
+    for (uint16_t row = 0; row < rowCnt; ++row) {
         __ubuf__ float* rowH = hAddr + row * nActual;
         __ubuf__ float* rowA = aAddr + row * nActual;
         __ubuf__ float* rowOut = outAddr + row * nActual;
@@ -213,8 +218,9 @@ public:
         maskUbTensor = resource.ubBuf.template GetBufferByByte<float>(MASK_UB_TENSOR_OFFSET);
         gbrcLeftcastUbTensor = resource.ubBuf.template GetBufferByByte<float>(GBRCLEFTCAST_UB_TENSOR_OFFSET);
         gbrcUpUbTensor = resource.ubBuf.template GetBufferByByte<float>(GBRCUP_UB_TENSOR_OFFSET);
-        gcompUbTensor = resource.ubBuf.template GetBufferByByte<float>(GCOMP_UB_TENSOR_OFFSET);
         shareUbTensor = resource.ubBuf.template GetBufferByByte<uint8_t>(SHARE_UB_TENSOR_OFFSET);
+        // gcomp 区域仍由 qkmask epilogue 持有（同物理 UB、同偏移）；本 epilogue 的
+        // V128 路径经 BRC_B32 直读 g buffer，V256(Wide) 路径经 gbrcLeftcast 物化。
 
         // Cube2/Cube3 Fixpipe work slots (kernel owns the same constants).
         constexpr uint32_t UB_V_WORK_PING_OFFSET = 71 * 1024;
@@ -344,9 +350,7 @@ public:
             AscendC::Cast(gUbTensor, gUbFPTensor, AscendC::RoundMode::CAST_NONE, mActual);
             AscendC::PipeBarrier<PIPE_V>();
         }
-        AscendC::Copy(gcompUbTensor, gUbTensor, 64, 2, {1, 1, 8, 8});
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Exp(gcompUbTensor, gcompUbTensor, mActual);
+        AscendC::Exp(gUbTensor, gUbTensor, mActual);
         AscendC::PipeBarrier<PIPE_V>();
 
         uint32_t rowStart = rowBegin;
@@ -358,6 +362,8 @@ public:
                 rowsThisTile = maxRowsThisTile;
             }
 
+            // Broadcast 物化 exp(g)：其发出位置在 h/a 的 MTE2 传输期间（免费），
+            // V256(Wide/GM) 路径保留此结构（V128 路径已改为 VF 内 BRC_B32）
             uint32_t gbrcRealStart = rowStart & ~7;
             uint32_t gbrcRealProcess = alignExtra + rowsThisTile;
             uint32_t gbrcEffStart = alignExtra;
@@ -389,7 +395,7 @@ public:
                 Arch::CrossCoreSetFlag<0x2, PIPE_MTE2>(*setFlag);
             }
 
-            AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gcompUbTensor[gbrcRealStart], dstShape_, srcShape_, shareUbTensor);
+            AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gUbTensor[gbrcRealStart], dstShape_, srcShape_, shareUbTensor);
             AscendC::PipeBarrier<PIPE_V>();
 
             AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
@@ -455,9 +461,6 @@ public:
         Arch::CrossCoreFlag* setFlag = nullptr
         )
     {
-        static_assert(std::is_same_v<WorkInputA, AscendC::GlobalTensor<AElementInput>>
-            || std::is_same_v<WorkInputA, AscendC::LocalTensor<AElementInput>>,
-            "attnInput must be a GlobalTensor (GM path) or LocalTensor (l0c2ub slot)");
         uint32_t mActual = chunkSize;
         uint32_t nActual = vBlockDim;
         if (nActual > 128) {
@@ -499,24 +502,17 @@ public:
         uint32_t nOffset = 0;
         int64_t offsetA = mOffset * nActual + nOffset;
 
-        uint32_t gbrcStart, gbrcRealStart, gbrcRealEnd, gbrcRealProcess, gbrcEffStart, gbrcEffEnd, mulsRemain, mulsRemainIdx;
+        uint32_t gbrcStart;
         if(mActualThisSubBlock <= 32)
         {
             if(subBlockIdx == 0)
             {
                 gbrcStart = 0;
-                gbrcRealStart = 0;
-                gbrcRealProcess = mActualThisSubBlock;
             }
             else
             {
                 gbrcStart = mActualPerSubBlock;
-                gbrcRealStart = gbrcStart & ~7;
-                gbrcRealProcess = mActual - gbrcRealStart;
             }
-            gbrcEffStart = gbrcStart - gbrcRealStart;
-            uint32_t dstShape_[2] = {gbrcRealProcess, nActual};
-            uint32_t srcShape_[2] = {gbrcRealProcess, 1};
 
             AscendC::ResetMask();
             // l0c2ub slot inputs: Fixpipe SPLIT_M delivers each subBlock's own row
@@ -568,9 +564,6 @@ public:
                 AscendC::Cast(gUbTensor, gUbFPTensor, AscendC::RoundMode::CAST_NONE, mActual);
                 AscendC::PipeBarrier<PIPE_V>();
             }
-            AscendC::Copy(gcompUbTensor, gUbTensor, 64, 2, {1, 1, 8, 8});
-            AscendC::PipeBarrier<PIPE_V>();
-
 
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
             if (waitFlag) Arch::CrossCoreWaitFlag(*waitFlag);
@@ -597,9 +590,7 @@ public:
                 // vector read has no implicit ordering). Release after consumption.
             }
 
-            AscendC::Exp(gcompUbTensor, gcompUbTensor, mActual);
-            AscendC::PipeBarrier<PIPE_V>();
-            AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gcompUbTensor[gbrcRealStart], dstShape_, srcShape_, shareUbTensor);
+            AscendC::Exp(gUbTensor, gUbTensor, mActual);
             AscendC::PipeBarrier<PIPE_V>();
 
             AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
@@ -608,23 +599,20 @@ public:
                 auto outAddr = reinterpret_cast<uint64_t>(outUbTensor.GetPhyAddr());
                 auto hAddr = reinterpret_cast<uint64_t>(hUbTensor.GetPhyAddr());
                 auto aAddr = reinterpret_cast<uint64_t>(aUbTensor.GetPhyAddr());
-                auto expAddr = reinterpret_cast<uint64_t>(gbrcLeftcastUbTensor.GetPhyAddr()) + gbrcEffStart * nActual * sizeof(float);
+                auto gExpAddr = reinterpret_cast<uint64_t>(gUbTensor.GetPhyAddr()) + gbrcStart * sizeof(float);
                 OutputFusedVf((__ubuf__ float*)outAddr,
                                (__ubuf__ float*)hAddr,
                                (__ubuf__ float*)aAddr,
-                               (__ubuf__ float*)expAddr,
+                               (__ubuf__ float*)gExpAddr,
                                mActualThisSubBlock, nActual, scale);
                 AscendC::PipeBarrier<PIPE_V>();
             }
             if constexpr (kWorkFromUb) {
-                // l0c2ub: slot fully consumed — release slot ownership now. The pipe
-                // template decides WHICH pipe must drain before the scheduler is
-                // notified: the slot is consumed by VECTOR reads (OutputFusedVf), so
-                // this must be PIPE_V. The previous PIPE_MTE2 reported completion as
-                // soon as the MTE2 queue drained, letting the AIC's next Fixpipe
-                // overwrite the UB slot while the slower subBlock's VF reads were
-                // still in flight — the intermittent garbage rows seen only under
-                // cross-device parallel load.
+                // l0c2ub: slot fully consumed — release slot ownership now. The slot
+                // is consumed by VECTOR reads (OutputFusedVf), so gate the notify on
+                // PIPE_V (a PipeBarrier<PIPE_V> precedes this point either way, making
+                // the pipe choice functionally equivalent — see
+                // docs/agents/chunk_fwd_o_intermittent_accuracy_fix.md §4.2).
                 if (setFlag) Arch::CrossCoreSetFlag<0x2, PIPE_V>(*setFlag);
             }
             if(std::is_same<HElementOutput, half>::value)
@@ -675,9 +663,7 @@ public:
                 AscendC::Cast(gUbTensor, gUbFPTensor, AscendC::RoundMode::CAST_NONE, mActual);
                 AscendC::PipeBarrier<PIPE_V>();
             }
-            AscendC::Copy(gcompUbTensor, gUbTensor, 64, 2, {1, 1, 8, 8});
-            AscendC::PipeBarrier<PIPE_V>();
-            AscendC::Exp(gcompUbTensor, gcompUbTensor, mActual);
+            AscendC::Exp(gUbTensor, gUbTensor, mActual);
             AscendC::PipeBarrier<PIPE_V>();
             uint32_t mActualPerStage = CeilDiv(mActualThisSubBlock, 2);
             uint32_t mActualThisStage = 0;
@@ -689,30 +675,19 @@ public:
                 if(subBlockIdx == 0 && stage == 0)
                 {
                     gbrcStart = 0;
-                    gbrcRealStart = 0;
-                    gbrcRealProcess = mActualThisStage;
                 }
                 else if(subBlockIdx == 0 && stage == 1)
                 {
                     gbrcStart = mActualPerStage;
-                    gbrcRealStart = gbrcStart & ~7;
-                    gbrcRealProcess = mActualThisSubBlock - gbrcRealStart;
                 }
                 else if(subBlockIdx == 1 && stage == 0)
                 {
                     gbrcStart = mActualPerSubBlock;
-                    gbrcRealStart = gbrcStart & ~7;
-                    gbrcRealProcess = mActualPerSubBlock + mActualThisStage - gbrcRealStart;
                 }
                 else if(subBlockIdx == 1 && stage == 1)
                 {
                     gbrcStart = mActualPerSubBlock + mActualPerStage;
-                    gbrcRealStart = gbrcStart & ~7;
-                    gbrcRealProcess = mActual - gbrcRealStart;
                 }
-                gbrcEffStart = gbrcStart - gbrcRealStart;
-                uint32_t dstShape_[2] = {gbrcRealProcess, nActual};
-                uint32_t srcShape_[2] = {gbrcRealProcess, 1};
 
                 AscendC::GlobalTensor<HElementOutput> hOutputThisSubBlock = hOutput[gbrcStart * nActual];
                 // l0c2ub: SPLIT_M already delivered this subBlock's row half at its own
@@ -760,9 +735,6 @@ public:
                     // (Cube's next-round Fixpipe would race the slot reads).
                 }
 
-                AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gcompUbTensor[gbrcRealStart], dstShape_, srcShape_, shareUbTensor);
-                AscendC::PipeBarrier<PIPE_V>();
-
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
                 if (stage == 1) {
@@ -775,18 +747,19 @@ public:
                     auto outAddr = reinterpret_cast<uint64_t>(outUbTensor.GetPhyAddr());
                     auto hAddr = reinterpret_cast<uint64_t>(hUbTensor.GetPhyAddr());
                     auto aAddr = reinterpret_cast<uint64_t>(aUbTensor.GetPhyAddr());
-                    auto expAddr = reinterpret_cast<uint64_t>(gbrcLeftcastUbTensor.GetPhyAddr()) + gbrcEffStart * nActual * sizeof(float);
+                    auto gExpAddr = reinterpret_cast<uint64_t>(gUbTensor.GetPhyAddr()) + gbrcStart * sizeof(float);
                     OutputFusedVf((__ubuf__ float*)outAddr,
                                    (__ubuf__ float*)hAddr,
                                    (__ubuf__ float*)aAddr,
-                                   (__ubuf__ float*)expAddr,
+                                   (__ubuf__ float*)gExpAddr,
                                    mActualThisStage, nActual, scale);
                     AscendC::PipeBarrier<PIPE_V>();
                 }
                 if constexpr (kWorkFromUb) {
-                    // l0c2ub: slot fully consumed at the end of the last stage.
+                    // l0c2ub: slot fully consumed at the end of the last stage; gate
+                    // on PIPE_V like the <=32 branch (Vector reads consume the slot).
                     if (setFlag && stage == 1) {
-                        Arch::CrossCoreSetFlag<0x2, PIPE_MTE2>(*setFlag);
+                        Arch::CrossCoreSetFlag<0x2, PIPE_V>(*setFlag);
                     }
                 }
 
@@ -820,7 +793,6 @@ private:
     AscendC::LocalTensor<float> maskUbTensor;
     AscendC::LocalTensor<float> gbrcLeftcastUbTensor;
     AscendC::LocalTensor<float> gbrcUpUbTensor;
-    AscendC::LocalTensor<float> gcompUbTensor;
     AscendC::LocalTensor<uint8_t> shareUbTensor;
 
     AscendC::LocalTensor<float> gUbTensorPing;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdo_qkmask.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdo_qkmask.hpp
@@ -53,13 +53,25 @@ __simd_vf__ inline void QkmaskCausalMaskVf(
 
     uint32_t gbrcEnd = gbrcStart + mActualThisStage;
 
+    // Hardware Loop 规范（asc-devkit vf_loop_optimization）：边界/基址外提，三元与
+    // clamp 只出现在循环外；归纳变量 uint16_t、零基、步长 1。段 2 的 up 行基址
+    // upBase2 = upAddr + (seg2Start - gbrcStart) * alignedNActual 恒非负——原实现
+    // 以 absRow(从 64 起) - gbrcStart 计行号，gbrcStart > 64 时（chunk128 的
+    // subBlock1/stage1）前段迭代无符号下溢，靠地址回绕落在死缓冲才未出错。
+    uint32_t seg1End = gbrcEnd > VL ? VL : gbrcEnd;
+    uint32_t loop1Cnt = seg1End > gbrcStart ? seg1End - gbrcStart : 0;
+    uint32_t seg2Start = gbrcStart > VL ? gbrcStart : VL;
+    uint32_t loop2Cnt = gbrcEnd > seg2Start ? gbrcEnd - seg2Start : 0;
+    __ubuf__ float* maskBase1 = maskBase + gbrcStart * VL;
+    __ubuf__ float* maskBase2 = maskBase + (seg2Start - VL) * VL;
+    __ubuf__ float* upBase2 = upAddr + (seg2Start - gbrcStart) * alignedNActual;
+
     // 第一个循环：absRow < 64，对角线在第一个 64 列 tile 内
     //   列 [0, 64):   Mins(0)→Exp→Mul(maskUbTensor[absRow]) 因果掩码
     //   列 [64, 128): 置零（远未来区域）
-    for (uint32_t absRow = gbrcStart; absRow < (gbrcEnd > 64 ? 64 : gbrcEnd); ++absRow) {
-        uint32_t row = absRow - gbrcStart;
+    for (uint16_t row = 0; row < static_cast<uint16_t>(loop1Cnt); ++row) {
         __ubuf__ float* rowAddr = upAddr + row * alignedNActual;
-        __ubuf__ float* maskRowAddr = maskBase + absRow * VL;
+        __ubuf__ float* maskRowAddr = maskBase1 + row * VL;
 
         LoadAlign<float, LoadDist::DIST_NORM>(vregUp, rowAddr);
         LoadAlign<float, LoadDist::DIST_NORM>(vregMask, maskRowAddr);
@@ -73,10 +85,9 @@ __simd_vf__ inline void QkmaskCausalMaskVf(
     // 第二个循环：absRow >= 64，对角线在第二个 64 列 tile 内
     //   列 [0, 64):   Mins(0)→Exp 保留（全部 j < 64 <= absRow，无需 mask）
     //   列 [64, 128): Mins(0)→Exp→Mul(maskUbTensor[absRow-64]) 因果掩码
-    for (uint32_t absRow = 64; absRow < gbrcEnd; ++absRow) {
-        uint32_t row = absRow - gbrcStart;
-        __ubuf__ float* rowAddr = upAddr + row * alignedNActual;
-        __ubuf__ float* maskRowAddr = maskBase + (absRow - 64) * VL;
+    for (uint16_t row = 0; row < static_cast<uint16_t>(loop2Cnt); ++row) {
+        __ubuf__ float* rowAddr = upBase2 + row * alignedNActual;
+        __ubuf__ float* maskRowAddr = maskBase2 + row * VL;
 
         LoadAlign<float, LoadDist::DIST_NORM>(vregUp, rowAddr);
         Mins(vregUp, vregUp, 0.0f, maskFull);
@@ -127,13 +138,22 @@ __simd_vf__ inline void QkmaskCausalMaskVfTail(
     MaskReg maskTail1 = UpdateMask<float>(tailWidth1);
     MaskReg maskTail2 = UpdateMask<float>(tailWidth2);
 
+    // 同满块版：边界/基址外提 + 零基 uint16_t 归纳变量（Hardware Loop 规范）
+    uint32_t seg1End = gbrcEnd > VL ? VL : gbrcEnd;
+    uint32_t loop1Cnt = seg1End > gbrcStart ? seg1End - gbrcStart : 0;
+    uint32_t seg2Start = gbrcStart > VL ? gbrcStart : VL;
+    uint32_t loop2Cnt = gbrcEnd > seg2Start ? gbrcEnd - seg2Start : 0;
+    __ubuf__ float* maskBase1 = maskBase + gbrcStart * VL;
+    __ubuf__ float* maskBase2 = maskBase + (seg2Start - VL) * VL;
+    __ubuf__ float* upBase2 = upAddr + (seg2Start - gbrcStart) * alignedNActual;
+    (void)tailWidth;
+
     // 第一个循环：absRow < 64，对角线在第一个 64 列 tile 内
     //   列 [0, 64):      Mins(0)→Exp→Mul(mask[absRow])
     //   列 [64, N):       置零（tailWidth 个）
-    for (uint32_t absRow = gbrcStart; absRow < (gbrcEnd > 64 ? 64 : gbrcEnd); ++absRow) {
-        uint32_t row = absRow - gbrcStart;
+    for (uint16_t row = 0; row < static_cast<uint16_t>(loop1Cnt); ++row) {
         __ubuf__ float* rowAddr = upAddr + row * alignedNActual;
-        __ubuf__ float* maskRowAddr = maskBase + absRow * VL;
+        __ubuf__ float* maskRowAddr = maskBase1 + row * VL;
 
         LoadAlign<float, LoadDist::DIST_NORM>(vregUp, rowAddr);
         LoadAlign<float, LoadDist::DIST_NORM>(vregMask, maskRowAddr);
@@ -146,10 +166,9 @@ __simd_vf__ inline void QkmaskCausalMaskVfTail(
     // 第二个循环：absRow >= 64，对角线在第二个 64 列 tile 内
     //   列 [0, 64):      Mins(0)→Exp 保留
     //   列 [64, N):       Mins(0)→Exp→Mul(mask[absRow-64])（tailWidth 个）
-    for (uint32_t absRow = 64; absRow < gbrcEnd; ++absRow) {
-        uint32_t row = absRow - gbrcStart;
-        __ubuf__ float* rowAddr = upAddr + row * alignedNActual;
-        __ubuf__ float* maskRowAddr = maskBase + (absRow - 64) * VL;
+    for (uint16_t row = 0; row < static_cast<uint16_t>(loop2Cnt); ++row) {
+        __ubuf__ float* rowAddr = upBase2 + row * alignedNActual;
+        __ubuf__ float* maskRowAddr = maskBase2 + row * VL;
 
         LoadAlign<float, LoadDist::DIST_NORM>(vregUp, rowAddr);
         Mins(vregUp, vregUp, 0.0f, maskTail1);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdo_qkmask.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/epilogue/block/block_epilogue_gdn_fwdo_qkmask.hpp
@@ -10,7 +10,6 @@
 #ifndef CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDO_QKMASK_HPP
 #define CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDO_QKMASK_HPP
 
-#include "kernel_operator.h"
 #include "catlass/catlass.hpp"
 #include "catlass/arch/resource.hpp"
 #include "../gdn_fwd_o_epilogue_policies.hpp"
@@ -18,39 +17,169 @@
 #include "catlass/matrix_coord.hpp"
 #include "catlass/epilogue/tile/tile_copy.hpp"
 
-namespace Catlass::Epilogue::Block {
+// regbase.hpp 自身无 include guard，本算子 kernel 会同时包含 qkmask 与 output 两个
+// epilogue 头，此处用算子私有宏防止同一编译单元内重复包含（重定义 constexpr/inline 符号）
+#ifndef FLA_FWD_O_REGBASE_HPP_SEEN
+#define FLA_FWD_O_REGBASE_HPP_SEEN
+#include "kernel_utils/vector/regbase.hpp"
+#endif
 
-static __simd_vf__ inline void GdnFwdoQKMaskSubMinsExpVf(__ubuf__ float *dst, __ubuf__ float *left, __ubuf__ float *up,
-                                                         uint32_t elementCount)
+// RegBase VF 函数：Mins(0) → Exp → Mul(maskUbTensor) + 置零，全融合
+// 按对角线所在 64 列 tile 分两个循环处理：
+//   absRow < 64:  列 [0,64) 乘 maskUbTensor[absRow]，列 [64,128) 置零
+//   absRow >= 64: 列 [0,64) 保留 Exp，列 [64,128) 乘 maskUbTensor[absRow-64]
+// maskUbTensor 为 64×64 下三角矩阵，行 r 的前 r+1 个元素为 1.0，其余为 0.0。
+__simd_vf__ inline void QkmaskCausalMaskVf(
+    __ubuf__ float* __restrict__ upAddr,        // gbrcUpUbTensor 起始地址（Sub 结果，也是输出）
+    __ubuf__ float* __restrict__ maskBase,      // maskUbTensor[0] 起始地址（64×64 矩阵起点）
+    uint32_t mActualThisStage,                  // 本 stage 行数
+    uint32_t alignedNActual,                    // 对齐列数（64 或 128）
+    uint32_t gbrcStart,                         // 本 stage 起始绝对行号
+    uint32_t gbrcEffStart,                      // mask 行起始偏移（gbrcStart - gbrcRealStart，0-7）
+    uint32_t gbrcRealStart,                     // 列偏移起点（8 对齐，与 MemBase gbrcRealStart 一致）
+    uint32_t gbrcRealEnd)                       // 列有效上界（8 对齐，与 MemBase gbrcRealEnd 一致）
 {
-    AscendC::Reg::RegTensor<float> leftReg0;
-    AscendC::Reg::RegTensor<float> leftReg1;
-    AscendC::Reg::RegTensor<float> upReg0;
-    AscendC::Reg::RegTensor<float> upReg1;
-    AscendC::Reg::RegTensor<float> dstReg0;
-    AscendC::Reg::RegTensor<float> dstReg1;
-    constexpr uint32_t ELEMS_PER_REG = AscendC::VECTOR_REG_WIDTH / sizeof(float);
-    constexpr uint32_t ELEMS_PER_DUAL = ELEMS_PER_REG * 2;
-    auto maskFull = AscendC::Reg::CreateMask<float, AscendC::Reg::MaskPattern::ALL>();
-    uint16_t dualRepeats = static_cast<uint16_t>(elementCount / ELEMS_PER_DUAL);
+    using namespace AscendC::MicroAPI;
+    constexpr uint32_t VL = AscendC::VECTOR_REG_WIDTH / sizeof(float);  // 64
 
-    for (uint16_t i = 0; i < dualRepeats; ++i) {
-        uint32_t offset = static_cast<uint32_t>(i) * ELEMS_PER_DUAL;
-        AscendC::Reg::LoadAlign<float, AscendC::Reg::LoadDist::DIST_DINTLV_B32>(leftReg0, leftReg1, left + offset);
-        AscendC::Reg::LoadAlign<float, AscendC::Reg::LoadDist::DIST_DINTLV_B32>(upReg0, upReg1, up + offset);
-        AscendC::Reg::Sub(dstReg0, leftReg0, upReg0, maskFull);
-        AscendC::Reg::Sub(dstReg1, leftReg1, upReg1, maskFull);
-        AscendC::Reg::Mins(dstReg0, dstReg0, 0.0f, maskFull);
-        AscendC::Reg::Mins(dstReg1, dstReg1, 0.0f, maskFull);
-        AscendC::Reg::Exp(dstReg0, dstReg0, maskFull);
-        AscendC::Reg::Exp(dstReg1, dstReg1, maskFull);
-        AscendC::Reg::StoreAlign<float, AscendC::Reg::StoreDist::DIST_INTLV_B32>(dst + offset, dstReg0, dstReg1,
-                                                                                 maskFull);
+    (void)gbrcEffStart;  // mask 行号直接用 absRow 计算，gbrcEffStart 仅供外部 Sub 偏移使用
+
+    RegTensor<float> vregUp;
+    RegTensor<float> vregMask;
+    RegTensor<float> vregZero;
+    MaskReg maskFull = CreateMask<float, MaskPattern::ALL>();
+
+    Duplicate(vregZero, 0.0f, maskFull);
+
+    uint32_t gbrcEnd = gbrcStart + mActualThisStage;
+
+    // 第一个循环：absRow < 64，对角线在第一个 64 列 tile 内
+    //   列 [0, 64):   Mins(0)→Exp→Mul(maskUbTensor[absRow]) 因果掩码
+    //   列 [64, 128): 置零（远未来区域）
+    for (uint32_t absRow = gbrcStart; absRow < (gbrcEnd > 64 ? 64 : gbrcEnd); ++absRow) {
+        uint32_t row = absRow - gbrcStart;
+        __ubuf__ float* rowAddr = upAddr + row * alignedNActual;
+        __ubuf__ float* maskRowAddr = maskBase + absRow * VL;
+
+        LoadAlign<float, LoadDist::DIST_NORM>(vregUp, rowAddr);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregMask, maskRowAddr);
+        Mins(vregUp, vregUp, 0.0f, maskFull);
+        Exp(vregUp, vregUp, maskFull);
+        Mul(vregUp, vregUp, vregMask, maskFull);
+        StoreAlign(rowAddr, vregUp, maskFull);
+
+        StoreAlign(rowAddr + VL, vregZero, maskFull);
+    }
+    // 第二个循环：absRow >= 64，对角线在第二个 64 列 tile 内
+    //   列 [0, 64):   Mins(0)→Exp 保留（全部 j < 64 <= absRow，无需 mask）
+    //   列 [64, 128): Mins(0)→Exp→Mul(maskUbTensor[absRow-64]) 因果掩码
+    for (uint32_t absRow = 64; absRow < gbrcEnd; ++absRow) {
+        uint32_t row = absRow - gbrcStart;
+        __ubuf__ float* rowAddr = upAddr + row * alignedNActual;
+        __ubuf__ float* maskRowAddr = maskBase + (absRow - 64) * VL;
+
+        LoadAlign<float, LoadDist::DIST_NORM>(vregUp, rowAddr);
+        Mins(vregUp, vregUp, 0.0f, maskFull);
+        Exp(vregUp, vregUp, maskFull);
+        StoreAlign(rowAddr, vregUp, maskFull);
+
+        LoadAlign<float, LoadDist::DIST_NORM>(vregUp, rowAddr + VL);
+        Mins(vregUp, vregUp, 0.0f, maskFull);
+        Exp(vregUp, vregUp, maskFull);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregMask, maskRowAddr);
+        Mul(vregUp, vregUp, vregMask, maskFull);
+        StoreAlign(rowAddr + VL, vregUp, maskFull);
     }
 }
 
-template <class AOutputType_, class GInputType_, class AInputType_, class MaskInputType_>
-class BlockEpilogue<EpilogueAtlasGDNFwdOQkmask, AOutputType_, GInputType_, AInputType_, MaskInputType_> {
+// 尾块 VF 函数：alignedNActual ∈ (64, 128)，如 80, 96, 112
+// 与满块 VF 的差异：第二段宽度 = alignedNActual - 64 (< 64)，用 UpdateMask 限制有效元素数
+//   absRow < 64:  列 [0,64) 乘 mask[absRow]，列 [64,N) 置零 (tailWidth 个)
+//   absRow >= 64: 列 [0,64) 保留 Exp，列 [64,N) 乘 mask[absRow-64] (tailWidth 个)
+__simd_vf__ inline void QkmaskCausalMaskVfTail(
+    __ubuf__ float* __restrict__ upAddr,
+    __ubuf__ float* __restrict__ maskBase,
+    uint32_t mActualThisStage,
+    uint32_t alignedNActual,
+    uint32_t gbrcStart,
+    uint32_t gbrcEffStart,
+    uint32_t gbrcRealStart,
+    uint32_t gbrcRealEnd)
+{
+    using namespace AscendC::MicroAPI;
+    constexpr uint32_t VL = AscendC::VECTOR_REG_WIDTH / sizeof(float);  // 64
+
+    (void)gbrcEffStart;
+    (void)gbrcRealStart;
+    (void)gbrcRealEnd;
+
+    RegTensor<float> vregUp;
+    RegTensor<float> vregMask;
+    RegTensor<float> vregZero;
+    MaskReg maskFull = CreateMask<float, MaskPattern::ALL>();
+
+    Duplicate(vregZero, 0.0f, maskFull);
+
+    uint32_t gbrcEnd = gbrcStart + mActualThisStage;
+    uint32_t tailWidth = alignedNActual - VL;
+    uint32_t tailWidth1 = alignedNActual > VL ? VL : alignedNActual;
+    uint32_t tailWidth2 = alignedNActual > tailWidth1 ? alignedNActual - tailWidth1 : 0;
+    MaskReg maskTail1 = UpdateMask<float>(tailWidth1);
+    MaskReg maskTail2 = UpdateMask<float>(tailWidth2);
+
+    // 第一个循环：absRow < 64，对角线在第一个 64 列 tile 内
+    //   列 [0, 64):      Mins(0)→Exp→Mul(mask[absRow])
+    //   列 [64, N):       置零（tailWidth 个）
+    for (uint32_t absRow = gbrcStart; absRow < (gbrcEnd > 64 ? 64 : gbrcEnd); ++absRow) {
+        uint32_t row = absRow - gbrcStart;
+        __ubuf__ float* rowAddr = upAddr + row * alignedNActual;
+        __ubuf__ float* maskRowAddr = maskBase + absRow * VL;
+
+        LoadAlign<float, LoadDist::DIST_NORM>(vregUp, rowAddr);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregMask, maskRowAddr);
+        Mins(vregUp, vregUp, 0.0f, maskTail1);
+        Exp(vregUp, vregUp, maskTail1);
+        Mul(vregUp, vregUp, vregMask, maskTail1);
+        StoreAlign(rowAddr, vregUp, maskTail1);
+        StoreAlign(rowAddr + VL, vregZero, maskTail2);
+    }
+    // 第二个循环：absRow >= 64，对角线在第二个 64 列 tile 内
+    //   列 [0, 64):      Mins(0)→Exp 保留
+    //   列 [64, N):       Mins(0)→Exp→Mul(mask[absRow-64])（tailWidth 个）
+    for (uint32_t absRow = 64; absRow < gbrcEnd; ++absRow) {
+        uint32_t row = absRow - gbrcStart;
+        __ubuf__ float* rowAddr = upAddr + row * alignedNActual;
+        __ubuf__ float* maskRowAddr = maskBase + (absRow - 64) * VL;
+
+        LoadAlign<float, LoadDist::DIST_NORM>(vregUp, rowAddr);
+        Mins(vregUp, vregUp, 0.0f, maskTail1);
+        Exp(vregUp, vregUp, maskTail1);
+        StoreAlign(rowAddr, vregUp, maskTail1);
+
+        LoadAlign<float, LoadDist::DIST_NORM>(vregUp, rowAddr + VL);
+        Mins(vregUp, vregUp, 0.0f, maskTail2);
+        Exp(vregUp, vregUp, maskTail2);
+        LoadAlign<float, LoadDist::DIST_NORM>(vregMask, maskRowAddr);
+        Mul(vregUp, vregUp, vregMask, maskTail2);
+        StoreAlign(rowAddr + VL, vregUp, maskTail2);
+    }
+}
+
+namespace Catlass::Epilogue::Block {
+
+template <
+    class AOutputType_,
+    class GInputType_,
+    class AInputType_,
+    class MaskInputType_
+>
+class BlockEpilogue <
+    EpilogueAtlasGDNFwdOQkmask,
+    AOutputType_,
+    GInputType_,
+    AInputType_,
+    MaskInputType_
+> {
 public:
     // Type aliases
     using DispatchPolicy = EpilogueAtlasGDNFwdOQkmask;
@@ -65,71 +194,80 @@ public:
     static constexpr uint32_t FLOAT_ELENUM_PER_BLK = 8;
     static constexpr uint32_t HALF_ELENUM_PER_VECCALC = 128;
     static constexpr uint32_t FLOAT_ELENUM_PER_VECCALC = 64;
-    static constexpr uint32_t UB_TILE_SIZE = 16384;        // 64 * 128 * 2B
-    static constexpr uint32_t UB_LINE_SIZE = 512;          // 128 * 2 * 2B
-    static constexpr uint32_t HALF_ELENUM_PER_LINE = 256;  // 128 * 2
-    static constexpr uint32_t FLOAT_ELENUM_PER_LINE = 128; // 128
+    static constexpr uint32_t UB_TILE_SIZE = 16384;  // 64 * 128 * 2B
+    static constexpr uint32_t UB_LINE_SIZE = 512;   // 128 * 2 * 2B
+    static constexpr uint32_t HALF_ELENUM_PER_LINE = 256;    // 128 * 2
+    static constexpr uint32_t FLOAT_ELENUM_PER_LINE = 128;   // 128
     static constexpr uint32_t MULTIPLIER = 2;
-    static constexpr uint32_t VEC_TILE_ROWS = 32;
-    using LayoutL1MaskOutput = Catlass::layout::zN;
 
     CATLASS_DEVICE
     BlockEpilogue(Arch::Resource<ArchTag> &resource)
     {
+        // UB layout (ub2l1, shared contract with the kernel and output epilogue —
+        // see docs/agents/chunk_fwd_o_l0c2ub_ub2l1_design.md §4.1):
+        //   [0, 71K)    base region — maskUbTensor (kernel-lifetime tril mask, read
+        //              every round) + gbrc/gcomp/share/g; offsets identical to the
+        //              output epilogue.
+        //   [71K, 199K) Cube work slots (4 x 32KB) — written by Cube-side Fixpipe
+        //              while Vec1 runs; all Vec1 buffers must stay out of this range.
+        //   [199K, 248K) Vec1 scratch (a fp32 + out fp32 + out half), time-shared
+        //              with Vec2's out scratch (Vec1/Vec2 never run concurrently
+        //              within one AIV subBlock).
         constexpr uint32_t BASE = 0;
         constexpr uint32_t MASK_UB_TENSOR_SIZE = 32 * UB_LINE_SIZE;
         constexpr uint32_t GBRCLEFTCAST_UB_TENSOR_SIZE = 40 * UB_LINE_SIZE;
         constexpr uint32_t GBRCUP_UB_TENSOR_SIZE = 32 * UB_LINE_SIZE;
-        constexpr uint32_t TILE_FLOAT_UB_TENSOR_SIZE = VEC_TILE_ROWS * FLOAT_ELENUM_PER_LINE * sizeof(float);
-        constexpr uint32_t TILE_HALF_UB_TENSOR_SIZE = VEC_TILE_ROWS * FLOAT_ELENUM_PER_LINE * sizeof(AElementOutput);
+        constexpr uint32_t FLOAT_UB_TENSOR_SIZE = 32 * UB_LINE_SIZE;
+        constexpr uint32_t HALF_UB_TENSOR_SIZE = 16 * UB_LINE_SIZE;
         constexpr uint32_t G_HALF_UB_TENSOR_SIZE = 2 * UB_LINE_SIZE;
         constexpr uint32_t G_FLOAT_UB_TENSOR_SIZE = 2 * UB_LINE_SIZE;
+        constexpr uint32_t UB_WORK_SLOT_BYTES = 64 * 128 * sizeof(float);
+        constexpr uint32_t UB_SLOT_REGION_END = 71 * 1024 + 4 * UB_WORK_SLOT_BYTES;
 
         constexpr uint32_t MASK_UB_TENSOR_OFFSET = BASE;
         constexpr uint32_t GBRCLEFTCAST_UB_TENSOR_OFFSET = MASK_UB_TENSOR_OFFSET + MASK_UB_TENSOR_SIZE;
         constexpr uint32_t GBRCUP_UB_TENSOR_OFFSET = GBRCLEFTCAST_UB_TENSOR_OFFSET + GBRCLEFTCAST_UB_TENSOR_SIZE;
-        constexpr uint32_t SHARE_UB_TENSOR_OFFSET = GBRCUP_UB_TENSOR_OFFSET + GBRCUP_UB_TENSOR_SIZE;
+        constexpr uint32_t GCOMP_UB_TENSOR_OFFSET = GBRCUP_UB_TENSOR_OFFSET + GBRCUP_UB_TENSOR_SIZE;
+        constexpr uint32_t SHARE_UB_TENSOR_OFFSET = GCOMP_UB_TENSOR_OFFSET + G_FLOAT_UB_TENSOR_SIZE;
 
         maskUbTensor = resource.ubBuf.template GetBufferByByte<float>(MASK_UB_TENSOR_OFFSET);
         gbrcLeftcastUbTensor = resource.ubBuf.template GetBufferByByte<float>(GBRCLEFTCAST_UB_TENSOR_OFFSET);
         gbrcUpUbTensor = resource.ubBuf.template GetBufferByByte<float>(GBRCUP_UB_TENSOR_OFFSET);
+        gcompUbTensor = resource.ubBuf.template GetBufferByByte<float>(GCOMP_UB_TENSOR_OFFSET);
         shareUbTensor = resource.ubBuf.template GetBufferByByte<uint8_t>(SHARE_UB_TENSOR_OFFSET);
 
-        constexpr uint32_t VEC1_SCRATCH_BASE = 203776;
-        constexpr uint32_t G_UB_TENSOR_OFFSET_PING = SHARE_UB_TENSOR_OFFSET + TILE_FLOAT_UB_TENSOR_SIZE;
-        constexpr uint32_t G_HALF_UB_TENSOR_OFFSET_PING = G_UB_TENSOR_OFFSET_PING + G_FLOAT_UB_TENSOR_SIZE;
-        constexpr uint32_t A_UB_TENSOR_OFFSET_PING = VEC1_SCRATCH_BASE;
-        constexpr uint32_t OUT_UB_TENSOR_OFFSET_PING = A_UB_TENSOR_OFFSET_PING;
-        constexpr uint32_t OUT_HALF_UB_TENSOR_OFFSET_PING = OUT_UB_TENSOR_OFFSET_PING + TILE_FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t G_UB_TENSOR_OFFSET = SHARE_UB_TENSOR_OFFSET + FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t G_HALF_UB_TENSOR_OFFSET = G_UB_TENSOR_OFFSET + G_FLOAT_UB_TENSOR_SIZE;
 
-        gUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(G_UB_TENSOR_OFFSET_PING);
-        gUbFPTensorPing = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PING);
-        gUbBFTensorPing = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PING);
-        aUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(A_UB_TENSOR_OFFSET_PING);
-        outUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(OUT_UB_TENSOR_OFFSET_PING);
-        outUbFPTensorPing = resource.ubBuf.template GetBufferByByte<AElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PING);
-        outUbBFTensorPing = resource.ubBuf.template GetBufferByByte<AElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PING);
+        constexpr uint32_t A_UB_TENSOR_OFFSET = UB_SLOT_REGION_END;
+        constexpr uint32_t OUT_UB_TENSOR_OFFSET = A_UB_TENSOR_OFFSET + FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t OUT_HALF_UB_TENSOR_OFFSET = OUT_UB_TENSOR_OFFSET + FLOAT_UB_TENSOR_SIZE;
+        static_assert(OUT_HALF_UB_TENSOR_OFFSET + HALF_UB_TENSOR_SIZE <= 248 * 1024, "UB overflow");
 
-        constexpr uint32_t G_UB_TENSOR_OFFSET_PONG = G_UB_TENSOR_OFFSET_PING;
-        constexpr uint32_t G_HALF_UB_TENSOR_OFFSET_PONG = G_UB_TENSOR_OFFSET_PONG + G_FLOAT_UB_TENSOR_SIZE;
-        constexpr uint32_t A_UB_TENSOR_OFFSET_PONG = OUT_HALF_UB_TENSOR_OFFSET_PING + TILE_HALF_UB_TENSOR_SIZE;
-        constexpr uint32_t OUT_UB_TENSOR_OFFSET_PONG = A_UB_TENSOR_OFFSET_PONG;
-        constexpr uint32_t OUT_HALF_UB_TENSOR_OFFSET_PONG = OUT_UB_TENSOR_OFFSET_PONG + TILE_FLOAT_UB_TENSOR_SIZE;
+        gUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(G_UB_TENSOR_OFFSET);
+        gUbFPTensorPing = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET);
+        gUbBFTensorPing = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET);
+        aUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(A_UB_TENSOR_OFFSET);
+        outUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(OUT_UB_TENSOR_OFFSET);
+        outUbFPTensorPing = resource.ubBuf.template GetBufferByByte<AElementOutput>(OUT_HALF_UB_TENSOR_OFFSET);
+        outUbBFTensorPing = resource.ubBuf.template GetBufferByByte<AElementOutput>(OUT_HALF_UB_TENSOR_OFFSET);
 
-        gUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(G_UB_TENSOR_OFFSET_PONG);
-        gUbFPTensorPong = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PONG);
-        gUbBFTensorPong = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PONG);
-        aUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(A_UB_TENSOR_OFFSET_PONG);
-        outUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(OUT_UB_TENSOR_OFFSET_PONG);
-        outUbFPTensorPong = resource.ubBuf.template GetBufferByByte<AElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PONG);
-        outUbBFTensorPong = resource.ubBuf.template GetBufferByByte<AElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PONG);
+        // Ping == Pong for Vec1's a/out tiles: consumed within one Vec1 call before
+        // reuse (V event handoffs); the Cube slots carry the real ping-pong semantics.
+        gUbTensorPong = gUbTensorPing;
+        gUbFPTensorPong = gUbFPTensorPing;
+        gUbBFTensorPong = gUbBFTensorPing;
+        aUbTensorPong = aUbTensorPing;
+        outUbTensorPong = outUbTensorPing;
+        outUbFPTensorPong = outUbFPTensorPing;
+        outUbBFTensorPong = outUbBFTensorPing;
     }
 
     CATLASS_DEVICE
     ~BlockEpilogue()
-    {
-    }
+    {}
 
+    /// ub2l1: direct the aftermask output to an L1 slot (zN layout) instead of GM.
     CATLASS_DEVICE
     void EnableL1Output(AscendC::LocalTensor<AElementOutput> l1OutputTensor)
     {
@@ -138,14 +276,24 @@ public:
     }
 
     CATLASS_DEVICE
-    void operator()(AscendC::GlobalTensor<AElementOutput> maskOutput, AscendC::GlobalTensor<GElementInput> gInput,
-                    AscendC::GlobalTensor<AElementInput> attnInput, AscendC::GlobalTensor<MaskElementInput> boolInput,
-                    uint32_t fullChunkSize, uint32_t chunkSize, uint32_t kHeadDim, uint32_t vHeadDim,
-                    uint32_t &pingpongFlag, uint32_t batchIdx, uint32_t headIdx, uint32_t chunkIdx)
+    void operator()(
+        AscendC::GlobalTensor<AElementOutput> maskOutput,
+        AscendC::GlobalTensor<GElementInput> gInput,
+        AscendC::GlobalTensor<AElementInput> attnInput,
+        AscendC::GlobalTensor<MaskElementInput> boolInput,
+        uint32_t fullChunkSize,
+        uint32_t chunkSize,
+        uint32_t kHeadDim,
+        uint32_t vHeadDim,
+        uint32_t &pingpongFlag
+        , uint32_t batchIdx, uint32_t headIdx, uint32_t chunkIdx,
+        Arch::CrossCoreFlag* waitFlag = nullptr
+        )
     {
         uint32_t mActual = chunkSize;
         uint32_t nActual = chunkSize;
         uint32_t alignedNActual = CeilDiv(nActual, 16) * 16;
+        bool isContiguousFullTile = chunkSize == fullChunkSize && nActual == alignedNActual;
         uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
         uint32_t subBlockNum = AscendC::GetSubBlockNum();
         uint32_t blockIdx = AscendC::GetBlockIdx();
@@ -155,19 +303,19 @@ public:
         uint32_t nOffset = 0;
         int64_t offsetA = mOffset * nActual + nOffset;
         uint16_t aInputDstStride;
-        if ((nActual - 1) % 16 <= 7)
-            aInputDstStride = 1;
-        else
-            aInputDstStride = 0;
+        if((nActual - 1) % 16 <= 7) aInputDstStride = 1;
+        else aInputDstStride = 0;
 
-        uint32_t gbrcStart, gbrcRealStart, gbrcRealEnd, gbrcRealProcess, gbrcEffStart, gbrcEffEnd, mulsRemain,
-            mulsRemainIdx;
-        if (mActualThisSubBlock <= VEC_TILE_ROWS) {
-            if (subBlockIdx == 0) {
+        uint32_t gbrcStart, gbrcRealStart, gbrcRealEnd, gbrcRealProcess, gbrcEffStart, gbrcEffEnd, mulsRemain, mulsRemainIdx;
+        if(mActualThisSubBlock <= 32)
+        {   if(subBlockIdx == 0)
+            {
                 gbrcStart = 0;
                 gbrcRealStart = 0;
                 gbrcRealProcess = mActualThisSubBlock;
-            } else {
+            }
+            else
+            {
                 gbrcStart = mActualPerSubBlock;
                 gbrcRealStart = gbrcStart & ~7;
                 gbrcRealProcess = mActual - gbrcRealStart;
@@ -187,22 +335,20 @@ public:
             AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
 
 
-            AscendC::DataCopyParams aInputUbParams{(uint16_t)mActualThisSubBlock, (uint16_t)(nActual * sizeof(float)),
-                                                   0, aInputDstStride};
+            AscendC::DataCopyParams aInputUbParams{(uint16_t)mActualThisSubBlock, (uint16_t)(nActual*sizeof(float)), 0, aInputDstStride};
             AscendC::DataCopyPadParams aInputUbPadParams{false, 0, 0, 0};
-            AscendC::DataCopyExtParams aOutputUbParams{(uint16_t)mActualThisSubBlock,
-                                                       (uint32_t)(nActual * sizeof(half)), 0, 0, 0};
+            // UB->GM DataCopyPad advances the UB source by AlignUp(blockLen, 32B).
+            // For fp16/bf16 qk-mask rows this matches alignedNActual, so srcStride stays 0.
+            AscendC::DataCopyExtParams aOutputUbParams{(uint16_t)mActualThisSubBlock, (uint32_t)(nActual*sizeof(half)), 0, 0, 0};
 
-            AscendC::DataCopyParams gfloatUbParams{1, (uint16_t)(mActual * sizeof(float)), 0, 0};
-            AscendC::DataCopyParams ghalfUbParams{1, (uint16_t)(mActual * sizeof(half)), 0, 0};
+            AscendC::DataCopyParams gfloatUbParams{1, (uint16_t)(mActual*sizeof(float)), 0, 0};
+            AscendC::DataCopyParams ghalfUbParams{1, (uint16_t)(mActual*sizeof(half)), 0, 0};
             AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
 
             AscendC::LocalTensor<float> aUbTensor = (pingpongFlag == 0) ? aUbTensorPing : aUbTensorPong;
             AscendC::LocalTensor<float> outUbTensor = (pingpongFlag == 0) ? outUbTensorPing : outUbTensorPong;
-            AscendC::LocalTensor<AElementOutput> outUbFPTensor =
-                (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
-            AscendC::LocalTensor<AElementOutput> outUbBFTensor =
-                (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
+            AscendC::LocalTensor<AElementOutput> outUbFPTensor = (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
+            AscendC::LocalTensor<AElementOutput> outUbBFTensor = (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
             AscendC::LocalTensor<float> gUbTensor = (pingpongFlag == 0) ? gUbTensorPing : gUbTensorPong;
             AscendC::LocalTensor<GElementInput> gUbFPTensor = (pingpongFlag == 0) ? gUbFPTensorPing : gUbFPTensorPong;
             AscendC::LocalTensor<GElementInput> gUbBFTensor = (pingpongFlag == 0) ? gUbBFTensorPing : gUbBFTensorPong;
@@ -214,106 +360,80 @@ public:
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
 
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
-            if constexpr (std::is_same<GElementInput, float>::value) { 
+            if constexpr(std::is_same<GElementInput, float>::value) {
                 AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gfloatUbParams, gUbPadParams);
             } else {
                 AscendC::DataCopyPad(gUbFPTensor, gInputThisSubBlock, ghalfUbParams, gUbPadParams);
             }
             AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
             AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
-            if constexpr (!std::is_same<GElementInput, float>::value) {
+            if constexpr(!std::is_same<GElementInput, float>::value) {
                 AscendC::Cast(gUbTensor, gUbFPTensor, AscendC::RoundMode::CAST_NONE, mActual);
                 AscendC::PipeBarrier<PIPE_V>();
             }
-
-            AscendC::Broadcast<float, 2, 0>(gbrcUpUbTensor, gUbTensor, dstUpShape_, srcUpShape_, shareUbTensor);
-            AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gUbTensor[gbrcRealStart], dstLeftShape_,
-                                            srcLeftShape_, shareUbTensor);
-            AscendC::PipeBarrier<PIPE_V>();
-            __ubuf__ float *gbrcUpAddr = (__ubuf__ float *)gbrcUpUbTensor.GetPhyAddr();
-            __ubuf__ float *gbrcLeftAddr =
-                (__ubuf__ float *)gbrcLeftcastUbTensor[gbrcEffStart * alignedNActual].GetPhyAddr();
-            constexpr uint32_t VF_DUAL_ELEMENTS = 2 * AscendC::VECTOR_REG_WIDTH / sizeof(float);
-            uint32_t totalElements = mActualThisSubBlock * alignedNActual;
-            uint32_t vfElements = totalElements / VF_DUAL_ELEMENTS * VF_DUAL_ELEMENTS;
-            if (vfElements != 0) {
-                AscendC::VF_CALL<GdnFwdoQKMaskSubMinsExpVf>(gbrcUpAddr, gbrcLeftAddr, gbrcUpAddr, vfElements);
-            }
-            uint32_t tailElements = totalElements - vfElements;
-            if (tailElements != 0) {
-                AscendC::Sub(gbrcUpUbTensor[vfElements],
-                             gbrcLeftcastUbTensor[gbrcEffStart * alignedNActual + vfElements],
-                             gbrcUpUbTensor[vfElements], tailElements);
-                AscendC::PipeBarrier<PIPE_V>();
-                AscendC::Mins(gbrcUpUbTensor[vfElements], gbrcUpUbTensor[vfElements], 0.0f, tailElements);
-                AscendC::PipeBarrier<PIPE_V>();
-                AscendC::Exp(gbrcUpUbTensor[vfElements], gbrcUpUbTensor[vfElements], tailElements);
-            }
+            AscendC::Copy(gcompUbTensor, gUbTensor, 64, 2, {1, 1, 8, 8});
             AscendC::PipeBarrier<PIPE_V>();
 
+            AscendC::Broadcast<float, 2, 0>(gbrcUpUbTensor, gcompUbTensor, dstUpShape_, srcUpShape_, shareUbTensor);
+            AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gcompUbTensor[gbrcRealStart], dstLeftShape_, srcLeftShape_, shareUbTensor);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Sub(gbrcUpUbTensor, gbrcLeftcastUbTensor[gbrcEffStart*alignedNActual], gbrcUpUbTensor, mActualThisSubBlock * alignedNActual);
+            AscendC::PipeBarrier<PIPE_V>();
             gbrcRealEnd = CeilDiv(gbrcStart + mActualThisSubBlock, 8) * 8;
-            AscendC::Mul(gbrcUpUbTensor[gbrcRealStart], gbrcUpUbTensor[gbrcRealStart], maskUbTensor[gbrcEffStart * 64],
-                         gbrcRealEnd - gbrcRealStart, mActualThisSubBlock,
-                         {1, 1, 1, static_cast<uint8_t>(alignedNActual / 8), static_cast<uint8_t>(alignedNActual / 8),
-                          static_cast<uint8_t>(64 / 8)});
-            AscendC::PipeBarrier<PIPE_V>();
-
-            mulsRemain = alignedNActual - gbrcRealEnd;
-            mulsRemainIdx = gbrcRealEnd;
-            while (mulsRemain > 64) {
-                AscendC::Muls(
-                    gbrcUpUbTensor[mulsRemainIdx], gbrcUpUbTensor[mulsRemainIdx], (float)0.0, 64, mActualThisSubBlock,
-                    {1, 1, static_cast<uint8_t>(alignedNActual / 8), static_cast<uint8_t>(alignedNActual / 8)});
-                mulsRemain -= 64;
-                mulsRemainIdx += 64;
+            // [RegBase] Mins(0) → Exp → Mul(maskUbTensor) + 置零 全融合为单个 VF 函数。
+            // 本分支 mActualThisSubBlock<=32 ⇒ chunkSize<=65 ⇒ alignedNActual∈{64,80}，
+            // 永远 < 128，直接走 QkmaskCausalMaskVfTail（alignedNActual==64 时 tailWidth2=0，第二段为 no-op）。
+            {
+                auto upAddr = reinterpret_cast<uint64_t>(gbrcUpUbTensor.GetPhyAddr());
+                auto maskBase = reinterpret_cast<uint64_t>(maskUbTensor.GetPhyAddr());
+                QkmaskCausalMaskVfTail((__ubuf__ float*)upAddr,
+                                       (__ubuf__ float*)maskBase,
+                                       mActualThisSubBlock, alignedNActual,
+                                       gbrcStart, gbrcEffStart, gbrcRealStart, gbrcRealEnd);
+                AscendC::PipeBarrier<PIPE_V>();
             }
-            AscendC::Muls(gbrcUpUbTensor[mulsRemainIdx], gbrcUpUbTensor[mulsRemainIdx], (float)0.0, mulsRemain,
-                          mActualThisSubBlock,
-                          {1, 1, static_cast<uint8_t>(alignedNActual / 8), static_cast<uint8_t>(alignedNActual / 8)});
-            AscendC::PipeBarrier<PIPE_V>();
+            (void)gbrcRealEnd;
 
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
-            if (chunkSize == fullChunkSize)
-                AscendC::DataCopy(aUbTensor, attnInputThisSubBlock, mActualThisSubBlock * nActual);
-            else
-                AscendC::DataCopyPad(aUbTensor, attnInputThisSubBlock, aInputUbParams, aInputUbPadParams);
+            if (waitFlag) Arch::CrossCoreWaitFlag(*waitFlag);
+            if(isContiguousFullTile) AscendC::DataCopy(aUbTensor, attnInputThisSubBlock, mActualThisSubBlock*nActual);
+            else AscendC::DataCopyPad(aUbTensor, attnInputThisSubBlock, aInputUbParams, aInputUbPadParams);
             AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
             AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
             AscendC::Mul(outUbTensor, aUbTensor, gbrcUpUbTensor, mActualThisSubBlock * alignedNActual);
             AscendC::PipeBarrier<PIPE_V>();
 
-            if constexpr (std::is_same<AElementOutput, half>::value) {
-                AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE,
-                              mActualThisSubBlock * alignedNActual);
+            if(std::is_same<AElementOutput, half>::value)
+            {
+                AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * alignedNActual);
+                AscendC::PipeBarrier<PIPE_V>();
                 AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
                 AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-                CopyOutputToL1(outUbFPTensor, gbrcStart, mActualThisSubBlock, nActual, alignedNActual);
-                if (!enableL1Output) {
-                    if (chunkSize == fullChunkSize)
-                        AscendC::DataCopy(maskOutputThisSubBlock, outUbFPTensor, mActualThisSubBlock * nActual);
-                    else
-                        AscendC::DataCopyPad(maskOutputThisSubBlock, outUbFPTensor, aOutputUbParams);
-                }
-            } else {
-                AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT,
-                              mActualThisSubBlock * alignedNActual);
-                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-                CopyOutputToL1(outUbBFTensor, gbrcStart, mActualThisSubBlock, nActual, alignedNActual);
-                if (!enableL1Output) {
-                    if (chunkSize == fullChunkSize)
-                        AscendC::DataCopy(maskOutputThisSubBlock, outUbBFTensor, mActualThisSubBlock * nActual);
-                    else
-                        AscendC::DataCopyPad(maskOutputThisSubBlock, outUbBFTensor, aOutputUbParams);
-                }
+                if (enableL1Output) {
+                    CopyOutputToL1(outUbFPTensor, gbrcStart, mActualThisSubBlock, nActual, alignedNActual);
+                } else if(isContiguousFullTile) AscendC::DataCopy(maskOutputThisSubBlock, outUbFPTensor, mActualThisSubBlock*nActual);
+                else AscendC::DataCopyPad(maskOutputThisSubBlock, outUbFPTensor, aOutputUbParams);
             }
-        } else // mActualThisSubBlock  > 32 ; <=64
+            else
+            {
+                AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * alignedNActual);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                if (enableL1Output) {
+                    CopyOutputToL1(outUbBFTensor, gbrcStart, mActualThisSubBlock, nActual, alignedNActual);
+                } else if(isContiguousFullTile) AscendC::DataCopy(maskOutputThisSubBlock, outUbBFTensor, mActualThisSubBlock*nActual);
+                else AscendC::DataCopyPad(maskOutputThisSubBlock, outUbBFTensor, aOutputUbParams);
+            }
+            pingpongFlag = 1 - pingpongFlag;
+        }
+        else // mActualThisSubBlock  > 32 ; <=64
         {
             AscendC::ResetMask();
             AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
 
-            AscendC::DataCopyParams gfloatUbParams{1, (uint16_t)(mActual * sizeof(float)), 0, 0};
-            AscendC::DataCopyParams ghalfUbParams{1, (uint16_t)(mActual * sizeof(half)), 0, 0};
+            AscendC::DataCopyParams gfloatUbParams{1, (uint16_t)(mActual*sizeof(float)), 0, 0};
+            AscendC::DataCopyParams ghalfUbParams{1, (uint16_t)(mActual*sizeof(half)), 0, 0};
             AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
 
             AscendC::LocalTensor<float> gUbTensor = (pingpongFlag == 0) ? gUbTensorPing : gUbTensorPong;
@@ -326,53 +446,73 @@ public:
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
 
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
-            if constexpr (std::is_same<GElementInput, float>::value) {
+            if constexpr(std::is_same<GElementInput, float>::value) {
                 AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gfloatUbParams, gUbPadParams);
             } else {
                 AscendC::DataCopyPad(gUbFPTensor, gInputThisSubBlock, ghalfUbParams, gUbPadParams);
             }
             AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
             AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
-            if constexpr (!std::is_same<GElementInput, float>::value) {
+            if constexpr(!std::is_same<GElementInput, float>::value) {
                 AscendC::Cast(gUbTensor, gUbFPTensor, AscendC::RoundMode::CAST_NONE, mActual);
                 AscendC::PipeBarrier<PIPE_V>();
             }
+            AscendC::Copy(gcompUbTensor, gUbTensor, 64, 2, {1, 1, 8, 8});
+            AscendC::PipeBarrier<PIPE_V>();
 
+            uint32_t mActualPerStage = CeilDiv(mActualThisSubBlock, 2);
             uint32_t mActualThisStage = 0;
-            uint32_t stageCount = CeilDiv(mActualThisSubBlock, VEC_TILE_ROWS);
-            for (uint32_t stage = 0; stage < stageCount; ++stage) {
-                uint32_t tileOffset = stage * VEC_TILE_ROWS;
-                mActualThisStage = (tileOffset + VEC_TILE_ROWS <= mActualThisSubBlock) ?
-                                       VEC_TILE_ROWS :
-                                       (mActualThisSubBlock - tileOffset);
-                gbrcStart = mOffset + tileOffset;
-                gbrcRealStart = gbrcStart & ~7;
-                gbrcRealProcess = gbrcStart + mActualThisStage - gbrcRealStart;
+            for(uint32_t stage = 0; stage < 2; ++stage)
+            {
+                if(stage==0) mActualThisStage = mActualPerStage;
+                else mActualThisStage = mActualThisSubBlock - mActualPerStage;
+
+                if(subBlockIdx == 0 && stage == 0)
+                {
+                    gbrcStart = 0;
+                    gbrcRealStart = 0;
+                    gbrcRealProcess = mActualThisStage;
+                }
+                else if(subBlockIdx == 0 && stage == 1)
+                {
+                    gbrcStart = mActualPerStage;
+                    gbrcRealStart = gbrcStart & ~7;
+                    gbrcRealProcess = mActualThisSubBlock - gbrcRealStart;
+                }
+                else if(subBlockIdx == 1 && stage == 0)
+                {
+                    gbrcStart = mActualPerSubBlock;
+                    gbrcRealStart = gbrcStart & ~7;
+                    gbrcRealProcess = mActualPerSubBlock + mActualThisStage - gbrcRealStart;
+                }
+                else if(subBlockIdx == 1 && stage == 1)
+                {
+                    gbrcStart = mActualPerSubBlock + mActualPerStage;
+                    gbrcRealStart = gbrcStart & ~7;
+                    gbrcRealProcess = mActual - gbrcRealStart;
+                }
 
                 gbrcEffStart = gbrcStart - gbrcRealStart;
 
                 AscendC::GlobalTensor<AElementOutput> maskOutputThisSubBlock = maskOutput[gbrcStart * nActual];
                 AscendC::GlobalTensor<AElementInput> attnInputThisSubBlock = attnInput[gbrcStart * nActual];
 
-                AscendC::DataCopyParams aInputUbParams{(uint16_t)mActualThisStage, (uint16_t)(nActual * sizeof(float)),
-                                                       0, aInputDstStride};
+                AscendC::DataCopyParams aInputUbParams{(uint16_t)mActualThisStage, (uint16_t)(nActual*sizeof(float)), 0, aInputDstStride};
                 AscendC::DataCopyPadParams aInputUbPadParams{false, 0, 0, 0};
-                AscendC::DataCopyExtParams aOutputUbParams{(uint16_t)mActualThisStage,
-                                                           (uint32_t)(nActual * sizeof(half)), 0, 0, 0};
+                // UB->GM DataCopyPad advances the UB source by AlignUp(blockLen, 32B).
+                // For fp16/bf16 qk-mask rows this matches alignedNActual, so srcStride stays 0.
+                AscendC::DataCopyExtParams aOutputUbParams{(uint16_t)mActualThisStage, (uint32_t)(nActual*sizeof(half)), 0, 0, 0};
 
                 AscendC::LocalTensor<float> aUbTensor = (pingpongFlag == 0) ? aUbTensorPing : aUbTensorPong;
                 AscendC::LocalTensor<float> outUbTensor = (pingpongFlag == 0) ? outUbTensorPing : outUbTensorPong;
-                AscendC::LocalTensor<AElementOutput> outUbFPTensor =
-                    (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
-                AscendC::LocalTensor<AElementOutput> outUbBFTensor =
-                    (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
+                AscendC::LocalTensor<AElementOutput> outUbFPTensor = (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
+                AscendC::LocalTensor<AElementOutput> outUbBFTensor = (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
 
                 AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
                 AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
-                if (chunkSize == fullChunkSize)
-                    AscendC::DataCopy(aUbTensor, attnInputThisSubBlock, mActualThisStage * nActual);
-                else
-                    AscendC::DataCopyPad(aUbTensor, attnInputThisSubBlock, aInputUbParams, aInputUbPadParams);
+                if (waitFlag && stage == 0) Arch::CrossCoreWaitFlag(*waitFlag);
+                if(isContiguousFullTile) AscendC::DataCopy(aUbTensor, attnInputThisSubBlock, mActualThisStage*nActual);
+                else AscendC::DataCopyPad(aUbTensor, attnInputThisSubBlock, aInputUbParams, aInputUbPadParams);
                 AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
 
                 uint32_t dstUpShape_[2] = {mActualThisStage, alignedNActual};
@@ -380,128 +520,130 @@ public:
                 uint32_t dstLeftShape_[2] = {gbrcRealProcess, alignedNActual};
                 uint32_t srcLeftShape_[2] = {gbrcRealProcess, 1};
 
-                AscendC::Broadcast<float, 2, 0>(gbrcUpUbTensor, gUbTensor, dstUpShape_, srcUpShape_, shareUbTensor);
-                AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gUbTensor[gbrcRealStart], dstLeftShape_,
-                                                srcLeftShape_, shareUbTensor);
+                AscendC::Broadcast<float, 2, 0>(gbrcUpUbTensor, gcompUbTensor, dstUpShape_, srcUpShape_, shareUbTensor);
+                AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gcompUbTensor[gbrcRealStart], dstLeftShape_, srcLeftShape_, shareUbTensor);
                 AscendC::PipeBarrier<PIPE_V>();
-                __ubuf__ float *gbrcUpAddr = (__ubuf__ float *)gbrcUpUbTensor.GetPhyAddr();
-                __ubuf__ float *gbrcLeftAddr =
-                    (__ubuf__ float *)gbrcLeftcastUbTensor[gbrcEffStart * alignedNActual].GetPhyAddr();
-                constexpr uint32_t VF_DUAL_ELEMENTS = 2 * AscendC::VECTOR_REG_WIDTH / sizeof(float);
-                uint32_t totalElements = mActualThisStage * alignedNActual;
-                uint32_t vfElements = totalElements / VF_DUAL_ELEMENTS * VF_DUAL_ELEMENTS;
-                if (vfElements != 0) {
-                    AscendC::VF_CALL<GdnFwdoQKMaskSubMinsExpVf>(gbrcUpAddr, gbrcLeftAddr, gbrcUpAddr, vfElements);
-                }
-                uint32_t tailElements = totalElements - vfElements;
-                if (tailElements != 0) {
-                    AscendC::Sub(gbrcUpUbTensor[vfElements],
-                                 gbrcLeftcastUbTensor[gbrcEffStart * alignedNActual + vfElements],
-                                 gbrcUpUbTensor[vfElements], tailElements);
-                    AscendC::PipeBarrier<PIPE_V>();
-                    AscendC::Mins(gbrcUpUbTensor[vfElements], gbrcUpUbTensor[vfElements], 0.0f, tailElements);
-                    AscendC::PipeBarrier<PIPE_V>();
-                    AscendC::Exp(gbrcUpUbTensor[vfElements], gbrcUpUbTensor[vfElements], tailElements);
-                }
+                AscendC::Sub(gbrcUpUbTensor, gbrcLeftcastUbTensor[gbrcEffStart*alignedNActual], gbrcUpUbTensor, mActualThisStage * alignedNActual);
                 AscendC::PipeBarrier<PIPE_V>();
 
                 gbrcRealEnd = CeilDiv(gbrcStart + mActualThisStage, 8) * 8;
-                AscendC::Mul(gbrcUpUbTensor[gbrcRealStart], gbrcUpUbTensor[gbrcRealStart],
-                             maskUbTensor[gbrcEffStart * 64], gbrcRealEnd - gbrcRealStart, mActualThisStage,
-                             {1, 1, 1, static_cast<uint8_t>(alignedNActual / 8),
-                              static_cast<uint8_t>(alignedNActual / 8), static_cast<uint8_t>(64 / 8)});
-                AscendC::PipeBarrier<PIPE_V>();
-                mulsRemain = alignedNActual - gbrcRealEnd;
-                mulsRemainIdx = gbrcRealEnd;
-                while (mulsRemain > 64) {
-                    AscendC::Muls(
-                        gbrcUpUbTensor[mulsRemainIdx], gbrcUpUbTensor[mulsRemainIdx], (float)0.0, 64, mActualThisStage,
-                        {1, 1, static_cast<uint8_t>(alignedNActual / 8), static_cast<uint8_t>(alignedNActual / 8)});
-                    mulsRemain -= 64;
-                    mulsRemainIdx += 64;
+                // [RegBase] Mins(0) → Exp → Mul(maskUbTensor) + 置零 全融合为单个 VF 函数。
+                // 满块 (alignedNActual==128) 走 QkmaskCausalMaskVf，尾块 (>64,<128) 走 QkmaskCausalMaskVfTail。
+                {
+                    auto upAddr = reinterpret_cast<uint64_t>(gbrcUpUbTensor.GetPhyAddr());
+                    auto maskBase = reinterpret_cast<uint64_t>(maskUbTensor.GetPhyAddr());
+                    if (alignedNActual == 128) {
+                        QkmaskCausalMaskVf((__ubuf__ float*)upAddr,
+                                           (__ubuf__ float*)maskBase,
+                                           mActualThisStage, alignedNActual,
+                                           gbrcStart, gbrcEffStart, gbrcRealStart, gbrcRealEnd);
+                    } else {
+                        QkmaskCausalMaskVfTail((__ubuf__ float*)upAddr,
+                                               (__ubuf__ float*)maskBase,
+                                               mActualThisStage, alignedNActual,
+                                               gbrcStart, gbrcEffStart, gbrcRealStart, gbrcRealEnd);
+                    }
+                    AscendC::PipeBarrier<PIPE_V>();
                 }
-                AscendC::Muls(
-                    gbrcUpUbTensor[mulsRemainIdx], gbrcUpUbTensor[mulsRemainIdx], (float)0.0, mulsRemain,
-                    mActualThisStage,
-                    {1, 1, static_cast<uint8_t>(alignedNActual / 8), static_cast<uint8_t>(alignedNActual / 8)});
-                AscendC::PipeBarrier<PIPE_V>();
+                (void)gbrcRealEnd;
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
                 AscendC::Mul(outUbTensor, aUbTensor, gbrcUpUbTensor, mActualThisStage * alignedNActual);
                 AscendC::PipeBarrier<PIPE_V>();
-                if constexpr (std::is_same<AElementOutput, half>::value) {
-                    AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE,
-                                  mActualThisStage * alignedNActual);
+                if(std::is_same<AElementOutput, half>::value)
+                {
+                    AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisStage * alignedNActual);
+                    AscendC::PipeBarrier<PIPE_V>();
                     AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
                     AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-                    CopyOutputToL1(outUbFPTensor, gbrcStart, mActualThisStage, nActual, alignedNActual);
-                    if (!enableL1Output) {
-                        if (chunkSize == fullChunkSize)
-                            AscendC::DataCopy(maskOutputThisSubBlock, outUbFPTensor, mActualThisStage * nActual);
-                        else
-                            AscendC::DataCopyPad(maskOutputThisSubBlock, outUbFPTensor, aOutputUbParams);
-                    }
-                } else {
-                    AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT,
-                                  mActualThisStage * alignedNActual);
-                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-                    CopyOutputToL1(outUbBFTensor, gbrcStart, mActualThisStage, nActual, alignedNActual);
-                    if (!enableL1Output) {
-                        if (chunkSize == fullChunkSize)
-                            AscendC::DataCopy(maskOutputThisSubBlock, outUbBFTensor, mActualThisStage * nActual);
-                        else
-                            AscendC::DataCopyPad(maskOutputThisSubBlock, outUbBFTensor, aOutputUbParams);
-                    }
+                    if (enableL1Output) {
+                        CopyOutputToL1(outUbFPTensor, gbrcStart, mActualThisStage, nActual, alignedNActual);
+                    } else if(isContiguousFullTile) AscendC::DataCopy(maskOutputThisSubBlock, outUbFPTensor, mActualThisStage*nActual);
+                    else AscendC::DataCopyPad(maskOutputThisSubBlock, outUbFPTensor, aOutputUbParams);
                 }
+                else
+                {
+                    AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisStage * alignedNActual);
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    if (enableL1Output) {
+                        CopyOutputToL1(outUbBFTensor, gbrcStart, mActualThisStage, nActual, alignedNActual);
+                    } else if(isContiguousFullTile) AscendC::DataCopy(maskOutputThisSubBlock, outUbBFTensor, mActualThisStage*nActual);
+                    else AscendC::DataCopyPad(maskOutputThisSubBlock, outUbBFTensor, aOutputUbParams);
+                }
+                pingpongFlag = 1 - pingpongFlag;
             }
         }
+
     }
 
 private:
+    /// ub2l1: copy a rows x cols half/bf16 tile from UB (row-major, stride
+    /// srcStride) into the L1 aftermask slot at zN row offset rowOffset.
+    /// Faithful port of the catlass CopyUb2L1Tla reference (Ascend950,
+    /// RowMajor -> zN, see copy_ub_to_l1_tla.hpp): stride-derived addressing on a
+    /// GetTile sub-tile, NOT hand-derived algebra — the zN sub-tile stride units
+    /// only stay consistent with Cube3's L1A reader when derived from the tile.
     CATLASS_DEVICE
-    void CopyOutputToL1(AscendC::LocalTensor<AElementOutput> ubTensor, uint32_t rowOffset, uint32_t rows, uint32_t cols,
-                        uint32_t srcStride)
+    void CopyOutputToL1(
+        AscendC::LocalTensor<AElementOutput> ubTensor,
+        uint32_t rowOffset,
+        uint32_t rows,
+        uint32_t cols,
+        uint32_t srcStride)
     {
         if (!enableL1Output || rows == 0) {
             return;
         }
 
-        auto ubLayout = tla::MakeLayout(tla::MakeShape(rows, cols), tla::MakeStride(srcStride, tla::Int<1>{}),
-                                        tla::MakeShape(rows, cols));
-        auto l1Layout = tla::MakeLayout<AElementOutput, LayoutL1MaskOutput>(tla::Int<128>{}, tla::Int<128>{});
+        auto ubLayout = tla::MakeLayout(
+            tla::MakeShape(rows, cols), tla::MakeStride(srcStride, tla::Int<1>{}), tla::MakeShape(rows, cols));
+        auto l1Layout = tla::MakeLayout<AElementOutput, Catlass::layout::zN>(tla::Int<128>{}, tla::Int<128>{});
         auto tensorUb = tla::MakeTensor(ubTensor, ubLayout, Catlass::Arch::PositionUB{});
         auto tensorL1 = tla::MakeTensor(l1Output, l1Layout, Catlass::Arch::PositionL1{});
         auto tensorL1Tile = GetTile(tensorL1, tla::MakeCoord(rowOffset, 0), tla::MakeShape(rows, cols));
 
+        constexpr uint32_t BYTE_PER_BLK = 32;
+        constexpr uint32_t BYTE_PER_C0 = 32;  // zN fractal C0 size (16 x 2B half/bf16), same as catlass
         constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(AElementOutput);
-        uint32_t srcDValue = tla::get<0>(tensorUb.stride());
-        uint32_t dstNzNStride = tla::get<0, 0>(tensorL1Tile.stride()) / ELE_NUM_PER_C0;
-        uint32_t dstNzC0Stride = tla::get<1, 1>(tensorL1Tile.stride()) / ELE_NUM_PER_C0;
+        const uint32_t srcDValue = tla::get<0>(tensorUb.stride());
+        const uint32_t dstNzNStride = tla::get<0, 0>(tensorL1Tile.stride()) / ELE_NUM_PER_C0;
+        const uint32_t dstNzC0Stride = tla::get<1, 1>(tensorL1Tile.stride()) / ELE_NUM_PER_C0;
+
         auto dstOffset = tensorL1Tile.layout()(tensorL1Tile.coord());
         auto srcOffset = tensorUb.layout()(tensorUb.coord());
-        uint32_t copyCols = RoundUp<BYTE_PER_BLK>(cols * sizeof(AElementOutput)) / BYTE_PER_BLK;
 
-        if (copyCols > rows) {
-            for (uint32_t i = 0; i < rows; ++i) {
+        uint32_t nRows = rows;
+        uint32_t nCols = RoundUp<BYTE_PER_BLK>(cols * sizeof(AElementOutput)) / BYTE_PER_BLK;
+        if (nCols > nRows) {
+            for (uint32_t i = 0; i < nRows; i++) {
                 uint32_t dst = i * dstNzNStride * BYTE_PER_BLK / sizeof(AElementOutput);
                 uint32_t src = i * srcDValue;
-                AscendC::DataCopyParams params(copyCols, 1, 0, dstNzC0Stride - 1);
-                AscendC::DataCopy(tensorL1Tile.data()[dstOffset + dst], tensorUb.data()[srcOffset + src], params);
+                AscendC::DataCopyParams dataCopyParams(nCols, 1, 0, dstNzC0Stride - 1);
+                AscendC::DataCopy(
+                    tensorL1Tile.data()[dstOffset + dst], tensorUb.data()[srcOffset + src], dataCopyParams);
             }
         } else {
-            for (uint32_t i = 0; i < copyCols; ++i) {
+            for (uint32_t i = 0; i < nCols; i++) {
                 uint32_t dst = i * dstNzC0Stride * BYTE_PER_BLK / sizeof(AElementOutput);
                 uint32_t src = i * BYTE_PER_BLK / sizeof(AElementOutput);
-                AscendC::DataCopyParams params(rows, 1, srcDValue * sizeof(AElementOutput) / BYTE_PER_BLK - 1,
-                                               dstNzNStride - 1);
-                AscendC::DataCopy(tensorL1Tile.data()[dstOffset + dst], tensorUb.data()[srcOffset + src], params);
+                AscendC::DataCopyParams dataCopyParams(
+                    nRows, 1, srcDValue * sizeof(AElementOutput) / BYTE_PER_BLK - 1, dstNzNStride - 1);
+                AscendC::DataCopy(
+                    tensorL1Tile.data()[dstOffset + dst], tensorUb.data()[srcOffset + src], dataCopyParams);
             }
         }
+        // SSBuffer write-completion fence: block the Vector pipeline until the
+        // MTE3 queue has issued these L1 writes, so the caller's cross-core
+        // completion flag (vec1Done) cannot overtake the data in flight.
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0);
     }
 
     AscendC::LocalTensor<float> maskUbTensor;
     AscendC::LocalTensor<float> gbrcLeftcastUbTensor;
     AscendC::LocalTensor<float> gbrcUpUbTensor;
+    AscendC::LocalTensor<float> gcompUbTensor;
     AscendC::LocalTensor<uint8_t> shareUbTensor;
 
     AscendC::LocalTensor<float> gUbTensorPing;
@@ -519,9 +661,12 @@ private:
     AscendC::LocalTensor<float> outUbTensorPong;
     AscendC::LocalTensor<AElementOutput> outUbFPTensorPong;
     AscendC::LocalTensor<AElementOutput> outUbBFTensorPong;
+
+    // ub2l1 state (set via EnableL1Output before operator()).
+    bool enableL1Output = false;
     AscendC::LocalTensor<AElementOutput> l1Output;
-    bool enableL1Output{false};
+
 };
-} // namespace Catlass::Epilogue::Block
+}
 
 #endif

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/epilogue/gdn_fwd_o_epilogue_policies.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/epilogue/gdn_fwd_o_epilogue_policies.hpp
@@ -22,6 +22,6 @@ struct EpilogueAtlasGDNFwdOOutput {
     using ArchTag = Arch::Ascend950;
 };
 
-} // namespace Catlass::Epilogue
+}  // namespace Catlass::Epilogue
 
-#endif // CATLASS_EPILOGUE_GDN_FWD_O_EPILOGUE_POLICIES_HPP
+#endif  // CATLASS_EPILOGUE_GDN_FWD_O_EPILOGUE_POLICIES_HPP

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/gemm/block/block_scheduler_gdn_fwd_o.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/gemm/block/block_scheduler_gdn_fwd_o.hpp
@@ -17,27 +17,18 @@ constexpr uint32_t PING_PONG_STAGES = 2;
 constexpr uint32_t BYTE_SIZE_16_BIT = 2;
 
 template <typename T>
-CATLASS_DEVICE T AlignUp(T a, T b)
-{
+CATLASS_DEVICE T AlignUp(T a, T b) {
     return (b == 0) ? 0 : (a + b - 1) / b * b;
 }
 
 template <typename T>
-CATLASS_DEVICE T Min(T a, T b)
-{
+CATLASS_DEVICE T Min(T a, T b) {
     return (a > b) ? b : a;
 }
 
 template <typename T>
-CATLASS_DEVICE T Max(T a, T b)
-{
+CATLASS_DEVICE T Max(T a, T b) {
     return (a > b) ? a : b;
-}
-
-template <typename T>
-CATLASS_DEVICE T CeilDiv(T a, T b)
-{
-    return (b == 0) ? 0 : (a + b - 1) / b;
 }
 
 namespace Catlass::Gemm::Block {
@@ -58,6 +49,7 @@ struct GDNFwdOOffsets {
     uint32_t batchIdx;
     uint32_t headIdx;
     uint32_t chunkIdx;
+
 };
 
 struct BlockSchedulerGdnFwdO {
@@ -76,20 +68,17 @@ struct BlockSchedulerGdnFwdO {
     uint32_t taskIdx;
     uint32_t cubeCoreIdx;
     uint32_t cubeCoreNum;
-    uint32_t vLoops;
     uint32_t taskNum;
     uint32_t headGroups;
 
     bool isRunning;
-    bool processNewTask{true};
-    bool firstLoop{true};
-    bool lastLoop{false};
+    bool processNewTask {true};
+    bool firstLoop {true};
+    bool lastLoop {false};
     GDNFwdOOffsets offsets[PING_PONG_STAGES];
     int32_t currStage{PING_PONG_STAGES - 1};
 
     uint32_t baseTaskIdx;
-    uint32_t vIdx;
-    uint32_t baseHeadIdx;
     uint32_t chunkIdx;
     uint32_t headInnerIdx;
     uint32_t vHeadIdx;
@@ -106,20 +95,23 @@ struct BlockSchedulerGdnFwdO {
     AscendC::GlobalTensor<int64_t> gmSeqlen;
     AscendC::GlobalTensor<int64_t> gmChunkOffsets;
 
-    Arch::CrossCoreFlag cube1Done[PING_PONG_STAGES]{Arch::CrossCoreFlag{0}, Arch::CrossCoreFlag{1}};
-    Arch::CrossCoreFlag vec1Done[PING_PONG_STAGES]{Arch::CrossCoreFlag{2}, Arch::CrossCoreFlag{3}};
-    Arch::CrossCoreFlag cube3Done[PING_PONG_STAGES]{Arch::CrossCoreFlag{4}, Arch::CrossCoreFlag{5}};
-    Arch::CrossCoreFlag vec2Done[PING_PONG_STAGES]{Arch::CrossCoreFlag{6}, Arch::CrossCoreFlag{7}};
+    Arch::CrossCoreFlag cube1Done[PING_PONG_STAGES] = {0, 1};
+    Arch::CrossCoreFlag vec1Done[PING_PONG_STAGES] = {2, 3};
+    Arch::CrossCoreFlag cube3Done[PING_PONG_STAGES] = {4, 5};
+    Arch::CrossCoreFlag vec2Done[PING_PONG_STAGES] = {6, 7};
+    // ub2l1 reverse sync: L1 slot ownership. Vec1 must not rewrite an L1 aftermask
+    // slot until Cube3's previous read of that slot has completed. Set by the AIC
+    // after Cube3's MTE1 read of the slot is issued+drained; waited by the AIV
+    // before writing the slot. flagId 10/11 (0-7 in use, 8/9 reserved by catlass
+    // inter-block barriers).
+    Arch::CrossCoreFlag l1SlotConsumed[PING_PONG_STAGES] = {10, 11};
 
     CATLASS_DEVICE
-    BlockSchedulerGdnFwdO()
-    {
-    }
+    BlockSchedulerGdnFwdO() {}
 
     CATLASS_DEVICE
-    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::ChunkFwdOTilingData *tilingData, uint32_t coreIdx,
-              uint32_t coreNum)
-    {
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::ChunkFwdOTilingData *tilingData,
+              uint32_t coreIdx, uint32_t coreNum) {
         shapeBatch = tilingData->shapeBatch;
         seqlen = tilingData->seqlen;
         kNumHead = tilingData->kNumHead;
@@ -143,16 +135,16 @@ struct BlockSchedulerGdnFwdO {
 
         cubeCoreIdx = coreIdx;
         cubeCoreNum = coreNum;
-        vLoops = CeilDiv(vHeadDim, vBlockSize);
-        taskNum = vLoops * shapeBatch * numChunks * vNumHead;
+        vBlockSize = vHeadDim;
+        taskNum = shapeBatch * numChunks * vNumHead;
         headGroups = vNumHead / kNumHead;
         taskIdx = cubeCoreIdx * PING_PONG_STAGES;
         isRunning = taskIdx < taskNum;
+
     }
 
     CATLASS_DEVICE
-    void InitTask()
-    {
+    void InitTask() {
         if (processNewTask) {
             headInnerIdx = 0;
             baseTaskIdx = taskIdx;
@@ -168,40 +160,37 @@ struct BlockSchedulerGdnFwdO {
             return;
         }
 
-        vIdx = curTaskIdx / (shapeBatch * numChunks * vNumHead);
-        shapeBatchIdx = (curTaskIdx - vIdx * shapeBatch * numChunks * vNumHead) / (numChunks * vNumHead);
-        chunkIdx =
-            (curTaskIdx - vIdx * shapeBatch * numChunks * vNumHead - shapeBatchIdx * numChunks * vNumHead) / vNumHead;
-        baseHeadIdx = curTaskIdx % vNumHead;
+        shapeBatchIdx = curTaskIdx / (numChunks * vNumHead);
+        chunkIdx = (curTaskIdx - shapeBatchIdx * numChunks * vNumHead) / vNumHead;
+        vHeadIdx = curTaskIdx % vNumHead;
+        kHeadIdx = vHeadIdx / headGroups;
         tokenBatchIdx = isVariedLen ? gmChunkOffsets.GetValue(2 * chunkIdx) : 0;
         batchChunkIdx = isVariedLen ? gmChunkOffsets.GetValue(2 * chunkIdx + 1) : chunkIdx;
         batchChunkStartIdx = chunkIdx - batchChunkIdx;
         tokenOffset = isVariedLen ? gmSeqlen.GetValue(tokenBatchIdx) : 0;
         batchTokens = isVariedLen ? (gmSeqlen.GetValue(tokenBatchIdx + 1) - tokenOffset) : seqlen;
-
-        vHeadIdx = baseHeadIdx;
-        kHeadIdx = vHeadIdx / headGroups;
-        uint32_t vBlockOffset = vIdx * vBlockSize;
-        uint32_t vBlockDim = Min(vBlockSize, vHeadDim - vBlockOffset);
-        const int64_t tokenStart = static_cast<int64_t>(tokenOffset) + static_cast<int64_t>(batchChunkIdx) * chunkSize;
-        const int64_t qkRowOffset = (static_cast<int64_t>(shapeBatchIdx) * kNumHead + kHeadIdx) * seqlen + tokenStart;
-        const int64_t ovRowOffset = (static_cast<int64_t>(shapeBatchIdx) * vNumHead + vHeadIdx) * seqlen + tokenStart;
+        uint32_t vBlockOffset = 0;
+        uint32_t vBlockDim = vBlockSize;
+        const int64_t tokenStart = static_cast<int64_t>(tokenOffset) +
+                                   static_cast<int64_t>(batchChunkIdx) * chunkSize;
+        const int64_t qkRowOffset = (static_cast<int64_t>(shapeBatchIdx) * kNumHead + kHeadIdx) * seqlen +
+                                    tokenStart;
+        const int64_t ovRowOffset = (static_cast<int64_t>(shapeBatchIdx) * vNumHead + vHeadIdx) * seqlen +
+                                    tokenStart;
         const int64_t hBlockOffset = (static_cast<int64_t>(shapeBatchIdx) * vNumHead * numChunks +
                                       static_cast<int64_t>(vHeadIdx) * numChunks + chunkIdx) *
                                      kHeadDim;
-        const int64_t workspaceSlotIdx = static_cast<int64_t>(cubeCoreIdx) * PING_PONG_STAGES + currStage;
+        const int64_t workStageOffset = static_cast<int64_t>(cubeCoreIdx) * PING_PONG_STAGES + currStage;
         offsets[currStage].qkOffset = qkRowOffset * kHeadDim;
         offsets[currStage].ovOffset = ovRowOffset * vHeadDim + vBlockOffset;
         offsets[currStage].hOffset = hBlockOffset * vHeadDim + vBlockOffset;
         offsets[currStage].gOffset = ovRowOffset;
-        offsets[currStage].attnWorkOffset = workspaceSlotIdx * chunkSize * chunkSize;
-        offsets[currStage].hvWorkOffset = workspaceSlotIdx * chunkSize * vBlockSize;
+        offsets[currStage].attnWorkOffset = workStageOffset * chunkSize * chunkSize;
+        offsets[currStage].hvWorkOffset = workStageOffset * chunkSize * vBlockSize;
         offsets[currStage].vBlockOffset = vBlockOffset;
         offsets[currStage].vBlockDim = vBlockDim;
-        offsets[currStage].isFinalState =
-            chunkIdx == (numChunks - 1) || (isVariedLen && gmChunkOffsets.GetValue(2 * chunkIdx + 3) == 0);
-        offsets[currStage].blockTokens =
-            offsets[currStage].isFinalState ? (batchTokens - batchChunkIdx * chunkSize) : chunkSize;
+        offsets[currStage].isFinalState = chunkIdx == (numChunks - 1) || (isVariedLen && gmChunkOffsets.GetValue(2 * chunkIdx + 3) == 0);
+        offsets[currStage].blockTokens = offsets[currStage].isFinalState ? (batchTokens - batchChunkIdx * chunkSize) : chunkSize;
         offsets[currStage].batchIdx = shapeBatchIdx;
         offsets[currStage].headIdx = vHeadIdx;
         offsets[currStage].chunkIdx = chunkIdx;
@@ -215,53 +204,46 @@ struct BlockSchedulerGdnFwdO {
     }
 
     CATLASS_DEVICE
-    uint32_t GetStage(uint32_t distance) const
-    {
-        return (static_cast<uint32_t>(currStage) + PING_PONG_STAGES - distance) % PING_PONG_STAGES;
+    uint32_t GetCurStageId() const {
+        return (currStage + PING_PONG_STAGES - 1) % PING_PONG_STAGES;
     }
+
+    CATLASS_DEVICE
+    uint32_t GetPrevStageId() const {
+        return (currStage + PING_PONG_STAGES - 2) % PING_PONG_STAGES;
+    }
+
+
 };
 
 struct BlockSchedulerGdnFwdOCube : public BlockSchedulerGdnFwdO {
     CATLASS_DEVICE
-    BlockSchedulerGdnFwdOCube()
-    {
-    }
+    BlockSchedulerGdnFwdOCube() {}
 
     CATLASS_DEVICE
-    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::ChunkFwdOTilingData *tilingData)
-    {
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::ChunkFwdOTilingData *tilingData) {
         BlockSchedulerGdnFwdO::Init(cu_seqlens, chunk_offsets, tilingData, AscendC::GetBlockIdx(),
                                     AscendC::GetBlockNum());
     }
 
     CATLASS_DEVICE
-    bool NeedProcessCube1()
-    {
+    bool NeedProcessCube1() {
         return true;
     }
 
     CATLASS_DEVICE
-    GDNFwdOOffsets &GetCube1Offsets()
-    {
-        return offsets[GetCube1Stage()];
+    GDNFwdOOffsets& GetCube1Offsets() {
+        return offsets[GetCurStageId()];
     }
 
     CATLASS_DEVICE
-    uint32_t GetCube1Stage() const
-    {
-        return GetStage(1);
-    }
-
-    CATLASS_DEVICE
-    GemmCoord GetCube1Shape()
-    {
-        GDNFwdOOffsets &cube1Offsets = GetCube1Offsets();
+    GemmCoord GetCube1Shape() {
+        GDNFwdOOffsets& cube1Offsets = GetCube1Offsets();
         return GemmCoord{cube1Offsets.blockTokens, cube1Offsets.blockTokens, kHeadDim};
     }
 
     CATLASS_DEVICE
-    bool NeedProcessCube23()
-    {
+    bool NeedProcessCube23() {
         if (unlikely(firstLoop)) {
             firstLoop = false;
             return false;
@@ -270,54 +252,41 @@ struct BlockSchedulerGdnFwdOCube : public BlockSchedulerGdnFwdO {
     }
 
     CATLASS_DEVICE
-    GDNFwdOOffsets &GetCube23Offsets()
-    {
-        return offsets[GetCube23Stage()];
+    GDNFwdOOffsets& GetCube23Offsets() {
+        return offsets[GetPrevStageId()];
     }
 
     CATLASS_DEVICE
-    uint32_t GetCube23Stage() const
-    {
-        return GetStage(2);
+    GemmCoord GetCube2Shape() {
+        GDNFwdOOffsets& cube2Offsets = GetCube23Offsets();
+        return GemmCoord{cube2Offsets.blockTokens, cube2Offsets.vBlockDim, kHeadDim};
     }
 
     CATLASS_DEVICE
-    GemmCoord GetCube2Shape()
-    {
-        GDNFwdOOffsets &cube2Offsets = GetCube23Offsets();
-        return GemmCoord{kHeadDim, vHeadDim, cube2Offsets.blockTokens};
+    GemmCoord GetCube3Shape() {
+        GDNFwdOOffsets& cube2Offsets = GetCube23Offsets();
+        return GemmCoord{cube2Offsets.blockTokens, cube2Offsets.vBlockDim, cube2Offsets.blockTokens};
     }
 
-    CATLASS_DEVICE
-    GemmCoord GetCube3Shape()
-    {
-        GDNFwdOOffsets &cube2Offsets = GetCube23Offsets();
-        return GemmCoord{kHeadDim, vHeadDim, cube2Offsets.blockTokens};
-    }
 };
 
 struct BlockSchedulerGdnFwdOVec : public BlockSchedulerGdnFwdO {
     CATLASS_DEVICE
-    BlockSchedulerGdnFwdOVec()
-    {
-    }
+    BlockSchedulerGdnFwdOVec() {}
 
     CATLASS_DEVICE
-    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::ChunkFwdOTilingData *tilingData)
-    {
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::ChunkFwdOTilingData *tilingData) {
         BlockSchedulerGdnFwdO::Init(cu_seqlens, chunk_offsets, tilingData,
                                     AscendC::GetBlockIdx() / AscendC::GetSubBlockNum(), AscendC::GetBlockNum());
     }
 
     CATLASS_DEVICE
-    bool NeedProcessVec1()
-    {
+    bool NeedProcessVec1() {
         return isRunning;
     }
 
     CATLASS_DEVICE
-    bool NeedProcessVec2()
-    {
+    bool NeedProcessVec2() {
         if (unlikely(firstLoop)) {
             firstLoop = false;
             return false;
@@ -326,30 +295,17 @@ struct BlockSchedulerGdnFwdOVec : public BlockSchedulerGdnFwdO {
     }
 
     CATLASS_DEVICE
-    GDNFwdOOffsets &GetVec1Offsets()
-    {
-        return offsets[GetVec1Stage()];
+    GDNFwdOOffsets& GetVec1Offsets() {
+        return offsets[GetCurStageId()];
     }
 
     CATLASS_DEVICE
-    uint32_t GetVec1Stage() const
-    {
-        return GetStage(1);
+    GDNFwdOOffsets& GetVec2Offsets() {
+        return offsets[GetPrevStageId()];
     }
 
-    CATLASS_DEVICE
-    GDNFwdOOffsets &GetVec2Offsets()
-    {
-        return offsets[GetVec2Stage()];
-    }
-
-    CATLASS_DEVICE
-    uint32_t GetVec2Stage() const
-    {
-        return GetStage(2);
-    }
 };
 
-} // namespace Catlass::Gemm::Block
+}  // namespace Catlass::Gemm::Block
 
 #endif // CATLASS_GEMM_SCHEDULER_GDN_FWD_O_HPP

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/gemm/kernel/gdn_fwd_o_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/gemm/kernel/gdn_fwd_o_kernel.hpp
@@ -18,7 +18,8 @@
 #include "../../epilogue/block/block_epilogue_gdn_fwdo_qkmask.hpp"
 #include "../../epilogue/block/block_epilogue_gdn_fwdo_output.hpp"
 #include "catlass/gemm/block/block_mmad.hpp"
-#include "kernel_utils/block/block_mmad_pingpong_tla_multi.hpp"
+#include "kernel_utils/block/block_mmad_pingpong_tla_pipelined.hpp"
+#include "kernel_utils/tile/copy_l0c_to_ub.hpp"
 #include "catlass/gemm/block/block_swizzle.hpp"
 #include "../block/block_scheduler_gdn_fwd_o.hpp"
 #include "catlass/gemm/dispatch_policy.hpp"
@@ -48,7 +49,6 @@ using _16384 = tla::Int<16384>;
 using _32768 = tla::Int<32768>;
 using _65536 = tla::Int<65536>;
 
-
 #include "kernel_operator.h"
 #include "../../../chunk_fwd_o_struct.h"
 using namespace Catlass;
@@ -57,16 +57,21 @@ using namespace tla;
 // template <>
 namespace Catlass::Gemm::Kernel {
 
-template <typename INPUT_TYPE, typename G_TYPE, typename WORKSPACE_TYPE>
+template<
+    typename INPUT_TYPE,
+    typename G_TYPE,
+    typename WORKSPACE_TYPE
+>
 class GDNFwdOKernel {
 public:
+
     using ArchTag = Arch::Ascend950;
     using GDNFwdOOffsets = Catlass::Gemm::Block::GDNFwdOOffsets;
 
     using CubeScheduler = typename Catlass::Gemm::Block::BlockSchedulerGdnFwdOCube;
     using VecScheduler = typename Catlass::Gemm::Block::BlockSchedulerGdnFwdOVec;
 
-    using DispatchPolicyTla = Gemm::MmadPingpongTlaMulti<ArchTag, true, false>;
+    using DispatchPolicyTla = Gemm::MmadPingpongTlaGdnFwdO<ArchTag, true, false>;
     using L1TileShapeQKTla = Shape<_128, _128, _128>;
     using L0TileShapeQKTla = L1TileShapeQKTla;
     using L1TileShapeV128Tla = Shape<_128, _128, _128>;
@@ -85,52 +90,53 @@ public:
     using OType = Gemm::GemmType<INPUT_TYPE, layout::RowMajor>;
     using MaskType = Gemm::GemmType<bool, layout::RowMajor>;
 
-    static constexpr bool ENABLE_REUSE_Q_L1_FOR_QH = true;
-    static constexpr bool ENABLE_VEC1_UB_TO_L1_FOR_CUBE3 = true;
+    // === l0c2ub / ub2l1 data-path switches (docs/agents/chunk_fwd_o_l0c2ub_ub2l1_design.md) ===
+    // ENABLE_L0C2UB: Cube2/Cube3 V128 output goes L0C -> UB slot directly (skip GM workspace).
+    static constexpr bool ENABLE_L0C2UB = true;
+    // ENABLE_UB2L1: Vec1 aftermask goes UB -> L1 directly (skip GM aftermaskWorkspace).
+    static constexpr bool ENABLE_UB2L1 = false; // accurate but slower (1.02x vs 1.09x l0c2ub-only): sync overhead exceeds the GM-roundtrip saving; kept for future rework, see design doc R-7
+    // UB work-slot layout (4 x 32KB: V/H ping + V/H pong), shared contract with both epilogues.
+    static constexpr uint32_t UB_WORK_SLOT_BYTES = 64 * 128 * sizeof(float);
+    static constexpr uint32_t UB_WORK_BASE = 71 * 1024;
+    static constexpr uint32_t UB_V_WORK_PING_OFFSET = UB_WORK_BASE;
+    static constexpr uint32_t UB_H_WORK_PING_OFFSET = UB_V_WORK_PING_OFFSET + UB_WORK_SLOT_BYTES;
+    static constexpr uint32_t UB_V_WORK_PONG_OFFSET = UB_H_WORK_PING_OFFSET + UB_WORK_SLOT_BYTES;
+    static constexpr uint32_t UB_H_WORK_PONG_OFFSET = UB_V_WORK_PONG_OFFSET + UB_WORK_SLOT_BYTES;
+    // L1 head reservation for ub2l1: 2 stages x (128x128 INPUT_TYPE, zN layout).
     static constexpr uint32_t VEC1_L1_STAGES = PING_PONG_STAGES;
-    static constexpr uint32_t VEC1_L1_TILE_SIZE = 128 * 128 * sizeof(INPUT_TYPE);
+    static constexpr uint32_t VEC1_L1_TILE_BYTES = 128 * 128 * sizeof(INPUT_TYPE);
 
     // cube 1
-    using TileCopyQK = Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE,
-                                                              layout::ColumnMajor, WORKSPACE_TYPE, layout::RowMajor>;
-    using BlockMmadQK = Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeQKTla, L0TileShapeQKTla, INPUT_TYPE,
-                                                  INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyQK>;
+    using TileCopyQK = Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::ColumnMajor, WORKSPACE_TYPE, layout::RowMajor>;
+    using BlockMmadQK = Gemm::Block::BlockMmadTlaPipelined<DispatchPolicyTla, L1TileShapeQKTla, L0TileShapeQKTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyQK>;
 
-    // cube 2
-    using TileCopyQH = Catlass::Gemm::Tile::PackedTileCopyTlaToUB<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE,
-                                                                  layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor,
-                                                                  void, Catlass::Gemm::Tile::CopyL0CToUBMode::SPLIT_M>;
-    using BlockMmadQH128 = Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeV128Tla, L0TileShapeV128Tla,
-                                                     INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyQH>;
-    using BlockMmadQH256 = Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeV256Tla, L0TileShapeV256Tla,
-                                                     INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyQH>;
+    // cube 2 (V128 direct-UB variant: L0C -> UB slot via Fixpipe SPLIT_M)
+    using TileCopyQH = Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor>;
+    using TileCopyQHToUB = Common::Tile::PackedTileCopyTlaToUB<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor, void, Catlass::Gemm::Tile::CopyL0CToUBMode::SPLIT_M>;
+    using DispatchPolicyTlaShareL1A = Gemm::MmadPingpongTlaGdnFwdO<ArchTag, true, false, 1, false, true>;
+    using BlockMmadQH128 = Gemm::Block::BlockMmadTlaPipelined<DispatchPolicyTlaShareL1A, L1TileShapeV128Tla, L0TileShapeV128Tla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyQH>;
+    using BlockMmadQH256 = Gemm::Block::BlockMmadTlaPipelined<DispatchPolicyTlaShareL1A, L1TileShapeV256Tla, L0TileShapeV256Tla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyQH>;
+    using BlockMmadQH128ToUB = Gemm::Block::BlockMmadTlaPipelined<DispatchPolicyTlaShareL1A, L1TileShapeV128Tla, L0TileShapeV128Tla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyQHToUB>;
 
-    // cube 3
-    using TileCopyAttenVNEW =
-        Catlass::Gemm::Tile::PackedTileCopyTlaToUB<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::RowMajor,
-                                                   WORKSPACE_TYPE, layout::RowMajor, void,
-                                                   Catlass::Gemm::Tile::CopyL0CToUBMode::SPLIT_M>;
-    using BlockMmadAttenVNEW128 =
-        Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeV128Tla, L0TileShapeV128Tla, INPUT_TYPE, INPUT_TYPE,
-                                  WORKSPACE_TYPE, void, TileCopyAttenVNEW>;
-    using BlockMmadAttenVNEW256 =
-        Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeV256Tla, L0TileShapeV256Tla, INPUT_TYPE, INPUT_TYPE,
-                                  WORKSPACE_TYPE, void, TileCopyAttenVNEW>;
+    // cube 3 — BlockMmadTlaPipelined for overlap with Cube2 (V128 direct-UB variant included)
+    using TileCopyAttenVNEW = Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor>;
+    using TileCopyAttenVNEWToUB = Common::Tile::PackedTileCopyTlaToUB<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor, void, Catlass::Gemm::Tile::CopyL0CToUBMode::SPLIT_M>;
+    using BlockMmadAttenVNEW128 = Gemm::Block::BlockMmadTlaPipelined<DispatchPolicyTla, L1TileShapeV128Tla, L0TileShapeV128Tla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyAttenVNEW>;
+    using BlockMmadAttenVNEW256 = Gemm::Block::BlockMmadTlaPipelined<DispatchPolicyTla, L1TileShapeV256Tla, L0TileShapeV256Tla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyAttenVNEW>;
+    using BlockMmadAttenVNEW128ToUB = Gemm::Block::BlockMmadTlaPipelined<DispatchPolicyTla, L1TileShapeV128Tla, L0TileShapeV128Tla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyAttenVNEWToUB>;
 
     // vec 1
     using DispatchPolicyGDNFwdOQkmask = Epilogue::EpilogueAtlasGDNFwdOQkmask;
-    using EpilogueGDNFwdOQkmask =
-        Epilogue::Block::BlockEpilogue<DispatchPolicyGDNFwdOQkmask, AttenMaskedType, GType, AttenType, MaskType>;
+    using EpilogueGDNFwdOQkmask = Epilogue::Block::BlockEpilogue<DispatchPolicyGDNFwdOQkmask, AttenMaskedType, GType, AttenType, MaskType>;
 
     // vec 2
     using DispatchPolicyGDNFwdOOutput = Epilogue::EpilogueAtlasGDNFwdOOutput;
-    using EpilogueGDNFwdOOutput =
-        Epilogue::Block::BlockEpilogue<DispatchPolicyGDNFwdOOutput, OType, GType, OinterType, OinterType>;
+    using EpilogueGDNFwdOOutput = Epilogue::Block::BlockEpilogue<DispatchPolicyGDNFwdOOutput, OType, GType, OinterType, OinterType>;
 
     using ElementQ = typename BlockMmadQK::ElementA;
     using LayoutQ = Catlass::layout::RowMajor;
 
-    using ElementK = typename BlockMmadQK::ElementB;
+    using ElementK =  typename BlockMmadQK::ElementB;
     using LayoutK = Catlass::layout::ColumnMajor;
 
     using ElementAtten = typename BlockMmadQK::ElementC;
@@ -183,28 +189,27 @@ public:
     AscendC::GlobalTensor<ElementAtten> gmAttnWorkspace;
     AscendC::GlobalTensor<ElementAttenMasked> gmAftermaskWorkspace;
     AscendC::GlobalTensor<ElementMask> gmMask;
+
+    // ub2l1: L1 head slots holding Vec1's aftermask output (zN layout), indexed by stage.
     AscendC::LocalTensor<ElementAttenMasked> l1AttenMaskWorkspace[VEC1_L1_STAGES];
 
-    AscendC::LocalTensor<ElementAtten> ubAttenPing;
-    AscendC::LocalTensor<ElementAtten> ubAttenPong;
-    AscendC::LocalTensor<ElementOinter> ubHWorkPing;
-    AscendC::LocalTensor<ElementOinter> ubHWorkPong;
-    AscendC::LocalTensor<ElementOinter> ubVWorkPing;
-    AscendC::LocalTensor<ElementOinter> ubVWorkPong;
+    // l0c2ub: number of Fixpipe writes this AIC has issued to the UB work slots.
+    // The first PING_PONG_STAGES writes (first fill per slot stage) target slots no
+    // one has read yet, so their vec2Done wait is skipped; from then on every wait
+    // maps 1:1 to a real Vec2 consumption. A core with fewer than PING_PONG_STAGES
+    // writes never overwrote a slot, so its end-of-kernel drain waits are skipped too.
+    uint32_t l0c2ubProduceCount = 0;
 
     CubeScheduler cubeBlockScheduler;
     VecScheduler vecBlockScheduler;
 
     Arch::Resource<ArchTag> resource;
 
-    __aicore__ inline GDNFwdOKernel()
-    {
-    }
+    __aicore__ inline GDNFwdOKernel() {}
 
-    __aicore__ inline void Init(GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR h, GM_ADDR g, GM_ADDR cu_seqlens,
-                                GM_ADDR chunk_offsets, GM_ADDR o, const GDN::ChunkFwdOTilingData *tilingData,
-                                GM_ADDR user)
-    {
+    __aicore__ inline void Init(GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR h, GM_ADDR g,
+        GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, GM_ADDR o, const GDN::ChunkFwdOTilingData *tilingData, GM_ADDR user) {
+
         shapeBatch = tilingData->shapeBatch;
         seqlen = tilingData->seqlen;
         kNumHead = tilingData->kNumHead;
@@ -233,20 +238,6 @@ public:
         gmAftermaskWorkspace.SetGlobalBuffer((__gm__ ElementAttenMasked *)(user + aftermaskWorkspaceOffset));
         gmMask.SetGlobalBuffer((__gm__ ElementMask *)(user + maskWorkspaceOffset));
 
-        constexpr uint32_t UB_WORK_SLOT_BYTES = 64 * 128 * sizeof(ElementOinter);
-        constexpr uint32_t UB_WORK_BASE = 71 * 1024;
-        constexpr uint32_t UB_V_WORK_PING_OFFSET = UB_WORK_BASE;
-        constexpr uint32_t UB_H_WORK_PING_OFFSET = UB_V_WORK_PING_OFFSET + UB_WORK_SLOT_BYTES;
-        constexpr uint32_t UB_V_WORK_PONG_OFFSET = UB_H_WORK_PING_OFFSET + UB_WORK_SLOT_BYTES;
-        constexpr uint32_t UB_H_WORK_PONG_OFFSET = UB_V_WORK_PONG_OFFSET + UB_WORK_SLOT_BYTES;
-
-        ubAttenPing = resource.ubBuf.template GetBufferByByte<ElementAtten>(UB_V_WORK_PING_OFFSET);
-        ubAttenPong = resource.ubBuf.template GetBufferByByte<ElementAtten>(UB_V_WORK_PONG_OFFSET);
-        ubHWorkPing = resource.ubBuf.template GetBufferByByte<ElementOinter>(UB_H_WORK_PING_OFFSET);
-        ubHWorkPong = resource.ubBuf.template GetBufferByByte<ElementOinter>(UB_H_WORK_PONG_OFFSET);
-        ubVWorkPing = resource.ubBuf.template GetBufferByByte<ElementOinter>(UB_V_WORK_PING_OFFSET);
-        ubVWorkPong = resource.ubBuf.template GetBufferByByte<ElementOinter>(UB_V_WORK_PONG_OFFSET);
-
         if ASCEND_IS_AIC {
             cubeBlockScheduler.Init(cu_seqlens, chunk_offsets, tilingData);
         }
@@ -256,240 +247,392 @@ public:
         }
     }
 
-    __aicore__ inline void Process()
-    {
+    __aicore__ inline void Process() {
         if ASCEND_IS_AIC {
             uint32_t coreIdx = AscendC::GetBlockIdx();
             uint32_t coreNum = AscendC::GetBlockNum();
-            uint32_t subBlockNum = AscendC::GetSubBlockNum();
-            uint32_t l1BufAddrStart = ENABLE_VEC1_UB_TO_L1_FOR_CUBE3 ? VEC1_L1_TILE_SIZE * VEC1_L1_STAGES : 0;
 
-            if constexpr (ENABLE_VEC1_UB_TO_L1_FOR_CUBE3) {
+            BlockMmadQK blockMmadQK(resource);
+            BlockMmadQH128 blockMmadQH128(resource);
+            BlockMmadQH128ToUB blockMmadQH128ToUB(resource);
+            BlockMmadQH256 blockMmadQH256(resource);
+            // Cube3: independent L1 buffer and eventID (offset 4).
+            // V128 path: Cube1 L1A[0,64KB) + L1B[64KB,128KB) = 128KB total.
+            //   Cube3 starts at 128KB → no overlap.
+            // V256 path: Cube1 L1A[0,64KB) + Cube2 L1B[64KB,192KB) = 192KB total.
+            //   Cube3 must start at 192KB to avoid overlapping Cube2's L1B.
+            // Use 192KB to cover both paths safely.
+            constexpr uint32_t cube3L1Offset = 192 * 1024;
+            constexpr uint32_t cube3L1AEventId = 4;
+            constexpr uint32_t cube3L1BEventId = 6;
+            BlockMmadAttenVNEW128 blockMmadAttenVNEW128(resource, cube3L1Offset, cube3L1AEventId, cube3L1BEventId);
+            BlockMmadAttenVNEW128ToUB blockMmadAttenVNEW128ToUB(resource, cube3L1Offset, cube3L1AEventId, cube3L1BEventId);
+            BlockMmadAttenVNEW256 blockMmadAttenVNEW256(resource, cube3L1Offset, cube3L1AEventId, cube3L1BEventId);
+            // ub2l1: Vec1 aftermask slots live at the L1 tail [448KB, 512KB).
+            // The head cannot be used: SHARE_L1A pins Cube1's L1A at absolute address 0.
+            // Cube region tops out at 384KB (V256: 192KB + 128KB L1B + 64KB L1A),
+            // so the tail reservation is physically disjoint from all Cube tiles.
+            static_assert(VEC1_L1_STAGES * VEC1_L1_TILE_BYTES <= 64 * 1024, "L1 tail reservation exceeds 64KB");
+            constexpr uint32_t VEC1_L1_BASE = 512 * 1024 - VEC1_L1_STAGES * VEC1_L1_TILE_BYTES;
+            if constexpr (ENABLE_UB2L1) {
                 for (uint32_t i = 0; i < VEC1_L1_STAGES; ++i) {
-                    l1AttenMaskWorkspace[i] =
-                        resource.l1Buf.template GetBufferByByte<ElementAttenMasked>(i * VEC1_L1_TILE_SIZE);
+                    l1AttenMaskWorkspace[i] = resource.l1Buf.template GetBufferByByte<ElementAttenMasked>(
+                        VEC1_L1_BASE + i * VEC1_L1_TILE_BYTES);
                 }
+                // Pre-arm the reverse-sync flags so the AIV's first write to each
+                // slot does not block (mode-2 counter semantics: each preset lets
+                // exactly one wait pass).
+                Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.l1SlotConsumed[0]);
+                Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.l1SlotConsumed[1]);
             }
-
-            BlockMmadQK blockMmadQK(resource, l1BufAddrStart);
-            BlockMmadQH128 blockMmadQH128(resource, l1BufAddrStart);
-            BlockMmadQH256 blockMmadQH256(resource, l1BufAddrStart);
-            BlockMmadAttenVNEW128 blockMmadAttenVNEW128(resource, l1BufAddrStart);
-            BlockMmadAttenVNEW256 blockMmadAttenVNEW256(resource, l1BufAddrStart);
 
             auto qLayout = tla::MakeLayout<ElementQ, LayoutQ>(shapeBatch * kNumHead * seqlen, kHeadDim);
             auto kLayout = tla::MakeLayout<ElementK, LayoutK>(kHeadDim, shapeBatch * kNumHead * seqlen);
             auto hLayout = tla::MakeLayout<ElementH, LayoutH>(shapeBatch * vNumHead * seqlen * kHeadDim, vHeadDim);
+            auto ointerLayout = tla::MakeLayout<ElementOinter, LayoutOinter>(coreNum * chunkSize * PING_PONG_STAGES, cubeBlockScheduler.vBlockSize);
             auto vnewLayout = tla::MakeLayout<ElementVNEW, LayoutVNEW>(shapeBatch * vNumHead * seqlen, vHeadDim);
 
             bool needRun = false;
-            uint32_t cube2pingpongFlag = 0;
-            uint32_t cube3pingpongFlag = 0;
-            uint32_t l0c2ubProduceCount = 0;
-            uint32_t l0c2ubProducedStages[PING_PONG_STAGES] = {0};
 
             while (cubeBlockScheduler.isRunning) {
                 cubeBlockScheduler.InitTask();
 
+                // === Phase 1a: Cube1 operator() + waitL1Drained ===
                 if (cubeBlockScheduler.isRunning && coreIdx < coreNum) {
-                    GDNFwdOOffsets &cube1Offsets = cubeBlockScheduler.GetCube1Offsets();
-                    uint32_t cube1Stage = cubeBlockScheduler.GetCube1Stage();
+                    uint32_t streamId = cubeBlockScheduler.GetCurStageId();
+
+                    GDNFwdOOffsets& cube1Offsets = cubeBlockScheduler.GetCube1Offsets();
                     int64_t cube1OffsetQ = cube1Offsets.qkOffset;
                     int64_t cube1OffsetK = cube1Offsets.qkOffset;
                     int64_t cube1OffsetAttn = cube1Offsets.attnWorkOffset;
-                    auto attenLayout = tla::MakeLayout<ElementAtten, LayoutAtten>(
-                        coreNum * chunkSize * PING_PONG_STAGES, cube1Offsets.blockTokens);
+                    auto attenLayout = tla::MakeLayout<ElementAtten, LayoutAtten>(coreNum * chunkSize * PING_PONG_STAGES, cube1Offsets.blockTokens);
                     auto tensorQ = tla::MakeTensor(gmQ[cube1OffsetQ], qLayout, Catlass::Arch::PositionGM{});
                     auto tensorK = tla::MakeTensor(gmK[cube1OffsetK], kLayout, Catlass::Arch::PositionGM{});
-                    auto tensorAttn =
-                        tla::MakeTensor(gmAttnWorkspace[cube1OffsetAttn], attenLayout, Catlass::Arch::PositionGM{});
+                    auto tensorAttn = tla::MakeTensor(gmAttnWorkspace[cube1OffsetAttn], attenLayout, Catlass::Arch::PositionGM{});
                     GemmCoord cube1Shape{cube1Offsets.blockTokens, cube1Offsets.blockTokens, kHeadDim};
-                    auto tensorBlockQ =
-                        GetTile(tensorQ, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.k()));
-                    auto tensorBlockK =
-                        GetTile(tensorK, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.k(), cube1Shape.n()));
-                    auto tensorBlockAttn =
-                        GetTile(tensorAttn, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.n()));
+                    auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.k()));
+                    auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.k(), cube1Shape.n()));
+                    auto tensorBlockAttn = GetTile(tensorAttn, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.n()));
                     blockMmadQK.preSetFlags();
                     blockMmadQK(tensorBlockQ, tensorBlockK, tensorBlockAttn, cube1Shape);
-                    blockMmadQK.finalWaitFlags();
-                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done[cube1Stage]);
+                    blockMmadQK.waitL1Drained();
                 }
 
+                // === Phase 1b: Cube2 copyGmToL1 (overlaps with Cube1's Mmad) ===
                 if (needRun && coreIdx < coreNum) {
-                    uint32_t cube23Stage = cubeBlockScheduler.GetCube23Stage();
-                    if (l0c2ubProduceCount >= PING_PONG_STAGES) {
-                        for (uint32_t i = 0; i < subBlockNum; ++i) {
-                            Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[cube23Stage]);
-                        }
-                    }
-                    for (uint32_t i = 0; i < subBlockNum; ++i) {
-                        Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done[cube23Stage]);
-                    }
-                    GDNFwdOOffsets &cube2Offsets = cubeBlockScheduler.GetCube23Offsets();
+                    GDNFwdOOffsets& cube2Offsets = cubeBlockScheduler.GetCube23Offsets();
                     int64_t cube2OffsetQ = cube2Offsets.qkOffset;
                     int64_t cube2OffsetH = cube2Offsets.hOffset;
-                    auto cube2OinterLayout =
-                        tla::MakeLayout<ElementOinter, LayoutOinter>(cube2Offsets.blockTokens, cube2Offsets.vBlockDim);
-                    auto tensorQ = tla::MakeTensor(gmQ[cube2OffsetQ], qLayout, Catlass::Arch::PositionGM{});
+                    auto tensorQ2 = tla::MakeTensor(gmQ[cube2OffsetQ], qLayout, Catlass::Arch::PositionGM{});
                     auto tensorH = tla::MakeTensor(gmH[cube2OffsetH], hLayout, Catlass::Arch::PositionGM{});
-                    AscendC::LocalTensor<ElementOinter> ubHWork = (cube2pingpongFlag == 0) ? ubHWorkPing : ubHWorkPong;
-                    auto tensorHWork = tla::MakeTensor(ubHWork, cube2OinterLayout, Catlass::Arch::PositionUB{});
                     GemmCoord cube2Shape{cube2Offsets.blockTokens, cube2Offsets.vBlockDim, kHeadDim};
-                    auto tensorBlockQ =
-                        GetTile(tensorQ, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.k()));
-                    auto tensorBlockH =
-                        GetTile(tensorH, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.k(), cube2Shape.n()));
-                    if (cube2Offsets.vBlockDim <= 128) {
-                        blockMmadQH128.preSetFlags();
-                        if constexpr (ENABLE_REUSE_Q_L1_FOR_QH) {
-                            blockMmadQH128.SkipNextADataCopy();
+                    auto tensorBlockQ2 = GetTile(tensorQ2, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.k()));
+                    auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.k(), cube2Shape.n()));
+                    // The same instance must be used for copyGmToL1 here and executeCompute in
+                    // Phase 2: per-instance l1ListId/event bookkeeping must stay in lockstep.
+                    if constexpr (ENABLE_L0C2UB) {
+                        if (cube2Offsets.vBlockDim <= 128) {
+                            blockMmadQH128ToUB.preSetL1Flags();
+                            blockMmadQH128ToUB.copyGmToL1(tensorBlockQ2, tensorBlockH, cube2Shape);
+                        } else {
+                            blockMmadQH256.preSetL1Flags();
+                            blockMmadQH256.copyGmToL1(tensorBlockQ2, tensorBlockH, cube2Shape);
                         }
-                        blockMmadQH128(tensorBlockQ, tensorBlockH, tensorHWork, cube2Shape);
-                        blockMmadQH128.finalWaitFlags();
                     } else {
-                        blockMmadQH256.preSetFlags();
-                        if constexpr (ENABLE_REUSE_Q_L1_FOR_QH) {
-                            blockMmadQH256.SkipNextADataCopy();
+                        if (cube2Offsets.vBlockDim <= 128) {
+                            blockMmadQH128.preSetL1Flags();
+                            blockMmadQH128.copyGmToL1(tensorBlockQ2, tensorBlockH, cube2Shape);
+                        } else {
+                            blockMmadQH256.preSetL1Flags();
+                            blockMmadQH256.copyGmToL1(tensorBlockQ2, tensorBlockH, cube2Shape);
                         }
-                        blockMmadQH256(tensorBlockQ, tensorBlockH, tensorHWork, cube2Shape);
-                        blockMmadQH256.finalWaitFlags();
                     }
-                    cube2pingpongFlag = 1 - cube2pingpongFlag;
                 }
 
-                AscendC::PipeBarrier<PIPE_MTE2>();
-                AscendC::PipeBarrier<PIPE_FIX>();
+                // === Phase 1c: Cube1 waitL0Drained + cube1Done ===
+                if (cubeBlockScheduler.isRunning && coreIdx < coreNum) {
+                    uint32_t streamId = cubeBlockScheduler.GetCurStageId();
+                    blockMmadQK.waitL0Drained();
+                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done[streamId]);
+                }
 
+                // === Phase 2: Cube2 executeCompute + Cube3 copyGmToL1 (overlapped) ===
                 if (needRun && coreIdx < coreNum) {
-                    GDNFwdOOffsets &cube3Offsets = cubeBlockScheduler.GetCube23Offsets();
+                    uint32_t streamId = cubeBlockScheduler.GetPrevStageId();
+                    // First write per slot stage has no previous data to protect, so
+                    // skip the vec2Done wait — this keeps flag credits strictly paired
+                    // with real Vec2 consumptions. With the AIV startup preset removed
+                    // (see the AIV entry below), a preset credit can no longer be
+                    // spent by an early Fixpipe while the slower subBlock is still
+                    // reading the slot — that race was the intermittent garbage rows.
+                    if (l0c2ubProduceCount >= PING_PONG_STAGES) {
+                        Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[streamId]);
+                    }
+                    ++l0c2ubProduceCount;
+                    GDNFwdOOffsets& cube2Offsets = cubeBlockScheduler.GetCube23Offsets();
+                    int64_t cube2OffsetHWork = cube2Offsets.hvWorkOffset;
+                    auto tensorHWork = tla::MakeTensor(gmHWorkspace[cube2OffsetHWork], ointerLayout, Catlass::Arch::PositionGM{});
+                    GemmCoord cube2Shape{cube2Offsets.blockTokens, cube2Offsets.vBlockDim, kHeadDim};
+                    auto tensorBlockHWork = GetTile(tensorHWork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.n()));
+                    // l0c2ub: Cube2 V128 output goes to its UB work slot (indexed by the
+                    // stage the Vec2 consumer will read); V256 keeps the GM workspace path.
+                    auto ubHWorkSlot = resource.ubBuf.template GetBufferByByte<ElementOinter>(
+                        (streamId == 0) ? UB_H_WORK_PING_OFFSET : UB_H_WORK_PONG_OFFSET);
+                    auto tensorHWorkUb = tla::MakeTensor(ubHWorkSlot,
+                        tla::MakeLayout<ElementOinter, LayoutOinter>(cube2Shape.m(), cube2Shape.n()),
+                        Catlass::Arch::PositionUB{});
+                    auto tensorBlockHWorkUb = GetTile(tensorHWorkUb, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.n()));
+                    // Cube3 offsets/shapes (computed early for V preload)
+                    GDNFwdOOffsets& cube3Offsets = cubeBlockScheduler.GetCube23Offsets();
                     int64_t cube3OffsetAttnMask = cube3Offsets.attnWorkOffset;
                     int64_t cube3OffsetV = cube3Offsets.ovOffset;
-                    auto ointerLayout =
-                        tla::MakeLayout<ElementOinter, LayoutOinter>(cube3Offsets.blockTokens, cube3Offsets.vBlockDim);
-                    auto attenLayout = tla::MakeLayout<ElementAtten, LayoutAtten>(
-                        coreNum * chunkSize * PING_PONG_STAGES, cube3Offsets.blockTokens);
-                    auto tensorAttnMask = tla::MakeTensor(gmAftermaskWorkspace[cube3OffsetAttnMask], attenLayout,
-                                                          Catlass::Arch::PositionGM{});
+                    auto attenLayout = tla::MakeLayout<ElementAtten, LayoutAtten>(coreNum * chunkSize * PING_PONG_STAGES, cube3Offsets.blockTokens);
+                    auto tensorAttnMask = tla::MakeTensor(gmAftermaskWorkspace[cube3OffsetAttnMask], attenLayout, Catlass::Arch::PositionGM{});
                     auto tensorV = tla::MakeTensor(gmV[cube3OffsetV], vnewLayout, Catlass::Arch::PositionGM{});
-                    AscendC::LocalTensor<ElementOinter> ubVWork = (cube3pingpongFlag == 0) ? ubVWorkPing : ubVWorkPong;
-                    auto tensorVWork = tla::MakeTensor(ubVWork, ointerLayout, Catlass::Arch::PositionUB{});
                     GemmCoord cube3Shape{cube3Offsets.blockTokens, cube3Offsets.vBlockDim, cube3Offsets.blockTokens};
-                    auto tensorBlockAttnMask =
-                        GetTile(tensorAttnMask, tla::MakeCoord(0, 0), tla::MakeShape(cube3Shape.m(), cube3Shape.k()));
-                    auto tensorBlockV =
-                        GetTile(tensorV, tla::MakeCoord(0, 0), tla::MakeShape(cube3Shape.k(), cube3Shape.n()));
-                    if (cube3Offsets.vBlockDim <= 128) {
-                        blockMmadAttenVNEW128.preSetFlags();
-                        if constexpr (ENABLE_VEC1_UB_TO_L1_FOR_CUBE3) {
-                            uint32_t l1Stage = cubeBlockScheduler.GetCube23Stage();
-                            blockMmadAttenVNEW128.UseExternalL1ATensor(l1AttenMaskWorkspace[l1Stage]);
+                    auto tensorBlockAttnMask = GetTile(tensorAttnMask, tla::MakeCoord(0, 0), tla::MakeShape(cube3Shape.m(), cube3Shape.k()));
+                    auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), tla::MakeShape(cube3Shape.k(), cube3Shape.n()));
+                    auto ubVWorkSlot = resource.ubBuf.template GetBufferByByte<ElementOinter>(
+                        (streamId == 0) ? UB_V_WORK_PING_OFFSET : UB_V_WORK_PONG_OFFSET);
+                    auto tensorVWorkUb = tla::MakeTensor(ubVWorkSlot,
+                        tla::MakeLayout<ElementOinter, LayoutOinter>(cube3Shape.m(), cube3Shape.n()),
+                        Catlass::Arch::PositionUB{});
+                    int64_t cube3OffsetVWork = cube3Offsets.hvWorkOffset;
+                    auto tensorVWork = tla::MakeTensor(gmVWorkspace[cube3OffsetVWork], ointerLayout, Catlass::Arch::PositionGM{});
+                    auto tensorBlockVWork = GetTile(tensorVWork, tla::MakeCoord(0, 0), tla::MakeShape(cube3Shape.m(), cube3Shape.n()));
+                    auto tensorBlockVWorkUb = GetTile(tensorVWorkUb, tla::MakeCoord(0, 0), tla::MakeShape(cube3Shape.m(), cube3Shape.n()));
+                    constexpr bool cubeToUb128 = ENABLE_L0C2UB;  // V128-only by the vBlockDim guards below
+                    // Cube3: preload V (L1B) before Cube2 executeCompute — V has no cross-core dependency
+                    if constexpr (cubeToUb128) {
+                        if (cube3Offsets.vBlockDim <= 128) {
+                            blockMmadAttenVNEW128ToUB.preSetL1Flags();
+                            blockMmadAttenVNEW128ToUB.copyGmToL1BOnly(tensorBlockV, cube3Shape);
+                        } else {
+                            blockMmadAttenVNEW256.preSetL1Flags();
+                            blockMmadAttenVNEW256.copyGmToL1BOnly(tensorBlockV, cube3Shape);
                         }
-                        blockMmadAttenVNEW128(tensorBlockAttnMask, tensorBlockV, tensorVWork, cube3Shape);
-                        blockMmadAttenVNEW128.finalWaitFlags();
                     } else {
-                        blockMmadAttenVNEW256.preSetFlags();
-                        if constexpr (ENABLE_VEC1_UB_TO_L1_FOR_CUBE3) {
-                            uint32_t l1Stage = cubeBlockScheduler.GetCube23Stage();
-                            blockMmadAttenVNEW256.UseExternalL1ATensor(l1AttenMaskWorkspace[l1Stage]);
+                        if (cube3Offsets.vBlockDim <= 128) {
+                            blockMmadAttenVNEW128.preSetL1Flags();
+                            blockMmadAttenVNEW128.copyGmToL1BOnly(tensorBlockV, cube3Shape);
+                        } else {
+                            blockMmadAttenVNEW256.preSetL1Flags();
+                            blockMmadAttenVNEW256.copyGmToL1BOnly(tensorBlockV, cube3Shape);
                         }
-                        blockMmadAttenVNEW256(tensorBlockAttnMask, tensorBlockV, tensorVWork, cube3Shape);
-                        blockMmadAttenVNEW256.finalWaitFlags();
                     }
-                    cube3pingpongFlag = 1 - cube3pingpongFlag;
-                    l0c2ubProducedStages[l0c2ubProduceCount % PING_PONG_STAGES] = cubeBlockScheduler.GetCube23Stage();
-                    ++l0c2ubProduceCount;
-                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(
-                        cubeBlockScheduler.cube3Done[cubeBlockScheduler.GetCube23Stage()]);
+                    // Cube2: executeCompute (L0 Mmad overlaps with Cube3's V GM->L1B above)
+                    if constexpr (cubeToUb128) {
+                        if (cube2Offsets.vBlockDim <= 128) {
+                            blockMmadQH128ToUB.preSetL0Flags();
+                            blockMmadQH128ToUB.executeCompute(tensorBlockHWorkUb, cube2Shape);
+                        } else {
+                            blockMmadQH256.preSetL0Flags();
+                            blockMmadQH256.executeCompute(tensorBlockHWork, cube2Shape);
+                        }
+                    } else {
+                        if (cube2Offsets.vBlockDim <= 128) {
+                            blockMmadQH128.preSetL0Flags();
+                            blockMmadQH128.executeCompute(tensorBlockHWork, cube2Shape);
+                        } else {
+                            blockMmadQH256.preSetL0Flags();
+                            blockMmadQH256.executeCompute(tensorBlockHWork, cube2Shape);
+                        }
+                    }
+                    // Cube3: acquire AttnMasked (L1A) — depends on vec1Done.
+                    // ub2l1: Vec1 already wrote the aftermask into the L1 tail slot for
+                    // this stage; consume it directly and skip the GM->L1A copy.
+                    Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done[streamId]);
+                    if constexpr (ENABLE_UB2L1) {
+                        // SSBuffer visibility barrier (PR #245 pattern + MTE1): drain
+                        // inbound L1 writes (MTE2), FIX and the MTE1 reader queue itself
+                        // so the L1A reads below are ordered after all landed data.
+                        AscendC::PipeBarrier<PIPE_MTE2>();
+                        AscendC::PipeBarrier<PIPE_FIX>();
+                        AscendC::PipeBarrier<PIPE_MTE1>();
+                        if (cube3Offsets.vBlockDim <= 128) {
+                            if constexpr (cubeToUb128) {
+                                blockMmadAttenVNEW128ToUB.UseExternalL1ATensor(l1AttenMaskWorkspace[streamId]);
+                            } else {
+                                blockMmadAttenVNEW128.UseExternalL1ATensor(l1AttenMaskWorkspace[streamId]);
+                            }
+                        } else {
+                            blockMmadAttenVNEW256.UseExternalL1ATensor(l1AttenMaskWorkspace[streamId]);
+                        }
+                    } else if (cube3Offsets.vBlockDim <= 128) {
+                        if constexpr (cubeToUb128) {
+                            blockMmadAttenVNEW128ToUB.copyGmToL1AOnly(tensorBlockAttnMask, cube3Shape);
+                        } else {
+                            blockMmadAttenVNEW128.copyGmToL1AOnly(tensorBlockAttnMask, cube3Shape);
+                        }
+                    } else {
+                        blockMmadAttenVNEW256.copyGmToL1AOnly(tensorBlockAttnMask, cube3Shape);
+                    }
+                    if constexpr (cubeToUb128) {
+                        if (cube2Offsets.vBlockDim <= 128) { blockMmadQH128ToUB.finalWaitFlags(); }
+                        else { blockMmadQH256.finalWaitFlags(); }
+                    } else {
+                        if (cube2Offsets.vBlockDim <= 128) { blockMmadQH128.finalWaitFlags(); }
+                        else { blockMmadQH256.finalWaitFlags(); }
+                    }
+                    if constexpr (cubeToUb128) {
+                        if (cube3Offsets.vBlockDim <= 128) {
+                            blockMmadAttenVNEW128ToUB.preSetL0Flags();
+                            blockMmadAttenVNEW128ToUB.executeCompute(tensorBlockVWorkUb, cube3Shape);
+                            blockMmadAttenVNEW128ToUB.finalWaitFlags();
+                        } else {
+                            blockMmadAttenVNEW256.preSetL0Flags();
+                            blockMmadAttenVNEW256.executeCompute(tensorBlockVWork, cube3Shape);
+                            blockMmadAttenVNEW256.finalWaitFlags();
+                        }
+                    } else {
+                        if (cube3Offsets.vBlockDim <= 128) {
+                            blockMmadAttenVNEW128.preSetL0Flags();
+                            blockMmadAttenVNEW128.executeCompute(tensorBlockVWork, cube3Shape);
+                            blockMmadAttenVNEW128.finalWaitFlags();
+                        } else {
+                            blockMmadAttenVNEW256.preSetL0Flags();
+                            blockMmadAttenVNEW256.executeCompute(tensorBlockVWork, cube3Shape);
+                            blockMmadAttenVNEW256.finalWaitFlags();
+                        }
+                    }
+                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube3Done[streamId]);
+                    if constexpr (ENABLE_UB2L1) {
+                        // ub2l1 reverse sync: drain Cube3's MTE1 queue (the actual L1A
+                        // reader) before releasing the slot — finalWaitFlags covers the
+                        // L0 pipeline but the MTE1 drain makes the release strictly
+                        // after the last L1A read has retired.
+                        AscendC::PipeBarrier<PIPE_MTE1>();
+                        Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.l1SlotConsumed[streamId]);
+                    }
                 }
                 needRun = true;
             }
-
-            uint32_t l0c2ubDrainCount = (l0c2ubProduceCount < PING_PONG_STAGES) ? l0c2ubProduceCount : PING_PONG_STAGES;
-            uint32_t l0c2ubDrainStart = l0c2ubProduceCount - l0c2ubDrainCount;
-            for (uint32_t drainIdx = 0; drainIdx < l0c2ubDrainCount; ++drainIdx) {
-                uint32_t drainStage = l0c2ubProducedStages[(l0c2ubDrainStart + drainIdx) % PING_PONG_STAGES];
-                for (uint32_t subIdx = 0; subIdx < subBlockNum; ++subIdx) {
-                    Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[drainStage]);
-                }
+            // End-of-kernel drain: only a core that overwrote a slot (>= PING_PONG_STAGES
+            // Fixpipe writes) has an in-flight Vec2 consumption left to wait for. Cores
+            // with 0/1 writes never raced a reader, and with the startup preset removed
+            // there is no credit for their wait to consume — waiting would deadlock
+            // (task counts below coreNum leave such cores idle-but-waiting).
+            if (l0c2ubProduceCount >= PING_PONG_STAGES) {
+                Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[0]);
+                Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done[1]);
             }
         }
 
         if ASCEND_IS_AIV {
+
             uint32_t coreIdx = AscendC::GetBlockIdx();
             uint32_t coreNum = AscendC::GetBlockNum();
             uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
             uint32_t subBlockNum = AscendC::GetSubBlockNum();
 
-            if constexpr (ENABLE_VEC1_UB_TO_L1_FOR_CUBE3) {
+            // NOTE: no startup preset of vec2Done. The AIC skips the vec2Done wait
+            // for the first write of each slot stage, so the flags start un-credited
+            // and every later AIC wait maps 1:1 to a real Vec2 consumption. The old
+            // preset over-credited the flags, and an early Fixpipe could spend that
+            // credit before the slower subBlock finished reading the slot — the
+            // intermittent garbage rows seen only under cross-device parallel load.
+
+            // ub2l1: mirror the AIC-side L1 tail slots (same physical L1 per block).
+            static_assert(VEC1_L1_STAGES * VEC1_L1_TILE_BYTES <= 64 * 1024, "L1 tail reservation exceeds 64KB");
+            constexpr uint32_t VEC1_L1_BASE = 512 * 1024 - VEC1_L1_STAGES * VEC1_L1_TILE_BYTES;
+            if constexpr (ENABLE_UB2L1) {
                 for (uint32_t i = 0; i < VEC1_L1_STAGES; ++i) {
-                    l1AttenMaskWorkspace[i] =
-                        resource.l1Buf.template GetBufferByByte<ElementAttenMasked>(i * VEC1_L1_TILE_SIZE);
+                    l1AttenMaskWorkspace[i] = resource.l1Buf.template GetBufferByByte<ElementAttenMasked>(
+                        VEC1_L1_BASE + i * VEC1_L1_TILE_BYTES);
                 }
             }
 
             AscendC::LocalTensor<float> maskUbTensor = resource.ubBuf.template GetBufferByByte<float>(0);
-            AscendC::Duplicate<float>(maskUbTensor, (float)0.0, 64 * 64);
+            AscendC::Duplicate<float>(maskUbTensor, (float)0.0, 64*64);
             AscendC::PipeBarrier<PIPE_V>();
-            for (uint32_t i = 0; i < 64; ++i)
-                AscendC::Duplicate<float>(maskUbTensor[i * 64], (float)1.0, i + 1);
+            for(uint32_t i = 0; i < 64; ++ i) AscendC::Duplicate<float>(maskUbTensor[i * 64], (float)1.0, i + 1);
             AscendC::PipeBarrier<PIPE_V>();
 
             bool needRun = false;
-            uint32_t vec1pingpongFlag = 0;
-            uint32_t vec2pingpongFlag = 0;
-            bool vec2Mte3Pending = false;
-            uint32_t vec2Mte3PendingEvent = 0;
+            uint32_t pingpongFlag = 0;
 
             while (vecBlockScheduler.isRunning) {
                 vecBlockScheduler.InitTask();
 
                 if (vecBlockScheduler.isRunning && coreIdx < coreNum * subBlockNum) {
-                    if (vec2Mte3Pending) {
-                        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(vec2Mte3PendingEvent);
-                        vec2Mte3Pending = false;
-                    }
-                    uint32_t vec1Stage = vecBlockScheduler.GetVec1Stage();
-                    Arch::CrossCoreWaitFlag(vecBlockScheduler.cube1Done[vec1Stage]);
-                    GDNFwdOOffsets &vec1Offsets = vecBlockScheduler.GetVec1Offsets();
+                    uint32_t streamId = vecBlockScheduler.GetCurStageId();
+                    GDNFwdOOffsets& vec1Offsets = vecBlockScheduler.GetVec1Offsets();
                     int64_t vec1OffsetAttnMask = vec1Offsets.attnWorkOffset;
                     int64_t vec1OffsetG = vec1Offsets.gOffset;
                     int64_t vec1OffsetAttn = vec1Offsets.attnWorkOffset;
                     EpilogueGDNFwdOQkmask epilogueGDNFwdOQkmask(resource);
-                    if constexpr (ENABLE_VEC1_UB_TO_L1_FOR_CUBE3) {
-                        epilogueGDNFwdOQkmask.EnableL1Output(l1AttenMaskWorkspace[vec1Stage]);
+                    if constexpr (ENABLE_UB2L1) {
+                        // ub2l1: Vec1 writes its aftermask into the L1 tail slot of this
+                        // stage instead of the GM aftermask workspace. Wait for the
+                        // reverse-sync flag first: Cube3's previous MTE1 read of this
+                        // slot must have completed before the SSBuffer write overwrites it.
+                        Arch::CrossCoreWaitFlag(vecBlockScheduler.l1SlotConsumed[streamId]);
+                        epilogueGDNFwdOQkmask.EnableL1Output(l1AttenMaskWorkspace[streamId]);
                     }
-                    epilogueGDNFwdOQkmask(gmAftermaskWorkspace[vec1OffsetAttnMask], gmG[vec1OffsetG],
-                                          gmAttnWorkspace[vec1OffsetAttn], gmMask, chunkSize, vec1Offsets.blockTokens,
-                                          kHeadDim, vHeadDim, vec1pingpongFlag, vec1Offsets.batchIdx,
-                                          vec1Offsets.headIdx, vec1Offsets.chunkIdx);
-                    vec1pingpongFlag = 1 - vec1pingpongFlag;
-                    Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec1Done[vec1Stage]);
+                    epilogueGDNFwdOQkmask(
+                        gmAftermaskWorkspace[vec1OffsetAttnMask],
+                        gmG[vec1OffsetG], gmAttnWorkspace[vec1OffsetAttn], gmMask,
+                        chunkSize, vec1Offsets.blockTokens, kHeadDim, vHeadDim, pingpongFlag, vec1Offsets.batchIdx, vec1Offsets.headIdx, vec1Offsets.chunkIdx,
+                        &vecBlockScheduler.cube1Done[streamId]
+                    );
+                    if constexpr (ENABLE_UB2L1) {
+                        // ub2l1: drain this AIV's MTE3 queue first so the SSBuffer write
+                        // (CopyOutputToL1) has fully left the Vector core before the
+                        // completion flag becomes visible to the AIC.
+                        AscendC::PipeBarrier<PIPE_MTE3>();
+                    }
+                    Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec1Done[streamId]);
                 }
 
+                // AscendC::PipeBarrier<PIPE_ALL>();
+
                 if (needRun && coreIdx < coreNum * subBlockNum) {
-                    uint32_t vec2Stage = vecBlockScheduler.GetVec2Stage();
-                    Arch::CrossCoreWaitFlag(vecBlockScheduler.cube3Done[vec2Stage]);
-                    GDNFwdOOffsets &vec2Offsets = vecBlockScheduler.GetVec2Offsets();
+                    uint32_t streamId = vecBlockScheduler.GetPrevStageId();
+                    GDNFwdOOffsets& vec2Offsets = vecBlockScheduler.GetVec2Offsets();
                     int64_t vec2OffsetO = vec2Offsets.ovOffset;
                     int64_t vec2OffsetG = vec2Offsets.gOffset;
-                    AscendC::LocalTensor<ElementOinter> ubVWork = (vec2pingpongFlag == 0) ? ubVWorkPing : ubVWorkPong;
-                    AscendC::LocalTensor<ElementOinter> ubHWork = (vec2pingpongFlag == 0) ? ubHWorkPing : ubHWorkPong;
+                    int64_t vec2OffsetVWork = vec2Offsets.hvWorkOffset;
+                    int64_t vec2OffsetHWork = vec2Offsets.hvWorkOffset;
                     EpilogueGDNFwdOOutput epilogueGDNFwdOOutput(resource);
-                    epilogueGDNFwdOOutput(gmO[vec2OffsetO], gmG[vec2OffsetG], ubVWork, ubHWork, scale,
-                                          vec2Offsets.blockTokens, kHeadDim, vec2Offsets.vBlockDim, vHeadDim,
-                                          vec2pingpongFlag, vec2Mte3Pending, vec2Mte3PendingEvent, vec2Offsets.batchIdx,
-                                          vec2Offsets.headIdx, vec2Offsets.chunkIdx);
-                    Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done[vec2Stage]);
-                    vec2pingpongFlag = 1 - vec2pingpongFlag;
+                    if constexpr (ENABLE_L0C2UB) {
+                        if (vec2Offsets.vBlockDim <= 128) {
+                            // l0c2ub: read Cube2/Cube3 results straight from the UB work
+                            // slots of this stage (Fixpipe wrote them there directly).
+                            auto ubVWork = resource.ubBuf.template GetBufferByByte<ElementOinter>(
+                                (streamId == 0) ? UB_V_WORK_PING_OFFSET : UB_V_WORK_PONG_OFFSET);
+                            auto ubHWork = resource.ubBuf.template GetBufferByByte<ElementOinter>(
+                                (streamId == 0) ? UB_H_WORK_PING_OFFSET : UB_H_WORK_PONG_OFFSET);
+                            epilogueGDNFwdOOutput(
+                                gmO[vec2OffsetO],
+                                gmG[vec2OffsetG], ubVWork, ubHWork,
+                                scale, vec2Offsets.blockTokens, kHeadDim, vec2Offsets.vBlockDim, vHeadDim, pingpongFlag, vec2Offsets.batchIdx, vec2Offsets.headIdx, vec2Offsets.chunkIdx,
+                                &vecBlockScheduler.cube3Done[streamId],
+                                &vecBlockScheduler.vec2Done[streamId]
+                            );
+                        } else {
+                            epilogueGDNFwdOOutput(
+                                gmO[vec2OffsetO],
+                                gmG[vec2OffsetG], gmVWorkspace[vec2OffsetVWork], gmHWorkspace[vec2OffsetHWork],
+                                scale, vec2Offsets.blockTokens, kHeadDim, vec2Offsets.vBlockDim, vHeadDim, pingpongFlag, vec2Offsets.batchIdx, vec2Offsets.headIdx, vec2Offsets.chunkIdx,
+                                &vecBlockScheduler.cube3Done[streamId],
+                                &vecBlockScheduler.vec2Done[streamId]
+                            );
+                        }
+                    } else {
+                        epilogueGDNFwdOOutput(
+                            gmO[vec2OffsetO],
+                            gmG[vec2OffsetG], gmVWorkspace[vec2OffsetVWork], gmHWorkspace[vec2OffsetHWork],
+                            scale, vec2Offsets.blockTokens, kHeadDim, vec2Offsets.vBlockDim, vHeadDim, pingpongFlag, vec2Offsets.batchIdx, vec2Offsets.headIdx, vec2Offsets.chunkIdx,
+                            &vecBlockScheduler.cube3Done[streamId],
+                            &vecBlockScheduler.vec2Done[streamId]
+                        );
+                    }
                 }
                 needRun = true;
             }
-            if (vec2Mte3Pending) {
-                AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(vec2Mte3PendingEvent);
-            }
         }
     }
+
 };
 
-} // namespace Catlass::Gemm::Kernel
+}

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/epilogue/gdn_fwd_o_epilogue_policies.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/epilogue/gdn_fwd_o_epilogue_policies.hpp
@@ -15,19 +15,11 @@
 namespace Catlass::Epilogue {
 
 struct EpilogueAtlasGDNFwdOQkmask {
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
-    using ArchTag = Arch::Ascend950;
-#else
     using ArchTag = Arch::AtlasA2;
-#endif
 };
 
 struct EpilogueAtlasGDNFwdOOutput {
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
-    using ArchTag = Arch::Ascend950;
-#else
     using ArchTag = Arch::AtlasA2;
-#endif
 };
 
 }  // namespace Catlass::Epilogue


### PR DESCRIPTION
## 关联 Issue / 背景

- 关联 Issue: 无直接关联 Issue（延续 #434 的 chunk_fwd_o 算子内部优化，不涉及公开接口变更）
- 背景与目标: 基于 #434 合入后的 origin/main 基线。#434 为 A5 (arch35) 引入了 l0c2ub、RegBase、Q 复用、ub2l1 等优化，但实现为串行 `operator()` + 全量 flag 屏障的语义直搬，三个 GEMM 仍串行执行。本 PR 将 chunk_fwd_o A5 实现重构为 **BlockMmadTlaPipelined 拆相流水线架构**（policy、基类特化与拆相层合并于 `block_mmad_pingpong_tla_pipelined.hpp` 单文件）：把单个 GEMM 拆为「GM→L1 搬运相」（仅触碰 L1 flag）与「L0 装载 + Mmad + L0C 输出相」（L0 flag），配合细粒度 flag API 与 Cube3 独立 L1 分区/eventID，使相邻 Cube 的搬运与计算在同核重叠；并将 l0c2ub 直通（L0C→Fixpipe(SPLIT_M)→UB 槽）落地到该架构，消除 Cube2/Cube3 V128 输出的 GM 往返。同时修复重构暴露的三处正确性缺陷，并合入 `block_epilogue_gdn_fwdo_output.hpp` 与 `gdn_fwd_o_kernel.hpp` 的精度修复。
- 本 PR 解决的问题:
  - 拆相流水线架构（新增 `block_mmad_pingpong_tla_pipelined.hpp`，1181 行）：GEMM 拆相 + 细粒度 flag API（`waitL1Drained`/`preSetL1Flags`/`waitL0Drained`/`preSetL0Flags`，替代全量屏障）+ 操作数级拆分搬运（`copyGmToL1AOnly`/`copyGmToL1BOnly`）
  - 跨 Cube 三段重叠编排（kernel Process 显式 Phase 序列）：Cube2 GM→L1 与 Cube1 Mmad 重叠；Cube3 V 预载与 Cube2 Mmad 重叠；AttnMasked 等 vec1Done 后单独载入
  - Cube3 独立 L1 分区（192KB 偏移）与独立 eventID 段，支撑三 Cube 并行占用 L1 与事件通道
  - l0c2ub 直通落地：Cube2/Cube3 V128 输出 L0C→Fixpipe(SPLIT_M)→UB slot 直通，消除每任务 2 次 GM 写 + 2 次 GM 读；UB 布局 247KB ≤ 248KB（基础区 + 4×32KB Cube 工作槽 + Vec1/Vec2 分时 scratch），调度器/flag 0-7 布局零改动
  - 调度器去 vLoops：任务粒度改为 chunk×head 整块，V256 单块整算走 GM 路径，消除 V 切分导致的 Cube1/Vec1 重复执行
  - RegBase VF 融合重写：因果掩码 Mins→Exp→Mul(mask) 逐行融合核（尾块 UpdateMask）；输出 Mul(H,exp(g))→Add(attn)→Muls(scale) 全融合（2/4 寄存器组连续流水）
  - 同步协议修复：SPLIT_M 双目标消费偏移、chunk128 stage 行偏移、vec2Done 提前释放竞争（UB 路径改为消费后 PIPE_V 释放）；vec2Done 信用记账重算（删除 AIV 启动预置，修复跨设备并行负载下偶发脏行）；out scratch 真 ping-pong + MTE3_V 握手
  - ub2l1 保留与入口分流：新增 l1SlotConsumed 反向同步 flag 与 CopyOutputToL1 尾部 MTE3_V fence（`ENABLE_UB2L1=false`：同步代价超过 GM 往返收益，实测 1.02x/1.03x）；入口沿用上游 TilingKey 分流：Key=1 → 本实现（A5 默认）；Key=2 use_exp2+BSND/TND → #435 A5 实现（保留不动）

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [x] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: chunk_fwd_o（chunk_gdn_fwd 前向 O）
- 涉及目录 / 文件:
  - `fla/ops/ascendc/common/kernel_utils/block/block_mmad_pingpong_tla_pipelined.hpp`（新增，1181 行）
  - `fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/arch35/` 下 5 个文件（epilogue output/qkmask、epilogue policies、block scheduler、kernel）
  - `fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_fwd_o/op_kernel/epilogue/gdn_fwd_o_epilogue_policies.hpp`（移除 `__CCE_AICORE__==310` 条件分支）
- 责任人 / 提交人: @seinage
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 不变（纯 kernel 内部数据通路与调度优化）
- 明确不包含的范围: TilingKey=2 路径（#435 A5 实现）保留不动；ub2l1 路径保留代码但默认关闭；测试用例扩展不在本 PR 提交范围
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
  说明：`common/kernel_utils` 下为纯新增文件，当前仅被 chunk_fwd_o arch35 kernel 引用，不影响其他算子；非 arch35 epilogue policies 仅移除条件编译（A2/A3 路径 ArchTag 原本即为 AtlasA2，行为等价）
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 不涉及

<details>
<summary>修改算子测试</summary>

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.2 | `bash build.sh --pkg --soc=ascend910b --ops=chunk_fwd_o --vendor_name=fla_npu` + 安装 | 通过（编译+安装） |  |
| A3 | `ascend910_93` | 9.2 | `bash build.sh --pkg --soc=ascend910_93 --ops=chunk_fwd_o --vendor_name=fla_npu` + 安装 | 通过（编译+安装） |  |
| A5 | `ascend950` | 9.2 | 构建 + 安装后 msprof op 级 A/B 采集 | 通过 | 编译安装通过；性能数据见下 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | — | 不涉及 | 本 PR kernel 改动全部位于 arch35（A5 专用）目录，A2 运行路径 kernel 逻辑未变，仅验证编译+安装（已通过） |
| A3 | `ascend910_93` | — | 不涉及 | 同 A2：非 arch35 改动仅为行为等价的条件编译清理，运行逻辑未变 |
| A5 | `ascend950` | `torch_custom/fla_npu/test/test_npu_fwd_o_generalization.py` | 通过 | 分支内 3 用例 PASS；本地扩展用例集 9/9 PASS；32 条模型用例 + 1400 条泛化用例与合入前基线输出二进制一致（详见精度对比） |

- 精度对比: A5 扩展用例集 9/9 PASS（dense MHA / GVA / varlen / 尾块 / V256 场景）；另覆盖 32 条真实模型形状用例与 1400 条泛化用例，与合入前基线（origin/main 构建）逐用例比对，输出二进制完全一致（bit-exact），确认 l0c2ub 直通重构不改变计算结果
- 性能对比: A5 同机 A/B（本提交 vs 合并前 origin/main），msprof op 级，warm-up 10 / launch-count 5，覆盖扩展用例集 9 用例：`fixed_mha_long_seq_32k` 1.22x（169.20→138.15us）、`fixed_mha_multi_batch_8x4k` 1.18x（322.65→272.41us）、chunk64 短序 1.39x、真实模型形状 1.24x、varlen 1.14x~1.33x，合计 1.24x（-19.0%）；mte2_ratio 46.1%→32.6%
- 边界 / 异常场景: varlen 尾块、chunk64/chunk128、V256、GVA 3:1 已覆盖
- 未覆盖风险: A2/A3 运行路径不受本 PR 改动影响（kernel 逻辑未变，编译+安装已验证通过，单算子测试不涉及）；ub2l1 路径保留代码默认关闭（ENABLE_UB2L1=false），未启用

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 未执行 | 待 CI |
| A3 | `ascend910_93` |  | 未执行 | 待 CI |
| A5 | `ascend950` |  | 未执行 | 待 CI |

- 端到端场景说明: 改动为算子内部数据通路，入口 TilingKey 分流保持，端到端行为预期不变
- 与本 PR 修改算子的关联: chunk_fwd_o 为 GDN 前向 O 环节，未改接口与 shape 逻辑
- 未覆盖原因及补充计划: 待 `/run-npu-ci quick` 或仓库 Admin 触发 NPU CI 后补充结果

</details>

## 兼容性、风险与回退

- 兼容性说明: 入口沿用上游 TilingKey 分流（Key=1 → 本实现，A5 默认；Key=2 → #435 实现保留不动）；A2/A3 非 arch35 路径仅条件编译清理、行为等价
- 风险点: UB 布局 247KB 贴近 248KB 上限，后续扩展需注意预留；ub2l1 路径保留代码默认关闭
- 回退方案: 单提交 revert 即可回到 #434 基线行为
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因（延续 #434 内部优化，无公开接口变更）
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过（实际验证环境为 CANN 9.2，未在 8.5 环境单独验证）
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过（三档编译+安装均通过）
- [x] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过（A5 通过；A2/A3 运行路径 kernel 逻辑未变，单算子测试不涉及，仅验证编译+安装）
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过（待 CI）
- [x] 已完成必要的精度、性能或回归验证（A5：精度 9/9 PASS；32 条模型用例 + 1400 条泛化用例与合入前基线输出二进制一致；性能合计 1.24x）
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用（不涉及接口/用法变更，无需更新）
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

评审可重点关注：

- 新增 `block_mmad_pingpong_tla_pipelined.hpp`（1181 行）：拆相流水线（policy、基类特化与拆相层合并于单文件），支撑跨 Cube 搬运/计算重叠，UB 布局含 4×32KB 工作槽 + 双 epilogue 分时 scratch
- 三处 GM 路径缺陷修复：SPLIT_M 双目标消费偏移、chunk128 stage 行偏移、vec2Done 提前释放竞争
- l1SlotConsumed 反向同步 flag 与 CopyOutputToL1 尾部 MTE3_V fence（ub2l1 保留路径）
- 性能 A/B 方法：同机、msprof op 级、warm-up 10 / launch-count 5；性能用例为本地扩展用例集（不在本 PR 提交范围），扩展用例后续单独提 PR
- 精度回归方法：32 条真实模型形状用例 + 1400 条泛化用例，本提交与合入前 origin/main 基线同机构建后逐用例运行，比对输出 tensor 二进制完全一致，验证数据通路重构（L0C→UB 直通）不影响计算结果



