### PR TITLE
fix(gdn): 修正前向新旧路径选择与 Torch 参数透传

### DIFF
--- a/examples/flash_gated_delta_rule.py
+++ b/examples/flash_gated_delta_rule.py
@@ -827,6 +827,8 @@ def flash_chunk_gated_delta_rule_fwd(
             cu_seqlens=cu_list,
             chunk_indices=chunk_list,
             scale=scale,
+            disable_recompute=False,
+            return_intermediate_states=False,
         )
         if not output_final_state:
             final_state = None

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/README.md
@@ -56,9 +56,10 @@ A5 依次调度 `ChunkGatedDeltaRuleFwdPrepare`、`ChunkFwdH` 和 `ChunkFwdO`。
 | `betaEffOutOptional` | A5 `useExp2=true` 可选 | 与 beta 同 shape；FP32 | 非空时启用并输出 beta sigmoid |
 | `hOutOptional` | A5 `useExp2=true` 可选 | `stateVFirst=false` 时末两维为 `[K,V]`，否则为 `[V,K]`；与 q 同 dtype | 分块状态 |
 
-Python ctypes 入口通过 `disable_recompute=False` 选择训练输出，返回 `gCumsum` 和 `A`；
-设为 `True` 选择推理输出，仍返回四元组，但后两项为 `None`，底层公共输出指针也为空。
-设置 `return_intermediate_states=True` 时在原返回值末尾追加分块状态 `h`，
+Python ctypes 入口默认使用 `disable_recompute=False`，返回
+`(o, finalState, gCumsum, A)` 四元组；
+设为 `True` 选择推理输出，返回值中不包含 `gCumsum` 和 `A`，底层公共输出指针也为空。
+设置 `return_intermediate_states=True` 时在当前返回值末尾追加分块状态 `h`，
 其 shape 为 `[B,Hv,NT,K,V]`；`state_v_first=True` 时末两维为 `[V,K]`。
 
 ## 属性

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/README.md
@@ -2,10 +2,11 @@
 
 ## 功能
 
-`ChunkGatedDeltaRuleFwd` 实现 Gated Delta Rule 的分块前向计算。A5 上 `useExp2=true`
-且 `useQkL2norm=true`
-时依次调度 `ChunkGatedDeltaRuleFwdPrepare`、`ChunkGatedDeltaRuleFwdH` 和 `ChunkFwdO`；
-其他组合继续使用原 Phase6 kernel。当前实现支持定长和变长序列、GVA、可选初始状态
+`ChunkGatedDeltaRuleFwd` 实现 Gated Delta Rule 的分块前向计算。仅当 `useExp2=false`、
+`useQkL2norm=false`、`useGateInKernel=false`、不启用 beta sigmoid、`allowNegEigval=false`、输出 A、
+`stateVFirst=false` 且 layout 为 `BNSD/NTD` 时使用原 Phase6 kernel；任意条件不满足时，
+A5 依次调度 `ChunkGatedDeltaRuleFwdPrepare`、`ChunkFwdH` 和 `ChunkFwdO`。
+新路径不支持的参数组合由 `ChunkGatedDeltaRuleFwdPrepare` 报错。当前实现支持定长和变长序列、GVA、可选初始状态
 以及可选最终状态输出。
 
 用于精度对比的公开算子链依次由以下算子组成：
@@ -62,11 +63,11 @@ Python ctypes 入口通过 `disable_recompute=False` 选择训练输出，返回
 
 | 名称 | 当前支持范围 | 说明 |
 | --- | --- | --- |
-| `layout` | A5 `useExp2=true` 支持 `BNSD/BSND/NTD/TND`；其他路径保持原有支持范围 | q/k/v 的输入布局；BSND/TND 输入在拼接路径内转为 head-first，o 固定输出 BSND |
+| `layout` | 原 Phase6 路径支持 `BNSD/NTD`；A5 新路径支持 `BNSD/BSND/NTD/TND` | q/k/v 的输入布局；BSND/TND 输入在拼接路径内转为 head-first，o 固定输出 BSND |
 | `scale` | 通常为 `K**-0.5` | Query 缩放因子 |
 | `chunkSize` | `64`、`128` | 分块大小 |
