### PR TITLE
recompute_w_u_fwd算子A5性能优化

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_w_u_fwd/op_host/op_tiling/recompute_w_u_fwd_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_w_u_fwd/op_host/op_tiling/recompute_w_u_fwd_tiling.cpp
@@ -15,6 +15,7 @@
 #include "recompute_w_u_fwd_tiling.h"
 #include "recompute_w_u_fwd_tiling_processor.h"
 #include <register/op_impl_registry.h>
+#include "platform/soc_spec.h"
 #include "tiling_base/data_copy_transpose_tiling.h"
 #include "tiling_base/tiling_templates_registry.h"
 
@@ -34,6 +35,7 @@ static void RecomputeWUFwdTilingDataPrint(gert::TilingContext *context, const Re
     OP_LOGD(nodeName, "=== chunkSize: %ld", tiling.chunkSize);
     OP_LOGD(nodeName, "=== vbVecRow: %ld", tiling.vbVecRow);
     OP_LOGD(nodeName, "=== kbgExpVecRow: %ld", tiling.kbgExpVecRow);
+    OP_LOGD(nodeName, "=== interleavedVecRow: %ld", tiling.interleavedVecRow);
     OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Print RecomputeWUFwd tiling data end <<<<<<<<<<<<<<<<");
 }
 
@@ -55,6 +57,8 @@ ge::graphStatus Tiling4RecomputeWUFwd(gert::TilingContext *context)
     uint64_t ubSize = 0;
     ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
     size_t sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
+    bool enableA5CompactWorkspace =
+        ascendcPlatform.GetCurNpuArch() == NpuArch::DAV_3510;
 
     auto cuSeqlensTensor = context->GetOptionalInputTensor(RECOMPUTE_W_U_FWD_INPUT_SEQLENS_IDX);
     auto chunkIndicesTensor = context->GetOptionalInputTensor(RECOMPUTE_W_U_FWD_INPUT_CHUNK_INDICES_IDX);
@@ -78,6 +82,8 @@ ge::graphStatus Tiling4RecomputeWUFwd(gert::TilingContext *context)
         betaDesc->GetDataType(),
         ubSize,
         sysWorkspaceSize,
+        ascendcPlatform.GetCoreNumAic(),
+        enableA5CompactWorkspace,
     };
 
     RecomputeWUFwdTilingProcessor processor(ctx, *tiling);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_w_u_fwd/op_host/op_tiling/recompute_w_u_fwd_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_w_u_fwd/op_host/op_tiling/recompute_w_u_fwd_tiling_processor.h
@@ -62,6 +62,10 @@ static constexpr const char *const RECOMPUTE_W_U_FWD_INPUT_SEQLENS_NAME = "cu_se
 static constexpr uint64_t RECOMPUTE_W_U_FWD_SIZE_HALF = 2;
 static constexpr uint64_t RECOMPUTE_W_U_FWD_SIZE_FP32 = 4;
 static constexpr uint64_t RECOMPUTE_W_U_FWD_ONE_BLOCK_32 = 32;
+static constexpr uint64_t RECOMPUTE_W_U_FWD_INTERLEAVED_UB_RESERVED_BYTES = 16 * 1024;
+static constexpr uint64_t RECOMPUTE_W_U_FWD_INTERLEAVED_MIN_VEC_ROW = 8;
+static constexpr uint32_t RECOMPUTE_W_U_FWD_A5_GM_RING_DEPTH =
+    GDN::RECOMPUTE_W_U_FWD_GM_RING_DEPTH;
 
 struct RecomputeWUFwdTilingContext {
     const char *nodeName;
@@ -79,6 +83,8 @@ struct RecomputeWUFwdTilingContext {
     ge::DataType betaDtype;
     uint64_t ubSize;
     size_t sysWorkspaceSize;
+    uint64_t aicCoreNum;
+    bool enableA5CompactWorkspace;
 };
 
 class RecomputeWUFwdTilingProcessor {
@@ -224,6 +230,33 @@ public:
         return ge::GRAPH_SUCCESS;
     }
 
+    ge::graphStatus SetInterleavedVecRow(uint64_t ubSize, ge::DataType kType, ge::DataType betaType)
+    {
+        uint64_t sizeofKType = kType == ge::DataType::DT_FLOAT ? RECOMPUTE_W_U_FWD_SIZE_FP32 :
+                                                                 RECOMPUTE_W_U_FWD_SIZE_HALF;
+        uint64_t sizeofBetaType = betaType == ge::DataType::DT_FLOAT ? RECOMPUTE_W_U_FWD_SIZE_FP32 :
+                                                                       RECOMPUTE_W_U_FWD_SIZE_HALF;
+        OP_CHECK_IF(ubSize <= RECOMPUTE_W_U_FWD_INTERLEAVED_UB_RESERVED_BYTES,
+                    OP_LOGE(ctx_.nodeName, "UB size is too small for the interleaved vector path."),
+                    return ge::GRAPH_FAILED);
+
+        const uint64_t usableUbSize = ubSize - RECOMPUTE_W_U_FWD_INTERLEAVED_UB_RESERVED_BYTES;
+        const uint64_t dataDim = static_cast<uint64_t>(K > V ? K : V);
+        // dataIn/dataOut/beta/g are all double-buffered in the A5 interleaved vector path.
+        const uint64_t bytesPerRow = 4 * (dataDim * sizeofKType + sizeofBetaType);
+        uint64_t rowNum = static_cast<uint64_t>(chunkSize);
+        uint64_t useUbSize = rowNum * bytesPerRow;
+        while (rowNum > RECOMPUTE_W_U_FWD_INTERLEAVED_MIN_VEC_ROW && useUbSize > usableUbSize) {
+            rowNum = rowNum / 2;
+            useUbSize = rowNum * bytesPerRow;
+        }
+        OP_CHECK_IF(rowNum < RECOMPUTE_W_U_FWD_INTERLEAVED_MIN_VEC_ROW || useUbSize > usableUbSize,
+                    OP_LOGE(ctx_.nodeName, "UB size is insufficient for the interleaved vector path."),
+                    return ge::GRAPH_FAILED);
+        tiling_.interleavedVecRow = static_cast<int64_t>(rowNum);
+        return ge::GRAPH_SUCCESS;
+    }
+
     ge::graphStatus CommonTiling()
     {
         const gert::Shape kStorageShape = ctx_.kShape->GetStorageShape();
@@ -306,6 +339,8 @@ public:
                     OP_LOGE(ctx_.nodeName, "SetVbVecRow Failed."), return ge::GRAPH_FAILED);
         OP_CHECK_IF(SetKbgExpVecRow(ctx_.ubSize, ctx_.kDtype, ctx_.betaDtype) != ge::GRAPH_SUCCESS,
                     OP_LOGE(ctx_.nodeName, "SetKbgExpVecRow Failed."), return ge::GRAPH_FAILED);
+        OP_CHECK_IF(SetInterleavedVecRow(ctx_.ubSize, ctx_.kDtype, ctx_.betaDtype) != ge::GRAPH_SUCCESS,
+                    OP_LOGE(ctx_.nodeName, "SetInterleavedVecRow Failed."), return ge::GRAPH_FAILED);
         return ge::GRAPH_SUCCESS;
     }
 
