### PR TITLE
fix(ascendc): correct KKT event initialization and lifecycle (v26.9.0)

### DIFF
--- a/fla/ops/ascendc/common/kernel_utils/block/block_mmad_pingpong_tla_multi.hpp
+++ b/fla/ops/ascendc/common/kernel_utils/block/block_mmad_pingpong_tla_multi.hpp
@@ -238,6 +238,8 @@ public:
                 }
             } else {
                 l0CTensorList[0] = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(0);
+                // MTE1-to-M still uses an event when MMAD/Fixpipe use unit flags.
+                l0CEventList[0] = 0;
             }
             if constexpr (HAS_BIAS) {
                 uint32_t l1BiasOffset = l1BOffset + L1B_TILE_SIZE * L1B_STAGES;

--- a/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_scaled_dot_kkt/op_kernel/chunk_scaled_dot_kkt.h
+++ b/fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_scaled_dot_kkt/op_kernel/chunk_scaled_dot_kkt.h
@@ -403,6 +403,11 @@ private:
         using BlockMmad = Catlass::Gemm::Block::BlockMmadTla<KktScoreDispatchPolicy, L1TileShape, L0TileShape, KType,
                                                               KType, float, void, TileCopy>;
 
+        Catlass::Arch::Resource<KktArchTag> resource;
+        BlockMmad blockMmad(resource);
+        // Preserve the event and buffer-slot lifecycle across this AIC's score tasks.
+        blockMmad.preSetFlags();
+
         int64_t scoreGroupSeq = 0;
         // Score blocks are computed once per key head; epilogue fans each block out to hvPerHk value heads.
         const int64_t scoreBlockTaskNum = B_ * NT_ * Hk_ * ScoreRowBlockCount();
@@ -414,7 +419,6 @@ private:
             if (scoreGroupSeq >= SCORE_WORKSPACE_BUFFER_NUM) {
                 Catlass::Arch::CrossCoreWaitFlag(scoreDoneFlag_[scoreSlot]);
             }
-            Catlass::Arch::Resource<KktArchTag> resource;
             for (int64_t batchIdx = 0; batchIdx < scoreGroupBatch; ++batchIdx) {
                 const int64_t scoreBlockTask = scoreGroupBase + batchIdx * usedAicNum_;
                 if (scoreBlockTask >= scoreBlockTaskNum) {
@@ -428,14 +432,19 @@ private:
                     continue;
                 }
                 const int64_t scoreOffset = GetScoreOffset(cubeIdx, scoreSlot, batchIdx);
-                BlockMmad blockMmad(resource);
-                blockMmad.preSetFlags();
                 ComputeCatlassScoreBlock(meta, rowBegin, rowCount, colCount, scoreOffset, blockMmad);
-                blockMmad.finalWaitFlags();
+                // Keep the next task's L0A/B loads behind this task's Fixpipe.
+                // Unit flags order MMAD/Fixpipe on L0C; MTE2 may still prefetch.
+                AscendC::SetFlag<AscendC::HardEvent::FIX_MTE1>(0);
+                AscendC::WaitFlag<AscendC::HardEvent::FIX_MTE1>(0);
             }
             Catlass::Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(scoreReadyFlag_[scoreSlot]);
             ++scoreGroupSeq;
         }
