### PR TITLE
chunk_kda_bwd_recompute编译问题

### DIFF
--- a/fla/ops/ascendc/kda/chunk_kda_bwd_recompute/op_kernel/arch35/chunk_kda_bwd_recompute_vector.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_recompute/op_kernel/arch35/chunk_kda_bwd_recompute_vector.h
@@ -72,10 +72,7 @@ public:
         useExp2_ = tiling_->useExp2 != 0;
         hasALog_ = tiling_->hasALog != 0;
         hasDtBias_ = tiling_->hasDtBias != 0;
-        {
-            uint32_t bits = static_cast<uint32_t>(tiling_->lowerBoundBits);
-            memcpy(&lowerBound_, &bits, sizeof(lowerBound_));
-        }
+        lowerBound_ = KdaBwdRecomputeBitsToFloat(static_cast<uint32_t>(tiling_->lowerBoundBits));
         gateScale_ = lowerBound_ * (useExp2_ ? KDA_BWD_RECOMPUTE_RCP_LN2 : 1.0f);
 
         l1Buffer_ = LocalTensor<uint8_t>(TPosition::A1, 0, 512 * 1024);

--- a/fla/ops/ascendc/kda/chunk_kda_bwd_recompute/op_kernel/chunk_kda_bwd_recompute_common.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_recompute/op_kernel/chunk_kda_bwd_recompute_common.h
@@ -17,6 +17,18 @@ constexpr uint32_t KDA_BWD_RECOMPUTE_BT = 64;
 constexpr uint32_t KDA_BWD_RECOMPUTE_K = 128;
 constexpr uint32_t KDA_BWD_RECOMPUTE_V = 128;
 
+__aicore__ inline float KdaBwdRecomputeBitsToFloat(uint32_t bits)
+{
+    float value = 0.0f;
+    auto *dst = reinterpret_cast<uint8_t *>(&value);
+    const auto *src = reinterpret_cast<const uint8_t *>(&bits);
+    dst[0] = src[0];
+    dst[1] = src[1];
+    dst[2] = src[2];
+    dst[3] = src[3];
+    return value;
+}
+
 __aicore__ inline void KdaBwdRecomputeGetChunkOffset(
     GM_ADDR cu_seqlens, GM_ADDR chunk_indices, uint64_t B, uint64_t H, uint64_t T,
     uint64_t chunkSize, uint32_t loopIdx, uint32_t &bos, uint32_t &eos, int64_t isVariable)

--- a/fla/ops/ascendc/kda/chunk_kda_bwd_recompute/op_kernel/chunk_kda_bwd_recompute_vector.h
+++ b/fla/ops/ascendc/kda/chunk_kda_bwd_recompute/op_kernel/chunk_kda_bwd_recompute_vector.h
@@ -62,10 +62,7 @@ public:
         useExp2_ = tiling_->useExp2 != 0;
         hasALog_ = tiling_->hasALog != 0;
         hasDtBias_ = tiling_->hasDtBias != 0;
-        {
-            uint32_t bits = static_cast<uint32_t>(tiling_->lowerBoundBits);
-            memcpy(&lowerBound_, &bits, sizeof(lowerBound_));
-        }
+        lowerBound_ = KdaBwdRecomputeBitsToFloat(static_cast<uint32_t>(tiling_->lowerBoundBits));
         gateScale_ = lowerBound_ * (useExp2_ ? KDA_BWD_RECOMPUTE_RCP_LN2 : 1.0f);
         kbgBytes_ = B_ * Hv_ * T_ * K_ * sizeof(QkType);
         kbgTensor_.SetGlobalBuffer((__gm__ QkType *)workspace_);


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue:
- 背景与目标: 误用函数导致编译错误
- 本 PR 解决的问题: 解决编译问题

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] 算子精度 / 稳定性修复
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新