@@ -393,9 +428,17 @@ public:
 
     ge::graphStatus WorkspaceTiling()
     {
-        uint64_t userWorkspaceSize =
-            static_cast<uint64_t>(2) * static_cast<uint64_t>(tiling_.B) * static_cast<uint64_t>(tiling_.Hv) *
-            static_cast<uint64_t>(tiling_.T) * static_cast<uint64_t>(tiling_.V);
+        uint64_t elementSize = ctx_.kDtype == ge::DataType::DT_FLOAT ? RECOMPUTE_W_U_FWD_SIZE_FP32 :
+                                                                       RECOMPUTE_W_U_FWD_SIZE_HALF;
+        uint64_t userWorkspaceSize = elementSize * static_cast<uint64_t>(tiling_.B) *
+            static_cast<uint64_t>(tiling_.Hv) * static_cast<uint64_t>(tiling_.T) *
+            static_cast<uint64_t>(tiling_.V + tiling_.K);
+        if (ctx_.enableA5CompactWorkspace) {
+            userWorkspaceSize = elementSize * static_cast<uint64_t>(ctx_.aicCoreNum) *
+                static_cast<uint64_t>(RECOMPUTE_W_U_FWD_A5_GM_RING_DEPTH) *
+                static_cast<uint64_t>(tiling_.chunkSize) *
+                static_cast<uint64_t>(tiling_.V + tiling_.K);
+        }
         workspaceSize_ = ctx_.sysWorkspaceSize + static_cast<size_t>(userWorkspaceSize);
         return ge::GRAPH_SUCCESS;
     }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_w_u_fwd/op_kernel/arch35/recompute_w_u_fwd_cube_l1resident.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_w_u_fwd/op_kernel/arch35/recompute_w_u_fwd_cube_l1resident.h
