### PR TITLE
ChunkGatedDeltaRuleFwdPrepare Optimize

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_prepare/op_host/chunk_gated_delta_rule_fwd_prepare_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_prepare/op_host/chunk_gated_delta_rule_fwd_prepare_tiling.cpp
@@ -26,26 +26,6 @@ const gert::Shape &LogicalShape(const gert::StorageShape *shape)
     return origin.GetDimNum() >= storage.GetDimNum() ? origin : storage;
 }
 
-void PrintShape(const char *name, const gert::StorageShape *shape)
-{
-    if (shape == nullptr) {
-        printf("[ChunkGatedDeltaRuleFwdPrepare][Tiling] %s=null\n", name);
-        return;
-    }
-    const gert::Shape &origin = shape->GetOriginShape();
-    const gert::Shape &storage = shape->GetStorageShape();
-    printf("[ChunkGatedDeltaRuleFwdPrepare][Tiling] %s originRank=%zu storageRank=%zu origin=[",
-           name, origin.GetDimNum(), storage.GetDimNum());
-    for (size_t i = 0; i < origin.GetDimNum(); ++i) {
-        printf("%s%ld", i == 0 ? "" : ",", origin.GetDim(i));
-    }
-    printf("] storage=[");
-    for (size_t i = 0; i < storage.GetDimNum(); ++i) {
-        printf("%s%ld", i == 0 ? "" : ",", storage.GetDim(i));
-    }
-    printf("]\n");
-}
-
 bool HasOutput(const gert::TilingContext *context, size_t index)
 {
     return context->GetOutputDesc(index) != nullptr && context->GetOutputShape(index) != nullptr;
@@ -74,16 +54,6 @@ static ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdPrepare(gert::TilingContext 
         printf("[ChunkGatedDeltaRuleFwdPrepare][Tiling] required input shape is null\n");
         return ge::GRAPH_FAILED;
     }
-
-    PrintShape("q", qShape);
-    PrintShape("k", kShape);
-    PrintShape("v", vShape);
-    PrintShape("g", gShape);
-    PrintShape("beta", betaShape);
-    PrintShape("a_log", context->GetOptionalInputShape(PREPARE_INPUT_A_LOG));
-    PrintShape("dt_bias", context->GetOptionalInputShape(PREPARE_INPUT_DT_BIAS));
-    PrintShape("cu_seqlens", context->GetOptionalInputShape(PREPARE_INPUT_CU_SEQLENS));
-    PrintShape("chunk_indices", context->GetOptionalInputShape(PREPARE_INPUT_CHUNK_INDICES));
 
     const auto &q = LogicalShape(qShape);
     const auto &v = LogicalShape(vShape);
@@ -247,21 +217,6 @@ static ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdPrepare(gert::TilingContext 
         return ge::GRAPH_FAILED;
     }
 
-    printf("[ChunkGatedDeltaRuleFwdPrepare][Tiling] B=%ld Hk=%ld Hv=%ld T=%ld K=%ld V=%ld chunkSize=%ld seqNum=%ld totalChunks=%ld\n",
-           B, HK, HV, T, K, V, chunkSize, seqNum, totalChunks);
-    printf("[ChunkGatedDeltaRuleFwdPrepare][Tiling] flags: useQkL2norm=1 (qHat=%d kHat=%d qRstd=%d kRstd=%d) "
-           "useGate=%d (aLog=%d dtBias=%d) useBetaSigmoid=%d allowNegEigval=%d useExp2=%d "
-           "isVarlen=%d chunkIndices=%d\n",
-           static_cast<int>(hasQHat), static_cast<int>(hasKHat),
-           static_cast<int>(hasQRstd), static_cast<int>(hasKRstd),
-           static_cast<int>(useGateInKernel), static_cast<int>(hasALog), static_cast<int>(hasDtBias),
-           static_cast<int>(useBetaSigmoid), static_cast<int>(allowNegEigval), static_cast<int>(useExp2),
-           static_cast<int>(hasCuSeqlens), static_cast<int>(hasChunkIndices));
-    printf("[ChunkGatedDeltaRuleFwdPrepare][Tiling] dtype: q=%d g=%d beta=%d HRatio=%ld\n",
-           static_cast<int>(qDtype), static_cast<int>(gDtype), static_cast<int>(betaDtype),
-           HK == 0 ? 0 : (HV / HK));
-    fflush(stdout);
-
     ChunkGatedDeltaRuleFwdPrepareTilingData tiling;
     tiling.set_inputBatchSize(B);
     tiling.set_queryKeyHeadCount(HK);
@@ -294,9 +249,6 @@ static ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdPrepare(gert::TilingContext 
     const size_t tilingBytes = tiling.GetDataSize();
     const size_t tilingBytesDevice = tilingBytes + 8;
     context->GetRawTilingData()->SetDataSize(tilingBytesDevice);
-    printf("[ChunkGatedDeltaRuleFwdPrepare][Tiling] tilingBytes=%zu deviceBytes=%zu capacity=%zu coreNum=%ld\n",
-           tilingBytes, tilingBytesDevice, context->GetRawTilingData()->GetCapacity(), coreNum);
-    fflush(stdout);
     context->SetTilingKey(0);
     context->SetBlockDim(static_cast<uint32_t>(coreNum > 0 ? coreNum : 1));
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_prepare/op_host/op_api/chunk_gated_delta_rule_fwd_prepare.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_prepare/op_host/op_api/chunk_gated_delta_rule_fwd_prepare.cpp
@@ -90,7 +90,7 @@ const std::array<const aclTensor *, 9> ChunkGatedDeltaRuleFwdPrepare(
     auto ret = ADD_TO_LAUNCHER_LIST_AICORE(
         ChunkGatedDeltaRuleFwdPrepare,
         OP_INPUT(q, k, v, g, beta, aLogOptional, dtBiasOptional, actualCuSeqlens, actualChunkIndices),
-        OP_OUTPUT(gOut, wOut, uOut, aOut, qHatOptional, kHatOptional, qRstdOptional, kRstdOptional, actualBetaEff),
+        OP_OUTPUT(gOut, wOut, uOut, aOut, qHatOptional, kHatOptional, qRstdOptional, kRstdOptional, betaEffOptional),
         OP_ATTR(chunkSize, allowNegEigval, useExp2, useQkL2norm, useGateInKernel, useBetaSigmoid, outputA));
     if (ret != ACLNN_SUCCESS) {
         OP_LOGE(ACLNN_ERR_PARAM_INVALID, "ADD_TO_LAUNCHER_LIST_AICORE ChunkGatedDeltaRuleFwdPrepare failed.");

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_prepare/op_kernel/arch35/chunk_gated_delta_rule_fwd_prepare.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_prepare/op_kernel/arch35/chunk_gated_delta_rule_fwd_prepare.h
@@ -218,11 +218,11 @@ public:
         }
 
         // HardEvent ids (do not reuse a live id without Wait):
-        //   0  S1 Q/K GM copy; S3 V_MTE3 before UB→L1 (after S1 Wait); S6 v GM
+        //   0  S1 Q/K GM copy; S3 V_MTE3 (L ready / VCS done); S6 v GM
         //   1  S1 gate/beta GM copy; S6 k' GM copy
         //   2  S1 L2Norm store / gate scalar aLog
         //   3  S1 g' / beta_eff GM store
-        //   4  unused
+        //   4  S3 MTE3_V after pack so VCS can overlap -L UB→L1
         //   5  S1 k' ND -> L1 NZ / S6 vb then kbg UB -> L1
         //   6  unused (was S3 PRINTF)
         //   7  unused
@@ -530,19 +530,31 @@ public:
     }
 
     // ========================= Stage 3 =========================
-    // Wait Cube kkt, build -L = -tril(exp2(g_i-g_j))*β*kkt, pack diag
-    // leaves, VCS (I+Lii)^{-1}, upload leaves/-L to L1 NZ C0=8, Notify AIC.
+    // Gate (no kkt) is emitted before WaitCubeKktDone so Exp overlaps Cube
+    // kkt. After kkt: L = kkt ⊙ G, pack, -L UB→L1 on MTE3, VCS on V, leaves.
+    __aicore__ inline void Stage3_PrepareGate(int64_t taskIdx)
+    {
+        const int32_t db = PingPongSlot(taskIdx);
+        GateLowerLVF(ubGPrime[db], ubBetaEff[db], ubLFull[db]);
+    }
+
     __aicore__ inline void Stage3_AivOne(int64_t hv, int64_t taskIdx)
     {
         WaitCubeKktDone(taskIdx);
         const int32_t db = PingPongSlot(taskIdx);
         const int32_t kktDb = PingPongSlot(OwnerTaskIdx(hv, taskIdx));
-        Stage3_ConstructLAndVcs(ubKkt[kktDb], ubGPrime[db], ubBetaEff[db], ubLFull[db], ubLPacked[db],
-                                ubIVcs, ubResVcs[db], ubVcsIdx);
+        MulKktGateVF(ubKkt[kktDb], ubLFull[db]);
         SetFlag<HardEvent::V_MTE3>(0);
         WaitFlag<HardEvent::V_MTE3>(0);
-        UploadDiagLeavesAndFullAToL1(l1LeafRight[taskIdx], l1LeafLeft[taskIdx], l1NegL[taskIdx], ubResVcs[db],
-                                     ubLFull[db]);
+        PackDiagLeavesFromUb(ubLPacked[db], ubLFull[db]);
+        DataCopy(ubResVcs[db], ubIVcs, static_cast<int32_t>(kVcsPackedElems32));
+        SetFlag<HardEvent::MTE3_V>(4);
+        WaitFlag<HardEvent::MTE3_V>(4);
+        UbNd64ToL1Nz8(l1NegL[taskIdx], ubLFull[db]);
+        MulReduceScatterVF32(ubResVcs[db], ubLPacked[db], ubResVcs[db], ubVcsIdx);
+        SetFlag<HardEvent::V_MTE3>(0);
+        WaitFlag<HardEvent::V_MTE3>(0);
+        UploadDiagLeavesToL1(l1LeafRight[taskIdx], l1LeafLeft[taskIdx], ubResVcs[db]);
         NotifyAicStage3Done(taskIdx);
     }
 
@@ -739,17 +751,27 @@ public:
         SetFlag<HardEvent::M_FIX>(1);
         SetFlag<HardEvent::M_MTE1>(1);
         WaitFlag<HardEvent::M_FIX>(1);
-        Fixpipe<InDtype, float, CFG_ROW_MAJOR_UB>(ubS7U[db], l0CS71, wuFixpipeParams);
-        SetFlag<HardEvent::FIX_M>(1);
-
+        // V=128 U is 16 KiB and stays in ubS7U until the next pack drains.
+        // V=256 U is 32 KiB; UB is 248 KiB and the retain window [204, 248)
+        // cannot hold two 32 KiB tiles, so both 128-col halves go to GM.
         if (nV > kGdnHeadDimK) {
+            const int64_t offU = OffsetBHTD(chunk.batch, hv, chunk.tokenStart, HV, T, V);
+            FixpipeL0cToGmNd<InDtype>(gmU[offU], l0CS71, rows, kGdnHeadDimK, nV);
+            SetFlag<HardEvent::FIX_MTE2>(1);
+            WaitFlag<HardEvent::FIX_MTE2>(1);
+            SetFlag<HardEvent::FIX_M>(1);
             WaitFlag<HardEvent::M_MTE1>(1);
             WuMatmulToL0C<InDtype>(l1A[taskIdx], l1Vb1[taskIdx], l0AS71, l0BS71, l0CS71, bt,
                                    static_cast<int32_t>(kGdnHeadDimK), bt, 1);
             SetFlag<HardEvent::M_FIX>(1);
             SetFlag<HardEvent::M_MTE1>(1);
             WaitFlag<HardEvent::M_FIX>(1);
-            Fixpipe<InDtype, float, CFG_ROW_MAJOR_UB>(ubS7U[db][kGdnHeadDimK], l0CS71, wuFixpipeParams);
+            FixpipeL0cToGmNd<InDtype>(gmU[offU + kGdnHeadDimK], l0CS71, rows, kGdnHeadDimK, nV);
+            SetFlag<HardEvent::FIX_MTE2>(1);
+            WaitFlag<HardEvent::FIX_MTE2>(1);
+            SetFlag<HardEvent::FIX_M>(1);
+        } else {
+            Fixpipe<InDtype, float, CFG_ROW_MAJOR_UB>(ubS7U[db], l0CS71, wuFixpipeParams);
             SetFlag<HardEvent::FIX_M>(1);
         }
     }
@@ -788,6 +810,9 @@ public:
             SetFlag<HardEvent::MTE3_V>(0);
             WaitFlag<HardEvent::MTE3_V>(0);
             for (int64_t t = subBlock; t < nThis; t += 2) {
+                Stage3_PrepareGate(t);
+            }
+            for (int64_t t = subBlock; t < nThis; t += 2) {
                 const int64_t workId = PackWorkId(base, nThis, t);
                 Stage3_AivOne(workId % HV, t);
             }
@@ -797,8 +822,10 @@ public:
                     const ChunkRange chunk = GetChunkRange(*this, gmCu, gmIdx, workId / HV);
                     CopyUbToGmElems(gmW[OffsetBHTD(chunk.batch, workId % HV, chunk.tokenStart, HV, T, K)],
                                     ubS7W[PingPongSlot(t)], static_cast<uint32_t>(chunk.M * K));
-                    CopyUbToGmElems(gmU[OffsetBHTD(chunk.batch, workId % HV, chunk.tokenStart, HV, T, V)],
-                                    ubS7U[PingPongSlot(t)], static_cast<uint32_t>(chunk.M * V));
+                    if (V <= kGdnHeadDimK) {
+                        CopyUbToGmElems(gmU[OffsetBHTD(chunk.batch, workId % HV, chunk.tokenStart, HV, T, V)],
+                                        ubS7U[PingPongSlot(t)], static_cast<uint32_t>(chunk.M * V));
+                    }
                 }
             }
             SetFlag<HardEvent::MTE3_MTE2>(0);
