### PR TITLE
fix(chunk_local_cumsum): register Ascend950 op config (v26.9.0)

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_local_cumsum/op_host/chunk_local_cumsum_def.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_local_cumsum/op_host/chunk_local_cumsum_def.cpp
@@ -78,11 +78,7 @@ public:
             .ExtendCfgInfo("opFile.value", "chunk_local_cumsum");
         this->AICore().AddConfig("ascend910b", aicoreConfig);
         this->AICore().AddConfig("ascend910_93", aicoreConfig);
-#ifdef ASCEND_SOC_VERSION
-        if (std::string(ASCEND_SOC_VERSION) == "ascend950") {
-            this->AICore().AddConfig("ascend950", aicoreConfig);
-        }
-#endif
+        this->AICore().AddConfig("ascend950", aicoreConfig);
     }
 };
 OP_ADD(ChunkLocalCumsum);


### PR DESCRIPTION
单独编译 Ascend950 的 `chunk_local_cumsum` 时，未定义的 `ASCEND_SOC_VERSION` 宏会跳过 A5 注册，导致缺少 `aic-ascend950-ops-info.ini`，最终复制 ops-info JSON 失败。本修改直接注册 `ascend950`，由构建参数选择目标 SoC，使 A5 单算子构建能够生成配置并打包。

## 变更类型

- [x] Bug 修复

## 算子责任范围

- 涉及算子：`chunk_local_cumsum`
- 责任人 / 提交人: @fazhenyao
- 修改文件：`fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_local_cumsum/op_host/chunk_local_cumsum_def.cpp`
- 仅移除 A5 AddConfig 的宏条件；算子输入输出、属性、dtype/layout 和 ACLNN ABI 未改变。

## 验证

在 v26.9.0 工作树修复后执行以下命令，wheel 构建成功，并确认生成的 `aic-ascend950-ops-info.json` 包含该算子：

```bash
FLA_NPU_SOC=ascend950 FLA_NPU_OPS=chunk_local_cumsum python scripts/build_wheel.py
```

环境：Python 3.12.3，CANN 路径 `/usr/local/Ascend/cann-9.1.0`。
产物：`flash_linear_attention_npu-26.7.0.dev0-950.x86_64-py3-none-any.whl`。

- `git diff --check` 通过。
- 未执行 A2/A3 构建、NPU 精度/性能/内存检测或端到端 Example/ST；本次验证结论仅覆盖上述构建问题。
- NPU CI 仍需按仓库规则由管理员触发。

## 兼容性、风险与回退

注册方式与仓库其他支持 A5 的算子一致。变更不涉及 kernel 数学实现；如出现回归可回退本提交。