+        // Drain Fixpipe before finalWaitFlags changes the MMAD layout mode.
+        AscendC::SetFlag<AscendC::HardEvent::FIX_S>(0);
+        AscendC::WaitFlag<AscendC::HardEvent::FIX_S>(0);
+        blockMmad.finalWaitFlags();
         const int64_t pendingSlots = MinI64(scoreGroupSeq, static_cast<int64_t>(SCORE_WORKSPACE_BUFFER_NUM));
         for (int64_t slot = 0; slot < pendingSlots; ++slot) {
             Catlass::Arch::CrossCoreWaitFlag(scoreDoneFlag_[slot]);


### PR DESCRIPTION
连续异步调用 KKT 时，AIC 的 score-task 循环原来逐任务创建和结束 BlockMmad 事件生命周期。本修改将其提升到整段任务循环，并以 FIX_MTE1 完成任务间交接、在退出时等待 FIX_S，再释放事件和恢复布局模式。

## 合入门禁提醒

当前提交仍需管理员触发 NPU CI，并满足仓库要求的两个 approval。下列本地单算子结果不替代 NPU CI 或整体 Example/ST 验收。

## 关联 Issue / 背景

- 关联 Issue：#360。
- 目标分支：`v26.9.0`；验证提交：`1ca3f4dc90c0aeb6caf587a6f0f2aa1e5e717ae3`；对比其直接父提交：`26919d1c2b71370cee5e074b256e5d30e121a76a`。
- 本 PR 解决的问题：稳定 CATLASS 任务序列内的事件和缓冲区槽位生命周期，避免逐任务重复初始化和回收；为相邻任务与内核退出建立显式同步关系。
- 保留 UnitFlag；任务间使用 `FIX_MTE1` 的 SetFlag/WaitFlag，退出使用 `FIX_S`，没有任务边界 `PIPE_ALL`。
- UnitFlag 不替代 MTE1→M 同步。补齐公共 helper 在 UnitFlag 模式下仍被 MTE1→M 使用的事件 ID 初始化：l0CEventList[0] = 0。

## 变更类型

- [x] Bug 修复
- [x] 算子精度 / 稳定性修复
- [ ] 新功能 / 新算子
- [ ] 算子性能优化
- [ ] Tiling / InferShape / OpApi 调整
- [ ] 构建 / CI / 脚本变更
- [ ] 文档 / 示例 / 测试更新

## 算子责任范围

- 涉及算子：`chunk_scaled_dot_kkt`。
- 涉及文件（仅两个）：
  - `fla/ops/ascendc/common/kernel_utils/block/block_mmad_pingpong_tla_multi.hpp`
  - `fla/ops/ascendc/gdn/chunk_gdn_fwd/chunk_scaled_dot_kkt/op_kernel/chunk_scaled_dot_kkt.h`
- 责任人 / 提交人：<!-- pr-author -->
- 修改范围：
  - [x] `op_kernel` / Ascend C Kernel
  - [x] 公共 MMAD helper 的 UnitFlag 分支事件初始化
- 输入、输出、shape、dtype、format 支持范围：保持既有契约；本轮覆盖 FP16/BF16、BT16/32/64/128、fixed/varlen、GVA、尾块。
- 明确不包含：Host/Tiling、公开接口、Triton 实现、构建产物和本地测试资产。
- 是否影响公共模块或其他算子：
  - [x] 是。公共 helper 的使用方包括 `chunk_fwd_o`、`chunk_gated_delta_rule_fwd_h`、`chunk_kda_fwd`，存在潜在影响；本轮只回归 KKT，其他使用方仍需 CI/回归覆盖。非 UnitFlag 分支保持原实现。
- ABI / 接口兼容性：
  - [x] 不涉及算子 def、aclnn 或 torch 接口入参、返回值和属性变化。
- ABI 不兼容风险：无接口变更。KKT Host 仍只在 Ascend950 启用该 CATLASS 路径，A2/A3 保留既有 Matmul API 路径。

<details>
<summary>版本与产品编译矩阵</summary>

| 产品 | SOC | 本轮 CANN | 编译结果 |
| --- | --- | --- | --- |
| A2 | ascend910b | 未执行 | 未执行 |
| A3 | ascend910_93 | 未执行 | 未执行 |
| A5 | ascend950 | 9.1.0 | 修改前后均通过，生成独立 wheel |

</details>

<details>
<summary>验证方法</summary>

- 环境：Linux，CANN 9.1.0，Ascend950PR，Python 3.10，torch 2.12.0+cpu，torch_npu 2.12.0，ATK 26.7.8。
- 两个提交分别使用对应源码和独立算子包，检查构建产物哈希及运行时加载来源。
- 构建命令：`FLA_NPU_SOC=ascend950 FLA_NPU_OPS=chunk_scaled_dot_kkt python scripts/build_wheel.py -g --build-args=-j16 --wheel-dir ../wheel`，Release 构建。
- 精度：ATK `--task accuracy --bm_device cpu`，200 条 case × 3 个固定种子；CPU FP64 golden / FP32 control 双标杆。阈值 max_re_ratio=5、avg_re_ratio=1.5、root_mean_squared_ratio=1.5，输入、值域与阈值未调整。
- 性能：ATK `--task performance_device --performance_data 20,50,30 --save_data profile`，原 shape 表的 33 条 BF16 head-first 用例；每轮每条预热 20 次、采样 50 次，按 Task Start Time 排序取最后 30 条 KKT Task Duration。
- 交替顺序：before1 → after1 → after2 → before2；每条 shape 合并两轮均值，再对 shape 等权算术平均。仅统计 KKT 内核，不含布局转换或模型端到端耗时。

</details>

<details>
<summary>修改算子测试</summary>

### CANN 8.5 及以上

A2 / A3 编译本轮未执行；不能用历史版本结果代替当前提交验收。

### CANN 9.0 及以上

A5 / CANN 9.1.0 修改前后均编译通过；A2 / A3 未执行。未覆盖项待合入前补齐，尚未安排补测时间。

### 单算子测试结果

| 产品 | 验证 | 修改前 | 修改后 |
| --- | --- | --- | --- |
| A2 | 精度 / 性能 | 未执行 | 未执行 |
| A3 | 精度 / 性能 | 未执行 | 未执行 |
| A5 | CPU 双标杆精度 | 600/600 通过 | 600/600 通过 |
| A5 | 性能采样 | 2 轮，各 33/33 成功 | 2 轮，各 33/33 成功 |

600 个预期唯一 case ID 均执行成功、精度为 True、进程退出码为 0。132 份 profile 各含 50 条 KKT 记录，最终采用 3960 条采样。

| 范围 | shape 数 | 修改前（µs） | 修改后（µs） | 耗时变化 |
| --- | ---: | ---: | ---: | ---: |
| 全部 | 33 | 1937.970 | 1939.764 | +0.093% |
| BT64 | 25 | 987.875 | 989.498 | +0.164% |
| BT128 | 8 | 4907.018 | 4909.347 | +0.047% |

共享设备存在其他任务，平均耗时基本持平；这些小幅变化不能直接认定为稳定收益或回退。单 shape 最大轮间差：修改前 4.396%，修改后 4.460%；未做统计显著性检验。

- 边界覆盖：FP16/BF16、BT16/32/64/128、fixed/varlen、GVA、尾块等既有 200 条用例。
- 未覆盖风险：本轮未重跑 memcheck、确定性、synccheck、racecheck 或连续异步压力；精度和性能结果不等价于 issue 中超时问题已完成专项验收。

</details>

<details>
<summary>整体 Example ST 验证</summary>

| 产品 | 结果 | 说明 |
| --- | --- | --- |
| A2 | 未执行 | 本轮限于指定 KKT 提交的精度、性能对比 |
| A3 | 未执行 | 同上 |
| A5 | 未执行 | 同上 |

KKT 属于 GDN 端到端链路；整体 ST 及公共 helper 其他使用方回归仍需合入前完成，补测时间待安排。

</details>

## 兼容性、风险与回退

- 兼容性：不改变公开接口、支持范围或 Host 路由。
- 风险：公共 helper 影响面、未覆盖产品和连续异步压力需要进一步验证；本轮未断言某一种 L0C 数据覆盖是超时的唯一原因。
- 回退方案：如出现回归，revert 本 PR 的单个修复提交，恢复其父提交的同步实现。
- 回退责任确认：
  - [ ] 提交人与维护者确认回退安排。

## Checklist

- [x] 已关联 Issue，并明确算子责任范围。
- [ ] CANN 8.5 及以上已验证 A2 / A3 编译。
- [ ] CANN 9.0 及以上已验证 A2 / A3 / A5 编译（目前仅 A5）。
- [ ] 修改算子 test 在 A2 / A3 / A5 均通过（目前仅 A5）。
- [ ] 整体 Example ST 在 A2 / A3 / A5 均通过。
- [x] 已完成并说明本轮 A5 精度和性能验证。
- [x] 没有无关格式化、重构或构建产物。
- [x] PR 标题使用 fix 类型。
- [ ] 当前 head 的 NPU CI 和审核门禁已通过。

## 其他信息

测试结论针对上述明确提交及其直接父提交；上游分支后续提交的合并结果尚未单独执行上述测试。