@@ -820,8 +847,10 @@ public:
                 const ChunkRange chunk = GetChunkRange(*this, gmCu, gmIdx, workId / HV);
                 CopyUbToGmElems(gmW[OffsetBHTD(chunk.batch, workId % HV, chunk.tokenStart, HV, T, K)],
                                 ubS7W[PingPongSlot(t)], static_cast<uint32_t>(chunk.M * K));
-                CopyUbToGmElems(gmU[OffsetBHTD(chunk.batch, workId % HV, chunk.tokenStart, HV, T, V)],
-                                ubS7U[PingPongSlot(t)], static_cast<uint32_t>(chunk.M * V));
+                if (V <= kGdnHeadDimK) {
+                    CopyUbToGmElems(gmU[OffsetBHTD(chunk.batch, workId % HV, chunk.tokenStart, HV, T, V)],
+                                    ubS7U[PingPongSlot(t)], static_cast<uint32_t>(chunk.M * V));
+                }
             }
         }
     }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_prepare/op_kernel/arch35/chunk_gated_delta_rule_fwd_prepare_datacopy.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_prepare/op_kernel/arch35/chunk_gated_delta_rule_fwd_prepare_datacopy.h
@@ -215,27 +215,14 @@ __aicore__ inline void PackDiagLeavesFromUb(LocalTensor<float> packed, LocalTens
     DataCopy(packed[32], L[32 * 64 + 32], DataCopyParams(32, burst, gap, gap));
 }
 