-| `useExp2` | A5 支持 `true`；其他路径为 `false` | A5 true 时走三小算子拼接路径 |
-| `useQkL2norm` | `true/false` | 仅与 `useExp2=true` 同时成立时走三小算子拼接路径；false 时走原 Phase6 kernel |
+| `useExp2` | A5 新路径支持 `true` | true 时走三小算子拼接路径；新路径收到 false 时由 prepare 校验 |
+| `useQkL2norm` | A5 新路径支持 `true` | true 时走三小算子拼接路径；新路径收到 false 时由 prepare 校验 |
 | `allowNegEigval` | A5 `useExp2=true` 支持 | 为 true 时必须提供 `betaEffOutOptional` |
 | `stateVFirst` | A5 三小算子拼接路径支持 `true/false` | 控制初始状态、分块状态和最终状态的末两维采用 `[V,K]` 或 `[K,V]` |
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/README.md
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/README.md
@@ -58,6 +58,8 @@ A5 依次调度 `ChunkGatedDeltaRuleFwdPrepare`、`ChunkFwdH` 和 `ChunkFwdO`。
 
 Python ctypes 入口通过 `disable_recompute=False` 选择训练输出，返回 `gCumsum` 和 `A`；
 设为 `True` 选择推理输出，仍返回四元组，但后两项为 `None`，底层公共输出指针也为空。
+设置 `return_intermediate_states=True` 时在原返回值末尾追加分块状态 `h`，
+其 shape 为 `[B,Hv,NT,K,V]`；`state_v_first=True` 时末两维为 `[V,K]`。
 
 ## 属性
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_host/op_api/aclnn_chunk_gated_delta_rule_fwd.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_host/op_api/aclnn_chunk_gated_delta_rule_fwd.cpp
@@ -87,7 +87,8 @@ static bool UsePreparePath(const ChunkGatedDeltaRuleFwdParams &params)
     return params.useExp2 || params.useQkL2norm ||
            params.aLogOptional != nullptr || params.dtBiasOptional != nullptr ||
            params.betaEffOutOptional != nullptr || params.allowNegEigval ||
