### PR TITLE
docs: enforce run package install verification

### DIFF
--- a/docs/agents/04-算子开发.md
+++ b/docs/agents/04-算子开发.md
@@ -116,6 +116,9 @@ Stage 方案和测试标准沿用前面阶段的结论。
    ```
 
    多个算子使用逗号分隔：`--ops=<算子1>,<算子2>`。
+   常规单算子开发和验证固定使用上述 `--install`，将本轮 run 包覆盖到当前 conda 环境中
+   wheel 内嵌的 OPP。只有用户明确要求使用独立 OPP 根目录时，才进入 `--install-path` 路线；
+   标准安装失败或当前环境不适合覆盖时停止并报告。
 
 2. 修改算子参数、aclnn/schema 接口、Python wrapper 或公开导出时，重新构建并安装完整 wheel：
 
@@ -130,6 +133,13 @@ Stage 方案和测试标准沿用前面阶段的结论。
      --no-deps \
      "$WHEEL_PATH"
    ```
+
+安装单算子 run 包后，执行以下产物一致性检查。只有检查全部返回 `[OK]`，才开始精度测试、
+性能测试或 profiling：
+
+```sh
+python scripts/verify_libcust_opapi_md5.py --run-package <本轮 run 包>
+```
 
 构建产物安装完成后，重启测试 Python 进程，并确认运行时加载的是本轮构建产物。构建和安装的
 详细说明见 [`开发者指南`](../开发者指南.md)。


### PR DESCRIPTION
## 关联 Issue / 背景

- 关联 Issue: 无，本 PR 补充现有算子开发流程的执行闸门。
- 背景与目标: 常规单算子开发已经规定使用 run 包覆盖当前 wheel，但缺少偏离标准安装路线时的停止条件，也未把现有产物 MD5 校验设为测试前置条件。
- 本 PR 解决的问题: 固定常规单算子开发与验证使用 `run 包 --install`，并要求产物一致性检查通过后再开始精度、性能或 profiling。

## 变更类型

- [x] 文档 / 示例 / 测试更新

## 修改范围

- 更新 `docs/agents/04-算子开发.md`。
- 常规单算子开发固定使用 `--install` 覆盖当前 conda wheel 的内嵌 OPP。
- 仅在用户明确要求独立 OPP 根目录时进入 `--install-path` 路线。
- 标准安装失败时停止并报告。
- 安装后运行现有 `scripts/verify_libcust_opapi_md5.py`；全部返回 `[OK]` 后才进入精度、性能或 profiling。
- 不涉及算子接口、ABI、kernel、构建脚本或运行时行为。

## 验证

- `git diff --check`：通过。
- 校验文档引用的 `scripts/verify_libcust_opapi_md5.py` 在当前 main 中存在。
- 纯文档修改，未执行 NPU 测试。

## 兼容性、风险与回退

- 兼容性：不改变已有命令和代码行为，只收紧 Agent 执行流程。
- 风险：低。
- 回退：回退本 PR 的文档提交即可。