@@ -1,0 +1,329 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file recompute_w_u_fwd_cube_l1resident.h
+ * \brief A5 L1 Resident 版本：在同一 chunk+head 内连续做 U 和 W 两个 matmul，
+ *        A 矩阵在 L1 中复用，避免重复 GM→L1 搬运。
+ *        使用 ENABLE_L1_RESIDENT=true，BlockMmadTla 自动跳过地址相同的 A/B 加载。
+ */
+
+#ifndef RECOMPUTE_W_U_FWD_CUBE_L1RESIDENT_H
+#define RECOMPUTE_W_U_FWD_CUBE_L1RESIDENT_H
+
+#include "../recompute_w_u_fwd_struct.h"
+#include "../recompute_w_u_fwd_common.h"
+
+using GDN::RecomputeWUFwdTilingData;
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#define CATLASS_ARCH 3510
+#else
+#define CATLASS_ARCH 2201
+#endif
+#include "catlass/arch/arch.hpp"
+#include "catlass/catlass.hpp"
+#include "catlass/gemm/block/block_mmad.hpp"
+#include "kernel_utils/block/block_mmad_pingpong_tla_multi.hpp"
+#include "catlass/gemm/block/block_swizzle.hpp"
+#include "catlass/gemm/device/device_gemm.hpp"
+#include "catlass/gemm/dispatch_policy.hpp"
+#include "catlass/gemm/gemm_type.hpp"
+#include "catlass/layout/layout.hpp"
+#include "catlass/status.hpp"
+#include "tla/layout.hpp"
+#include "tla/tensor.hpp"
+#include "catlass/arch/cross_core_sync.hpp"
+using namespace Catlass;
+using namespace tla;
+namespace Catlass::Gemm::Kernel {
+
+template <class BlockMmadU_, class BlockMmadW_>
+class RecomputeWUFwdTlaL1Resident {
+public:
+    using BlockMmadU = BlockMmadU_;
+    using BlockMmadW = BlockMmadW_;
+
+    using ArchTag = typename BlockMmadU::ArchTag;
+    using BdkL1TileShape = typename BlockMmadU::L1TileShape;
+
+    using ElementA = typename BlockMmadU::ElementA;
+    using LayoutA = typename BlockMmadU::LayoutA;
+    using ElementVb = typename BlockMmadU::ElementB;
+    using LayoutVb = typename BlockMmadU::LayoutB;
+    using ElementU = typename BlockMmadU::ElementC;
+    using LayoutU = typename BlockMmadU::LayoutC;
+
+    using ElementKbgExp = typename BlockMmadW::ElementB;
+    using LayoutKbgExp = typename BlockMmadW::LayoutB;
+    using ElementW = typename BlockMmadW::ElementC;
+    using LayoutW = typename BlockMmadW::LayoutC;
+    static constexpr uint32_t GM_RING_DEPTH = GDN::RECOMPUTE_W_U_FWD_GM_RING_DEPTH;
+    Arch::CrossCoreFlagWithReverse<GM_RING_DEPTH> flagAivVbReady{
+        SYNC_AIC_AIV_FLAG_5, SYNC_AIV_AIC_FLAG_3};
+    Arch::CrossCoreFlagWithReverse<GM_RING_DEPTH> flagAivKbgExpReady{
+        SYNC_AIC_AIV_FLAG_6, SYNC_AIV_AIC_FLAG_4};
+    Arch::CrossCoreFlagWithReverse<GM_RING_DEPTH> flagAicRingSlotFree{
+        SYNC_AIC_AIV_RING_SLOT_FREE_FLAG, SYNC_AIV_AIC_RING_SLOT_FREE_REVERSE_FLAG};
+    struct Params {
+        GM_ADDR ptrA;
+        LayoutA layoutA;
+        GM_ADDR ptrVb;
+        LayoutVb layoutVb;
+        GM_ADDR ptrU;
+        LayoutU layoutU;
+        GM_ADDR ptrKbgExp;
+        LayoutKbgExp layoutKbgExp;
+        GM_ADDR ptrW;
+        LayoutW layoutW;
+        GM_ADDR ptrCuSeqLens;
+        GM_ADDR ptrChunkIndices;
+        uint64_t chunkNum;
+        uint64_t B = 1;
+        uint64_t Hk = 1;
+        uint64_t Hv = 1;
+        uint64_t hvPerHk = 1;
+        uint64_t T = 32768;
+        uint64_t K = 128;
+        uint64_t V = 128;
+        uint64_t chunkSize = 64;
+
+        CATLASS_DEVICE
+        Params() {}
+
+        CATLASS_DEVICE
+        Params(GM_ADDR ptrA_, LayoutA layoutA_, GM_ADDR ptrVb_, LayoutVb layoutVb_, GM_ADDR ptrU_,
+               LayoutU layoutU_, GM_ADDR ptrKbgExp_, LayoutKbgExp layoutKbgExp_, GM_ADDR ptrW_, LayoutW layoutW_,
+               GM_ADDR ptrCuSeqLens_, GM_ADDR ptrChunkIndices_, uint64_t chunkNum_, uint64_t B_,
+               uint64_t Hk_, uint64_t Hv_, uint64_t hvPerHk_, uint64_t T_, uint64_t K_, uint64_t V_, uint64_t BT_)
+            : ptrA(ptrA_), layoutA(layoutA_), ptrVb(ptrVb_), layoutVb(layoutVb_), ptrU(ptrU_),
+              layoutU(layoutU_), ptrKbgExp(ptrKbgExp_), layoutKbgExp(layoutKbgExp_), ptrW(ptrW_), layoutW(layoutW_),
+              ptrCuSeqLens(ptrCuSeqLens_), ptrChunkIndices(ptrChunkIndices_),
+              chunkNum(chunkNum_), B(B_), Hk(Hk_), Hv(Hv_), hvPerHk(hvPerHk_), T(T_), K(K_), V(V_), chunkSize(BT_)
+        {}
+    };
+
+    CATLASS_DEVICE
+    RecomputeWUFwdTlaL1Resident() {}
+
+    template <int32_t CORE_TYPE = g_coreType>
+    CATLASS_DEVICE void operator()(Params const &params);
+
+    /// Executes one Matmul — L1 Resident 版本：同一 chunk+head 内连续做 U 和 W
+    template <>
+    CATLASS_DEVICE void operator()<AscendC::AIC>(Params const &params)
+    {
+        Arch::Resource<ArchTag> resource;
+        uint32_t coreIdx = AscendC::GetBlockIdx();
+        uint32_t coreLoops = params.chunkNum;
+        uint32_t bos = 0;
+        uint32_t eos = 0;
+        uint32_t taskIdx = 0;
+
+        // 使用 BlockMmadU 做两次 matmul：
+        // 第一次 U = A @ Vb，第二次 W = A @ KbgExp
+        // 同一个实例内 lastAddrA 状态共享，A 地址相同时 L1_RESIDENT 跳过搬运
+        BlockMmadU blockMmad(resource);
+        blockMmad.preSetFlags();
+        AscendC::GlobalTensor<ElementA> gmA;
+        AscendC::GlobalTensor<ElementVb> gmVb;
+        AscendC::GlobalTensor<ElementU> gmU;
+        AscendC::GlobalTensor<ElementKbgExp> gmKbgExp;
+        AscendC::GlobalTensor<ElementW> gmW;
+
+        for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
+            GetChunkOffset(params.ptrCuSeqLens, params.ptrChunkIndices, params.B, params.Hv, params.T,
+                           params.chunkSize, loopIdx, bos, eos);
+            uint32_t curChunkSize = eos - bos;
+
+            for (int h = 0; h < params.Hv; h++) {
+                uint32_t slotId = taskIdx % GM_RING_DEPTH;
+                ++taskIdx;
+                uint64_t ringTask = static_cast<uint64_t>(coreIdx) * GM_RING_DEPTH + slotId;
+                // 设置 A 矩阵（U 和 W 共享同一个 A）
+                gmA.SetGlobalBuffer((__gm__ ElementA *)params.ptrA + (h * params.T + bos) * params.chunkSize);
+                auto tensorA = tla::MakeTensor(gmA, params.layoutA, Arch::PositionGM{});
+
+                // === 第一部分：U = A @ Vb ===
+                // 等待 Vector 完成 Vb 计算
+                WaitVbReady();
+
+                {
+                    uint32_t tileN = tla::get<1>(BdkL1TileShape{});
+                    for (uint32_t nOffset = 0; nOffset < params.V; nOffset += tileN) {
+                        uint32_t curN = (nOffset + tileN > params.V) ? (params.V - nOffset) : tileN;
+                        GemmCoord actualBlockShape{curChunkSize, curN, curChunkSize};
+                        gmVb.SetGlobalBuffer((__gm__ ElementVb *)params.ptrVb +
+                                             ringTask * params.chunkSize * params.V + nOffset);
+                        gmU.SetGlobalBuffer((__gm__ ElementU *)params.ptrU + (h * params.T + bos) * params.V + nOffset);
+
+                        auto tensorVb = tla::MakeTensor(gmVb, params.layoutVb, Arch::PositionGM{});
+                        auto tensorU = tla::MakeTensor(gmU, params.layoutU, Arch::PositionGM{});
+                        auto tensorBlockA = GetTile(tensorA, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                        auto tensorBlockVb = GetTile(tensorVb, tla::MakeCoord(0, 0),
+                                                        tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                        auto tensorBlockU = GetTile(tensorU, tla::MakeCoord(0, 0),
+                                                     tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                        blockMmad(tensorBlockA, tensorBlockVb, tensorBlockU, actualBlockShape);
+                    }
+                }
+
+                // === 第二部分：W = A @ KbgExp ===
+                // A 矩阵 GM 地址不变，L1_RESIDENT 会跳过 A 的重新加载
+                // 等待 Vector 完成 KbgExp 计算
+
+                WaitKbgExpReady();
+                {
+                    GemmCoord actualBlockShape{curChunkSize, static_cast<uint32_t>(params.K), curChunkSize};
+                    gmKbgExp.SetGlobalBuffer((__gm__ ElementKbgExp *)params.ptrKbgExp +
+                                             ringTask * params.chunkSize * params.K);
+                    gmW.SetGlobalBuffer((__gm__ ElementW *)params.ptrW + (h * params.T + bos) * params.K);
+
+                    auto tensorKbgExp = tla::MakeTensor(gmKbgExp, params.layoutKbgExp, Arch::PositionGM{});
+                    auto tensorW = tla::MakeTensor(gmW, params.layoutW, Arch::PositionGM{});
+
+                    auto tensorBlockA = GetTile(tensorA, tla::MakeCoord(0, 0),
+                                                  tla::MakeShape(actualBlockShape.m(), actualBlockShape.k()));
+                    auto tensorBlockKbgExp = GetTile(tensorKbgExp, tla::MakeCoord(0, 0),
+                                                tla::MakeShape(actualBlockShape.k(), actualBlockShape.n()));
+                    auto tensorBlockW = GetTile(tensorW, tla::MakeCoord(0, 0),
+                                                 tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                    blockMmad(tensorBlockA, tensorBlockKbgExp, tensorBlockW, actualBlockShape);
+                }
+                // The set is issued on the same MTE2 pipe as the KbgExp GM
+                // load, so the AIV cannot reuse this slot before that load is
+                // retired.
+                Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE2>(flagAicRingSlotFree);
+                // Ring slots reuse the same GM address after GM_RING_DEPTH
+                // tasks.  Invalidate the resident cache before the next task
+                // so a new generation of vb/kbg_exp is copied into L1.
+                blockMmad.RestoreStatus();
+            }
+        }
+        blockMmad.finalWaitFlags();
+    }
+
+    __aicore__ inline void WaitVbReady()
+    {
+        Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_FIX>(flagAivVbReady);
+    }
+
+    __aicore__ inline void WaitKbgExpReady()
+    {
+        Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_FIX>(flagAivKbgExpReady);
+    }
+};
+} // namespace Catlass::Gemm::Kernel
+
+template <class... Dims>
+using GemmCubeTileShape = tla::Shape<Dims...>;
+
+template <typename kType, typename betaType, typename L1TileShape, typename L0TileShape>
+class RecomputeWUFwdProcessL1Resident {
+public:
+    __aicore__ inline RecomputeWUFwdProcessL1Resident(GM_ADDR k_, GM_ADDR v_, GM_ADDR beta_, GM_ADDR A_, GM_ADDR g_,
+                                                        GM_ADDR cu_seqlens_, GM_ADDR chunk_indices_, GM_ADDR w_,
+                                                        GM_ADDR u_, GM_ADDR workspace_);
+
+    __aicore__ inline void Process();
+    __aicore__ inline void Init(const RecomputeWUFwdTilingData &tiling);
+
+private:
+    uint64_t B = 0;
+    uint64_t T = 0;
+    uint64_t Hv = 1;
+    uint64_t Hk = 1;
+    uint64_t hvPerHk = 1;
+    uint64_t K = 0;
+    uint64_t V = 0;
+    uint64_t chunkSize = 0;
+    uint64_t chunkNum;
+    GM_ADDR k;
+    GM_ADDR v;
+    GM_ADDR beta;
+    GM_ADDR A;
+    GM_ADDR g;
+    GM_ADDR cu_seqlens;
+    GM_ADDR chunk_indices;
+    GM_ADDR w;
+    GM_ADDR u;
+    GM_ADDR workspace;
+};
+
+template <typename kType, typename betaType, typename L1TileShape, typename L0TileShape>
+__aicore__ inline RecomputeWUFwdProcessL1Resident<kType, betaType, L1TileShape, L0TileShape>::RecomputeWUFwdProcessL1Resident(
+    GM_ADDR k_, GM_ADDR v_, GM_ADDR beta_, GM_ADDR A_, GM_ADDR g_, GM_ADDR cu_seqlens_,
+    GM_ADDR chunk_indices_, GM_ADDR w_, GM_ADDR u_, GM_ADDR workspace_)
+    : k(k_), v(v_), beta(beta_), A(A_), g(g_), cu_seqlens(cu_seqlens_),
+      chunk_indices(chunk_indices_), w(w_), u(u_), workspace(workspace_) {}
+
+template <typename kType, typename betaType, typename L1TileShape, typename L0TileShape>
+__aicore__ void inline RecomputeWUFwdProcessL1Resident<kType, betaType, L1TileShape, L0TileShape>::Init(
+    const RecomputeWUFwdTilingData &tiling)
+{
+    B = tiling.B; T = tiling.T; Hv = tiling.Hv; Hk = tiling.Hk; hvPerHk = tiling.hvPerHk;
+    K = tiling.K; V = tiling.V; chunkSize = tiling.chunkSize; chunkNum = tiling.chunkNum;
+}
+
+template <typename kType, typename betaType, typename L1TileShape, typename L0TileShape>
+__aicore__ void inline RecomputeWUFwdProcessL1Resident<kType, betaType, L1TileShape, L0TileShape>::Process()
+{
+    using LayoutTagA = layout::RowMajor;
+    using LayoutTagKbgExp = layout::RowMajor;
+    using LayoutTagVb = layout::RowMajor;
+    using LayoutTagW = layout::RowMajor;
+    using LayoutTagU = layout::RowMajor;
+
+    LayoutTagA tagA = LayoutTagA::MakeLayout<kType>(chunkSize, chunkSize);
+    LayoutTagKbgExp tagKbgExp = LayoutTagKbgExp::MakeLayout<kType>(chunkSize, K);
+    LayoutTagVb tagVb = LayoutTagVb::MakeLayout<kType>(chunkSize, V);
+    LayoutTagW tagW = LayoutTagW::MakeLayout<kType>(chunkSize, K);
+    LayoutTagU tagU = LayoutTagU::MakeLayout<kType>(chunkSize, V);
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    using ArchTag = Arch::Ascend950;
+    // 使用 MmadPingpongTlaMulti（与原始版本一致），支持 preSetFlags/finalWaitFlags
+    using DispatchPolicy = Gemm::MmadPingpongTlaMulti<ArchTag, true, false, 1, true>;
+#else
+    using ArchTag = Arch::AtlasA2;
+    using DispatchPolicy = Gemm::MmadPingpongTlaMulti<ArchTag, true, false>;
+#endif
+
+    using TileCopyU =
+        Gemm::Tile::PackedTileCopyTla<ArchTag, kType, LayoutTagA, kType, LayoutTagVb, kType, LayoutTagU>;
+    using BlockMmadU =
+        Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, kType, kType, kType, void, TileCopyU>;
+
+    using TileCopyW =
+        Gemm::Tile::PackedTileCopyTla<ArchTag, kType, LayoutTagA, kType, LayoutTagKbgExp, kType, LayoutTagW>;
+    using BlockMmadW =
+        Gemm::Block::BlockMmadTla<DispatchPolicy, L1TileShape, L0TileShape, kType, kType, kType, void, TileCopyW>;
+
+    auto layoutA = MakeLayoutFromTag(tagA);
+    auto layoutVb = MakeLayoutFromTag(tagVb);
+    auto layoutU = MakeLayoutFromTag(tagU);
+    auto layoutKbgExp = MakeLayoutFromTag(tagKbgExp);
+    auto layoutW = MakeLayoutFromTag(tagW);
+
+    using MatmulKernel = Gemm::Kernel::RecomputeWUFwdTlaL1Resident<BlockMmadU, BlockMmadW>;
+    MatmulKernel kernel;
+
+    GM_ADDR vb = workspace;
+    GM_ADDR kbgExp = workspace + static_cast<uint64_t>(AscendC::GetBlockNum()) *
+        MatmulKernel::GM_RING_DEPTH * chunkSize * V * sizeof(kType);
+    typename MatmulKernel::Params param{
+        A, layoutA, vb, layoutVb, u, layoutU,
+        kbgExp, layoutKbgExp, w, layoutW,
+        cu_seqlens, chunk_indices, chunkNum, B,
+        Hk, Hv, hvPerHk, T, K, V, chunkSize};
+    kernel(param);
+}
+
+#endif // RECOMPUTE_W_U_FWD_CUBE_L1RESIDENT_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_w_u_fwd/op_kernel/arch35/recompute_w_u_fwd_vector_regbase.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_w_u_fwd/op_kernel/arch35/recompute_w_u_fwd_vector_regbase.h
@@ -1,0 +1,422 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file recompute_w_u_fwd_vector_regbase.h
+ * \brief A5 Regbase Vector 实现。
+ *        相对 Membase 版本的改动：
+ *          - ProcessVb / ProcessKbgExp 计算内核用 Regbase API 替代 Membase
+ *          - 消除 Brcb、PipeBarrier，用 RegTensor/MulFloatTwoReg 替代
+ *          - 双行预取隐藏延迟
+ */
+
+#ifndef RECOMPUTE_W_U_FWD_VECTOR_REGBASE_H
+#define RECOMPUTE_W_U_FWD_VECTOR_REGBASE_H
+
+#include "../recompute_w_u_fwd_struct.h"
+#include "../recompute_w_u_fwd_common.h"
+#include "catlass/arch/cross_core_sync.hpp"
+#include "kernel_utils/vector/regbase.hpp"
+
+using namespace AscendC;
+using namespace AscendC::MicroAPI;
+
+using GDN::RecomputeWUFwdTilingData;
+
+template <typename kType, typename betaType, int VDim>
+class RecomputeWUFwdVectorProcessRegbase {
+public:
+    constexpr static CastTrait ctHalf2Fp32Zero = {
+        RegLayout::ZERO, SatMode::SAT, MaskMergeMode::ZEROING, AscendC::RoundMode::CAST_NONE};
+    constexpr static CastTrait ctFp322KTypeRintZero = {
+        RegLayout::ZERO, SatMode::NO_SAT, MaskMergeMode::MERGING, AscendC::RoundMode::CAST_RINT};
+    constexpr static CastTrait ctFp322KTypeRintOne = {
+        RegLayout::ONE, SatMode::NO_SAT, MaskMergeMode::ZEROING, AscendC::RoundMode::CAST_RINT};
+
+    __aicore__ inline RecomputeWUFwdVectorProcessRegbase(
+        GM_ADDR k_, GM_ADDR v_, GM_ADDR beta_, GM_ADDR A_, GM_ADDR g_, GM_ADDR cu_seqlens_,
+        GM_ADDR chunk_indices_, GM_ADDR w_, GM_ADDR u_, GM_ADDR workspace_);
+
+    __aicore__ inline void Process();
+    __aicore__ inline void ProcessVbAndKbgExpInterleaved();
+    __aicore__ inline void Init(const RecomputeWUFwdTilingData &tiling, AscendC::TPipe *pipe_);
+
+private:
+    uint64_t B = 0;
+    uint64_t T = 0;
+    uint64_t Hv = 1;
+    uint64_t Hk = 1;
+    uint64_t hvPerHk = 1;
+    uint64_t K = 0;
+    uint64_t V = 0;
+    uint64_t chunkSize = 0;
+    uint64_t chunkNum = 0;
+    uint64_t interleavedVecRow = 0;
+
+    GM_ADDR k;
+    GM_ADDR v;
+    GM_ADDR beta;
+    GM_ADDR A;
+    GM_ADDR g;
+    GM_ADDR cu_seqlens;
+    GM_ADDR chunk_indices;
+    GM_ADDR w;
+    GM_ADDR u;
+    GM_ADDR workspace;
+    AscendC::TPipe *pipe = nullptr;
+
+    // Keep the two stages on independent channels so a later KbgExp event
+    // cannot satisfy the preceding Vb wait when many tasks are in flight.
+    static constexpr uint32_t GM_RING_DEPTH = GDN::RECOMPUTE_W_U_FWD_GM_RING_DEPTH;
+    Arch::CrossCoreFlagWithReverse<GM_RING_DEPTH> flagAivVbReady{
+        SYNC_AIC_AIV_FLAG_5, SYNC_AIV_AIC_FLAG_3};
+    Arch::CrossCoreFlagWithReverse<GM_RING_DEPTH> flagAivKbgExpReady{
+        SYNC_AIC_AIV_FLAG_6, SYNC_AIV_AIC_FLAG_4};
+    Arch::CrossCoreFlagWithReverse<GM_RING_DEPTH> flagAivRingSlotFree{
+        SYNC_AIC_AIV_RING_SLOT_FREE_FLAG, SYNC_AIV_AIC_RING_SLOT_FREE_REVERSE_FLAG};
+    GlobalTensor<kType> kTensor;
+    GlobalTensor<kType> vTensor;
+    GlobalTensor<betaType> betaTensor;
+    GlobalTensor<betaType> gTensor;
+    GlobalTensor<kType> workSpaceTensor;
+
+    TQue<AscendC::TPosition::VECIN, 1> dataInQue;
+    TQue<AscendC::TPosition::VECIN, 1> betaInQue;
+    TQue<AscendC::TPosition::VECIN, 1> gInQue;
+    TQue<AscendC::TPosition::VECOUT, 1> dataOutQue;
+
+    __aicore__ inline void NotifyVbReady();
+    __aicore__ inline void NotifyKbgExpReady();
+    __aicore__ inline void WaitRingSlotFree();
+    __simd_callee__ inline void CastFloat2KTypeRint(
+        RegTensor<kType>& dstReg, RegTensor<float>& srcZeroReg,
+        RegTensor<float>& srcOneReg, MaskReg& mask);
+
+    // Regbase VB compute: vb = v * beta
+    __simd_vf__ inline void ProcessVbComputerVF(
+        __ubuf__ kType* vbOut, __ubuf__ kType* vIn, __ubuf__ betaType* betaIn,
+        uint16_t mSize, uint16_t nSize);
+
+    // Regbase KbgExp compute: kbg_exp = k * beta * exp(g)
+    __simd_vf__ inline void ProcessKbgExpComputerVF(
+        __ubuf__ kType* kbgOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+        __ubuf__ betaType* gIn, uint16_t mSize, uint16_t nSize);
+};
+
+template <typename kType, typename betaType, int VDim>
+__aicore__ inline RecomputeWUFwdVectorProcessRegbase<kType, betaType, VDim>::RecomputeWUFwdVectorProcessRegbase(
+    GM_ADDR k_, GM_ADDR v_, GM_ADDR beta_, GM_ADDR A_, GM_ADDR g_,
+    GM_ADDR cu_seqlens_, GM_ADDR chunk_indices_, GM_ADDR w_, GM_ADDR u_,
+    GM_ADDR workspace_)
+    : k(k_), v(v_), beta(beta_), A(A_), g(g_), cu_seqlens(cu_seqlens_),
+      chunk_indices(chunk_indices_), w(w_), u(u_), workspace(workspace_){};
+
+template <typename kType, typename betaType, int VDim>
+__aicore__ void inline RecomputeWUFwdVectorProcessRegbase<kType, betaType, VDim>::Init(
+    const RecomputeWUFwdTilingData &tiling, AscendC::TPipe *pipe_)
+{
+    pipe = pipe_;
+    workSpaceTensor.SetGlobalBuffer((__gm__ kType *)workspace);
+    kTensor.SetGlobalBuffer((__gm__ kType *)k);
+    vTensor.SetGlobalBuffer((__gm__ kType *)v);
+    betaTensor.SetGlobalBuffer((__gm__ betaType *)beta);
+    gTensor.SetGlobalBuffer((__gm__ betaType *)g);
+
+    B = tiling.B;
+    T = tiling.T;
+    Hv = tiling.Hv;
+    Hk = tiling.Hk;
+    hvPerHk = tiling.hvPerHk;
+    K = tiling.K;
+    V = tiling.V;
+    chunkSize = tiling.chunkSize;
+    chunkNum = tiling.chunkNum;
+    interleavedVecRow = tiling.interleavedVecRow;
+    return;
+}
+
+template <typename kType, typename betaType, int VDim>
+__aicore__ void inline RecomputeWUFwdVectorProcessRegbase<kType, betaType, VDim>::Process()
+{
+    ProcessVbAndKbgExpInterleaved();
+    return;
+}
+
+template <typename kType, typename betaType, int VDim>
+__aicore__ inline void RecomputeWUFwdVectorProcessRegbase<kType, betaType, VDim>::NotifyVbReady()
+{
+    Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(flagAivVbReady);
+}
+
+template <typename kType, typename betaType, int VDim>
+__aicore__ inline void RecomputeWUFwdVectorProcessRegbase<kType, betaType, VDim>::NotifyKbgExpReady()
+{
+    Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_MTE3>(flagAivKbgExpReady);
+}
+
+template <typename kType, typename betaType, int VDim>
+__aicore__ inline void RecomputeWUFwdVectorProcessRegbase<kType, betaType, VDim>::WaitRingSlotFree()
+{
+    // Block the next MTE3 store until AIC has retired the slot's MTE2 read.
+    Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE3>(flagAivRingSlotFree);
+}
+
+template <typename kType, typename betaType, int VDim>
+__simd_callee__ inline void RecomputeWUFwdVectorProcessRegbase<kType, betaType, VDim>::CastFloat2KTypeRint(
+    RegTensor<kType>& dstReg, RegTensor<float>& srcZeroReg,
+    RegTensor<float>& srcOneReg, MaskReg& mask)
+{
+    Cast<kType, float, ctFp322KTypeRintOne>(dstReg, srcOneReg, mask);
+    Cast<kType, float, ctFp322KTypeRintZero>(dstReg, srcZeroReg, mask);
+}
+
+// =================== Regbase VB compute ===================
+// vb = v * beta
+// Regbase: LoadIn beta (broadcast), LoadIn v, Cast to FP32, Mul, Cast back, StoreAlign
+template <typename kType, typename betaType, int VDim>
+__simd_vf__ inline void RecomputeWUFwdVectorProcessRegbase<kType, betaType, VDim>::ProcessVbComputerVF(
+    __ubuf__ kType* vbOut, __ubuf__ kType* vIn, __ubuf__ betaType* betaIn,
+    uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint16_t nLoopCnt = (nSize + eleNumPerVf - 1) / eleNumPerVf;
+    uint32_t oneEleNum = min(eleNumPerVf, (uint32_t)nSize);
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    for (uint16_t mIdx = 0; mIdx < mSize; mIdx++) {
+        RegTensor<betaType> betaInReg;
+        RegTensor<kType> vInReg;
+        RegTensor<float> vFP32ZeroReg, vFP32OneReg;
+        RegTensor<float> vBetaFP32ZeroReg, vBetaFP32OneReg;
+        RegTensor<float> betaBrcbFP32Reg;
+        RegTensor<kType> vbOutReg;
+
+        LoadIn<betaType, true>(betaInReg, betaIn + mIdx);
+        HalfOrFloat2Float<betaType>(betaBrcbFP32Reg, betaInReg, maskFull16, maskFull32);
+
+        uint16_t nIdx = 0;
+        for (nIdx = 0; nIdx + 1 < nLoopCnt; nIdx += 2) {
+            // 双列预取
+            RegTensor<kType> vInReg1;
+            RegTensor<float> vFP32ZeroReg1, vFP32OneReg1;
+            RegTensor<float> vBetaFP32ZeroReg1, vBetaFP32OneReg1;
+            RegTensor<kType> vbOutReg1;
+
+            LoadIn<kType, false>(vInReg, vIn + mIdx * nSize + nIdx * eleNumPerVf);
+            LoadIn<kType, false>(vInReg1, vIn + mIdx * nSize + (nIdx + 1) * eleNumPerVf);
+            CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+            CastHalf2Float<kType>(vFP32ZeroReg1, vFP32OneReg1, vInReg1, maskFull16);
+            MulFloatTwoReg(vBetaFP32ZeroReg, vBetaFP32OneReg, vFP32ZeroReg, vFP32OneReg,
+                           betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+            MulFloatTwoReg(vBetaFP32ZeroReg1, vBetaFP32OneReg1, vFP32ZeroReg1, vFP32OneReg1,
+                           betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+            CastFloat2KTypeRint(vbOutReg, vBetaFP32ZeroReg, vBetaFP32OneReg, maskFull32);
+            CastFloat2KTypeRint(vbOutReg1, vBetaFP32ZeroReg1, vBetaFP32OneReg1, maskFull32);
+            StoreAlign(vbOut + mIdx * nSize + nIdx * eleNumPerVf, vbOutReg, maskFull16);
+            StoreAlign(vbOut + mIdx * nSize + (nIdx + 1) * eleNumPerVf, vbOutReg1, maskFull16);
+        }
+        for (; nIdx < nLoopCnt; nIdx++) {
+            LoadIn<kType, false>(vInReg, vIn + mIdx * nSize + nIdx * eleNumPerVf);
+            CastHalf2Float<kType>(vFP32ZeroReg, vFP32OneReg, vInReg, maskFull16);
+            MulFloatTwoReg(vBetaFP32ZeroReg, vBetaFP32OneReg, vFP32ZeroReg, vFP32OneReg,
+                           betaBrcbFP32Reg, betaBrcbFP32Reg, maskFull32);
+            CastFloat2KTypeRint(vbOutReg, vBetaFP32ZeroReg, vBetaFP32OneReg, maskFull32);
+            StoreAlign(vbOut + mIdx * nSize + nIdx * eleNumPerVf, vbOutReg, maskFull16);
+        }
+    }
+}
+
+// =================== Regbase KbgExp compute ===================
+// kbg_exp = k * beta * exp(g)
+template <typename kType, typename betaType, int VDim>
+__simd_vf__ inline void RecomputeWUFwdVectorProcessRegbase<kType, betaType, VDim>::ProcessKbgExpComputerVF(
+    __ubuf__ kType* kbgOut, __ubuf__ kType* kIn, __ubuf__ betaType* betaIn,
+    __ubuf__ betaType* gIn, uint16_t mSize, uint16_t nSize)
+{
+    uint32_t eleNumPerVf = AscendC::VECTOR_REG_WIDTH / sizeof(kType);
+    uint16_t nLoopCnt = (nSize + eleNumPerVf - 1) / eleNumPerVf;
+
+    MaskReg maskFull32 = CreateMask<float, MaskPattern::ALL>();
+    MaskReg maskFull16 = CreateMask<half, MaskPattern::ALL>();
+
+    for (uint16_t mIdx = 0; mIdx < mSize; mIdx++) {
+        RegTensor<betaType> betaInReg;
+        RegTensor<betaType> gInReg;
+        RegTensor<float> betaFP32Reg, gFP32Reg, betaGFP32Reg;
+        RegTensor<kType> kInReg;
+        RegTensor<float> kFP32ZeroReg, kFP32OneReg;
+        RegTensor<float> kBetaGFP32ZeroReg, kBetaGFP32OneReg;
+        RegTensor<kType> kbgOutReg;
+
+        LoadIn<betaType, true>(betaInReg, betaIn + mIdx);
+        LoadIn<betaType, true>(gInReg, gIn + mIdx);
+        HalfOrFloat2Float<betaType>(betaFP32Reg, betaInReg, maskFull16, maskFull32);
+        HalfOrFloat2Float<betaType>(gFP32Reg, gInReg, maskFull16, maskFull32);
+        Exp(gFP32Reg, gFP32Reg, maskFull32);
+        Mul(betaGFP32Reg, betaFP32Reg, gFP32Reg, maskFull32);
+
+        for (uint16_t nIdx = 0; nIdx < nLoopCnt; nIdx++) {
+            LoadIn<kType, false>(kInReg, kIn + mIdx * nSize + nIdx * eleNumPerVf);
+            CastHalf2Float<kType>(kFP32ZeroReg, kFP32OneReg, kInReg, maskFull16);
+            MulFloatTwoReg(kBetaGFP32ZeroReg, kBetaGFP32OneReg, kFP32ZeroReg, kFP32OneReg,
+                           betaGFP32Reg, betaGFP32Reg, maskFull32);
+            CastFloat2KTypeRint(kbgOutReg, kBetaGFP32ZeroReg, kBetaGFP32OneReg, maskFull32);
+            StoreAlign(kbgOut + mIdx * nSize + nIdx * eleNumPerVf, kbgOutReg, maskFull16);
+        }
+    }
+}
+
+// =================== ProcessVbAndKbgExpInterleaved ===================
+// 交替模式：每个 chunk+head 内先做 Vb 再做 KbgExp，使 Cube 端能复用 L1 中的 A 矩阵
+// 优化：一次性初始化所有 6 个 buffer，避免循环内 pipe->Reset() 调用
+template <typename kType, typename betaType, int VDim>
+__aicore__ void inline RecomputeWUFwdVectorProcessRegbase<kType, betaType, VDim>::ProcessVbAndKbgExpInterleaved()
+{
+    uint32_t coreLoops = chunkNum;
+    uint32_t coreIdx = GetBlockIdx() / GetSubBlockNum();
+    uint32_t coreNumAic = GetBlockNum();
+    uint32_t rowNum = interleavedVecRow;
+    uint32_t vecTaskIdx = 0;
+    uint32_t bos = 0;
+    uint32_t eos = 0;
+    uint32_t curRowNum = rowNum;
+
+    // Vb and KbgExp execute sequentially, so reuse data queues sized for the
+    // larger K/V dimension. This keeps the A5 double-buffer queue count at four.
+    uint32_t maxDataDim = K > V ? K : V;
+    pipe->InitBuffer(dataInQue, 2, rowNum * maxDataDim * sizeof(kType));
+    pipe->InitBuffer(betaInQue, 2, rowNum * sizeof(betaType));
+    pipe->InitBuffer(gInQue, 2, rowNum * sizeof(betaType));
+    pipe->InitBuffer(dataOutQue, 2, rowNum * maxDataDim * sizeof(kType));
+
+    for (uint32_t loopIdx = coreIdx; loopIdx < coreLoops; loopIdx += coreNumAic) {
+        GetChunkOffset(cu_seqlens, chunk_indices, B, Hv, T, chunkSize, loopIdx, bos, eos);
+        uint32_t curChunkSize = eos - bos;
+        for (int h = 0; h < Hv; h++) {
+            ++vecTaskIdx;
+            // The first ring window is initially empty.  Thereafter every
+            // task reuses the slot released by the task GM_RING_DEPTH steps
+            // earlier.  All AIV subblocks consume the release token so the
+            // reverse-depth accounting remains aligned with AIC.
+            if (vecTaskIdx > GM_RING_DEPTH) {
+                WaitRingSlotFree();
+            }
+            if (vecTaskIdx % GetSubBlockNum() != GetSubBlockIdx()) {
+                // Both AIV subcores must contribute one credit per stage.
+                NotifyVbReady();
+                NotifyKbgExpReady();
+                continue;
+            }
+
+            // === 第一部分：Vb = v * beta ===
+            const uint64_t ringTask = static_cast<uint64_t>(coreIdx) *
+                GM_RING_DEPTH + (vecTaskIdx - 1) % GM_RING_DEPTH;
+            const uint64_t vbDstBase = ringTask * chunkSize * V;
+            for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
+                curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
+                auto vOffset = (h * T + bos + rowOffset) * V;
+                auto betaOffset = h * T + bos + rowOffset;
+                {
+                    auto tensorVin = dataInQue.AllocTensor<kType>();
+                    auto tensorBetain = betaInQue.AllocTensor<betaType>();
+                    DataCopy(tensorVin, vTensor[vOffset], V * curRowNum);
+                    DataCopyPad(tensorBetain, betaTensor[betaOffset],
+                                {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},
+                                {false, 0, 0, 0});
+                    dataInQue.EnQue(tensorVin);
+                    betaInQue.EnQue(tensorBetain);
+                }
+                {
+                    auto tensorVin = dataInQue.DeQue<kType>();
+                    auto tensorBetain = betaInQue.DeQue<betaType>();
+                    auto tensorVbOut = dataOutQue.AllocTensor<kType>();
+                    __ubuf__ kType* vInAddr = (__ubuf__ kType*)tensorVin.GetPhyAddr();
+                    __ubuf__ betaType* betaInAddr = (__ubuf__ betaType*)tensorBetain.GetPhyAddr();
+                    __ubuf__ kType* vbOutAddr = (__ubuf__ kType*)tensorVbOut.GetPhyAddr();
+                    ProcessVbComputerVF(vbOutAddr, vInAddr, betaInAddr,
+                                        static_cast<uint16_t>(curRowNum), static_cast<uint16_t>(V));
+                    dataInQue.FreeTensor(tensorVin);
+                    betaInQue.FreeTensor(tensorBetain);
+                    dataOutQue.EnQue(tensorVbOut);
+                }
+                {
+                    auto tensorVbOut = dataOutQue.DeQue<kType>();
+                    DataCopy(workSpaceTensor[vbDstBase + rowOffset * V], tensorVbOut, V * curRowNum);
+                    dataOutQue.FreeTensor(tensorVbOut);
+                }
+            }
+            // Vb 完成通知 AIC 可以做 U matmul
+            NotifyVbReady();
+
+            // === 第二部分：KbgExp = k * beta * exp(g) ===
+            uint64_t hk = h / hvPerHk;
+            for (uint32_t rowOffset = 0; rowOffset < curChunkSize; rowOffset += rowNum) {
+                curRowNum = (rowOffset + rowNum) > curChunkSize ? curChunkSize - rowOffset : rowNum;
+                uint64_t coreLoopsInB = (T + chunkSize - 1) / chunkSize;
+                uint64_t bIdx = cu_seqlens ? 0 : (loopIdx / coreLoopsInB);
+                uint64_t bosK = cu_seqlens ? bos : (bos - bIdx * (Hv - Hk) * T);
+                auto kSrcOffset = (hk * T + bosK + rowOffset) * K;
+                const uint64_t kbgRingBase = static_cast<uint64_t>(coreNumAic) *
+                    GM_RING_DEPTH * chunkSize * V;
+                const uint64_t kbgDstBase = kbgRingBase + ringTask * chunkSize * K;
+                auto betaOffset = h * T + bos + rowOffset;
+                {
+                    auto tensorKin = dataInQue.AllocTensor<kType>();
+                    auto tensorBetain = betaInQue.AllocTensor<betaType>();
+                    auto tensorGin = gInQue.AllocTensor<betaType>();
+                    DataCopy(tensorKin, kTensor[kSrcOffset], K * curRowNum);
+                    DataCopyPad(tensorBetain, betaTensor[betaOffset],
+                                {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},
+                                {false, 0, 0, 0});
+                    DataCopyPad(tensorGin, gTensor[betaOffset],
+                                {1, curRowNum * static_cast<uint32_t>(sizeof(betaType)), 0, 0, 0},
+                                {false, 0, 0, 0});
+                    dataInQue.EnQue(tensorKin);
+                    betaInQue.EnQue(tensorBetain);
+                    gInQue.EnQue(tensorGin);
+                }
+                {
+                    auto tensorKin = dataInQue.DeQue<kType>();
+                    auto tensorBetain = betaInQue.DeQue<betaType>();
+                    auto tensorGin = gInQue.DeQue<betaType>();
+                    auto tensorOut = dataOutQue.AllocTensor<kType>();
+                    __ubuf__ kType* kInAddr = (__ubuf__ kType*)tensorKin.GetPhyAddr();
+                    __ubuf__ betaType* betaInAddr = (__ubuf__ betaType*)tensorBetain.GetPhyAddr();
+                    __ubuf__ betaType* gInAddr = (__ubuf__ betaType*)tensorGin.GetPhyAddr();
+                    __ubuf__ kType* kbgOutAddr = (__ubuf__ kType*)tensorOut.GetPhyAddr();
+                    ProcessKbgExpComputerVF(kbgOutAddr, kInAddr, betaInAddr, gInAddr,
+                                             static_cast<uint16_t>(curRowNum), static_cast<uint16_t>(K));
+                    dataInQue.FreeTensor(tensorKin);
+                    betaInQue.FreeTensor(tensorBetain);
+                    gInQue.FreeTensor(tensorGin);
+                    dataOutQue.EnQue(tensorOut);
+                }
+                {
+                    auto tensorOut = dataOutQue.DeQue<kType>();
+                    DataCopy(workSpaceTensor[kbgDstBase + rowOffset * K], tensorOut, K * curRowNum);
+                    dataOutQue.FreeTensor(tensorOut);
+                }
+            }
+            // KbgExp 完成通知 AIC 可以做 W matmul
+            NotifyKbgExpReady();
+        }
+    }
+
+    // AIC publishes one release for every task, while the first ring window
+    // does not consume a release token. Drain the outstanding tail so the
+    // AIC/AIV Set/Wait and reverse-credit counts stay balanced on Ascend 950.
+    uint32_t pendingRingSlots = vecTaskIdx < GM_RING_DEPTH ? vecTaskIdx : GM_RING_DEPTH;
+    for (uint32_t i = 0; i < pendingRingSlots; ++i) {
+        WaitRingSlotFree();
+    }
+}
+
+#endif // RECOMPUTE_W_U_FWD_VECTOR_REGBASE_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd.cpp
@@ -18,8 +18,13 @@
 #endif
 #include "recompute_w_u_fwd_struct.h"
 #include "recompute_w_u_fwd_common.h"
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#include "arch35/recompute_w_u_fwd_cube_l1resident.h"
+#include "arch35/recompute_w_u_fwd_vector_regbase.h"
+#else
 #include "recompute_w_u_fwd_cube.h"
 #include "recompute_w_u_fwd_vector.h"
+#endif
 
 template <class... Dims>
 using GemmCubeTileShape = tla::Shape<Dims...>;
@@ -45,14 +50,22 @@ __aicore__ inline void RecomputeWUFwdKernelImplTyped(
     GM_ADDR w, GM_ADDR u, GM_ADDR workspace, const RecomputeWUFwdTilingData *tilingData)
 {
     if ASCEND_IS_AIC {
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+        RecomputeWUFwdProcessL1Resident<kType, betaType, typename TileShapes::L1TileShape, typename TileShapes::L0TileShape>
+#else
         RecomputeWUFwdProcess<kType, betaType, typename TileShapes::L1TileShape, typename TileShapes::L0TileShape>
+#endif
             recomputeWUFwdProcess(k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
         recomputeWUFwdProcess.Init(*tilingData);
         recomputeWUFwdProcess.Process();
     }
     if ASCEND_IS_AIV {
         AscendC::TPipe tPipe;
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+        RecomputeWUFwdVectorProcessRegbase<kType, betaType, VDim> recomputeWUFwdVectorProcess(
+#else
         RecomputeWUFwdVectorProcess<kType, betaType> recomputeWUFwdVectorProcess(
+#endif
             k, v, beta, A, g, cu_seqlens, chunk_indices, w, u, workspace);
         recomputeWUFwdVectorProcess.Init(*tilingData, &tPipe);
         recomputeWUFwdVectorProcess.Process();

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd_common.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd_common.h
@@ -15,7 +15,17 @@
 #ifndef RECOMPUTE_W_U_FWD_COMMON_H
 #define RECOMPUTE_W_U_FWD_COMMON_H
 constexpr uint64_t SYNC_AIV_AIC_FLAG_3 = 3;
+constexpr uint64_t SYNC_AIV_AIC_FLAG_4 = 4;
 constexpr uint64_t SYNC_AIC_AIV_FLAG_5 = 5;
+constexpr uint64_t SYNC_AIC_AIV_FLAG_6 = 6;
+// AIC publishes a ring-slot release after the W matmul has consumed the
+// KbgExp GM input. Mode 2 broadcasts this token to both AIV sub-blocks; the
+// reverse token is sent after eight AIV waits.
+// IDs 8-10 are reserved by Catlass for inter-block/sub-block barriers.  IDs
+// 0/1 are unused by this kernel (ready channels use 3-6); confirm the target
+// runtime's mode-2 namespace before assigning them to another channel.
+constexpr uint64_t SYNC_AIC_AIV_RING_SLOT_FREE_FLAG = 0;
+constexpr uint64_t SYNC_AIV_AIC_RING_SLOT_FREE_REVERSE_FLAG = 1;
 constexpr uint64_t ONE_BLOCK_32 = 32;
 constexpr uint32_t FP32_PER_BLOCK_8 = 8;
 constexpr uint32_t FP32_PER_REPEAT_64 = 64;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd_struct.h
@@ -19,6 +19,14 @@
 
 namespace GDN {
 
+// The compact Ascend 950 path uses this depth for both workspace slots and
+// the reverse-credit cadence of its cross-core synchronization channels.
+// Keep the value in the shared tiling header so host sizing and kernel
+// addressing cannot silently diverge.
+constexpr uint32_t RECOMPUTE_W_U_FWD_GM_RING_DEPTH = 8;
+static_assert(RECOMPUTE_W_U_FWD_GM_RING_DEPTH > 0 && RECOMPUTE_W_U_FWD_GM_RING_DEPTH <= 15,
+              "GM ring depth must fit the cross-core flag counter limit.");
+
 struct RecomputeWUFwdTilingData {
     int64_t B;
     int64_t Hk;
@@ -31,6 +39,7 @@ struct RecomputeWUFwdTilingData {
     int64_t chunkSize;
     int64_t vbVecRow;
     int64_t kbgExpVecRow;
+    int64_t interleavedVecRow;
     int64_t isVariable;
 };
 


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:https://github.com/flashserve/flash-linear-attention-npu/issues/479
- 背景与目标:recompute_w_u_fwd算子在A5上性能优化提升20%
- 本 PR 解决的问题:recompute_w_u_fwd算子在A5上进行性能提升

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [x] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @liujie12345678-lab
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [x] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
# 默认 CANN 安装路径；自定义安装路径时替换为实际路径下对应的 set_env.sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [x] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
