### PR TITLE
fix(gdn): 隔离融合私有 WU/H/O tiling 类型与 FwdH 注册

### DIFF
--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_host/op_tiling/arch22/chunk_gated_delta_rule_fwd_arch22_state_output_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_host/op_tiling/arch22/chunk_gated_delta_rule_fwd_arch22_state_output_tiling.cpp
@@ -70,8 +70,8 @@ bool IsRank(const gert::StorageShape *shape, size_t rank)
     return shape != nullptr && shape->GetStorageShape().GetDimNum() == rank;
 }
 
-void FillHMacroTiling(const ::ChunkGatedDeltaRuleFwdHTilingData &src,
-                      ChunkGatedDeltaRuleFwdHTilingData &dst)
+void FillHMacroTiling(const ::GdnMegaArch22FwdHTilingData &src,
+                      GdnMegaArch22FwdHTilingData &dst)
 {
     dst.set_batch(src.batch);
     dst.set_seqlen(src.seqlen);
@@ -97,7 +97,7 @@ void FillHMacroTiling(const ::ChunkGatedDeltaRuleFwdHTilingData &src,
     dst.set_numChunksWorkspaceOffset(src.numChunksWorkspaceOffset);
 }
 
-size_t FillOTilingWorkspace(GDN::ChunkFwdOTilingData &tiling, uint32_t aicCoreNum,
+size_t FillOTilingWorkspace(GDN::GdnMegaArch22FwdOTilingData &tiling, uint32_t aicCoreNum,
                             size_t baseOffset)
 {
     size_t offset = baseOffset;
@@ -246,7 +246,7 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdArch22StateOutput(gert::TilingConte
     const int64_t *cuSeqlensData = cuSeqlensTensor == nullptr ? nullptr : cuSeqlensTensor->GetData<int64_t>();
     const int64_t *chunkIndicesData =
         chunkIndicesTensor == nullptr ? nullptr : chunkIndicesTensor->GetData<int64_t>();
-    GDN::RecomputeWUFwdTilingData recomputeTiling{};
+    GDN::GdnMegaArch22RecomputeWUTilingData recomputeTiling{};
     RecomputeWUFwdTilingContext recomputeContext{
         context->GetNodeName(),
         context->GetRequiredInputShape(INPUT_K),
@@ -290,15 +290,15 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdArch22StateOutput(gert::TilingConte
     hContext.aicCoreNum = aicCoreNum;
     hContext.libApiWorkSpaceSize = sysWorkspaceSize;
 
-    ::ChunkGatedDeltaRuleFwdHTilingData hPlain{};
+    ::GdnMegaArch22FwdHTilingData hPlain{};
     uint32_t hBlockDim = 0;
     size_t hWorkspaceSize = 0;
     ChunkGatedDeltaRuleFwdHTilingProcessor hProcessor(hContext);
     hProcessor.Process(hPlain, hBlockDim, hWorkspaceSize);
 
-    ChunkGatedDeltaRuleFwdHTilingData hTiling;
+    GdnMegaArch22FwdHTilingData hTiling;
     FillHMacroTiling(hPlain, hTiling);
-    GDN::ChunkFwdOTilingData oTiling{};
+    GDN::GdnMegaArch22FwdOTilingData oTiling{};
     oTiling.shapeBatch = isVarlen ? 1 : batch;
     oTiling.seqlen = seqlen;
     oTiling.kNumHead = kNumHead;
@@ -322,7 +322,7 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdArch22StateOutput(gert::TilingConte
     const size_t defaultHoBase = sysWorkspaceSize + WORKSPACE_RESERVE;
     const size_t hoBase = AlignUp(std::max(defaultHoBase, wuEnd), WORKSPACE_ALIGNMENT);
     const size_t hoShift = hoBase - defaultHoBase;
-    auto ShiftHWorkspace = [hoShift](ChunkGatedDeltaRuleFwdHTilingData &tiling) {
+    auto ShiftHWorkspace = [hoShift](GdnMegaArch22FwdHTilingData &tiling) {
         tiling.set_vWorkspaceOffset(tiling.get_vWorkspaceOffset() + static_cast<int64_t>(hoShift));
         tiling.set_vUpdateWorkspaceOffset(tiling.get_vUpdateWorkspaceOffset() + static_cast<int64_t>(hoShift));
         tiling.set_kDecayWorkspaceOffset(tiling.get_kDecayWorkspaceOffset() + static_cast<int64_t>(hoShift));

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_host/op_tiling/arch22/chunk_gated_delta_rule_fwd_arch22_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_host/op_tiling/arch22/chunk_gated_delta_rule_fwd_arch22_tiling.cpp
@@ -319,15 +319,15 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdArch22(gert::TilingContext *context
     }
     workspaceSizes[0] = systemWorkspace + workspaceOffset;
 
-    ChunkGatedDeltaRuleFwdHTilingData hTiling;
+    GdnMegaArch22FwdHTilingData hTiling;
     const uint64_t hTilingSize = hTiling.GetDataSize();
-    OP_CHECK_IF(hTilingSize != sizeof(::ChunkGatedDeltaRuleFwdHTilingData),
+    OP_CHECK_IF(hTilingSize != sizeof(::GdnMegaArch22FwdHTilingData),
                 OP_LOGE(context->GetNodeName(),
                         "FwdH host/kernel tiling size mismatch: host=%lu, kernel=%zu.",
-                        hTilingSize, sizeof(::ChunkGatedDeltaRuleFwdHTilingData)),
+                        hTilingSize, sizeof(::GdnMegaArch22FwdHTilingData)),
                 return ge::GRAPH_FAILED);
     const uint64_t oTilingOffset = AlignUp(hTilingSize, TILING_ALIGNMENT);
-    const uint64_t phase5TrailerEnd = oTilingOffset + sizeof(GDN::ChunkFwdOTilingData) +
+    const uint64_t phase5TrailerEnd = oTilingOffset + sizeof(GDN::GdnMegaArch22FwdOTilingData) +
                                       sizeof(GDN::ChunkRecomputeWUFwdHOTrailer);
     const uint64_t phase6TrailerOffset = AlignUp(phase5TrailerEnd, TILING_ALIGNMENT);
     auto *rawTiling = context->GetRawTilingData();

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_host/op_tiling/arch35/chunk_gated_delta_rule_fwd_arch35_state_output_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_host/op_tiling/arch35/chunk_gated_delta_rule_fwd_arch35_state_output_tiling.cpp
@@ -68,8 +68,8 @@ bool IsRank(const gert::StorageShape *shape, size_t rank)
     return shape != nullptr && shape->GetStorageShape().GetDimNum() == rank;
 }
 
-void FillHMacroTiling(const ::ChunkGatedDeltaRuleFwdHTilingData &src,
-                      ChunkGatedDeltaRuleFwdHTilingData &dst)
+void FillHMacroTiling(const ::GdnMegaArch35FwdHTilingData &src,
+                      GdnMegaArch35FwdHTilingData &dst)
 {
     dst.set_batch(src.batch);
     dst.set_seqlen(src.seqlen);
@@ -95,7 +95,7 @@ void FillHMacroTiling(const ::ChunkGatedDeltaRuleFwdHTilingData &src,
     dst.set_numChunksWorkspaceOffset(src.numChunksWorkspaceOffset);
 }
 
-size_t FillOTilingWorkspace(GDN::ChunkFwdOTilingData &tiling, uint32_t aicCoreNum,
+size_t FillOTilingWorkspace(GDN::GdnMegaArch35FwdOTilingData &tiling, uint32_t aicCoreNum,
                             size_t baseOffset)
 {
     size_t offset = baseOffset;
@@ -244,7 +244,7 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdArch35StateOutput(gert::TilingConte
     const int64_t *cuSeqlensData = cuSeqlensTensor == nullptr ? nullptr : cuSeqlensTensor->GetData<int64_t>();
     const int64_t *chunkIndicesData =
         chunkIndicesTensor == nullptr ? nullptr : chunkIndicesTensor->GetData<int64_t>();
-    GDN::RecomputeWUFwdTilingData recomputeTiling{};
+    GDN::GdnMegaArch35RecomputeWUTilingData recomputeTiling{};
     RecomputeWUFwdTilingContext recomputeContext{
         context->GetNodeName(),
         context->GetRequiredInputShape(INPUT_K),
@@ -290,15 +290,15 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdArch35StateOutput(gert::TilingConte
     hContext.aicCoreNum = aicCoreNum;
     hContext.libApiWorkSpaceSize = sysWorkspaceSize;
 
-    ::ChunkGatedDeltaRuleFwdHTilingData hPlain{};
+    ::GdnMegaArch35FwdHTilingData hPlain{};
     uint32_t hBlockDim = 0;
     size_t hWorkspaceSize = 0;
     ChunkGatedDeltaRuleFwdHTilingProcessor hProcessor(hContext);
     hProcessor.Process(hPlain, hBlockDim, hWorkspaceSize);
 
-    ChunkGatedDeltaRuleFwdHTilingData hTiling;
+    GdnMegaArch35FwdHTilingData hTiling;
     FillHMacroTiling(hPlain, hTiling);
-    GDN::ChunkFwdOTilingData oTiling{};
+    GDN::GdnMegaArch35FwdOTilingData oTiling{};
     oTiling.shapeBatch = isVarlen ? 1 : batch;
     oTiling.seqlen = seqlen;
     oTiling.kNumHead = kNumHead;
@@ -322,7 +322,7 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdArch35StateOutput(gert::TilingConte
     const size_t defaultHoBase = sysWorkspaceSize + WORKSPACE_RESERVE;
     const size_t hoBase = AlignUp(std::max(defaultHoBase, wuEnd), WORKSPACE_ALIGNMENT);
     const size_t hoShift = hoBase - defaultHoBase;
-    auto ShiftHWorkspace = [hoShift](ChunkGatedDeltaRuleFwdHTilingData &tiling) {
+    auto ShiftHWorkspace = [hoShift](GdnMegaArch35FwdHTilingData &tiling) {
         tiling.set_vWorkspaceOffset(tiling.get_vWorkspaceOffset() + static_cast<int64_t>(hoShift));
         tiling.set_vUpdateWorkspaceOffset(tiling.get_vUpdateWorkspaceOffset() + static_cast<int64_t>(hoShift));
         tiling.set_kDecayWorkspaceOffset(tiling.get_kDecayWorkspaceOffset() + static_cast<int64_t>(hoShift));

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_host/op_tiling/arch35/chunk_gated_delta_rule_fwd_arch35_tiling.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_host/op_tiling/arch35/chunk_gated_delta_rule_fwd_arch35_tiling.cpp
@@ -312,15 +312,15 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdArch35(gert::TilingContext *context
     workspaceOffset += AlignUp(coefficient.B * coefficient.Hv * coefficient.T * sizeof(float), WORKSPACE_ALIGNMENT);
     workspaceSizes[0] = systemWorkspace + workspaceOffset;
 
-    ChunkGatedDeltaRuleFwdHTilingData hTiling;
+    GdnMegaArch35FwdHTilingData hTiling;
     const uint64_t hTilingSize = hTiling.GetDataSize();
-    OP_CHECK_IF(hTilingSize != sizeof(::ChunkGatedDeltaRuleFwdHTilingData),
+    OP_CHECK_IF(hTilingSize != sizeof(::GdnMegaArch35FwdHTilingData),
                 OP_LOGE(context->GetNodeName(),
                         "FwdH host/kernel tiling size mismatch: host=%lu, kernel=%zu.",
-                        hTilingSize, sizeof(::ChunkGatedDeltaRuleFwdHTilingData)),
+                        hTilingSize, sizeof(::GdnMegaArch35FwdHTilingData)),
                 return ge::GRAPH_FAILED);
     const uint64_t oTilingOffset = AlignUp(hTilingSize, TILING_ALIGNMENT);
-    const uint64_t stateOutputTilingEnd = oTilingOffset + sizeof(GDN::ChunkFwdOTilingData) +
+    const uint64_t stateOutputTilingEnd = oTilingOffset + sizeof(GDN::GdnMegaArch35FwdOTilingData) +
                                           sizeof(GDN::ChunkGatedDeltaRuleStateOutputTrailer);
     const uint64_t phase6TrailerOffset = AlignUp(stateOutputTilingEnd, TILING_ALIGNMENT);
     auto *rawTiling = context->GetRawTilingData();

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/chunk_gated_delta_rule_fwd_arch22.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/chunk_gated_delta_rule_fwd_arch22.cpp
@@ -38,16 +38,16 @@ __aicore__ inline uint64_t AlignPhase6(uint64_t value, uint64_t alignment)
 __aicore__ inline const __gm__ ChunkRecomputeWUFwdHOTrailer *GetPhase5Trailer(GM_ADDR tiling)
 {
     const uint64_t oTilingOffset = AlignPhase6(
-        sizeof(ChunkGatedDeltaRuleFwdHTilingData), PHASE6_TILING_ALIGNMENT);
+        sizeof(GdnMegaArch22FwdHTilingData), PHASE6_TILING_ALIGNMENT);
     return reinterpret_cast<const __gm__ ChunkRecomputeWUFwdHOTrailer *>(
-        tiling + oTilingOffset + sizeof(ChunkFwdOTilingData));
+        tiling + oTilingOffset + sizeof(GdnMegaArch22FwdOTilingData));
 }
 
 __aicore__ inline const __gm__ Arch22ChunkGatedDeltaRuleFwdTrailer *GetPhase6Trailer(GM_ADDR tiling)
 {
     const uint64_t oTilingOffset = AlignPhase6(
-        sizeof(ChunkGatedDeltaRuleFwdHTilingData), PHASE6_TILING_ALIGNMENT);
-    const uint64_t phase5End = oTilingOffset + sizeof(ChunkFwdOTilingData) +
+        sizeof(GdnMegaArch22FwdHTilingData), PHASE6_TILING_ALIGNMENT);
+    const uint64_t phase5End = oTilingOffset + sizeof(GdnMegaArch22FwdOTilingData) +
                                sizeof(ChunkRecomputeWUFwdHOTrailer);
     return reinterpret_cast<const __gm__ Arch22ChunkGatedDeltaRuleFwdTrailer *>(
         tiling + AlignPhase6(phase5End, PHASE6_TILING_ALIGNMENT));
@@ -342,7 +342,7 @@ __aicore__ inline void RunPhase6(
     GM_ADDR u = userWorkspace + phase5->uIntermediateOffset;
     GM_ADDR h = userWorkspace + phase5->hIntermediateOffset;
     GM_ADDR vNew = userWorkspace + phase5->vNewIntermediateOffset;
-    RecomputeWUFwdTilingData recomputeTiling{};
+    GdnMegaArch22RecomputeWUTilingData recomputeTiling{};
     CopyRecomputeTiling(&phase5->recompute, recomputeTiling);
     if (phase5->recompute.V == 256) {
         DispatchRecompute<InputT, float, 256, true>(
@@ -368,10 +368,10 @@ __aicore__ inline void RunPhase6(
 #endif
 
     const uint64_t oTilingOffset =
-        AlignPhase6(sizeof(ChunkGatedDeltaRuleFwdHTilingData), PHASE6_TILING_ALIGNMENT);
-    const __gm__ ChunkFwdOTilingData *gmOTiling =
-        reinterpret_cast<const __gm__ ChunkFwdOTilingData *>(tiling + oTilingOffset);
-    ChunkFwdOTilingData oTiling{};
+        AlignPhase6(sizeof(GdnMegaArch22FwdHTilingData), PHASE6_TILING_ALIGNMENT);
+    const __gm__ GdnMegaArch22FwdOTilingData *gmOTiling =
+        reinterpret_cast<const __gm__ GdnMegaArch22FwdOTilingData *>(tiling + oTilingOffset);
+    GdnMegaArch22FwdOTilingData oTiling{};
     CopyOTiling(gmOTiling, oTiling);
     DispatchFwdO<InputT>(q, k, vNew, h, gCumsumBht, cuSeqlens, chunkIndices, o,
                  userWorkspace, &oTiling);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_fwd_o/op_kernel/chunk_fwd_o_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_fwd_o/op_kernel/chunk_fwd_o_struct.h
@@ -12,14 +12,14 @@
  * \brief Shared tiling data for chunk_fwd_o.
  */
 
-#ifndef CHUNK_FWD_O_STRUCT_H
-#define CHUNK_FWD_O_STRUCT_H
+#ifndef GDN_MEGA_ARCH22_CHUNK_FWD_O_STRUCT_H
+#define GDN_MEGA_ARCH22_CHUNK_FWD_O_STRUCT_H
 
 #include <cstdint>
 
 namespace GDN {
 
-struct ChunkFwdOTilingData {
+struct GdnMegaArch22FwdOTilingData {
     int64_t shapeBatch;
     int64_t seqlen;
     int64_t kNumHead;
@@ -41,4 +41,4 @@ struct ChunkFwdOTilingData {
 
 } // namespace GDN
 
-#endif // CHUNK_FWD_O_STRUCT_H
+#endif // GDN_MEGA_ARCH22_CHUNK_FWD_O_STRUCT_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_fwd_o/op_kernel/gemm/block/block_scheduler_gdn_fwd_o.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_fwd_o/op_kernel/gemm/block/block_scheduler_gdn_fwd_o.hpp
@@ -92,7 +92,7 @@ struct BlockSchedulerGdnFwdO {
     BlockSchedulerGdnFwdO() {}
 
     CATLASS_DEVICE
-    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::ChunkFwdOTilingData *tilingData,
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::GdnMegaArch22FwdOTilingData *tilingData,
               uint32_t coreIdx, uint32_t coreNum, bool enableChunkPipeline = false,
               bool enableTaskAffinity = false) {
         shapeBatch = tilingData->shapeBatch;
@@ -273,7 +273,7 @@ struct BlockSchedulerGdnFwdOCube : public BlockSchedulerGdnFwdO {
     BlockSchedulerGdnFwdOCube() {}
 
     CATLASS_DEVICE
-    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::ChunkFwdOTilingData *tilingData,
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::GdnMegaArch22FwdOTilingData *tilingData,
               bool enableChunkPipeline = false, bool enableTaskAffinity = false) {
         BlockSchedulerGdnFwdO::Init(cu_seqlens, chunk_offsets, tilingData, AscendC::GetBlockIdx(),
                                     AscendC::GetBlockNum(), enableChunkPipeline, enableTaskAffinity);
@@ -328,7 +328,7 @@ struct BlockSchedulerGdnFwdOVec : public BlockSchedulerGdnFwdO {
     BlockSchedulerGdnFwdOVec() {}
 
     CATLASS_DEVICE
-    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::ChunkFwdOTilingData *tilingData,
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::GdnMegaArch22FwdOTilingData *tilingData,
               bool enableChunkPipeline = false, bool enableTaskAffinity = false) {
         BlockSchedulerGdnFwdO::Init(cu_seqlens, chunk_offsets, tilingData,
                                     AscendC::GetBlockIdx() / AscendC::GetSubBlockNum(), AscendC::GetBlockNum(),

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_fwd_o/op_kernel/gemm/kernel/gdn_fwd_o_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_fwd_o/op_kernel/gemm/kernel/gdn_fwd_o_kernel.hpp
@@ -253,7 +253,7 @@ public:
     __aicore__ inline GDNFwdOKernel() {}
 
     __aicore__ inline void Init(GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR h, GM_ADDR g,
-        GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, GM_ADDR o, const GDN::ChunkFwdOTilingData *tilingData, GM_ADDR user) {
+        GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, GM_ADDR o, const GDN::GdnMegaArch22FwdOTilingData *tilingData, GM_ADDR user) {
 
         shapeBatch = tilingData->shapeBatch;
         seqlen = tilingData->seqlen;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.h
@@ -22,7 +22,7 @@ namespace optiling {
 // Fusion-only serialization type; the standalone operator owns its registration.
 namespace {
 
-BEGIN_TILING_DATA_DEF(ChunkGatedDeltaRuleFwdHTilingData)
+BEGIN_TILING_DATA_DEF(GdnMegaArch22FwdHTilingData)
 TILING_DATA_FIELD_DEF(int64_t, batch);
 TILING_DATA_FIELD_DEF(int64_t, seqlen);
 TILING_DATA_FIELD_DEF(int64_t, kNumHead);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.h
@@ -19,6 +19,8 @@
 #include <tiling/tiling_api.h>
 
 namespace optiling {
+// Fusion-only serialization type; the standalone operator owns its registration.
+namespace {
 
 BEGIN_TILING_DATA_DEF(ChunkGatedDeltaRuleFwdHTilingData)
 TILING_DATA_FIELD_DEF(int64_t, batch);
@@ -46,7 +48,6 @@ TILING_DATA_FIELD_DEF(int64_t, numSeqWorkspaceOffset);
 TILING_DATA_FIELD_DEF(int64_t, numChunksWorkspaceOffset);
 END_TILING_DATA_DEF;
 
-REGISTER_TILING_DATA_CLASS(ChunkGatedDeltaRuleFwdH, ChunkGatedDeltaRuleFwdHTilingData)
-
 struct ChunkGatedDeltaRuleFwdHCompileInfo {};
+} // namespace
 } // namespace optiling

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling_processor.h
@@ -27,6 +27,7 @@
 #include "../op_kernel/chunk_gated_delta_rule_fwd_h_struct.h"
 
 namespace optiling {
+namespace {
 
 // dtype enum convention shared with the kernel: 0 - fp16, 1 - bf16, 2 - fp32
 static constexpr int64_t GDN_FWD_H_DTYPE_FP16 = 0;
@@ -149,6 +150,7 @@ private:
     const ChunkGatedDeltaRuleFwdHTilingContext &ctx_;
 };
 
+} // namespace
 } // namespace optiling
 
 #endif // CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling_processor.h
@@ -14,12 +14,12 @@
  *
  * The caller is responsible for resolving framework-specific information (shapes, dtypes,
  * platform core number, lib-api workspace size) into the plain context struct below. The
- * processor then fills the plain ChunkGatedDeltaRuleFwdHTilingData together with the block
+ * processor then fills the plain GdnMegaArch22FwdHTilingData together with the block
  * dim and the total workspace size, mirroring exactly the original Tiling4ChunkGatedDeltaRuleFwdH.
  */
 
-#ifndef CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H
-#define CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H
+#ifndef GDN_MEGA_ARCH22_CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H
+#define GDN_MEGA_ARCH22_CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H
 
 #include <cstddef>
 #include <cstdint>
@@ -70,7 +70,7 @@ public:
     explicit ChunkGatedDeltaRuleFwdHTilingProcessor(const ChunkGatedDeltaRuleFwdHTilingContext &ctx) : ctx_(ctx) {}
 
     // Fills the plain tiling struct, the block dim and the total workspace size.
-    void Process(::ChunkGatedDeltaRuleFwdHTilingData &tiling, uint32_t &blockDim, size_t &workspaceSize) const
+    void Process(::GdnMegaArch22FwdHTilingData &tiling, uint32_t &blockDim, size_t &workspaceSize) const
     {
         int64_t isVariedLen;
         int64_t shapeBatch;
@@ -153,4 +153,4 @@ private:
 } // namespace
 } // namespace optiling
 
-#endif // CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H
+#endif // GDN_MEGA_ARCH22_CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h_struct.h
@@ -12,7 +12,7 @@
  * \brief Plain tiling data struct for chunk_gated_delta_rule_fwd_h.
  *
  * The aclnn/ascendc framework auto-generates a kernel-side tiling struct named
- * ChunkGatedDeltaRuleFwdHTilingData (global scope) from the BEGIN_TILING_DATA_DEF
+ * GdnMegaArch22FwdHTilingData (global scope) from the BEGIN_TILING_DATA_DEF
  * macro in chunk_gated_delta_rule_fwd_h_tiling.h. The fast kernel launch extension
  * compiles the kernel standalone (without that auto-generated header), so it provides
  * the same plain struct here. The field order/types mirror the macro definition so the
@@ -20,12 +20,12 @@
  * to the kernel via the <<<>>> launch (its address is a valid GM_ADDR on Atlas A2).
  */
 
-#ifndef CHUNK_GATED_DELTA_RULE_FWD_H_STRUCT_H
-#define CHUNK_GATED_DELTA_RULE_FWD_H_STRUCT_H
+#ifndef GDN_MEGA_ARCH22_CHUNK_GATED_DELTA_RULE_FWD_H_STRUCT_H
+#define GDN_MEGA_ARCH22_CHUNK_GATED_DELTA_RULE_FWD_H_STRUCT_H
 
 #include <cstdint>
 
-struct ChunkGatedDeltaRuleFwdHTilingData {
+struct GdnMegaArch22FwdHTilingData {
     int64_t batch;
     int64_t seqlen;
     int64_t kNumHead;
@@ -51,4 +51,4 @@ struct ChunkGatedDeltaRuleFwdHTilingData {
     int64_t numChunksWorkspaceOffset;
 };
 
-#endif // CHUNK_GATED_DELTA_RULE_FWD_H_STRUCT_H
+#endif // GDN_MEGA_ARCH22_CHUNK_GATED_DELTA_RULE_FWD_H_STRUCT_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
@@ -134,7 +134,7 @@ struct BlockSchedulerGdnFwdH {
 
     CATLASS_DEVICE
     void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR tiling, GM_ADDR user, uint32_t coreIdx, uint32_t coreNum) {
-        __gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict>(tiling);
+        __gm__ GdnMegaArch22FwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ GdnMegaArch22FwdHTilingData *__restrict>(tiling);
 
         batch = gdnFwdHTilingData->batch;
         seqlen = gdnFwdHTilingData->seqlen;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -236,7 +236,7 @@ public:
     __aicore__ inline void Init(GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g, GM_ADDR gk, GM_ADDR inital_state, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
         GM_ADDR h, GM_ADDR v_new, GM_ADDR final_state, GM_ADDR tiling, GM_ADDR user) {
 
-        __gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict>(tiling);
+        __gm__ GdnMegaArch22FwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ GdnMegaArch22FwdHTilingData *__restrict>(tiling);
 
         batch = gdnFwdHTilingData->batch;
         seqlen = gdnFwdHTilingData->seqlen;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_recompute_wu_fwd_ho/op_kernel/chunk_recompute_wu_fwd_ho.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_recompute_wu_fwd_ho/op_kernel/chunk_recompute_wu_fwd_ho.cpp
@@ -61,8 +61,8 @@ __aicore__ inline void DispatchFwdH(GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g, 
                                     GM_ADDR h, GM_ADDR vNew, GM_ADDR finalState, GM_ADDR tiling,
                                     GM_ADDR userWorkspace)
 {
-    const __gm__ ChunkGatedDeltaRuleFwdHTilingData *hTiling =
-        reinterpret_cast<const __gm__ ChunkGatedDeltaRuleFwdHTilingData *>(tiling);
+    const __gm__ GdnMegaArch22FwdHTilingData *hTiling =
+        reinterpret_cast<const __gm__ GdnMegaArch22FwdHTilingData *>(tiling);
     // Mega's input dtype is fixed by the generated DTYPE_Q variant, and its
     // cumsum/gk contract is FP32. State remains runtime-selected: a disabled
     // final-state output is an FP32 placeholder, not the initial-state dtype.
@@ -94,8 +94,8 @@ __aicore__ inline void DispatchFwdH(GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g, 
                                     GM_ADDR h, GM_ADDR vNew, GM_ADDR finalState, GM_ADDR tiling,
                                     GM_ADDR userWorkspace)
 {
-    const __gm__ ChunkGatedDeltaRuleFwdHTilingData *hTiling =
-        reinterpret_cast<const __gm__ ChunkGatedDeltaRuleFwdHTilingData *>(tiling);
+    const __gm__ GdnMegaArch22FwdHTilingData *hTiling =
+        reinterpret_cast<const __gm__ GdnMegaArch22FwdHTilingData *>(tiling);
     const bool useGk = hTiling->useGk;
     if (hTiling->dataType == 1) {
         if (hTiling->stateDataType == 2) {
@@ -180,7 +180,7 @@ __aicore__ inline void DispatchFwdH(GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g, 
 
 #endif
 
-__aicore__ inline void CopyOTiling(const __gm__ ChunkFwdOTilingData *src, ChunkFwdOTilingData &dst)
+__aicore__ inline void CopyOTiling(const __gm__ GdnMegaArch22FwdOTilingData *src, GdnMegaArch22FwdOTilingData &dst)
 {
     dst.shapeBatch = src->shapeBatch;
     dst.seqlen = src->seqlen;
@@ -201,8 +201,8 @@ __aicore__ inline void CopyOTiling(const __gm__ ChunkFwdOTilingData *src, ChunkF
     dst.scale = src->scale;
 }
 
-__aicore__ inline void CopyRecomputeTiling(const __gm__ RecomputeWUFwdTilingData *src,
-                                            RecomputeWUFwdTilingData &dst)
+__aicore__ inline void CopyRecomputeTiling(const __gm__ GdnMegaArch22RecomputeWUTilingData *src,
+                                            GdnMegaArch22RecomputeWUTilingData &dst)
 {
     // Tiling data is serialized in GM; the recompute process consumes a local-memory copy.
     dst.B = src->B;
@@ -222,7 +222,7 @@ __aicore__ inline void CopyRecomputeTiling(const __gm__ RecomputeWUFwdTilingData
 template <typename InputT, typename GT>
 __aicore__ inline void RunFwdO(GM_ADDR q, GM_ADDR k, GM_ADDR vNew, GM_ADDR h, GM_ADDR g,
                                GM_ADDR cuSeqlens, GM_ADDR chunkIndices, GM_ADDR o,
-                               GM_ADDR userWorkspace, const ChunkFwdOTilingData *tiling)
+                               GM_ADDR userWorkspace, const GdnMegaArch22FwdOTilingData *tiling)
 {
     using Kernel = Catlass::Gemm::Kernel::GDNFwdOKernel<InputT, GT, float, true>;
     Kernel kernel;
@@ -235,7 +235,7 @@ template <typename kType, typename betaType, int VDim, typename TileShapes,
 __aicore__ inline void RunRecompute(
     GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR g, GM_ADDR cuSeqlens,
     GM_ADDR chunkIndices, GM_ADDR w, GM_ADDR u, GM_ADDR workspace,
-    const RecomputeWUFwdTilingData *tiling)
+    const GdnMegaArch22RecomputeWUTilingData *tiling)
 {
     if ASCEND_IS_AIC {
         RecomputeWUFwdProcess<kType, betaType, typename TileShapes::L1TileShape,
@@ -257,7 +257,7 @@ template <typename kType, typename betaType, int VDim, bool kAbcTaskOrder = fals
 __aicore__ inline void DispatchRecompute(
     GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR g, GM_ADDR cuSeqlens,
     GM_ADDR chunkIndices, GM_ADDR w, GM_ADDR u, GM_ADDR workspace,
-    const RecomputeWUFwdTilingData *tiling)
+    const GdnMegaArch22RecomputeWUTilingData *tiling)
 {
     if constexpr (VDim == 256) {
         RunRecompute<kType, betaType, VDim,
@@ -273,7 +273,7 @@ __aicore__ inline void DispatchRecompute(
 template <typename InputT>
 __aicore__ inline void DispatchFwdO(GM_ADDR q, GM_ADDR k, GM_ADDR vNew, GM_ADDR h, GM_ADDR g,
                                     GM_ADDR cuSeqlens, GM_ADDR chunkIndices, GM_ADDR o,
-                                    GM_ADDR userWorkspace, const ChunkFwdOTilingData *tiling)
+                                    GM_ADDR userWorkspace, const GdnMegaArch22FwdOTilingData *tiling)
 {
     RunFwdO<InputT, float>(q, k, vNew, h, g, cuSeqlens, chunkIndices, o, userWorkspace, tiling);
 }
@@ -281,7 +281,7 @@ __aicore__ inline void DispatchFwdO(GM_ADDR q, GM_ADDR k, GM_ADDR vNew, GM_ADDR 
 #ifndef GDN_CHUNK_RECOMPUTE_WU_FWD_HO_IMPL_ONLY
 __aicore__ inline void DispatchFwdO(GM_ADDR q, GM_ADDR k, GM_ADDR vNew, GM_ADDR h, GM_ADDR g,
                                     GM_ADDR cuSeqlens, GM_ADDR chunkIndices, GM_ADDR o,
-                                    GM_ADDR userWorkspace, const ChunkFwdOTilingData *tiling)
+                                    GM_ADDR userWorkspace, const GdnMegaArch22FwdOTilingData *tiling)
 {
     if (tiling->dataType == 1) {
         if (tiling->gDataType == 2) {
@@ -305,17 +305,17 @@ __aicore__ inline void RunFused(
     GM_ADDR finalState, GM_ADDR workspace, GM_ADDR tiling)
 {
     GM_ADDR userWorkspace = AscendC::GetUserWorkspace(workspace);
-    const uint64_t oTilingOffset = AlignTilingSize(sizeof(ChunkGatedDeltaRuleFwdHTilingData));
-    const __gm__ ChunkFwdOTilingData *gmOTiling =
-        reinterpret_cast<const __gm__ ChunkFwdOTilingData *>(tiling + oTilingOffset);
+    const uint64_t oTilingOffset = AlignTilingSize(sizeof(GdnMegaArch22FwdHTilingData));
+    const __gm__ GdnMegaArch22FwdOTilingData *gmOTiling =
+        reinterpret_cast<const __gm__ GdnMegaArch22FwdOTilingData *>(tiling + oTilingOffset);
     const __gm__ ChunkRecomputeWUFwdHOTrailer *trailer =
         reinterpret_cast<const __gm__ ChunkRecomputeWUFwdHOTrailer *>(
-            tiling + oTilingOffset + sizeof(ChunkFwdOTilingData));
+            tiling + oTilingOffset + sizeof(GdnMegaArch22FwdOTilingData));
     GM_ADDR w = userWorkspace + trailer->wIntermediateOffset;
     GM_ADDR u = userWorkspace + trailer->uIntermediateOffset;
     GM_ADDR h = userWorkspace + trailer->hIntermediateOffset;
     GM_ADDR vNew = userWorkspace + trailer->vNewIntermediateOffset;
-    RecomputeWUFwdTilingData recomputeTiling{};
+    GdnMegaArch22RecomputeWUTilingData recomputeTiling{};
     CopyRecomputeTiling(&trailer->recompute, recomputeTiling);
 
     if (trailer->qDataType == 1) {
@@ -342,7 +342,7 @@ __aicore__ inline void RunFused(
     DispatchFwdH<TileShapes>(k, w, u, g, gk, initialState, cuSeqlens, chunkIndices,
                              h, vNew, finalState, tiling, userWorkspace);
 
-    ChunkFwdOTilingData oTiling{};
+    GdnMegaArch22FwdOTilingData oTiling{};
     CopyOTiling(gmOTiling, oTiling);
     DispatchFwdO(q, k, vNew, h, g, cuSeqlens, chunkIndices, o, userWorkspace, &oTiling);
 }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_recompute_wu_fwd_ho/op_kernel/chunk_recompute_wu_fwd_ho_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/chunk_recompute_wu_fwd_ho/op_kernel/chunk_recompute_wu_fwd_ho_struct.h
@@ -12,7 +12,7 @@
 namespace GDN {
 
 struct ChunkRecomputeWUFwdHOTrailer {
-    RecomputeWUFwdTilingData recompute;
+    GdnMegaArch22RecomputeWUTilingData recompute;
     int64_t recomputeWorkspaceOffset;
     int64_t wIntermediateOffset;
     int64_t uIntermediateOffset;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/recompute_w_u_fwd/op_host/op_tiling/recompute_w_u_fwd_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/recompute_w_u_fwd/op_host/op_tiling/recompute_w_u_fwd_tiling.h
@@ -18,7 +18,7 @@
 
 namespace optiling {
 
-using GDN::RecomputeWUFwdTilingData;
+using GDN::GdnMegaArch22RecomputeWUTilingData;
 
 struct RecomputeWUFwdCompileInfo {};
 

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/recompute_w_u_fwd/op_host/op_tiling/recompute_w_u_fwd_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/recompute_w_u_fwd/op_host/op_tiling/recompute_w_u_fwd_tiling_processor.h
@@ -12,8 +12,8 @@
  * \brief Tiling processor shared by aclnn tiling and fast kernel launch.
  */
 
-#ifndef RECOMPUTE_W_U_FWD_TILING_PROCESSOR_H
-#define RECOMPUTE_W_U_FWD_TILING_PROCESSOR_H
+#ifndef GDN_MEGA_ARCH22_RECOMPUTE_W_U_FWD_TILING_PROCESSOR_H
+#define GDN_MEGA_ARCH22_RECOMPUTE_W_U_FWD_TILING_PROCESSOR_H
 
 #include <cstddef>
 #include <cstdint>
@@ -24,7 +24,7 @@
 #include "tiling_base/tiling_templates_registry.h"
 #include "../../op_kernel/recompute_w_u_fwd_struct.h"
 
-using GDN::RecomputeWUFwdTilingData;
+using GDN::GdnMegaArch22RecomputeWUTilingData;
 
 namespace optiling {
 namespace {
@@ -87,7 +87,7 @@ struct RecomputeWUFwdTilingContext {
 
 class RecomputeWUFwdTilingProcessor {
     RecomputeWUFwdTilingContext &ctx_;
-    RecomputeWUFwdTilingData &tiling_;
+    GdnMegaArch22RecomputeWUTilingData &tiling_;
     size_t workspaceSize_ = 0;
     int64_t B = 0;
     int64_t Hk = 0;
@@ -99,7 +99,7 @@ class RecomputeWUFwdTilingProcessor {
     int64_t chunkSize = 0;
 
 public:
-    explicit RecomputeWUFwdTilingProcessor(RecomputeWUFwdTilingContext &ctx, RecomputeWUFwdTilingData &tiling)
+    explicit RecomputeWUFwdTilingProcessor(RecomputeWUFwdTilingContext &ctx, GdnMegaArch22RecomputeWUTilingData &tiling)
         : ctx_(ctx), tiling_(tiling)
     {
     }
@@ -428,4 +428,4 @@ public:
 } // namespace
 } // namespace optiling
 
-#endif // RECOMPUTE_W_U_FWD_TILING_PROCESSOR_H
+#endif // GDN_MEGA_ARCH22_RECOMPUTE_W_U_FWD_TILING_PROCESSOR_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd_cube.h
@@ -18,7 +18,7 @@
 
 #include "recompute_w_u_fwd_struct.h"
 
-using GDN::RecomputeWUFwdTilingData;
+using GDN::GdnMegaArch22RecomputeWUTilingData;
 
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
 #define CATLASS_ARCH 3510
@@ -259,7 +259,7 @@ public:
 
     __aicore__ inline void Process();
 
-    __aicore__ inline void Init(const RecomputeWUFwdTilingData &tiling);
+    __aicore__ inline void Init(const GdnMegaArch22RecomputeWUTilingData &tiling);
 
 private:
     uint64_t B = 0;
@@ -297,7 +297,7 @@ template <typename kType, typename betaType, typename L1TileShape, typename L0Ti
           bool kFlattenHeadTasks, bool kAbcTaskOrder>
 __aicore__ void inline RecomputeWUFwdProcess<kType, betaType, L1TileShape, L0TileShape,
                                              kFlattenHeadTasks, kAbcTaskOrder>::Init(
-    const RecomputeWUFwdTilingData &tiling)
+    const GdnMegaArch22RecomputeWUTilingData &tiling)
 {
     B = tiling.B;
     T = tiling.T;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd_struct.h
@@ -12,14 +12,14 @@
  * \brief Shared tiling data for recompute_w_u_fwd.
  */
 
-#ifndef RECOMPUTE_W_U_FWD_STRUCT_H
-#define RECOMPUTE_W_U_FWD_STRUCT_H
+#ifndef GDN_MEGA_ARCH22_RECOMPUTE_W_U_FWD_STRUCT_H
+#define GDN_MEGA_ARCH22_RECOMPUTE_W_U_FWD_STRUCT_H
 
 #include <cstdint>
 
 namespace GDN {
 
-struct RecomputeWUFwdTilingData {
+struct GdnMegaArch22RecomputeWUTilingData {
     int64_t B;
     int64_t Hk;
     int64_t Hv;
@@ -36,4 +36,4 @@ struct RecomputeWUFwdTilingData {
 
 } // namespace GDN
 
-#endif // RECOMPUTE_W_U_FWD_STRUCT_H
+#endif // GDN_MEGA_ARCH22_RECOMPUTE_W_U_FWD_STRUCT_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch22/operators/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd_vector.h
@@ -20,7 +20,7 @@
 #include "catlass/arch/cross_core_sync.hpp"
 using namespace AscendC;
 
-using GDN::RecomputeWUFwdTilingData;
+using GDN::GdnMegaArch22RecomputeWUTilingData;
 
 template <typename kType, typename betaType, bool kFlattenHeadTasks = false,
           bool kAbcTaskOrder = false>
@@ -34,7 +34,7 @@ public:
     __aicore__ inline void Process();
     __aicore__ inline void ProcessVb();
     __aicore__ inline void ProcessKbgExp();
-    __aicore__ inline void Init(const RecomputeWUFwdTilingData &tiling, AscendC::TPipe *pipe_);
+    __aicore__ inline void Init(const GdnMegaArch22RecomputeWUTilingData &tiling, AscendC::TPipe *pipe_);
 
 private:
     uint64_t B = 0;
@@ -97,7 +97,7 @@ __aicore__ inline RecomputeWUFwdVectorProcess<kType, betaType,
 template <typename kType, typename betaType, bool kFlattenHeadTasks, bool kAbcTaskOrder>
 __aicore__ void inline RecomputeWUFwdVectorProcess<kType, betaType, kFlattenHeadTasks,
                                                    kAbcTaskOrder>::Init(
-    const RecomputeWUFwdTilingData &tiling, AscendC::TPipe *pipe_)
+    const GdnMegaArch22RecomputeWUTilingData &tiling, AscendC::TPipe *pipe_)
 {
     pipe = pipe_;
     workSpaceTensor.SetGlobalBuffer((__gm__ kType *)workspace);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch35/chunk_gated_delta_rule_fwd_arch35.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/arch35/chunk_gated_delta_rule_fwd_arch35.cpp
@@ -36,16 +36,16 @@ __aicore__ inline uint64_t AlignPhase6(uint64_t value, uint64_t alignment)
 __aicore__ inline const __gm__ ChunkGatedDeltaRuleStateOutputTrailer *GetStateOutputTrailer(GM_ADDR tiling)
 {
     const uint64_t oTilingOffset = AlignPhase6(
-        sizeof(ChunkGatedDeltaRuleFwdHTilingData), PHASE6_TILING_ALIGNMENT);
+        sizeof(GdnMegaArch35FwdHTilingData), PHASE6_TILING_ALIGNMENT);
     return reinterpret_cast<const __gm__ ChunkGatedDeltaRuleStateOutputTrailer *>(
-        tiling + oTilingOffset + sizeof(ChunkFwdOTilingData));
+        tiling + oTilingOffset + sizeof(GdnMegaArch35FwdOTilingData));
 }
 
 __aicore__ inline const __gm__ Arch35ChunkGatedDeltaRuleFwdTrailer *GetPhase6Trailer(GM_ADDR tiling)
 {
     const uint64_t oTilingOffset = AlignPhase6(
-        sizeof(ChunkGatedDeltaRuleFwdHTilingData), PHASE6_TILING_ALIGNMENT);
-    const uint64_t stateOutputTilingEnd = oTilingOffset + sizeof(ChunkFwdOTilingData) +
+        sizeof(GdnMegaArch35FwdHTilingData), PHASE6_TILING_ALIGNMENT);
+    const uint64_t stateOutputTilingEnd = oTilingOffset + sizeof(GdnMegaArch35FwdOTilingData) +
                                           sizeof(ChunkGatedDeltaRuleStateOutputTrailer);
     return reinterpret_cast<const __gm__ Arch35ChunkGatedDeltaRuleFwdTrailer *>(
         tiling + AlignPhase6(stateOutputTilingEnd, PHASE6_TILING_ALIGNMENT));
@@ -347,7 +347,7 @@ __aicore__ inline void RunPhase6(
     GM_ADDR u = userWorkspace + stateOutputTiling->uIntermediateOffset;
     GM_ADDR h = userWorkspace + stateOutputTiling->hIntermediateOffset;
     GM_ADDR vNew = userWorkspace + stateOutputTiling->vNewIntermediateOffset;
-    RecomputeWUFwdTilingData recomputeTiling{};
+    GdnMegaArch35RecomputeWUTilingData recomputeTiling{};
     CopyRecomputeTiling(&stateOutputTiling->recompute, recomputeTiling);
     if constexpr (Arch35GdnSyncTraits<Variant>::kB30) {
         DispatchRecompute<InputT, float, 128, true>(
@@ -379,10 +379,10 @@ __aicore__ inline void RunPhase6(
 #endif
 
     const uint64_t oTilingOffset =
-        AlignPhase6(sizeof(ChunkGatedDeltaRuleFwdHTilingData), PHASE6_TILING_ALIGNMENT);
-    const __gm__ ChunkFwdOTilingData *gmOTiling =
-        reinterpret_cast<const __gm__ ChunkFwdOTilingData *>(tiling + oTilingOffset);
-    ChunkFwdOTilingData oTiling{};
+        AlignPhase6(sizeof(GdnMegaArch35FwdHTilingData), PHASE6_TILING_ALIGNMENT);
+    const __gm__ GdnMegaArch35FwdOTilingData *gmOTiling =
+        reinterpret_cast<const __gm__ GdnMegaArch35FwdOTilingData *>(tiling + oTilingOffset);
+    GdnMegaArch35FwdOTilingData oTiling{};
     CopyOTiling(gmOTiling, oTiling);
     DispatchFwdO<InputT, Variant>(q, k, vNew, h, gCumsumBht, cuSeqlens, chunkIndices, o,
                  userWorkspace, &oTiling);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/gated_delta_rule_state_update_output/chunk_gated_delta_rule_state_update_output.cpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/gated_delta_rule_state_update_output/chunk_gated_delta_rule_state_update_output.cpp
@@ -64,8 +64,8 @@ __aicore__ inline void DispatchFwdH(GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g, 
                                     GM_ADDR h, GM_ADDR vNew, GM_ADDR finalState, GM_ADDR tiling,
                                     GM_ADDR userWorkspace)
 {
-    const __gm__ ChunkGatedDeltaRuleFwdHTilingData *hTiling =
-        reinterpret_cast<const __gm__ ChunkGatedDeltaRuleFwdHTilingData *>(tiling);
+    const __gm__ GdnMegaArch35FwdHTilingData *hTiling =
+        reinterpret_cast<const __gm__ GdnMegaArch35FwdHTilingData *>(tiling);
     // Mega's input dtype is fixed by the generated DTYPE_Q variant, and its
     // cumsum/gk contract is FP32. State remains runtime-selected: a disabled
     // final-state output is an FP32 placeholder, not the initial-state dtype.
@@ -100,7 +100,7 @@ __aicore__ inline void DispatchFwdH(GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g, 
     }
 }
 
-__aicore__ inline void CopyOTiling(const __gm__ ChunkFwdOTilingData *src, ChunkFwdOTilingData &dst)
+__aicore__ inline void CopyOTiling(const __gm__ GdnMegaArch35FwdOTilingData *src, GdnMegaArch35FwdOTilingData &dst)
 {
     dst.shapeBatch = src->shapeBatch;
     dst.seqlen = src->seqlen;
@@ -121,8 +121,8 @@ __aicore__ inline void CopyOTiling(const __gm__ ChunkFwdOTilingData *src, ChunkF
     dst.scale = src->scale;
 }
 
-__aicore__ inline void CopyRecomputeTiling(const __gm__ RecomputeWUFwdTilingData *src,
-                                            RecomputeWUFwdTilingData &dst)
+__aicore__ inline void CopyRecomputeTiling(const __gm__ GdnMegaArch35RecomputeWUTilingData *src,
+                                            GdnMegaArch35RecomputeWUTilingData &dst)
 {
     // Tiling data is serialized in GM; the recompute process consumes a local-memory copy.
     dst.B = src->B;
@@ -142,7 +142,7 @@ __aicore__ inline void CopyRecomputeTiling(const __gm__ RecomputeWUFwdTilingData
 template <typename InputT, typename GT, Arch35GdnSyncVariant Variant>
 __aicore__ inline void RunFwdO(GM_ADDR q, GM_ADDR k, GM_ADDR vNew, GM_ADDR h, GM_ADDR g,
                                GM_ADDR cuSeqlens, GM_ADDR chunkIndices, GM_ADDR o,
-                               GM_ADDR userWorkspace, const ChunkFwdOTilingData *tiling)
+                               GM_ADDR userWorkspace, const GdnMegaArch35FwdOTilingData *tiling)
 {
     using Sync = Arch35GdnSyncTraits<Variant>;
     using Kernel = Catlass::Gemm::Kernel::GDNFwdOKernel<
@@ -157,7 +157,7 @@ template <typename kType, typename betaType, int VDim, typename TileShapes,
 __aicore__ inline void RunRecompute(
     GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR g, GM_ADDR cuSeqlens,
     GM_ADDR chunkIndices, GM_ADDR w, GM_ADDR u, GM_ADDR workspace,
-    const RecomputeWUFwdTilingData *tiling)
+    const GdnMegaArch35RecomputeWUTilingData *tiling)
 {
     if ASCEND_IS_AIC {
         RecomputeWUFwdProcess<kType, betaType, typename TileShapes::L1TileShape,
@@ -179,7 +179,7 @@ template <typename kType, typename betaType, int VDim, bool kCoefficientGenerati
 __aicore__ inline void DispatchRecompute(
     GM_ADDR k, GM_ADDR v, GM_ADDR beta, GM_ADDR A, GM_ADDR g, GM_ADDR cuSeqlens,
     GM_ADDR chunkIndices, GM_ADDR w, GM_ADDR u, GM_ADDR workspace,
-    const RecomputeWUFwdTilingData *tiling)
+    const GdnMegaArch35RecomputeWUTilingData *tiling)
 {
     if constexpr (VDim == 256) {
         RunRecompute<kType, betaType, VDim,
@@ -195,7 +195,7 @@ __aicore__ inline void DispatchRecompute(
 template <typename InputT, Arch35GdnSyncVariant Variant>
 __aicore__ inline void DispatchFwdO(GM_ADDR q, GM_ADDR k, GM_ADDR vNew, GM_ADDR h, GM_ADDR g,
                                     GM_ADDR cuSeqlens, GM_ADDR chunkIndices, GM_ADDR o,
-                                    GM_ADDR userWorkspace, const ChunkFwdOTilingData *tiling)
+                                    GM_ADDR userWorkspace, const GdnMegaArch35FwdOTilingData *tiling)
 {
     RunFwdO<InputT, float, Variant>(q, k, vNew, h, g, cuSeqlens, chunkIndices, o, userWorkspace, tiling);
 }

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/gated_delta_rule_state_update_output/chunk_gated_delta_rule_state_update_output_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/gated_delta_rule_state_update_output/chunk_gated_delta_rule_state_update_output_struct.h
@@ -12,7 +12,7 @@
 namespace GDN {
 
 struct ChunkGatedDeltaRuleStateOutputTrailer {
-    RecomputeWUFwdTilingData recompute;
+    GdnMegaArch35RecomputeWUTilingData recompute;
     int64_t recomputeWorkspaceOffset;
     int64_t wIntermediateOffset;
     int64_t uIntermediateOffset;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_fwd_o/op_kernel/chunk_fwd_o_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_fwd_o/op_kernel/chunk_fwd_o_struct.h
@@ -12,14 +12,14 @@
  * \brief Shared tiling data for chunk_fwd_o.
  */
 
-#ifndef CHUNK_FWD_O_STRUCT_H
-#define CHUNK_FWD_O_STRUCT_H
+#ifndef GDN_MEGA_ARCH35_CHUNK_FWD_O_STRUCT_H
+#define GDN_MEGA_ARCH35_CHUNK_FWD_O_STRUCT_H
 
 #include <cstdint>
 
 namespace GDN {
 
-struct ChunkFwdOTilingData {
+struct GdnMegaArch35FwdOTilingData {
     int64_t shapeBatch;
     int64_t seqlen;
     int64_t kNumHead;
@@ -41,4 +41,4 @@ struct ChunkFwdOTilingData {
 
 } // namespace GDN
 
-#endif // CHUNK_FWD_O_STRUCT_H
+#endif // GDN_MEGA_ARCH35_CHUNK_FWD_O_STRUCT_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_fwd_o/op_kernel/gemm/block/block_scheduler_gdn_fwd_o.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_fwd_o/op_kernel/gemm/block/block_scheduler_gdn_fwd_o.hpp
@@ -92,7 +92,7 @@ struct BlockSchedulerGdnFwdO {
     BlockSchedulerGdnFwdO() {}
 
     CATLASS_DEVICE
-    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::ChunkFwdOTilingData *tilingData,
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::GdnMegaArch35FwdOTilingData *tilingData,
               uint32_t coreIdx, uint32_t coreNum, bool enableChunkPipeline = false,
               bool enableTaskAffinity = false) {
         shapeBatch = tilingData->shapeBatch;
@@ -298,7 +298,7 @@ struct BlockSchedulerGdnFwdOCube : public BlockSchedulerGdnFwdO {
     BlockSchedulerGdnFwdOCube() {}
 
     CATLASS_DEVICE
-    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::ChunkFwdOTilingData *tilingData,
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::GdnMegaArch35FwdOTilingData *tilingData,
               bool enableChunkPipeline = false, bool enableTaskAffinity = false) {
         BlockSchedulerGdnFwdO::Init(cu_seqlens, chunk_offsets, tilingData, AscendC::GetBlockIdx(),
                                     AscendC::GetBlockNum(), enableChunkPipeline, enableTaskAffinity);
@@ -353,7 +353,7 @@ struct BlockSchedulerGdnFwdOVec : public BlockSchedulerGdnFwdO {
     BlockSchedulerGdnFwdOVec() {}
 
     CATLASS_DEVICE
-    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::ChunkFwdOTilingData *tilingData,
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, const GDN::GdnMegaArch35FwdOTilingData *tilingData,
               bool enableChunkPipeline = false, bool enableTaskAffinity = false) {
         BlockSchedulerGdnFwdO::Init(cu_seqlens, chunk_offsets, tilingData,
                                     AscendC::GetBlockIdx() / AscendC::GetSubBlockNum(), AscendC::GetBlockNum(),

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_fwd_o/op_kernel/gemm/kernel/gdn_fwd_o_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_fwd_o/op_kernel/gemm/kernel/gdn_fwd_o_kernel.hpp
@@ -275,7 +275,7 @@ public:
     __aicore__ inline GDNFwdOKernel() {}
 
     __aicore__ inline void Init(GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR h, GM_ADDR g,
-        GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, GM_ADDR o, const GDN::ChunkFwdOTilingData *tilingData, GM_ADDR user) {
+        GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, GM_ADDR o, const GDN::GdnMegaArch35FwdOTilingData *tilingData, GM_ADDR user) {
 
         shapeBatch = tilingData->shapeBatch;
         seqlen = tilingData->seqlen;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.h
@@ -22,7 +22,7 @@ namespace optiling {
 // Fusion-only serialization type; the standalone operator owns its registration.
 namespace {
 
-BEGIN_TILING_DATA_DEF(ChunkGatedDeltaRuleFwdHTilingData)
+BEGIN_TILING_DATA_DEF(GdnMegaArch35FwdHTilingData)
 TILING_DATA_FIELD_DEF(int64_t, batch);
 TILING_DATA_FIELD_DEF(int64_t, seqlen);
 TILING_DATA_FIELD_DEF(int64_t, kNumHead);

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.h
@@ -19,6 +19,8 @@
 #include <tiling/tiling_api.h>
 
 namespace optiling {
+// Fusion-only serialization type; the standalone operator owns its registration.
+namespace {
 
 BEGIN_TILING_DATA_DEF(ChunkGatedDeltaRuleFwdHTilingData)
 TILING_DATA_FIELD_DEF(int64_t, batch);
@@ -46,7 +48,6 @@ TILING_DATA_FIELD_DEF(int64_t, numSeqWorkspaceOffset);
 TILING_DATA_FIELD_DEF(int64_t, numChunksWorkspaceOffset);
 END_TILING_DATA_DEF;
 
-REGISTER_TILING_DATA_CLASS(ChunkGatedDeltaRuleFwdH, ChunkGatedDeltaRuleFwdHTilingData)
-
 struct ChunkGatedDeltaRuleFwdHCompileInfo {};
+} // namespace
 } // namespace optiling

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling_processor.h
@@ -14,12 +14,12 @@
  *
  * The caller is responsible for resolving framework-specific information (shapes, dtypes,
  * platform core number, lib-api workspace size) into the plain context struct below. The
- * processor then fills the plain ChunkGatedDeltaRuleFwdHTilingData together with the block
+ * processor then fills the plain GdnMegaArch35FwdHTilingData together with the block
  * dim and the total workspace size, mirroring exactly the original Tiling4ChunkGatedDeltaRuleFwdH.
  */
 
-#ifndef CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H
-#define CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H
+#ifndef GDN_MEGA_ARCH35_CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H
+#define GDN_MEGA_ARCH35_CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H
 
 #include <cstddef>
 #include <cstdint>
@@ -70,7 +70,7 @@ public:
     explicit ChunkGatedDeltaRuleFwdHTilingProcessor(const ChunkGatedDeltaRuleFwdHTilingContext &ctx) : ctx_(ctx) {}
 
     // Fills the plain tiling struct, the block dim and the total workspace size.
-    void Process(::ChunkGatedDeltaRuleFwdHTilingData &tiling, uint32_t &blockDim, size_t &workspaceSize) const
+    void Process(::GdnMegaArch35FwdHTilingData &tiling, uint32_t &blockDim, size_t &workspaceSize) const
     {
         int64_t isVariedLen;
         int64_t shapeBatch;
@@ -153,4 +153,4 @@ private:
 } // namespace
 } // namespace optiling
 
-#endif // CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H
+#endif // GDN_MEGA_ARCH35_CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling_processor.h
@@ -27,6 +27,7 @@
 #include "../op_kernel/chunk_gated_delta_rule_fwd_h_struct.h"
 
 namespace optiling {
+namespace {
 
 // dtype enum convention shared with the kernel: 0 - fp16, 1 - bf16, 2 - fp32
 static constexpr int64_t GDN_FWD_H_DTYPE_FP16 = 0;
@@ -149,6 +150,7 @@ private:
     const ChunkGatedDeltaRuleFwdHTilingContext &ctx_;
 };
 
+} // namespace
 } // namespace optiling
 
 #endif // CHUNK_GATED_DELTA_RULE_FWD_H_TILING_PROCESSOR_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/block/block_scheduler_gdn_fwd_h.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/block/block_scheduler_gdn_fwd_h.hpp
@@ -133,7 +133,7 @@ struct BlockSchedulerGdnFwdH {
     CATLASS_DEVICE
     void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR tiling, GM_ADDR user,
               uint32_t coreIdx, uint32_t coreNum, bool useWaveTaskMapping = false) {
-        __gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict>(tiling);
+        __gm__ GdnMegaArch35FwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ GdnMegaArch35FwdHTilingData *__restrict>(tiling);
 
         batch = gdnFwdHTilingData->batch;
         seqlen = gdnFwdHTilingData->seqlen;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_kernel/arch35/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -255,7 +255,7 @@ public:
     __aicore__ inline void Init(GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g, GM_ADDR gk, GM_ADDR inital_state, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
         GM_ADDR h, GM_ADDR v_new, GM_ADDR final_state, GM_ADDR tiling, GM_ADDR user) {
 
-        __gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict>(tiling);
+        __gm__ GdnMegaArch35FwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ GdnMegaArch35FwdHTilingData *__restrict>(tiling);
 
         batch = gdnFwdHTilingData->batch;
         seqlen = gdnFwdHTilingData->seqlen;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h_struct.h
@@ -12,7 +12,7 @@
  * \brief Plain tiling data struct for chunk_gated_delta_rule_fwd_h.
  *
  * The aclnn/ascendc framework auto-generates a kernel-side tiling struct named
- * ChunkGatedDeltaRuleFwdHTilingData (global scope) from the BEGIN_TILING_DATA_DEF
+ * GdnMegaArch35FwdHTilingData (global scope) from the BEGIN_TILING_DATA_DEF
  * macro in chunk_gated_delta_rule_fwd_h_tiling.h. The fast kernel launch extension
  * compiles the kernel standalone (without that auto-generated header), so it provides
  * the same plain struct here. The field order/types mirror the macro definition so the
@@ -20,12 +20,12 @@
  * to the kernel via the <<<>>> launch (its address is a valid GM_ADDR on Atlas A2).
  */
 
-#ifndef CHUNK_GATED_DELTA_RULE_FWD_H_STRUCT_H
-#define CHUNK_GATED_DELTA_RULE_FWD_H_STRUCT_H
+#ifndef GDN_MEGA_ARCH35_CHUNK_GATED_DELTA_RULE_FWD_H_STRUCT_H
+#define GDN_MEGA_ARCH35_CHUNK_GATED_DELTA_RULE_FWD_H_STRUCT_H
 
 #include <cstdint>
 
-struct ChunkGatedDeltaRuleFwdHTilingData {
+struct GdnMegaArch35FwdHTilingData {
     int64_t batch;
     int64_t seqlen;
     int64_t kNumHead;
@@ -51,4 +51,4 @@ struct ChunkGatedDeltaRuleFwdHTilingData {
     int64_t numChunksWorkspaceOffset;
 };
 
-#endif // CHUNK_GATED_DELTA_RULE_FWD_H_STRUCT_H
+#endif // GDN_MEGA_ARCH35_CHUNK_GATED_DELTA_RULE_FWD_H_STRUCT_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
@@ -132,7 +132,7 @@ struct BlockSchedulerGdnFwdH {
 
     CATLASS_DEVICE
     void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR tiling, GM_ADDR user, uint32_t coreIdx, uint32_t coreNum) {
-        __gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict>(tiling);
+        __gm__ GdnMegaArch35FwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ GdnMegaArch35FwdHTilingData *__restrict>(tiling);
 
         batch = gdnFwdHTilingData->batch;
         seqlen = gdnFwdHTilingData->seqlen;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -236,7 +236,7 @@ public:
     __aicore__ inline void Init(GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g, GM_ADDR gk, GM_ADDR inital_state, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
         GM_ADDR h, GM_ADDR v_new, GM_ADDR final_state, GM_ADDR tiling, GM_ADDR user) {
 
-        __gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict>(tiling);
+        __gm__ GdnMegaArch35FwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ GdnMegaArch35FwdHTilingData *__restrict>(tiling);
 
         batch = gdnFwdHTilingData->batch;
         seqlen = gdnFwdHTilingData->seqlen;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/recompute_w_u_fwd/op_host/op_tiling/recompute_w_u_fwd_tiling_processor.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/recompute_w_u_fwd/op_host/op_tiling/recompute_w_u_fwd_tiling_processor.h
@@ -12,8 +12,8 @@
  * \brief Tiling processor shared by aclnn tiling and fast kernel launch.
  */
 
-#ifndef RECOMPUTE_W_U_FWD_TILING_PROCESSOR_H
-#define RECOMPUTE_W_U_FWD_TILING_PROCESSOR_H
+#ifndef GDN_MEGA_ARCH35_RECOMPUTE_W_U_FWD_TILING_PROCESSOR_H
+#define GDN_MEGA_ARCH35_RECOMPUTE_W_U_FWD_TILING_PROCESSOR_H
 
 #include <cstddef>
 #include <cstdint>
@@ -24,7 +24,7 @@
 #include "tiling_base/tiling_templates_registry.h"
 #include "../../op_kernel/recompute_w_u_fwd_struct.h"
 
-using GDN::RecomputeWUFwdTilingData;
+using GDN::GdnMegaArch35RecomputeWUTilingData;
 
 namespace optiling {
 namespace {
@@ -94,7 +94,7 @@ struct RecomputeWUFwdTilingContext {
 
 class RecomputeWUFwdTilingProcessor {
     RecomputeWUFwdTilingContext &ctx_;
-    RecomputeWUFwdTilingData &tiling_;
+    GdnMegaArch35RecomputeWUTilingData &tiling_;
     size_t workspaceSize_ = 0;
     int64_t B = 0;
     int64_t Hk = 0;
@@ -106,7 +106,7 @@ class RecomputeWUFwdTilingProcessor {
     int64_t chunkSize = 0;
 
 public:
-    explicit RecomputeWUFwdTilingProcessor(RecomputeWUFwdTilingContext &ctx, RecomputeWUFwdTilingData &tiling)
+    explicit RecomputeWUFwdTilingProcessor(RecomputeWUFwdTilingContext &ctx, GdnMegaArch35RecomputeWUTilingData &tiling)
         : ctx_(ctx), tiling_(tiling)
     {
     }
@@ -483,4 +483,4 @@ public:
 } // namespace
 } // namespace optiling
 
-#endif // RECOMPUTE_W_U_FWD_TILING_PROCESSOR_H
+#endif // GDN_MEGA_ARCH35_RECOMPUTE_W_U_FWD_TILING_PROCESSOR_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd_cube.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd_cube.h
@@ -18,7 +18,7 @@
 
 #include "recompute_w_u_fwd_struct.h"
 
-using GDN::RecomputeWUFwdTilingData;
+using GDN::GdnMegaArch35RecomputeWUTilingData;
 
 #if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
 #define CATLASS_ARCH 3510
@@ -371,7 +371,7 @@ public:
 
     __aicore__ inline void Process();
 
-    __aicore__ inline void Init(const RecomputeWUFwdTilingData &tiling);
+    __aicore__ inline void Init(const GdnMegaArch35RecomputeWUTilingData &tiling);
 
 private:
     uint64_t B = 0;
@@ -409,7 +409,7 @@ template <typename kType, typename betaType, typename L1TileShape, typename L0Ti
           bool kFlattenHeadTasks, bool kCoefficientGenerationTaskOrder>
 __aicore__ void inline RecomputeWUFwdProcess<kType, betaType, L1TileShape, L0TileShape,
                                              kFlattenHeadTasks, kCoefficientGenerationTaskOrder>::Init(
-    const RecomputeWUFwdTilingData &tiling)
+    const GdnMegaArch35RecomputeWUTilingData &tiling)
 {
     B = tiling.B;
     T = tiling.T;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd_struct.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd_struct.h
@@ -12,14 +12,14 @@
  * \brief Shared tiling data for recompute_w_u_fwd.
  */
 
-#ifndef RECOMPUTE_W_U_FWD_STRUCT_H
-#define RECOMPUTE_W_U_FWD_STRUCT_H
+#ifndef GDN_MEGA_ARCH35_RECOMPUTE_W_U_FWD_STRUCT_H
+#define GDN_MEGA_ARCH35_RECOMPUTE_W_U_FWD_STRUCT_H
 
 #include <cstdint>
 
 namespace GDN {
 
-struct RecomputeWUFwdTilingData {
+struct GdnMegaArch35RecomputeWUTilingData {
     int64_t B;
     int64_t Hk;
     int64_t Hv;
@@ -36,4 +36,4 @@ struct RecomputeWUFwdTilingData {
 
 } // namespace GDN
 
-#endif // RECOMPUTE_W_U_FWD_STRUCT_H
+#endif // GDN_MEGA_ARCH35_RECOMPUTE_W_U_FWD_STRUCT_H

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd_vector.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/op_kernel/internal/operators/recompute_w_u_fwd/op_kernel/recompute_w_u_fwd_vector.h
@@ -26,7 +26,7 @@ using namespace AscendC;
 using namespace AscendC::MicroAPI;
 #endif
 
-using GDN::RecomputeWUFwdTilingData;
+using GDN::GdnMegaArch35RecomputeWUTilingData;
 
 template <typename kType, typename betaType, bool kFlattenHeadTasks = false,
           bool kCoefficientGenerationTaskOrder = false>
@@ -44,7 +44,7 @@ public:
     __aicore__ inline void ProcessVb();
     __aicore__ inline void ProcessKbgExp();
 #endif
-    __aicore__ inline void Init(const RecomputeWUFwdTilingData &tiling, AscendC::TPipe *pipe_);
+    __aicore__ inline void Init(const GdnMegaArch35RecomputeWUTilingData &tiling, AscendC::TPipe *pipe_);
 
 private:
     uint64_t B = 0;
@@ -136,7 +136,7 @@ __aicore__ inline RecomputeWUFwdVectorProcess<kType, betaType,
 template <typename kType, typename betaType, bool kFlattenHeadTasks, bool kCoefficientGenerationTaskOrder>
 __aicore__ void inline RecomputeWUFwdVectorProcess<kType, betaType, kFlattenHeadTasks,
                                                    kCoefficientGenerationTaskOrder>::Init(
-    const RecomputeWUFwdTilingData &tiling, AscendC::TPipe *pipe_)
+    const GdnMegaArch35RecomputeWUTilingData &tiling, AscendC::TPipe *pipe_)
 {
     pipe = pipe_;
     workSpaceTensor.SetGlobalBuffer((__gm__ kType *)workspace);


### PR DESCRIPTION
# Pull Request 模板

## 合入门禁提醒

> **NPU CI 不会在 PR 新建、重开或 push 新 commit 时自动执行。**
>
> PR 新建、重开或 push 新 commit 后，GitHub 会自动把当前 head commit 标记为 `NPU CI / 手动验证 pending`，说明该 commit 暂未执行 NPU CI。机器人评论会提示可请求仓库 Admin 权限账号触发。
>
> 合入前，当前 head commit 必须具备成功的 `NPU CI / 手动验证` 状态，并且满足 GitHub 分支保护要求的 2 个 approval；如果本 PR 后续更新了 commit，旧 commit 的 CI 结果不再有效，需要仓库 Admin 权限账号重新触发。即使已有 2 个 approval，只要当前 commit 未完成 NPU CI，仍不可合入（`weinachuan` 可按仓库保护规则 bypass）。
>
> 触发方式：
>
> - GitHub `Actions` 页面选择 `NPU CI`，点击 `Run workflow`，填写本 PR 编号。
> - 在 PR 评论区发送 `/run-npu-ci quick` 或 `/run-npu-ci full`。
> - 同一 PR 的同一 commit 如果已有 NPU CI 在排队或运行，重复评论只会更新机器人评论，不会再次占用 NPU。
> - NPU CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例；当前 `case1_current_default` 保持原始 shape。新增 GVA、`Vdim=256` 等场景时，请在用例文件中显式填写 `B`、`T`、`chunk_size`、`query_head`、`value_head`、`Kdim`、`Vdim` 等 shape 字段，以及 `gate_source`、`gate_function`、`initial_state`、`output_final_state`、`qk_l2norm` 等行为字段。
> - Example ST 必须使用 Ascend PyTorch `v26.1.0-beta.1` 对应的 `torch_npu` 可用版本 wheel（已包含 `torchnpugen` 并修复 GDN stream 同步问题）；PyTorch 小版本可按环境选择，但不要拉取 `op-plugin` 重新编译或安装不属于该 `torch_npu` 可用版本范围的旧版 `torch-npu`。
> - 修改算子 `def`、`aclnn` 接口入参类型，或修改 `torch` 接口入参类型等导致不满足 ABI 一致性的改动，必须由 `weinachuan` 在当前 head commit 上检视通过；ABI 敏感路径已由 CODEOWNERS 指向 `weinachuan`。
> - NPU CI 部署与排障教程见 [`docs/Fla-npu仓CI部署教程.md`](docs/Fla-npu仓CI部署教程.md)。

## 关联 Issue / 背景

- 关联 Issue: Related to #437（GDN Phase6 架构隔离，已关闭）；本 PR 是该实现的后续私有 tiling 隔离修复，不重新关闭原 Issue。相关 PR：#432、#518。测试侧尚未复现的特定 shape 越界不在已证明解决的范围内。
- 背景与目标: 基于已合入 #518 的 main@ebb5694d，隔离融合内部 WU/H/O 与公共单算子的 tiling 定义和注册归属，避免独立迭代引入类型冲突。
- 本 PR 解决的问题:
  1. 删除融合私有 A5/arch22 FwdH 的两处公共名 factory 注册，将私有宏类及 Context/Processor 放入匿名 namespace；公共 FwdH 保留自己的注册。
  2. WU/H/O 六份私有 tiling 类型及对应头文件保护宏按 Arch22/Arch35 独立命名，避免公共/私有及架构间重名。旧 WU 公共结构104字节、私有96字节，旧头包含顺序可决定实际可见的结构。
  3. 保持字段、sizeof/offsetof、序列化布局、分块策略、workspace、同步和公开 ABI 不变。此次37文件变化均在融合目录内，没有修改公共单算子实现、测试矩阵、构建配置或README。

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [x] 算子精度 / 稳定性修复
- [x] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

请明确本 PR 修改的算子责任边界，便于审查、验收和后续维护。

- 涉及算子名称: `chunk_gated_delta_rule_fwd`；内部 WU、FwdH、FwdO 组件。
- 涉及目录 / 文件: `fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_gated_delta_rule_fwd/` 内的 `op_host/op_tiling/arch22`、`arch35` 和 `op_kernel/internal/` 私有实现，共37文件。
- 责任人 / 提交人: @yjmyl
- 修改范围:
  - [x] `op_host` / 算子定义
  - [ ] `InferShape` / 参数校验
  - [x] `Tiling` 策略（仅类型与注册隔离，计算策略未变）
  - [x] `op_kernel` / Ascend C Kernel
  - [ ] `op_api` / aclnn 接口
  - [ ] `torch_custom` 适配
  - [ ] `Triton` 算子
  - [ ] 单算子测试
  - [ ] `example / ST` 测试
  - [ ] 文档
- 输入 / 输出 / shape / dtype / format 支持范围: 沿用main现有合同；不新增shape/dtype/layout或路由。`disable_recompute=True`（默认）为训练输出，False为推理输出，语义不变。
- 明确不包含的范围: 公共WU/H/O内核功能变更、公共FwdH两行尾块测试依赖、性能优化、Prepare路径扩展，以及尚未复现的特定shape越界根因结论。
- 是否影响公共模块或其他算子:
  - [ ] 否
  - [x] 是，请说明影响面、兼容策略和回归范围: 公共单算子源码与ABI不变；解除融合私有FwdH对公共factory注册，以及WU/H/O同名类型的干扰，回归涵盖WU原200条联编对照与原Example/ST。
- ABI / 接口兼容性:
  - [x] 不涉及算子 `def`、`aclnn` 接口或 `torch` 接口入参 / 返回值 / 必选可选属性变化
  - [ ] 涉及 ABI 不兼容风险，已说明原因，并需要 `weinachuan` 检视通过
- ABI 不兼容风险说明: 无公开ABI变更；六份私有结构的sizeof和每字段offsetof已对照main验证，原29参数ABI检查及8个Python ABI单测通过。

<details>
<summary>版本与产品编译矩阵</summary>

本 PR 必须保证配套版本满足以下编译要求。当前工程中产品与 `--soc` 参数的对应关系如下:

| 产品 | `--soc` |
| --- | --- |
| A2 | `ascend910b` |
| A3 | `ascend910_93` |
| A5 | `ascend950` |

</details>

<details>
<summary>验证方法</summary>

请按本节方法执行验证，并把实际命令、结果和日志填写到后续矩阵中。`chunk_gated_delta_rule_fwd` 替换为本 PR 修改的算子名；多个算子用逗号分隔，或逐个填写。

### 1. 环境确认

在每套 CANN / 产品环境中先确认基础信息。

```sh
# 默认 CANN 安装路径；自定义安装路径时替换为实际路径下对应的 set_env.sh
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cat /usr/local/Ascend/ascend-toolkit/latest/opp/version.info
npu-smi info
```

记录项:

- CANN 版本: 实测9.1.0（满足下述“8.5及以上/9.0及以上”，不是8.5、9.0原版本的独立测试）。
- 产品 / 芯片类型: A5实机；A2/A3目标在同一CANN9.1环境交叉编译。
- 机器或 CI 链接: 本地受控A5验证；运行ID与归档摘要见下表，当前产品head尚未执行仓库NPU CI。

### 2. 编译验证

CANN 8.5 及以上需要验证 A2 / A3:

```sh
bash build.sh --pkg --soc=ascend910b --ops=chunk_gated_delta_rule_fwd --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=chunk_gated_delta_rule_fwd --vendor_name=fla_npu
```

CANN 9.0 及以上需要验证 A2 / A3 / A5:

```sh
bash build.sh --pkg --soc=ascend910b --ops=chunk_gated_delta_rule_fwd --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend910_93 --ops=chunk_gated_delta_rule_fwd --vendor_name=fla_npu
bash build.sh --pkg --soc=ascend950 --ops=chunk_gated_delta_rule_fwd --vendor_name=fla_npu
```

通过标准:

- 命令退出码为 0
- `build_out/` 下生成对应 `.run` 包
- 编译日志无 `ERROR` / `FAILED` / 关键 warning

### 3. 修改算子 test 验证

根据本 PR 修改范围选择对应测试入口；涉及多个入口时均需执行。

本 PR 未修改 torch_custom 适配；模板中的 torch_custom 独立测试及 fast_kernel_launch_example 通用入口不适用于本次融合目标，因此未执行这些入口。实际使用原生融合双标杆套件、WU联编诊断和 ci/run_example_st_cases.py，具体命令与结果填写在后续矩阵中。
如果对应算子目录下已有专用测试脚本或 ATK 用例，请填写实际脚本命令，并说明覆盖的 shape / dtype / format / 边界场景。

通过标准:

- 命令退出码为 0
- 测试日志显示 `PASS` / `passed` / `execute samples success`
- 精度误差满足该算子 README、测试脚本或需求说明中的阈值

### 4. 整体 example ST 验证

整体 example ST 用于确认修改没有破坏 GDN 端到端调用链。请在 A2 / A3 / A5 对应环境分别执行。

```sh
python examples/flash_gated_delta_rule.py
```

也可以由仓库 Admin 权限账号触发 CI 验证：`/run-npu-ci quick`。CI 会执行 `ci/example_st_cases.json` 中启用的 Example/ST 用例，默认覆盖当前 `case1_current_default`，仅覆盖容器内逻辑设备号 `--device`。

通过标准:

- 命令退出码为 0
- 端到端结果与 golden / PyTorch 参考实现一致
- 日志无精度异常、运行时异常、fallback 异常或 device error

</details>

<details>
<summary>修改算子测试</summary>

本 PR 修改到的算子必须完成对应 test 测试，并在 A2 / A3 / A5 覆盖验证结果。请填写实际执行命令，避免填写当前工程不支持的占位命令。

### CANN 8.5 及以上

要求: 可以编译出 A2 / A3 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0 | `FLA_NPU_SOC=ascend910b FLA_NPU_OPS="$OPS" FLA_NPU_BUILD_ARGS="--ccache off" OPS_CPU_NUMBER=8 MAX_JOBS=8 CCACHE_DISABLE=1 python -m pip wheel --no-build-isolation --no-deps --no-cache-dir -v . -w "$E/builds/main-phase6-route-private-types-ascend910b-r1/dist"` | 通过，exit=0 | `main-phase6-route-private-types-ascend910b-r1`；融合目标交叉编译，4设备对象；约89秒 |
| A3 | `ascend910_93` | 9.1.0 | `FLA_NPU_SOC=ascend910_93 FLA_NPU_OPS="$OPS" FLA_NPU_BUILD_ARGS="--ccache off" OPS_CPU_NUMBER=8 MAX_JOBS=8 CCACHE_DISABLE=1 python -m pip wheel --no-build-isolation --no-deps --no-cache-dir -v . -w "$E/builds/main-phase6-route-private-types-ascend910_93-r1/dist"` | 通过，exit=0 | `main-phase6-route-private-types-ascend910_93-r1`；融合目标交叉编译，4设备对象；约89秒 |

### CANN 9.0 及以上

要求: 可以编译出 A2 / A3 / A5 目标产物。

| 产品 | `--soc` | CANN 实际版本 | 实际执行命令 | 结果 | 产物 / 日志 |
| --- | --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 9.1.0 | `FLA_NPU_SOC=ascend910b FLA_NPU_OPS="$OPS" FLA_NPU_BUILD_ARGS="--ccache off" OPS_CPU_NUMBER=8 MAX_JOBS=8 CCACHE_DISABLE=1 python -m pip wheel --no-build-isolation --no-deps --no-cache-dir -v . -w "$E/builds/main-phase6-route-private-types-ascend910b-r1/dist"` | 通过，exit=0 | `main-phase6-route-private-types-ascend910b-r1`；融合目标交叉编译，4设备对象；约89秒 |
| A3 | `ascend910_93` | 9.1.0 | `FLA_NPU_SOC=ascend910_93 FLA_NPU_OPS="$OPS" FLA_NPU_BUILD_ARGS="--ccache off" OPS_CPU_NUMBER=8 MAX_JOBS=8 CCACHE_DISABLE=1 python -m pip wheel --no-build-isolation --no-deps --no-cache-dir -v . -w "$E/builds/main-phase6-route-private-types-ascend910_93-r1/dist"` | 通过，exit=0 | `main-phase6-route-private-types-ascend910_93-r1`；融合目标交叉编译，4设备对象；约89秒 |
| A5 | `ascend950` | 9.1.0 | `FLA_NPU_SOC=ascend950 FLA_NPU_OPS="$OPS" FLA_NPU_BUILD_ARGS="--ccache off" OPS_CPU_NUMBER=8 MAX_JOBS=8 CCACHE_DISABLE=1 python -m pip wheel --no-build-isolation --no-deps --no-cache-dir -v . -w "$E/builds/main-phase6-route-private-types-r1/dist"` | 通过，exit=0 | `main-phase6-route-private-types-r1`；14算子整包，50设备对象；317.333秒 |

如结果为“未通过”或“未执行”，请在日志列填写原因、当前阻塞点、责任人和预计补齐时间。

### 单算子测试结果

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 精度结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | 未执行 | 本轮无该平台实机；@yjmyl配合合入前补齐，资源排期待定 |
| A3 | `ascend910_93` | 未执行 | 未执行 | 本轮无该平台实机；@yjmyl配合合入前补齐，资源排期待定 |
| A5 | `ascend950` | `GDN_ATK_OUTPUT_MODE=full bash "$ATK/run_matrix_500.sh" 3`；`GDN_ATK_OUTPUT_MODE=inference bash "$ATK/run_matrix_500.sh" 4` | 验证树通过，500/500 × 2 | `main-phase6-route-private-types-full500-r1-d3`、`main-phase6-route-private-types-inference500-r1-d4`；无遗漏/重复/失败 |

- 精度对比: 验证提交41838f7a的训练full、推理inference各500/500，通过融合DUT/公共六算子benchmark/CPU FP64 golden三路比较。原矩阵、seed=20260908+caseID、5/1.5/1.5阈值未变。
- 性能对比: 本轮未重测算子性能或MSS。A5整包50个设备对象及.text与main基线逐字节相同；同配置单次构建317.333秒，基线339.219秒，仅说明本次未见编译耗时增加。
- 边界 / 异常场景: 原融合500条完整ID与边界覆盖保留。公共WU原200条BF16/FP16、GVA/noGVA、V128/V256、C64/C128各重复两次；beta/g为原用例FP32。独立包、main整包及修复整包输入/输出逐位一致。
- 未覆盖风险: A2/A3实机test/ST待补；WU200联编诊断不替代公共WU的ATK混合容差门禁，现有ATK26.7.8未绕过仓库统一入口26.8.8检查。特定shape越界尚未复现。

</details>

<details>
<summary>整体 Example ST 验证</summary>

整体 example 的 ST 测试必须在 A2 / A3 / A5 通过。

| 产品 | `--soc` | 实际执行命令 | 结果 | 日志 / 结论 |
| --- | --- | --- | --- | --- |
| A2 | `ascend910b` | 未执行 | 未执行 | 无该平台实机；@yjmyl配合合入前补齐，排期待定 |
| A3 | `ascend910_93` | 未执行 | 未执行 | 无该平台实机；@yjmyl配合合入前补齐，排期待定 |
| A5 | `ascend950` | `python ci/run_example_st_cases.py --device 5 --cases-file ci/example_st_cases.json --accuracy-report-file "$E/integration/main-phase6-route-private-types-example-r1-d5/accuracy.json"` | 验证树通过 | 4/4执行及精度通过；保留原反向检查 |

- 端到端场景说明: 原ci/example_st_cases.json四例均执行，精度4/4，包括dense/变长及原反向梯度检查；原shape、输入、golden和阈值未改。
- 与本 PR 修改算子的关联: 验证融合前向及同包公共WU反向调用链，检查类型隔离不破坏端到端执行。
- 未覆盖原因及补充计划: 本轮只有A5实机环境，A2/A3仅编译；@yjmyl配合维护者在合入前补齐，具体资源排期未定。当前产品head的仓库NPU CI及2个approval仍需正常门禁。

</details>

## 兼容性、风险与回退

- 兼容性说明: 私有类型改名不改变序列化布局、模板组合和公开ABI；公共单算子目录不变。仍共用CANN/公共模板等基础依赖，不宣称完全无耦合。
- 风险点: 后续私有字段演化必须同时维护host/device布局。实际验证树比产品多公共FwdH两行测试依赖；本地结果不能替代原样产品head的CI及多平台实机验收。
- 回退方案: 按顺序revert ab7cffbb、8fa1c71f，恢复到main@ebb5694d；无公开ABI或数据格式迁移。
- 回退责任确认:
  - [x] 若本 PR 未满足上述编译 / 测试要求，或引入阻塞性 bug，PR 提交人承诺第一时间回退或配合维护者完成回退
  - [x] 回退后会同步说明影响范围、恢复版本、后续修复计划

## Checklist

- [x] 已关联 Issue，或说明无需 Issue 的原因
- [x] 已明确本 PR 的算子责任范围和不包含范围
- [x] CANN 8.5 及以上已验证 A2 / A3 可以编译通过
- [x] CANN 9.0 及以上已验证 A2 / A3 / A5 可以编译通过
- [ ] 已验证修改算子的对应 test 在 A2 / A3 / A5 通过
- [ ] 已验证整体 example ST 在 A2 / A3 / A5 通过
- [x] 已完成必要的精度、性能或回归验证
- [x] 已确认没有引入与本 PR 无关的格式化或大规模重构
- [ ] 已更新相关 README、算子说明或变更记录，如适用
- [x] PR 标题已使用合适类型标签，如 `feat:`, `fix:`, `perf:`, `docs:`
- [x] 已确认如不满足准入要求或引入 bug，将第一时间回退

## 其他信息

产品head为ab7cffbbdb032448e3b85592c1d2111ceba8ad84，基线ebb5694d。候选版本的构建与硬件回归针对验证提交41838f7a60e64c1d9605aeba7bec85c5f853eb76：比产品额外保留公共FwdH的两行尾块测试依赖（移除两处Shape调用中的`, EmptyClass{}, true`），该依赖由另一提交人处理，不在本PR。请勿将这些结果表述为原样产品head已完成CI。

表中命令来自封存manifest；省略的环境初始化由受控包装器完成。`$E`代表证据根目录，`$ATK`代表原生独立双标杆套件（提交6395b207），路径均已去除机器信息。A2/A3的`$OPS=chunk_gated_delta_rule_fwd`；A5的`$OPS`为：

```text
chunk_gated_delta_rule_fwd,chunk_local_cumsum,chunk_scaled_dot_kkt,solve_tri,recompute_w_u_fwd,chunk_gated_delta_rule_fwd_h,chunk_fwd_o,chunk_gated_delta_rule_fwd_prepare,chunk_fwd_h,chunk_bwd_dv_local,chunk_gated_delta_rule_bwd_dhu,chunk_bwd_dqkwg,prepare_wy_repr_bwd_da,prepare_wy_repr_bwd_full
```

A5固定Python3.11.15、CANN9.1、torch2.10.0+cpu、torch_npu2.10.0；测试开始前已在隔离runtime固定triton3.2.0/triton-ascend3.2.2/expecttest0.3.0及依赖。测试工具9654b802，构建/安装/类型契约工具6871d579。

- 六私有/三公共头的C++14共存及sizeof/每字段offsetof契约通过；旧头顺序104/96只是源码控制实验，不是NPU越界复现。
- WU单独包、main整包、修复整包原200条各重复两次，输入/输出逐位一致；实际载入各自OPP。原WU统一ATK入口未执行，不替代其混合容差验收。
- 50个设备对象及.text与main基线完全一致；私有host不再包含公共FwdH宏类弱符号及其factory回调。共享SDK的其他注册仍保留。
- 最终A5 wheel SHA256：`7dd06798fa489413023773febf888f44fbb2c9c144d0ebf40c26ca5d851b82d4`。
- full/inference aggregate summary均为500/500，SHA256：`2602da7f57237589cde3fc9e2e9c9771a0d4662c56b65ff4e34047c997b6f44f`。
- 原始日志与逐文件SHA256收据已封存；本PR不增加产品诊断脚本或README。仓库CI的公开链接产生后可补充。