-// Packed VCS ND -> L1 NZ quadrants (Right=TL L00, Left=BR L11), and
-// -L ND64 -> L1 NZ. 8-col DataCopy, no UB TransDataTo5HD.
-// Off-diagonal leaves stay Stage0 zero.
-__aicore__ inline void UploadDiagLeavesAndFullAToL1(LocalTensor<float> l1LeafRight, LocalTensor<float> l1LeafLeft,
-                                                    LocalTensor<float> l1NegL, LocalTensor<float> packedNd32x64,
-                                                    LocalTensor<float> negLNd64)
+// Packed VCS ND -> L1 NZ quadrants (Right=TL L00, Left=BR L11).
+// Off-diagonal leaves stay Stage0 zero. -L is uploaded separately so it
+// can overlap VCS on MTE3.
+__aicore__ inline void UploadDiagLeavesToL1(LocalTensor<float> l1LeafRight, LocalTensor<float> l1LeafLeft,
+                                            LocalTensor<float> packedNd32x64)
 {
     UbPackedLeafToL1(l1LeafRight, packedNd32x64, 0, 0, 0);
     UbPackedLeafToL1(l1LeafLeft, packedNd32x64, 1, 1, static_cast<int32_t>(kVcs32));
-    UbNd64ToL1Nz8(l1NegL, negLNd64);
-}
-
-// -L from kkt/g/β, pack diag leaves, VCS (I+Lii)^{-1} into ubResVcs.
-__aicore__ inline void Stage3_ConstructLAndVcs(LocalTensor<float> kkt, LocalTensor<float> g, LocalTensor<float> beta,
-                                               LocalTensor<float> ubL, LocalTensor<float> packed, LocalTensor<float> ubIVcs,
-                                               LocalTensor<float> ubResVcs, LocalTensor<uint32_t> ubVcsIdx)
-{
-    NegLowerLVF(kkt, g, beta, ubL);
-    PackDiagLeavesFromUb(packed, ubL);
-    DataCopy(ubResVcs, ubIVcs, static_cast<int32_t>(kVcsPackedElems32));
-    MulReduceScatterVF32(ubResVcs, packed, ubResVcs, ubVcsIdx);
 }
 
 } // namespace ChunkGatedDeltaRuleFwdPrepare

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_prepare/op_kernel/arch35/chunk_gated_delta_rule_fwd_prepare_vf.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_prepare/op_kernel/arch35/chunk_gated_delta_rule_fwd_prepare_vf.h
@@ -334,24 +334,22 @@ __aicore__ inline void BetaSigmoidVF(LocalTensor<T> &betaIn, LocalTensor<float> 
 }
 
 /**
- * function: 构造 MBH 用的 -L。整块写 64x64。
- *           -L[i,j] = -beta[i] * kkt[i,j] * exp2(clip(g[i]-g[j], -50, 50)), i>j；其余为 0。
- * input:  kkt [64,64] fp32, g [64] fp32, beta [64] fp32
- * output: L [64,64] fp32（即 -L）
+ * function: 构造与 kkt 无关的下三角 gate。
+ *           G[i,j] = -beta[i] * exp2(clip(g[i]-g[j], -50, 50)), i>j；其余为 0。
+ * input:  g [64] fp32, beta [64] fp32
+ * output: G [64,64] fp32
  */