-           params.aOutOptional == nullptr || params.stateVFirst || !legacyLayout;
+           params.aOutOptional == nullptr || params.hOutOptional != nullptr ||
+           params.stateVFirst || !legacyLayout;
 }
 
 static op::Shape MakeShape(std::initializer_list<int64_t> dims)

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_host/op_api/aclnn_chunk_gated_delta_rule_fwd.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_host/op_api/aclnn_chunk_gated_delta_rule_fwd.cpp
@@ -82,7 +82,12 @@ struct GdnShapeInfo {
 
 static bool UsePreparePath(const ChunkGatedDeltaRuleFwdParams &params)
 {
-    return params.useExp2 && params.useQkL2norm;
+    const bool legacyLayout = std::strcmp(params.layout, "BNSD") == 0 ||
+                              std::strcmp(params.layout, "NTD") == 0;
+    return params.useExp2 || params.useQkL2norm ||
+           params.aLogOptional != nullptr || params.dtBiasOptional != nullptr ||
+           params.betaEffOutOptional != nullptr || params.allowNegEigval ||
+           params.aOutOptional == nullptr || params.stateVFirst || !legacyLayout;
 }
 
 static op::Shape MakeShape(std::initializer_list<int64_t> dims)
@@ -330,26 +335,17 @@ static aclnnStatus ResolveShapeInfo(const ChunkGatedDeltaRuleFwdParams &params, 
 static aclnnStatus CheckSupportedL2Contract(const ChunkGatedDeltaRuleFwdParams &params)
 {
     CHECK_COND(params.layout != nullptr, ACLNN_ERR_PARAM_NULLPTR, "layout must not be nullptr.");
-    CHECK_COND(params.aLogOptional == nullptr && params.dtBiasOptional == nullptr, ACLNN_ERR_PARAM_INVALID,
-               "aLogOptional and dtBiasOptional are reserved by the stable ABI but are not supported yet.");
     if (UsePreparePath(params)) {
         CHECK_COND(IsAscend950(), ACLNN_ERR_PARAM_INVALID,
-                   "useExp2=true is supported on Ascend950 only.");
+                   "The prepare path is supported on Ascend950 only.");
         CHECK_COND(std::strcmp(params.layout, "BNSD") == 0 || std::strcmp(params.layout, "BSND") == 0 ||
                        std::strcmp(params.layout, "NTD") == 0 || std::strcmp(params.layout, "TND") == 0,
                    ACLNN_ERR_PARAM_INVALID,
-                   "Ascend950 useExp2 path supports BNSD, BSND, NTD and TND.");
-        CHECK_COND(!params.allowNegEigval || params.betaEffOutOptional != nullptr,
-                   ACLNN_ERR_PARAM_INVALID,
-                   "allowNegEigval=true requires betaEffOutOptional to enable beta sigmoid.");
+                   "The Ascend950 prepare path supports BNSD, BSND, NTD and TND.");
         return ACLNN_SUCCESS;
     }
-    CHECK_COND(std::strcmp(params.layout, "BNSD") == 0, ACLNN_ERR_PARAM_INVALID,
-               "The current Phase 6 implementation supports layout=BNSD only.");
-    CHECK_COND(!params.stateVFirst, ACLNN_ERR_PARAM_INVALID,
-               "stateVFirst=true is supported by the Ascend950 useExp2 path only.");
-    CHECK_COND(!params.allowNegEigval, ACLNN_ERR_PARAM_INVALID,
-               "allowNegEigval=true is supported by the Ascend950 useExp2 path only.");
+    CHECK_COND(std::strcmp(params.layout, "BNSD") == 0 || std::strcmp(params.layout, "NTD") == 0,
+               ACLNN_ERR_PARAM_INVALID, "The Phase 6 implementation supports BNSD and NTD only.");
     CHECK_COND(params.qHatOutOptional == nullptr && params.kHatOutOptional == nullptr &&
                    params.qRstdOutOptional == nullptr && params.kRstdOutOptional == nullptr,
                ACLNN_ERR_PARAM_INVALID,
@@ -638,9 +634,10 @@ static aclnnStatus ChunkGatedDeltaRuleFwdGetWorkspaceSizeImpl(
         GDN_STAGE_CHECK(qHead != nullptr && kHead != nullptr && vHead != nullptr, 169108);
 
         auto prepareResult = l0op::ChunkGatedDeltaRuleFwdPrepare(
-            qHead, kHead, vHead, gBht, betaBht, nullptr, nullptr,
+            qHead, kHead, vHead, gBht, betaBht, params.aLogOptional, params.dtBiasOptional,
             params.cuSeqlensOptional, params.chunkIndicesOptional, params.chunkSize,
-            params.allowNegEigval, true, true, false, betaEffBht != nullptr,
+            params.allowNegEigval, params.useExp2, params.useQkL2norm,
+            params.aLogOptional != nullptr || params.dtBiasOptional != nullptr, betaEffBht != nullptr,
             params.aOutOptional != nullptr, gCumsumBht, w, u, a, qHat, kHat, qRstd,
             kRstd, betaEffBht, executorPtr);
         GDN_STAGE_CHECK(prepareResult[0] != nullptr && prepareResult[1] != nullptr &&
@@ -651,12 +648,12 @@ static aclnnStatus ChunkGatedDeltaRuleFwdGetWorkspaceSizeImpl(
         auto hResult = l0op::ChunkFwdH(
             kHat, w, u, gCumsumBht, nullptr, params.initialStateOptional,
             params.cuSeqlensOptional, params.chunkIndicesOptional, outputFinalState,
-            params.chunkSize, true, true, params.stateVFirst, h, vNew, finalState, executorPtr);
+            params.chunkSize, true, params.useExp2, params.stateVFirst, h, vNew, finalState, executorPtr);
         GDN_STAGE_CHECK(hResult[0] != nullptr && hResult[1] != nullptr, 169105);
 
         auto oResult = l0op::ChunkFwdO(
             qHat, kHat, vNew, h, gCumsumBht, params.cuSeqlensOptional,
-            params.chunkIndicesOptional, params.scale, params.chunkSize, true, params.stateVFirst,
+            params.chunkIndicesOptional, params.scale, params.chunkSize, params.useExp2, params.stateVFirst,
             "BSND", params.oOut, executorPtr);
         GDN_STAGE_CHECK(oResult[0] != nullptr, 169106);
 

--- a/tests/atk/chunk_gated_delta_rule_fwd/aclnn_abi_contract.py
+++ b/tests/atk/chunk_gated_delta_rule_fwd/aclnn_abi_contract.py
@@ -131,7 +131,14 @@ def main() -> None:
     required_patterns = {
         "final-state selector": r"const\s+bool\s+outputFinalState\s*=\s*"
         r"params\.finalStateOutOptional\s*!=\s*nullptr\s*;",
-        "BNSD default path": r'std::strcmp\(params\.layout,\s*"BNSD"\)\s*==\s*0',
+        "BNSD legacy layout": r'std::strcmp\(params\.layout,\s*"BNSD"\)\s*==\s*0',
+        "NTD legacy layout": r'std::strcmp\(params\.layout,\s*"NTD"\)\s*==\s*0',
+        "prepare path selector": r"return\s+params\.useExp2\s*\|\|\s*params\.useQkL2norm\s*\|\|.*"
+        r"params\.aLogOptional\s*!=\s*nullptr\s*\|\|\s*params\.dtBiasOptional\s*!=\s*nullptr\s*\|\|.*"
+        r"params\.betaEffOutOptional\s*!=\s*nullptr\s*\|\|\s*params\.allowNegEigval\s*\|\|.*"
+        r"params\.aOutOptional\s*==\s*nullptr\s*\|\|\s*params\.stateVFirst\s*\|\|\s*!legacyLayout",
+        "prepare path A5 guard": r"if\s*\(UsePreparePath\(params\)\)\s*\{\s*"
+        r"CHECK_COND\(IsAscend950\(\),\s*ACLNN_ERR_PARAM_INVALID",
         "gCumsum scratch": r"gCumsumCompute\s*=\s*executorPtr->AllocTensor",
         "A scratch": r"aCompute\s*=\s*executorPtr->AllocTensor",
     }
@@ -151,7 +158,7 @@ def main() -> None:
                 "symbol": SYMBOL,
                 "parameter_count": len(parameters),
                 "final_state_selector": "finalStateOutOptional != nullptr",
-                "supported_layout": "BNSD",
+                "legacy_layouts": ["BNSD", "NTD"],
             },
             ensure_ascii=False,
             indent=2,

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
@@ -1686,15 +1686,6 @@ def npu_chunk_gated_delta_rule_fwd(
     allow_neg_eigval = _optional_bool(allow_neg_eigval, False)
     disable_recompute = _optional_bool(disable_recompute, False)
     state_v_first = _optional_bool(state_v_first, False)
-    if use_gate_in_kernel:
-        raise ValueError("use_gate_in_kernel currently only supports False.")
-    if use_beta_sigmoid_in_kernel and not (use_exp2 and use_qk_l2norm_in_kernel):
-        raise ValueError(
-            "use_beta_sigmoid_in_kernel=True requires use_exp2=True and "
-            "use_qk_l2norm_in_kernel=True."
-        )
-    if allow_neg_eigval and not use_beta_sigmoid_in_kernel:
-        raise ValueError("allow_neg_eigval=True requires use_beta_sigmoid_in_kernel=True.")
     scale = _optional_float(scale, float(k_dim) ** -0.5)
     o = _empty((batch, tokens, v_heads, v_dim), v)
     g_cumsum = (
@@ -1707,6 +1698,7 @@ def npu_chunk_gated_delta_rule_fwd(
         if not disable_recompute
         else None
     )
+    a_log = _empty((v_heads,), g, dtype=torch.float32) if use_gate_in_kernel else None
     beta_eff = (
         _empty((batch, tokens, v_heads), beta, dtype=torch.float32)
         if use_beta_sigmoid_in_kernel
@@ -1731,7 +1723,7 @@ def npu_chunk_gated_delta_rule_fwd(
             ctx.tensor(v, "v"),
             ctx.tensor(g, "g"),
             ctx.tensor(beta, "beta"),
-            ctx.tensor(None, "a_log"),
+            ctx.tensor(a_log, "a_log"),
             ctx.tensor(None, "dt_bias"),
             ctx.tensor(initial_state, "initial_state"),
             ctx.int_array(cu_seqlens),

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
@@ -1620,6 +1620,7 @@ def npu_chunk_gated_delta_rule_fwd(
     use_beta_sigmoid_in_kernel=False,
     allow_neg_eigval=False,
     disable_recompute=False,
+    return_intermediate_states=False,
     state_v_first=False,
     layout="BNSD",
 ):
@@ -1685,6 +1686,7 @@ def npu_chunk_gated_delta_rule_fwd(
     use_beta_sigmoid_in_kernel = _optional_bool(use_beta_sigmoid_in_kernel, False)
     allow_neg_eigval = _optional_bool(allow_neg_eigval, False)
     disable_recompute = _optional_bool(disable_recompute, False)
+    return_intermediate_states = _optional_bool(return_intermediate_states, False)
     state_v_first = _optional_bool(state_v_first, False)
     scale = _optional_float(scale, float(k_dim) ** -0.5)
     o = _empty((batch, tokens, v_heads, v_dim), v)
@@ -1713,8 +1715,22 @@ def npu_chunk_gated_delta_rule_fwd(
             state_dtype = initial_state.dtype
         state_tail = (v_dim, k_dim) if state_v_first else (k_dim, v_dim)
         final_state = _empty((seq_num, v_heads, *state_tail), q, dtype=state_dtype)
+    h = None
+    if return_intermediate_states:
+        chunks = (
+            sum(
+                (right - left + chunk_size - 1) // chunk_size
+                for left, right in zip(cu_seqlens, cu_seqlens[1:])
+            )
+            if cu_seqlens is not None
+            else (tokens + chunk_size - 1) // chunk_size
+        )
+        state_tail = (v_dim, k_dim) if state_v_first else (k_dim, v_dim)
+        h = _empty((batch, v_heads, chunks, *state_tail), q)
     layout_buffer = ctypes.create_string_buffer(layout.encode("utf-8"))
     outputs = (o, final_state, g_cumsum, A)
+    if return_intermediate_states:
+        outputs += (h,)
     return _call_aclnn(
         "aclnnChunkGatedDeltaRuleFwd",
         lambda ctx: [
@@ -1744,7 +1760,7 @@ def npu_chunk_gated_delta_rule_fwd(
             ctx.tensor(beta_eff, "beta_eff"),
             ctx.tensor(g_cumsum, "g_cumsum"),
             ctx.tensor(A, "A"),
-            ctx.tensor(None, "h"),
+            ctx.tensor(h, "h"),
         ],
         outputs,
     )

--- a/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
+++ b/torch_custom/fla_npu/fla_npu/ops/ascendc/_aclnn_ctypes.py
@@ -1728,7 +1728,9 @@ def npu_chunk_gated_delta_rule_fwd(
         state_tail = (v_dim, k_dim) if state_v_first else (k_dim, v_dim)
         h = _empty((batch, v_heads, chunks, *state_tail), q)
     layout_buffer = ctypes.create_string_buffer(layout.encode("utf-8"))
-    outputs = (o, final_state, g_cumsum, A)
+    outputs = (o, final_state)
+    if not disable_recompute:
+        outputs += (g_cumsum, A)
     if return_intermediate_states:
         outputs += (h,)
     return _call_aclnn(


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> 本 PR 更新后需要重新触发 NPU CI；合入前须具备成功的 `NPU CI / 手动验证` 状态并满足分支保护要求。

## 关联 Issue / 背景

- 关联 Issue: #471、#521
- 背景与目标: 补充 Gated Delta Rule forward 的路径选择规则，并将 A5 拼接路径已经计算的分块状态 `h` 暴露给 Torch 调用方。
- 本 PR 解决的问题: 原路径选择未覆盖全部配置；同时 Torch ctypes 始终向 `hOutOptional` 传空指针，无法返回每个 chunk 的进入状态。

## 变更类型

- [x] Bug 修复
- [x] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [x] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子名称: `ChunkGatedDeltaRuleFwd`
- 涉及目录 / 文件: 主算子 op_api、Torch ctypes 适配、README 和 ACLNN ABI 合同测试
- 责任人 / 提交人: @zhangshuolei-hfut
- 修改范围:
  - [x] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [x] `op_api` / aclnn 接口
  - [x] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [x] 单算子测试
  - [ ] `example / ST` 测试
  - [x] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 原 Phase6 路径仅处理完整支持的参数组合；其余配置进入 A5 prepare 拼接路径。默认 `disable_recompute=False`，返回 `(o, final_state, g_cumsum, A)`；设为 `True` 时返回 `(o, final_state)`。`return_intermediate_states=True` 时在当前返回值末尾追加 `h`，shape 为 `[B,Hv,NT,K,V]`；`state_v_first=True` 时末两维为 `[V,K]`。
- 明确不包含的范围: 不扩展 prepare 算子当前支持能力；新路径不支持的参数组合仍由 prepare 算子返回参数错误。
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [x] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: ACLNN 参数数量与顺序保持不变。Torch 增加默认为 false 的可选参数；默认返回值不变，仅在调用方显式启用时追加 `h`。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

- 构建并安装包含大融合算子、prepare、`chunk_fwd_h` 和 `chunk_fwd_o` 的 Ascend 950 wheel。
- 验证 `disable_recompute` 和 `return_intermediate_states` 四种组合分别返回 4、5、2、3 项。
- 验证 example 显式使用训练配置并保持默认四输出解包。
- 检查多 chunk 场景下 `h` 的 shape、有限性和实际写入。

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  |  | 未执行 | 待 CI 补充 |
| A3 | `ascend910_93` |  |  | 未执行 | 待 CI 补充 |

### CANN 9.0 及以上

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  |  | 未执行 | 待 CI 补充 |
| A3 | `ascend910_93` |  |  | 未执行 | 待 CI 补充 |
| A5 | `ascend950` | CANN 9.1 | 完整调用链 wheel 构建 | 通过 | wheel 构建和安装通过 |

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 未执行 | 待 CI 补充 |
| A3 | `ascend910_93` |  | 未执行 | 待 CI 补充 |
| A5 | `ascend950` | 定长多 chunk 功能测试 | 通过 | 四种组合分别返回 4、5、2、3 项；`h` shape 和写入结果正确 |

- 精度对比: 本 PR 不修改计算 kernel；本轮验证 `h` 数据可读、全部有限且非首 chunk 状态已写入。
- 性能对比: 本 PR 未执行性能测试。
- 边界 / 异常场景: 默认参数保持四元组返回；`disable_recompute=True` 时省略 `gCumsum/A`；显式请求 `h` 时进入 A5 拼接路径。
- 未覆盖风险: A2/A3 编译、整体 Example ST 和 `h` 独立 golden 精度对比尚未执行。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 未执行 | 待 CI 补充 |
| A3 | `ascend910_93` |  | 未执行 | 待 CI 补充 |
| A5 | `ascend950` |  | 未执行 | 待 NPU CI 补充 |

- 端到端场景说明: Gated Delta Rule forward 新旧路径选择与可选分块状态输出。
- 与本 PR 修改算子的关联: 修改主算子路径选择和 Torch 输出映射。
- 未覆盖原因及补充计划: PR 更新后请求仓库维护者触发当前 head 的 NPU CI。

</details>

## 兼容性、风险与回退

- 兼容性说明: ACLNN ABI 保持不变；Torch 新参数有默认值，原调用方的入参和返回值不变；仅显式启用 `disable_recompute` 时缩减返回项。
- 风险点: 显式请求 `h` 会增加输出内存，并使调用进入 A5 拼接路径。
- 回退方案: 回退本 PR 中对应的独立提交即可恢复。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [x] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

- 本 PR 现包含三笔独立提交：前向路径选择修正、Torch 分块状态 `h` 输出、按需返回重计算中间量并同步 example 调用。
- `use_gate_in_kernel=true` 通过稳定 ACLNN ABI 的可选 gate 输入进入新路径，并由 prepare 算子统一拦截。