-__aicore__ inline void NegLowerLVF(LocalTensor<float> &kkt, LocalTensor<float> &g, LocalTensor<float> &beta,
-                                   LocalTensor<float> &L)
+__aicore__ inline void GateLowerLVF(LocalTensor<float> &g, LocalTensor<float> &beta, LocalTensor<float> &G)
 {
     constexpr float kLn2 = 0.6931471825f;
-    __ubuf__ float *kktAddr = (__ubuf__ float *)kkt.GetPhyAddr();
     __ubuf__ float *gAddr = (__ubuf__ float *)g.GetPhyAddr();
     __ubuf__ float *betaAddr = (__ubuf__ float *)beta.GetPhyAddr();
-    __ubuf__ float *lAddr = (__ubuf__ float *)L.GetPhyAddr();
+    __ubuf__ float *gMatAddr = (__ubuf__ float *)G.GetPhyAddr();
     __VEC_SCOPE__
     {
         MaskReg pregAll = CreateMask<float, MaskPattern::ALL>();
         MaskReg lowerMask0, lowerMask1;
-        RegTensor<float> gJ, gI0, gI1, kkt0, kkt1, d0, d1, gate0, gate1;
+        RegTensor<float> gJ, gI0, gI1, d0, d1, gate0, gate1;
         RegTensor<float> b0, b1, out0, out1, lo, hi, zero;
         uint32_t lowerCount0 = 0;
         uint32_t lowerCount1 = 0;
@@ -369,8 +367,6 @@ __aicore__ inline void NegLowerLVF(LocalTensor<float> &kkt, LocalTensor<float> &
             LoadAlign<float, LoadDist::DIST_BRC_B32>(gI1, gAddr + static_cast<uint32_t>(i) * 2 + 1);
             LoadAlign<float, LoadDist::DIST_BRC_B32>(b0, betaAddr + static_cast<uint32_t>(i) * 2);
             LoadAlign<float, LoadDist::DIST_BRC_B32>(b1, betaAddr + static_cast<uint32_t>(i) * 2 + 1);
-            LoadAlign(kkt0, kktAddr + r0);
-            LoadAlign(kkt1, kktAddr + r0 + 64);
             Sub(d0, gI0, gJ, pregAll);
             Sub(d1, gI1, gJ, pregAll);
             Max(d0, d0, lo, pregAll);
@@ -381,16 +377,41 @@ __aicore__ inline void NegLowerLVF(LocalTensor<float> &kkt, LocalTensor<float> &
             Muls(d1, d1, kLn2, pregAll);
             Exp(gate0, d0, pregAll);
             Exp(gate1, d1, pregAll);
-            Mul(out0, kkt0, gate0, pregAll);
-            Mul(out1, kkt1, gate1, pregAll);
-            Mul(out0, out0, b0, pregAll);
-            Mul(out1, out1, b1, pregAll);
+            Mul(out0, gate0, b0, pregAll);
+            Mul(out1, gate1, b1, pregAll);
             Muls(out0, out0, -1.0f, pregAll);
             Muls(out1, out1, -1.0f, pregAll);
             Select(out0, out0, zero, lowerMask0);
             Select(out1, out1, zero, lowerMask1);
-            StoreAlign(lAddr + r0, out0, pregAll);
-            StoreAlign(lAddr + r0 + 64, out1, pregAll);
+            StoreAlign(gMatAddr + r0, out0, pregAll);
+            StoreAlign(gMatAddr + r0 + 64, out1, pregAll);
+        }
+    }
+}
+
+/**
+ * function: -L = kkt ⊙ G，原地覆盖 G。
+ * input:  kkt [64,64] fp32, G [64,64] fp32
+ * output: L [64,64] fp32（即 -L）
+ */
+__aicore__ inline void MulKktGateVF(LocalTensor<float> &kkt, LocalTensor<float> &G)
+{
+    __ubuf__ float *kktAddr = (__ubuf__ float *)kkt.GetPhyAddr();
+    __ubuf__ float *gMatAddr = (__ubuf__ float *)G.GetPhyAddr();
+    __VEC_SCOPE__
+    {
+        MaskReg pregAll = CreateMask<float, MaskPattern::ALL>();
+        RegTensor<float> k0, k1, g0, g1;
+        for (uint16_t i = 0; i < 32; i++) {
+            const uint32_t r0 = static_cast<uint32_t>(i) * 128;
+            LoadAlign(k0, kktAddr + r0);
+            LoadAlign(k1, kktAddr + r0 + 64);
+            LoadAlign(g0, gMatAddr + r0);
+            LoadAlign(g1, gMatAddr + r0 + 64);
+            Mul(g0, k0, g0, pregAll);
+            Mul(g1, k1, g1, pregAll);
+            StoreAlign(gMatAddr + r0, g0, pregAll);
+            StoreAlign(gMatAddr + r0 + 64, g1, pregAll);
         }
     }
 }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_prepare/test/test_chunk_gated_delta_rule_fwd_prepare_pipe_acc.py
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd_prepare/test/test_chunk_gated_delta_rule_fwd_prepare_pipe_acc.py
@@ -1,8 +1,8 @@
 """Accuracy gate for pipeline edits on chunk_gated_delta_rule_fwd_prepare.
 
-Single case only (same shape as the simulator dump):
+Single case (G=2 long-seq, same generate_inputs as official GDN case 1):
 
-  B=1, HK=HV=8, T=1792, K=V=128, BT=64, BF16
+  B=1, HK=16, HV=32, T=11264, K=V=128, BT=64, BF16
 
 From the test directory::
 
@@ -19,6 +19,7 @@ from pathlib import Path
 import torch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+from cases import GdnCase, case_inputs  # noqa: E402
 from test_chunk_gated_delta_rule_fwd_prepare import (  # noqa: E402
     GDN_DIR,
     BT,
@@ -27,26 +28,39 @@ from test_chunk_gated_delta_rule_fwd_prepare import (  # noqa: E402
     setup_npu,
 )
 
-B, HK, HV, T, K, V = 1, 8, 8, 1792, 128, 128
+B, HK, HV, T, K, V = 1, 16, 32, 11264, 128, 128
 
 
 def main():
     os.environ["TBE_PARALLEL_COMPILE_ENABLE"] = "0"
     os.environ["PARALLEL_COMPILE"] = "0"
     setup_npu()
-    torch.manual_seed(0)
-    dtype = torch.bfloat16
-    q = torch.randn(B, HK, T, K, dtype=dtype)
-    k = torch.randn(B, HK, T, K, dtype=dtype)
-    v = torch.randn(B, HV, T, V, dtype=dtype)
-    g = torch.randn(B, HV, T, dtype=torch.float32)
-    beta = torch.randn(B, HV, T, dtype=torch.float32)
+    case = GdnCase(
+        case_id=0,
+        batch=B,
+        hk=HK,
+        hv=HV,
+        seq_len=T,
+        head_k=K,
+        head_v=V,
+        chunk_size=BT,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=False,
+        use_beta_sigmoid_in_kernel=True,
+        allow_neg_eigval=True,
+    )
+    inp = case_inputs(case, dtype=torch.float32, device=torch.device("cpu"), seed=0, layout="bnsd")
+    q = inp["q"].to(torch.bfloat16)
+    k = inp["k"].to(torch.bfloat16)
+    v = inp["v"].to(torch.bfloat16)
+    g = inp["g"].float()
+    beta = inp["beta"].float()
     flags = dict(
         chunk_size=BT,
         use_qk_l2norm_in_kernel=True,
         use_gate_in_kernel=False,
         use_beta_sigmoid_in_kernel=True,
-        allow_neg_eigval=False,
+        allow_neg_eigval=True,
         output_a=os.environ.get("OUTPUT_A", "1") != "0",
     )
     print(f"golden={GDN_DIR}")


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标:
- 本 PR 解决的问题:

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称:
- 涉及目录 / 文件:
- 责任人 / 提交人: @ww-blue
- 修改范围:
  - [ ] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [ ] `Tiling` 策略
  - [ ] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围:
- 明确不包含的范围:
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [ ] 是，请说明影响面、兼容策略和回归范围:
- ABI / 接口兼容性:
  - [ ] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明:

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`<op_name>` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
# 默认 CANN 安装路径；自定义安装路径时替换为实际路径下对应的 set_env.sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本:
- 产品 / 芯片类型:
- 机器或 CI 链接:

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

`torch_custom` 适配验证:

```sh
cd torch_custom/fla_npu
bash build.sh
cd test
python3 test_npu_<op_name>.py
# 或执行全部 GDN 单算子测试
bash test.sh
```

`examples/fast_kernel_launch_example` 验证:

```sh
cd examples/fast_kernel_launch_example
bash build_and_test.sh <op_name>
# 不传 <op_name> 时执行该 example 下全部测试
bash build_and_test.sh
```

如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | `bash build.sh --pkg --soc=ascend910b --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | `bash build.sh --pkg --soc=ascend910_93 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | `bash build.sh --pkg --soc=ascend950 --ops=<op_name> --vendor_name=fla_npu` | 通过 / 未通过 / 未执行 |  |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` |  | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` |  | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` |  | 通过 / 未通过 / 未执行 |  |

- 精度对比:
- 性能对比:
- 边界 / 异常场景:
- 未覆盖风险:

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A3 | `ascend910_93` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |
| A5 | `ascend950` | `python3 ci/run_example_st_cases.py --device 0 --cases-file ci/example_st_cases.json` | 通过 / 未通过 / 未执行 |  |

- 端到端场景说明:
- 与本 PR 修改算子的关联:
- 未覆盖原因及补充计划:

</details>

## 兼容性、风险与回退

- 兼容性说明:
- 风险点:
- 回退方案:
- 回退责任确认:
  - [ ] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [ ] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [ ] 已关联 Issue，或说明无需 Issue 的原因
- [ ] 已明确本 PR 的算子责任范围和不包含范围
- [ ] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [ ] 已完成必要的精度、性能或回归验证
- [ ] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [ ] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [ ] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

在这里补充评审人需要关注的实现细节、限制条件或后续计划。
